### PR TITLE
Support Python 3.14

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -49,7 +49,7 @@ jobs:
           ]
         include:
           # Default to most recent python version
-          - python-version: "3.13"
+          - python-version: "3.14"
           # As at 2024-10-10, docbuild fails on 3.13, so fall back to 3.12
           - job: docbuild
             python-version: "3.12"
@@ -94,7 +94,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.13'
+          python-version: '3.14'
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
@@ -150,7 +150,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.13'
+          python-version: '3.14'
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
@@ -202,7 +202,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.13'
+          python-version: '3.14'
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
@@ -249,7 +249,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.13'
+          python-version: '3.14'
           architecture: ${{ matrix.platform.target }}
 
       - name: Install uv
@@ -296,7 +296,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.13'
+          python-version: '3.14'
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
@@ -335,7 +335,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.13'
+          python-version: '3.14'
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
@@ -363,19 +363,19 @@ jobs:
           name: wheels-sdist
           path: dist
 
-  # Test with coverage tracking on most recent python (py313).
+  # Test with coverage tracking on most recent python (py314).
   python-version-tests:
     name: Python Tests
     needs: rs-build-linux-x86_64
     strategy:
       matrix:
-        python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13" ]
+        python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13", "3.14" ]
         include:
           # Default to test without coverage tracking on older python versions.
           # This saves time, as testing without coverage tracking is faster.
           - coverage: false
           # Override coverage to be true for most recent python version.
-          - python-version: "3.13"
+          - python-version: "3.14"
             coverage: true
         with-rust: [ "-rust", "" ]
     permissions:
@@ -454,7 +454,7 @@ jobs:
 
     uses: ./.github/workflows/ci-test-python.yml
     with:
-      python-version: "3.13"
+      python-version: "3.14"
       marks: ${{ matrix.marks }}
       coverage: ${{ matrix.coverage }}
       with-rust: ${{ matrix.with-rust }}
@@ -473,7 +473,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v6
       with:
-        python-version: '3.13'
+        python-version: '3.14'
 
     - name: Install uv
       uses: astral-sh/setup-uv@v7
@@ -516,7 +516,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v6
       with:
-        python-version: '3.13'
+        python-version: '3.14'
 
     - name: Install uv
       uses: astral-sh/setup-uv@v7
@@ -541,7 +541,7 @@ jobs:
 
   python-windows-tests:
     runs-on: windows-latest
-    name: Python 3.13 Windows tests
+    name: Python 3.14 Windows tests
     steps:
     - name: Set git to use LF
       run: |
@@ -556,7 +556,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v6
       with:
-        python-version: '3.13'
+        python-version: '3.14'
 
     - name: Install uv
       uses: astral-sh/setup-uv@v7
@@ -588,7 +588,7 @@ jobs:
     - name: Upload coverage data (github)
       uses: actions/upload-artifact@v4
       with:
-        name: coverage-data-winpy3.13
+        name: coverage-data-winpy3.14
         path: ".coverage.*"
         if-no-files-found: ignore
         include-hidden-files: true
@@ -661,7 +661,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v6
       with:
-        python-version: '3.13'
+        python-version: '3.14'
 
     - name: Install uv
       uses: astral-sh/setup-uv@v7
@@ -710,7 +710,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.13'
+          python-version: '3.14'
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7

--- a/.github/workflows/create-release-pull-request.yaml
+++ b/.github/workflows/create-release-pull-request.yaml
@@ -28,7 +28,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.13'
+          python-version: '3.14'
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/publish-dbt-templater-release-to-pypi.yaml
+++ b/.github/workflows/publish-dbt-templater-release-to-pypi.yaml
@@ -16,7 +16,7 @@ jobs:
 
       - uses: actions/setup-python@v6
         with:
-          python-version: "3.13"
+          python-version: "3.14"
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7

--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -43,7 +43,7 @@ jobs:
       - name: 🐍 Setup Python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.13'
+          python-version: '3.14'
           cache: 'pip'
 
       - name: 📦 Install SQLFluff

--- a/.github/workflows/publish-sqlfluff-release-to-pypi.yaml
+++ b/.github/workflows/publish-sqlfluff-release-to-pypi.yaml
@@ -15,7 +15,7 @@ jobs:
           fetch-depth: 1
       - uses: actions/setup-python@v6
         with:
