### PR TITLE
TSQL: add support for NEXT VALUE FOR with OVER clause

### DIFF
--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -3299,7 +3299,10 @@ class CreateSequenceOptionsSegment(BaseSegment):
 
 
 class NextValueSequenceSegment(BaseSegment):
-    """Segment to get next value from a sequence."""
+    """Segment to get next value from a sequence.
+
+    https://learn.microsoft.com/en-us/sql/t-sql/functions/next-value-for-transact-sql
+    """
 
     type = "sequence_next_value"
     match_grammar = Sequence(
@@ -3307,6 +3310,11 @@ class NextValueSequenceSegment(BaseSegment):
         "VALUE",
         "FOR",
         Ref("ObjectReferenceSegment"),
+        Sequence(
+            "OVER",
+            Bracketed(Ref("OrderByClauseSegment")),
+            optional=True,
+        ),
     )
 
 

--- a/test/fixtures/dialects/tsql/next_value_for_over.sql
+++ b/test/fixtures/dialects/tsql/next_value_for_over.sql
@@ -1,0 +1,35 @@
+-- NEXT VALUE FOR with OVER clause
+-- https://learn.microsoft.com/en-us/sql/t-sql/functions/next-value-for-transact-sql
+
+-- Basic OVER clause with ORDER BY
+SELECT NEXT VALUE FOR my_sequence OVER (ORDER BY some_column) AS new_id
+FROM my_table;
+
+-- OVER clause with multiple ORDER BY columns
+SELECT
+    NEXT VALUE FOR dbo.seq1 OVER (ORDER BY col1, col2 DESC) AS seq_num,
+    col1,
+    col2
+FROM my_table;
+
+-- OVER clause with COLLATE
+SELECT
+    NEXT VALUE FOR schema1.my_seq OVER (ORDER BY name COLLATE Latin1_General_CI_AS) AS id
+FROM users;
+
+-- Multiple NEXT VALUE FOR with different sequences
+SELECT
+    NEXT VALUE FOR seq1 OVER (ORDER BY date_column) AS id1,
+    NEXT VALUE FOR seq2 OVER (ORDER BY date_column) AS id2,
+    data
+FROM transactions;
+
+-- NEXT VALUE FOR without OVER clause (still supported)
+SELECT NEXT VALUE FOR my_sequence AS next_val;
+
+-- NEXT VALUE FOR in INSERT statement with OVER
+INSERT INTO target_table (id, data)
+SELECT
+    NEXT VALUE FOR my_seq OVER (ORDER BY source_id),
+    data
+FROM source_table;

