### PR TITLE
TSQL: Enhance GROUP BY clause to support T-SQL specific terminators

### DIFF
--- a/test/fixtures/dialects/tsql/group_by_termination.sql
+++ b/test/fixtures/dialects/tsql/group_by_termination.sql
@@ -1,0 +1,81 @@
+-- Test that GROUP BY properly terminates before the next statement
+-- Without a semicolon terminator, the parser should still recognize
+-- that a new SELECT statement starts a new query, not continues GROUP BY
+
+-- QUERY 1: Simple GROUP BY followed by another query
+SELECT FIELD2
+FROM TABLE2
+GROUP BY
+    FIELD3
+
+-- QUERY 2: UNION query with 2 columns
+SELECT
+    FIELD1,
+    FIELD2
+FROM TABLE2
+
+UNION ALL
+
+SELECT
+    FIELD3,
+    FIELD4
+FROM TABLE3
+
+-- edge cases
+-- Test various GROUP BY termination scenarios
+
+-- Test 1: GROUP BY followed by SELECT (without semicolon)
+SELECT FIELD1
+FROM TABLE1
+GROUP BY FIELD1
+
+SELECT FIELD2
+FROM TABLE2
+
+-- Test 2: GROUP BY followed by UNION (should be separate queries)
+SELECT FIELD1
+FROM TABLE1
+GROUP BY FIELD1
+
+SELECT FIELD2
+FROM TABLE2
+UNION ALL
+SELECT FIELD3
+FROM TABLE3
+
+-- Test 3: GROUP BY followed by HAVING (same query)
+SELECT FIELD1, COUNT(*)
+FROM TABLE1
+GROUP BY FIELD1
+HAVING COUNT(*) > 1
+
+-- Test 4: GROUP BY followed by ORDER BY (same query)
+SELECT FIELD1, COUNT(*)
+FROM TABLE1
+GROUP BY FIELD1
+ORDER BY COUNT(*) DESC
+
+-- Test 5: GROUP BY with WITH ROLLUP followed by SELECT
+SELECT FIELD1, COUNT(*)
+FROM TABLE1
+GROUP BY FIELD1 WITH ROLLUP
+
+SELECT FIELD2
+FROM TABLE2
+
+-- Test 6: GROUP BY followed by OPTION clause (same query)
+SELECT FIELD1, COUNT(*)
+FROM TABLE1
+GROUP BY FIELD1
+OPTION (MAXDOP 4)
+
+-- Test 7: Multiple GROUP BY expressions
+SELECT FIELD1, FIELD2, COUNT(*)
+FROM TABLE1
+GROUP BY
+    FIELD1,
+    FIELD2,
+    YEAR(DateField)
+
+SELECT FIELD3
+FROM TABLE2