-          python-version: "3.13"
+          python-version: "3.14"
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7

--- a/.github/workflows/publish-sqlfluffrs-release-to-pypi.yaml
+++ b/.github/workflows/publish-sqlfluffrs-release-to-pypi.yaml
@@ -43,7 +43,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.13"
+          python-version: "3.14"
           architecture: ${{ matrix.platform.arch || null }}
 
       - name: Build wheels

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ SQLFluff is a dialect-flexible SQL linter and auto-fixer supporting 25+ SQL dial
 ## Universal Conventions
 
 ### Language Support
-- **Python**: 3.9 minimum, 3.12 recommended for development, 3.13 supported
+- **Python**: 3.9 minimum, 3.13 recommended for development, 3.14 supported
 - **Rust**: Experimental, used for performance-critical lexing/parsing
 
 ### Code Quality Standards

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,7 +86,7 @@ changes.
 The simplest way to set up a development environment is to use [`tox`](https://tox.wiki/en/latest/installation.html).
 
 **IMPORTANT:** Python 3.9 is the minimum version we support. Feel free
-to test on anything between `python3.9` and `python3.13`.
+to test on anything between `python3.9` and `python3.14`.
 
 #### Creating a virtual environment
 
@@ -102,7 +102,7 @@ source .venv/bin/activate
 ```
 (The `dbt180` environment is a good default choice.
 However any version can be installed by replacing `dbt180` with
-`py`, `py39` through `py313`, `dbt170` through `dbt1100`, etc.
+`py`, `py39` through `py314`, `dbt170` through `dbt1100`, etc.
 `py` defaults to the python version that was used to install tox.
 To be able to run all tests including the dbt templater,
 choose one of the dbt environments.)

--- a/plugins/sqlfluff-templater-dbt/pyproject.toml
+++ b/plugins/sqlfluff-templater-dbt/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Programming Language :: Python :: Implementation :: CPython",
     "Topic :: Utilities",
     "Topic :: Software Development :: Quality Assurance",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: SQL",
     "Topic :: Utilities",

--- a/sqlfluffrs/pyproject.toml
+++ b/sqlfluffrs/pyproject.toml
@@ -25,6 +25,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
     "Programming Language :: SQL",

--- a/src/sqlfluff/AGENTS.md
+++ b/src/sqlfluff/AGENTS.md
@@ -6,8 +6,8 @@ This file provides Python-specific development guidelines for SQLFluff's main so
 
 ### Version Support
 - **Minimum**: Python 3.9
-- **Recommended for development**: Python 3.12
-- **Maximum tested**: Python 3.13
+- **Recommended for development**: Python 3.13
+- **Maximum tested**: Python 3.14
 
 ### Code Style & Formatting
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = generate-fixture-yml, generate-rs, check-rs, build-rs, linting, doclinting, ruleslinting, docbuild, cov-init, doctests, py{39,310,311,312,313}, dbt{170,180,190,1100}, rust, cov-report, mypy, mypyc, winpy, dbt{180,190}-winpy, yamllint, bench, bench-rust, bench-compare
+envlist = generate-fixture-yml, generate-rs, check-rs, build-rs, linting, doclinting, ruleslinting, docbuild, cov-init, doctests, py{39,310,311,312,313,314}, dbt{170,180,190,1100}, rust, cov-report, mypy, mypyc, winpy, dbt{180,190}-winpy, yamllint, bench, bench-rust, bench-compare
 min_version = 4.0  # Require 4.0+ for proper pyproject.toml support
 
 [testenv]
@@ -40,7 +40,7 @@ commands =
     # the python version is not specified and instead the "py" or "winpy"
     # environment is invoked. Leaving the trailing comma ensures that this
     # environment still installs the relevant plugins.
-    {py,winpy}{39,310,311,312,313,}: python -m pip install "{toxinidir}/plugins/sqlfluff-plugin-example"
+    {py,winpy}{39,310,311,312,313,314,}: python -m pip install "{toxinidir}/plugins/sqlfluff-plugin-example"
     rust: python -m pip install --force-reinstall --no-deps --no-index --find-links="{toxinidir}/dist" sqlfluffrs
     # Clean up from previous tests
     python "{toxinidir}/util.py" clean-tests


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
This PR adds Python 3.14 to our CI matrix, tox, and makes 3.13 the recommended Python version for development, following the trend of being one release behind.

### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
