### PR TITLE
Duckdb: Trailing commas in values clause

### DIFF
--- a/src/sqlfluff/dialects/dialect_duckdb.py
+++ b/src/sqlfluff/dialects/dialect_duckdb.py
@@ -1186,3 +1186,27 @@ class ArrayLiteralSegment(BaseSegment):
         ),
         bracket_type="square",
     )
+
+
+class ValuesClauseSegment(postgres.ValuesClauseSegment):
+    """A `VALUES` clause within in `WITH` or `SELECT`."""
+
+    match_grammar = Sequence(
+        "VALUES",
+        Delimited(
+            Bracketed(
+                Delimited(
+                    Ref("ExpressionSegment"),
+                    # DEFAULT keyword used in
+                    # INSERT INTO statement.
+                    "DEFAULT",
+                    allow_trailing=True,
+                ),
+                parse_mode=ParseMode.GREEDY,
+            ),
+            allow_trailing=True,
+        ),
+        Ref("AliasExpressionSegment", optional=True),
+        Ref("OrderByClauseSegment", optional=True),
+        Ref("LimitClauseSegment", optional=True),
+    )

--- a/test/fixtures/dialects/duckdb/select.sql
+++ b/test/fixtures/dialects/duckdb/select.sql
@@ -9,3 +9,8 @@ SELECT 1_000;
 SELECT 1_000_000;
 SELECT 1.0_000;
 SELECT 1_000_000.0_000_000;
+
+SELECT *,
+FROM (VALUES ('Amsterdam', 1),
+('London', 2),
+) cities(name, id);

--- a/test/fixtures/dialects/duckdb/select.yml
+++ b/test/fixtures/dialects/duckdb/select.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: a367cefb1135af487a34618fd4bd5cfd4a348549920d3a124ae545f7af23d785
+_hash: 490ad890e6d2b5ec1b7ea73d5d3c7b8ae8719c1a235c2109dba3c2f70c9d9b95
 file:
 - statement:
     select_statement:
@@ -113,4 +113,51 @@ file:
         keyword: SELECT
         select_clause_element:
           numeric_literal: '1_000_000.0_000_000'
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+        comma: ','
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            bracketed:
+              start_bracket: (
+              table_expression:
+                values_clause:
+                - keyword: VALUES
+                - bracketed:
+                  - start_bracket: (
+                  - expression:
+                      quoted_literal: "'Amsterdam'"
+                  - comma: ','
+                  - expression:
+                      numeric_literal: '1'
+                  - end_bracket: )
+                - comma: ','
+                - bracketed:
+                  - start_bracket: (
+                  - expression:
+                      quoted_literal: "'London'"
+                  - comma: ','
+                  - expression:
+                      numeric_literal: '2'
+                  - end_bracket: )
+                - comma: ','
+              end_bracket: )
+            alias_expression:
+              naked_identifier: cities
+              bracketed:
+                start_bracket: (
+                identifier_list:
+                - naked_identifier: name
+                - comma: ','
+                - naked_identifier: id
+                end_bracket: )
 - statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
Fixes #7451

### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
