### PR TITLE
Adds support for associative array of collections in Oracle.

### DIFF
--- a/src/sqlfluff/dialects/dialect_oracle.py
+++ b/src/sqlfluff/dialects/dialect_oracle.py
@@ -838,6 +838,18 @@ oracle_dialect.replace(
             Ref("LocalAliasSegment"),
             Ref("SqlplusSubstitutionVariableSegment"),
             Ref("ImplicitCursorAttributesGrammar"),
+            Sequence(
+                Ref("ObjectReferenceSegment"),
+                Bracketed(
+                    OneOf(
+                        Ref("ObjectReferenceSegment"),
+                        Ref("SingleQuotedIdentifierSegment"),
+                        Ref("NumericLiteralSegment"),
+                    ),
+                    optional=True,
+                ),
+                Ref("DotSegment", optional=True),
+            ),
             terminators=[Ref("CommaSegment")],
         ),
         Ref("AccessorGrammar", optional=True),
@@ -2466,7 +2478,14 @@ class AssignmentStatementSegment(BaseSegment):
     match_grammar = Sequence(
         AnyNumberOf(
             Ref("ObjectReferenceSegment"),
-            Bracketed(Ref("ObjectReferenceSegment"), optional=True),
+            Bracketed(
+                OneOf(
+                    Ref("ObjectReferenceSegment"),
+                    Ref("SingleQuotedIdentifierSegment"),
+                    Ref("NumericLiteralSegment"),
+                ),
+                optional=True,
+            ),
             Ref("DotSegment", optional=True),
             Ref("SqlplusVariableGrammar"),
             optional=True,

--- a/test/fixtures/dialects/oracle/assignment.yml
+++ b/test/fixtures/dialects/oracle/assignment.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 27c89f3f773c4ab48fd82b38dc7e2e469c8eb1cf038769db5fc8ed49ae00a05c
+_hash: 18f2bea7d542d49dde95156ebde94bb25d6be17107a3762ae3f1f0e221df718c
 file:
 - statement:
     begin_end_block:
@@ -194,17 +194,13 @@ file:
               naked_identifier: emp_rec2
     - statement_terminator: ;
     - statement:
-        function:
-          function_name:
-            function_name_identifier: comm_tab
-          function_contents:
-            bracketed:
-              start_bracket: (
-              expression:
-                numeric_literal: '5'
-              end_bracket: )
-    - statement:
         assignment_segment_statement:
+          object_reference:
+            naked_identifier: comm_tab
+          bracketed:
+            start_bracket: (
+            numeric_literal: '5'
+            end_bracket: )
           assignment_operator: :=
           expression:
           - numeric_literal: '20000'

--- a/test/fixtures/dialects/oracle/collections.sql
+++ b/test/fixtures/dialects/oracle/collections.sql
@@ -117,3 +117,33 @@ BEGIN
   print_names('Current Values:');
 END;
 /
+
+DECLARE
+  TYPE employee_rec_type IS RECORD (
+    employee_id   NUMBER,
+    first_name    VARCHAR2(50),
+    last_name     VARCHAR2(50),
+    salary        NUMBER
+  );
+
+  TYPE employee_array_type IS TABLE OF employee_rec_type INDEX BY PLS_INTEGER;
+
+  l_employees employee_array_type;
+
+BEGIN
+  -- Populate the array
+  l_employees(101).employee_id := 101;
+  l_employees(101).first_name := 'John';
+  l_employees(101).last_name := 'Doe';
+  l_employees(101).salary := 50000;
+
+  l_employees(102).employee_id := 102;
+  l_employees(102).first_name := 'Jane';
+  l_employees(102).last_name := 'Smith';
+  l_employees(102).salary := 60000;
+
+  -- Access and display data
+  DBMS_OUTPUT.PUT_LINE('Employee 101: ' || l_employees(101).first_name || ' ' || l_employees(101).last_name);
+  DBMS_OUTPUT.PUT_LINE('Employee 102 Salary: ' || l_employees(102).salary);
+END;
+/

--- a/test/fixtures/dialects/oracle/collections.yml
+++ b/test/fixtures/dialects/oracle/collections.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 4699ead08fa070b0eada379fb27af50b081adca4963fa918da87b206d7516b08
+_hash: 52c776d470b9e017d81ecd197a55c922912dc047589aaf26d3e6f09076fc8cb0
 file:
 - statement:
     begin_end_block:
@@ -42,65 +42,49 @@ file:
       - statement_terminator: ;
     - keyword: BEGIN
     - statement:
-        function:
-          function_name:
-            function_name_identifier: city_population
-          function_contents:
-            bracketed:
-              start_bracket: (
-              expression:
-                quoted_literal: "'Smallville'"
-              end_bracket: )
-    - statement:
         assignment_segment_statement:
+          object_reference:
+            naked_identifier: city_population
+          bracketed:
+            start_bracket: (
+            quoted_identifier: "'Smallville'"
+            end_bracket: )
           assignment_operator: :=
           expression:
             numeric_literal: '2000'
     - statement_terminator: ;
     - statement:
-        function:
-          function_name:
-            function_name_identifier: city_population
-          function_contents:
-            bracketed:
-              start_bracket: (
-              expression:
-                quoted_literal: "'Midland'"
-              end_bracket: )
-    - statement:
         assignment_segment_statement:
+          object_reference:
+            naked_identifier: city_population
+          bracketed:
+            start_bracket: (
+            quoted_identifier: "'Midland'"
+            end_bracket: )
           assignment_operator: :=
           expression:
             numeric_literal: '750000'
     - statement_terminator: ;
     - statement:
-        function:
-          function_name:
-            function_name_identifier: city_population
-          function_contents:
-            bracketed:
-              start_bracket: (
-              expression:
-                quoted_literal: "'Megalopolis'"
-              end_bracket: )
-    - statement:
         assignment_segment_statement:
+          object_reference:
+            naked_identifier: city_population
+          bracketed:
+            start_bracket: (
+            quoted_identifier: "'Megalopolis'"
+            end_bracket: )
           assignment_operator: :=
           expression:
             numeric_literal: '1000000'
     - statement_terminator: ;
     - statement:
-        function:
-          function_name:
-            function_name_identifier: city_population
-          function_contents:
-            bracketed:
-              start_bracket: (
-              expression:
-                quoted_literal: "'Smallville'"
-              end_bracket: )
-    - statement:
         assignment_segment_statement:
+          object_reference:
+            naked_identifier: city_population
+          bracketed:
+            start_bracket: (
+            quoted_identifier: "'Smallville'"
+            end_bracket: )
           assignment_operator: :=
           expression:
             numeric_literal: '2001'
@@ -546,33 +530,25 @@ file:
               end_bracket: )
     - statement_terminator: ;
     - statement:
-        function:
-          function_name:
-            function_name_identifier: team
-          function_contents:
-            bracketed:
-              start_bracket: (
-              expression:
-                numeric_literal: '3'
-              end_bracket: )
-    - statement:
         assignment_segment_statement:
+          object_reference:
+            naked_identifier: team
+          bracketed:
+            start_bracket: (
+            numeric_literal: '3'
+            end_bracket: )
           assignment_operator: :=
           expression:
             quoted_literal: "'Pierre'"
     - statement_terminator: ;
     - statement:
-        function:
-          function_name:
-            function_name_identifier: team
-          function_contents:
-            bracketed:
-              start_bracket: (
-              expression:
-                numeric_literal: '4'
-              end_bracket: )
-    - statement:
         assignment_segment_statement:
+          object_reference:
+            naked_identifier: team
+          bracketed:
+            start_bracket: (
+            numeric_literal: '4'
+            end_bracket: )
           assignment_operator: :=
           expression:
             quoted_literal: "'Yvonne'"
@@ -765,17 +741,13 @@ file:
               end_bracket: )
     - statement_terminator: ;
     - statement:
-        function:
-          function_name:
-            function_name_identifier: names
-          function_contents:
-            bracketed:
-              start_bracket: (
-              expression:
-                numeric_literal: '3'
-              end_bracket: )
-    - statement:
         assignment_segment_statement:
+          object_reference:
+            naked_identifier: names
+          bracketed:
+            start_bracket: (
+            numeric_literal: '3'
+            end_bracket: )
           assignment_operator: :=
           expression:
             quoted_literal: "'P Perez'"
@@ -820,6 +792,254 @@ file:
               expression:
                 quoted_literal: "'Current Values:'"
               end_bracket: )
+    - statement_terminator: ;
+    - keyword: END
+- statement_terminator: ;
+- statement_terminator: /
+- statement:
+    begin_end_block:
+    - declare_segment:
+      - keyword: DECLARE
+      - record_type:
+        - keyword: TYPE
+        - naked_identifier: employee_rec_type
+        - keyword: IS
+        - keyword: RECORD
+        - bracketed:
+          - start_bracket: (
+          - naked_identifier: employee_id
+          - data_type:
+              data_type_identifier: NUMBER
+          - comma: ','
+          - naked_identifier: first_name
+          - data_type:
+              data_type_identifier: VARCHAR2
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  numeric_literal: '50'
+                  end_bracket: )
+          - comma: ','
+          - naked_identifier: last_name
+          - data_type:
+              data_type_identifier: VARCHAR2
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  numeric_literal: '50'
+                  end_bracket: )
+          - comma: ','
+          - naked_identifier: salary
+          - data_type:
+              data_type_identifier: NUMBER
+          - end_bracket: )
+      - statement_terminator: ;
+      - collection_type:
+        - keyword: TYPE
+        - naked_identifier: employee_array_type
+        - keyword: IS
+        - keyword: TABLE
+        - keyword: OF
+        - data_type:
+            data_type_identifier: employee_rec_type
+        - keyword: INDEX
+        - keyword: BY
+        - data_type:
+            data_type_identifier: PLS_INTEGER
+      - statement_terminator: ;
+      - naked_identifier: l_employees
+      - data_type:
+          data_type_identifier: employee_array_type
+      - statement_terminator: ;
+    - keyword: BEGIN
+    - statement:
+        assignment_segment_statement:
+        - object_reference:
+            naked_identifier: l_employees
+        - bracketed:
+            start_bracket: (
+            numeric_literal: '101'
+            end_bracket: )
+        - dot: .
+        - object_reference:
+            naked_identifier: employee_id
+        - assignment_operator: :=
+        - expression:
+            numeric_literal: '101'
+    - statement_terminator: ;
+    - statement:
+        assignment_segment_statement:
+        - object_reference:
+            naked_identifier: l_employees
+        - bracketed:
+            start_bracket: (
+            numeric_literal: '101'
+            end_bracket: )
+        - dot: .
+        - object_reference:
+            naked_identifier: first_name
+        - assignment_operator: :=
+        - expression:
+            quoted_literal: "'John'"
+    - statement_terminator: ;
+    - statement:
+        assignment_segment_statement:
+        - object_reference:
+            naked_identifier: l_employees
+        - bracketed:
+            start_bracket: (
+            numeric_literal: '101'
+            end_bracket: )
+        - dot: .
+        - object_reference:
+            naked_identifier: last_name
+        - assignment_operator: :=
+        - expression:
+            quoted_literal: "'Doe'"
+    - statement_terminator: ;
+    - statement:
+        assignment_segment_statement:
+        - object_reference:
+            naked_identifier: l_employees
+        - bracketed:
+            start_bracket: (
+            numeric_literal: '101'
+            end_bracket: )
+        - dot: .
+        - object_reference:
+            naked_identifier: salary
+        - assignment_operator: :=
+        - expression:
+            numeric_literal: '50000'
+    - statement_terminator: ;
+    - statement:
+        assignment_segment_statement:
+        - object_reference:
+            naked_identifier: l_employees
+        - bracketed:
+            start_bracket: (
+            numeric_literal: '102'
+            end_bracket: )
+        - dot: .
+        - object_reference:
+            naked_identifier: employee_id
+        - assignment_operator: :=
+        - expression:
+            numeric_literal: '102'
+    - statement_terminator: ;
+    - statement:
+        assignment_segment_statement:
+        - object_reference:
+            naked_identifier: l_employees
+        - bracketed:
+            start_bracket: (
+            numeric_literal: '102'
+            end_bracket: )
+        - dot: .
+        - object_reference:
+            naked_identifier: first_name
+        - assignment_operator: :=
+        - expression:
+            quoted_literal: "'Jane'"
+    - statement_terminator: ;
+    - statement:
+        assignment_segment_statement:
+        - object_reference:
+            naked_identifier: l_employees
+        - bracketed:
+            start_bracket: (
+            numeric_literal: '102'
+            end_bracket: )
+        - dot: .
+        - object_reference:
+            naked_identifier: last_name
+        - assignment_operator: :=
+        - expression:
+            quoted_literal: "'Smith'"
+    - statement_terminator: ;
+    - statement:
+        assignment_segment_statement:
+        - object_reference:
+            naked_identifier: l_employees
+        - bracketed:
+            start_bracket: (
+            numeric_literal: '102'
+            end_bracket: )
+        - dot: .
+        - object_reference:
+            naked_identifier: salary
+        - assignment_operator: :=
+        - expression:
+            numeric_literal: '60000'
+    - statement_terminator: ;
+    - statement:
+        function:
+          function_name:
+            naked_identifier: DBMS_OUTPUT
+            dot: .
+            function_name_identifier: PUT_LINE
+          function_contents:
+            bracketed:
+            - start_bracket: (
+            - expression:
+                quoted_literal: "'Employee 101: '"
+                binary_operator:
+                - pipe: '|'
+                - pipe: '|'
+                object_reference:
+                  naked_identifier: l_employees
+                bracketed:
+                  start_bracket: (
+                  numeric_literal: '101'
+                  end_bracket: )
+                dot: .
+            - expression:
+              - column_reference:
+                  naked_identifier: first_name
+              - binary_operator:
+                - pipe: '|'
+                - pipe: '|'
+              - quoted_literal: "' '"
+              - binary_operator:
+                - pipe: '|'
+                - pipe: '|'
+              - object_reference:
+                  naked_identifier: l_employees
+              - bracketed:
+                  start_bracket: (
+                  numeric_literal: '101'
+                  end_bracket: )
+              - dot: .
+            - expression:
+                column_reference:
+                  naked_identifier: last_name
+            - end_bracket: )
+    - statement_terminator: ;
+    - statement:
+        function:
+          function_name:
+            naked_identifier: DBMS_OUTPUT
+            dot: .
+            function_name_identifier: PUT_LINE
+          function_contents:
+            bracketed:
+            - start_bracket: (
+            - expression:
+                quoted_literal: "'Employee 102 Salary: '"
+                binary_operator:
+                - pipe: '|'
+                - pipe: '|'
+                object_reference:
+                  naked_identifier: l_employees
+                bracketed:
+                  start_bracket: (
+                  numeric_literal: '102'
+                  end_bracket: )
+                dot: .
+            - expression:
+                column_reference:
+                  naked_identifier: salary
+            - end_bracket: )
     - statement_terminator: ;
     - keyword: END
 - statement_terminator: ;

