### PR TITLE
feat: ANSI as cli dialect default

### DIFF
--- a/src/sqlfluff/core/config/fluffconfig.py
+++ b/src/sqlfluff/core/config/fluffconfig.py
@@ -162,6 +162,10 @@ class FluffConfig:
             self._configs["core"]["dialect_obj"] = dialect_selector(dialect)
         elif require_dialect:
             self.verify_dialect_specified()
+        else:
+            # Default to ANSI dialect when none is specified
+            self._configs["core"]["dialect"] = "ansi"
+            self._configs["core"]["dialect_obj"] = dialect_selector("ansi")
 
     def verify_dialect_specified(self) -> None:
         """Check if the config specifies a dialect, raising an error if not.

--- a/test/cli/commands_test.py
+++ b/test/cli/commands_test.py
@@ -135,18 +135,21 @@ def test__cli__command_dialect():
     ],
 )
 def test__cli__command_no_dialect(command):
-    """Check the script raises the right exception no dialect."""
-    # The dialect is unknown should be a non-zero exit code
+    """Check the script defaults to ANSI dialect when no dialect is specified."""
+    # With no dialect specified, should default to ANSI and succeed
+    # Note: For lint command, we use --nofail to ignore lint violations
+    # which may occur due to formatting issues in the test input
+    args = [command, ["-"]]
+    if command == lint:
+        args = [command, ["--nofail", "-"]]
     result = invoke_assert_code(
-        ret_code=2,
-        args=[
-            command,
-            ["-"],
-        ],
-        cli_input="SELECT 1",
+        ret_code=0,
+        args=args,
+        cli_input="SELECT 1\n",
     )
-    assert "User Error" in result.stderr
-    assert "No dialect was specified" in result.stderr
+    assert "User Error" not in result.stderr
+    # No dialect specification error should occur anymore since we default to ANSI
+    assert "No dialect was specified" not in result.stderr
     # No traceback should be in the output
     assert "Traceback (most recent call last)" not in result.stderr
 


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
fixes #7278

### Are there any other side effects of this change that we should be aware of?
This will not not cause the cli to fail when no dialect is specified as an arg.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
