### PR TITLE
feat(vertica): add support for lambda expressions

### DIFF
--- a/src/sqlfluff/dialects/dialect_vertica.py
+++ b/src/sqlfluff/dialects/dialect_vertica.py
@@ -78,6 +78,7 @@ vertica_dialect.insert_lexer_matchers(
 
 vertica_dialect.insert_lexer_matchers(
     [
+        StringLexer("lambda_arrow", "->", CodeSegment),
         # This is similar to the Unicode regex, the key differences being:
         # - [eE] - must start with e or E
         # - The final quote character must be preceded by:
@@ -245,9 +246,14 @@ vertica_dialect.add(
         ),
     ),
     IntegerDivideSegment=StringParser("//", SymbolSegment, type="binary_operator"),
+    LambdaArrowSegment=StringParser("->", SymbolSegment, type="lambda_arrow"),
 )
 
 vertica_dialect.replace(
+    FunctionContentsExpressionGrammar=OneOf(
+        Ref("LambdaExpressionSegment"),
+        Ref("ExpressionSegment"),
+    ),
     FunctionContentsGrammar=AnyNumberOf(
         Ref("ExpressionSegment"),
         OptionallyBracketed(Ref("SetExpressionSegment")),
@@ -1853,6 +1859,23 @@ class CopyStatementSegment(BaseSegment):
         ),
         OneOf("NATIVE", Sequence("NATIVE", "VARCHAR"), "ORC", "PARQUET", optional=True),
         Ref("CopyOptionsSegment", optional=True),
+    )
+
+
+class LambdaExpressionSegment(BaseSegment):
+    """Lambda function used in a function.
+
+    https://docs.vertica.com/latest/en/sql-reference/functions/array-functions/array-find/
+    """
+
+    type = "lambda_function"
+    match_grammar = Sequence(
+        OneOf(
+            Ref("ParameterNameSegment"),
+            Bracketed(Delimited(Ref("ParameterNameSegment"))),
+        ),
+        Ref("LambdaArrowSegment"),
+        Ref("ExpressionSegment"),
     )
 
 

--- a/test/fixtures/dialects/vertica/lambda_functions.sql
+++ b/test/fixtures/dialects/vertica/lambda_functions.sql
@@ -1,0 +1,21 @@
+with
+hits as (
+    select
+        hit_id as hit_code,
+        string_to_array(coalesce(hit_categories, '[]') using parameters collection_delimiter = ',') as hit_categories_array
+    from test.table_name
+    where not is_deleted_flg
+),
+
+result as (
+    select
+        hit_code,
+        array_find(
+            hit_categories_array,
+            e -> e not in (
+                'Apple', 'Banana', 'Cherry', 'Durian', 'Elderberry', 'Fig'
+            )
+        ) > -1 as is_unknown_category_flg
+    from hits
+)
+select * from result;

--- a/test/fixtures/dialects/vertica/lambda_functions.yml
+++ b/test/fixtures/dialects/vertica/lambda_functions.yml
@@ -1,0 +1,154 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: fbf4a76e75cbd0d67db2608d26721153c7272a63a628d809a23b71c0e2a313c6
+file:
+  statement:
+    with_compound_statement:
+    - keyword: with
+    - common_table_expression:
+        naked_identifier: hits
+        keyword: as
+        bracketed:
+          start_bracket: (
+          select_statement:
+            select_clause:
+            - keyword: select
+            - select_clause_element:
+                column_reference:
+                  naked_identifier: hit_id
+                alias_expression:
+                  alias_operator:
+                    keyword: as
+                  naked_identifier: hit_code
+            - comma: ','
+            - select_clause_element:
+                function:
+                  function_name:
+                    function_name_identifier: string_to_array
+                  function_contents:
+                    bracketed:
+                    - start_bracket: (
+                    - expression:
+                        function:
+                          function_name:
+                            function_name_identifier: coalesce
+                          function_contents:
+                            bracketed:
+                            - start_bracket: (
+                            - expression:
+                                column_reference:
+                                  naked_identifier: hit_categories
+                            - comma: ','
+                            - expression:
+                                quoted_literal: "'[]'"
+                            - end_bracket: )
+                    - keyword: using
+                    - keyword: parameters
+                    - parameter: collection_delimiter
+                    - comparison_operator:
+                        raw_comparison_operator: '='
+                    - quoted_literal: "','"
+                    - end_bracket: )
+                alias_expression:
+                  alias_operator:
+                    keyword: as
+                  naked_identifier: hit_categories_array
+            from_clause:
+              keyword: from
+              from_expression:
+                from_expression_element:
+                  table_expression:
+                    table_reference:
+                    - naked_identifier: test
+                    - dot: .
+                    - naked_identifier: table_name
+            where_clause:
+              keyword: where
+              expression:
+                keyword: not
+                column_reference:
+                  naked_identifier: is_deleted_flg
+          end_bracket: )
+    - comma: ','
+    - common_table_expression:
+        naked_identifier: result
+        keyword: as
+        bracketed:
+          start_bracket: (
+          select_statement:
+            select_clause:
+            - keyword: select
+            - select_clause_element:
+                column_reference:
+                  naked_identifier: hit_code
+            - comma: ','
+            - select_clause_element:
+                expression:
+                  function:
+                    function_name:
+                      function_name_identifier: array_find
+                    function_contents:
+                      bracketed:
+                        start_bracket: (
+                        expression:
+                          column_reference:
+                            naked_identifier: hit_categories_array
+                        comma: ','
+                        lambda_function:
+                          parameter: e
+                          lambda_arrow: ->
+                          expression:
+                          - column_reference:
+                              naked_identifier: e
+                          - keyword: not
+                          - keyword: in
+                          - bracketed:
+                            - start_bracket: (
+                            - quoted_literal: "'Apple'"
+                            - comma: ','
+                            - quoted_literal: "'Banana'"
+                            - comma: ','
+                            - quoted_literal: "'Cherry'"
+                            - comma: ','
+                            - quoted_literal: "'Durian'"
+                            - comma: ','
+                            - quoted_literal: "'Elderberry'"
+                            - comma: ','
+                            - quoted_literal: "'Fig'"
+                            - end_bracket: )
+                        end_bracket: )
+                  comparison_operator:
+                    raw_comparison_operator: '>'
+                  numeric_literal:
+                    sign_indicator: '-'
+                    numeric_literal: '1'
+                alias_expression:
+                  alias_operator:
+                    keyword: as
+                  naked_identifier: is_unknown_category_flg
+            from_clause:
+              keyword: from
+              from_expression:
+                from_expression_element:
+                  table_expression:
+                    table_reference:
+                      naked_identifier: hits
+          end_bracket: )
+    - select_statement:
+        select_clause:
+          keyword: select
+          select_clause_element:
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+        from_clause:
+          keyword: from
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: result
+  statement_terminator: ;

--- a/test/fixtures/rules/std_rule_cases/RF01.yml
+++ b/test/fixtures/rules/std_rule_cases/RF01.yml
@@ -340,6 +340,21 @@ test_pass_trino_lambda_expression:
     core:
       dialect: trino
 
+test_pass_vertica_lambda_expression:
+  pass_str: |
+    select
+        hit_code,
+        array_find(
+            hit_categories_array,
+            e -> e not in (
+                'Apple', 'Banana', 'Cherry', 'Durian', 'Elderberry', 'Fig'
+            )
+        ) > -1 as is_unknown_category_flg
+    from hits
+  configs:
+    core:
+      dialect: vertica
+
 test_athena_ignore_rule_if_single_table:
   pass_str: |
     select

--- a/test/fixtures/rules/std_rule_cases/RF02.yml
+++ b/test/fixtures/rules/std_rule_cases/RF02.yml
@@ -103,6 +103,21 @@ test_allow_unqualified_references_in_sparksql_lambdas:
     core:
       dialect: sparksql
 
+test_allow_unqualified_references_in_vertica_lambdas:
+  pass_str: |
+    select
+        hit_code,
+        array_find(
+            hit_categories_array,
+            e -> e not in (
+                'Apple', 'Banana', 'Cherry', 'Durian', 'Elderberry', 'Fig'
+            )
+        ) > -1 as is_unknown_category_flg
+    from hits
+  configs:
+    core:
+      dialect: vertica
+
 test_pass_databricks_lambdas:
   pass_str: |
     select


### PR DESCRIPTION
### Brief summary of the change made
This PR adds support for **lambda expressions** to the Vertica dialect. This enables parsing of expressions like `e -> e not in (...)` which are used in Vertica functions such as `array_find`.

**Key changes:**
- **Lexer**: Added the `lambda_arrow` operator (`->`).
- **Parser**: Implemented `LambdaExpressionSegment`, supporting both single parameters (e.g., `e -> ...`) and bracketed parameter lists (e.g., `(x, y) -> ...`).
- **Grammar**: Overrode `FunctionContentsExpressionGrammar` in the Vertica dialect to include lambda expressions, allowing them to be used within function calls.
- **Rust Synchronization**: Synchronized the Python dialect changes with the Rust-based components (`sqlfluffrs`).
- **Rule Support**: Added specific test cases for `RF01` and `RF02` to ensure lambda parameters are correctly recognized as local variables, avoiding false positive linting errors.
- **Documentation**: Updated the Vertica dialect docstring with a description and example of lambda expression usage.

fixes #7345

### Are there any other side effects of this change that we should be aware of?
None.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - [x] `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - [x] `.sql`/`.yml` parser test cases in `test/fixtures/dialects`.
  - [ ] Full autofix test cases in `test/fixtures/linter/autofix`.
  - [ ] Other.
- [x] Added appropriate documentation for the change.
- [x] Created GitHub issues for any relevant followup/future enhancements if appropriate.