### PR TITLE
Fix click version constraint, bumping to 8.3.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,7 @@ dependencies = [
     "chardet",
     # Click can include breaking changes in minor releases. Make sure to test
     # well before updating upper bound.
-    "click<=8.3.0",
+    "click<8.4.0",
     "colorama>=0.3",
     # Used for diffcover plugin
     "diff-cover>=2.5.0",


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->

Fix version constraint for `click`, while bumping it to include all 8.3.x versions.

In #6892, we tried to pin click to keep it under 8.3, but the pin as defined _includes_ 8.3.0.
[That version has been out for about a month](https://pypi.org/project/click/#history) and I don't see anyone complaining, so I'm assuming that we're indeed compatible with 8.3.x by chance.

Now, the pin as it's defined keep click from updating to 8.3 patches, which I guess it wasn't the original plan.

With this PR, I'd avance the pin to include all 8.3.x, but excluding 8.4+.

### Are there any other side effects of this change that we should be aware of?

Don't think so

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
