### PR TITLE
TSQL: use `ColonDelimiterSegment` in JSON key-value pairs grammar

### DIFF
--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -4282,7 +4282,7 @@ class JsonFunctionContentsSegment(BaseSegment):
             Ref("QuotedLiteralSegment"),
             Ref("ParameterNameSegment"),
         ),
-        Ref("ColonSegment"),
+        Ref("ColonDelimiterSegment"),
         Sequence(
             OneOf(
                 Ref("QuotedLiteralSegment"),
@@ -4436,7 +4436,7 @@ class JsonAggFunctionContentsSegment(BaseSegment):
             # Single expression OR two expressions separated by colon
             Ref("ExpressionSegment"),
             Sequence(
-                Ref("ColonSegment"),
+                Ref("ColonDelimiterSegment"),
                 Ref("ExpressionSegment"),
                 # Optional for JSON_ARRAYAGG, required for JSON_OBJECTAGG
                 optional=True,

--- a/test/fixtures/dialects/tsql/json_aggregate_functions.yml
+++ b/test/fixtures/dialects/tsql/json_aggregate_functions.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: b626c56f4d7624d0ba715e0c7e33750ce7dfbf41ae94cb7f2623df882a27df07
+_hash: cc31705eb94536e4c6dbeef78c923caca322998653865aa58bc616bdc1cf3cae
 file:
   batch:
   - statement:
@@ -363,7 +363,7 @@ file:
                 - expression:
                     column_reference:
                       naked_identifier: name
-                - colon: ':'
+                - colon_delimiter: ':'
                 - expression:
                     column_reference:
                       naked_identifier: value
@@ -390,7 +390,7 @@ file:
                 - expression:
                     column_reference:
                       naked_identifier: key_column
-                - colon: ':'
+                - colon_delimiter: ':'
                 - expression:
                     column_reference:
                       naked_identifier: value_column
@@ -417,7 +417,7 @@ file:
                 - expression:
                     column_reference:
                       naked_identifier: setting_name
-                - colon: ':'
+                - colon_delimiter: ':'
                 - expression:
                     column_reference:
                       naked_identifier: setting_value
@@ -447,7 +447,7 @@ file:
                 - expression:
                     column_reference:
                       naked_identifier: config_key
-                - colon: ':'
+                - colon_delimiter: ':'
                 - expression:
                     column_reference:
                       naked_identifier: config_value
@@ -477,7 +477,7 @@ file:
                 - expression:
                     column_reference:
                       naked_identifier: prop_name
-                - colon: ':'
+                - colon_delimiter: ':'
                 - expression:
                     column_reference:
                       naked_identifier: prop_value
@@ -506,7 +506,7 @@ file:
                 - expression:
                     column_reference:
                       naked_identifier: name
-                - colon: ':'
+                - colon_delimiter: ':'
                 - expression:
                     column_reference:
                       naked_identifier: score
@@ -545,7 +545,7 @@ file:
                 - expression:
                     column_reference:
                       naked_identifier: attr_name
-                - colon: ':'
+                - colon_delimiter: ':'
                 - expression:
                     column_reference:
                       naked_identifier: attr_value
@@ -590,7 +590,7 @@ file:
                 - expression:
                     column_reference:
                       naked_identifier: item_name
-                - colon: ':'
+                - colon_delimiter: ':'
                 - expression:
                     column_reference:
                       naked_identifier: item_price
@@ -641,7 +641,7 @@ file:
                 - expression:
                     column_reference:
                       naked_identifier: setting_name
-                - colon: ':'
+                - colon_delimiter: ':'
                 - expression:
                     column_reference:
                       naked_identifier: setting_value
@@ -676,7 +676,7 @@ file:
                 - start_bracket: (
                 - expression:
                     quoted_literal: "'key'"
-                - colon: ':'
+                - colon_delimiter: ':'
                 - expression:
                     column_reference:
                       naked_identifier: value_column
@@ -708,7 +708,7 @@ file:
                   - binary_operator: +
                   - column_reference:
                       naked_identifier: suffix
-                - colon: ':'
+                - colon_delimiter: ':'
                 - expression:
                     column_reference:
                       naked_identifier: data_value
@@ -739,7 +739,7 @@ file:
                 - expression:
                     column_reference:
                       naked_identifier: employee_id
-                - colon: ':'
+                - colon_delimiter: ':'
                 - expression:
                     column_reference:
                       naked_identifier: employee_name
@@ -795,7 +795,7 @@ file:
                 - expression:
                     column_reference:
                       naked_identifier: employee_id
-                - colon: ':'
+                - colon_delimiter: ':'
                 - expression:
                     column_reference:
                       naked_identifier: employee_email
@@ -870,7 +870,7 @@ file:
                 - expression:
                     column_reference:
                       naked_identifier: product_name
-                - colon: ':'
+                - colon_delimiter: ':'
                 - expression:
                     bracketed:
                       start_bracket: (
@@ -1049,7 +1049,7 @@ file:
                 bracketed:
                 - start_bracket: (
                 - quoted_literal: "'items'"
-                - colon: ':'
+                - colon_delimiter: ':'
                 - function:
                     function_name:
                       keyword: JSON_ARRAYAGG
@@ -1062,7 +1062,7 @@ file:
                         end_bracket: )
                 - comma: ','
                 - quoted_literal: "'count'"
-                - colon: ':'
+                - colon_delimiter: ':'
                 - function:
                     function_name:
                       function_name_identifier: COUNT
@@ -1175,7 +1175,7 @@ file:
                 - expression:
                     column_reference:
                       naked_identifier: user_id
-                - colon: ':'
+                - colon_delimiter: ':'
                 - expression:
                     bracketed:
                       start_bracket: (

--- a/test/fixtures/dialects/tsql/json_functions.sql
+++ b/test/fixtures/dialects/tsql/json_functions.sql
@@ -4,24 +4,24 @@ SELECT JSON_ARRAY('a', 1, 'b', 2);
 
 SELECT JSON_ARRAY('a', 1, NULL, 2, NULL ON NULL);
 
-SELECT JSON_OBJECT('name': 'value', 'new': 1);
+SELECT JSON_OBJECT('name':'value', 'new':1);
 
-SELECT JSON_OBJECT('name': 'value', 'type': NULL ABSENT ON NULL)
+SELECT JSON_OBJECT('name':'value', 'type':NULL ABSENT ON NULL)
 
-SELECT JSON_OBJECT('name': 'value', 'type': JSON_ARRAY(1, 2))
+SELECT JSON_OBJECT('name':'value', 'type':JSON_ARRAY(1, 2))
 
-SELECT JSON_OBJECT('name': 'value', 'type': JSON_OBJECT('type_id': 1, 'name': 'a'))
+SELECT JSON_OBJECT('name':'value', 'type':JSON_OBJECT('type_id':1, 'name':'a'))
 
 DECLARE @id_key nvarchar(10) = N'id', @id_value nvarchar(64) = NEWID();
-SELECT JSON_OBJECT('user_name': USER_NAME(), @id_key: @id_value, 'sid': (SELECT @@SPID));
+SELECT JSON_OBJECT('user_name':USER_NAME(), @id_key:@id_value, 'sid':(SELECT @@SPID));
 
-SELECT s.session_id, JSON_OBJECT('security_id': s.security_id, 'login': s.login_name, 'status': s.status) AS info
+SELECT s.session_id, JSON_OBJECT('security_id':s.security_id, 'login':s.login_name, 'status':s.status) AS info
 FROM sys.dm_exec_sessions AS s
 WHERE s.is_user_process = 1;
 
-SELECT JSON_ARRAY('a', JSON_OBJECT('name': 'value', 'type': 1));
+SELECT JSON_ARRAY('a', JSON_OBJECT('name':'value', 'type':1));
 
-SELECT JSON_ARRAY('a', JSON_OBJECT('name': 'value', 'type': 1), JSON_ARRAY(1, NULL, 2 NULL ON NULL));
+SELECT JSON_ARRAY('a', JSON_OBJECT('name':'value', 'type':1), JSON_ARRAY(1, NULL, 2 NULL ON NULL));
 
 DECLARE @id_value nvarchar(64) = NEWID();
 SELECT JSON_ARRAY(1, @id_value, (SELECT @@SPID));

--- a/test/fixtures/dialects/tsql/json_functions.yml
+++ b/test/fixtures/dialects/tsql/json_functions.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: be768cf5638cac420924be39f8ae3d9436e1f17562d47d33699e52db22b5e37f
+_hash: ce758daa106109323d822d670f41b46292876e22991f3ce128ae080f0b0a9144
 file:
   batch:
   - statement:
@@ -82,11 +82,11 @@ file:
                 bracketed:
                 - start_bracket: (
                 - quoted_literal: "'name'"
-                - colon: ':'
+                - colon_delimiter: ':'
                 - quoted_literal: "'value'"
                 - comma: ','
                 - quoted_literal: "'new'"
-                - colon: ':'
+                - colon_delimiter: ':'
                 - integer_literal: '1'
                 - end_bracket: )
   - statement_terminator: ;
@@ -102,11 +102,11 @@ file:
                 bracketed:
                 - start_bracket: (
                 - quoted_literal: "'name'"
-                - colon: ':'
+                - colon_delimiter: ':'
                 - quoted_literal: "'value'"
                 - comma: ','
                 - quoted_literal: "'type'"
-                - colon: ':'
+                - colon_delimiter: ':'
                 - null_literal: 'NULL'
                 - keyword: ABSENT
                 - keyword: 'ON'
@@ -124,11 +124,11 @@ file:
                 bracketed:
                 - start_bracket: (
                 - quoted_literal: "'name'"
-                - colon: ':'
+                - colon_delimiter: ':'
                 - quoted_literal: "'value'"
                 - comma: ','
                 - quoted_literal: "'type'"
-                - colon: ':'
+                - colon_delimiter: ':'
                 - function:
                     function_name:
                       function_name_identifier: JSON_ARRAY
@@ -154,11 +154,11 @@ file:
                 bracketed:
                 - start_bracket: (
                 - quoted_literal: "'name'"
-                - colon: ':'
+                - colon_delimiter: ':'
                 - quoted_literal: "'value'"
                 - comma: ','
                 - quoted_literal: "'type'"
-                - colon: ':'
+                - colon_delimiter: ':'
                 - function:
                     function_name:
                       keyword: JSON_OBJECT
@@ -166,11 +166,11 @@ file:
                       bracketed:
                       - start_bracket: (
                       - quoted_literal: "'type_id'"
-                      - colon: ':'
+                      - colon_delimiter: ':'
                       - integer_literal: '1'
                       - comma: ','
                       - quoted_literal: "'name'"
-                      - colon: ':'
+                      - colon_delimiter: ':'
                       - quoted_literal: "'a'"
                       - end_bracket: )
                 - end_bracket: )
@@ -223,7 +223,7 @@ file:
                 bracketed:
                 - start_bracket: (
                 - quoted_literal: "'user_name'"
-                - colon: ':'
+                - colon_delimiter: ':'
                 - function:
                     function_name:
                       function_name_identifier: USER_NAME
@@ -233,11 +233,11 @@ file:
                         end_bracket: )
                 - comma: ','
                 - parameter: '@id_key'
-                - colon: ':'
+                - colon_delimiter: ':'
                 - parameter: '@id_value'
                 - comma: ','
                 - quoted_literal: "'sid'"
-                - colon: ':'
+                - colon_delimiter: ':'
                 - bracketed:
                     start_bracket: (
                     select_statement:
@@ -266,21 +266,21 @@ file:
                 bracketed:
                 - start_bracket: (
                 - quoted_literal: "'security_id'"
-                - colon: ':'
+                - colon_delimiter: ':'
                 - column_reference:
                   - naked_identifier: s
                   - dot: .
                   - naked_identifier: security_id
                 - comma: ','
                 - quoted_literal: "'login'"
-                - colon: ':'
+                - colon_delimiter: ':'
                 - column_reference:
                   - naked_identifier: s
                   - dot: .
                   - naked_identifier: login_name
                 - comma: ','
                 - quoted_literal: "'status'"
-                - colon: ':'
+                - colon_delimiter: ':'
                 - column_reference:
                   - naked_identifier: s
                   - dot: .
@@ -336,11 +336,11 @@ file:
                         bracketed:
                         - start_bracket: (
                         - quoted_literal: "'name'"
-                        - colon: ':'
+                        - colon_delimiter: ':'
                         - quoted_literal: "'value'"
                         - comma: ','
                         - quoted_literal: "'type'"
-                        - colon: ':'
+                        - colon_delimiter: ':'
                         - integer_literal: '1'
                         - end_bracket: )
                 - end_bracket: )
@@ -367,11 +367,11 @@ file:
                         bracketed:
                         - start_bracket: (
                         - quoted_literal: "'name'"
-                        - colon: ':'
+                        - colon_delimiter: ':'
                         - quoted_literal: "'value'"
                         - comma: ','
                         - quoted_literal: "'type'"
-                        - colon: ':'
+                        - colon_delimiter: ':'
                         - integer_literal: '1'
                         - end_bracket: )
                 - comma: ','

--- a/test/fixtures/rules/std_rule_cases/LT01-excessive.yml
+++ b/test/fixtures/rules/std_rule_cases/LT01-excessive.yml
@@ -402,6 +402,22 @@ test_hive_set_statement:
     core:
       dialect: hive
 
+test_tsql_json_object_colon:
+  # ColonDelimiter in JSON_OBJECT key:value pairs shouldn't have spacing.
+  pass_str: |
+    SELECT JSON_OBJECT('name':'value', 'type':1);
+  configs:
+    core:
+      dialect: tsql
+
+test_tsql_json_objectagg_colon:
+  # ColonDelimiter in JSON_OBJECTAGG key:value pairs shouldn't have spacing.
+  pass_str: |
+    SELECT JSON_OBJECTAGG(name:value) FROM t;
+  configs:
+    core:
+      dialect: tsql
+
 test_spark_set_statement:
   pass_str: |
     SET -v;


### PR DESCRIPTION
### Brief summary of the change made

The existing T-SQL JSON grammar used `ColonSegment`  to separate key-value pairs in JSON function arguments. That grammar defaults to `spacing_after = single`, so `LT01` enforced a space after the colon in JSON key-value pairs like `JSON_OBJECT('name':value)` which resulted wrong code.

This PR switches to `ColonDelimiterSegment`which has spacing_before = touch and spacing_after = touch (no spaces on either side).

### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
