### PR TITLE
docs: Update tox installation command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,21 +83,10 @@ changes.
 
 #### Requirements
 
-If you plan on working with a particular dbt plugin, you will need
-to ensure your python version is high enough to support it. For example,
-the instructions below use `python3.13`, and we support as low as `python3.9`.
+The simplest way to set up a development environment is to use [`tox`](https://tox.wiki/en/latest/installation.html).
 
-The simplest way to set up a development environment is to use `tox`.
-
-First ensure that you have tox installed:
-```shell
-python3.12 -m pip install -U tox
-```
 **IMPORTANT:** Python 3.9 is the minimum version we support. Feel free
 to test on anything between `python3.9` and `python3.13`.
-
-Note: Unfortunately tox does not currently support setting just a minimum
-Python version (though this may be be coming in tox 4!).
 
 #### Creating a virtual environment
 


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
The current CONTRIBUTING.md docs state that you can install tox using `python3.12 -m pip install -U tox`.
However, this gives you an error like:
```
error: externally-managed-environment

× This environment is externally managed
╰─> To install Python packages system-wide, try brew install
    xyz, where xyz is the package you are trying to
    install.
```
This is confusing, because running `brew install tox` uses the latest python version for the tox package by default, which may not be supported yet by sqlfluff. For example, if you activate your venv and run `dbt --version`, you will run into this issue: https://github.com/dbt-labs/dbt-core/issues/12098

There are multiple ways to install tox, and these might change over time, so it is best to link the official installation docs from tox.

Furthermore, sqlfluff already uses tox 4.0 and the python versions are defined in `tox.ini`, so the note can be removed.

### Are there any other side effects of this change that we should be aware of?
no

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- [x] Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
