### PR TITLE
chore: make pytest as optional dependency

### DIFF
--- a/docs/source/guides/contributing/plugins.rst
+++ b/docs/source/guides/contributing/plugins.rst
@@ -82,7 +82,14 @@ while "Rule_PluginName_L000" will have code "PluginName_L000".
 Codes are used to display errors, they are also used as configuration keys.
 
 We make it easy for plugin developers to test their rules by
-exposing a testing library in *sqlfluff.utils.testing*.
+exposing a testing library in *sqlfluff.utils.testing*. This testing
+library depends on ``pytest``, which is not installed as part of the
+core SQLFluff package. To use it, install SQLFluff with the
+``testutils`` extra:
+
+.. code-block:: bash
+
+    pip install sqlfluff[testutils]
 
 .. _`sqlfluff/plugins/sqlfluff-plugin-example`: https://github.com/sqlfluff/sqlfluff/tree/main/plugins/sqlfluff-plugin-example
 .. _`sqlfluff/plugins/sqlfluff-templater-dbt`: https://github.com/sqlfluff/sqlfluff/tree/main/plugins/sqlfluff-templater-dbt

--- a/docsv/development/plugins.md
+++ b/docsv/development/plugins.md
@@ -43,7 +43,11 @@ Run `pip install -e .`, inside the plugin folder so custom rules in linting are 
 
 A plugin Rule code includes the PluginName, so a rule `Rule_L000` in core will have code `L000`, while `Rule_PluginName_L000` will have code `PluginName_L000`. Codes are used to display errors, they are also used as configuration keys.
 
-We make it easy for plugin developers to test their rules by exposing a testing library in *sqlfluff.utils.testing*.
+We make it easy for plugin developers to test their rules by exposing a testing library in *sqlfluff.utils.testing*. This testing library depends on `pytest`, which is not installed as part of the core SQLFluff package. To use it, install SQLFluff with the `testutils` extra:
+
+```bash
+pip install sqlfluff[testutils]
+```
 
 ## Giving feedback
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,8 +80,6 @@ dependencies = [
     "Jinja2",
     # Used for .sqlfluffignore
     "pathspec",
-    # We provide a testing library for plugins in sqlfluff.utils.testing
-    "pytest",
     # We require pyyaml >= 5.1 so that we can preserve the ordering of keys.
     "pyyaml>=5.1",
     # The new regex module to allow for more complex pattern matching,
@@ -100,6 +98,8 @@ dependencies = [
 
 [project.optional-dependencies]
 rs = ["sqlfluffrs==4.1.0"]
+# Testing utilities for plugin developers
+testutils = ["pytest"]
 
 [project.urls]
 Homepage = "https://www.sqlfluff.com"

--- a/src/sqlfluff/__init__.py
+++ b/src/sqlfluff/__init__.py
@@ -3,7 +3,10 @@
 import sys
 from importlib import metadata
 
-import pytest
+try:
+    import pytest  # isort: skip
+except ImportError:
+    pytest = None  # type: ignore[assignment]
 
 # Expose the public API.
 from sqlfluff.api import fix, lint, list_dialects, list_rules, parse
@@ -30,4 +33,5 @@ elif sys.version_info[1] < 8:
     )
 
 # Register helper functions to support variable introspection on failure.
-pytest.register_assert_rewrite("sqlfluff.utils.testing")
+if pytest is not None:
+    pytest.register_assert_rewrite("sqlfluff.utils.testing")

--- a/src/sqlfluff/__init__.py
+++ b/src/sqlfluff/__init__.py
@@ -5,7 +5,7 @@ from importlib import metadata
 
 try:
     import pytest  # isort: skip
-except ImportError:
+except ImportError:  # pragma: no cover
     pytest = None  # type: ignore[assignment]
 
 # Expose the public API.

--- a/src/sqlfluff/utils/testing/logging.py
+++ b/src/sqlfluff/utils/testing/logging.py
@@ -23,7 +23,7 @@ try:
         LogCaptureHandler,
         _remove_ansi_escape_sequences,
     )  # isort: skip
