### PR TITLE
Make CP02 ignore templated slices

### DIFF
--- a/src/sqlfluff/rules/capitalisation/CP02.py
+++ b/src/sqlfluff/rules/capitalisation/CP02.py
@@ -107,6 +107,11 @@ class Rule_CP02(Rule_CP01):
         ):
             return None
 
+        # Skip templated segments (e.g., placeholder parameters like :accountId)
+        # to avoid incorrect qualification suggestions
+        if context.segment.is_templated:
+            return [LintResult(memory=context.memory)]
+
         if identifiers_policy_applicable(
             self.unquoted_identifiers_policy,  # type: ignore
             context.parent_stack,

--- a/test/fixtures/rules/std_rule_cases/CP02.yml
+++ b/test/fixtures/rules/std_rule_cases/CP02.yml
@@ -347,3 +347,69 @@ test_fail_camel_aliases:
     rules:
       capitalisation.identifiers:
         extended_capitalisation_policy: camel
+
+test_pass_placeholder_templater_colon_parameters:
+  # Test that placeholder parameters are not incorrectly qualified with table aliases
+  pass_str: |
+    DELETE
+    FROM STATUSVIEWDATAENTITY
+    WHERE NOT EXISTS (
+        SELECT 1
+        FROM REFERENCEDSTATUSID AS R
+        WHERE
+            R.PACHLIACCOUNTID = :accountId
+    )
+  configs:
+    core:
+      templater: placeholder
+    templater:
+      placeholder:
+        param_style: colon
+
+
+test_fail_placeholder_templater_colon_parameters:
+  # Test that placeholder parameters are not incorrectly qualified with table aliases
+  fail_str: |
+    DELETE
+    FROM STATUSVIEWDATAENTITY
+    WHERE NOT EXISTS (
+        SELECT 1
+        FROM REFERENCEDSTATUSID AS R
+        WHERE
+            r.PACHLIACCOUNTID = :accountId
+    )
+  fix_str: |
+    DELETE
+    FROM STATUSVIEWDATAENTITY
+    WHERE NOT EXISTS (
+        SELECT 1
+        FROM REFERENCEDSTATUSID AS R
+        WHERE
+            R.PACHLIACCOUNTID = :accountId
+    )
+  configs:
+    core:
+      templater: placeholder
+    templater:
+      placeholder:
+        param_style: colon
+
+test_pass_placeholder_templater_dollar_parameters:
+  # Test that dollar-style placeholder parameters are not incorrectly qualified
+  pass_str: SELECT * FROM users WHERE id = $userId AND name = $userName
+  configs:
+    core:
+      templater: placeholder
+    templater:
+      placeholder:
+        param_style: dollar
+
+test_pass_placeholder_templater_percent_parameters:
+  # Test that percent-style placeholder parameters are not incorrectly qualified
+  pass_str: SELECT * FROM users WHERE id = %s AND name = %s
+  configs:
+    core:
+      templater: placeholder
+    templater:
+      placeholder:
+        param_style: percent


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
Fixes #7293

### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
