### PR TITLE
Oracle: Add support for referencing correlation names as pseudorecords

### DIFF
--- a/test/fixtures/dialects/oracle/create_trigger.yml
+++ b/test/fixtures/dialects/oracle/create_trigger.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 902b791e01120f3e64d3fab27c1c8bb51cd227a2190d355864611f008e83b957
+_hash: 5ac384e5956234f029ccc05622864d0192b9c6eadc800ff5bad7fbfc82764e02
 file:
   statement:
     create_trigger_statement:
@@ -189,23 +189,26 @@ file:
                     keyword: VALUES
                     bracketed:
                     - start_bracket: (
-                    - sqlplus_variable:
-                      - colon: ':'
-                      - parameter: new
-                      - dot: .
-                      - parameter: customer_id
+                    - bind_variable:
+                        colon_delimiter: ':'
+                        trigger_correlation_name:
+                          keyword: new
+                        dot: .
+                        naked_identifier: customer_id
                     - comma: ','
-                    - sqlplus_variable:
-                      - colon: ':'
-                      - parameter: new
-                      - dot: .
-                      - parameter: cust_last_name
+                    - bind_variable:
+                        colon_delimiter: ':'
+                        trigger_correlation_name:
+                          keyword: new
+                        dot: .
+                        naked_identifier: cust_last_name
                     - comma: ','
-                    - sqlplus_variable:
-                      - colon: ':'
-                      - parameter: new
-                      - dot: .
-                      - parameter: cust_first_name
+                    - bind_variable:
+                        colon_delimiter: ':'
+                        trigger_correlation_name:
+                          keyword: new
+                        dot: .
+                        naked_identifier: cust_first_name
                     - end_bracket: )
             - statement_terminator: ;
             - statement:
@@ -229,23 +232,26 @@ file:
                     keyword: VALUES
                     bracketed:
                     - start_bracket: (
-                    - sqlplus_variable:
-                      - colon: ':'
-                      - parameter: new
-                      - dot: .
-                      - parameter: order_id
+                    - bind_variable:
+                        colon_delimiter: ':'
+                        trigger_correlation_name:
+                          keyword: new
+                        dot: .
+                        naked_identifier: order_id
                     - comma: ','
-                    - sqlplus_variable:
-                      - colon: ':'
-                      - parameter: new
-                      - dot: .
-                      - parameter: order_date
+                    - bind_variable:
+                        colon_delimiter: ':'
+                        trigger_correlation_name:
+                          keyword: new
+                        dot: .
+                        naked_identifier: order_date
                     - comma: ','
-                    - sqlplus_variable:
-                      - colon: ':'
-                      - parameter: new
-                      - dot: .
-                      - parameter: customer_id
+                    - bind_variable:
+                        colon_delimiter: ':'
+                        trigger_correlation_name:
+                          keyword: new
+                        dot: .
+                        naked_identifier: customer_id
                     - end_bracket: )
             - statement_terminator: ;
             - keyword: EXCEPTION
@@ -301,10 +307,12 @@ file:
                   naked_identifier: dept_view
             - referencing_clause:
               - keyword: REFERENCING
-              - keyword: NEW
+              - trigger_correlation_name:
+                  keyword: NEW
               - keyword: AS
               - naked_identifier: Employee
-              - keyword: PARENT
+              - trigger_correlation_name:
+                  keyword: PARENT
               - keyword: AS
               - naked_identifier: Department
             - keyword: FOR
@@ -578,11 +586,12 @@ file:
                             naked_identifier: employee_id
                         - assignment_operator: :=
                         - expression:
-                            sqlplus_variable:
-                            - colon: ':'
-                            - parameter: NEW
-                            - dot: .
-                            - parameter: employee_id
+                            bind_variable:
+                              colon_delimiter: ':'
+                              trigger_correlation_name:
+                                keyword: NEW
+                              dot: .
+                              naked_identifier: employee_id
                     - statement_terminator: ;
                     - statement:
                         assignment_segment_statement:
@@ -614,11 +623,12 @@ file:
                             naked_identifier: salary
                         - assignment_operator: :=
                         - expression:
-                            sqlplus_variable:
-                            - colon: ':'
-                            - parameter: NEW
-                            - dot: .
-                            - parameter: salary
+                            bind_variable:
+                              colon_delimiter: ':'
+                              trigger_correlation_name:
+                                keyword: NEW
+                              dot: .
+                              naked_identifier: salary
                     - statement_terminator: ;
                     - statement:
                         if_then_statement:
@@ -703,11 +713,12 @@ file:
                           - keyword: THEN
                         - statement:
                             assignment_segment_statement:
-                              sqlplus_variable:
-                              - colon: ':'
-                              - parameter: new
-                              - dot: .
-                              - parameter: created_at
+                              bind_variable:
+                                colon_delimiter: ':'
+                                trigger_correlation_name:
+                                  keyword: new
+                                dot: .
+                                naked_identifier: created_at
                               assignment_operator: :=
                               expression:
                                 bare_function: CURRENT_TIMESTAMP
@@ -717,11 +728,12 @@ file:
                         - keyword: THEN
                         - statement:
                             assignment_segment_statement:
-                              sqlplus_variable:
-                              - colon: ':'
-                              - parameter: new
-                              - dot: .
-                              - parameter: updated_at
+                              bind_variable:
+                                colon_delimiter: ':'
+                                trigger_correlation_name:
+                                  keyword: new
+                                dot: .
+                                naked_identifier: updated_at
                               assignment_operator: :=
                               expression:
                                 bare_function: CURRENT_TIMESTAMP

--- a/test/fixtures/dialects/oracle/pseudorecords.sql
+++ b/test/fixtures/dialects/oracle/pseudorecords.sql
@@ -1,0 +1,15 @@
+CREATE OR REPLACE TRIGGER example_trigger
+BEFORE INSERT OR UPDATE ON example_table
+FOR EACH ROW
+BEGIN
+    -- Using pseudorecords in assignments
+    :NEW.column_name := :OLD.column_name;
+
+    -- Using pseudorecords in conditions
+    IF :NEW.val > :OLD.val THEN
+        :NEW.status := 'changed';
+    END IF;
+
+    -- PARENT pseudorecord
+    :NEW.parent_val := :PARENT.val;
+END;

--- a/test/fixtures/dialects/oracle/pseudorecords.yml
+++ b/test/fixtures/dialects/oracle/pseudorecords.yml
@@ -1,0 +1,100 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: c51b711fd30141bde95ddc56f3cd3112fb6372dfe3f0fa34a0d93d21a980b960
+file:
+  statement:
+    create_trigger_statement:
+    - keyword: CREATE
+    - keyword: OR
+    - keyword: REPLACE
+    - keyword: TRIGGER
+    - trigger_reference:
+        naked_identifier: example_trigger
+    - keyword: BEFORE
+    - dml_event_clause:
+      - keyword: INSERT
+      - keyword: OR
+      - keyword: UPDATE
+      - keyword: 'ON'
+      - table_reference:
+          naked_identifier: example_table
+    - keyword: FOR
+    - keyword: EACH
+    - keyword: ROW
+    - statement:
+        begin_end_block:
+        - keyword: BEGIN
+        - statement:
+            assignment_segment_statement:
+              bind_variable:
+                colon_delimiter: ':'
+                trigger_correlation_name:
+                  keyword: NEW
+                dot: .
+                naked_identifier: column_name
+              assignment_operator: :=
+              expression:
+                bind_variable:
+                  colon_delimiter: ':'
+                  trigger_correlation_name:
+                    keyword: OLD
+                  dot: .
+                  naked_identifier: column_name
+        - statement_terminator: ;
+        - statement:
+            if_then_statement:
+            - if_clause:
+              - keyword: IF
+              - expression:
+                - bind_variable:
+                    colon_delimiter: ':'
+                    trigger_correlation_name:
+                      keyword: NEW
+                    dot: .
+                    naked_identifier: val
+                - comparison_operator:
+                    raw_comparison_operator: '>'
+                - bind_variable:
+                    colon_delimiter: ':'
+                    trigger_correlation_name:
+                      keyword: OLD
+                    dot: .
+                    naked_identifier: val
+              - keyword: THEN
+            - statement:
+                assignment_segment_statement:
+                  bind_variable:
+                    colon_delimiter: ':'
+                    trigger_correlation_name:
+                      keyword: NEW
+                    dot: .
+                    naked_identifier: status
+                  assignment_operator: :=
+                  expression:
+                    quoted_literal: "'changed'"
+            - statement_terminator: ;
+            - keyword: END
+            - keyword: IF
+        - statement_terminator: ;
+        - statement:
+            assignment_segment_statement:
+              bind_variable:
+                colon_delimiter: ':'
+                trigger_correlation_name:
+                  keyword: NEW
+                dot: .
+                naked_identifier: parent_val
+              assignment_operator: :=
+              expression:
+                bind_variable:
+                  colon_delimiter: ':'
+                  trigger_correlation_name:
+                    keyword: PARENT
+                  dot: .
+                  naked_identifier: val
+        - statement_terminator: ;
+        - keyword: END
+    - statement_terminator: ;


### PR DESCRIPTION
### Brief summary of the change made

Ensure correct parsing and layout rules for :NEW, :OLD, and :PARENT within Oracle triggers, preventing spacing violations.

Fixes #7495.

### Are there any other side effects of this change that we should be aware of?

No.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.