-except ImportError:
+except ImportError:  # pragma: no cover
     LogCaptureHandler = None  # type: ignore[assignment,misc]
     _remove_ansi_escape_sequences = None  # type: ignore[assignment]
 
@@ -54,7 +54,7 @@ if LogCaptureHandler is not None:
             result = self.stream.getvalue()
             return _remove_ansi_escape_sequences(result)
 
-else:
+else:  # pragma: no cover
     # Create a placeholder class that will never be instantiated
     # (since _ensure_pytest_logging will fail)
     class FluffLogHandler:  # type: ignore[no-redef]

--- a/src/sqlfluff/utils/testing/rules.py
+++ b/src/sqlfluff/utils/testing/rules.py
@@ -4,10 +4,14 @@ from collections.abc import Collection
 from glob import glob
 from typing import NamedTuple, Optional, Union
 
-import pytest
 import yaml
 
 from sqlfluff.core import Linter
+
+try:
+    import pytest  # isort: skip
+except ImportError:
+    pytest = None  # type: ignore[assignment]
 from sqlfluff.core.config import FluffConfig
 from sqlfluff.core.errors import (
     SQLBaseError,
@@ -21,6 +25,15 @@ from sqlfluff.core.types import ConfigMappingType
 
 FixDictType = dict[str, Union[str, int]]
 ViolationDictType = dict[str, Union[str, int, bool, list[FixDictType]]]
+
+
+def _ensure_pytest():
+    """Ensure pytest is available for testing functions."""
+    if pytest is None:
+        raise ImportError(
+            "pytest is required for SQLFluff testing utilities. "
+            "Please install it with: pip install sqlfluff[testutils]"
+        )
 
 
 class RuleTestCase(NamedTuple):
@@ -44,6 +57,7 @@ class RuleTestCase(NamedTuple):
         will call methods such as `pytest.skip()` as part of it's execution.
         It may not be suitable for other testing contexts.
         """
+        _ensure_pytest()
         rules__test_helper(self)
 
 
@@ -122,6 +136,7 @@ def assert_rule_fail_in_sql(
             violations (list of SQLBaseError): the violations found during
                 linting.
     """
+    _ensure_pytest()
     print("# Asserting Rule Fail in SQL")
     # Set up the config to only use the rule we are testing.
     cfg = _setup_config(code, configs)
@@ -179,6 +194,7 @@ def assert_rule_pass_in_sql(
     msg: Optional[str] = None,
 ) -> None:
     """Assert that a given rule doesn't fail on the given sql."""
+    _ensure_pytest()
     # Configs allows overrides if we want to use them.
     print("# Asserting Rule Pass in SQL")
     cfg = _setup_config(code, configs)
@@ -296,6 +312,7 @@ def rules__test_helper(test_case: RuleTestCase) -> None:
 
     Optionally, also test the fixed string if provided in the test case.
     """
+    _ensure_pytest()
     if test_case.skip:
         pytest.skip(test_case.skip)
 

--- a/src/sqlfluff/utils/testing/rules.py
+++ b/src/sqlfluff/utils/testing/rules.py
@@ -10,7 +10,7 @@ from sqlfluff.core import Linter
 
 try:
     import pytest  # isort: skip
-except ImportError:
+except ImportError:  # pragma: no cover
     pytest = None  # type: ignore[assignment]
 from sqlfluff.core.config import FluffConfig
 from sqlfluff.core.errors import (

--- a/test/utils/testing/conditional_imports_test.py
+++ b/test/utils/testing/conditional_imports_test.py
@@ -1,0 +1,124 @@
+"""Test conditional import paths when pytest is not available."""
+
+import os
+import sys
+
+# Add src to Python path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "..", "src"))
+
+
+def test_testing_rules_error_message():
+    """Test that _ensure_pytest gives helpful error message."""
+    from sqlfluff.utils.testing.rules import _ensure_pytest, pytest
+
+    # pytest should be available in test environment,
+    # so let's test the error path manually
+    original_pytest = pytest
+    try:
+        # Temporarily set pytest to None to simulate ImportError path
+        import sqlfluff.utils.testing.rules
+
+        sqlfluff.utils.testing.rules.pytest = None
+
+        try:
+            _ensure_pytest()
+            assert False, "Should have raised ImportError"
+        except ImportError as e:
+            assert "testutils" in str(e)
+            assert "pytest is required" in str(e)
+            print("✓ testing.rules error message test passed")
+
+    finally:
+        # Restore original pytest
+        sqlfluff.utils.testing.rules.pytest = original_pytest
+
+
+def test_testing_logging_error_message():
+    """Test that _ensure_pytest_logging gives helpful error message."""
+    from sqlfluff.utils.testing.logging import (
+        LogCaptureHandler,
+        _ensure_pytest_logging,
+        _remove_ansi_escape_sequences,
+    )
+
+    # Test the error path manually by setting variables to None
+    original_handler = LogCaptureHandler
+    original_remove_func = _remove_ansi_escape_sequences
+
+    try:
+        # Simulate ImportError path by setting to None
+        import sqlfluff.utils.testing.logging
+
+        sqlfluff.utils.testing.logging.LogCaptureHandler = None
+        sqlfluff.utils.testing.logging._remove_ansi_escape_sequences = None
+
+        try:
+            _ensure_pytest_logging()
+            assert False, "Should have raised ImportError"
+        except ImportError as e:
+            assert "testutils" in str(e)
+            assert "pytest is required" in str(e)
+            print("✓ testing.logging error message test passed")
+
+    finally:
+        # Restore original values
+        sqlfluff.utils.testing.logging.LogCaptureHandler = original_handler
+        sqlfluff.utils.testing.logging._remove_ansi_escape_sequences = (
+            original_remove_func
+        )
+
+
+def test_sqlfluff_pytest_assignment():
+    """Test that pytest gets assigned correctly in __init__.py."""
+    # Read the __init__.py file and verify the conditional import logic exists
+    init_path = os.path.join("src", "sqlfluff", "__init__.py")
+    with open(init_path, "r") as f:
+        content = f.read()
+
+    # Verify the try/except ImportError pattern exists
+    assert "try:" in content
+    assert "import pytest" in content
+    assert "except ImportError:" in content
+    assert "pytest = None" in content
+    print("✓ sqlfluff.__init__ conditional import structure verified")
+
+
+def test_testing_rules_import_structure():
+    """Test that testing.rules has the correct conditional import structure."""
+    rules_path = os.path.join("src", "sqlfluff", "utils", "testing", "rules.py")
+    with open(rules_path, "r") as f:
+        content = f.read()
+
+    # Verify the try/except ImportError pattern exists
+    assert "try:" in content
+    assert "import pytest" in content
+    assert "except ImportError:" in content
+    assert "pytest = None" in content
+    assert "def _ensure_pytest():" in content
+    print("✓ testing.rules conditional import structure verified")
+
+
+def test_testing_logging_import_structure():
+    """Test that testing.logging has the correct conditional import structure."""
+    logging_path = os.path.join("src", "sqlfluff", "utils", "testing", "logging.py")
+    with open(logging_path, "r") as f:
+        content = f.read()
+
+    # Verify the try/except ImportError pattern exists
+    assert "try:" in content
+    assert "from _pytest.logging import (" in content
+    assert "LogCaptureHandler" in content
+    assert "except ImportError:" in content
+    assert "LogCaptureHandler = None" in content
+    assert "_remove_ansi_escape_sequences = None" in content
+    assert "def _ensure_pytest_logging():" in content
+    print("✓ testing.logging conditional import structure verified")
+
+
+if __name__ == "__main__":
+    test_sqlfluff_pytest_assignment()
+    test_testing_rules_import_structure()
+    test_testing_logging_import_structure()
+    test_testing_rules_error_message()
+    test_testing_logging_error_message()
+    print("All conditional import tests passed!")

--- a/test/utils/testing/conditional_imports_test.py
+++ b/test/utils/testing/conditional_imports_test.py
@@ -1,33 +1,25 @@
 """Test conditional import paths when pytest is not available."""
 
-import os
+import builtins
 import sys
+from unittest.mock import MagicMock, patch
 
-# Add src to Python path
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "..", "src"))
+import pytest
 
 
 def test_testing_rules_error_message():
     """Test that _ensure_pytest gives helpful error message."""
-    from sqlfluff.utils.testing.rules import _ensure_pytest, pytest
+    from sqlfluff.utils.testing.rules import _ensure_pytest
 
-    # pytest should be available in test environment,
-    # so let's test the error path manually
-    original_pytest = pytest
+    import sqlfluff.utils.testing.rules
+
+    original_pytest = sqlfluff.utils.testing.rules.pytest
     try:
         # Temporarily set pytest to None to simulate ImportError path
-        import sqlfluff.utils.testing.rules
-
         sqlfluff.utils.testing.rules.pytest = None
-
-        try:
+        with pytest.raises(ImportError, match="testutils") as exc_info:
             _ensure_pytest()
-            assert False, "Should have raised ImportError"
-        except ImportError as e:
-            assert "testutils" in str(e)
-            assert "pytest is required" in str(e)
-            print("✓ testing.rules error message test passed")
-
+        assert "pytest is required" in str(exc_info.value)
     finally:
         # Restore original pytest
         sqlfluff.utils.testing.rules.pytest = original_pytest
@@ -41,84 +33,69 @@ def test_testing_logging_error_message():
         _remove_ansi_escape_sequences,
     )
 
-    # Test the error path manually by setting variables to None
-    original_handler = LogCaptureHandler
-    original_remove_func = _remove_ansi_escape_sequences
+    import sqlfluff.utils.testing.logging
 
     try:
         # Simulate ImportError path by setting to None
-        import sqlfluff.utils.testing.logging
-
         sqlfluff.utils.testing.logging.LogCaptureHandler = None
         sqlfluff.utils.testing.logging._remove_ansi_escape_sequences = None
-
-        try:
+        with pytest.raises(ImportError, match="testutils") as exc_info:
             _ensure_pytest_logging()
-            assert False, "Should have raised ImportError"
-        except ImportError as e:
-            assert "testutils" in str(e)
-            assert "pytest is required" in str(e)
-            print("✓ testing.logging error message test passed")
-
+        assert "pytest is required" in str(exc_info.value)
     finally:
         # Restore original values
-        sqlfluff.utils.testing.logging.LogCaptureHandler = original_handler
+        sqlfluff.utils.testing.logging.LogCaptureHandler = LogCaptureHandler
         sqlfluff.utils.testing.logging._remove_ansi_escape_sequences = (
-            original_remove_func
+            _remove_ansi_escape_sequences
         )
 
 
-def test_sqlfluff_pytest_assignment():
-    """Test that pytest gets assigned correctly in __init__.py."""
-    # Read the __init__.py file and verify the conditional import logic exists
-    init_path = os.path.join("src", "sqlfluff", "__init__.py")
-    with open(init_path, "r") as f:
-        content = f.read()
-
-    # Verify the try/except ImportError pattern exists
-    assert "try:" in content
-    assert "import pytest" in content
-    assert "except ImportError:" in content
-    assert "pytest = None" in content
-    print("✓ sqlfluff.__init__ conditional import structure verified")
-
-
-def test_testing_rules_import_structure():
-    """Test that testing.rules has the correct conditional import structure."""
-    rules_path = os.path.join("src", "sqlfluff", "utils", "testing", "rules.py")
-    with open(rules_path, "r") as f:
-        content = f.read()
-
-    # Verify the try/except ImportError pattern exists
-    assert "try:" in content
-    assert "import pytest" in content
-    assert "except ImportError:" in content
-    assert "pytest = None" in content
-    assert "def _ensure_pytest():" in content
-    print("✓ testing.rules conditional import structure verified")
+def test_sqlfluff_init_registers_assert_rewrite_when_pytest_available():
+    """sqlfluff.__init__ calls pytest.register_assert_rewrite when pytest is importable."""
+    mock_pytest = MagicMock()
+    saved = sys.modules.pop("sqlfluff", None)
+    try:
+        with patch.dict(sys.modules, {"pytest": mock_pytest}):
+            import sqlfluff  # noqa: F401
+        mock_pytest.register_assert_rewrite.assert_called_once_with(
+            "sqlfluff.utils.testing"
+        )
+    finally:
+        if saved is not None:
+            sys.modules["sqlfluff"] = saved
+        elif "sqlfluff" in sys.modules:
+            del sys.modules["sqlfluff"]
 
 
-def test_testing_logging_import_structure():
-    """Test that testing.logging has the correct conditional import structure."""
-    logging_path = os.path.join("src", "sqlfluff", "utils", "testing", "logging.py")
-    with open(logging_path, "r") as f:
-        content = f.read()
+def test_sqlfluff_init_handles_missing_pytest():
+    """Importing sqlfluff when pytest is unavailable does not raise an error."""
+    real_import = builtins.__import__
 
-    # Verify the try/except ImportError pattern exists
-    assert "try:" in content
-    assert "from _pytest.logging import (" in content
-    assert "LogCaptureHandler" in content
-    assert "except ImportError:" in content
-    assert "LogCaptureHandler = None" in content
-    assert "_remove_ansi_escape_sequences = None" in content
-    assert "def _ensure_pytest_logging():" in content
-    print("✓ testing.logging conditional import structure verified")
+    def import_without_pytest(name, *args, **kwargs):  # type: ignore[no-untyped-def]
+        if name == "pytest":
+            raise ImportError("No module named 'pytest'")
+        return real_import(name, *args, **kwargs)
+
+    saved = sys.modules.pop("sqlfluff", None)
+    try:
+        with patch("builtins.__import__", side_effect=import_without_pytest):
+            import sqlfluff  # noqa: F401
+    finally:
+        if saved is not None:
+            sys.modules["sqlfluff"] = saved
+        elif "sqlfluff" in sys.modules:
+            del sys.modules["sqlfluff"]
 
 
-if __name__ == "__main__":
-    test_sqlfluff_pytest_assignment()
-    test_testing_rules_import_structure()
-    test_testing_logging_import_structure()
-    test_testing_rules_error_message()
-    test_testing_logging_error_message()
-    print("All conditional import tests passed!")
+def test_ensure_pytest_does_not_raise_when_pytest_available():
+    """_ensure_pytest() succeeds without raising when pytest is importable."""
+    from sqlfluff.utils.testing.rules import _ensure_pytest
+
+    _ensure_pytest()  # Should not raise
+
+
+def test_ensure_pytest_logging_does_not_raise_when_pytest_available():
+    """_ensure_pytest_logging() succeeds without raising when pytest is importable."""
+    from sqlfluff.utils.testing.logging import _ensure_pytest_logging
+
+    _ensure_pytest_logging()  # Should not raise

--- a/test/utils/testing/conditional_imports_test.py
+++ b/test/utils/testing/conditional_imports_test.py
@@ -9,9 +9,8 @@ import pytest
 
 def test_testing_rules_error_message():
     """Test that _ensure_pytest gives helpful error message."""
-    from sqlfluff.utils.testing.rules import _ensure_pytest
-
     import sqlfluff.utils.testing.rules
+    from sqlfluff.utils.testing.rules import _ensure_pytest
 
     original_pytest = sqlfluff.utils.testing.rules.pytest
     try:
@@ -27,13 +26,12 @@ def test_testing_rules_error_message():
 
 def test_testing_logging_error_message():
     """Test that _ensure_pytest_logging gives helpful error message."""
+    import sqlfluff.utils.testing.logging
     from sqlfluff.utils.testing.logging import (
         LogCaptureHandler,
         _ensure_pytest_logging,
         _remove_ansi_escape_sequences,
     )
-
-    import sqlfluff.utils.testing.logging
 
     try:
         # Simulate ImportError path by setting to None


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made

make pytest as optional dependency， fix #7267 

### Are there any other side effects of this change that we should be aware of?

no

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
