### PR TITLE
fix(RF03): don't treat COLLATE clauses as unqualified references

### DIFF
--- a/src/sqlfluff/utils/analysis/select.py
+++ b/src/sqlfluff/utils/analysis/select.py
@@ -33,6 +33,9 @@ def _get_object_references(segment: BaseSegment) -> list[ObjectReferenceSegment]
             "object_reference",
             no_recursive_seg_type=["select_statement", "merge_statement"],
         )
+        # Exclude collation references - they inherit from ObjectReferenceSegment
+        # but should not be treated as column/table references for linting purposes
+        if not _seg.is_type("collation_reference")
     )
 
 

--- a/test/fixtures/rules/std_rule_cases/RF03.yml
+++ b/test/fixtures/rules/std_rule_cases/RF03.yml
@@ -527,3 +527,14 @@ test_pass_snowflake_lambda_expression:
   configs:
     core:
       dialect: snowflake
+
+test_pass_tsql_collate_clause:
+  # Collation references should not be treated as column references
+  # and should not trigger RF03
+  pass_str: |
+    SELECT T.FIELD1
+    FROM TABLE1 AS T
+    WHERE T.name COLLATE LATIN1_GENERAL_CI_AI LIKE '%';
+  configs:
+    core:
+      dialect: tsql


### PR DESCRIPTION
### Brief summary of the change made

When using COLLATE in T-SQL queries like:

```sql
SELECT T.FIELD1
FROM TABLE1 AS T
WHERE T.[name] COLLATE LATIN1_GENERAL_CI_AI LIKE 'A%';
```

`sqlfluff` was incorrectly reporting `RF03` errors treating `LATIN1_GENERAL_CI_AI` (the collation name) as an unqualified column reference.

**Root Cause**
The `CollationReferenceSegment` class inherits from `ObjectReferenceSegment`, which means it has both "collation_reference" and "object_reference" in its type hierarchy. The `_get_object_references()` function was using `recursive_crawl("object_reference")` which matched all segments with "object_reference" in their type hierarchy, including collation references.

As a fix, modified `select.py` to filter out collation references, and added test cases as well.

### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