--- a/test/fixtures/dialects/oracle/cursor.yml
+++ b/test/fixtures/dialects/oracle/cursor.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: b2ecfa015011fb4c82498dda4193ea6dc5edc0b404befe3998f8a34ac47fe8af
+_hash: d9ed54d452073bf1d4f5ae2bbac40ec0ccef435994959d3f0be6e149002f9c7a
 file:
 - statement:
     begin_end_block:
@@ -591,41 +591,33 @@ file:
       - statement_terminator: ;
     - keyword: BEGIN
     - statement:
-        function:
-          function_name:
-            function_name_identifier: v1
-          function_contents:
-            bracketed:
-              start_bracket: (
-              expression:
-                numeric_literal: '1'
-              end_bracket: )
-    - statement:
         assignment_segment_statement:
-          dot: .
-          object_reference:
+        - object_reference:
+            naked_identifier: v1
+        - bracketed:
+            start_bracket: (
+            numeric_literal: '1'
+            end_bracket: )
+        - dot: .
+        - object_reference:
             naked_identifier: f1
-          assignment_operator: :=
-          expression:
+        - assignment_operator: :=
+        - expression:
             numeric_literal: '1'
     - statement_terminator: ;
     - statement:
-        function:
-          function_name:
-            function_name_identifier: v1
-          function_contents:
-            bracketed:
-              start_bracket: (
-              expression:
-                numeric_literal: '1'
-              end_bracket: )
-    - statement:
         assignment_segment_statement:
