### PR TITLE
DuckDB: Add support for SET

### DIFF
--- a/src/sqlfluff/dialects/dialect_duckdb.py
+++ b/src/sqlfluff/dialects/dialect_duckdb.py
@@ -1130,6 +1130,45 @@ class CopyStatementSegment(postgres.CopyStatementSegment):
     )
 
 
+class SetStatementSegment(postgres.SetStatementSegment):
+    """A `SET` Statement.
+
+    DuckDB documentation: https://duckdb.org/docs/sql/statements/set
+    """
+
+    type = "set_statement"
+
+    match_grammar = Sequence(
+        "SET",
+        OneOf(
+            Sequence(
+                "VARIABLE",
+                Ref("NakedIdentifierSegment"),  # variable_name
+                OneOf("TO", Ref("EqualsSegment")),
+                OneOf(
+                    Ref("LiteralGrammar"),
+                    Ref("NakedIdentifierSegment"),
+                    Ref("QuotedIdentifierSegment"),
+                ),
+            ),
+            Sequence(
+                OneOf("SESSION", "LOCAL", "GLOBAL", optional=True),
+                Ref("ParameterNameSegment"),
+                OneOf("TO", Ref("EqualsSegment")),
+                OneOf(
+                    "DEFAULT",
+                    Delimited(
+                        Ref("LiteralGrammar"),
+                        Ref("NakedIdentifierSegment"),
+                        Ref("QuotedIdentifierSegment"),
+                        Ref("OnKeywordAsIdentifierSegment"),
+                    ),
+                ),
+            ),
+        ),
+    )
+
+
 class ArrayLiteralSegment(BaseSegment):
     """An array literal segment.
 

--- a/test/fixtures/dialects/duckdb/set.sql
+++ b/test/fixtures/dialects/duckdb/set.sql
@@ -1,0 +1,21 @@
+-- SET VARIABLE
+SET VARIABLE my_var = 30;
+SET VARIABLE other_var TO 'hello';
+
+-- Basic SET parameter = value
+SET memory_limit = '10GB';
+SET threads = 1;
+
+-- SET parameter TO value
+SET threads TO 1;
+
+-- SET SESSION parameter = value
+SET SESSION default_collation = 'nocase';
+
+-- SET GLOBAL parameter = value
+SET GLOBAL sort_order = 'desc';
+SET GLOBAL threads = 4;
+
+
+-- SET LOCAL parameter = value
+SET LOCAL sort_order = 'desc';

--- a/test/fixtures/dialects/duckdb/set.yml
+++ b/test/fixtures/dialects/duckdb/set.yml
@@ -1,0 +1,83 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 0ae8e2248b599e2e435c42700cc3f2c71103f61c4a45b7b32c62518b4a514d28
+file:
+- statement:
+    set_statement:
+    - keyword: SET
+    - keyword: VARIABLE
+    - naked_identifier: my_var
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - numeric_literal: '30'
+- statement_terminator: ;
+- statement:
+    set_statement:
+    - keyword: SET
+    - keyword: VARIABLE
+    - naked_identifier: other_var
+    - keyword: TO
+    - quoted_literal: "'hello'"
+- statement_terminator: ;
+- statement:
+    set_statement:
+      keyword: SET
+      parameter: memory_limit
+      comparison_operator:
+        raw_comparison_operator: '='
+      quoted_literal: "'10GB'"
+- statement_terminator: ;
+- statement:
+    set_statement:
+      keyword: SET
+      parameter: threads
+      comparison_operator:
+        raw_comparison_operator: '='
+      numeric_literal: '1'
+- statement_terminator: ;
+- statement:
+    set_statement:
+    - keyword: SET
+    - parameter: threads
+    - keyword: TO
+    - numeric_literal: '1'
+- statement_terminator: ;
+- statement:
+    set_statement:
+    - keyword: SET
+    - keyword: SESSION
+    - parameter: default_collation
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - quoted_literal: "'nocase'"
+- statement_terminator: ;
+- statement:
+    set_statement:
+    - keyword: SET
+    - keyword: GLOBAL
+    - parameter: sort_order
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - quoted_literal: "'desc'"
+- statement_terminator: ;
+- statement:
+    set_statement:
+    - keyword: SET
+    - keyword: GLOBAL
+    - parameter: threads
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - numeric_literal: '4'
+- statement_terminator: ;
+- statement:
+    set_statement:
+    - keyword: SET
+    - keyword: LOCAL
+    - parameter: sort_order
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - quoted_literal: "'desc'"
+- statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->

Adds comprehensive SET statement support for DuckDB dialect, including `SET VARIABLE`, `SET GLOBAL`, `SET SESSION`, and basic `SET parameter = value` patterns with both `=` and `TO` assignment operators.

Previously, DuckDB SET statements were unparsable and caused errors like: `Found unparsable section: 'SET VARIABLE my_var = 30;'`

Fixes #7325

### Are there any other side effects of this change that we should be aware of?

None. The implementation only extends existing functionality without breaking changes:

- Only adds new DuckDB-specific patterns 
- Does not affect other dialects or existing functionality
- All existing DuckDB features continue to work unchanged

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - [ ] `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - [x] `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - [ ] Full autofix test cases in `test/fixtures/linter/autofix`.
  - [ ] Other.
- [x] Added appropriate documentation for the change.
- [ ] Created GitHub issues for any relevant followup/future enhancements if appropriate.