### PR TITLE
rust: strip debug info

### DIFF
--- a/sqlfluffrs/Cargo.lock
+++ b/sqlfluffrs/Cargo.lock
@@ -1993,7 +1993,7 @@ dependencies = [
 
 [[package]]
 name = "sqlfluffrs"
-version = "4.0.4-alpha.1"
+version = "4.0.4"
 dependencies = [
  "bincode",
  "blake2",
@@ -2023,7 +2023,7 @@ dependencies = [
 
 [[package]]
 name = "sqlfluffrs_dialects"
-version = "4.0.4-alpha.1"
+version = "4.0.4"
 dependencies = [
  "fancy-regex",
  "hashbrown 0.15.5",
@@ -2034,7 +2034,7 @@ dependencies = [
 
 [[package]]
 name = "sqlfluffrs_lexer"
-version = "4.0.4-alpha.1"
+version = "4.0.4"
 dependencies = [
  "env_logger",
  "fancy-regex",
@@ -2053,7 +2053,7 @@ dependencies = [
 
 [[package]]
 name = "sqlfluffrs_parser"
-version = "4.0.4-alpha.1"
+version = "4.0.4"
 dependencies = [
  "env_logger",
  "hashbrown 0.15.5",
@@ -2071,7 +2071,7 @@ dependencies = [
 
 [[package]]
 name = "sqlfluffrs_python"
-version = "4.0.4-alpha.1"
+version = "4.0.4"
 dependencies = [
  "bincode",
  "hashbrown 0.15.5",
@@ -2085,7 +2085,7 @@ dependencies = [
 
 [[package]]
 name = "sqlfluffrs_types"
-version = "4.0.4-alpha.1"
+version = "4.0.4"
 dependencies = [
  "bincode",
  "fancy-regex",

--- a/sqlfluffrs/Cargo.toml
+++ b/sqlfluffrs/Cargo.toml
@@ -74,4 +74,5 @@ harness = false
 [profile.bench]
 debug = true
 [profile.release]
-debug = true
+debug = false
+strip = true


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
This strips debug info from the built/published objects.

### Are there any other side effects of this change that we should be aware of?
None

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
