### PR TITLE
TSQL: new rule to remove empty batches

### DIFF
--- a/src/sqlfluff/core/default_config.cfg
+++ b/src/sqlfluff/core/default_config.cfg
@@ -447,6 +447,7 @@ ignore_comment_clauses = False
 [sqlfluff:rules:layout.newlines]
 maximum_empty_lines_between_statements = 2
 maximum_empty_lines_inside_statements = 1
+maximum_empty_lines_between_batches = 1
 
 [sqlfluff:rules:layout.select_targets]
 wildcard_policy = single

--- a/src/sqlfluff/rules/layout/__init__.py
+++ b/src/sqlfluff/rules/layout/__init__.py
@@ -36,6 +36,13 @@ def get_configs_info() -> dict[str, ConfigInfo]:
                 "The maximum number of empty lines allowed inside statements."
             ),
         },
+        "maximum_empty_lines_between_batches": {
+            "validation": range(1000),
+            "definition": (
+                "The maximum number of empty lines allowed between batches "
+                "in T-SQL. Batches are separated by GO statements."
+            ),
+        },
         "wildcard_policy": {
             "validation": ["single", "multiple"],
             "definition": "Treatment of wildcards. Defaults to ``single``.",

--- a/src/sqlfluff/rules/tsql/TQ03.py
+++ b/src/sqlfluff/rules/tsql/TQ03.py
@@ -1,0 +1,96 @@
+"""Implementation of Rule TQ03."""
+
+from typing import Optional
+
+from sqlfluff.core.rules import BaseRule, LintFix, LintResult, RuleContext
+from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
+
+
+class Rule_TQ03(BaseRule):
+    """Remove empty batches.
+
+    **Anti-pattern**
+
+    Empty batches (containing only GO statements) should be removed.
+
+    .. code-block:: sql
+       :force:
+
+        CREATE TABLE dbo.test (
+            testcol1 INT NOT NULL,
+            testcol2 INT NOT NULL
+        );
+
+        GO
+
+        GO
+
+    **Best practice**
+
+    Remove empty batches.
+
+    .. code-block:: sql
+       :force:
+
+        CREATE TABLE dbo.test (
+            testcol1 INT NOT NULL,
+            testcol2 INT NOT NULL
+        );
+
+        GO
+    """
+
+    name = "tsql.empty_batch"
+    aliases = ()
+    groups = ("all", "tsql")
+    crawl_behaviour = SegmentSeekerCrawler({"batch"})
+    is_fix_compatible = True
+
+    def _eval(self, context: RuleContext) -> Optional[list[LintResult]]:
+        """Remove empty batches."""
+        # Rule only applies to T-SQL syntax.
+        if context.dialect.name != "tsql":
+            return None  # pragma: no cover
+
+        if not context.segment.is_type("batch"):  # pragma: no cover
+            return None
+
+        # Get all non-whitespace, non-meta segments
+        content_segments = [
+            s
+            for s in context.segment.segments
+            if not s.is_type("whitespace", "newline", "indent", "dedent")
+            and not s.is_meta
+        ]
+
+        # Check if batch contains only GO statement
+        has_real_content = False
+        has_go = False
+        for content_seg in content_segments:
+            if content_seg.is_type("go_statement"):
+                has_go = True
+            elif not content_seg.is_meta:
+                has_real_content = True
+                break
+
+        # If batch has no real content (only GO and whitespace), remove it
+        if not has_real_content and has_go:
+            fixes = [LintFix.delete(context.segment)]
+
+            # Also delete the trailing newline after the batch if present
+            segments = context.parent_stack[-1].segments
+            idx = segments.index(context.segment)
+            if idx + 1 < len(segments):
+                next_seg = segments[idx + 1]
+                if next_seg.is_type("newline"):
+                    fixes.append(LintFix.delete(next_seg))
+
+            return [
+                LintResult(
+                    anchor=context.segment,
+                    description="Empty batch with only GO statement should be removed.",
+                    fixes=fixes,
+                )
+            ]
+
+        return None

--- a/src/sqlfluff/rules/tsql/__init__.py
+++ b/src/sqlfluff/rules/tsql/__init__.py
@@ -19,5 +19,6 @@ def get_rules() -> list[type[BaseRule]]:
     """
     from sqlfluff.rules.tsql.TQ01 import Rule_TQ01
     from sqlfluff.rules.tsql.TQ02 import Rule_TQ02
+    from sqlfluff.rules.tsql.TQ03 import Rule_TQ03
 
-    return [Rule_TQ01, Rule_TQ02]
+    return [Rule_TQ01, Rule_TQ02, Rule_TQ03]

--- a/test/fixtures/rules/std_rule_cases/LT15.yml
+++ b/test/fixtures/rules/std_rule_cases/LT15.yml
@@ -154,3 +154,75 @@ test_pass_macros_with_embedded_newlines:
 
             {% endmacro %}
 # yamllint enable
+
+test_pass_tsql_batches_one_empty_line:
+  # T-SQL specific: allow 1 empty line between batches
+  pass_str: |
+    SELECT 1;
+
+    GO
+
+    SELECT 2;
+  configs:
+    core:
+      dialect: tsql
+    rules:
+      layout.newlines:
+        maximum_empty_lines_between_batches: 1
+
+test_fail_tsql_batches_too_many_empty_lines:
+  # T-SQL specific: more than 1 empty line between batches should fail
+  fail_str: |
+    SELECT 1;
+
+    GO
+
+
+    SELECT 2;
+  fix_str: |
+    SELECT 1;
+
+    GO
+
+    SELECT 2;
+  configs:
+    core:
+      dialect: tsql
+    rules:
+      layout.newlines:
+        maximum_empty_lines_between_batches: 1
+
+test_fail_tsql_batches_zero_empty_lines:
+  # T-SQL specific: no empty lines between batches when set to 0
+  fail_str: |
+    SELECT 1;
+    GO
+
+
+    SELECT 2;
+  fix_str: |
+    SELECT 1;
+    GO
+    SELECT 2;
+  configs:
+    core:
+      dialect: tsql
+    rules:
+      layout.newlines:
+        maximum_empty_lines_between_batches: 0
+
+test_pass_tsql_inside_batch_respects_statement_limit:
+  # Inside a batch, statement limits should apply
+  pass_str: |
+    SELECT 1;
+
+    SELECT 2;
+
+    GO
+  configs:
+    core:
+      dialect: tsql
+    rules:
+      layout.newlines:
+        maximum_empty_lines_inside_statements: 1
+        maximum_empty_lines_between_statements: 1

--- a/test/fixtures/rules/std_rule_cases/TQ03.yml
+++ b/test/fixtures/rules/std_rule_cases/TQ03.yml
@@ -1,0 +1,110 @@
+---
+# yamllint disable rule:empty-lines
+rule: TQ03
+
+# TQ03 now only handles empty batches (batches with only GO statements).
+# Newline handling is now done by LT15 with maximum_empty_lines_between_batches config.
+
+# Test cases for empty batches
+test_fail_empty_batch_1:
+  fail_str: |
+    CREATE TABLE dbo.test (
+        testcol1 INT NOT NULL,
+        testcol2 INT NOT NULL
+    );
+    GO
+    GO
+  fix_str: |
+    CREATE TABLE dbo.test (
+        testcol1 INT NOT NULL,
+        testcol2 INT NOT NULL
+    );
+    GO
+  configs:
+    core:
+      dialect: tsql
+
+test_fail_empty_batch_2:
+  fail_str: |
+    SELECT 1;
+    GO
+    GO
+  fix_str: |
+    SELECT 1;
+    GO
+  configs:
+    core:
+      dialect: tsql
+
+test_fail_empty_batch_3:
+  fail_str: |
+    SELECT 1;
+    GO
+    GO
+    SELECT 2;
+    GO
+  fix_str: |
+    SELECT 1;
+    GO
+    SELECT 2;
+    GO
+  configs:
+    core:
+      dialect: tsql
+
+test_fail_multiple_empty_batches:
+  fail_str: |
+    SELECT 1;
+    GO
+    GO
+    GO
+    SELECT 2;
+    GO
+  fix_str: |
+    SELECT 1;
+    GO
+    SELECT 2;
+    GO
+  configs:
+    core:
+      dialect: tsql
+
+# Test cases that should pass
+
+test_pass_no_empty_batches:
+  pass_str: |
+    SELECT 1;
+    SELECT 2;
+  configs:
+    core:
+      dialect: tsql
+
+test_pass_batch_with_content:
+  pass_str: |
+    CREATE TABLE dbo.test (
+        testcol1 INT NOT NULL,
+        testcol2 INT NOT NULL
+    );
+    GO
+    SELECT * FROM dbo.test;
+  configs:
+    core:
+      dialect: tsql
+
+test_pass_single_go:
+  pass_str: |
+    SELECT 1;
+    GO
+  configs:
+    core:
+      dialect: tsql
+
+test_pass_multiple_statements_with_go:
+  pass_str: |
+    SELECT 1;
+    GO
+    SELECT 2;
+    GO
+  configs:
+    core:
+      dialect: tsql


### PR DESCRIPTION
### Brief summary of the change made

This PR adds a new T-SQL specific rule to remove empty batches.
Also add support for maximum empty lines between T-SQL batches in rule L15

Changes made:
* Added `maximum_empty_lines_between_batches` configuration parameter (default: 1)
* `L15`: Enhanced `_eval()` method with batch-aware logic that checks `parent_stack` to determine context:
  * Inside statement → uses `maximum_empty_lines_between_statements`
  * Inside batch → uses `maximum_empty_lines_between_statements`
  * Between batches (T-SQL) → uses `maximum_empty_lines_between_batches`
  * Between statements (file level) → uses `maximum_empty_lines_between_statements`
* Added test cases for `L15` to test functionality of new line removal between batches
* Added new `TQ03` rule to find and remove empty batches and eventual new line after that
* Added test cases to `TQ03`

Fixes #3521 

### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
