### PR TITLE
DuckDB: parse simplified UNPIVOT `ON` expressions and `INTO` optional

### DIFF
--- a/src/sqlfluff/dialects/dialect_duckdb.py
+++ b/src/sqlfluff/dialects/dialect_duckdb.py
@@ -945,23 +945,21 @@ class SimplifiedUnpivotExpressionSegment(BaseSegment):
         Delimited(
             Sequence(
                 OneOf(
-                    Bracketed(
-                        Delimited(
-                            Ref("ColumnReferenceSegment"),
-                        ),
-                    ),
-                    Ref("ColumnReferenceSegment"),
+                    Ref("ExpressionSegment"),
+                    Bracketed(Delimited(Ref("ExpressionSegment"))),
                 ),
                 Ref("AliasExpressionSegment", optional=True),
             ),
-            Ref("ColumnsExpressionGrammar"),
         ),
-        "INTO",
-        "NAME",
-        Ref("SingleIdentifierGrammar"),
-        "VALUE",
-        Delimited(
+        Sequence(
+            "INTO",
+            "NAME",
             Ref("SingleIdentifierGrammar"),
+            "VALUE",
+            Delimited(
+                Ref("SingleIdentifierGrammar"),
+            ),
+            optional=True,
         ),
         Ref("OrderByClauseSegment", optional=True),
         Ref("LimitClauseSegment", optional=True),

--- a/test/fixtures/dialects/duckdb/unpivot.sql
+++ b/test/fixtures/dialects/duckdb/unpivot.sql
@@ -27,6 +27,19 @@ WITH unpivot_alias AS (
 
 SELECT * FROM unpivot_alias;
 
+-- Simplified UNPIVOT with expressions and default name/value columns
+UNPIVOT
+    (SELECT 42 AS col1, 'woot' AS col2)
+ON
+    (col1 * 2)::VARCHAR,
+    col2;
+
+UNPIVOT monthly_sales
+ON COLUMNS (* EXCLUDE (empid, dept))::float4 AS '\1_\2'
+INTO
+NAME month
+VALUE sales;
+
 -- Standard UNPIVOT
 FROM monthly_sales UNPIVOT (
     sales

--- a/test/fixtures/dialects/duckdb/unpivot.yml
+++ b/test/fixtures/dialects/duckdb/unpivot.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 4fd86cf86d5fb835b936a1b395a37aa7f8dc1eb247d1791af3b8ff65613b54db
+_hash: 13f92ec3bed41fd51e9247ff65217c3c0057be3b4a0795e44907a755e1d4b9bf
 file:
 - statement:
     simplified_unpivot:
@@ -12,95 +12,105 @@ file:
         table_reference:
           naked_identifier: monthly_sales
     - keyword: 'ON'
-    - column_reference:
-        naked_identifier: jan
-    - comma: ','
-    - column_reference:
-        naked_identifier: feb
-    - comma: ','
-    - column_reference:
-        naked_identifier: mar
-    - comma: ','
-    - column_reference:
-        naked_identifier: apr
-    - comma: ','
-    - column_reference:
-        naked_identifier: may
-    - comma: ','
-    - column_reference:
-        naked_identifier: jun
-    - keyword: INTO
-    - keyword: NAME
-    - naked_identifier: month
-    - keyword: VALUE
-    - naked_identifier: sales
-- statement_terminator: ;
-- statement:
-    simplified_unpivot:
-    - keyword: UNPIVOT
-    - table_expression:
-        table_reference:
-          naked_identifier: monthly_sales
-    - keyword: 'ON'
-    - function_name:
-        keyword: COLUMNS
-    - function_contents:
-        bracketed:
-          start_bracket: (
-          wildcard_expression:
-            wildcard_identifier:
-              star: '*'
-            wildcard_exclude:
-              keyword: EXCLUDE
-              bracketed:
-              - start_bracket: (
-              - column_reference:
-                  naked_identifier: empid
-              - comma: ','
-              - column_reference:
-                  naked_identifier: dept
-              - end_bracket: )
-          end_bracket: )
-    - keyword: INTO
-    - keyword: NAME
-    - naked_identifier: month
-    - keyword: VALUE
-    - naked_identifier: sales
-- statement_terminator: ;
-- statement:
-    simplified_unpivot:
-    - keyword: UNPIVOT
-    - table_expression:
-        table_reference:
-          naked_identifier: monthly_sales
-    - keyword: 'ON'
-    - bracketed:
-      - start_bracket: (
-      - column_reference:
+    - expression:
+        column_reference:
           naked_identifier: jan
-      - comma: ','
-      - column_reference:
+    - comma: ','
+    - expression:
+        column_reference:
           naked_identifier: feb
-      - comma: ','
-      - column_reference:
+    - comma: ','
+    - expression:
+        column_reference:
           naked_identifier: mar
-      - end_bracket: )
+    - comma: ','
+    - expression:
+        column_reference:
+          naked_identifier: apr
+    - comma: ','
+    - expression:
+        column_reference:
+          naked_identifier: may
+    - comma: ','
+    - expression:
+        column_reference:
+          naked_identifier: jun
+    - keyword: INTO
+    - keyword: NAME
+    - naked_identifier: month
+    - keyword: VALUE
+    - naked_identifier: sales
+- statement_terminator: ;
+- statement:
+    simplified_unpivot:
+    - keyword: UNPIVOT
+    - table_expression:
+        table_reference:
+          naked_identifier: monthly_sales
+    - keyword: 'ON'
+    - expression:
+        function:
+          function_name:
+            keyword: COLUMNS
+          function_contents:
+            bracketed:
+              start_bracket: (
+              wildcard_expression:
+                wildcard_identifier:
+                  star: '*'
+                wildcard_exclude:
+                  keyword: EXCLUDE
+                  bracketed:
+                  - start_bracket: (
+                  - column_reference:
+                      naked_identifier: empid
+                  - comma: ','
+                  - column_reference:
+                      naked_identifier: dept
+                  - end_bracket: )
+              end_bracket: )
+    - keyword: INTO
+    - keyword: NAME
+    - naked_identifier: month
+    - keyword: VALUE
+    - naked_identifier: sales
+- statement_terminator: ;
+- statement:
+    simplified_unpivot:
+    - keyword: UNPIVOT
+    - table_expression:
+        table_reference:
+          naked_identifier: monthly_sales
+    - keyword: 'ON'
+    - expression:
+        bracketed:
+        - start_bracket: (
+        - column_reference:
+            naked_identifier: jan
+        - comma: ','
+        - column_reference:
+            naked_identifier: feb
+        - comma: ','
+        - column_reference:
+            naked_identifier: mar
+        - end_bracket: )
     - alias_expression:
         alias_operator:
           keyword: AS
         naked_identifier: q1
     - comma: ','
-    - bracketed:
-      - start_bracket: (
-      - column_reference:
-          naked_identifier: apr
-      - comma: ','
-      - column_reference:
-          naked_identifier: may
-      - comma: ','
-      - column_reference:
-          naked_identifier: jun
-      - end_bracket: )
+    - expression:
+        bracketed:
+        - start_bracket: (
+        - column_reference:
+            naked_identifier: apr
+        - comma: ','
+        - column_reference:
+            naked_identifier: may
+        - comma: ','
+        - column_reference:
+            naked_identifier: jun
+        - end_bracket: )
     - alias_expression:
         alias_operator:
           keyword: AS
@@ -129,25 +139,27 @@ file:
               table_reference:
                 naked_identifier: monthly_sales
           - keyword: 'ON'
-          - function_name:
-              keyword: COLUMNS
-          - function_contents:
-              bracketed:
-                start_bracket: (
-                wildcard_expression:
-                  wildcard_identifier:
-                    star: '*'
-                  wildcard_exclude:
-                    keyword: EXCLUDE
-                    bracketed:
-                    - start_bracket: (
-                    - column_reference:
-                        naked_identifier: empid
-                    - comma: ','
-                    - column_reference:
-                        naked_identifier: dept
-                    - end_bracket: )
-                end_bracket: )
+          - expression:
+              function:
+                function_name:
+                  keyword: COLUMNS
+                function_contents:
+                  bracketed:
+                    start_bracket: (
+                    wildcard_expression:
+                      wildcard_identifier:
+                        star: '*'
+                      wildcard_exclude:
+                        keyword: EXCLUDE
+                        bracketed:
+                        - start_bracket: (
+                        - column_reference:
+                            naked_identifier: empid
+                        - comma: ','
+                        - column_reference:
+                            naked_identifier: dept
+                        - end_bracket: )
+                    end_bracket: )
           - keyword: INTO
           - keyword: NAME
           - naked_identifier: month
@@ -168,6 +180,90 @@ file:
               table_expression:
                 table_reference:
                   naked_identifier: unpivot_alias
+- statement_terminator: ;
+- statement:
+    simplified_unpivot:
+    - keyword: UNPIVOT
+    - table_expression:
+        bracketed:
+          start_bracket: (
+          select_statement:
+            select_clause:
+            - keyword: SELECT
+            - select_clause_element:
+                numeric_literal: '42'
+                alias_expression:
+                  alias_operator:
+                    keyword: AS
+                  naked_identifier: col1
+            - comma: ','
+            - select_clause_element:
+                quoted_literal: "'woot'"
+                alias_expression:
+                  alias_operator:
+                    keyword: AS
+                  naked_identifier: col2
+          end_bracket: )
+    - keyword: 'ON'
+    - expression:
+        cast_expression:
+          bracketed:
+            start_bracket: (
+            expression:
+              column_reference:
+                naked_identifier: col1
+              binary_operator: '*'
+              numeric_literal: '2'
+            end_bracket: )
+          casting_operator: '::'
+          data_type:
+            keyword: VARCHAR
+    - comma: ','
+    - expression:
+        column_reference:
+          naked_identifier: col2
+- statement_terminator: ;
+- statement:
+    simplified_unpivot:
+    - keyword: UNPIVOT
+    - table_expression:
+        table_reference:
+          naked_identifier: monthly_sales
+    - keyword: 'ON'
+    - expression:
+        cast_expression:
+          function:
+            function_name:
+              keyword: COLUMNS
+            function_contents:
+              bracketed:
+                start_bracket: (
+                wildcard_expression:
+                  wildcard_identifier:
+                    star: '*'
+                  wildcard_exclude:
+                    keyword: EXCLUDE
+                    bracketed:
+                    - start_bracket: (
+                    - column_reference:
+                        naked_identifier: empid
+                    - comma: ','
+                    - column_reference:
+                        naked_identifier: dept
+                    - end_bracket: )
+                end_bracket: )
+          casting_operator: '::'
+          data_type:
+            keyword: float4
+    - alias_expression:
+        alias_operator:
+          keyword: AS
+        quoted_identifier: "'\\1_\\2'"
+    - keyword: INTO
+    - keyword: NAME
+    - naked_identifier: month
+    - keyword: VALUE
+    - naked_identifier: sales
 - statement_terminator: ;
 - statement:
     select_statement:


### PR DESCRIPTION
Fixes #7391

### Brief summary of the change made

This PR fixes DuckDB dialect parsing for the "simplified UNPIVOT" form when used with **expressions in the `ON` list**, as documented by DuckDB.

DuckDB allows expressions within simplified `UNPIVOT` statements (including casts and simple arithmetic), as shown in the [UNPIVOT Statement – DuckDB](https://duckdb.org/docs/stable/sql/statements/unpivot) documentation under "Expressions within UNPIVOT Statements".



**Example from DuckDB docs:**

```sql
UNPIVOT
    (SELECT 42 AS col1, 'woot' AS col2)
    ON
        (col1 * 2)::VARCHAR,
        col2;
```
**Note:** This broadens parsing for simplified `UNPIVOT ... ON ...` targets from column references to general expressions. As a result, SQLFluff may parse some syntactically-valid expressions that DuckDB would later reject semantically (DuckDB docs note `UNPIVOT` expressions should reference only a single column), e.g.:

```sql
UNPIVOT my_table
ON (col1 + col2)  -- multiple columns: SQLFluff parses, DuckDB will reject it with a `Binder Error`
INTO NAME name
VALUE value;
```

**Before this change:**

SQLFluff (DuckDB dialect) raised a parser error (`PRS`) at the start of the statement because the simplified UNPIVOT grammar only handled column references / grouped column references, not general expressions (and required `INTO NAME ... VALUE ...`).

**After this change:**

SQLFluff can parse:
- Expression targets in the simplified `UNPIVOT ... ON ...` list (casts, arithmetic)
- `COLUMNS(...)` targets with casts and aliases
- Simplified UNPIVOT statements that omit the `INTO NAME ... VALUE ...` clause (matching the DuckDB docs example)


### Are there any other side effects of this change that we should be aware of?

- **None expected.** This expands DuckDB simplified `UNPIVOT` parsing to accept `ON` expressions.

### Pull Request checklist

- [x] Please confirm you have completed any of the necessary steps below.

- [x] Included test cases to demonstrate any code changes, which may be one or more of the following:
  - [ ] `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - [x] `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - [ ] Full autofix test cases in `test/fixtures/linter/autofix`.
  - [ ] Other.
- [x] Added appropriate documentation for the change.
- [ ] Created GitHub issues for any relevant followup/future enhancements if appropriate.

### Testing

- All linting + typing checks pass .
- All DuckDB dialect tests pass (**102 selected tests**), including the new expression tests.

