### PR TITLE
fix: pin `platformdirs` to <4.6.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ dependencies = [
     # Pinned to <4.6.0 due to breaking changes in 4.6.0 (released 2026-02-12)
     # which added XDG_CONFIG_HOME support to macOS (https://github.com/tox-dev/platformdirs/pull/375)
     # This breaks our tests which expect the old macOS behavior.
-    # TODO: Update tests to support both old and new behavior or drop Python 3.9 support.
+    # TODO: Update tests to support both old and new behavior.
     "platformdirs<4.6.0",
     # To get the encoding of files.
     "chardet",


### PR DESCRIPTION
### Brief summary of the change made

The version pin will prevent the test failures with Python tests while we work on a proper fix in the future. 

### Are there any other side effects of this change that we should be aware of?
N/A

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