--- a/test/fixtures/dialects/tsql/next_value_for_over.yml
+++ b/test/fixtures/dialects/tsql/next_value_for_over.yml
@@ -1,0 +1,249 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: dea59d293d9ce700314ba7cfc0709317b93a7232a60b8f3ae1d6de36771adc8f
+file:
+  batch:
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            expression:
+              sequence_next_value:
+              - keyword: NEXT
+              - keyword: VALUE
+              - keyword: FOR
+              - object_reference:
+                  naked_identifier: my_sequence
+              - keyword: OVER
+              - bracketed:
+                  start_bracket: (
+                  orderby_clause:
+                  - keyword: ORDER
+                  - keyword: BY
+                  - column_reference:
+                      naked_identifier: some_column
+                  end_bracket: )
+            alias_expression:
+              alias_operator:
+                keyword: AS
+              naked_identifier: new_id
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: my_table
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            expression:
+              sequence_next_value:
+              - keyword: NEXT
+              - keyword: VALUE
+              - keyword: FOR
+              - object_reference:
+                - naked_identifier: dbo
+                - dot: .
+                - naked_identifier: seq1
+              - keyword: OVER
+              - bracketed:
+                  start_bracket: (
+                  orderby_clause:
+                  - keyword: ORDER
+                  - keyword: BY
+                  - column_reference:
+                      naked_identifier: col1
+                  - comma: ','
+                  - column_reference:
+                      naked_identifier: col2
+                  - keyword: DESC
+                  end_bracket: )
+            alias_expression:
+              alias_operator:
+                keyword: AS
+              naked_identifier: seq_num
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+              naked_identifier: col1
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+              naked_identifier: col2
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: my_table
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            expression:
+              sequence_next_value:
+              - keyword: NEXT
+              - keyword: VALUE
+              - keyword: FOR
+              - object_reference:
+                - naked_identifier: schema1
+                - dot: .
+                - naked_identifier: my_seq
+              - keyword: OVER
+              - bracketed:
+                  start_bracket: (
+                  orderby_clause:
+                  - keyword: ORDER
+                  - keyword: BY
+                  - expression:
+                      column_reference:
+                        naked_identifier: name
+                      keyword: COLLATE
+                      collation_reference:
+                        naked_identifier: Latin1_General_CI_AS
+                  end_bracket: )
+            alias_expression:
+              alias_operator:
+                keyword: AS
+              naked_identifier: id
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: users
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            expression:
+              sequence_next_value:
+              - keyword: NEXT
+              - keyword: VALUE
+              - keyword: FOR
+              - object_reference:
+                  naked_identifier: seq1
+              - keyword: OVER
+              - bracketed:
+                  start_bracket: (
+                  orderby_clause:
+                  - keyword: ORDER
+                  - keyword: BY
+                  - column_reference:
+                      naked_identifier: date_column
+                  end_bracket: )
+            alias_expression:
+              alias_operator:
+                keyword: AS
+              naked_identifier: id1
+        - comma: ','
+        - select_clause_element:
+            expression:
+              sequence_next_value:
+              - keyword: NEXT
+              - keyword: VALUE
+              - keyword: FOR
+              - object_reference:
+                  naked_identifier: seq2
+              - keyword: OVER
+              - bracketed:
+                  start_bracket: (
+                  orderby_clause:
+                  - keyword: ORDER
+                  - keyword: BY
+                  - column_reference:
+                      naked_identifier: date_column
+                  end_bracket: )
+            alias_expression:
+              alias_operator:
+                keyword: AS
+              naked_identifier: id2
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+              naked_identifier: data
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: transactions
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            expression:
+              sequence_next_value:
+              - keyword: NEXT
+              - keyword: VALUE
+              - keyword: FOR
+              - object_reference:
+                  naked_identifier: my_sequence
+            alias_expression:
+              alias_operator:
+                keyword: AS
+              naked_identifier: next_val
+  - statement_terminator: ;
+  - statement:
+      insert_statement:
+      - keyword: INSERT
+      - keyword: INTO
+      - table_reference:
+          naked_identifier: target_table
+      - bracketed:
+        - start_bracket: (
+        - column_reference:
+            naked_identifier: id
+        - comma: ','
+        - column_reference:
+            naked_identifier: data
+        - end_bracket: )
+      - select_statement:
+          select_clause:
+          - keyword: SELECT
+          - select_clause_element:
+              expression:
+                sequence_next_value:
+                - keyword: NEXT
+                - keyword: VALUE
+                - keyword: FOR
+                - object_reference:
+                    naked_identifier: my_seq
+                - keyword: OVER
+                - bracketed:
+                    start_bracket: (
+                    orderby_clause:
+                    - keyword: ORDER
+                    - keyword: BY
+                    - column_reference:
+                        naked_identifier: source_id
+                    end_bracket: )
+          - comma: ','
+          - select_clause_element:
+              column_reference:
+                naked_identifier: data
+          from_clause:
+            keyword: FROM
+            from_expression:
+              from_expression_element:
+                table_expression:
+                  table_reference:
+                    naked_identifier: source_table
+  - statement_terminator: ;


### PR DESCRIPTION
### Brief summary of the change made

This PR adds support for the optional `OVER` clause to the `NEXT VALUE FOR` sequences. I have also added test cases.

Fixes #7324 

### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
