### PR TITLE
Fix double print of highlights in changelog

### DIFF
--- a/util.py
+++ b/util.py
@@ -235,7 +235,7 @@ def release(new_version_num):
 
             else:
                 click.echo(f"...creating new entry for {new_version_num}")
-                write_changelog.write(f"\n{new_heading}\n## Highlights\n\n")
+                write_changelog.write(f"\n{new_heading}\n")
                 write_changelog.write(whats_changed_text)
                 write_changelog.write("\n## New Contributors\n\n")
                 # Ensure contributor names don't appear in input_changelog list


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
The changelog prints the `Highlights` subheader twice, this is because it's also in the release-drafter template. Removing the direct write and leaving release-drafter in there.

### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