-          dot: .
-          object_reference:
+        - object_reference:
+            naked_identifier: v1
+        - bracketed:
+            start_bracket: (
+            numeric_literal: '1'
+            end_bracket: )
+        - dot: .
+        - object_reference:
             naked_identifier: f2
-          assignment_operator: :=
-          expression:
+        - assignment_operator: :=
+        - expression:
             quoted_literal: "'one'"
     - statement_terminator: ;
     - statement:

--- a/test/fixtures/dialects/oracle/open_for.yml
+++ b/test/fixtures/dialects/oracle/open_for.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: c2fc4bbc3f638b5e51fda0f3ef445194adbdad05ae81867bcfec6cca30bb9534
+_hash: e8e77168b63ce895802141f261cb6eeb204f0a191de82fad37bae2df4bcab93b
 file:
 - statement:
     begin_end_block:
@@ -264,41 +264,33 @@ file:
       - statement_terminator: ;
     - keyword: BEGIN
     - statement:
-        function:
-          function_name:
-            function_name_identifier: v1
-          function_contents:
-            bracketed:
-              start_bracket: (
-              expression:
-                numeric_literal: '1'
-              end_bracket: )
-    - statement:
         assignment_segment_statement:
-          dot: .
-          object_reference:
+        - object_reference:
+            naked_identifier: v1
+        - bracketed:
+            start_bracket: (
+            numeric_literal: '1'
+            end_bracket: )
+        - dot: .
+        - object_reference:
             naked_identifier: f1
-          assignment_operator: :=
-          expression:
+        - assignment_operator: :=
+        - expression:
             numeric_literal: '1'
     - statement_terminator: ;
     - statement:
-        function:
-          function_name:
-            function_name_identifier: v1
-          function_contents:
-            bracketed:
-              start_bracket: (
-              expression:
-                numeric_literal: '1'
-              end_bracket: )
-    - statement:
         assignment_segment_statement:
-          dot: .
-          object_reference:
+        - object_reference:
+            naked_identifier: v1
+        - bracketed:
+            start_bracket: (
+            numeric_literal: '1'
+            end_bracket: )
+        - dot: .
+        - object_reference:
             naked_identifier: f2
-          assignment_operator: :=
-          expression:
+        - assignment_operator: :=
+        - expression:
             quoted_literal: "'one'"
     - statement_terminator: ;
     - statement:


### PR DESCRIPTION
Closes #7247 

<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->


### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
