### PR TITLE
build: Further workflow optimizations

### DIFF
--- a/.github/workflows/add-to-release-notes.yml
+++ b/.github/workflows/add-to-release-notes.yml
@@ -8,7 +8,7 @@ on:
       - main
 jobs:
   draft-release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     if: github.repository == 'sqlfluff/sqlfluff'
     steps:
     - name: Update release notes

--- a/.github/workflows/ci-pr-comments.yml
+++ b/.github/workflows/ci-pr-comments.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   comment-on-pr:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     if: >
       github.event.workflow_run.event == 'pull_request'
     steps:

--- a/.github/workflows/ci-test-python.yml
+++ b/.github/workflows/ci-test-python.yml
@@ -65,8 +65,7 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         path: ./dist
-        pattern: wheels-*
-        merge-multiple: true
+        name: wheels-linux-x86_64
 
     - name: Install dependencies
       run: uv pip install --system tox tox-uv

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -81,23 +81,65 @@ jobs:
     - name: Run the tests
       run: tox -e ${{ matrix.job }}
 
-  rs-build-linux:
-    runs-on: ${{ matrix.platform.runner }}
+  rs-build-linux-x86_64:
+    # Fast build for CI testing (always runs)
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.13'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          cache-dependency-glob: |
+            requirements_dev.txt
+            pyproject.toml
+            constraints/*.txt
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: "sqlfluffrs"
+          cache-on-failure: true
+
+      - name: Generate Rust dialect files
+        run: |
+          uv pip install --system -e .
+          python utils/rustify.py build
+
+      - name: Build wheels
+        uses: PyO3/maturin-action@v1
+        with:
+          target: x86_64
+          args: --release --out dist --find-interpreter --manifest-path sqlfluffrs/Cargo.toml
+          manylinux: auto
+        env:
+          # Use all 4 cores for parallel Rust compilation
+          CARGO_BUILD_JOBS: 4
+
+      - name: Upload wheels
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels-linux-x86_64
+          path: dist
+
+  rs-build-linux-exotic:
+    # Exotic architectures - only build on main branch, tags, or manual dispatch
+    # Skip on PRs to save CI time since tests only need x86_64
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        platform:
-          - runner: ubuntu-latest
-            target: x86_64
-          - runner: ubuntu-latest
-            target: x86
-          - runner: ubuntu-latest
-            target: aarch64
-          - runner: ubuntu-latest
-            target: armv7
-          - runner: ubuntu-latest
-            target: s390x
-          - runner: ubuntu-latest
-            target: ppc64le
+        target: [x86, aarch64, armv7, s390x, ppc64le]
     steps:
 
       - name: Checkout code
@@ -127,15 +169,14 @@ jobs:
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
-          target: ${{ matrix.platform.target }}
+          target: ${{ matrix.target }}
           args: --release --out dist --find-interpreter --manifest-path sqlfluffrs/Cargo.toml
-          sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
           manylinux: auto
 
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
-          name: wheels-linux-${{ matrix.platform.target }}
+          name: wheels-linux-${{ matrix.target }}
           path: dist
 
   rs-build-musllinux:
@@ -182,7 +223,6 @@ jobs:
         with:
           target: ${{ matrix.platform.target }}
           args: --release --out dist --find-interpreter --manifest-path sqlfluffrs/Cargo.toml
-          sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
           manylinux: musllinux_1_2
 
       - name: Upload wheels
@@ -231,7 +271,6 @@ jobs:
         with:
           target: ${{ matrix.platform.target }}
           args: --release --out dist --find-interpreter --manifest-path sqlfluffrs/Cargo.toml
-          sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
 
       - name: Upload wheels
         uses: actions/upload-artifact@v4
@@ -278,7 +317,6 @@ jobs:
         with:
           target: ${{ matrix.platform.target }}
           args: --release --out dist --find-interpreter --manifest-path sqlfluffrs/Cargo.toml
-          sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
 
       - name: Upload wheels
         uses: actions/upload-artifact@v4
@@ -328,7 +366,7 @@ jobs:
   # Test with coverage tracking on most recent python (py313).
   python-version-tests:
     name: Python Tests
-    needs: rs-build-linux
+    needs: rs-build-linux-x86_64
     strategy:
       matrix:
         python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13" ]
@@ -381,7 +419,7 @@ jobs:
 
   dialect-tests:
     name: Dialect ${{ matrix.marks }}${{ matrix.with-rust }}
-    needs: rs-build-linux
+    needs: rs-build-linux-x86_64
     strategy:
       matrix:
         marks: [ "parse_suite", "fix_suite", "rules_suite" ]

--- a/.github/workflows/create-release-pull-request.yaml
+++ b/.github/workflows/create-release-pull-request.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   run:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   pre-commit:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     env:
       RAW_LOG: pre-commit.log
       CS_XML: pre-commit.xml

--- a/.github/workflows/publish-sqlfluff-release-to-pypi.yaml
+++ b/.github/workflows/publish-sqlfluff-release-to-pypi.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   run:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/publish-sqlfluffrs-release-to-pypi.yaml
+++ b/.github/workflows/publish-sqlfluffrs-release-to-pypi.yaml
@@ -51,7 +51,6 @@ jobs:
         with:
           target: ${{ matrix.platform.target }}
           args: --release --out dist --find-interpreter --manifest-path sqlfluffrs/Cargo.toml
-          sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
           manylinux: ${{ matrix.platform.manylinux || '' }}
 
       - name: Upload wheels


### PR DESCRIPTION
### Brief summary of the change made

This PR is aiming to add further optimization to the existing workflows.

The following changes were added:

* Using `ubuntu-slim` image when it is enough to tun the workflows
* Splitting `rs-build-linux` job into two part:
  * `rs-build-linux-x86_64`: that is the fastest, and that is needed for the subsequent python test.
  * `rs-build-linux-exotic`: all other linux architectures, which are typically 2-3 minutes slower than the x86_64, so decoupling brings some time benefits. This part is configured to run only on main, and not on every pull request.
* I have disabled `sccache` for the rust builds as it has generated excessive cache entries without too much chance for reusability
* But added `Swatinem/rust-cache@v2` which caches the rust build env, and brings around 20 -30 seconds benefits.

I have experimented with 4 test workers (github runners for public repos are having 4 vCPUs), but -n 4 actually even made tests significantly slower to my great surprise. So I have not changed the two worker config.

I have tested the CI build and the overall runtime is defined by two jobs:
* the length of the `rs-build-linux-x86_64` job: currently with the cache it is around ~6:20-6:40 minutes
* the length of the parser_suite test with coverage job: that is around 8:40-8:50 minutes

Here is a run log: https://github.com/peterbud/sqlfluff/actions/runs/21716386629

If any of these can be accelerated the overall pipeline would be faster. All other jobs are running parallel, and are shorter.

Makes progress on #7384

### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