--- a/test/fixtures/dialects/tsql/group_by_termination.yml
+++ b/test/fixtures/dialects/tsql/group_by_termination.yml
@@ -1,0 +1,379 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 9a38516a07b4cb7279afd490de7b931bbd9173fa26c328740fa30139031aeb7a
+file:
+  batch:
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            column_reference:
+              naked_identifier: FIELD2
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: TABLE2
+        groupby_clause:
+        - keyword: GROUP
+        - keyword: BY
+        - column_reference:
+            naked_identifier: FIELD3
+  - statement:
+      set_expression:
+      - select_statement:
+          select_clause:
+          - keyword: SELECT
+          - select_clause_element:
+              column_reference:
+                naked_identifier: FIELD1
+          - comma: ','
+          - select_clause_element:
+              column_reference:
+                naked_identifier: FIELD2
+          from_clause:
+            keyword: FROM
+            from_expression:
+              from_expression_element:
+                table_expression:
+                  table_reference:
+                    naked_identifier: TABLE2
+      - set_operator:
+        - keyword: UNION
+        - keyword: ALL
+      - select_statement:
+          select_clause:
+          - keyword: SELECT
+          - select_clause_element:
+              column_reference:
+                naked_identifier: FIELD3
+          - comma: ','
+          - select_clause_element:
+              column_reference:
+                naked_identifier: FIELD4
+          from_clause:
+            keyword: FROM
+            from_expression:
+              from_expression_element:
+                table_expression:
+                  table_reference:
+                    naked_identifier: TABLE3
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            column_reference:
+              naked_identifier: FIELD1
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: TABLE1
+        groupby_clause:
+        - keyword: GROUP
+        - keyword: BY
+        - column_reference:
+            naked_identifier: FIELD1
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            column_reference:
+              naked_identifier: FIELD2
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: TABLE2
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            column_reference:
+              naked_identifier: FIELD1
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: TABLE1
+        groupby_clause:
+        - keyword: GROUP
+        - keyword: BY
+        - column_reference:
+            naked_identifier: FIELD1
+  - statement:
+      set_expression:
+      - select_statement:
+          select_clause:
+            keyword: SELECT
+            select_clause_element:
+              column_reference:
+                naked_identifier: FIELD2
+          from_clause:
+            keyword: FROM
+            from_expression:
+              from_expression_element:
+                table_expression:
+                  table_reference:
+                    naked_identifier: TABLE2
+      - set_operator:
+        - keyword: UNION
+        - keyword: ALL
+      - select_statement:
+          select_clause:
+            keyword: SELECT
+            select_clause_element:
+              column_reference:
+                naked_identifier: FIELD3
+          from_clause:
+            keyword: FROM
+            from_expression:
+              from_expression_element:
+                table_expression:
+                  table_reference:
+                    naked_identifier: TABLE3
+  - statement:
+      select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            column_reference:
+              naked_identifier: FIELD1
+        - comma: ','
+        - select_clause_element:
+            function:
+              function_name:
+                function_name_identifier: COUNT
+              function_contents:
+                bracketed:
+                  start_bracket: (
+                  star: '*'
+                  end_bracket: )
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: TABLE1
+        groupby_clause:
+        - keyword: GROUP
+        - keyword: BY
+        - column_reference:
+            naked_identifier: FIELD1
+        having_clause:
+          keyword: HAVING
+          expression:
+            function:
+              function_name:
+                function_name_identifier: COUNT
+              function_contents:
+                bracketed:
+                  start_bracket: (
+                  star: '*'
+                  end_bracket: )
+            comparison_operator:
+              raw_comparison_operator: '>'
+            integer_literal: '1'
+  - statement:
+      select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            column_reference:
+              naked_identifier: FIELD1
+        - comma: ','
+        - select_clause_element:
+            function:
+              function_name:
+                function_name_identifier: COUNT
+              function_contents:
+                bracketed:
+                  start_bracket: (
+                  star: '*'
+                  end_bracket: )
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: TABLE1
+        groupby_clause:
+        - keyword: GROUP
+        - keyword: BY
+        - column_reference:
+            naked_identifier: FIELD1
+        orderby_clause:
+        - keyword: ORDER
+        - keyword: BY
+        - expression:
+            function:
+              function_name:
+                function_name_identifier: COUNT
+              function_contents:
+                bracketed:
+                  start_bracket: (
+                  star: '*'
+                  end_bracket: )
+        - keyword: DESC
+  - statement:
+      select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            column_reference:
+              naked_identifier: FIELD1
+        - comma: ','
+        - select_clause_element:
+            function:
+              function_name:
+                function_name_identifier: COUNT
+              function_contents:
+                bracketed:
+                  start_bracket: (
+                  star: '*'
+                  end_bracket: )
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: TABLE1
+        groupby_clause:
+        - keyword: GROUP
+        - keyword: BY
+        - column_reference:
+            naked_identifier: FIELD1
+        - with_rollup_clause:
+          - keyword: WITH
+          - keyword: ROLLUP
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            column_reference:
+              naked_identifier: FIELD2
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: TABLE2
+  - statement:
+      select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            column_reference:
+              naked_identifier: FIELD1
+        - comma: ','
+        - select_clause_element:
+            function:
+              function_name:
+                function_name_identifier: COUNT
+              function_contents:
+                bracketed:
+                  start_bracket: (
+                  star: '*'
+                  end_bracket: )
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: TABLE1
+        groupby_clause:
+        - keyword: GROUP
+        - keyword: BY
+        - column_reference:
+            naked_identifier: FIELD1
+        option_clause:
+          keyword: OPTION
+          bracketed:
+            start_bracket: (
+            query_hint_segment:
+              keyword: MAXDOP
+              numeric_literal: '4'
+            end_bracket: )
+  - statement:
+      select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            column_reference:
+              naked_identifier: FIELD1
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+              naked_identifier: FIELD2
+        - comma: ','
+        - select_clause_element:
+            function:
+              function_name:
+                function_name_identifier: COUNT
+              function_contents:
+                bracketed:
+                  start_bracket: (
+                  star: '*'
+                  end_bracket: )
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: TABLE1
+        groupby_clause:
+        - keyword: GROUP
+        - keyword: BY
+        - column_reference:
+            naked_identifier: FIELD1
+        - comma: ','
+        - column_reference:
+            naked_identifier: FIELD2
+        - comma: ','
+        - expression:
+            function:
+              function_name:
+                function_name_identifier: YEAR
+              function_contents:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    column_reference:
+                      naked_identifier: DateField
+                  end_bracket: )
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            column_reference:
+              naked_identifier: FIELD3
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: TABLE2


### PR DESCRIPTION
### Brief summary of the change made

#### The Problem
The T-SQL parser was incorrectly treating two separate SQL queries as a single UNION query when:

* The first query had a `GROUP BY` clause
* There was no semicolon terminator after the `GROUP BY`
* A second `SELECT` statement followed

#### Root Cause

The `GroupByClauseSegment` in T-SQL was using `AnyNumberOf()` to manually parse comma-separated expressions without proper terminators. Since `ExpressionSegment` can match a `SELECT` statement (for subqueries), the parser would consume the next `SELECT` statement as part of the GROUP BY clause.

#### The Fix
Modified `dialect_tsql.py` to use `Delimited()` with proper terminators instead of the manual `AnyNumberOf()` approach. The terminators include:

* Clauses that follow `GROUP BY`: `HAVING`, `ORDER BY`, `OPTION`, `FOR`, `WINDOW`
* Set operators: `UNION`, `INTERSECT`, `EXCEPT`
* Statement-level keywords: `SELECT`, `INSERT`, `UPDATE`, `DELETE`, `MERGE`, `WITH`
* Delimiters: Semicolons and other statement terminators

Fixes #7326

### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
