### PR TITLE
Oracle: Redesign slash as buffer executor

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,6 +135,7 @@ sqlfluff_rules_structure = "sqlfluff.rules.structure"
 sqlfluff_rules_convention = "sqlfluff.rules.convention"
 sqlfluff_rules_jinja = "sqlfluff.rules.jinja"
 sqlfluff_rules_tsql = "sqlfluff.rules.tsql"
+sqlfluff_rules_oracle = "sqlfluff.rules.oracle"
 
 
 [tool.sqlfluff_docs]

--- a/src/sqlfluff/rules/oracle/OR01.py
+++ b/src/sqlfluff/rules/oracle/OR01.py
@@ -1,0 +1,90 @@
+"""Implementation of Rule OR01."""
+
+from typing import Optional
+
+from sqlfluff.core.rules import BaseRule, LintFix, LintResult, RuleContext
+from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
+
+
+class Rule_OR01(BaseRule):
+    """Remove empty batches.
+
+    **Anti-pattern**
+
+    Empty batches (containing only / statements) should be removed.
+
+    .. code-block:: sql
+       :force:
+
+        SELECT 1 FROM DUAL;
+
+        /
+
+        /
+
+    **Best practice**
+
+    Remove empty batches.
+
+    .. code-block:: sql
+       :force:
+
+        SELECT 1 FROM DUAL;
+
+        /
+    """
+
+    name = "oracle.empty_batch"
+    aliases = ()
+    groups = ("all", "oracle")
+    crawl_behaviour = SegmentSeekerCrawler({"batch"})
+    is_fix_compatible = True
+
+    def _eval(self, context: RuleContext) -> Optional[list[LintResult]]:
+        """Remove empty batches."""
+        # Rule only applies to Oracle syntax.
+        if context.dialect.name != "oracle":
+            return None  # pragma: no cover
+
+        if not context.segment.is_type("batch"):  # pragma: no cover
+            return None
+
+        # Get all non-whitespace, non-meta segments
+        content_segments = [
+            s
+            for s in context.segment.segments
+            if not s.is_type("whitespace", "newline", "indent", "dedent")
+            and not s.is_meta
+        ]
+
+        # Check if batch contains only slash_buffer_executor statement
+        has_real_content = False
+        has_slash = False
+        for content_seg in content_segments:
+            if content_seg.is_type("slash_buffer_executor"):
+                has_slash = True
+            elif not content_seg.is_meta:
+                has_real_content = True
+                break
+
+        # If batch has no real content (only / and whitespace), remove it
+        if not has_real_content and has_slash:
+            fixes = [LintFix.delete(context.segment)]
+
+            # Also delete the trailing newline after the batch if present
+            segments = context.parent_stack[-1].segments
+            idx = segments.index(context.segment)
+            if idx + 1 < len(segments):
+                next_seg = segments[idx + 1]
+                if next_seg.is_type("newline"):
+                    fixes.append(LintFix.delete(next_seg))
+
+            return [
+                LintResult(
+                    anchor=context.segment,
+                    description="Empty batch with only / statement should be removed.",
+                    fixes=fixes,
+                )
+            ]
+
+        return None

--- a/src/sqlfluff/rules/oracle/__init__.py
+++ b/src/sqlfluff/rules/oracle/__init__.py
@@ -1,0 +1,16 @@
+"""The oracle rules plugin bundle."""
+
+from sqlfluff.core.plugin import hookimpl
+from sqlfluff.core.rules import BaseRule
+
+
+@hookimpl
+def get_rules() -> list[type[BaseRule]]:
+    """Get plugin rules.
+
+    NOTE: Rules are imported only on fetch to manage import times
+    when rules aren't used.
+    """
+    from sqlfluff.rules.oracle.OR01 import Rule_OR01
+
+    return [Rule_OR01]

--- a/test/fixtures/dialects/oracle/alter_database_link.yml
+++ b/test/fixtures/dialects/oracle/alter_database_link.yml
@@ -3,76 +3,77 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 816c3def67ca43619b23914d7e07bc53fe94f8c1c82827c2285c08c18ceaa89a
+_hash: 5cd07da28bd351dd1159e00ff893cdfb9d2f51f5128fefc8af15d9e54e345716
 file:
-- statement:
-    alter_database_link_statement:
-    - keyword: ALTER
-    - keyword: DATABASE
-    - keyword: LINK
-    - database_link_reference:
-        naked_identifier: private_link
-    - keyword: CONNECT
-    - keyword: TO
-    - role_reference:
-        naked_identifier: hr
-    - keyword: IDENTIFIED
-    - keyword: BY
-    - naked_identifier: hr_new_password
-- statement_terminator: ;
-- statement:
-    alter_database_link_statement:
-    - keyword: ALTER
-    - keyword: PUBLIC
-    - keyword: DATABASE
-    - keyword: LINK
-    - database_link_reference:
-        naked_identifier: public_link
-    - keyword: CONNECT
-    - keyword: TO
-    - role_reference:
-        naked_identifier: scott
-    - keyword: IDENTIFIED
-    - keyword: BY
-    - naked_identifier: scott_new_password
-- statement_terminator: ;
-- statement:
-    alter_database_link_statement:
-    - keyword: ALTER
-    - keyword: SHARED
-    - keyword: PUBLIC
-    - keyword: DATABASE
-    - keyword: LINK
-    - database_link_reference:
-        naked_identifier: shared_pub_link
-    - keyword: CONNECT
-    - keyword: TO
-    - role_reference:
-        naked_identifier: scott
-    - keyword: IDENTIFIED
-    - keyword: BY
-    - naked_identifier: scott_new_password
-    - keyword: AUTHENTICATED
-    - keyword: BY
-    - role_reference:
-        naked_identifier: hr
-    - keyword: IDENTIFIED
-    - keyword: BY
-    - naked_identifier: hr_new_password
-- statement_terminator: ;
-- statement:
-    alter_database_link_statement:
-    - keyword: ALTER
-    - keyword: SHARED
-    - keyword: DATABASE
-    - keyword: LINK
-    - database_link_reference:
-        naked_identifier: shared_pub_link
-    - keyword: CONNECT
-    - keyword: TO
-    - role_reference:
-        naked_identifier: scott
-    - keyword: IDENTIFIED
-    - keyword: BY
-    - naked_identifier: scott_new_password
-- statement_terminator: ;
+  batch:
+  - statement:
+      alter_database_link_statement:
+      - keyword: ALTER
+      - keyword: DATABASE
+      - keyword: LINK
+      - database_link_reference:
+          naked_identifier: private_link
+      - keyword: CONNECT
+      - keyword: TO
+      - role_reference:
+          naked_identifier: hr
+      - keyword: IDENTIFIED
+      - keyword: BY
+      - naked_identifier: hr_new_password
+  - statement_terminator: ;
+  - statement:
+      alter_database_link_statement:
+      - keyword: ALTER
+      - keyword: PUBLIC
+      - keyword: DATABASE
+      - keyword: LINK
+      - database_link_reference:
+          naked_identifier: public_link
+      - keyword: CONNECT
+      - keyword: TO
+      - role_reference:
+          naked_identifier: scott
+      - keyword: IDENTIFIED
+      - keyword: BY
+      - naked_identifier: scott_new_password
+  - statement_terminator: ;
+  - statement:
+      alter_database_link_statement:
+      - keyword: ALTER
+      - keyword: SHARED
+      - keyword: PUBLIC
+      - keyword: DATABASE
+      - keyword: LINK
+      - database_link_reference:
+          naked_identifier: shared_pub_link
+      - keyword: CONNECT
+      - keyword: TO
+      - role_reference:
+          naked_identifier: scott
+      - keyword: IDENTIFIED
+      - keyword: BY
+      - naked_identifier: scott_new_password
+      - keyword: AUTHENTICATED
+      - keyword: BY
+      - role_reference:
+          naked_identifier: hr
+      - keyword: IDENTIFIED
+      - keyword: BY
+      - naked_identifier: hr_new_password
+  - statement_terminator: ;
+  - statement:
+      alter_database_link_statement:
+      - keyword: ALTER
+      - keyword: SHARED
+      - keyword: DATABASE
+      - keyword: LINK
+      - database_link_reference:
+          naked_identifier: shared_pub_link
+      - keyword: CONNECT
+      - keyword: TO
+      - role_reference:
+          naked_identifier: scott
+      - keyword: IDENTIFIED
+      - keyword: BY
+      - naked_identifier: scott_new_password
+  - statement_terminator: ;

--- a/test/fixtures/dialects/oracle/alter_function.yml
+++ b/test/fixtures/dialects/oracle/alter_function.yml
@@ -3,27 +3,28 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 35d74f03abcec25009bdcbeddff50fa383676308f2d496ad49df2e789c456b4b
+_hash: 7446ec88767508d0c5e89f796950ee6be99e889b48ffb77661202445e33cd754
 file:
-- statement:
-    alter_function_statement:
-    - keyword: ALTER
-    - keyword: FUNCTION
-    - function_name:
-        naked_identifier: oe
-        dot: .
-        function_name_identifier: get_bal
-    - keyword: COMPILE
-- statement_terminator: ;
-- statement:
-    alter_function_statement:
-    - keyword: ALTER
-    - keyword: PROCEDURE
-    - keyword: IF
-    - keyword: EXISTS
-    - function_name:
-        naked_identifier: hr
-        dot: .
-        function_name_identifier: remove_emp
-    - keyword: COMPILE
-- statement_terminator: ;
+  batch:
+  - statement:
+      alter_function_statement:
+      - keyword: ALTER
+      - keyword: FUNCTION
+      - function_name:
+          naked_identifier: oe
+          dot: .
+          function_name_identifier: get_bal
+      - keyword: COMPILE
+  - statement_terminator: ;
+  - statement:
+      alter_function_statement:
+      - keyword: ALTER
+      - keyword: PROCEDURE
+      - keyword: IF
+      - keyword: EXISTS
+      - function_name:
+          naked_identifier: hr
+          dot: .
+          function_name_identifier: remove_emp
+      - keyword: COMPILE
+  - statement_terminator: ;

--- a/test/fixtures/dialects/oracle/alter_index.yml
+++ b/test/fixtures/dialects/oracle/alter_index.yml
@@ -3,168 +3,169 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: e0823860f2d0f1ec5f74c5a9a1411ddc619b669824b86a6602ced70423211ac7
+_hash: 4c2a20bca8012028d742a9fed3a1d2bbd38e8647e4434e6862426bc9599b2e05
 file:
-- statement:
-    alter_index_statement:
-    - keyword: ALTER
-    - keyword: INDEX
-    - index_reference:
-      - naked_identifier: some
-      - dot: .
-      - naked_identifier: idx_name
-    - keyword: REBUILD
-- statement_terminator: ;
-- statement:
-    alter_index_statement:
-    - keyword: ALTER
-    - keyword: INDEX
-    - index_reference:
-      - naked_identifier: some
-      - dot: .
-      - naked_identifier: idx_name
-    - keyword: REBUILD
-    - keyword: REVERSE
-- statement_terminator: ;
-- statement:
-    alter_index_statement:
-    - keyword: ALTER
-    - keyword: INDEX
-    - index_reference:
-      - naked_identifier: some
-      - dot: .
-      - naked_identifier: idx_name
-    - keyword: REBUILD
-    - keyword: NOREVERSE
-- statement_terminator: ;
-- statement:
-    alter_index_statement:
-    - keyword: ALTER
-    - keyword: INDEX
-    - index_reference:
-      - naked_identifier: some
-      - dot: .
-      - naked_identifier: idx_name
-    - keyword: PARAMETERS
-    - bracketed:
-        start_bracket: (
-        quoted_literal: "'ODCI_OPTIMIZE=ALL'"
-        end_bracket: )
-- statement_terminator: ;
-- statement:
-    alter_index_statement:
-    - keyword: ALTER
-    - keyword: INDEX
-    - index_reference:
-      - naked_identifier: some
-      - dot: .
-      - naked_identifier: idx_name
-    - keyword: COMPILE
-- statement_terminator: ;
-- statement:
-    alter_index_statement:
-    - keyword: ALTER
-    - keyword: INDEX
-    - index_reference:
-      - naked_identifier: some
-      - dot: .
-      - naked_identifier: idx_name
-    - keyword: LOGGING
-- statement_terminator: ;
-- statement:
-    alter_index_statement:
-    - keyword: ALTER
-    - keyword: INDEX
-    - index_reference:
-      - naked_identifier: some
-      - dot: .
-      - naked_identifier: idx_name
-    - keyword: NOLOGGING
-- statement_terminator: ;
-- statement:
-    alter_index_statement:
-    - keyword: ALTER
-    - keyword: INDEX
-    - index_reference:
-      - naked_identifier: some
-      - dot: .
-      - naked_identifier: idx_name
-    - keyword: ENABLE
-- statement_terminator: ;
-- statement:
-    alter_index_statement:
-    - keyword: ALTER
-    - keyword: INDEX
-    - index_reference:
-      - naked_identifier: some
-      - dot: .
-      - naked_identifier: idx_name
-    - keyword: DISABLE
-- statement_terminator: ;
-- statement:
-    alter_index_statement:
-    - keyword: ALTER
-    - keyword: INDEX
-    - index_reference:
-      - naked_identifier: some
-      - dot: .
-      - naked_identifier: idx_name
-    - keyword: UNUSABLE
-- statement_terminator: ;
-- statement:
-    alter_index_statement:
-    - keyword: ALTER
-    - keyword: INDEX
-    - index_reference:
-      - naked_identifier: some
-      - dot: .
-      - naked_identifier: idx_name
-    - keyword: INVISIBLE
-- statement_terminator: ;
-- statement:
-    alter_index_statement:
-    - keyword: ALTER
-    - keyword: INDEX
-    - index_reference:
-      - naked_identifier: some
-      - dot: .
-      - naked_identifier: idx_name
-    - keyword: VISIBLE
-- statement_terminator: ;
-- statement:
-    alter_index_statement:
-    - keyword: ALTER
-    - keyword: INDEX
-    - index_reference:
-      - naked_identifier: some
-      - dot: .
-      - naked_identifier: idx_name
-    - keyword: RENAME
-    - keyword: TO
-    - index_reference:
-      - naked_identifier: some
-      - dot: .
-      - naked_identifier: new_idx_name
-- statement_terminator: ;
-- statement:
-    alter_index_statement:
-    - keyword: ALTER
-    - keyword: INDEX
-    - index_reference:
-      - naked_identifier: some
-      - dot: .
-      - naked_identifier: idx_name
-    - keyword: MONITORING
-    - keyword: USAGE
-- statement_terminator: ;
-- statement:
-    alter_index_statement:
-    - keyword: ALTER
-    - keyword: INDEX
-    - index_reference:
-      - naked_identifier: some
-      - dot: .
-      - naked_identifier: idx_name
-    - keyword: NOMONITORING
-    - keyword: USAGE
-- statement_terminator: ;
+  batch:
+  - statement:
+      alter_index_statement:
+      - keyword: ALTER
+      - keyword: INDEX
+      - index_reference:
+        - naked_identifier: some
+        - dot: .
+        - naked_identifier: idx_name
+      - keyword: REBUILD
+  - statement_terminator: ;
+  - statement:
+      alter_index_statement:
+      - keyword: ALTER
+      - keyword: INDEX
+      - index_reference:
+        - naked_identifier: some
+        - dot: .
+        - naked_identifier: idx_name
+      - keyword: REBUILD
+      - keyword: REVERSE
+  - statement_terminator: ;
+  - statement:
+      alter_index_statement:
+      - keyword: ALTER
+      - keyword: INDEX
+      - index_reference:
+        - naked_identifier: some
+        - dot: .
+        - naked_identifier: idx_name
+      - keyword: REBUILD
+      - keyword: NOREVERSE
+  - statement_terminator: ;
+  - statement:
+      alter_index_statement:
+      - keyword: ALTER
+      - keyword: INDEX
+      - index_reference:
+        - naked_identifier: some
+        - dot: .
+        - naked_identifier: idx_name
+      - keyword: PARAMETERS
+      - bracketed:
+          start_bracket: (
+          quoted_literal: "'ODCI_OPTIMIZE=ALL'"
+          end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      alter_index_statement:
+      - keyword: ALTER
+      - keyword: INDEX
+      - index_reference:
+        - naked_identifier: some
+        - dot: .
+        - naked_identifier: idx_name
+      - keyword: COMPILE
+  - statement_terminator: ;
+  - statement:
+      alter_index_statement:
+      - keyword: ALTER
+      - keyword: INDEX
+      - index_reference:
+        - naked_identifier: some
+        - dot: .
+        - naked_identifier: idx_name
+      - keyword: LOGGING
+  - statement_terminator: ;
+  - statement:
+      alter_index_statement:
+      - keyword: ALTER
+      - keyword: INDEX
+      - index_reference:
+        - naked_identifier: some
+        - dot: .
+        - naked_identifier: idx_name
+      - keyword: NOLOGGING
+  - statement_terminator: ;
+  - statement:
+      alter_index_statement:
+      - keyword: ALTER
+      - keyword: INDEX
+      - index_reference:
+        - naked_identifier: some
+        - dot: .
+        - naked_identifier: idx_name
+      - keyword: ENABLE
+  - statement_terminator: ;
+  - statement:
+      alter_index_statement:
+      - keyword: ALTER
+      - keyword: INDEX
+      - index_reference:
+        - naked_identifier: some
+        - dot: .
+        - naked_identifier: idx_name
+      - keyword: DISABLE
+  - statement_terminator: ;
+  - statement:
+      alter_index_statement:
+      - keyword: ALTER
+      - keyword: INDEX
+      - index_reference:
+        - naked_identifier: some
+        - dot: .
+        - naked_identifier: idx_name
+      - keyword: UNUSABLE
+  - statement_terminator: ;
+  - statement:
+      alter_index_statement:
+      - keyword: ALTER
+      - keyword: INDEX
+      - index_reference:
+        - naked_identifier: some
+        - dot: .
+        - naked_identifier: idx_name
+      - keyword: INVISIBLE
+  - statement_terminator: ;
+  - statement:
+      alter_index_statement:
+      - keyword: ALTER
+      - keyword: INDEX
+      - index_reference:
+        - naked_identifier: some
+        - dot: .
+        - naked_identifier: idx_name
+      - keyword: VISIBLE
+  - statement_terminator: ;
+  - statement:
+      alter_index_statement:
+      - keyword: ALTER
+      - keyword: INDEX
+      - index_reference:
+        - naked_identifier: some
+        - dot: .
+        - naked_identifier: idx_name
+      - keyword: RENAME
+      - keyword: TO
+      - index_reference:
+        - naked_identifier: some
+        - dot: .
+        - naked_identifier: new_idx_name
+  - statement_terminator: ;
+  - statement:
+      alter_index_statement:
+      - keyword: ALTER
+      - keyword: INDEX
+      - index_reference:
+        - naked_identifier: some
+        - dot: .
+        - naked_identifier: idx_name
+      - keyword: MONITORING
+      - keyword: USAGE
+  - statement_terminator: ;
+  - statement:
+      alter_index_statement:
+      - keyword: ALTER
+      - keyword: INDEX
+      - index_reference:
+        - naked_identifier: some
+        - dot: .
+        - naked_identifier: idx_name
+      - keyword: NOMONITORING
+      - keyword: USAGE
+  - statement_terminator: ;

--- a/test/fixtures/dialects/oracle/alter_package.yml
+++ b/test/fixtures/dialects/oracle/alter_package.yml
@@ -3,25 +3,26 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 7b93f12aba96dc9e5ca0ee6f9da3100f3a126e4ae0f7e88d8e3d8d7fb410483a
+_hash: 3190468439c9116e752e28d0ad00e2b90d4b6d62eb464e8a9f38a73dc80aee87
 file:
-- statement:
-    alter_package_statement:
-    - keyword: ALTER
-    - keyword: PACKAGE
-    - package_reference:
-        naked_identifier: emp_mgmt
-    - keyword: COMPILE
-    - keyword: PACKAGE
-- statement_terminator: ;
-- statement:
-    alter_package_statement:
-    - keyword: ALTER
-    - keyword: PACKAGE
-    - package_reference:
-      - naked_identifier: hr
-      - dot: .
-      - naked_identifier: emp_mgmt
-    - keyword: COMPILE
-    - keyword: BODY
-- statement_terminator: ;
+  batch:
+  - statement:
+      alter_package_statement:
+      - keyword: ALTER
+      - keyword: PACKAGE
+      - package_reference:
+          naked_identifier: emp_mgmt
+      - keyword: COMPILE
+      - keyword: PACKAGE
+  - statement_terminator: ;
+  - statement:
+      alter_package_statement:
+      - keyword: ALTER
+      - keyword: PACKAGE
+      - package_reference:
+        - naked_identifier: hr
+        - dot: .
+        - naked_identifier: emp_mgmt
+      - keyword: COMPILE
+      - keyword: BODY
+  - statement_terminator: ;

--- a/test/fixtures/dialects/oracle/alter_synonym.yml
+++ b/test/fixtures/dialects/oracle/alter_synonym.yml
@@ -3,30 +3,31 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 405576ba8846593acb664fd4bc75aee02b4ea60ad31bd9b57ab802c52f093556
+_hash: 3f00f578686d4d42530b327ea637a416fc61f7518234344efe94f07720f36f3b
 file:
-- statement:
-    alter_synonym_statement:
-    - keyword: ALTER
-    - keyword: SYNONYM
-    - object_reference:
-        naked_identifier: offices
-    - keyword: COMPILE
-- statement_terminator: ;
-- statement:
-    alter_synonym_statement:
-    - keyword: ALTER
-    - keyword: PUBLIC
-    - keyword: SYNONYM
-    - object_reference:
-        naked_identifier: emp_table
-    - keyword: COMPILE
-- statement_terminator: ;
-- statement:
-    alter_synonym_statement:
-    - keyword: ALTER
-    - keyword: SYNONYM
-    - object_reference:
-        naked_identifier: offices
-    - keyword: NONEDITIONABLE
-- statement_terminator: ;
+  batch:
+  - statement:
+      alter_synonym_statement:
+      - keyword: ALTER
+      - keyword: SYNONYM
+      - object_reference:
+          naked_identifier: offices
+      - keyword: COMPILE
+  - statement_terminator: ;
+  - statement:
+      alter_synonym_statement:
+      - keyword: ALTER
+      - keyword: PUBLIC
+      - keyword: SYNONYM
+      - object_reference:
+          naked_identifier: emp_table
+      - keyword: COMPILE
+  - statement_terminator: ;
+  - statement:
+      alter_synonym_statement:
+      - keyword: ALTER
+      - keyword: SYNONYM
+      - object_reference:
+          naked_identifier: offices
+      - keyword: NONEDITIONABLE
+  - statement_terminator: ;

--- a/test/fixtures/dialects/oracle/alter_table.yml
+++ b/test/fixtures/dialects/oracle/alter_table.yml
@@ -3,33 +3,53 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 5c301b233899fc491f600b1719b16ff28fc4c304f2fec5c16ef2c9e4d0225741
+_hash: fc66dcd892c616fe6d48a210ed8fb2b87c96c76ba40b6aeacdd74de1ba46f314
 file:
-- statement:
-    alter_table_statement:
-    - keyword: ALTER
-    - keyword: TABLE
-    - table_reference:
-        naked_identifier: table_name
-    - alter_table_column_clauses:
-      - keyword: RENAME
-      - keyword: COLUMN
-      - column_reference:
-          naked_identifier: old_column_name
-      - keyword: TO
-      - column_reference:
-          naked_identifier: new_column_name
-- statement_terminator: ;
-- statement:
-    alter_table_statement:
-    - keyword: ALTER
-    - keyword: TABLE
-    - table_reference:
-        naked_identifier: table_name
-    - alter_table_column_clauses:
-        keyword: ADD
-        bracketed:
-          start_bracket: (
+  batch:
+  - statement:
+      alter_table_statement:
+      - keyword: ALTER
+      - keyword: TABLE
+      - table_reference:
+          naked_identifier: table_name
+      - alter_table_column_clauses:
+        - keyword: RENAME
+        - keyword: COLUMN
+        - column_reference:
+            naked_identifier: old_column_name
+        - keyword: TO
+        - column_reference:
+            naked_identifier: new_column_name
+  - statement_terminator: ;
+  - statement:
+      alter_table_statement:
+      - keyword: ALTER
+      - keyword: TABLE
+      - table_reference:
+          naked_identifier: table_name
+      - alter_table_column_clauses:
+          keyword: ADD
+          bracketed:
+            start_bracket: (
+            column_definition:
+              naked_identifier: column_name
+              data_type:
+                data_type_identifier: NUMBER
+                bracketed_arguments:
+                  bracketed:
+                    start_bracket: (
+                    numeric_literal: '18'
+                    end_bracket: )
+            end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      alter_table_statement:
+      - keyword: ALTER
+      - keyword: TABLE
+      - table_reference:
+          naked_identifier: table_name
+      - alter_table_column_clauses:
+          keyword: MODIFY
           column_definition:
             naked_identifier: column_name
             data_type:
@@ -39,186 +59,167 @@ file:
                   start_bracket: (
                   numeric_literal: '18'
                   end_bracket: )
-          end_bracket: )
-- statement_terminator: ;
-- statement:
-    alter_table_statement:
-    - keyword: ALTER
-    - keyword: TABLE
-    - table_reference:
-        naked_identifier: table_name
-    - alter_table_column_clauses:
-        keyword: MODIFY
-        column_definition:
-          naked_identifier: column_name
-          data_type:
-            data_type_identifier: NUMBER
-            bracketed_arguments:
-              bracketed:
-                start_bracket: (
-                numeric_literal: '18'
-                end_bracket: )
-- statement_terminator: ;
-- statement:
-    alter_table_statement:
-    - keyword: ALTER
-    - keyword: TABLE
-    - table_reference:
-        naked_identifier: table_name
-    - alter_table_column_clauses:
-      - keyword: DROP
-      - keyword: COLUMN
-      - column_reference:
-          naked_identifier: column_name
-- statement_terminator: ;
-- statement:
-    alter_table_statement:
-    - keyword: ALTER
-    - keyword: TABLE
-    - table_reference:
-        naked_identifier: table_name
-    - alter_table_column_clauses:
-        keyword: DROP
-        bracketed:
-        - start_bracket: (
+  - statement_terminator: ;
+  - statement:
+      alter_table_statement:
+      - keyword: ALTER
+      - keyword: TABLE
+      - table_reference:
+          naked_identifier: table_name
+      - alter_table_column_clauses:
+        - keyword: DROP
+        - keyword: COLUMN
         - column_reference:
-            naked_identifier: column_name_one
-        - comma: ','
-        - column_reference:
-            naked_identifier: column_name_two
-        - end_bracket: )
-- statement_terminator: ;
-- statement:
-    alter_table_statement:
-    - keyword: ALTER
-    - keyword: TABLE
-    - table_reference:
-        naked_identifier: table_name
-    - alter_table_constraint_clauses:
-        keyword: ADD
-        table_constraint:
+            naked_identifier: column_name
+  - statement_terminator: ;
+  - statement:
+      alter_table_statement:
+      - keyword: ALTER
+      - keyword: TABLE
+      - table_reference:
+          naked_identifier: table_name
+      - alter_table_column_clauses:
+          keyword: DROP
+          bracketed:
+          - start_bracket: (
+          - column_reference:
+              naked_identifier: column_name_one
+          - comma: ','
+          - column_reference:
+              naked_identifier: column_name_two
+          - end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      alter_table_statement:
+      - keyword: ALTER
+      - keyword: TABLE
+      - table_reference:
+          naked_identifier: table_name
+      - alter_table_constraint_clauses:
+          keyword: ADD
+          table_constraint:
+          - keyword: CONSTRAINT
+          - object_reference:
+              naked_identifier: constraint_name
+          - keyword: FOREIGN
+          - keyword: KEY
+          - bracketed:
+              start_bracket: (
+              column_reference:
+                naked_identifier: column_name
+              end_bracket: )
+          - keyword: REFERENCES
+          - table_reference:
+              naked_identifier: other_table_name
+          - bracketed:
+              start_bracket: (
+              column_reference:
+                naked_identifier: other_column_name
+              end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      alter_table_statement:
+      - keyword: ALTER
+      - keyword: TABLE
+      - table_reference:
+          naked_identifier: table_name
+      - alter_table_constraint_clauses:
+        - keyword: RENAME
+        - keyword: CONSTRAINT
+        - object_reference:
+            naked_identifier: source_constraint_name
+        - keyword: TO
+        - object_reference:
+            naked_identifier: target_constraint_name
+  - statement_terminator: ;
+  - statement:
+      alter_table_statement:
+      - keyword: ALTER
+      - keyword: TABLE
+      - table_reference:
+          naked_identifier: table_name
+      - alter_table_constraint_clauses:
+        - keyword: DROP
         - keyword: CONSTRAINT
         - object_reference:
             naked_identifier: constraint_name
-        - keyword: FOREIGN
-        - keyword: KEY
-        - bracketed:
+  - statement_terminator: ;
+  - statement:
+      alter_table_statement:
+      - keyword: ALTER
+      - keyword: TABLE
+      - table_reference:
+          naked_identifier: table_name
+      - alter_table_column_clauses:
+          keyword: MODIFY
+          bracketed:
             start_bracket: (
-            column_reference:
+            column_definition:
               naked_identifier: column_name
+              column_constraint_segment:
+              - keyword: NOT
+              - keyword: 'NULL'
+              keyword: ENABLE
             end_bracket: )
-        - keyword: REFERENCES
-        - table_reference:
-            naked_identifier: other_table_name
-        - bracketed:
+  - statement_terminator: ;
+  - statement:
+      alter_table_statement:
+      - keyword: ALTER
+      - keyword: TABLE
+      - table_reference:
+          naked_identifier: table_name
+      - alter_table_column_clauses:
+          keyword: MODIFY
+          bracketed:
             start_bracket: (
-            column_reference:
-              naked_identifier: other_column_name
+            column_definition:
+              naked_identifier: column_name
+              column_constraint_segment:
+                keyword: DEFAULT
+                numeric_literal: '10'
             end_bracket: )
-- statement_terminator: ;
-- statement:
-    alter_table_statement:
-    - keyword: ALTER
-    - keyword: TABLE
-    - table_reference:
-        naked_identifier: table_name
-    - alter_table_constraint_clauses:
-      - keyword: RENAME
-      - keyword: CONSTRAINT
-      - object_reference:
-          naked_identifier: source_constraint_name
-      - keyword: TO
-      - object_reference:
-          naked_identifier: target_constraint_name
-- statement_terminator: ;
-- statement:
-    alter_table_statement:
-    - keyword: ALTER
-    - keyword: TABLE
-    - table_reference:
-        naked_identifier: table_name
-    - alter_table_constraint_clauses:
-      - keyword: DROP
-      - keyword: CONSTRAINT
-      - object_reference:
-          naked_identifier: constraint_name
-- statement_terminator: ;
-- statement:
-    alter_table_statement:
-    - keyword: ALTER
-    - keyword: TABLE
-    - table_reference:
-        naked_identifier: table_name
-    - alter_table_column_clauses:
-        keyword: MODIFY
-        bracketed:
-          start_bracket: (
-          column_definition:
-            naked_identifier: column_name
-            column_constraint_segment:
-            - keyword: NOT
-            - keyword: 'NULL'
-            keyword: ENABLE
-          end_bracket: )
-- statement_terminator: ;
-- statement:
-    alter_table_statement:
-    - keyword: ALTER
-    - keyword: TABLE
-    - table_reference:
-        naked_identifier: table_name
-    - alter_table_column_clauses:
-        keyword: MODIFY
-        bracketed:
-          start_bracket: (
-          column_definition:
-            naked_identifier: column_name
-            column_constraint_segment:
-              keyword: DEFAULT
-              numeric_literal: '10'
-          end_bracket: )
-- statement_terminator: ;
-- statement:
-    alter_table_statement:
-    - keyword: ALTER
-    - keyword: TABLE
-    - table_reference:
-        naked_identifier: table_name
-    - alter_table_column_clauses:
-        keyword: MODIFY
-        bracketed:
-          start_bracket: (
-          column_definition:
-          - naked_identifier: column_name
-          - column_constraint_segment:
-              keyword: DEFAULT
-              numeric_literal: '10'
-          - column_constraint_segment:
-            - keyword: NOT
-            - keyword: 'NULL'
-          - keyword: ENABLE
-          end_bracket: )
-- statement_terminator: ;
-- statement:
-    alter_table_statement:
-    - keyword: ALTER
-    - keyword: TABLE
-    - table_reference:
-        naked_identifier: employees
-    - alter_table_constraint_clauses:
-        keyword: ADD
-        table_constraint:
-        - keyword: CONSTRAINT
-        - object_reference:
-            naked_identifier: salary_check
-        - keyword: CHECK
-        - bracketed:
+  - statement_terminator: ;
+  - statement:
+      alter_table_statement:
+      - keyword: ALTER
+      - keyword: TABLE
+      - table_reference:
+          naked_identifier: table_name
+      - alter_table_column_clauses:
+          keyword: MODIFY
+          bracketed:
             start_bracket: (
-            expression:
-              column_reference:
-                naked_identifier: salary
-              comparison_operator:
-                raw_comparison_operator: '>'
-              numeric_literal: '0'
+            column_definition:
+            - naked_identifier: column_name
+            - column_constraint_segment:
+                keyword: DEFAULT
+                numeric_literal: '10'
+            - column_constraint_segment:
+              - keyword: NOT
+              - keyword: 'NULL'
+            - keyword: ENABLE
             end_bracket: )
-- statement_terminator: ;
+  - statement_terminator: ;
+  - statement:
+      alter_table_statement:
+      - keyword: ALTER
+      - keyword: TABLE
+      - table_reference:
+          naked_identifier: employees
+      - alter_table_constraint_clauses:
+          keyword: ADD
+          table_constraint:
+          - keyword: CONSTRAINT
+          - object_reference:
+              naked_identifier: salary_check
+          - keyword: CHECK
+          - bracketed:
+              start_bracket: (
+              expression:
+                column_reference:
+                  naked_identifier: salary
+                comparison_operator:
+                  raw_comparison_operator: '>'
+                numeric_literal: '0'
+              end_bracket: )
+  - statement_terminator: ;

--- a/test/fixtures/dialects/oracle/alter_trigger.yml
+++ b/test/fixtures/dialects/oracle/alter_trigger.yml
@@ -3,21 +3,22 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: addf6d049dbc44b7783a567ed0e5debfff0bd5d500946a152fc8d4f331dad0b5
+_hash: 7447b138d5947f6bf22bf6d63b10b7f4b208fbb31c047b8407317731e1998116
 file:
-- statement:
-    alter_trigger_statement:
-    - keyword: ALTER
-    - keyword: TRIGGER
-    - function_name:
-        function_name_identifier: update_job_history
-    - keyword: DISABLE
-- statement_terminator: ;
-- statement:
-    alter_trigger_statement:
-    - keyword: ALTER
-    - keyword: TRIGGER
-    - function_name:
-        function_name_identifier: update_job_history
-    - keyword: ENABLE
-- statement_terminator: ;
+  batch:
+  - statement:
+      alter_trigger_statement:
+      - keyword: ALTER
+      - keyword: TRIGGER
+      - function_name:
+          function_name_identifier: update_job_history
+      - keyword: DISABLE
+  - statement_terminator: ;
+  - statement:
+      alter_trigger_statement:
+      - keyword: ALTER
+      - keyword: TRIGGER
+      - function_name:
+          function_name_identifier: update_job_history
+      - keyword: ENABLE
+  - statement_terminator: ;

--- a/test/fixtures/dialects/oracle/assignment.yml
+++ b/test/fixtures/dialects/oracle/assignment.yml
@@ -3,488 +3,496 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 18f2bea7d542d49dde95156ebde94bb25d6be17107a3762ae3f1f0e221df718c
+_hash: bfbf650d3b90eadefaad14e52bb3e4016107c0ab9ee240647a97f007d6f23706
 file:
-- statement:
-    begin_end_block:
-    - declare_segment:
-      - keyword: DECLARE
-      - naked_identifier: wages
-      - data_type:
-          data_type_identifier: NUMBER
-      - statement_terminator: ;
-      - naked_identifier: hours_worked
-      - data_type:
-          data_type_identifier: NUMBER
-      - assignment_operator: :=
-      - expression:
-          numeric_literal: '40'
-      - statement_terminator: ;
-      - naked_identifier: hourly_salary
-      - data_type:
-          data_type_identifier: NUMBER
-      - assignment_operator: :=
-      - expression:
-          numeric_literal: '22.50'
-      - statement_terminator: ;
-      - naked_identifier: bonus
-      - data_type:
-          data_type_identifier: NUMBER
-      - assignment_operator: :=
-      - expression:
-          numeric_literal: '150'
-      - statement_terminator: ;
-      - naked_identifier: country
-      - data_type:
-          data_type_identifier: VARCHAR2
-          bracketed_arguments:
-            bracketed:
-              start_bracket: (
-              numeric_literal: '128'
-              end_bracket: )
-      - statement_terminator: ;
-      - naked_identifier: counter
-      - data_type:
-          data_type_identifier: NUMBER
-      - assignment_operator: :=
-      - expression:
-          numeric_literal: '0'
-      - statement_terminator: ;
-      - naked_identifier: done
-      - data_type:
-          data_type_identifier: BOOLEAN
-      - statement_terminator: ;
-      - naked_identifier: valid_id
-      - data_type:
-          data_type_identifier: BOOLEAN
-      - statement_terminator: ;
-      - naked_identifier: emp_rec1
-      - row_type_reference:
-          table_reference:
-            naked_identifier: employees
-          binary_operator: '%'
-          keyword: ROWTYPE
-      - statement_terminator: ;
-      - naked_identifier: emp_rec2
-      - row_type_reference:
-          table_reference:
-            naked_identifier: employees
-          binary_operator: '%'
-          keyword: ROWTYPE
-      - statement_terminator: ;
-      - collection_type:
-        - keyword: TYPE
-        - naked_identifier: commissions
-        - keyword: IS
-        - keyword: TABLE
-        - keyword: OF
+- batch:
+    statement:
+      begin_end_block:
+      - declare_segment:
+        - keyword: DECLARE
+        - naked_identifier: wages
         - data_type:
             data_type_identifier: NUMBER
-        - keyword: INDEX
-        - keyword: BY
-        - data_type:
-            data_type_identifier: PLS_INTEGER
-      - statement_terminator: ;
-      - naked_identifier: comm_tab
-      - data_type:
-          data_type_identifier: commissions
-      - statement_terminator: ;
-      - naked_identifier: current_date
-      - data_type:
-          data_type_identifier: DATE
-      - assignment_operator: :=
-      - expression:
-          bare_function: SYSDATE
-      - statement_terminator: ;
-    - keyword: BEGIN
-    - statement:
-        assignment_segment_statement:
-          object_reference:
-            naked_identifier: wages
-          assignment_operator: :=
-          expression:
-            bracketed:
-              start_bracket: (
-              expression:
-              - column_reference:
-                  naked_identifier: hours_worked
-              - binary_operator: '*'
-              - column_reference:
-                  naked_identifier: hourly_salary
-              end_bracket: )
-            binary_operator: +
-            column_reference:
-              naked_identifier: bonus
-    - statement_terminator: ;
-    - statement:
-        assignment_segment_statement:
-          object_reference:
-            naked_identifier: country
-          assignment_operator: :=
-          expression:
-            quoted_literal: "'France'"
-    - statement_terminator: ;
-    - statement:
-        assignment_segment_statement:
-          object_reference:
-            naked_identifier: country
-          assignment_operator: :=
-          expression:
-            function:
-              function_name:
-                function_name_identifier: UPPER
-              function_contents:
-                bracketed:
-                  start_bracket: (
-                  expression:
-                    quoted_literal: "'Canada'"
-                  end_bracket: )
-    - statement_terminator: ;
-    - statement:
-        assignment_segment_statement:
-          object_reference:
-            naked_identifier: done
-          assignment_operator: :=
-          expression:
-            bracketed:
-              start_bracket: (
-              expression:
-                column_reference:
-                  naked_identifier: counter
-                comparison_operator:
-                  raw_comparison_operator: '>'
-                numeric_literal: '100'
-              end_bracket: )
-    - statement_terminator: ;
-    - statement:
-        assignment_segment_statement:
-          object_reference:
-            naked_identifier: valid_id
-          assignment_operator: :=
-          expression:
-            boolean_literal: 'TRUE'
-    - statement_terminator: ;
-    - statement:
-        assignment_segment_statement:
-          object_reference:
-          - naked_identifier: emp_rec1
-          - dot: .
-          - naked_identifier: first_name
-          assignment_operator: :=
-          expression:
-            quoted_literal: "'Antonio'"
-    - statement_terminator: ;
-    - statement:
-        assignment_segment_statement:
-          object_reference:
-          - naked_identifier: emp_rec1
-          - dot: .
-          - naked_identifier: last_name
-          assignment_operator: :=
-          expression:
-            quoted_literal: "'Ortiz'"
-    - statement_terminator: ;
-    - statement:
-        assignment_segment_statement:
-          object_reference:
-            naked_identifier: emp_rec1
-          assignment_operator: :=
-          expression:
-            column_reference:
-              naked_identifier: emp_rec2
-    - statement_terminator: ;
-    - statement:
-        assignment_segment_statement:
-          object_reference:
-            naked_identifier: comm_tab
-          bracketed:
-            start_bracket: (
-            numeric_literal: '5'
-            end_bracket: )
-          assignment_operator: :=
-          expression:
-          - numeric_literal: '20000'
-          - binary_operator: '*'
-          - numeric_literal: '0.15'
-    - statement_terminator: ;
-    - statement:
-        if_then_statement:
-        - if_clause:
-          - keyword: IF
-          - expression:
-              column_reference:
-                naked_identifier: counter
-              comparison_operator:
-                raw_comparison_operator: '>'
-              numeric_literal: '5'
-          - keyword: THEN
-        - statement:
-            assignment_segment_statement:
-              object_reference:
-                naked_identifier: wages
-              assignment_operator: :=
-              expression:
-                column_reference:
-                  naked_identifier: wages
-                binary_operator: '*'
-                numeric_literal: '1.10'
         - statement_terminator: ;
-        - keyword: END
-        - keyword: IF
-    - statement_terminator: ;
-    - statement:
-        assignment_segment_statement:
-          object_reference:
-            naked_identifier: bonus
-          assignment_operator: :=
-          expression:
-            case_expression:
-            - keyword: CASE
-            - when_clause:
-              - keyword: WHEN
-              - expression:
-                  column_reference:
-                    naked_identifier: wages
-                  comparison_operator:
-                    raw_comparison_operator: '>'
-                  numeric_literal: '60000'
-              - keyword: THEN
-              - expression:
-                  column_reference:
-                    naked_identifier: wages
-                  binary_operator: '*'
-                  numeric_literal: '0.15'
-            - else_clause:
-                keyword: ELSE
-                expression:
-                  column_reference:
-                    naked_identifier: wages
-                  binary_operator: '*'
-                  numeric_literal: '0.10'
-            - keyword: END
-    - statement_terminator: ;
-    - keyword: END
-- statement_terminator: ;
-- statement_terminator: /
-- statement:
-    begin_end_block:
-    - declare_segment:
-      - keyword: DECLARE
-      - naked_identifier: done
-      - data_type:
-          data_type_identifier: BOOLEAN
-      - statement_terminator: ;
-      - naked_identifier: counter
-      - data_type:
-          data_type_identifier: NUMBER
-      - assignment_operator: :=
-      - expression:
-          numeric_literal: '0'
-      - statement_terminator: ;
-    - keyword: BEGIN
-    - statement:
-        assignment_segment_statement:
-          object_reference:
-            naked_identifier: done
-          assignment_operator: :=
-          expression:
-            boolean_literal: 'FALSE'
-    - statement_terminator: ;
-    - statement:
-        while_loop_statement:
-          keyword: WHILE
-          expression:
-            column_reference:
-              naked_identifier: done
-            comparison_operator:
-            - raw_comparison_operator: '!'
-            - raw_comparison_operator: '='
-            boolean_literal: 'TRUE'
-          loop_statement:
-          - keyword: LOOP
-          - statement:
-              assignment_segment_statement:
-                object_reference:
-                  naked_identifier: counter
-                assignment_operator: :=
-                expression:
-                  column_reference:
-                    naked_identifier: counter
-                  binary_operator: +
-                  numeric_literal: '1'
-          - statement_terminator: ;
-          - statement:
-              assignment_segment_statement:
-                object_reference:
-                  naked_identifier: done
-                assignment_operator: :=
-                expression:
-                  bracketed:
-                    start_bracket: (
-                    expression:
-                      column_reference:
-                        naked_identifier: counter
-                      comparison_operator:
-                        raw_comparison_operator: '>'
-                      numeric_literal: '500'
-                    end_bracket: )
-          - statement_terminator: ;
-          - keyword: END
-          - keyword: LOOP
-    - statement_terminator: ;
-    - keyword: END
-- statement_terminator: ;
-- statement_terminator: /
-- statement:
-    begin_end_block:
-    - declare_segment:
-      - keyword: DECLARE
-      - collection_type:
-        - keyword: TYPE
-        - naked_identifier: triplet
-        - keyword: IS
+        - naked_identifier: hours_worked
         - data_type:
-            data_type_identifier: VARRAY
-            bracketed_arguments:
-              bracketed:
-                start_bracket: (
-                numeric_literal: '3'
-                end_bracket: )
-        - keyword: OF
+            data_type_identifier: NUMBER
+        - assignment_operator: :=
+        - expression:
+            numeric_literal: '40'
+        - statement_terminator: ;
+        - naked_identifier: hourly_salary
+        - data_type:
+            data_type_identifier: NUMBER
+        - assignment_operator: :=
+        - expression:
+            numeric_literal: '22.50'
+        - statement_terminator: ;
+        - naked_identifier: bonus
+        - data_type:
+            data_type_identifier: NUMBER
+        - assignment_operator: :=
+        - expression:
+            numeric_literal: '150'
+        - statement_terminator: ;
+        - naked_identifier: country
         - data_type:
             data_type_identifier: VARCHAR2
             bracketed_arguments:
               bracketed:
                 start_bracket: (
-                numeric_literal: '15'
+                numeric_literal: '128'
                 end_bracket: )
-      - statement_terminator: ;
-      - collection_type:
-        - keyword: TYPE
-        - naked_identifier: trio
-        - keyword: IS
-        - data_type:
-            data_type_identifier: VARRAY
-            bracketed_arguments:
-              bracketed:
-                start_bracket: (
-                numeric_literal: '3'
-                end_bracket: )
-        - keyword: OF
-        - data_type:
-            data_type_identifier: VARCHAR2
-            bracketed_arguments:
-              bracketed:
-                start_bracket: (
-                numeric_literal: '15'
-                end_bracket: )
-      - statement_terminator: ;
-      - naked_identifier: group1
-      - data_type:
-          data_type_identifier: triplet
-      - assignment_operator: :=
-      - expression:
-          function:
-            function_name:
-              function_name_identifier: triplet
-            function_contents:
-              bracketed:
-              - start_bracket: (
-              - expression:
-                  quoted_literal: "'Jones'"
-              - comma: ','
-              - expression:
-                  quoted_literal: "'Wong'"
-              - comma: ','
-              - expression:
-                  quoted_literal: "'Marceau'"
-              - end_bracket: )
-      - statement_terminator: ;
-      - naked_identifier: group2
-      - data_type:
-          data_type_identifier: triplet
-      - statement_terminator: ;
-      - naked_identifier: group3
-      - data_type:
-          data_type_identifier: trio
-      - statement_terminator: ;
-    - keyword: BEGIN
-    - statement:
-        assignment_segment_statement:
-          object_reference:
-            naked_identifier: group2
-          assignment_operator: :=
-          expression:
-            column_reference:
-              naked_identifier: group1
-    - statement_terminator: ;
-    - statement:
-        assignment_segment_statement:
-          object_reference:
-            naked_identifier: group3
-          assignment_operator: :=
-          expression:
-            column_reference:
-              naked_identifier: group1
-    - statement_terminator: ;
-    - keyword: END
-- statement_terminator: ;
-- statement_terminator: /
-- statement:
-    create_function_statement:
-    - keyword: CREATE
-    - keyword: OR
-    - keyword: REPLACE
-    - keyword: FUNCTION
-    - function_name:
-        function_name_identifier: CALCULATE_BONUS
-    - function_parameter_list:
-        bracketed:
-        - start_bracket: (
-        - parameter: base_salary
+        - statement_terminator: ;
+        - naked_identifier: counter
         - data_type:
             data_type_identifier: NUMBER
         - assignment_operator: :=
         - expression:
-            numeric_literal: '50000'
-        - comma: ','
-        - parameter: bonus_rate
+            numeric_literal: '0'
+        - statement_terminator: ;
+        - naked_identifier: done
         - data_type:
-            data_type_identifier: NUMBER
+            data_type_identifier: BOOLEAN
+        - statement_terminator: ;
+        - naked_identifier: valid_id
+        - data_type:
+            data_type_identifier: BOOLEAN
+        - statement_terminator: ;
+        - naked_identifier: emp_rec1
+        - row_type_reference:
+            table_reference:
+              naked_identifier: employees
+            binary_operator: '%'
+            keyword: ROWTYPE
+        - statement_terminator: ;
+        - naked_identifier: emp_rec2
+        - row_type_reference:
+            table_reference:
+              naked_identifier: employees
+            binary_operator: '%'
+            keyword: ROWTYPE
+        - statement_terminator: ;
+        - collection_type:
+          - keyword: TYPE
+          - naked_identifier: commissions
+          - keyword: IS
+          - keyword: TABLE
+          - keyword: OF
+          - data_type:
+              data_type_identifier: NUMBER
+          - keyword: INDEX
+          - keyword: BY
+          - data_type:
+              data_type_identifier: PLS_INTEGER
+        - statement_terminator: ;
+        - naked_identifier: comm_tab
+        - data_type:
+            data_type_identifier: commissions
+        - statement_terminator: ;
+        - naked_identifier: current_date
+        - data_type:
+            data_type_identifier: DATE
         - assignment_operator: :=
         - expression:
-            numeric_literal: '0.10'
-        - end_bracket: )
-    - keyword: RETURN
-    - data_type:
-        data_type_identifier: NUMBER
-    - keyword: AS
-    - declare_segment:
-        naked_identifier: result_bonus
-        data_type:
-          data_type_identifier: NUMBER
-        statement_terminator: ;
-    - begin_end_block:
+            bare_function: SYSDATE
+        - statement_terminator: ;
       - keyword: BEGIN
       - statement:
           assignment_segment_statement:
             object_reference:
-              naked_identifier: result_bonus
+              naked_identifier: wages
             assignment_operator: :=
             expression:
-            - column_reference:
-                naked_identifier: base_salary
-            - binary_operator: '*'
-            - column_reference:
-                naked_identifier: bonus_rate
+              bracketed:
+                start_bracket: (
+                expression:
+                - column_reference:
+                    naked_identifier: hours_worked
+                - binary_operator: '*'
+                - column_reference:
+                    naked_identifier: hourly_salary
+                end_bracket: )
+              binary_operator: +
+              column_reference:
+                naked_identifier: bonus
       - statement_terminator: ;
       - statement:
-          return_statement:
-            keyword: RETURN
+          assignment_segment_statement:
+            object_reference:
+              naked_identifier: country
+            assignment_operator: :=
+            expression:
+              quoted_literal: "'France'"
+      - statement_terminator: ;
+      - statement:
+          assignment_segment_statement:
+            object_reference:
+              naked_identifier: country
+            assignment_operator: :=
+            expression:
+              function:
+                function_name:
+                  function_name_identifier: UPPER
+                function_contents:
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                      quoted_literal: "'Canada'"
+                    end_bracket: )
+      - statement_terminator: ;
+      - statement:
+          assignment_segment_statement:
+            object_reference:
+              naked_identifier: done
+            assignment_operator: :=
+            expression:
+              bracketed:
+                start_bracket: (
+                expression:
+                  column_reference:
+                    naked_identifier: counter
+                  comparison_operator:
+                    raw_comparison_operator: '>'
+                  numeric_literal: '100'
+                end_bracket: )
+      - statement_terminator: ;
+      - statement:
+          assignment_segment_statement:
+            object_reference:
+              naked_identifier: valid_id
+            assignment_operator: :=
+            expression:
+              boolean_literal: 'TRUE'
+      - statement_terminator: ;
+      - statement:
+          assignment_segment_statement:
+            object_reference:
+            - naked_identifier: emp_rec1
+            - dot: .
+            - naked_identifier: first_name
+            assignment_operator: :=
+            expression:
+              quoted_literal: "'Antonio'"
+      - statement_terminator: ;
+      - statement:
+          assignment_segment_statement:
+            object_reference:
+            - naked_identifier: emp_rec1
+            - dot: .
+            - naked_identifier: last_name
+            assignment_operator: :=
+            expression:
+              quoted_literal: "'Ortiz'"
+      - statement_terminator: ;
+      - statement:
+          assignment_segment_statement:
+            object_reference:
+              naked_identifier: emp_rec1
+            assignment_operator: :=
             expression:
               column_reference:
-                naked_identifier: result_bonus
+                naked_identifier: emp_rec2
+      - statement_terminator: ;
+      - statement:
+          assignment_segment_statement:
+            object_reference:
+              naked_identifier: comm_tab
+            bracketed:
+              start_bracket: (
+              numeric_literal: '5'
+              end_bracket: )
+            assignment_operator: :=
+            expression:
+            - numeric_literal: '20000'
+            - binary_operator: '*'
+            - numeric_literal: '0.15'
+      - statement_terminator: ;
+      - statement:
+          if_then_statement:
+          - if_clause:
+            - keyword: IF
+            - expression:
+                column_reference:
+                  naked_identifier: counter
+                comparison_operator:
+                  raw_comparison_operator: '>'
+                numeric_literal: '5'
+            - keyword: THEN
+          - statement:
+              assignment_segment_statement:
+                object_reference:
+                  naked_identifier: wages
+                assignment_operator: :=
+                expression:
+                  column_reference:
+                    naked_identifier: wages
+                  binary_operator: '*'
+                  numeric_literal: '1.10'
+          - statement_terminator: ;
+          - keyword: END
+          - keyword: IF
+      - statement_terminator: ;
+      - statement:
+          assignment_segment_statement:
+            object_reference:
+              naked_identifier: bonus
+            assignment_operator: :=
+            expression:
+              case_expression:
+              - keyword: CASE
+              - when_clause:
+                - keyword: WHEN
+                - expression:
+                    column_reference:
+                      naked_identifier: wages
+                    comparison_operator:
+                      raw_comparison_operator: '>'
+                    numeric_literal: '60000'
+                - keyword: THEN
+                - expression:
+                    column_reference:
+                      naked_identifier: wages
+                    binary_operator: '*'
+                    numeric_literal: '0.15'
+              - else_clause:
+                  keyword: ELSE
+                  expression:
+                    column_reference:
+                      naked_identifier: wages
+                    binary_operator: '*'
+                    numeric_literal: '0.10'
+              - keyword: END
       - statement_terminator: ;
       - keyword: END
-    - statement_terminator: ;
-    - statement_terminator: /
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      begin_end_block:
+      - declare_segment:
+        - keyword: DECLARE
+        - naked_identifier: done
+        - data_type:
+            data_type_identifier: BOOLEAN
+        - statement_terminator: ;
+        - naked_identifier: counter
+        - data_type:
+            data_type_identifier: NUMBER
+        - assignment_operator: :=
+        - expression:
+            numeric_literal: '0'
+        - statement_terminator: ;
+      - keyword: BEGIN
+      - statement:
+          assignment_segment_statement:
+            object_reference:
+              naked_identifier: done
+            assignment_operator: :=
+            expression:
+              boolean_literal: 'FALSE'
+      - statement_terminator: ;
+      - statement:
+          while_loop_statement:
+            keyword: WHILE
+            expression:
+              column_reference:
+                naked_identifier: done
+              comparison_operator:
+              - raw_comparison_operator: '!'
+              - raw_comparison_operator: '='
+              boolean_literal: 'TRUE'
+            loop_statement:
+            - keyword: LOOP
+            - statement:
+                assignment_segment_statement:
+                  object_reference:
+                    naked_identifier: counter
+                  assignment_operator: :=
+                  expression:
+                    column_reference:
+                      naked_identifier: counter
+                    binary_operator: +
+                    numeric_literal: '1'
+            - statement_terminator: ;
+            - statement:
+                assignment_segment_statement:
+                  object_reference:
+                    naked_identifier: done
+                  assignment_operator: :=
+                  expression:
+                    bracketed:
+                      start_bracket: (
+                      expression:
+                        column_reference:
+                          naked_identifier: counter
+                        comparison_operator:
+                          raw_comparison_operator: '>'
+                        numeric_literal: '500'
+                      end_bracket: )
+            - statement_terminator: ;
+            - keyword: END
+            - keyword: LOOP
+      - statement_terminator: ;
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      begin_end_block:
+      - declare_segment:
+        - keyword: DECLARE
+        - collection_type:
+          - keyword: TYPE
+          - naked_identifier: triplet
+          - keyword: IS
+          - data_type:
+              data_type_identifier: VARRAY
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  numeric_literal: '3'
+                  end_bracket: )
+          - keyword: OF
+          - data_type:
+              data_type_identifier: VARCHAR2
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  numeric_literal: '15'
+                  end_bracket: )
+        - statement_terminator: ;
+        - collection_type:
+          - keyword: TYPE
+          - naked_identifier: trio
+          - keyword: IS
+          - data_type:
+              data_type_identifier: VARRAY
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  numeric_literal: '3'
+                  end_bracket: )
+          - keyword: OF
+          - data_type:
+              data_type_identifier: VARCHAR2
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  numeric_literal: '15'
+                  end_bracket: )
+        - statement_terminator: ;
+        - naked_identifier: group1
+        - data_type:
+            data_type_identifier: triplet
+        - assignment_operator: :=
+        - expression:
+            function:
+              function_name:
+                function_name_identifier: triplet
+              function_contents:
+                bracketed:
+                - start_bracket: (
+                - expression:
+                    quoted_literal: "'Jones'"
+                - comma: ','
+                - expression:
+                    quoted_literal: "'Wong'"
+                - comma: ','
+                - expression:
+                    quoted_literal: "'Marceau'"
+                - end_bracket: )
+        - statement_terminator: ;
+        - naked_identifier: group2
+        - data_type:
+            data_type_identifier: triplet
+        - statement_terminator: ;
+        - naked_identifier: group3
+        - data_type:
+            data_type_identifier: trio
+        - statement_terminator: ;
+      - keyword: BEGIN
+      - statement:
+          assignment_segment_statement:
+            object_reference:
+              naked_identifier: group2
+            assignment_operator: :=
+            expression:
+              column_reference:
+                naked_identifier: group1
+      - statement_terminator: ;
+      - statement:
+          assignment_segment_statement:
+            object_reference:
+              naked_identifier: group3
+            assignment_operator: :=
+            expression:
+              column_reference:
+                naked_identifier: group1
+      - statement_terminator: ;
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      create_function_statement:
+      - keyword: CREATE
+      - keyword: OR
+      - keyword: REPLACE
+      - keyword: FUNCTION
+      - function_name:
+          function_name_identifier: CALCULATE_BONUS
+      - function_parameter_list:
+          bracketed:
+          - start_bracket: (
+          - parameter: base_salary
+          - data_type:
+              data_type_identifier: NUMBER
+          - assignment_operator: :=
+          - expression:
+              numeric_literal: '50000'
+          - comma: ','
+          - parameter: bonus_rate
+          - data_type:
+              data_type_identifier: NUMBER
+          - assignment_operator: :=
+          - expression:
+              numeric_literal: '0.10'
+          - end_bracket: )
+      - keyword: RETURN
+      - data_type:
+          data_type_identifier: NUMBER
+      - keyword: AS
+      - declare_segment:
+          naked_identifier: result_bonus
+          data_type:
+            data_type_identifier: NUMBER
+          statement_terminator: ;
+      - begin_end_block:
+        - keyword: BEGIN
+        - statement:
+            assignment_segment_statement:
+              object_reference:
+                naked_identifier: result_bonus
+              assignment_operator: :=
+              expression:
+              - column_reference:
+                  naked_identifier: base_salary
+              - binary_operator: '*'
+              - column_reference:
+                  naked_identifier: bonus_rate
+        - statement_terminator: ;
+        - statement:
+            return_statement:
+              keyword: RETURN
+              expression:
+                column_reference:
+                  naked_identifier: result_bonus
+        - statement_terminator: ;
+        - keyword: END
+      - statement_terminator: ;
+    slash_buffer_executor:
+      slash: /

--- a/test/fixtures/dialects/oracle/at_signs.yml
+++ b/test/fixtures/dialects/oracle/at_signs.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: d687c62efbf650d4457868fae33d95c534fc475817ebf2075348fd2b89f86bcf
+_hash: c2a20b67329b6944b76ff3dd1f1234dc1b8364ca05c7978eb7c2c60f59c3a7c8
 file:
 - execute_file_statement:
   - at_sign: '@'
@@ -33,19 +33,20 @@ file:
   - naked_identifier: foo
   - naked_identifier: bar
   - naked_identifier: baz
-- statement:
-    select_statement:
-      select_clause:
-        keyword: SELECT
-        select_clause_element:
-          wildcard_expression:
-            wildcard_identifier:
-              star: '*'
-      from_clause:
-        keyword: from
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: some_table
-- statement_terminator: ;
+- batch:
+    statement:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+        from_clause:
+          keyword: from
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: some_table
+    statement_terminator: ;

--- a/test/fixtures/dialects/oracle/bare_functions.yml
+++ b/test/fixtures/dialects/oracle/bare_functions.yml
@@ -3,73 +3,74 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 8e263a00681db97d124e7a639374ee40f65642e13597c704ac5a150b1e308206
+_hash: 6c8e20fbc5145723c5d447ed4ecc614752cc0e01fa409c33c66b17bfe51311dd
 file:
-  statement:
-    select_statement:
-      select_clause:
-      - keyword: SELECT
-      - select_clause_element:
-          column_reference:
-          - naked_identifier: a
-          - dot: .
-          - naked_identifier: foo
-      - comma: ','
-      - select_clause_element:
-          column_reference:
-          - naked_identifier: b
-          - dot: .
-          - naked_identifier: bar
-      - comma: ','
-      - select_clause_element:
-          bare_function: current_date
-      - comma: ','
-      - select_clause_element:
-          bare_function: current_timestamp
-      - comma: ','
-      - select_clause_element:
-          bare_function: dbtimezone
-      - comma: ','
-      - select_clause_element:
-          bare_function: localtimestamp
-      - comma: ','
-      - select_clause_element:
-          bare_function: sessiontimestamp
-      - comma: ','
-      - select_clause_element:
-          bare_function: sysdate
-      - comma: ','
-      - select_clause_element:
-          bare_function: systimestamp
-      from_clause:
-        keyword: FROM
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: first_table
-            alias_expression:
-              naked_identifier: a
-          join_clause:
-          - keyword: INNER
-          - keyword: JOIN
-          - from_expression_element:
+  batch:
+    statement:
+      select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            column_reference:
+            - naked_identifier: a
+            - dot: .
+            - naked_identifier: foo
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+            - naked_identifier: b
+            - dot: .
+            - naked_identifier: bar
+        - comma: ','
+        - select_clause_element:
+            bare_function: current_date
+        - comma: ','
+        - select_clause_element:
+            bare_function: current_timestamp
+        - comma: ','
+        - select_clause_element:
+            bare_function: dbtimezone
+        - comma: ','
+        - select_clause_element:
+            bare_function: localtimestamp
+        - comma: ','
+        - select_clause_element:
+            bare_function: sessiontimestamp
+        - comma: ','
+        - select_clause_element:
+            bare_function: sysdate
+        - comma: ','
+        - select_clause_element:
+            bare_function: systimestamp
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
               table_expression:
                 table_reference:
-                  naked_identifier: second_table
+                  naked_identifier: first_table
               alias_expression:
-                naked_identifier: b
-          - join_on_condition:
-              keyword: 'ON'
-              expression:
-              - column_reference:
-                - naked_identifier: a
-                - dot: .
-                - naked_identifier: baz
-              - comparison_operator:
-                  raw_comparison_operator: '='
-              - column_reference:
-                - naked_identifier: b
-                - dot: .
-                - naked_identifier: baz
-  statement_terminator: ;
+                naked_identifier: a
+            join_clause:
+            - keyword: INNER
+            - keyword: JOIN
+            - from_expression_element:
+                table_expression:
+                  table_reference:
+                    naked_identifier: second_table
+                alias_expression:
+                  naked_identifier: b
+            - join_on_condition:
+                keyword: 'ON'
+                expression:
+                - column_reference:
+                  - naked_identifier: a
+                  - dot: .
+                  - naked_identifier: baz
+                - comparison_operator:
+                    raw_comparison_operator: '='
+                - column_reference:
+                  - naked_identifier: b
+                  - dot: .
+                  - naked_identifier: baz
+    statement_terminator: ;

--- a/test/fixtures/dialects/oracle/bind_variables.yml
+++ b/test/fixtures/dialects/oracle/bind_variables.yml
@@ -3,65 +3,66 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: dd712e00e905964fff249bd96878cc3008d776d7a6192bbec01a12b353109633
+_hash: b574dacaf5b9d379e2c253a13c5d2742fba5faf94db0e925c068e1d03d91587d
 file:
-- statement:
-    select_statement:
-      select_clause:
-        keyword: select
-        select_clause_element:
-          sqlplus_variable:
-            colon: ':'
-            parameter: abc
-      from_clause:
-        keyword: from
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: dual
-- statement_terminator: ;
-- statement:
-    insert_statement:
-    - keyword: insert
-    - keyword: into
-    - table_reference:
-        naked_identifier: mytab
-    - values_clause:
-        keyword: values
-        bracketed:
-        - start_bracket: (
-        - sqlplus_variable:
-            colon: ':'
-            parameter: abc
-        - comma: ','
-        - sqlplus_variable:
-            colon: ':'
-            parameter: xyz
-        - end_bracket: )
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-        keyword: select
-        select_clause_element:
-          column_reference:
-            naked_identifier: column_name
-      from_clause:
-        keyword: from
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: table_name
-      where_clause:
-        keyword: where
-        expression:
-          column_reference:
-            naked_identifier: column_name
-          comparison_operator:
-            raw_comparison_operator: '='
-          sqlplus_variable:
-            colon: ':'
-            parameter: column_name_filter
-- statement_terminator: ;
+  batch:
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: select
+          select_clause_element:
+            sqlplus_variable:
+              colon: ':'
+              parameter: abc
+        from_clause:
+          keyword: from
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: dual
+  - statement_terminator: ;
+  - statement:
+      insert_statement:
+      - keyword: insert
+      - keyword: into
+      - table_reference:
+          naked_identifier: mytab
+      - values_clause:
+          keyword: values
+          bracketed:
+          - start_bracket: (
+          - sqlplus_variable:
+              colon: ':'
+              parameter: abc
+          - comma: ','
+          - sqlplus_variable:
+              colon: ':'
+              parameter: xyz
+          - end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: select
+          select_clause_element:
+            column_reference:
+              naked_identifier: column_name
+        from_clause:
+          keyword: from
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: table_name
+        where_clause:
+          keyword: where
+          expression:
+            column_reference:
+              naked_identifier: column_name
+            comparison_operator:
+              raw_comparison_operator: '='
+            sqlplus_variable:
+              colon: ':'
+              parameter: column_name_filter
+  - statement_terminator: ;

--- a/test/fixtures/dialects/oracle/bulk_collect_into.yml
+++ b/test/fixtures/dialects/oracle/bulk_collect_into.yml
@@ -3,567 +3,568 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 928bef33af267bfcc67afc5abc899f007347b774f34a9b6fecbf4f30007792d3
+_hash: da6dcc8d4a8dc4fc205452b25cd1409162ac2025de9dbb0528052ac679171022
 file:
-- statement:
-    select_statement:
-      select_clause:
-        keyword: SELECT
-        select_clause_element:
-          column_reference:
-          - naked_identifier: foobar_table
-          - dot: .
-          - naked_identifier: foo
-      bulk_collect_into_clause:
-      - keyword: BULK
-      - keyword: COLLECT
-      - keyword: INTO
-      - naked_identifier: selected_foo_bars
-      from_clause:
-        keyword: FROM
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: foobar_table
-      where_clause:
-        keyword: WHERE
-        expression:
-        - column_reference:
-          - naked_identifier: foobar_table
-          - dot: .
-          - naked_identifier: id
-        - comparison_operator:
-            raw_comparison_operator: '='
-        - column_reference:
-          - naked_identifier: foobar_table
-          - dot: .
-          - naked_identifier: foo_bar_id
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-      - keyword: SELECT
-      - select_clause_element:
-          column_reference:
-          - naked_identifier: foobar_table
-          - dot: .
-          - naked_identifier: foo
-      - comma: ','
-      - select_clause_element:
-          column_reference:
-          - naked_identifier: foobar_table
-          - dot: .
-          - naked_identifier: bar
-      bulk_collect_into_clause:
-      - keyword: BULK
-      - keyword: COLLECT
-      - keyword: INTO
-      - naked_identifier: selected_foo_bars
-      - comma: ','
-      - naked_identifier: selected_bar_bars
-      from_clause:
-        keyword: FROM
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: foobar_table
-      where_clause:
-        keyword: WHERE
-        expression:
-        - column_reference:
-          - naked_identifier: foobar_table
-          - dot: .
-          - naked_identifier: id
-        - comparison_operator:
-            raw_comparison_operator: '='
-        - column_reference:
-          - naked_identifier: foobar_table
-          - dot: .
-          - naked_identifier: foo_bar_id
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-      - keyword: SELECT
-      - select_clause_element:
-          expression:
+  batch:
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
             column_reference:
             - naked_identifier: foobar_table
             - dot: .
             - naked_identifier: foo
-            binary_operator: '*'
-            numeric_literal: '2'
-      - comma: ','
-      - select_clause_element:
-          function:
-            function_name:
-              function_name_identifier: UPPER
-            function_contents:
-              bracketed:
-                start_bracket: (
-                expression:
-                  column_reference:
-                  - naked_identifier: foobar_table
-                  - dot: .
-                  - naked_identifier: bar
-                end_bracket: )
-      - comma: ','
-      - select_clause_element:
-          function:
-            function_name:
-              function_name_identifier: LENGTH
-            function_contents:
-              bracketed:
-                start_bracket: (
-                expression:
-                  column_reference:
-                  - naked_identifier: foobar_table
-                  - dot: .
-                  - naked_identifier: foo
-                end_bracket: )
-      bulk_collect_into_clause:
-      - keyword: BULK
-      - keyword: COLLECT
-      - keyword: INTO
-      - naked_identifier: selected_foo_bars
-      - comma: ','
-      - naked_identifier: selected_bar_bars
-      - comma: ','
-      - naked_identifier: selected_lengths
-      from_clause:
-        keyword: FROM
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: foobar_table
-      where_clause:
-        keyword: WHERE
-        expression:
-        - column_reference:
-          - naked_identifier: foobar_table
-          - dot: .
-          - naked_identifier: id
-        - comparison_operator:
-            raw_comparison_operator: '='
-        - column_reference:
-          - naked_identifier: foobar_table
-          - dot: .
-          - naked_identifier: foo_bar_id
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-      - keyword: SELECT
-      - select_clause_element:
+        bulk_collect_into_clause:
+        - keyword: BULK
+        - keyword: COLLECT
+        - keyword: INTO
+        - naked_identifier: selected_foo_bars
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: foobar_table
+        where_clause:
+          keyword: WHERE
           expression:
-            bracketed:
-              start_bracket: (
-              expression:
-                select_statement:
-                  select_clause:
-                    keyword: SELECT
-                    select_clause_element:
-                      function:
-                        function_name:
-                          function_name_identifier: MAX
-                        function_contents:
-                          bracketed:
-                            start_bracket: (
-                            expression:
-                              column_reference:
-                                naked_identifier: id
-                            end_bracket: )
-                  from_clause:
-                    keyword: FROM
-                    from_expression:
-                      from_expression_element:
-                        table_expression:
-                          table_reference:
-                            naked_identifier: other_table
-                  where_clause:
-                    keyword: WHERE
-                    expression:
-                    - column_reference:
-                      - naked_identifier: other_table
-                      - dot: .
-                      - naked_identifier: ref_id
-                    - comparison_operator:
-                        raw_comparison_operator: '='
-                    - column_reference:
-                      - naked_identifier: foobar_table
-                      - dot: .
-                      - naked_identifier: id
-              end_bracket: )
-      - comma: ','
-      - select_clause_element:
-          expression:
-            case_expression:
-            - keyword: CASE
-            - when_clause:
-              - keyword: WHEN
-              - expression:
-                  column_reference:
-                  - naked_identifier: foobar_table
-                  - dot: .
-                  - naked_identifier: foo
-                  comparison_operator:
-                    raw_comparison_operator: '='
-                  quoted_literal: "'A'"
-              - keyword: THEN
-              - expression:
-                  quoted_literal: "'Alpha'"
-            - when_clause:
-              - keyword: WHEN
-              - expression:
-                  column_reference:
-                  - naked_identifier: foobar_table
-                  - dot: .
-                  - naked_identifier: foo
-                  comparison_operator:
-                    raw_comparison_operator: '='
-                  quoted_literal: "'B'"
-              - keyword: THEN
-              - expression:
-                  quoted_literal: "'Beta'"
-            - else_clause:
-                keyword: ELSE
-                expression:
-                  quoted_literal: "'Other'"
-            - keyword: END
-      bulk_collect_into_clause:
-      - keyword: BULK
-      - keyword: COLLECT
-      - keyword: INTO
-      - naked_identifier: selected_max_ids
-      - comma: ','
-      - naked_identifier: selected_categories
-      from_clause:
-        keyword: FROM
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: foobar_table
-      where_clause:
-        keyword: WHERE
-        expression:
-        - column_reference:
-          - naked_identifier: foobar_table
-          - dot: .
-          - naked_identifier: id
-        - comparison_operator:
-            raw_comparison_operator: '='
-        - column_reference:
-          - naked_identifier: foobar_table
-          - dot: .
-          - naked_identifier: foo_bar_id
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-        keyword: SELECT
-        select_clause_modifier:
-          keyword: DISTINCT
-        select_clause_element:
-          column_reference:
-          - naked_identifier: foobar_table
-          - dot: .
-          - naked_identifier: foo
-      bulk_collect_into_clause:
-      - keyword: BULK
-      - keyword: COLLECT
-      - keyword: INTO
-      - naked_identifier: selected_unique_foos
-      from_clause:
-        keyword: FROM
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: foobar_table
-      where_clause:
-        keyword: WHERE
-        expression:
-        - column_reference:
-          - naked_identifier: foobar_table
-          - dot: .
-          - naked_identifier: id
-        - comparison_operator:
-            raw_comparison_operator: '='
-        - column_reference:
-          - naked_identifier: foobar_table
-          - dot: .
-          - naked_identifier: foo_bar_id
-      orderby_clause:
-      - keyword: ORDER
-      - keyword: BY
-      - column_reference:
-        - naked_identifier: foobar_table
-        - dot: .
-        - naked_identifier: foo
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-      - keyword: SELECT
-      - select_clause_element:
-          column_reference:
-          - naked_identifier: foobar_table
-          - dot: .
-          - naked_identifier: foo
-      - comma: ','
-      - select_clause_element:
-          function:
-            function_name:
-              function_name_identifier: ROW_NUMBER
-            function_contents:
-              bracketed:
-                start_bracket: (
-                end_bracket: )
-            over_clause:
-              keyword: OVER
-              bracketed:
-                start_bracket: (
-                window_specification:
-                  orderby_clause:
-                  - keyword: ORDER
-                  - keyword: BY
-                  - column_reference:
-                    - naked_identifier: foobar_table
-                    - dot: .
-                    - naked_identifier: foo
-                end_bracket: )
-          alias_expression:
-            alias_operator:
-              keyword: AS
-            naked_identifier: row_num
-      - comma: ','
-      - select_clause_element:
-          function:
-            function_name:
-              function_name_identifier: AVG
-            function_contents:
-              bracketed:
-                start_bracket: (
-                expression:
-                  column_reference:
-                  - naked_identifier: foobar_table
-                  - dot: .
-                  - naked_identifier: value
-                end_bracket: )
-            over_clause:
-              keyword: OVER
-              bracketed:
-                start_bracket: (
-                window_specification:
-                  partitionby_clause:
-                  - keyword: PARTITION
-                  - keyword: BY
-                  - expression:
-                      column_reference:
-                      - naked_identifier: foobar_table
-                      - dot: .
-                      - naked_identifier: category
-                end_bracket: )
-      bulk_collect_into_clause:
-      - keyword: BULK
-      - keyword: COLLECT
-      - keyword: INTO
-      - naked_identifier: selected_foo_bars
-      - comma: ','
-      - naked_identifier: selected_row_nums
-      - comma: ','
-      - naked_identifier: selected_avgs
-      from_clause:
-        keyword: FROM
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: foobar_table
-      where_clause:
-        keyword: WHERE
-        expression:
-        - column_reference:
-          - naked_identifier: foobar_table
-          - dot: .
-          - naked_identifier: id
-        - comparison_operator:
-            raw_comparison_operator: '='
-        - column_reference:
-          - naked_identifier: foobar_table
-          - dot: .
-          - naked_identifier: foo_bar_id
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-      - keyword: SELECT
-      - select_clause_element:
-          column_reference:
-          - naked_identifier: foobar_table
-          - dot: .
-          - naked_identifier: foo
-      - comma: ','
-      - select_clause_element:
-          bare_function: SYSDATE
-      - comma: ','
-      - select_clause_element:
-          function:
-            function_name:
-              function_name_identifier: CONCAT
-            function_contents:
-              bracketed:
-              - start_bracket: (
-              - expression:
-                  column_reference:
-                  - naked_identifier: foobar_table
-                  - dot: .
-                  - naked_identifier: foo
-              - comma: ','
-              - expression:
-                  quoted_literal: "'_suffix'"
-              - end_bracket: )
-      - comma: ','
-      - select_clause_element:
-          function:
-            function_name:
-              function_name_identifier: SUBSTR
-            function_contents:
-              bracketed:
-              - start_bracket: (
-              - expression:
-                  column_reference:
-                  - naked_identifier: foobar_table
-                  - dot: .
-                  - naked_identifier: foo
-              - comma: ','
-              - expression:
-                  numeric_literal: '1'
-              - comma: ','
-              - expression:
-                  numeric_literal: '3'
-              - end_bracket: )
-      bulk_collect_into_clause:
-      - keyword: BULK
-      - keyword: COLLECT
-      - keyword: INTO
-      - naked_identifier: selected_foos
-      - comma: ','
-      - naked_identifier: selected_sysdates
-      - comma: ','
-      - naked_identifier: selected_concat
-      - comma: ','
-      - naked_identifier: selected_substr
-      from_clause:
-        keyword: FROM
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: foobar_table
-      where_clause:
-        keyword: WHERE
-        expression:
-        - column_reference:
-          - naked_identifier: foobar_table
-          - dot: .
-          - naked_identifier: id
-        - comparison_operator:
-            raw_comparison_operator: '='
-        - column_reference:
-          - naked_identifier: foobar_table
-          - dot: .
-          - naked_identifier: foo_bar_id
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-      - keyword: SELECT
-      - select_clause_element:
-          column_reference:
-          - naked_identifier: foobar_table
-          - dot: .
-          - naked_identifier: foo
-      - comma: ','
-      - select_clause_element:
-          expression:
-            case_expression:
-            - keyword: CASE
-            - when_clause:
-              - keyword: WHEN
-              - expression:
-                  column_reference:
-                  - naked_identifier: foobar_table
-                  - dot: .
-                  - naked_identifier: value
-                  comparison_operator:
-                    raw_comparison_operator: '>'
-                  numeric_literal: '100'
-              - keyword: THEN
-              - expression:
-                  quoted_literal: "'High'"
-            - when_clause:
-              - keyword: WHEN
-              - expression:
-                  column_reference:
-                  - naked_identifier: foobar_table
-                  - dot: .
-                  - naked_identifier: value
-                  comparison_operator:
-                    raw_comparison_operator: '>'
-                  numeric_literal: '50'
-              - keyword: THEN
-              - expression:
-                  quoted_literal: "'Medium'"
-            - else_clause:
-                keyword: ELSE
-                expression:
-                  quoted_literal: "'Low'"
-            - keyword: END
-          alias_expression:
-            alias_operator:
-              keyword: AS
-            naked_identifier: value_category
-      - comma: ','
-      - select_clause_element:
-          expression:
+          - column_reference:
+            - naked_identifier: foobar_table
+            - dot: .
+            - naked_identifier: id
+          - comparison_operator:
+              raw_comparison_operator: '='
+          - column_reference:
+            - naked_identifier: foobar_table
+            - dot: .
+            - naked_identifier: foo_bar_id
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
             column_reference:
             - naked_identifier: foobar_table
             - dot: .
-            - naked_identifier: value
-            binary_operator: '*'
-            numeric_literal: '1.1'
-      bulk_collect_into_clause:
-      - keyword: BULK
-      - keyword: COLLECT
-      - keyword: INTO
-      - naked_identifier: selected_foos
-      - comma: ','
-      - naked_identifier: selected_categories
-      - comma: ','
-      - naked_identifier: selected_values
-      from_clause:
-        keyword: FROM
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: foobar_table
-      where_clause:
-        keyword: WHERE
-        expression:
+            - naked_identifier: foo
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+            - naked_identifier: foobar_table
+            - dot: .
+            - naked_identifier: bar
+        bulk_collect_into_clause:
+        - keyword: BULK
+        - keyword: COLLECT
+        - keyword: INTO
+        - naked_identifier: selected_foo_bars
+        - comma: ','
+        - naked_identifier: selected_bar_bars
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: foobar_table
+        where_clause:
+          keyword: WHERE
+          expression:
+          - column_reference:
+            - naked_identifier: foobar_table
+            - dot: .
+            - naked_identifier: id
+          - comparison_operator:
+              raw_comparison_operator: '='
+          - column_reference:
+            - naked_identifier: foobar_table
+            - dot: .
+            - naked_identifier: foo_bar_id
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            expression:
+              column_reference:
+              - naked_identifier: foobar_table
+              - dot: .
+              - naked_identifier: foo
+              binary_operator: '*'
+              numeric_literal: '2'
+        - comma: ','
+        - select_clause_element:
+            function:
+              function_name:
+                function_name_identifier: UPPER
+              function_contents:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    column_reference:
+                    - naked_identifier: foobar_table
+                    - dot: .
+                    - naked_identifier: bar
+                  end_bracket: )
+        - comma: ','
+        - select_clause_element:
+            function:
+              function_name:
+                function_name_identifier: LENGTH
+              function_contents:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    column_reference:
+                    - naked_identifier: foobar_table
+                    - dot: .
+                    - naked_identifier: foo
+                  end_bracket: )
+        bulk_collect_into_clause:
+        - keyword: BULK
+        - keyword: COLLECT
+        - keyword: INTO
+        - naked_identifier: selected_foo_bars
+        - comma: ','
+        - naked_identifier: selected_bar_bars
+        - comma: ','
+        - naked_identifier: selected_lengths
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: foobar_table
+        where_clause:
+          keyword: WHERE
+          expression:
+          - column_reference:
+            - naked_identifier: foobar_table
+            - dot: .
+            - naked_identifier: id
+          - comparison_operator:
+              raw_comparison_operator: '='
+          - column_reference:
+            - naked_identifier: foobar_table
+            - dot: .
+            - naked_identifier: foo_bar_id
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            expression:
+              bracketed:
+                start_bracket: (
+                expression:
+                  select_statement:
+                    select_clause:
+                      keyword: SELECT
+                      select_clause_element:
+                        function:
+                          function_name:
+                            function_name_identifier: MAX
+                          function_contents:
+                            bracketed:
+                              start_bracket: (
+                              expression:
+                                column_reference:
+                                  naked_identifier: id
+                              end_bracket: )
+                    from_clause:
+                      keyword: FROM
+                      from_expression:
+                        from_expression_element:
+                          table_expression:
+                            table_reference:
+                              naked_identifier: other_table
+                    where_clause:
+                      keyword: WHERE
+                      expression:
+                      - column_reference:
+                        - naked_identifier: other_table
+                        - dot: .
+                        - naked_identifier: ref_id
+                      - comparison_operator:
+                          raw_comparison_operator: '='
+                      - column_reference:
+                        - naked_identifier: foobar_table
+                        - dot: .
+                        - naked_identifier: id
+                end_bracket: )
+        - comma: ','
+        - select_clause_element:
+            expression:
+              case_expression:
+              - keyword: CASE
+              - when_clause:
+                - keyword: WHEN
+                - expression:
+                    column_reference:
+                    - naked_identifier: foobar_table
+                    - dot: .
+                    - naked_identifier: foo
+                    comparison_operator:
+                      raw_comparison_operator: '='
+                    quoted_literal: "'A'"
+                - keyword: THEN
+                - expression:
+                    quoted_literal: "'Alpha'"
+              - when_clause:
+                - keyword: WHEN
+                - expression:
+                    column_reference:
+                    - naked_identifier: foobar_table
+                    - dot: .
+                    - naked_identifier: foo
+                    comparison_operator:
+                      raw_comparison_operator: '='
+                    quoted_literal: "'B'"
+                - keyword: THEN
+                - expression:
+                    quoted_literal: "'Beta'"
+              - else_clause:
+                  keyword: ELSE
+                  expression:
+                    quoted_literal: "'Other'"
+              - keyword: END
+        bulk_collect_into_clause:
+        - keyword: BULK
+        - keyword: COLLECT
+        - keyword: INTO
+        - naked_identifier: selected_max_ids
+        - comma: ','
+        - naked_identifier: selected_categories
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: foobar_table
+        where_clause:
+          keyword: WHERE
+          expression:
+          - column_reference:
+            - naked_identifier: foobar_table
+            - dot: .
+            - naked_identifier: id
+          - comparison_operator:
+              raw_comparison_operator: '='
+          - column_reference:
+            - naked_identifier: foobar_table
+            - dot: .
+            - naked_identifier: foo_bar_id
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_modifier:
+            keyword: DISTINCT
+          select_clause_element:
+            column_reference:
+            - naked_identifier: foobar_table
+            - dot: .
+            - naked_identifier: foo
+        bulk_collect_into_clause:
+        - keyword: BULK
+        - keyword: COLLECT
+        - keyword: INTO
+        - naked_identifier: selected_unique_foos
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: foobar_table
+        where_clause:
+          keyword: WHERE
+          expression:
+          - column_reference:
+            - naked_identifier: foobar_table
+            - dot: .
+            - naked_identifier: id
+          - comparison_operator:
+              raw_comparison_operator: '='
+          - column_reference:
+            - naked_identifier: foobar_table
+            - dot: .
+            - naked_identifier: foo_bar_id
+        orderby_clause:
+        - keyword: ORDER
+        - keyword: BY
         - column_reference:
           - naked_identifier: foobar_table
           - dot: .
-          - naked_identifier: id
-        - comparison_operator:
-            raw_comparison_operator: '='
-        - column_reference:
-          - naked_identifier: foobar_table
-          - dot: .
-          - naked_identifier: foo_bar_id
-- statement_terminator: ;
+          - naked_identifier: foo
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            column_reference:
+            - naked_identifier: foobar_table
+            - dot: .
+            - naked_identifier: foo
+        - comma: ','
+        - select_clause_element:
+            function:
+              function_name:
+                function_name_identifier: ROW_NUMBER
+              function_contents:
+                bracketed:
+                  start_bracket: (
+                  end_bracket: )
+              over_clause:
+                keyword: OVER
+                bracketed:
+                  start_bracket: (
+                  window_specification:
+                    orderby_clause:
+                    - keyword: ORDER
+                    - keyword: BY
+                    - column_reference:
+                      - naked_identifier: foobar_table
+                      - dot: .
+                      - naked_identifier: foo
+                  end_bracket: )
+            alias_expression:
+              alias_operator:
+                keyword: AS
+              naked_identifier: row_num
+        - comma: ','
+        - select_clause_element:
+            function:
+              function_name:
+                function_name_identifier: AVG
+              function_contents:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    column_reference:
+                    - naked_identifier: foobar_table
+                    - dot: .
+                    - naked_identifier: value
+                  end_bracket: )
+              over_clause:
+                keyword: OVER
+                bracketed:
+                  start_bracket: (
+                  window_specification:
+                    partitionby_clause:
+                    - keyword: PARTITION
+                    - keyword: BY
+                    - expression:
+                        column_reference:
+                        - naked_identifier: foobar_table
+                        - dot: .
+                        - naked_identifier: category
+                  end_bracket: )
+        bulk_collect_into_clause:
+        - keyword: BULK
+        - keyword: COLLECT
+        - keyword: INTO
+        - naked_identifier: selected_foo_bars
+        - comma: ','
+        - naked_identifier: selected_row_nums
+        - comma: ','
+        - naked_identifier: selected_avgs
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: foobar_table
+        where_clause:
+          keyword: WHERE
+          expression:
+          - column_reference:
+            - naked_identifier: foobar_table
+            - dot: .
+            - naked_identifier: id
+          - comparison_operator:
+              raw_comparison_operator: '='
+          - column_reference:
+            - naked_identifier: foobar_table
+            - dot: .
+            - naked_identifier: foo_bar_id
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            column_reference:
+            - naked_identifier: foobar_table
+            - dot: .
+            - naked_identifier: foo
+        - comma: ','
+        - select_clause_element:
+            bare_function: SYSDATE
+        - comma: ','
+        - select_clause_element:
+            function:
+              function_name:
+                function_name_identifier: CONCAT
+              function_contents:
+                bracketed:
+                - start_bracket: (
+                - expression:
+                    column_reference:
+                    - naked_identifier: foobar_table
+                    - dot: .
+                    - naked_identifier: foo
+                - comma: ','
+                - expression:
+                    quoted_literal: "'_suffix'"
+                - end_bracket: )
+        - comma: ','
+        - select_clause_element:
+            function:
+              function_name:
+                function_name_identifier: SUBSTR
+              function_contents:
+                bracketed:
+                - start_bracket: (
+                - expression:
+                    column_reference:
+                    - naked_identifier: foobar_table
+                    - dot: .
+                    - naked_identifier: foo
+                - comma: ','
+                - expression:
+                    numeric_literal: '1'
+                - comma: ','
+                - expression:
+                    numeric_literal: '3'
+                - end_bracket: )
+        bulk_collect_into_clause:
+        - keyword: BULK
+        - keyword: COLLECT
+        - keyword: INTO
+        - naked_identifier: selected_foos
+        - comma: ','
+        - naked_identifier: selected_sysdates
+        - comma: ','
+        - naked_identifier: selected_concat
+        - comma: ','
+        - naked_identifier: selected_substr
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: foobar_table
+        where_clause:
+          keyword: WHERE
+          expression:
+          - column_reference:
+            - naked_identifier: foobar_table
+            - dot: .
+            - naked_identifier: id
+          - comparison_operator:
+              raw_comparison_operator: '='
+          - column_reference:
+            - naked_identifier: foobar_table
+            - dot: .
+            - naked_identifier: foo_bar_id
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            column_reference:
+            - naked_identifier: foobar_table
+            - dot: .
+            - naked_identifier: foo
+        - comma: ','
+        - select_clause_element:
+            expression:
+              case_expression:
+              - keyword: CASE
+              - when_clause:
+                - keyword: WHEN
+                - expression:
+                    column_reference:
+                    - naked_identifier: foobar_table
+                    - dot: .
+                    - naked_identifier: value
+                    comparison_operator:
+                      raw_comparison_operator: '>'
+                    numeric_literal: '100'
+                - keyword: THEN
+                - expression:
+                    quoted_literal: "'High'"
+              - when_clause:
+                - keyword: WHEN
+                - expression:
+                    column_reference:
+                    - naked_identifier: foobar_table
+                    - dot: .
+                    - naked_identifier: value
+                    comparison_operator:
+                      raw_comparison_operator: '>'
+                    numeric_literal: '50'
+                - keyword: THEN
+                - expression:
+                    quoted_literal: "'Medium'"
+              - else_clause:
+                  keyword: ELSE
+                  expression:
+                    quoted_literal: "'Low'"
+              - keyword: END
+            alias_expression:
+              alias_operator:
+                keyword: AS
+              naked_identifier: value_category
+        - comma: ','
+        - select_clause_element:
+            expression:
+              column_reference:
+              - naked_identifier: foobar_table
+              - dot: .
+              - naked_identifier: value
+              binary_operator: '*'
+              numeric_literal: '1.1'
+        bulk_collect_into_clause:
+        - keyword: BULK
+        - keyword: COLLECT
+        - keyword: INTO
+        - naked_identifier: selected_foos
+        - comma: ','
+        - naked_identifier: selected_categories
+        - comma: ','
+        - naked_identifier: selected_values
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: foobar_table
+        where_clause:
+          keyword: WHERE
+          expression:
+          - column_reference:
+            - naked_identifier: foobar_table
+            - dot: .
+            - naked_identifier: id
+          - comparison_operator:
+              raw_comparison_operator: '='
+          - column_reference:
+            - naked_identifier: foobar_table
+            - dot: .
+            - naked_identifier: foo_bar_id
+  - statement_terminator: ;

--- a/test/fixtures/dialects/oracle/case_expressions.yml
+++ b/test/fixtures/dialects/oracle/case_expressions.yml
@@ -3,877 +3,417 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 162ce31b0e333dc38b301e2cd94fff10314fd8eec6c2863fdd253212729da876
+_hash: dca18c63395c45a8a1f791f9fc91c357da9faffa6421a1a01d16aacba2752d9d
 file:
-- statement:
-    select_statement:
-      select_clause:
-        keyword: SELECT
-        select_clause_element:
-          expression:
-            case_expression:
-            - keyword: CASE
-            - when_clause:
-              - keyword: WHEN
-              - expression:
-                  column_reference:
-                    naked_identifier: x
-                  comparison_operator:
-                    raw_comparison_operator: '='
-                  numeric_literal: '5'
-              - keyword: THEN
-              - expression:
-                  numeric_literal: '1'
-            - when_clause:
-              - keyword: WHEN
-              - expression:
-                  column_reference:
-                    naked_identifier: x
-                  comparison_operator:
-                    raw_comparison_operator: '='
-                  numeric_literal: '10'
-              - keyword: THEN
-              - expression:
-                  numeric_literal: '2'
-            - else_clause:
-                keyword: ELSE
-                expression:
-                  numeric_literal: '0'
-            - keyword: END
-          alias_expression:
-            alias_operator:
-              keyword: AS
-            naked_identifier: result
-      from_clause:
-        keyword: FROM
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: abc
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-        keyword: SELECT
-        select_clause_element:
-          expression:
-            case_expression:
-            - keyword: CASE
-            - when_clause:
-              - keyword: WHEN
-              - expression:
-                  column_reference:
-                    naked_identifier: x
-                  comparison_operator:
-                    raw_comparison_operator: '='
-                  numeric_literal: '5'
-              - keyword: THEN
-              - expression:
-                  numeric_literal: '1'
-            - when_clause:
-              - keyword: WHEN
-              - expression:
-                  column_reference:
-                    naked_identifier: x
-                  comparison_operator:
-                    raw_comparison_operator: '='
-                  numeric_literal: '10'
-              - keyword: THEN
-              - expression:
-                  numeric_literal: '2'
-            - keyword: END
-          alias_expression:
-            alias_operator:
-              keyword: AS
-            naked_identifier: result
-      from_clause:
-        keyword: FROM
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: abc
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-        keyword: SELECT
-        select_clause_element:
-          expression:
-            case_expression:
-            - keyword: CASE
-            - when_clause:
-              - keyword: WHEN
-              - expression:
-                  column_reference:
-                    naked_identifier: x
-                  comparison_operator:
-                    raw_comparison_operator: '='
-                  numeric_literal: '5'
-              - keyword: THEN
-              - expression:
-                  case_expression:
-                  - keyword: CASE
-                  - when_clause:
-                    - keyword: WHEN
-                    - expression:
-                        column_reference:
-                          naked_identifier: y
-                        comparison_operator:
-                          raw_comparison_operator: '='
-                        numeric_literal: '6'
-                    - keyword: THEN
-                    - expression:
-                        numeric_literal: '999'
-                  - keyword: END
-            - keyword: END
-          alias_expression:
-            alias_operator:
-              keyword: AS
-            naked_identifier: hi
-      from_clause:
-        keyword: FROM
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: abc
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-        keyword: SELECT
-        select_clause_element:
-          expression:
-            case_expression:
-            - keyword: CASE
-            - when_clause:
-              - keyword: WHEN
-              - expression:
-                  column_reference:
-                    naked_identifier: x
-                  comparison_operator:
-                    raw_comparison_operator: '='
-                  numeric_literal: '5'
-              - keyword: THEN
-              - expression:
-                  case_expression:
-                  - keyword: CASE
-                  - when_clause:
-                    - keyword: WHEN
-                    - expression:
-                        column_reference:
-                          naked_identifier: y
-                        comparison_operator:
-                          raw_comparison_operator: '='
-                        numeric_literal: '6'
-                    - keyword: THEN
-                    - expression:
-                        numeric_literal: '999'
-                  - else_clause:
-                      keyword: ELSE
-                      expression:
-                        numeric_literal: '888'
-                  - keyword: END
-            - else_clause:
-                keyword: ELSE
-                expression:
-                  numeric_literal: '777'
-            - keyword: END
-          alias_expression:
-            alias_operator:
-              keyword: AS
-            naked_identifier: result
-      from_clause:
-        keyword: FROM
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: abc
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-        keyword: SELECT
-        select_clause_element:
-          expression:
-            case_expression:
-            - keyword: CASE
-            - expression:
-                column_reference:
-                  naked_identifier: x
-            - when_clause:
-              - keyword: WHEN
-              - expression:
-                  numeric_literal: '5'
-              - keyword: THEN
-              - expression:
-                  numeric_literal: '1'
-            - when_clause:
-              - keyword: WHEN
-              - expression:
-                  numeric_literal: '10'
-              - keyword: THEN
-              - expression:
-                  numeric_literal: '2'
-            - else_clause:
-                keyword: ELSE
-                expression:
-                  numeric_literal: '0'
-            - keyword: END
-          alias_expression:
-            alias_operator:
-              keyword: AS
-            naked_identifier: result
-      from_clause:
-        keyword: FROM
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: abc
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-        keyword: SELECT
-        select_clause_element:
-          expression:
-            case_expression:
-            - keyword: CASE
-            - expression:
-                column_reference:
-                  naked_identifier: x
-            - when_clause:
-              - keyword: WHEN
-              - expression:
-                  numeric_literal: '5'
-              - keyword: THEN
-              - expression:
-                  case_expression:
-                  - keyword: CASE
-                  - expression:
-                      column_reference:
-                        naked_identifier: y
-                  - when_clause:
-                    - keyword: WHEN
-                    - expression:
-                        numeric_literal: '6'
-                    - keyword: THEN
-                    - expression:
-                        numeric_literal: '999'
-                  - else_clause:
-                      keyword: ELSE
-                      expression:
-                        numeric_literal: '888'
-                  - keyword: END
-            - when_clause:
-              - keyword: WHEN
-              - expression:
-                  numeric_literal: '10'
-              - keyword: THEN
-              - expression:
-                  numeric_literal: '2'
-            - else_clause:
-                keyword: ELSE
-                expression:
-                  numeric_literal: '0'
-            - keyword: END
-          alias_expression:
-            alias_operator:
-              keyword: AS
-            naked_identifier: result
-      from_clause:
-        keyword: FROM
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: abc
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-        keyword: SELECT
-        select_clause_element:
-          expression:
-            case_expression:
-            - keyword: CASE
-            - when_clause:
-              - keyword: WHEN
-              - expression:
-                  column_reference:
-                    naked_identifier: x
-                  comparison_operator:
-                    raw_comparison_operator: '='
-                  numeric_literal: '5'
-              - keyword: THEN
-              - expression:
-                  case_expression:
-                  - keyword: CASE
-                  - when_clause:
-                    - keyword: WHEN
-                    - expression:
-                        column_reference:
-                          naked_identifier: y
-                        comparison_operator:
-                          raw_comparison_operator: '='
-                        numeric_literal: '6'
-                    - keyword: THEN
-                    - expression:
-                        case_expression:
-                        - keyword: CASE
-                        - expression:
-                            column_reference:
-                              naked_identifier: z
-                        - when_clause:
-                          - keyword: WHEN
-                          - expression:
-                              numeric_literal: '7'
-                          - keyword: THEN
-                          - expression:
-                              numeric_literal: '777'
-                        - when_clause:
-                          - keyword: WHEN
-                          - expression:
-                              numeric_literal: '8'
-                          - keyword: THEN
-                          - expression:
-                              numeric_literal: '888'
-                        - else_clause:
-                            keyword: ELSE
-                            expression:
-                              numeric_literal: '999'
-                        - keyword: END
-                  - else_clause:
-                      keyword: ELSE
-                      expression:
-                        numeric_literal: '666'
-                  - keyword: END
-            - when_clause:
-              - keyword: WHEN
-              - expression:
-                  column_reference:
-                    naked_identifier: x
-                  comparison_operator:
-                    raw_comparison_operator: '='
-                  numeric_literal: '10'
-              - keyword: THEN
-              - expression:
-                  case_expression:
-                  - keyword: CASE
-                  - expression:
-                      column_reference:
-                        naked_identifier: y
-                  - when_clause:
-                    - keyword: WHEN
-                    - expression:
-                        numeric_literal: '11'
-                    - keyword: THEN
-                    - expression:
-                        numeric_literal: '111'
-                  - else_clause:
-                      keyword: ELSE
-                      expression:
-                        numeric_literal: '222'
-                  - keyword: END
-            - else_clause:
-                keyword: ELSE
-                expression:
-                  numeric_literal: '333'
-            - keyword: END
-          alias_expression:
-            alias_operator:
-              keyword: AS
-            naked_identifier: complex_result
-      from_clause:
-        keyword: FROM
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: abc
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-        keyword: SELECT
-        select_clause_element:
-          wildcard_expression:
-            wildcard_identifier:
-              star: '*'
-      from_clause:
-        keyword: FROM
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: abc
-      where_clause:
-        keyword: WHERE
-        expression:
-          case_expression:
-          - keyword: CASE
-          - when_clause:
-            - keyword: WHEN
-            - expression:
-                column_reference:
-                  naked_identifier: x
-                comparison_operator:
-                  raw_comparison_operator: '='
-                numeric_literal: '5'
-            - keyword: THEN
-            - expression:
-                numeric_literal: '1'
-          - when_clause:
-            - keyword: WHEN
-            - expression:
-                column_reference:
-                  naked_identifier: x
-                comparison_operator:
-                  raw_comparison_operator: '='
-                numeric_literal: '10'
-            - keyword: THEN
-            - expression:
-                numeric_literal: '2'
-          - else_clause:
-              keyword: ELSE
-              expression:
-                numeric_literal: '0'
-          - keyword: END
-          comparison_operator:
-            raw_comparison_operator: '='
-          numeric_literal: '1'
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-      - keyword: SELECT
-      - select_clause_element:
-          column_reference:
-            naked_identifier: x
-      - comma: ','
-      - select_clause_element:
-          column_reference:
-            naked_identifier: y
-      - comma: ','
-      - select_clause_element:
-          column_reference:
-            naked_identifier: z
-      from_clause:
-        keyword: FROM
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: abc
-      orderby_clause:
-      - keyword: ORDER
-      - keyword: BY
-      - expression:
-          case_expression:
-          - keyword: CASE
-          - when_clause:
-            - keyword: WHEN
-            - expression:
-                column_reference:
-                  naked_identifier: x
-                comparison_operator:
-                  raw_comparison_operator: '='
-                numeric_literal: '5'
-            - keyword: THEN
-            - expression:
-                numeric_literal: '1'
-          - when_clause:
-            - keyword: WHEN
-            - expression:
-                column_reference:
-                  naked_identifier: x
-                comparison_operator:
-                  raw_comparison_operator: '='
-                numeric_literal: '10'
-            - keyword: THEN
-            - expression:
-                numeric_literal: '2'
-          - else_clause:
-              keyword: ELSE
-              expression:
-                numeric_literal: '3'
-          - keyword: END
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-        keyword: SELECT
-        select_clause_element:
-          expression:
-            case_expression:
-            - keyword: CASE
-            - when_clause:
-              - keyword: WHEN
-              - expression:
-                  function:
-                    function_name:
-                      function_name_identifier: LENGTH
-                    function_contents:
-                      bracketed:
-                        start_bracket: (
-                        expression:
-                          column_reference:
-                            naked_identifier: name
-                        end_bracket: )
-                  comparison_operator:
-                    raw_comparison_operator: '>'
-                  numeric_literal: '10'
-              - keyword: THEN
-              - expression:
-                  quoted_literal: "'Long'"
-            - when_clause:
-              - keyword: WHEN
-              - expression:
-                  function:
-                    function_name:
-                      function_name_identifier: LENGTH
-                    function_contents:
-                      bracketed:
-                        start_bracket: (
-                        expression:
-                          column_reference:
-                            naked_identifier: name
-                        end_bracket: )
-                  comparison_operator:
-                    raw_comparison_operator: '>'
-                  numeric_literal: '5'
-              - keyword: THEN
-              - expression:
-                  quoted_literal: "'Medium'"
-            - else_clause:
-                keyword: ELSE
-                expression:
-                  quoted_literal: "'Short'"
-            - keyword: END
-          alias_expression:
-            alias_operator:
-              keyword: AS
-            naked_identifier: name_length
-      from_clause:
-        keyword: FROM
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: abc
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-        keyword: SELECT
-        select_clause_element:
-          expression:
-            case_expression:
-            - keyword: CASE
-            - when_clause:
-              - keyword: WHEN
-              - expression:
-                  column_reference:
-                    naked_identifier: x
-                  keyword: IS
-                  null_literal: 'NULL'
-              - keyword: THEN
-              - expression:
-                  quoted_literal: "'NULL'"
-            - when_clause:
-              - keyword: WHEN
-              - expression:
-                  column_reference:
-                    naked_identifier: x
-                  comparison_operator:
-                    raw_comparison_operator: '='
-                  numeric_literal: '0'
-              - keyword: THEN
-              - expression:
-                  quoted_literal: "'Zero'"
-            - when_clause:
-              - keyword: WHEN
-              - expression:
-                  column_reference:
-                    naked_identifier: x
-                  comparison_operator:
-                    raw_comparison_operator: '>'
-                  numeric_literal: '0'
-              - keyword: THEN
-              - expression:
-                  quoted_literal: "'Positive'"
-            - else_clause:
-                keyword: ELSE
-                expression:
-                  quoted_literal: "'Negative'"
-            - keyword: END
-          alias_expression:
-            alias_operator:
-              keyword: AS
-            naked_identifier: x_status
-      from_clause:
-        keyword: FROM
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: abc
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-        keyword: SELECT
-        select_clause_element:
-          expression:
-            case_expression:
-            - keyword: CASE
-            - when_clause:
-              - keyword: WHEN
-              - expression:
-                - column_reference:
-                    naked_identifier: x
-                - comparison_operator:
-                    raw_comparison_operator: '='
-                - numeric_literal: '5'
-                - binary_operator: AND
-                - column_reference:
-                    naked_identifier: y
-                - comparison_operator:
-                    raw_comparison_operator: '='
-                - numeric_literal: '6'
-              - keyword: THEN
-              - expression:
-                  quoted_literal: "'Both match'"
-            - when_clause:
-              - keyword: WHEN
-              - expression:
-                - column_reference:
-                    naked_identifier: x
-                - comparison_operator:
-                    raw_comparison_operator: '='
-                - numeric_literal: '5'
-                - binary_operator: OR
-                - column_reference:
-                    naked_identifier: y
-                - comparison_operator:
-                    raw_comparison_operator: '='
-                - numeric_literal: '6'
-              - keyword: THEN
-              - expression:
-                  quoted_literal: "'One matches'"
-            - else_clause:
-                keyword: ELSE
-                expression:
-                  quoted_literal: "'Neither matches'"
-            - keyword: END
-          alias_expression:
-            alias_operator:
-              keyword: AS
-            naked_identifier: condition_result
-      from_clause:
-        keyword: FROM
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: abc
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-        keyword: SELECT
-        select_clause_element:
-          expression:
-            case_expression:
-            - keyword: CASE
-            - when_clause:
-              - keyword: WHEN
-              - expression:
-                  column_reference:
-                    naked_identifier: x
-                  comparison_operator:
-                    raw_comparison_operator: '='
-                  numeric_literal: '5'
-              - keyword: THEN
-              - expression:
-                  bracketed:
-                    start_bracket: (
-                    expression:
-                      select_statement:
-                        select_clause:
-                          keyword: SELECT
-                          select_clause_element:
-                            function:
-                              function_name:
-                                function_name_identifier: MAX
-                              function_contents:
-                                bracketed:
-                                  start_bracket: (
-                                  expression:
-                                    column_reference:
-                                      naked_identifier: id
-                                  end_bracket: )
-                        from_clause:
-                          keyword: FROM
-                          from_expression:
-                            from_expression_element:
-                              table_expression:
-                                table_reference:
-                                  naked_identifier: def
-                        where_clause:
-                          keyword: WHERE
-                          expression:
-                          - column_reference:
-                              naked_identifier: id
-                          - comparison_operator:
-                              raw_comparison_operator: '='
-                          - column_reference:
-                              naked_identifier: x
-                    end_bracket: )
-            - when_clause:
-              - keyword: WHEN
-              - expression:
-                  column_reference:
-                    naked_identifier: x
-                  comparison_operator:
-                    raw_comparison_operator: '='
-                  numeric_literal: '10'
-              - keyword: THEN
-              - expression:
-                  bracketed:
-                    start_bracket: (
-                    expression:
-                      select_statement:
-                        select_clause:
-                          keyword: SELECT
-                          select_clause_element:
-                            function:
-                              function_name:
-                                function_name_identifier: MIN
-                              function_contents:
-                                bracketed:
-                                  start_bracket: (
-                                  expression:
-                                    column_reference:
-                                      naked_identifier: id
-                                  end_bracket: )
-                        from_clause:
-                          keyword: FROM
-                          from_expression:
-                            from_expression_element:
-                              table_expression:
-                                table_reference:
-                                  naked_identifier: def
-                        where_clause:
-                          keyword: WHERE
-                          expression:
-                          - column_reference:
-                              naked_identifier: id
-                          - comparison_operator:
-                              raw_comparison_operator: '='
-                          - column_reference:
-                              naked_identifier: x
-                    end_bracket: )
-            - else_clause:
-                keyword: ELSE
-                expression:
-                  numeric_literal: '0'
-            - keyword: END
-          alias_expression:
-            alias_operator:
-              keyword: AS
-            naked_identifier: subquery_result
-      from_clause:
-        keyword: FROM
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: abc
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-        keyword: SELECT
-        select_clause_element:
-          expression:
-            case_expression:
-            - keyword: CASE
-            - when_clause:
-              - keyword: WHEN
-              - expression:
-                  column_reference:
-                    naked_identifier: x
-                  comparison_operator:
-                    raw_comparison_operator: '='
-                  numeric_literal: '5'
-              - keyword: THEN
-              - expression:
-                  function:
-                    function_name:
-                      function_name_identifier: TO_CHAR
-                    function_contents:
-                      bracketed:
-                      - start_bracket: (
+  batch:
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            expression:
+              case_expression:
+              - keyword: CASE
+              - when_clause:
+                - keyword: WHEN
+                - expression:
+                    column_reference:
+                      naked_identifier: x
+                    comparison_operator:
+                      raw_comparison_operator: '='
+                    numeric_literal: '5'
+                - keyword: THEN
+                - expression:
+                    numeric_literal: '1'
+              - when_clause:
+                - keyword: WHEN
+                - expression:
+                    column_reference:
+                      naked_identifier: x
+                    comparison_operator:
+                      raw_comparison_operator: '='
+                    numeric_literal: '10'
+                - keyword: THEN
+                - expression:
+                    numeric_literal: '2'
+              - else_clause:
+                  keyword: ELSE
+                  expression:
+                    numeric_literal: '0'
+              - keyword: END
+            alias_expression:
+              alias_operator:
+                keyword: AS
+              naked_identifier: result
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: abc
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            expression:
+              case_expression:
+              - keyword: CASE
+              - when_clause:
+                - keyword: WHEN
+                - expression:
+                    column_reference:
+                      naked_identifier: x
+                    comparison_operator:
+                      raw_comparison_operator: '='
+                    numeric_literal: '5'
+                - keyword: THEN
+                - expression:
+                    numeric_literal: '1'
+              - when_clause:
+                - keyword: WHEN
+                - expression:
+                    column_reference:
+                      naked_identifier: x
+                    comparison_operator:
+                      raw_comparison_operator: '='
+                    numeric_literal: '10'
+                - keyword: THEN
+                - expression:
+                    numeric_literal: '2'
+              - keyword: END
+            alias_expression:
+              alias_operator:
+                keyword: AS
+              naked_identifier: result
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: abc
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            expression:
+              case_expression:
+              - keyword: CASE
+              - when_clause:
+                - keyword: WHEN
+                - expression:
+                    column_reference:
+                      naked_identifier: x
+                    comparison_operator:
+                      raw_comparison_operator: '='
+                    numeric_literal: '5'
+                - keyword: THEN
+                - expression:
+                    case_expression:
+                    - keyword: CASE
+                    - when_clause:
+                      - keyword: WHEN
                       - expression:
                           column_reference:
-                            naked_identifier: x
-                      - comma: ','
+                            naked_identifier: y
+                          comparison_operator:
+                            raw_comparison_operator: '='
+                          numeric_literal: '6'
+                      - keyword: THEN
                       - expression:
-                          quoted_literal: "'999'"
-                      - end_bracket: )
-            - when_clause:
-              - keyword: WHEN
+                          numeric_literal: '999'
+                    - keyword: END
+              - keyword: END
+            alias_expression:
+              alias_operator:
+                keyword: AS
+              naked_identifier: hi
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: abc
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            expression:
+              case_expression:
+              - keyword: CASE
+              - when_clause:
+                - keyword: WHEN
+                - expression:
+                    column_reference:
+                      naked_identifier: x
+                    comparison_operator:
+                      raw_comparison_operator: '='
+                    numeric_literal: '5'
+                - keyword: THEN
+                - expression:
+                    case_expression:
+                    - keyword: CASE
+                    - when_clause:
+                      - keyword: WHEN
+                      - expression:
+                          column_reference:
+                            naked_identifier: y
+                          comparison_operator:
+                            raw_comparison_operator: '='
+                          numeric_literal: '6'
+                      - keyword: THEN
+                      - expression:
+                          numeric_literal: '999'
+                    - else_clause:
+                        keyword: ELSE
+                        expression:
+                          numeric_literal: '888'
+                    - keyword: END
+              - else_clause:
+                  keyword: ELSE
+                  expression:
+                    numeric_literal: '777'
+              - keyword: END
+            alias_expression:
+              alias_operator:
+                keyword: AS
+              naked_identifier: result
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: abc
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            expression:
+              case_expression:
+              - keyword: CASE
               - expression:
                   column_reference:
                     naked_identifier: x
-                  comparison_operator:
-                    raw_comparison_operator: '='
-                  numeric_literal: '10'
-              - keyword: THEN
+              - when_clause:
+                - keyword: WHEN
+                - expression:
+                    numeric_literal: '5'
+                - keyword: THEN
+                - expression:
+                    numeric_literal: '1'
+              - when_clause:
+                - keyword: WHEN
+                - expression:
+                    numeric_literal: '10'
+                - keyword: THEN
+                - expression:
+                    numeric_literal: '2'
+              - else_clause:
+                  keyword: ELSE
+                  expression:
+                    numeric_literal: '0'
+              - keyword: END
+            alias_expression:
+              alias_operator:
+                keyword: AS
+              naked_identifier: result
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: abc
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            expression:
+              case_expression:
+              - keyword: CASE
               - expression:
-                  function:
-                    function_name:
-                      function_name_identifier: TO_NUMBER
-                    function_contents:
-                      bracketed:
-                        start_bracket: (
+                  column_reference:
+                    naked_identifier: x
+              - when_clause:
+                - keyword: WHEN
+                - expression:
+                    numeric_literal: '5'
+                - keyword: THEN
+                - expression:
+                    case_expression:
+                    - keyword: CASE
+                    - expression:
+                        column_reference:
+                          naked_identifier: y
+                    - when_clause:
+                      - keyword: WHEN
+                      - expression:
+                          numeric_literal: '6'
+                      - keyword: THEN
+                      - expression:
+                          numeric_literal: '999'
+                    - else_clause:
+                        keyword: ELSE
                         expression:
-                          quoted_literal: "'10'"
-                        end_bracket: )
-            - else_clause:
-                keyword: ELSE
-                expression:
-                  quoted_literal: "'Unknown'"
-            - keyword: END
-          alias_expression:
-            alias_operator:
-              keyword: AS
-            naked_identifier: converted_result
-      from_clause:
-        keyword: FROM
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: abc
-- statement_terminator: ;
-- statement:
-    update_statement:
-      keyword: UPDATE
-      table_reference:
-        naked_identifier: abc
-      set_clause_list:
-        keyword: SET
-        set_clause:
-          column_reference:
-            naked_identifier: status
-          comparison_operator:
-            raw_comparison_operator: '='
+                          numeric_literal: '888'
+                    - keyword: END
+              - when_clause:
+                - keyword: WHEN
+                - expression:
+                    numeric_literal: '10'
+                - keyword: THEN
+                - expression:
+                    numeric_literal: '2'
+              - else_clause:
+                  keyword: ELSE
+                  expression:
+                    numeric_literal: '0'
+              - keyword: END
+            alias_expression:
+              alias_operator:
+                keyword: AS
+              naked_identifier: result
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: abc
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            expression:
+              case_expression:
+              - keyword: CASE
+              - when_clause:
+                - keyword: WHEN
+                - expression:
+                    column_reference:
+                      naked_identifier: x
+                    comparison_operator:
+                      raw_comparison_operator: '='
+                    numeric_literal: '5'
+                - keyword: THEN
+                - expression:
+                    case_expression:
+                    - keyword: CASE
+                    - when_clause:
+                      - keyword: WHEN
+                      - expression:
+                          column_reference:
+                            naked_identifier: y
+                          comparison_operator:
+                            raw_comparison_operator: '='
+                          numeric_literal: '6'
+                      - keyword: THEN
+                      - expression:
+                          case_expression:
+                          - keyword: CASE
+                          - expression:
+                              column_reference:
+                                naked_identifier: z
+                          - when_clause:
+                            - keyword: WHEN
+                            - expression:
+                                numeric_literal: '7'
+                            - keyword: THEN
+                            - expression:
+                                numeric_literal: '777'
+                          - when_clause:
+                            - keyword: WHEN
+                            - expression:
+                                numeric_literal: '8'
+                            - keyword: THEN
+                            - expression:
+                                numeric_literal: '888'
+                          - else_clause:
+                              keyword: ELSE
+                              expression:
+                                numeric_literal: '999'
+                          - keyword: END
+                    - else_clause:
+                        keyword: ELSE
+                        expression:
+                          numeric_literal: '666'
+                    - keyword: END
+              - when_clause:
+                - keyword: WHEN
+                - expression:
+                    column_reference:
+                      naked_identifier: x
+                    comparison_operator:
+                      raw_comparison_operator: '='
+                    numeric_literal: '10'
+                - keyword: THEN
+                - expression:
+                    case_expression:
+                    - keyword: CASE
+                    - expression:
+                        column_reference:
+                          naked_identifier: y
+                    - when_clause:
+                      - keyword: WHEN
+                      - expression:
+                          numeric_literal: '11'
+                      - keyword: THEN
+                      - expression:
+                          numeric_literal: '111'
+                    - else_clause:
+                        keyword: ELSE
+                        expression:
+                          numeric_literal: '222'
+                    - keyword: END
+              - else_clause:
+                  keyword: ELSE
+                  expression:
+                    numeric_literal: '333'
+              - keyword: END
+            alias_expression:
+              alias_operator:
+                keyword: AS
+              naked_identifier: complex_result
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: abc
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: abc
+        where_clause:
+          keyword: WHERE
           expression:
             case_expression:
             - keyword: CASE
@@ -887,7 +427,7 @@ file:
                   numeric_literal: '5'
               - keyword: THEN
               - expression:
-                  quoted_literal: "'Active'"
+                  numeric_literal: '1'
             - when_clause:
               - keyword: WHEN
               - expression:
@@ -898,43 +438,443 @@ file:
                   numeric_literal: '10'
               - keyword: THEN
               - expression:
-                  quoted_literal: "'Inactive'"
+                  numeric_literal: '2'
             - else_clause:
                 keyword: ELSE
                 expression:
-                  quoted_literal: "'Unknown'"
+                  numeric_literal: '0'
             - keyword: END
-      where_clause:
-        keyword: WHERE
-        expression:
-          column_reference:
-            naked_identifier: id
-          comparison_operator:
-            raw_comparison_operator: '='
-          numeric_literal: '1'
-- statement_terminator: ;
-- statement:
-    insert_statement:
-    - keyword: INSERT
-    - keyword: INTO
-    - table_reference:
-        naked_identifier: abc
-    - bracketed:
-      - start_bracket: (
-      - column_reference:
-          naked_identifier: id
-      - comma: ','
-      - column_reference:
-          naked_identifier: status
-      - end_bracket: )
-    - select_statement:
+            comparison_operator:
+              raw_comparison_operator: '='
+            numeric_literal: '1'
+  - statement_terminator: ;
+  - statement:
+      select_statement:
         select_clause:
         - keyword: SELECT
         - select_clause_element:
             column_reference:
-              naked_identifier: id
+              naked_identifier: x
         - comma: ','
         - select_clause_element:
+            column_reference:
+              naked_identifier: y
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+              naked_identifier: z
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: abc
+        orderby_clause:
+        - keyword: ORDER
+        - keyword: BY
+        - expression:
+            case_expression:
+            - keyword: CASE
+            - when_clause:
+              - keyword: WHEN
+              - expression:
+                  column_reference:
+                    naked_identifier: x
+                  comparison_operator:
+                    raw_comparison_operator: '='
+                  numeric_literal: '5'
+              - keyword: THEN
+              - expression:
+                  numeric_literal: '1'
+            - when_clause:
+              - keyword: WHEN
+              - expression:
+                  column_reference:
+                    naked_identifier: x
+                  comparison_operator:
+                    raw_comparison_operator: '='
+                  numeric_literal: '10'
+              - keyword: THEN
+              - expression:
+                  numeric_literal: '2'
+            - else_clause:
+                keyword: ELSE
+                expression:
+                  numeric_literal: '3'
+            - keyword: END
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            expression:
+              case_expression:
+              - keyword: CASE
+              - when_clause:
+                - keyword: WHEN
+                - expression:
+                    function:
+                      function_name:
+                        function_name_identifier: LENGTH
+                      function_contents:
+                        bracketed:
+                          start_bracket: (
+                          expression:
+                            column_reference:
+                              naked_identifier: name
+                          end_bracket: )
+                    comparison_operator:
+                      raw_comparison_operator: '>'
+                    numeric_literal: '10'
+                - keyword: THEN
+                - expression:
+                    quoted_literal: "'Long'"
+              - when_clause:
+                - keyword: WHEN
+                - expression:
+                    function:
+                      function_name:
+                        function_name_identifier: LENGTH
+                      function_contents:
+                        bracketed:
+                          start_bracket: (
+                          expression:
+                            column_reference:
+                              naked_identifier: name
+                          end_bracket: )
+                    comparison_operator:
+                      raw_comparison_operator: '>'
+                    numeric_literal: '5'
+                - keyword: THEN
+                - expression:
+                    quoted_literal: "'Medium'"
+              - else_clause:
+                  keyword: ELSE
+                  expression:
+                    quoted_literal: "'Short'"
+              - keyword: END
+            alias_expression:
+              alias_operator:
+                keyword: AS
+              naked_identifier: name_length
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: abc
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            expression:
+              case_expression:
+              - keyword: CASE
+              - when_clause:
+                - keyword: WHEN
+                - expression:
+                    column_reference:
+                      naked_identifier: x
+                    keyword: IS
+                    null_literal: 'NULL'
+                - keyword: THEN
+                - expression:
+                    quoted_literal: "'NULL'"
+              - when_clause:
+                - keyword: WHEN
+                - expression:
+                    column_reference:
+                      naked_identifier: x
+                    comparison_operator:
+                      raw_comparison_operator: '='
+                    numeric_literal: '0'
+                - keyword: THEN
+                - expression:
+                    quoted_literal: "'Zero'"
+              - when_clause:
+                - keyword: WHEN
+                - expression:
+                    column_reference:
+                      naked_identifier: x
+                    comparison_operator:
+                      raw_comparison_operator: '>'
+                    numeric_literal: '0'
+                - keyword: THEN
+                - expression:
+                    quoted_literal: "'Positive'"
+              - else_clause:
+                  keyword: ELSE
+                  expression:
+                    quoted_literal: "'Negative'"
+              - keyword: END
+            alias_expression:
+              alias_operator:
+                keyword: AS
+              naked_identifier: x_status
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: abc
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            expression:
+              case_expression:
+              - keyword: CASE
+              - when_clause:
+                - keyword: WHEN
+                - expression:
+                  - column_reference:
+                      naked_identifier: x
+                  - comparison_operator:
+                      raw_comparison_operator: '='
+                  - numeric_literal: '5'
+                  - binary_operator: AND
+                  - column_reference:
+                      naked_identifier: y
+                  - comparison_operator:
+                      raw_comparison_operator: '='
+                  - numeric_literal: '6'
+                - keyword: THEN
+                - expression:
+                    quoted_literal: "'Both match'"
+              - when_clause:
+                - keyword: WHEN
+                - expression:
+                  - column_reference:
+                      naked_identifier: x
+                  - comparison_operator:
+                      raw_comparison_operator: '='
+                  - numeric_literal: '5'
+                  - binary_operator: OR
+                  - column_reference:
+                      naked_identifier: y
+                  - comparison_operator:
+                      raw_comparison_operator: '='
+                  - numeric_literal: '6'
+                - keyword: THEN
+                - expression:
+                    quoted_literal: "'One matches'"
+              - else_clause:
+                  keyword: ELSE
+                  expression:
+                    quoted_literal: "'Neither matches'"
+              - keyword: END
+            alias_expression:
+              alias_operator:
+                keyword: AS
+              naked_identifier: condition_result
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: abc
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            expression:
+              case_expression:
+              - keyword: CASE
+              - when_clause:
+                - keyword: WHEN
+                - expression:
+                    column_reference:
+                      naked_identifier: x
+                    comparison_operator:
+                      raw_comparison_operator: '='
+                    numeric_literal: '5'
+                - keyword: THEN
+                - expression:
+                    bracketed:
+                      start_bracket: (
+                      expression:
+                        select_statement:
+                          select_clause:
+                            keyword: SELECT
+                            select_clause_element:
+                              function:
+                                function_name:
+                                  function_name_identifier: MAX
+                                function_contents:
+                                  bracketed:
+                                    start_bracket: (
+                                    expression:
+                                      column_reference:
+                                        naked_identifier: id
+                                    end_bracket: )
+                          from_clause:
+                            keyword: FROM
+                            from_expression:
+                              from_expression_element:
+                                table_expression:
+                                  table_reference:
+                                    naked_identifier: def
+                          where_clause:
+                            keyword: WHERE
+                            expression:
+                            - column_reference:
+                                naked_identifier: id
+                            - comparison_operator:
+                                raw_comparison_operator: '='
+                            - column_reference:
+                                naked_identifier: x
+                      end_bracket: )
+              - when_clause:
+                - keyword: WHEN
+                - expression:
+                    column_reference:
+                      naked_identifier: x
+                    comparison_operator:
+                      raw_comparison_operator: '='
+                    numeric_literal: '10'
+                - keyword: THEN
+                - expression:
+                    bracketed:
+                      start_bracket: (
+                      expression:
+                        select_statement:
+                          select_clause:
+                            keyword: SELECT
+                            select_clause_element:
+                              function:
+                                function_name:
+                                  function_name_identifier: MIN
+                                function_contents:
+                                  bracketed:
+                                    start_bracket: (
+                                    expression:
+                                      column_reference:
+                                        naked_identifier: id
+                                    end_bracket: )
+                          from_clause:
+                            keyword: FROM
+                            from_expression:
+                              from_expression_element:
+                                table_expression:
+                                  table_reference:
+                                    naked_identifier: def
+                          where_clause:
+                            keyword: WHERE
+                            expression:
+                            - column_reference:
+                                naked_identifier: id
+                            - comparison_operator:
+                                raw_comparison_operator: '='
+                            - column_reference:
+                                naked_identifier: x
+                      end_bracket: )
+              - else_clause:
+                  keyword: ELSE
+                  expression:
+                    numeric_literal: '0'
+              - keyword: END
+            alias_expression:
+              alias_operator:
+                keyword: AS
+              naked_identifier: subquery_result
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: abc
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            expression:
+              case_expression:
+              - keyword: CASE
+              - when_clause:
+                - keyword: WHEN
+                - expression:
+                    column_reference:
+                      naked_identifier: x
+                    comparison_operator:
+                      raw_comparison_operator: '='
+                    numeric_literal: '5'
+                - keyword: THEN
+                - expression:
+                    function:
+                      function_name:
+                        function_name_identifier: TO_CHAR
+                      function_contents:
+                        bracketed:
+                        - start_bracket: (
+                        - expression:
+                            column_reference:
+                              naked_identifier: x
+                        - comma: ','
+                        - expression:
+                            quoted_literal: "'999'"
+                        - end_bracket: )
+              - when_clause:
+                - keyword: WHEN
+                - expression:
+                    column_reference:
+                      naked_identifier: x
+                    comparison_operator:
+                      raw_comparison_operator: '='
+                    numeric_literal: '10'
+                - keyword: THEN
+                - expression:
+                    function:
+                      function_name:
+                        function_name_identifier: TO_NUMBER
+                      function_contents:
+                        bracketed:
+                          start_bracket: (
+                          expression:
+                            quoted_literal: "'10'"
+                          end_bracket: )
+              - else_clause:
+                  keyword: ELSE
+                  expression:
+                    quoted_literal: "'Unknown'"
+              - keyword: END
+            alias_expression:
+              alias_operator:
+                keyword: AS
+              naked_identifier: converted_result
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: abc
+  - statement_terminator: ;
+  - statement:
+      update_statement:
+        keyword: UPDATE
+        table_reference:
+          naked_identifier: abc
+        set_clause_list:
+          keyword: SET
+          set_clause:
+            column_reference:
+              naked_identifier: status
+            comparison_operator:
+              raw_comparison_operator: '='
             expression:
               case_expression:
               - keyword: CASE
@@ -965,805 +905,866 @@ file:
                   expression:
                     quoted_literal: "'Unknown'"
               - keyword: END
+        where_clause:
+          keyword: WHERE
+          expression:
+            column_reference:
+              naked_identifier: id
+            comparison_operator:
+              raw_comparison_operator: '='
+            numeric_literal: '1'
+  - statement_terminator: ;
+  - statement:
+      insert_statement:
+      - keyword: INSERT
+      - keyword: INTO
+      - table_reference:
+          naked_identifier: abc
+      - bracketed:
+        - start_bracket: (
+        - column_reference:
+            naked_identifier: id
+        - comma: ','
+        - column_reference:
+            naked_identifier: status
+        - end_bracket: )
+      - select_statement:
+          select_clause:
+          - keyword: SELECT
+          - select_clause_element:
+              column_reference:
+                naked_identifier: id
+          - comma: ','
+          - select_clause_element:
+              expression:
+                case_expression:
+                - keyword: CASE
+                - when_clause:
+                  - keyword: WHEN
+                  - expression:
+                      column_reference:
+                        naked_identifier: x
+                      comparison_operator:
+                        raw_comparison_operator: '='
+                      numeric_literal: '5'
+                  - keyword: THEN
+                  - expression:
+                      quoted_literal: "'Active'"
+                - when_clause:
+                  - keyword: WHEN
+                  - expression:
+                      column_reference:
+                        naked_identifier: x
+                      comparison_operator:
+                        raw_comparison_operator: '='
+                      numeric_literal: '10'
+                  - keyword: THEN
+                  - expression:
+                      quoted_literal: "'Inactive'"
+                - else_clause:
+                    keyword: ELSE
+                    expression:
+                      quoted_literal: "'Unknown'"
+                - keyword: END
+          from_clause:
+            keyword: FROM
+            from_expression:
+              from_expression_element:
+                table_expression:
+                  table_reference:
+                    naked_identifier: def
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            expression:
+              case_expression:
+              - keyword: CASE
+              - when_clause:
+                - keyword: WHEN
+                - expression:
+                    column_reference:
+                      naked_identifier: created_date
+                    comparison_operator:
+                      raw_comparison_operator: '>'
+                    bare_function: SYSDATE
+                    binary_operator: '-'
+                    numeric_literal: '1'
+                - keyword: THEN
+                - expression:
+                    quoted_literal: "'Recent'"
+              - when_clause:
+                - keyword: WHEN
+                - expression:
+                    column_reference:
+                      naked_identifier: created_date
+                    comparison_operator:
+                      raw_comparison_operator: '>'
+                    bare_function: SYSDATE
+                    binary_operator: '-'
+                    numeric_literal: '7'
+                - keyword: THEN
+                - expression:
+                    quoted_literal: "'This week'"
+              - when_clause:
+                - keyword: WHEN
+                - expression:
+                    column_reference:
+                      naked_identifier: created_date
+                    comparison_operator:
+                      raw_comparison_operator: '>'
+                    bare_function: SYSDATE
+                    binary_operator: '-'
+                    numeric_literal: '30'
+                - keyword: THEN
+                - expression:
+                    quoted_literal: "'This month'"
+              - else_clause:
+                  keyword: ELSE
+                  expression:
+                    quoted_literal: "'Old'"
+              - keyword: END
+            alias_expression:
+              alias_operator:
+                keyword: AS
+              naked_identifier: age_category
         from_clause:
           keyword: FROM
           from_expression:
             from_expression_element:
               table_expression:
                 table_reference:
-                  naked_identifier: def
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-        keyword: SELECT
-        select_clause_element:
-          expression:
-            case_expression:
-            - keyword: CASE
-            - when_clause:
-              - keyword: WHEN
-              - expression:
-                  column_reference:
-                    naked_identifier: created_date
-                  comparison_operator:
-                    raw_comparison_operator: '>'
-                  bare_function: SYSDATE
-                  binary_operator: '-'
-                  numeric_literal: '1'
-              - keyword: THEN
-              - expression:
-                  quoted_literal: "'Recent'"
-            - when_clause:
-              - keyword: WHEN
-              - expression:
-                  column_reference:
-                    naked_identifier: created_date
-                  comparison_operator:
-                    raw_comparison_operator: '>'
-                  bare_function: SYSDATE
-                  binary_operator: '-'
-                  numeric_literal: '7'
-              - keyword: THEN
-              - expression:
-                  quoted_literal: "'This week'"
-            - when_clause:
-              - keyword: WHEN
-              - expression:
-                  column_reference:
-                    naked_identifier: created_date
-                  comparison_operator:
-                    raw_comparison_operator: '>'
-                  bare_function: SYSDATE
-                  binary_operator: '-'
-                  numeric_literal: '30'
-              - keyword: THEN
-              - expression:
-                  quoted_literal: "'This month'"
-            - else_clause:
-                keyword: ELSE
-                expression:
-                  quoted_literal: "'Old'"
-            - keyword: END
-          alias_expression:
-            alias_operator:
-              keyword: AS
-            naked_identifier: age_category
-      from_clause:
-        keyword: FROM
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: abc
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-        keyword: SELECT
-        select_clause_element:
-          expression:
-            case_expression:
-            - keyword: CASE
-            - when_clause:
-              - keyword: WHEN
-              - expression:
-                  function:
-                    function_name:
-                      function_name_identifier: UPPER
-                    function_contents:
-                      bracketed:
-                        start_bracket: (
-                        expression:
-                          column_reference:
-                            naked_identifier: name
-                        end_bracket: )
-                  keyword: LIKE
-                  quoted_literal: "'%TEST%'"
-              - keyword: THEN
-              - expression:
-                  quoted_literal: "'Test record'"
-            - when_clause:
-              - keyword: WHEN
-              - expression:
-                  function:
-                    function_name:
-                      function_name_identifier: LOWER
-                    function_contents:
-                      bracketed:
-                        start_bracket: (
-                        expression:
-                          column_reference:
-                            naked_identifier: name
-                        end_bracket: )
-                  keyword: LIKE
-                  quoted_literal: "'%prod%'"
-              - keyword: THEN
-              - expression:
-                  quoted_literal: "'Production record'"
-            - else_clause:
-                keyword: ELSE
-                expression:
-                  quoted_literal: "'Other'"
-            - keyword: END
-          alias_expression:
-            alias_operator:
-              keyword: AS
-            naked_identifier: record_type
-      from_clause:
-        keyword: FROM
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: abc
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-        keyword: SELECT
-        select_clause_element:
-          expression:
-            case_expression:
-            - keyword: CASE
-            - when_clause:
-              - keyword: WHEN
-              - expression:
-                - column_reference:
-                    naked_identifier: x
-                - binary_operator: +
-                - column_reference:
-                    naked_identifier: y
-                - comparison_operator:
-                    raw_comparison_operator: '>'
-                - numeric_literal: '100'
-              - keyword: THEN
-              - expression:
-                  quoted_literal: "'High sum'"
-            - when_clause:
-              - keyword: WHEN
-              - expression:
-                - column_reference:
-                    naked_identifier: x
-                - binary_operator: '*'
-                - column_reference:
-                    naked_identifier: y
-                - comparison_operator:
-                    raw_comparison_operator: '>'
-                - numeric_literal: '50'
-              - keyword: THEN
-              - expression:
-                  quoted_literal: "'High product'"
-            - when_clause:
-              - keyword: WHEN
-              - expression:
-                - column_reference:
-                    naked_identifier: x
-                - binary_operator: '-'
-                - column_reference:
-                    naked_identifier: y
-                - comparison_operator:
-                    raw_comparison_operator: <
-                - numeric_literal: '0'
-              - keyword: THEN
-              - expression:
-                  quoted_literal: "'Negative difference'"
-            - else_clause:
-                keyword: ELSE
-                expression:
-                  quoted_literal: "'Normal'"
-            - keyword: END
-          alias_expression:
-            alias_operator:
-              keyword: AS
-            naked_identifier: calculation_result
-      from_clause:
-        keyword: FROM
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: abc
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-        keyword: SELECT
-        select_clause_element:
-          expression:
-            case_expression:
-            - keyword: CASE
-            - when_clause:
-              - keyword: WHEN
-              - expression:
-                  keyword: EXISTS
-                  bracketed:
-                    start_bracket: (
-                    select_statement:
-                      select_clause:
-                        keyword: SELECT
-                        select_clause_element:
-                          numeric_literal: '1'
-                      from_clause:
-                        keyword: FROM
-                        from_expression:
-                          from_expression_element:
-                            table_expression:
-                              table_reference:
-                                naked_identifier: def
-                      where_clause:
-                        keyword: WHERE
-                        expression:
-                        - column_reference:
-                          - naked_identifier: def
-                          - dot: .
-                          - naked_identifier: id
-                        - comparison_operator:
-                            raw_comparison_operator: '='
-                        - column_reference:
-                          - naked_identifier: abc
-                          - dot: .
-                          - naked_identifier: x
-                    end_bracket: )
-              - keyword: THEN
-              - expression:
-                  quoted_literal: "'Exists in def'"
-            - when_clause:
-              - keyword: WHEN
-              - expression:
-                  keyword: EXISTS
-                  bracketed:
-                    start_bracket: (
-                    select_statement:
-                      select_clause:
-                        keyword: SELECT
-                        select_clause_element:
-                          numeric_literal: '1'
-                      from_clause:
-                        keyword: FROM
-                        from_expression:
-                          from_expression_element:
-                            table_expression:
-                              table_reference:
-                                naked_identifier: ghi
-                      where_clause:
-                        keyword: WHERE
-                        expression:
-                        - column_reference:
-                          - naked_identifier: ghi
-                          - dot: .
-                          - naked_identifier: id
-                        - comparison_operator:
-                            raw_comparison_operator: '='
-                        - column_reference:
-                          - naked_identifier: abc
-                          - dot: .
-                          - naked_identifier: y
-                    end_bracket: )
-              - keyword: THEN
-              - expression:
-                  quoted_literal: "'Exists in ghi'"
-            - else_clause:
-                keyword: ELSE
-                expression:
-                  quoted_literal: "'Not found'"
-            - keyword: END
-          alias_expression:
-            alias_operator:
-              keyword: AS
-            naked_identifier: existence_check
-      from_clause:
-        keyword: FROM
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: abc
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-        keyword: SELECT
-        select_clause_element:
-          expression:
-            case_expression:
-            - keyword: CASE
-            - when_clause:
-              - keyword: WHEN
-              - expression:
-                  column_reference:
-                    naked_identifier: x
-                  keyword: IN
-                  bracketed:
-                  - start_bracket: (
+                  naked_identifier: abc
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            expression:
+              case_expression:
+              - keyword: CASE
+              - when_clause:
+                - keyword: WHEN
+                - expression:
+                    function:
+                      function_name:
+                        function_name_identifier: UPPER
+                      function_contents:
+                        bracketed:
+                          start_bracket: (
+                          expression:
+                            column_reference:
+                              naked_identifier: name
+                          end_bracket: )
+                    keyword: LIKE
+                    quoted_literal: "'%TEST%'"
+                - keyword: THEN
+                - expression:
+                    quoted_literal: "'Test record'"
+              - when_clause:
+                - keyword: WHEN
+                - expression:
+                    function:
+                      function_name:
+                        function_name_identifier: LOWER
+                      function_contents:
+                        bracketed:
+                          start_bracket: (
+                          expression:
+                            column_reference:
+                              naked_identifier: name
+                          end_bracket: )
+                    keyword: LIKE
+                    quoted_literal: "'%prod%'"
+                - keyword: THEN
+                - expression:
+                    quoted_literal: "'Production record'"
+              - else_clause:
+                  keyword: ELSE
+                  expression:
+                    quoted_literal: "'Other'"
+              - keyword: END
+            alias_expression:
+              alias_operator:
+                keyword: AS
+              naked_identifier: record_type
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: abc
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            expression:
+              case_expression:
+              - keyword: CASE
+              - when_clause:
+                - keyword: WHEN
+                - expression:
+                  - column_reference:
+                      naked_identifier: x
+                  - binary_operator: +
+                  - column_reference:
+                      naked_identifier: y
+                  - comparison_operator:
+                      raw_comparison_operator: '>'
+                  - numeric_literal: '100'
+                - keyword: THEN
+                - expression:
+                    quoted_literal: "'High sum'"
+              - when_clause:
+                - keyword: WHEN
+                - expression:
+                  - column_reference:
+                      naked_identifier: x
+                  - binary_operator: '*'
+                  - column_reference:
+                      naked_identifier: y
+                  - comparison_operator:
+                      raw_comparison_operator: '>'
+                  - numeric_literal: '50'
+                - keyword: THEN
+                - expression:
+                    quoted_literal: "'High product'"
+              - when_clause:
+                - keyword: WHEN
+                - expression:
+                  - column_reference:
+                      naked_identifier: x
+                  - binary_operator: '-'
+                  - column_reference:
+                      naked_identifier: y
+                  - comparison_operator:
+                      raw_comparison_operator: <
+                  - numeric_literal: '0'
+                - keyword: THEN
+                - expression:
+                    quoted_literal: "'Negative difference'"
+              - else_clause:
+                  keyword: ELSE
+                  expression:
+                    quoted_literal: "'Normal'"
+              - keyword: END
+            alias_expression:
+              alias_operator:
+                keyword: AS
+              naked_identifier: calculation_result
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: abc
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            expression:
+              case_expression:
+              - keyword: CASE
+              - when_clause:
+                - keyword: WHEN
+                - expression:
+                    keyword: EXISTS
+                    bracketed:
+                      start_bracket: (
+                      select_statement:
+                        select_clause:
+                          keyword: SELECT
+                          select_clause_element:
+                            numeric_literal: '1'
+                        from_clause:
+                          keyword: FROM
+                          from_expression:
+                            from_expression_element:
+                              table_expression:
+                                table_reference:
+                                  naked_identifier: def
+                        where_clause:
+                          keyword: WHERE
+                          expression:
+                          - column_reference:
+                            - naked_identifier: def
+                            - dot: .
+                            - naked_identifier: id
+                          - comparison_operator:
+                              raw_comparison_operator: '='
+                          - column_reference:
+                            - naked_identifier: abc
+                            - dot: .
+                            - naked_identifier: x
+                      end_bracket: )
+                - keyword: THEN
+                - expression:
+                    quoted_literal: "'Exists in def'"
+              - when_clause:
+                - keyword: WHEN
+                - expression:
+                    keyword: EXISTS
+                    bracketed:
+                      start_bracket: (
+                      select_statement:
+                        select_clause:
+                          keyword: SELECT
+                          select_clause_element:
+                            numeric_literal: '1'
+                        from_clause:
+                          keyword: FROM
+                          from_expression:
+                            from_expression_element:
+                              table_expression:
+                                table_reference:
+                                  naked_identifier: ghi
+                        where_clause:
+                          keyword: WHERE
+                          expression:
+                          - column_reference:
+                            - naked_identifier: ghi
+                            - dot: .
+                            - naked_identifier: id
+                          - comparison_operator:
+                              raw_comparison_operator: '='
+                          - column_reference:
+                            - naked_identifier: abc
+                            - dot: .
+                            - naked_identifier: y
+                      end_bracket: )
+                - keyword: THEN
+                - expression:
+                    quoted_literal: "'Exists in ghi'"
+              - else_clause:
+                  keyword: ELSE
+                  expression:
+                    quoted_literal: "'Not found'"
+              - keyword: END
+            alias_expression:
+              alias_operator:
+                keyword: AS
+              naked_identifier: existence_check
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: abc
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            expression:
+              case_expression:
+              - keyword: CASE
+              - when_clause:
+                - keyword: WHEN
+                - expression:
+                    column_reference:
+                      naked_identifier: x
+                    keyword: IN
+                    bracketed:
+                    - start_bracket: (
+                    - numeric_literal: '1'
+                    - comma: ','
+                    - numeric_literal: '2'
+                    - comma: ','
+                    - numeric_literal: '3'
+                    - end_bracket: )
+                - keyword: THEN
+                - expression:
+                    quoted_literal: "'Low'"
+              - when_clause:
+                - keyword: WHEN
+                - expression:
+                    column_reference:
+                      naked_identifier: x
+                    keyword: IN
+                    bracketed:
+                    - start_bracket: (
+                    - numeric_literal: '4'
+                    - comma: ','
+                    - numeric_literal: '5'
+                    - comma: ','
+                    - numeric_literal: '6'
+                    - end_bracket: )
+                - keyword: THEN
+                - expression:
+                    quoted_literal: "'Medium'"
+              - when_clause:
+                - keyword: WHEN
+                - expression:
+                    column_reference:
+                      naked_identifier: x
+                    keyword: IN
+                    bracketed:
+                    - start_bracket: (
+                    - numeric_literal: '7'
+                    - comma: ','
+                    - numeric_literal: '8'
+                    - comma: ','
+                    - numeric_literal: '9'
+                    - end_bracket: )
+                - keyword: THEN
+                - expression:
+                    quoted_literal: "'High'"
+              - else_clause:
+                  keyword: ELSE
+                  expression:
+                    quoted_literal: "'Unknown'"
+              - keyword: END
+            alias_expression:
+              alias_operator:
+                keyword: AS
+              naked_identifier: range_category
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: abc
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            expression:
+              case_expression:
+              - keyword: CASE
+              - when_clause:
+                - keyword: WHEN
+                - expression:
+                  - column_reference:
+                      naked_identifier: x
+                  - keyword: BETWEEN
                   - numeric_literal: '1'
-                  - comma: ','
-                  - numeric_literal: '2'
-                  - comma: ','
-                  - numeric_literal: '3'
-                  - end_bracket: )
-              - keyword: THEN
-              - expression:
-                  quoted_literal: "'Low'"
-            - when_clause:
-              - keyword: WHEN
-              - expression:
-                  column_reference:
-                    naked_identifier: x
-                  keyword: IN
-                  bracketed:
-                  - start_bracket: (
-                  - numeric_literal: '4'
-                  - comma: ','
-                  - numeric_literal: '5'
-                  - comma: ','
-                  - numeric_literal: '6'
-                  - end_bracket: )
-              - keyword: THEN
-              - expression:
-                  quoted_literal: "'Medium'"
-            - when_clause:
-              - keyword: WHEN
-              - expression:
-                  column_reference:
-                    naked_identifier: x
-                  keyword: IN
-                  bracketed:
-                  - start_bracket: (
-                  - numeric_literal: '7'
-                  - comma: ','
-                  - numeric_literal: '8'
-                  - comma: ','
-                  - numeric_literal: '9'
-                  - end_bracket: )
-              - keyword: THEN
-              - expression:
-                  quoted_literal: "'High'"
-            - else_clause:
-                keyword: ELSE
-                expression:
-                  quoted_literal: "'Unknown'"
-            - keyword: END
-          alias_expression:
-            alias_operator:
-              keyword: AS
-            naked_identifier: range_category
-      from_clause:
-        keyword: FROM
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: abc
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-        keyword: SELECT
-        select_clause_element:
-          expression:
-            case_expression:
-            - keyword: CASE
-            - when_clause:
-              - keyword: WHEN
-              - expression:
-                - column_reference:
-                    naked_identifier: x
-                - keyword: BETWEEN
-                - numeric_literal: '1'
-                - keyword: AND
-                - numeric_literal: '10'
-              - keyword: THEN
-              - expression:
-                  quoted_literal: "'First range'"
-            - when_clause:
-              - keyword: WHEN
-              - expression:
-                - column_reference:
-                    naked_identifier: x
-                - keyword: BETWEEN
-                - numeric_literal: '11'
-                - keyword: AND
-                - numeric_literal: '20'
-              - keyword: THEN
-              - expression:
-                  quoted_literal: "'Second range'"
-            - when_clause:
-              - keyword: WHEN
-              - expression:
-                - column_reference:
-                    naked_identifier: x
-                - keyword: BETWEEN
-                - numeric_literal: '21'
-                - keyword: AND
-                - numeric_literal: '30'
-              - keyword: THEN
-              - expression:
-                  quoted_literal: "'Third range'"
-            - else_clause:
-                keyword: ELSE
-                expression:
-                  quoted_literal: "'Out of range'"
-            - keyword: END
-          alias_expression:
-            alias_operator:
-              keyword: AS
-            naked_identifier: between_result
-      from_clause:
-        keyword: FROM
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: abc
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-        keyword: SELECT
-        select_clause_element:
-          expression:
-            case_expression:
-            - keyword: CASE
-            - when_clause:
-              - keyword: WHEN
-              - expression:
-                  function:
-                    function_name:
-                      function_name_identifier: REGEXP_LIKE
-                    function_contents:
-                      bracketed:
-                      - start_bracket: (
-                      - expression:
-                          column_reference:
-                            naked_identifier: name
-                      - comma: ','
-                      - expression:
-                          quoted_literal: "'^[A-Z]'"
-                      - end_bracket: )
-              - keyword: THEN
-              - expression:
-                  quoted_literal: "'Starts with uppercase'"
-            - when_clause:
-              - keyword: WHEN
-              - expression:
-                  function:
-                    function_name:
-                      function_name_identifier: REGEXP_LIKE
-                    function_contents:
-                      bracketed:
-                      - start_bracket: (
-                      - expression:
-                          column_reference:
-                            naked_identifier: name
-                      - comma: ','
-                      - expression:
-                          quoted_literal: "'[0-9]'"
-                      - end_bracket: )
-              - keyword: THEN
-              - expression:
-                  quoted_literal: "'Contains number'"
-            - else_clause:
-                keyword: ELSE
-                expression:
-                  quoted_literal: "'Other pattern'"
-            - keyword: END
-          alias_expression:
-            alias_operator:
-              keyword: AS
-            naked_identifier: pattern_match
-      from_clause:
-        keyword: FROM
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: abc
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-        keyword: SELECT
-        select_clause_element:
-          expression:
-            case_expression:
-            - keyword: CASE
-            - expression:
-                column_reference:
-                  naked_identifier: x
-            - when_clause:
-              - keyword: WHEN
-              - expression:
-                  numeric_literal: '1'
-              - keyword: THEN
-              - expression:
-                  quoted_literal: "'One'"
-            - when_clause:
-              - keyword: WHEN
-              - expression:
-                  numeric_literal: '2'
-              - keyword: THEN
-              - expression:
-                  quoted_literal: "'Two'"
-            - when_clause:
-              - keyword: WHEN
-              - expression:
-                  numeric_literal: '3'
-              - keyword: THEN
-              - expression:
-                  quoted_literal: "'Three'"
-            - else_clause:
-                keyword: ELSE
-                expression:
-                  quoted_literal: "'Other'"
-            - keyword: END
-          alias_expression:
-            alias_operator:
-              keyword: AS
-            naked_identifier: decode_equivalent
-      from_clause:
-        keyword: FROM
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: abc
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-        keyword: SELECT
-        select_clause_element:
-          expression:
-            case_expression:
-            - keyword: CASE
-            - when_clause:
-              - keyword: WHEN
-              - expression:
-                  column_reference:
-                    naked_identifier: x
-                  comparison_operator:
-                    raw_comparison_operator: '='
-                  numeric_literal: '1'
-              - keyword: THEN
-              - expression:
-                  case_expression:
-                  - keyword: CASE
-                  - expression:
-                      column_reference:
-                        naked_identifier: y
-                  - when_clause:
-                    - keyword: WHEN
-                    - expression:
-                        numeric_literal: '10'
-                    - keyword: THEN
-                    - expression:
-                        case_expression:
-                        - keyword: CASE
+                  - keyword: AND
+                  - numeric_literal: '10'
+                - keyword: THEN
+                - expression:
+                    quoted_literal: "'First range'"
+              - when_clause:
+                - keyword: WHEN
+                - expression:
+                  - column_reference:
+                      naked_identifier: x
+                  - keyword: BETWEEN
+                  - numeric_literal: '11'
+                  - keyword: AND
+                  - numeric_literal: '20'
+                - keyword: THEN
+                - expression:
+                    quoted_literal: "'Second range'"
+              - when_clause:
+                - keyword: WHEN
+                - expression:
+                  - column_reference:
+                      naked_identifier: x
+                  - keyword: BETWEEN
+                  - numeric_literal: '21'
+                  - keyword: AND
+                  - numeric_literal: '30'
+                - keyword: THEN
+                - expression:
+                    quoted_literal: "'Third range'"
+              - else_clause:
+                  keyword: ELSE
+                  expression:
+                    quoted_literal: "'Out of range'"
+              - keyword: END
+            alias_expression:
+              alias_operator:
+                keyword: AS
+              naked_identifier: between_result
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: abc
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            expression:
+              case_expression:
+              - keyword: CASE
+              - when_clause:
+                - keyword: WHEN
+                - expression:
+                    function:
+                      function_name:
+                        function_name_identifier: REGEXP_LIKE
+                      function_contents:
+                        bracketed:
+                        - start_bracket: (
                         - expression:
                             column_reference:
-                              naked_identifier: z
-                        - when_clause:
-                          - keyword: WHEN
-                          - expression:
-                              numeric_literal: '100'
-                          - keyword: THEN
-                          - expression:
-                              quoted_literal: "'Level 3 - 100'"
-                        - when_clause:
-                          - keyword: WHEN
-                          - expression:
-                              numeric_literal: '200'
-                          - keyword: THEN
-                          - expression:
-                              quoted_literal: "'Level 3 - 200'"
-                        - else_clause:
-                            keyword: ELSE
-                            expression:
-                              quoted_literal: "'Level 3 - Other'"
-                        - keyword: END
-                  - when_clause:
-                    - keyword: WHEN
+                              naked_identifier: name
+                        - comma: ','
+                        - expression:
+                            quoted_literal: "'^[A-Z]'"
+                        - end_bracket: )
+                - keyword: THEN
+                - expression:
+                    quoted_literal: "'Starts with uppercase'"
+              - when_clause:
+                - keyword: WHEN
+                - expression:
+                    function:
+                      function_name:
+                        function_name_identifier: REGEXP_LIKE
+                      function_contents:
+                        bracketed:
+                        - start_bracket: (
+                        - expression:
+                            column_reference:
+                              naked_identifier: name
+                        - comma: ','
+                        - expression:
+                            quoted_literal: "'[0-9]'"
+                        - end_bracket: )
+                - keyword: THEN
+                - expression:
+                    quoted_literal: "'Contains number'"
+              - else_clause:
+                  keyword: ELSE
+                  expression:
+                    quoted_literal: "'Other pattern'"
+              - keyword: END
+            alias_expression:
+              alias_operator:
+                keyword: AS
+              naked_identifier: pattern_match
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: abc
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            expression:
+              case_expression:
+              - keyword: CASE
+              - expression:
+                  column_reference:
+                    naked_identifier: x
+              - when_clause:
+                - keyword: WHEN
+                - expression:
+                    numeric_literal: '1'
+                - keyword: THEN
+                - expression:
+                    quoted_literal: "'One'"
+              - when_clause:
+                - keyword: WHEN
+                - expression:
+                    numeric_literal: '2'
+                - keyword: THEN
+                - expression:
+                    quoted_literal: "'Two'"
+              - when_clause:
+                - keyword: WHEN
+                - expression:
+                    numeric_literal: '3'
+                - keyword: THEN
+                - expression:
+                    quoted_literal: "'Three'"
+              - else_clause:
+                  keyword: ELSE
+                  expression:
+                    quoted_literal: "'Other'"
+              - keyword: END
+            alias_expression:
+              alias_operator:
+                keyword: AS
+              naked_identifier: decode_equivalent
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: abc
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            expression:
+              case_expression:
+              - keyword: CASE
+              - when_clause:
+                - keyword: WHEN
+                - expression:
+                    column_reference:
+                      naked_identifier: x
+                    comparison_operator:
+                      raw_comparison_operator: '='
+                    numeric_literal: '1'
+                - keyword: THEN
+                - expression:
+                    case_expression:
+                    - keyword: CASE
                     - expression:
-                        numeric_literal: '20'
-                    - keyword: THEN
+                        column_reference:
+                          naked_identifier: y
+                    - when_clause:
+                      - keyword: WHEN
+                      - expression:
+                          numeric_literal: '10'
+                      - keyword: THEN
+                      - expression:
+                          case_expression:
+                          - keyword: CASE
+                          - expression:
+                              column_reference:
+                                naked_identifier: z
+                          - when_clause:
+                            - keyword: WHEN
+                            - expression:
+                                numeric_literal: '100'
+                            - keyword: THEN
+                            - expression:
+                                quoted_literal: "'Level 3 - 100'"
+                          - when_clause:
+                            - keyword: WHEN
+                            - expression:
+                                numeric_literal: '200'
+                            - keyword: THEN
+                            - expression:
+                                quoted_literal: "'Level 3 - 200'"
+                          - else_clause:
+                              keyword: ELSE
+                              expression:
+                                quoted_literal: "'Level 3 - Other'"
+                          - keyword: END
+                    - when_clause:
+                      - keyword: WHEN
+                      - expression:
+                          numeric_literal: '20'
+                      - keyword: THEN
+                      - expression:
+                          quoted_literal: "'Level 2 - 20'"
+                    - else_clause:
+                        keyword: ELSE
+                        expression:
+                          quoted_literal: "'Level 2 - Other'"
+                    - keyword: END
+              - when_clause:
+                - keyword: WHEN
+                - expression:
+                    column_reference:
+                      naked_identifier: x
+                    comparison_operator:
+                      raw_comparison_operator: '='
+                    numeric_literal: '2'
+                - keyword: THEN
+                - expression:
+                    case_expression:
+                    - keyword: CASE
                     - expression:
-                        quoted_literal: "'Level 2 - 20'"
-                  - else_clause:
-                      keyword: ELSE
+                        column_reference:
+                          naked_identifier: y
+                    - when_clause:
+                      - keyword: WHEN
+                      - expression:
+                          numeric_literal: '30'
+                      - keyword: THEN
+                      - expression:
+                          quoted_literal: "'Level 2 - 30'"
+                    - else_clause:
+                        keyword: ELSE
+                        expression:
+                          quoted_literal: "'Level 2 - Other'"
+                    - keyword: END
+              - else_clause:
+                  keyword: ELSE
+                  expression:
+                    quoted_literal: "'Level 1 - Other'"
+              - keyword: END
+            alias_expression:
+              alias_operator:
+                keyword: AS
+              naked_identifier: multi_level_result
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: abc
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            expression:
+              case_expression:
+              - keyword: CASE
+              - when_clause:
+                - keyword: WHEN
+                - expression:
+                    column_reference:
+                      naked_identifier: x
+                    comparison_operator:
+                      raw_comparison_operator: '='
+                    numeric_literal: '5'
+                - keyword: THEN
+                - expression:
+                    numeric_literal: '1'
+              - when_clause:
+                - keyword: WHEN
+                - expression:
+                    column_reference:
+                      naked_identifier: x
+                    comparison_operator:
+                      raw_comparison_operator: '='
+                    numeric_literal: '10'
+                - keyword: THEN
+                - expression:
+                    numeric_literal: '2'
+              - else_clause:
+                  keyword: ELSE
+                  expression:
+                    numeric_literal: '0'
+              - keyword: END
+              - keyword: CASE
+            alias_expression:
+              alias_operator:
+                keyword: AS
+              naked_identifier: result
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: abc
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            expression:
+              case_expression:
+              - keyword: CASE
+              - when_clause:
+                - keyword: WHEN
+                - expression:
+                    column_reference:
+                      naked_identifier: x
+                    comparison_operator:
+                      raw_comparison_operator: '='
+                    numeric_literal: '5'
+                - keyword: THEN
+                - expression:
+                    numeric_literal: '1'
+              - when_clause:
+                - keyword: WHEN
+                - expression:
+                    column_reference:
+                      naked_identifier: x
+                    comparison_operator:
+                      raw_comparison_operator: '='
+                    numeric_literal: '10'
+                - keyword: THEN
+                - expression:
+                    numeric_literal: '2'
+              - else_clause:
+                  keyword: ELSE
+                  expression:
+                    numeric_literal: '0'
+              - keyword: END
+              - naked_identifier: my_case
+            alias_expression:
+              alias_operator:
+                keyword: AS
+              naked_identifier: result
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: abc
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            expression:
+              case_expression:
+              - keyword: CASE
+              - when_clause:
+                - keyword: WHEN
+                - expression:
+                    column_reference:
+                      naked_identifier: abc
+                    comparison_operator:
+                      raw_comparison_operator: '='
+                    numeric_literal: '1'
+                - keyword: THEN
+                - expression:
+                    null_literal: 'NULL'
+              - when_clause:
+                - keyword: WHEN
+                - expression:
+                    bracketed:
+                      start_bracket: (
                       expression:
-                        quoted_literal: "'Level 2 - Other'"
-                  - keyword: END
-            - when_clause:
-              - keyword: WHEN
-              - expression:
-                  column_reference:
-                    naked_identifier: x
-                  comparison_operator:
-                    raw_comparison_operator: '='
-                  numeric_literal: '2'
-              - keyword: THEN
-              - expression:
-                  case_expression:
-                  - keyword: CASE
-                  - expression:
-                      column_reference:
-                        naked_identifier: y
-                  - when_clause:
-                    - keyword: WHEN
-                    - expression:
-                        numeric_literal: '30'
-                    - keyword: THEN
-                    - expression:
-                        quoted_literal: "'Level 2 - 30'"
-                  - else_clause:
-                      keyword: ELSE
-                      expression:
-                        quoted_literal: "'Level 2 - Other'"
-                  - keyword: END
-            - else_clause:
-                keyword: ELSE
-                expression:
-                  quoted_literal: "'Level 1 - Other'"
-            - keyword: END
-          alias_expression:
-            alias_operator:
-              keyword: AS
-            naked_identifier: multi_level_result
-      from_clause:
-        keyword: FROM
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: abc
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-        keyword: SELECT
-        select_clause_element:
-          expression:
-            case_expression:
-            - keyword: CASE
-            - when_clause:
-              - keyword: WHEN
-              - expression:
-                  column_reference:
-                    naked_identifier: x
-                  comparison_operator:
-                    raw_comparison_operator: '='
-                  numeric_literal: '5'
-              - keyword: THEN
-              - expression:
-                  numeric_literal: '1'
-            - when_clause:
-              - keyword: WHEN
-              - expression:
-                  column_reference:
-                    naked_identifier: x
-                  comparison_operator:
-                    raw_comparison_operator: '='
-                  numeric_literal: '10'
-              - keyword: THEN
-              - expression:
-                  numeric_literal: '2'
-            - else_clause:
-                keyword: ELSE
-                expression:
-                  numeric_literal: '0'
-            - keyword: END
-            - keyword: CASE
-          alias_expression:
-            alias_operator:
-              keyword: AS
-            naked_identifier: result
-      from_clause:
-        keyword: FROM
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: abc
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-        keyword: SELECT
-        select_clause_element:
-          expression:
-            case_expression:
-            - keyword: CASE
-            - when_clause:
-              - keyword: WHEN
-              - expression:
-                  column_reference:
-                    naked_identifier: x
-                  comparison_operator:
-                    raw_comparison_operator: '='
-                  numeric_literal: '5'
-              - keyword: THEN
-              - expression:
-                  numeric_literal: '1'
-            - when_clause:
-              - keyword: WHEN
-              - expression:
-                  column_reference:
-                    naked_identifier: x
-                  comparison_operator:
-                    raw_comparison_operator: '='
-                  numeric_literal: '10'
-              - keyword: THEN
-              - expression:
-                  numeric_literal: '2'
-            - else_clause:
-                keyword: ELSE
-                expression:
-                  numeric_literal: '0'
-            - keyword: END
-            - naked_identifier: my_case
-          alias_expression:
-            alias_operator:
-              keyword: AS
-            naked_identifier: result
-      from_clause:
-        keyword: FROM
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: abc
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-        keyword: SELECT
-        select_clause_element:
-          expression:
-            case_expression:
-            - keyword: CASE
-            - when_clause:
-              - keyword: WHEN
-              - expression:
-                  column_reference:
-                    naked_identifier: abc
-                  comparison_operator:
-                    raw_comparison_operator: '='
-                  numeric_literal: '1'
-              - keyword: THEN
-              - expression:
-                  null_literal: 'NULL'
-            - when_clause:
-              - keyword: WHEN
-              - expression:
-                  bracketed:
-                    start_bracket: (
-                    expression:
-                    - column_reference:
-                        naked_identifier: defg
-                    - comparison_operator:
-                        raw_comparison_operator: '='
-                    - numeric_literal: '2'
-                    - binary_operator: AND
-                    - column_reference:
-                        naked_identifier: hijk
-                    - comparison_operator:
-                        raw_comparison_operator: '='
-                    - numeric_literal: '3'
-                    end_bracket: )
-              - keyword: THEN
-              - expression:
-                  null_literal: 'NULL'
-            - keyword: END
-          alias_expression:
-            alias_operator:
-              keyword: AS
-            naked_identifier: result
-      from_clause:
-        keyword: FROM
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: abc
-- statement_terminator: ;
+                      - column_reference:
+                          naked_identifier: defg
+                      - comparison_operator:
+                          raw_comparison_operator: '='
+                      - numeric_literal: '2'
+                      - binary_operator: AND
+                      - column_reference:
+                          naked_identifier: hijk
+                      - comparison_operator:
+                          raw_comparison_operator: '='
+                      - numeric_literal: '3'
+                      end_bracket: )
+                - keyword: THEN
+                - expression:
+                    null_literal: 'NULL'
+              - keyword: END
+            alias_expression:
+              alias_operator:
+                keyword: AS
+              naked_identifier: result
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: abc
+  - statement_terminator: ;

--- a/test/fixtures/dialects/oracle/collections.yml
+++ b/test/fixtures/dialects/oracle/collections.yml
@@ -3,22 +3,36 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 52c776d470b9e017d81ecd197a55c922912dc047589aaf26d3e6f09076fc8cb0
+_hash: db85c171633dd113466faa2967db83a2092957beb77a9faf7956335b8fef56a3
 file:
-- statement:
-    begin_end_block:
-    - declare_segment:
-      - keyword: DECLARE
-      - collection_type:
-        - keyword: TYPE
-        - naked_identifier: population
-        - keyword: IS
-        - keyword: TABLE
-        - keyword: OF
+- batch:
+    statement:
+      begin_end_block:
+      - declare_segment:
+        - keyword: DECLARE
+        - collection_type:
+          - keyword: TYPE
+          - naked_identifier: population
+          - keyword: IS
+          - keyword: TABLE
+          - keyword: OF
+          - data_type:
+              data_type_identifier: NUMBER
+          - keyword: INDEX
+          - keyword: BY
+          - data_type:
+              data_type_identifier: VARCHAR2
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  numeric_literal: '64'
+                  end_bracket: )
+        - statement_terminator: ;
+        - naked_identifier: city_population
         - data_type:
-            data_type_identifier: NUMBER
-        - keyword: INDEX
-        - keyword: BY
+            data_type_identifier: population
+        - statement_terminator: ;
+        - naked_identifier: i
         - data_type:
             data_type_identifier: VARCHAR2
             bracketed_arguments:
@@ -26,550 +40,381 @@ file:
                 start_bracket: (
                 numeric_literal: '64'
                 end_bracket: )
-      - statement_terminator: ;
-      - naked_identifier: city_population
-      - data_type:
-          data_type_identifier: population
-      - statement_terminator: ;
-      - naked_identifier: i
-      - data_type:
-          data_type_identifier: VARCHAR2
-          bracketed_arguments:
+        - statement_terminator: ;
+      - keyword: BEGIN
+      - statement:
+          assignment_segment_statement:
+            object_reference:
+              naked_identifier: city_population
             bracketed:
               start_bracket: (
-              numeric_literal: '64'
+              quoted_identifier: "'Smallville'"
               end_bracket: )
+            assignment_operator: :=
+            expression:
+              numeric_literal: '2000'
       - statement_terminator: ;
-    - keyword: BEGIN
-    - statement:
-        assignment_segment_statement:
-          object_reference:
-            naked_identifier: city_population
-          bracketed:
-            start_bracket: (
-            quoted_identifier: "'Smallville'"
-            end_bracket: )
-          assignment_operator: :=
-          expression:
-            numeric_literal: '2000'
-    - statement_terminator: ;
-    - statement:
-        assignment_segment_statement:
-          object_reference:
-            naked_identifier: city_population
-          bracketed:
-            start_bracket: (
-            quoted_identifier: "'Midland'"
-            end_bracket: )
-          assignment_operator: :=
-          expression:
-            numeric_literal: '750000'
-    - statement_terminator: ;
-    - statement:
-        assignment_segment_statement:
-          object_reference:
-            naked_identifier: city_population
-          bracketed:
-            start_bracket: (
-            quoted_identifier: "'Megalopolis'"
-            end_bracket: )
-          assignment_operator: :=
-          expression:
-            numeric_literal: '1000000'
-    - statement_terminator: ;
-    - statement:
-        assignment_segment_statement:
-          object_reference:
-            naked_identifier: city_population
-          bracketed:
-            start_bracket: (
-            quoted_identifier: "'Smallville'"
-            end_bracket: )
-          assignment_operator: :=
-          expression:
-            numeric_literal: '2001'
-    - statement_terminator: ;
-    - statement:
-        assignment_segment_statement:
-          object_reference:
-            naked_identifier: i
-          assignment_operator: :=
-          expression:
-            column_reference:
-            - naked_identifier: city_population
-            - dot: .
-            - naked_identifier: FIRST
-    - statement_terminator: ;
-    - statement:
-        while_loop_statement:
-          keyword: WHILE
-          expression:
-          - column_reference:
-              naked_identifier: i
-          - keyword: IS
-          - keyword: NOT
-          - null_literal: 'NULL'
-          loop_statement:
-          - keyword: LOOP
-          - statement:
-              function:
-                function_name:
-                  naked_identifier: DBMS_Output
-                  dot: .
-                  function_name_identifier: PUT_LINE
-                function_contents:
-                  bracketed:
-                    start_bracket: (
-                    expression:
-                    - quoted_literal: "'Population of '"
-                    - binary_operator:
-                      - pipe: '|'
-                      - pipe: '|'
-                    - column_reference:
-                        naked_identifier: i
-                    - binary_operator:
-                      - pipe: '|'
-                      - pipe: '|'
-                    - quoted_literal: "' is '"
-                    - binary_operator:
-                      - pipe: '|'
-                      - pipe: '|'
-                    - function:
-                        function_name:
-                          function_name_identifier: city_population
-                        function_contents:
-                          bracketed:
-                            start_bracket: (
-                            expression:
-                              column_reference:
-                                naked_identifier: i
-                            end_bracket: )
-                    end_bracket: )
-          - statement_terminator: ;
-          - statement:
-              assignment_segment_statement:
-                object_reference:
-                  naked_identifier: i
-                assignment_operator: :=
-                expression:
-                  function:
-                    function_name:
-                      naked_identifier: city_population
-                      dot: .
-                      function_name_identifier: NEXT
-                    function_contents:
-                      bracketed:
-                        start_bracket: (
-                        expression:
-                          column_reference:
-                            naked_identifier: i
-                        end_bracket: )
-          - statement_terminator: ;
-          - keyword: END
-          - keyword: LOOP
-    - statement_terminator: ;
-    - keyword: END
-- statement_terminator: ;
-- statement_terminator: /
-- statement:
-    begin_end_block:
-    - declare_segment:
-      - keyword: DECLARE
-      - collection_type:
-        - keyword: TYPE
-        - naked_identifier: sum_multiples
-        - keyword: IS
-        - keyword: TABLE
-        - keyword: OF
-        - data_type:
-            data_type_identifier: PLS_INTEGER
-        - keyword: INDEX
-        - keyword: BY
-        - data_type:
-            data_type_identifier: PLS_INTEGER
-      - statement_terminator: ;
-      - naked_identifier: n
-      - data_type:
-          data_type_identifier: PLS_INTEGER
-      - assignment_operator: :=
-      - expression:
-          numeric_literal: '5'
-      - statement_terminator: ;
-      - naked_identifier: sn
-      - data_type:
-          data_type_identifier: PLS_INTEGER
-      - assignment_operator: :=
-      - expression:
-          numeric_literal: '10'
-      - statement_terminator: ;
-      - naked_identifier: m
-      - data_type:
-          data_type_identifier: PLS_INTEGER
-      - assignment_operator: :=
-      - expression:
-          numeric_literal: '3'
-      - statement_terminator: ;
-      - create_function_statement:
-        - keyword: FUNCTION
-        - function_name:
-            function_name_identifier: get_sum_multiples
-        - function_parameter_list:
+      - statement:
+          assignment_segment_statement:
+            object_reference:
+              naked_identifier: city_population
             bracketed:
-            - start_bracket: (
-            - parameter: multiple
-            - keyword: IN
-            - data_type:
-                data_type_identifier: PLS_INTEGER
-            - comma: ','
-            - parameter: num
-            - keyword: IN
-            - data_type:
-                data_type_identifier: PLS_INTEGER
-            - end_bracket: )
-        - keyword: RETURN
-        - data_type:
-            data_type_identifier: sum_multiples
-        - keyword: IS
-        - declare_segment:
-            naked_identifier: s
-            data_type:
-              data_type_identifier: sum_multiples
-            statement_terminator: ;
-        - begin_end_block:
-          - keyword: BEGIN
-          - statement:
-              for_loop_statement:
-              - keyword: FOR
-              - naked_identifier: i
-              - keyword: IN
-              - numeric_literal: '1'
+              start_bracket: (
+              quoted_identifier: "'Midland'"
+              end_bracket: )
+            assignment_operator: :=
+            expression:
+              numeric_literal: '750000'
+      - statement_terminator: ;
+      - statement:
+          assignment_segment_statement:
+            object_reference:
+              naked_identifier: city_population
+            bracketed:
+              start_bracket: (
+              quoted_identifier: "'Megalopolis'"
+              end_bracket: )
+            assignment_operator: :=
+            expression:
+              numeric_literal: '1000000'
+      - statement_terminator: ;
+      - statement:
+          assignment_segment_statement:
+            object_reference:
+              naked_identifier: city_population
+            bracketed:
+              start_bracket: (
+              quoted_identifier: "'Smallville'"
+              end_bracket: )
+            assignment_operator: :=
+            expression:
+              numeric_literal: '2001'
+      - statement_terminator: ;
+      - statement:
+          assignment_segment_statement:
+            object_reference:
+              naked_identifier: i
+            assignment_operator: :=
+            expression:
+              column_reference:
+              - naked_identifier: city_population
               - dot: .
-              - dot: .
-              - naked_identifier: num
-              - loop_statement:
-                - keyword: LOOP
-                - statement:
-                    assignment_segment_statement:
-                      object_reference:
-                        naked_identifier: s
-                      bracketed:
-                        start_bracket: (
-                        object_reference:
-                          naked_identifier: i
-                        end_bracket: )
-                      assignment_operator: :=
+              - naked_identifier: FIRST
+      - statement_terminator: ;
+      - statement:
+          while_loop_statement:
+            keyword: WHILE
+            expression:
+            - column_reference:
+                naked_identifier: i
+            - keyword: IS
+            - keyword: NOT
+            - null_literal: 'NULL'
+            loop_statement:
+            - keyword: LOOP
+            - statement:
+                function:
+                  function_name:
+                    naked_identifier: DBMS_Output
+                    dot: .
+                    function_name_identifier: PUT_LINE
+                  function_contents:
+                    bracketed:
+                      start_bracket: (
                       expression:
-                        column_reference:
-                          naked_identifier: multiple
-                        binary_operator: '*'
-                        bracketed:
-                          start_bracket: (
-                          expression:
+                      - quoted_literal: "'Population of '"
+                      - binary_operator:
+                        - pipe: '|'
+                        - pipe: '|'
+                      - column_reference:
+                          naked_identifier: i
+                      - binary_operator:
+                        - pipe: '|'
+                        - pipe: '|'
+                      - quoted_literal: "' is '"
+                      - binary_operator:
+                        - pipe: '|'
+                        - pipe: '|'
+                      - function:
+                          function_name:
+                            function_name_identifier: city_population
+                          function_contents:
                             bracketed:
                               start_bracket: (
                               expression:
                                 column_reference:
                                   naked_identifier: i
-                                binary_operator: '*'
-                                bracketed:
-                                  start_bracket: (
-                                  expression:
-                                    column_reference:
-                                      naked_identifier: i
-                                    binary_operator: +
-                                    numeric_literal: '1'
-                                  end_bracket: )
                               end_bracket: )
-                            binary_operator: /
-                            numeric_literal: '2'
-                          end_bracket: )
-                - statement_terminator: ;
-                - keyword: END
-                - keyword: LOOP
-          - statement_terminator: ;
-          - statement:
-              return_statement:
-                keyword: RETURN
-                expression:
-                  column_reference:
-                    naked_identifier: s
-          - statement_terminator: ;
-          - keyword: END
-          - object_reference:
-              naked_identifier: get_sum_multiples
-        - statement_terminator: ;
-    - keyword: BEGIN
-    - statement:
-        function:
-          function_name:
-            naked_identifier: DBMS_OUTPUT
-            dot: .
-            function_name_identifier: PUT_LINE
-          function_contents:
-            bracketed:
-              start_bracket: (
-              expression:
-              - quoted_literal: "'Sum of the first '"
-              - binary_operator:
-                - pipe: '|'
-                - pipe: '|'
-              - function:
-                  function_name:
-                    function_name_identifier: TO_CHAR
-                  function_contents:
-                    bracketed:
-                      start_bracket: (
-                      expression:
-                        column_reference:
-                          naked_identifier: n
                       end_bracket: )
-              - binary_operator:
-                - pipe: '|'
-                - pipe: '|'
-              - quoted_literal: "' multiples of '"
-              - binary_operator:
-                - pipe: '|'
-                - pipe: '|'
-              - function:
-                  function_name:
-                    function_name_identifier: TO_CHAR
-                  function_contents:
-                    bracketed:
-                      start_bracket: (
-                      expression:
-                        column_reference:
-                          naked_identifier: m
-                      end_bracket: )
-              - binary_operator:
-                - pipe: '|'
-                - pipe: '|'
-              - quoted_literal: "' is '"
-              - binary_operator:
-                - pipe: '|'
-                - pipe: '|'
-              - function:
-                  function_name:
-                    function_name_identifier: TO_CHAR
-                  function_contents:
-                    bracketed:
-                    - start_bracket: (
-                    - expression:
-                        function:
-                          function_name:
-                            function_name_identifier: get_sum_multiples
-                          function_contents:
-                            bracketed:
-                            - start_bracket: (
-                            - expression:
-                                column_reference:
-                                  naked_identifier: m
-                            - comma: ','
-                            - expression:
-                                column_reference:
-                                  naked_identifier: sn
-                            - end_bracket: )
-                    - expression:
-                        bracketed:
-                          start_bracket: (
-                          expression:
-                            column_reference:
-                              naked_identifier: n
-                          end_bracket: )
-                    - end_bracket: )
-              end_bracket: )
-    - statement_terminator: ;
-    - keyword: END
-- statement_terminator: ;
-- statement_terminator: /
-- statement:
-    begin_end_block:
-    - declare_segment:
-      - keyword: DECLARE
-      - collection_type:
-        - keyword: TYPE
-        - naked_identifier: Foursome
-        - keyword: IS
-        - data_type:
-            data_type_identifier: VARRAY
-            bracketed_arguments:
-              bracketed:
-                start_bracket: (
-                numeric_literal: '4'
-                end_bracket: )
-        - keyword: OF
-        - data_type:
-            data_type_identifier: VARCHAR2
-            bracketed_arguments:
-              bracketed:
-                start_bracket: (
-                numeric_literal: '15'
-                end_bracket: )
-      - statement_terminator: ;
-      - naked_identifier: team
-      - data_type:
-          data_type_identifier: Foursome
-      - assignment_operator: :=
-      - expression:
-          function:
-            function_name:
-              function_name_identifier: Foursome
-            function_contents:
-              bracketed:
-              - start_bracket: (
-              - expression:
-                  quoted_literal: "'John'"
-              - comma: ','
-              - expression:
-                  quoted_literal: "'Mary'"
-              - comma: ','
-              - expression:
-                  quoted_literal: "'Alberto'"
-              - comma: ','
-              - expression:
-                  quoted_literal: "'Juanita'"
-              - end_bracket: )
-      - statement_terminator: ;
-      - create_procedure_statement:
-        - keyword: PROCEDURE
-        - function_name:
-            function_name_identifier: print_team
-        - function_parameter_list:
-            bracketed:
-              start_bracket: (
-              parameter: heading
-              data_type:
-                data_type_identifier: VARCHAR2
-              end_bracket: )
-        - keyword: IS
-        - begin_end_block:
-          - keyword: BEGIN
-          - statement:
-              function:
-                function_name:
-                  naked_identifier: DBMS_OUTPUT
-                  dot: .
-                  function_name_identifier: PUT_LINE
-                function_contents:
-                  bracketed:
-                    start_bracket: (
-                    expression:
-                      column_reference:
-                        naked_identifier: heading
-                    end_bracket: )
-          - statement_terminator: ;
-          - statement:
-              for_loop_statement:
-              - keyword: FOR
-              - naked_identifier: i
-              - keyword: IN
-              - numeric_literal: '1'
-              - dot: .
-              - dot: .
-              - numeric_literal: '4'
-              - loop_statement:
-                - keyword: LOOP
-                - statement:
+            - statement_terminator: ;
+            - statement:
+                assignment_segment_statement:
+                  object_reference:
+                    naked_identifier: i
+                  assignment_operator: :=
+                  expression:
                     function:
                       function_name:
-                        naked_identifier: DBMS_OUTPUT
+                        naked_identifier: city_population
                         dot: .
-                        function_name_identifier: PUT_LINE
+                        function_name_identifier: NEXT
                       function_contents:
                         bracketed:
                           start_bracket: (
                           expression:
-                          - column_reference:
+                            column_reference:
                               naked_identifier: i
-                          - binary_operator:
-                            - pipe: '|'
-                            - pipe: '|'
-                          - quoted_literal: "'.'"
-                          - binary_operator:
-                            - pipe: '|'
-                            - pipe: '|'
-                          - function:
-                              function_name:
-                                function_name_identifier: team
-                              function_contents:
-                                bracketed:
-                                  start_bracket: (
-                                  expression:
-                                    column_reference:
-                                      naked_identifier: i
-                                  end_bracket: )
                           end_bracket: )
-                - statement_terminator: ;
-                - keyword: END
-                - keyword: LOOP
-          - statement_terminator: ;
-          - statement:
-              function:
-                function_name:
-                  naked_identifier: DBMS_OUTPUT
-                  dot: .
-                  function_name_identifier: PUT_LINE
-                function_contents:
-                  bracketed:
-                    start_bracket: (
-                    expression:
-                      quoted_literal: "'---'"
-                    end_bracket: )
-          - statement_terminator: ;
-          - keyword: END
+            - statement_terminator: ;
+            - keyword: END
+            - keyword: LOOP
+      - statement_terminator: ;
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      begin_end_block:
+      - declare_segment:
+        - keyword: DECLARE
+        - collection_type:
+          - keyword: TYPE
+          - naked_identifier: sum_multiples
+          - keyword: IS
+          - keyword: TABLE
+          - keyword: OF
+          - data_type:
+              data_type_identifier: PLS_INTEGER
+          - keyword: INDEX
+          - keyword: BY
+          - data_type:
+              data_type_identifier: PLS_INTEGER
         - statement_terminator: ;
-    - keyword: BEGIN
-    - statement:
-        function:
-          function_name:
-            function_name_identifier: print_team
-          function_contents:
-            bracketed:
-              start_bracket: (
-              expression:
-                quoted_literal: "'2001 Team:'"
-              end_bracket: )
-    - statement_terminator: ;
-    - statement:
-        assignment_segment_statement:
-          object_reference:
-            naked_identifier: team
-          bracketed:
-            start_bracket: (
+        - naked_identifier: n
+        - data_type:
+            data_type_identifier: PLS_INTEGER
+        - assignment_operator: :=
+        - expression:
+            numeric_literal: '5'
+        - statement_terminator: ;
+        - naked_identifier: sn
+        - data_type:
+            data_type_identifier: PLS_INTEGER
+        - assignment_operator: :=
+        - expression:
+            numeric_literal: '10'
+        - statement_terminator: ;
+        - naked_identifier: m
+        - data_type:
+            data_type_identifier: PLS_INTEGER
+        - assignment_operator: :=
+        - expression:
             numeric_literal: '3'
-            end_bracket: )
-          assignment_operator: :=
-          expression:
-            quoted_literal: "'Pierre'"
-    - statement_terminator: ;
-    - statement:
-        assignment_segment_statement:
-          object_reference:
-            naked_identifier: team
-          bracketed:
-            start_bracket: (
-            numeric_literal: '4'
-            end_bracket: )
-          assignment_operator: :=
-          expression:
-            quoted_literal: "'Yvonne'"
-    - statement_terminator: ;
-    - statement:
-        function:
-          function_name:
-            function_name_identifier: print_team
-          function_contents:
-            bracketed:
-              start_bracket: (
-              expression:
-                quoted_literal: "'2005 Team:'"
-              end_bracket: )
-    - statement_terminator: ;
-    - statement:
-        assignment_segment_statement:
-          object_reference:
-            naked_identifier: team
-          assignment_operator: :=
-          expression:
+        - statement_terminator: ;
+        - create_function_statement:
+          - keyword: FUNCTION
+          - function_name:
+              function_name_identifier: get_sum_multiples
+          - function_parameter_list:
+              bracketed:
+              - start_bracket: (
+              - parameter: multiple
+              - keyword: IN
+              - data_type:
+                  data_type_identifier: PLS_INTEGER
+              - comma: ','
+              - parameter: num
+              - keyword: IN
+              - data_type:
+                  data_type_identifier: PLS_INTEGER
+              - end_bracket: )
+          - keyword: RETURN
+          - data_type:
+              data_type_identifier: sum_multiples
+          - keyword: IS
+          - declare_segment:
+              naked_identifier: s
+              data_type:
+                data_type_identifier: sum_multiples
+              statement_terminator: ;
+          - begin_end_block:
+            - keyword: BEGIN
+            - statement:
+                for_loop_statement:
+                - keyword: FOR
+                - naked_identifier: i
+                - keyword: IN
+                - numeric_literal: '1'
+                - dot: .
+                - dot: .
+                - naked_identifier: num
+                - loop_statement:
+                  - keyword: LOOP
+                  - statement:
+                      assignment_segment_statement:
+                        object_reference:
+                          naked_identifier: s
+                        bracketed:
+                          start_bracket: (
+                          object_reference:
+                            naked_identifier: i
+                          end_bracket: )
+                        assignment_operator: :=
+                        expression:
+                          column_reference:
+                            naked_identifier: multiple
+                          binary_operator: '*'
+                          bracketed:
+                            start_bracket: (
+                            expression:
+                              bracketed:
+                                start_bracket: (
+                                expression:
+                                  column_reference:
+                                    naked_identifier: i
+                                  binary_operator: '*'
+                                  bracketed:
+                                    start_bracket: (
+                                    expression:
+                                      column_reference:
+                                        naked_identifier: i
+                                      binary_operator: +
+                                      numeric_literal: '1'
+                                    end_bracket: )
+                                end_bracket: )
+                              binary_operator: /
+                              numeric_literal: '2'
+                            end_bracket: )
+                  - statement_terminator: ;
+                  - keyword: END
+                  - keyword: LOOP
+            - statement_terminator: ;
+            - statement:
+                return_statement:
+                  keyword: RETURN
+                  expression:
+                    column_reference:
+                      naked_identifier: s
+            - statement_terminator: ;
+            - keyword: END
+            - object_reference:
+                naked_identifier: get_sum_multiples
+          - statement_terminator: ;
+      - keyword: BEGIN
+      - statement:
+          function:
+            function_name:
+              naked_identifier: DBMS_OUTPUT
+              dot: .
+              function_name_identifier: PUT_LINE
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                - quoted_literal: "'Sum of the first '"
+                - binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                - function:
+                    function_name:
+                      function_name_identifier: TO_CHAR
+                    function_contents:
+                      bracketed:
+                        start_bracket: (
+                        expression:
+                          column_reference:
+                            naked_identifier: n
+                        end_bracket: )
+                - binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                - quoted_literal: "' multiples of '"
+                - binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                - function:
+                    function_name:
+                      function_name_identifier: TO_CHAR
+                    function_contents:
+                      bracketed:
+                        start_bracket: (
+                        expression:
+                          column_reference:
+                            naked_identifier: m
+                        end_bracket: )
+                - binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                - quoted_literal: "' is '"
+                - binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                - function:
+                    function_name:
+                      function_name_identifier: TO_CHAR
+                    function_contents:
+                      bracketed:
+                      - start_bracket: (
+                      - expression:
+                          function:
+                            function_name:
+                              function_name_identifier: get_sum_multiples
+                            function_contents:
+                              bracketed:
+                              - start_bracket: (
+                              - expression:
+                                  column_reference:
+                                    naked_identifier: m
+                              - comma: ','
+                              - expression:
+                                  column_reference:
+                                    naked_identifier: sn
+                              - end_bracket: )
+                      - expression:
+                          bracketed:
+                            start_bracket: (
+                            expression:
+                              column_reference:
+                                naked_identifier: n
+                            end_bracket: )
+                      - end_bracket: )
+                end_bracket: )
+      - statement_terminator: ;
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      begin_end_block:
+      - declare_segment:
+        - keyword: DECLARE
+        - collection_type:
+          - keyword: TYPE
+          - naked_identifier: Foursome
+          - keyword: IS
+          - data_type:
+              data_type_identifier: VARRAY
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  numeric_literal: '4'
+                  end_bracket: )
+          - keyword: OF
+          - data_type:
+              data_type_identifier: VARCHAR2
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  numeric_literal: '15'
+                  end_bracket: )
+        - statement_terminator: ;
+        - naked_identifier: team
+        - data_type:
+            data_type_identifier: Foursome
+        - assignment_operator: :=
+        - expression:
             function:
               function_name:
                 function_name_identifier: Foursome
@@ -577,198 +422,217 @@ file:
                 bracketed:
                 - start_bracket: (
                 - expression:
-                    quoted_literal: "'Arun'"
+                    quoted_literal: "'John'"
                 - comma: ','
                 - expression:
-                    quoted_literal: "'Amitha'"
+                    quoted_literal: "'Mary'"
                 - comma: ','
                 - expression:
-                    quoted_literal: "'Allan'"
+                    quoted_literal: "'Alberto'"
                 - comma: ','
                 - expression:
-                    quoted_literal: "'Mae'"
+                    quoted_literal: "'Juanita'"
                 - end_bracket: )
-    - statement_terminator: ;
-    - statement:
-        function:
-          function_name:
-            function_name_identifier: print_team
-          function_contents:
-            bracketed:
-              start_bracket: (
-              expression:
-                quoted_literal: "'2009 Team:'"
-              end_bracket: )
-    - statement_terminator: ;
-    - keyword: END
-- statement_terminator: ;
-- statement_terminator: /
-- statement:
-    begin_end_block:
-    - declare_segment:
-      - keyword: DECLARE
-      - collection_type:
-        - keyword: TYPE
-        - naked_identifier: Roster
-        - keyword: IS
-        - keyword: TABLE
-        - keyword: OF
-        - data_type:
-            data_type_identifier: VARCHAR2
-            bracketed_arguments:
+        - statement_terminator: ;
+        - create_procedure_statement:
+          - keyword: PROCEDURE
+          - function_name:
+              function_name_identifier: print_team
+          - function_parameter_list:
               bracketed:
                 start_bracket: (
-                numeric_literal: '15'
+                parameter: heading
+                data_type:
+                  data_type_identifier: VARCHAR2
                 end_bracket: )
-      - statement_terminator: ;
-      - naked_identifier: names
-      - data_type:
-          data_type_identifier: Roster
-      - assignment_operator: :=
-      - expression:
+          - keyword: IS
+          - begin_end_block:
+            - keyword: BEGIN
+            - statement:
+                function:
+                  function_name:
+                    naked_identifier: DBMS_OUTPUT
+                    dot: .
+                    function_name_identifier: PUT_LINE
+                  function_contents:
+                    bracketed:
+                      start_bracket: (
+                      expression:
+                        column_reference:
+                          naked_identifier: heading
+                      end_bracket: )
+            - statement_terminator: ;
+            - statement:
+                for_loop_statement:
+                - keyword: FOR
+                - naked_identifier: i
+                - keyword: IN
+                - numeric_literal: '1'
+                - dot: .
+                - dot: .
+                - numeric_literal: '4'
+                - loop_statement:
+                  - keyword: LOOP
+                  - statement:
+                      function:
+                        function_name:
+                          naked_identifier: DBMS_OUTPUT
+                          dot: .
+                          function_name_identifier: PUT_LINE
+                        function_contents:
+                          bracketed:
+                            start_bracket: (
+                            expression:
+                            - column_reference:
+                                naked_identifier: i
+                            - binary_operator:
+                              - pipe: '|'
+                              - pipe: '|'
+                            - quoted_literal: "'.'"
+                            - binary_operator:
+                              - pipe: '|'
+                              - pipe: '|'
+                            - function:
+                                function_name:
+                                  function_name_identifier: team
+                                function_contents:
+                                  bracketed:
+                                    start_bracket: (
+                                    expression:
+                                      column_reference:
+                                        naked_identifier: i
+                                    end_bracket: )
+                            end_bracket: )
+                  - statement_terminator: ;
+                  - keyword: END
+                  - keyword: LOOP
+            - statement_terminator: ;
+            - statement:
+                function:
+                  function_name:
+                    naked_identifier: DBMS_OUTPUT
+                    dot: .
+                    function_name_identifier: PUT_LINE
+                  function_contents:
+                    bracketed:
+                      start_bracket: (
+                      expression:
+                        quoted_literal: "'---'"
+                      end_bracket: )
+            - statement_terminator: ;
+            - keyword: END
+          - statement_terminator: ;
+      - keyword: BEGIN
+      - statement:
           function:
             function_name:
-              function_name_identifier: Roster
+              function_name_identifier: print_team
             function_contents:
               bracketed:
-              - start_bracket: (
-              - expression:
-                  quoted_literal: "'D Caruso'"
-              - comma: ','
-              - expression:
-                  quoted_literal: "'J Hamil'"
-              - comma: ','
-              - expression:
-                  quoted_literal: "'D Piro'"
-              - comma: ','
-              - expression:
-                  quoted_literal: "'R Singh'"
-              - end_bracket: )
+                start_bracket: (
+                expression:
+                  quoted_literal: "'2001 Team:'"
+                end_bracket: )
       - statement_terminator: ;
-      - create_procedure_statement:
-        - keyword: PROCEDURE
-        - function_name:
-            function_name_identifier: print_names
-        - function_parameter_list:
+      - statement:
+          assignment_segment_statement:
+            object_reference:
+              naked_identifier: team
             bracketed:
               start_bracket: (
-              parameter: heading
-              data_type:
-                data_type_identifier: VARCHAR2
+              numeric_literal: '3'
               end_bracket: )
-        - keyword: IS
-        - begin_end_block:
-          - keyword: BEGIN
-          - statement:
+            assignment_operator: :=
+            expression:
+              quoted_literal: "'Pierre'"
+      - statement_terminator: ;
+      - statement:
+          assignment_segment_statement:
+            object_reference:
+              naked_identifier: team
+            bracketed:
+              start_bracket: (
+              numeric_literal: '4'
+              end_bracket: )
+            assignment_operator: :=
+            expression:
+              quoted_literal: "'Yvonne'"
+      - statement_terminator: ;
+      - statement:
+          function:
+            function_name:
+              function_name_identifier: print_team
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  quoted_literal: "'2005 Team:'"
+                end_bracket: )
+      - statement_terminator: ;
+      - statement:
+          assignment_segment_statement:
+            object_reference:
+              naked_identifier: team
+            assignment_operator: :=
+            expression:
               function:
                 function_name:
-                  naked_identifier: DBMS_OUTPUT
-                  dot: .
-                  function_name_identifier: PUT_LINE
+                  function_name_identifier: Foursome
                 function_contents:
                   bracketed:
-                    start_bracket: (
-                    expression:
-                      column_reference:
-                        naked_identifier: heading
-                    end_bracket: )
-          - statement_terminator: ;
-          - statement:
-              for_loop_statement:
-              - keyword: FOR
-              - naked_identifier: i
-              - keyword: IN
-              - naked_identifier: names
-              - dot: .
-              - naked_identifier: FIRST
-              - dot: .
-              - dot: .
-              - naked_identifier: names
-              - dot: .
-              - naked_identifier: LAST
-              - loop_statement:
-                - keyword: LOOP
-                - statement:
-                    function:
-                      function_name:
-                        naked_identifier: DBMS_OUTPUT
-                        dot: .
-                        function_name_identifier: PUT_LINE
-                      function_contents:
-                        bracketed:
-                          start_bracket: (
-                          expression:
-                            function:
-                              function_name:
-                                function_name_identifier: names
-                              function_contents:
-                                bracketed:
-                                  start_bracket: (
-                                  expression:
-                                    column_reference:
-                                      naked_identifier: i
-                                  end_bracket: )
-                          end_bracket: )
-                - statement_terminator: ;
-                - keyword: END
-                - keyword: LOOP
-          - statement_terminator: ;
-          - statement:
-              function:
-                function_name:
-                  naked_identifier: DBMS_OUTPUT
-                  dot: .
-                  function_name_identifier: PUT_LINE
-                function_contents:
-                  bracketed:
-                    start_bracket: (
-                    expression:
-                      quoted_literal: "'---'"
-                    end_bracket: )
-          - statement_terminator: ;
-          - keyword: END
+                  - start_bracket: (
+                  - expression:
+                      quoted_literal: "'Arun'"
+                  - comma: ','
+                  - expression:
+                      quoted_literal: "'Amitha'"
+                  - comma: ','
+                  - expression:
+                      quoted_literal: "'Allan'"
+                  - comma: ','
+                  - expression:
+                      quoted_literal: "'Mae'"
+                  - end_bracket: )
+      - statement_terminator: ;
+      - statement:
+          function:
+            function_name:
+              function_name_identifier: print_team
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  quoted_literal: "'2009 Team:'"
+                end_bracket: )
+      - statement_terminator: ;
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      begin_end_block:
+      - declare_segment:
+        - keyword: DECLARE
+        - collection_type:
+          - keyword: TYPE
+          - naked_identifier: Roster
+          - keyword: IS
+          - keyword: TABLE
+          - keyword: OF
+          - data_type:
+              data_type_identifier: VARCHAR2
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  numeric_literal: '15'
+                  end_bracket: )
         - statement_terminator: ;
-    - keyword: BEGIN
-    - statement:
-        function:
-          function_name:
-            function_name_identifier: print_names
-          function_contents:
-            bracketed:
-              start_bracket: (
-              expression:
-                quoted_literal: "'Initial Values:'"
-              end_bracket: )
-    - statement_terminator: ;
-    - statement:
-        assignment_segment_statement:
-          object_reference:
-            naked_identifier: names
-          bracketed:
-            start_bracket: (
-            numeric_literal: '3'
-            end_bracket: )
-          assignment_operator: :=
-          expression:
-            quoted_literal: "'P Perez'"
-    - statement_terminator: ;
-    - statement:
-        function:
-          function_name:
-            function_name_identifier: print_names
-          function_contents:
-            bracketed:
-              start_bracket: (
-              expression:
-                quoted_literal: "'Current Values:'"
-              end_bracket: )
-    - statement_terminator: ;
-    - statement:
-        assignment_segment_statement:
-          object_reference:
-            naked_identifier: names
-          assignment_operator: :=
-          expression:
+        - naked_identifier: names
+        - data_type:
+            data_type_identifier: Roster
+        - assignment_operator: :=
+        - expression:
             function:
               function_name:
                 function_name_identifier: Roster
@@ -776,271 +640,417 @@ file:
                 bracketed:
                 - start_bracket: (
                 - expression:
-                    quoted_literal: "'A Jansen'"
+                    quoted_literal: "'D Caruso'"
                 - comma: ','
                 - expression:
-                    quoted_literal: "'B Gupta'"
+                    quoted_literal: "'J Hamil'"
+                - comma: ','
+                - expression:
+                    quoted_literal: "'D Piro'"
+                - comma: ','
+                - expression:
+                    quoted_literal: "'R Singh'"
                 - end_bracket: )
-    - statement_terminator: ;
-    - statement:
-        function:
-          function_name:
-            function_name_identifier: print_names
-          function_contents:
+        - statement_terminator: ;
+        - create_procedure_statement:
+          - keyword: PROCEDURE
+          - function_name:
+              function_name_identifier: print_names
+          - function_parameter_list:
+              bracketed:
+                start_bracket: (
+                parameter: heading
+                data_type:
+                  data_type_identifier: VARCHAR2
+                end_bracket: )
+          - keyword: IS
+          - begin_end_block:
+            - keyword: BEGIN
+            - statement:
+                function:
+                  function_name:
+                    naked_identifier: DBMS_OUTPUT
+                    dot: .
+                    function_name_identifier: PUT_LINE
+                  function_contents:
+                    bracketed:
+                      start_bracket: (
+                      expression:
+                        column_reference:
+                          naked_identifier: heading
+                      end_bracket: )
+            - statement_terminator: ;
+            - statement:
+                for_loop_statement:
+                - keyword: FOR
+                - naked_identifier: i
+                - keyword: IN
+                - naked_identifier: names
+                - dot: .
+                - naked_identifier: FIRST
+                - dot: .
+                - dot: .
+                - naked_identifier: names
+                - dot: .
+                - naked_identifier: LAST
+                - loop_statement:
+                  - keyword: LOOP
+                  - statement:
+                      function:
+                        function_name:
+                          naked_identifier: DBMS_OUTPUT
+                          dot: .
+                          function_name_identifier: PUT_LINE
+                        function_contents:
+                          bracketed:
+                            start_bracket: (
+                            expression:
+                              function:
+                                function_name:
+                                  function_name_identifier: names
+                                function_contents:
+                                  bracketed:
+                                    start_bracket: (
+                                    expression:
+                                      column_reference:
+                                        naked_identifier: i
+                                    end_bracket: )
+                            end_bracket: )
+                  - statement_terminator: ;
+                  - keyword: END
+                  - keyword: LOOP
+            - statement_terminator: ;
+            - statement:
+                function:
+                  function_name:
+                    naked_identifier: DBMS_OUTPUT
+                    dot: .
+                    function_name_identifier: PUT_LINE
+                  function_contents:
+                    bracketed:
+                      start_bracket: (
+                      expression:
+                        quoted_literal: "'---'"
+                      end_bracket: )
+            - statement_terminator: ;
+            - keyword: END
+          - statement_terminator: ;
+      - keyword: BEGIN
+      - statement:
+          function:
+            function_name:
+              function_name_identifier: print_names
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  quoted_literal: "'Initial Values:'"
+                end_bracket: )
+      - statement_terminator: ;
+      - statement:
+          assignment_segment_statement:
+            object_reference:
+              naked_identifier: names
             bracketed:
               start_bracket: (
-              expression:
-                quoted_literal: "'Current Values:'"
+              numeric_literal: '3'
               end_bracket: )
-    - statement_terminator: ;
-    - keyword: END
-- statement_terminator: ;
-- statement_terminator: /
-- statement:
-    begin_end_block:
-    - declare_segment:
-      - keyword: DECLARE
-      - record_type:
-        - keyword: TYPE
-        - naked_identifier: employee_rec_type
-        - keyword: IS
-        - keyword: RECORD
-        - bracketed:
-          - start_bracket: (
-          - naked_identifier: employee_id
-          - data_type:
-              data_type_identifier: NUMBER
-          - comma: ','
-          - naked_identifier: first_name
-          - data_type:
-              data_type_identifier: VARCHAR2
-              bracketed_arguments:
-                bracketed:
-                  start_bracket: (
-                  numeric_literal: '50'
-                  end_bracket: )
-          - comma: ','
-          - naked_identifier: last_name
-          - data_type:
-              data_type_identifier: VARCHAR2
-              bracketed_arguments:
-                bracketed:
-                  start_bracket: (
-                  numeric_literal: '50'
-                  end_bracket: )
-          - comma: ','
-          - naked_identifier: salary
-          - data_type:
-              data_type_identifier: NUMBER
-          - end_bracket: )
+            assignment_operator: :=
+            expression:
+              quoted_literal: "'P Perez'"
       - statement_terminator: ;
-      - collection_type:
-        - keyword: TYPE
-        - naked_identifier: employee_array_type
-        - keyword: IS
-        - keyword: TABLE
-        - keyword: OF
-        - data_type:
-            data_type_identifier: employee_rec_type
-        - keyword: INDEX
-        - keyword: BY
-        - data_type:
-            data_type_identifier: PLS_INTEGER
+      - statement:
+          function:
+            function_name:
+              function_name_identifier: print_names
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  quoted_literal: "'Current Values:'"
+                end_bracket: )
       - statement_terminator: ;
-      - naked_identifier: l_employees
-      - data_type:
-          data_type_identifier: employee_array_type
+      - statement:
+          assignment_segment_statement:
+            object_reference:
+              naked_identifier: names
+            assignment_operator: :=
+            expression:
+              function:
+                function_name:
+                  function_name_identifier: Roster
+                function_contents:
+                  bracketed:
+                  - start_bracket: (
+                  - expression:
+                      quoted_literal: "'A Jansen'"
+                  - comma: ','
+                  - expression:
+                      quoted_literal: "'B Gupta'"
+                  - end_bracket: )
       - statement_terminator: ;
-    - keyword: BEGIN
-    - statement:
-        assignment_segment_statement:
-        - object_reference:
-            naked_identifier: l_employees
-        - bracketed:
-            start_bracket: (
-            numeric_literal: '101'
-            end_bracket: )
-        - dot: .
-        - object_reference:
-            naked_identifier: employee_id
-        - assignment_operator: :=
-        - expression:
-            numeric_literal: '101'
-    - statement_terminator: ;
-    - statement:
-        assignment_segment_statement:
-        - object_reference:
-            naked_identifier: l_employees
-        - bracketed:
-            start_bracket: (
-            numeric_literal: '101'
-            end_bracket: )
-        - dot: .
-        - object_reference:
-            naked_identifier: first_name
-        - assignment_operator: :=
-        - expression:
-            quoted_literal: "'John'"
-    - statement_terminator: ;
-    - statement:
-        assignment_segment_statement:
-        - object_reference:
-            naked_identifier: l_employees
-        - bracketed:
-            start_bracket: (
-            numeric_literal: '101'
-            end_bracket: )
-        - dot: .
-        - object_reference:
-            naked_identifier: last_name
-        - assignment_operator: :=
-        - expression:
-            quoted_literal: "'Doe'"
-    - statement_terminator: ;
-    - statement:
-        assignment_segment_statement:
-        - object_reference:
-            naked_identifier: l_employees
-        - bracketed:
-            start_bracket: (
-            numeric_literal: '101'
-            end_bracket: )
-        - dot: .
-        - object_reference:
-            naked_identifier: salary
-        - assignment_operator: :=
-        - expression:
-            numeric_literal: '50000'
-    - statement_terminator: ;
-    - statement:
-        assignment_segment_statement:
-        - object_reference:
-            naked_identifier: l_employees
-        - bracketed:
-            start_bracket: (
-            numeric_literal: '102'
-            end_bracket: )
-        - dot: .
-        - object_reference:
-            naked_identifier: employee_id
-        - assignment_operator: :=
-        - expression:
-            numeric_literal: '102'
-    - statement_terminator: ;
-    - statement:
-        assignment_segment_statement:
-        - object_reference:
-            naked_identifier: l_employees
-        - bracketed:
-            start_bracket: (
-            numeric_literal: '102'
-            end_bracket: )
-        - dot: .
-        - object_reference:
-            naked_identifier: first_name
-        - assignment_operator: :=
-        - expression:
-            quoted_literal: "'Jane'"
-    - statement_terminator: ;
-    - statement:
-        assignment_segment_statement:
-        - object_reference:
-            naked_identifier: l_employees
-        - bracketed:
-            start_bracket: (
-            numeric_literal: '102'
-            end_bracket: )
-        - dot: .
-        - object_reference:
-            naked_identifier: last_name
-        - assignment_operator: :=
-        - expression:
-            quoted_literal: "'Smith'"
-    - statement_terminator: ;
-    - statement:
-        assignment_segment_statement:
-        - object_reference:
-            naked_identifier: l_employees
-        - bracketed:
-            start_bracket: (
-            numeric_literal: '102'
-            end_bracket: )
-        - dot: .
-        - object_reference:
-            naked_identifier: salary
-        - assignment_operator: :=
-        - expression:
-            numeric_literal: '60000'
-    - statement_terminator: ;
-    - statement:
-        function:
-          function_name:
-            naked_identifier: DBMS_OUTPUT
-            dot: .
-            function_name_identifier: PUT_LINE
-          function_contents:
-            bracketed:
+      - statement:
+          function:
+            function_name:
+              function_name_identifier: print_names
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  quoted_literal: "'Current Values:'"
+                end_bracket: )
+      - statement_terminator: ;
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      begin_end_block:
+      - declare_segment:
+        - keyword: DECLARE
+        - record_type:
+          - keyword: TYPE
+          - naked_identifier: employee_rec_type
+          - keyword: IS
+          - keyword: RECORD
+          - bracketed:
             - start_bracket: (
-            - expression:
-                quoted_literal: "'Employee 101: '"
-                binary_operator:
-                - pipe: '|'
-                - pipe: '|'
-                object_reference:
-                  naked_identifier: l_employees
-                bracketed:
-                  start_bracket: (
-                  numeric_literal: '101'
-                  end_bracket: )
-                dot: .
-            - expression:
-              - column_reference:
-                  naked_identifier: first_name
-              - binary_operator:
-                - pipe: '|'
-                - pipe: '|'
-              - quoted_literal: "' '"
-              - binary_operator:
-                - pipe: '|'
-                - pipe: '|'
-              - object_reference:
-                  naked_identifier: l_employees
-              - bracketed:
-                  start_bracket: (
-                  numeric_literal: '101'
-                  end_bracket: )
-              - dot: .
-            - expression:
-                column_reference:
-                  naked_identifier: last_name
+            - naked_identifier: employee_id
+            - data_type:
+                data_type_identifier: NUMBER
+            - comma: ','
+            - naked_identifier: first_name
+            - data_type:
+                data_type_identifier: VARCHAR2
+                bracketed_arguments:
+                  bracketed:
+                    start_bracket: (
+                    numeric_literal: '50'
+                    end_bracket: )
+            - comma: ','
+            - naked_identifier: last_name
+            - data_type:
+                data_type_identifier: VARCHAR2
+                bracketed_arguments:
+                  bracketed:
+                    start_bracket: (
+                    numeric_literal: '50'
+                    end_bracket: )
+            - comma: ','
+            - naked_identifier: salary
+            - data_type:
+                data_type_identifier: NUMBER
             - end_bracket: )
-    - statement_terminator: ;
-    - statement:
-        function:
-          function_name:
-            naked_identifier: DBMS_OUTPUT
-            dot: .
-            function_name_identifier: PUT_LINE
-          function_contents:
-            bracketed:
-            - start_bracket: (
-            - expression:
-                quoted_literal: "'Employee 102 Salary: '"
-                binary_operator:
-                - pipe: '|'
-                - pipe: '|'
-                object_reference:
-                  naked_identifier: l_employees
-                bracketed:
-                  start_bracket: (
-                  numeric_literal: '102'
-                  end_bracket: )
-                dot: .
-            - expression:
-                column_reference:
-                  naked_identifier: salary
-            - end_bracket: )
-    - statement_terminator: ;
-    - keyword: END
-- statement_terminator: ;
-- statement_terminator: /
+        - statement_terminator: ;
+        - collection_type:
+          - keyword: TYPE
+          - naked_identifier: employee_array_type
+          - keyword: IS
+          - keyword: TABLE
+          - keyword: OF
+          - data_type:
+              data_type_identifier: employee_rec_type
+          - keyword: INDEX
+          - keyword: BY
+          - data_type:
+              data_type_identifier: PLS_INTEGER
+        - statement_terminator: ;
+        - naked_identifier: l_employees
+        - data_type:
+            data_type_identifier: employee_array_type
+        - statement_terminator: ;
+      - keyword: BEGIN
+      - statement:
+          assignment_segment_statement:
+          - object_reference:
+              naked_identifier: l_employees
+          - bracketed:
+              start_bracket: (
+              numeric_literal: '101'
+              end_bracket: )
+          - dot: .
+          - object_reference:
+              naked_identifier: employee_id
+          - assignment_operator: :=
+          - expression:
+              numeric_literal: '101'
+      - statement_terminator: ;
+      - statement:
+          assignment_segment_statement:
+          - object_reference:
+              naked_identifier: l_employees
+          - bracketed:
+              start_bracket: (
+              numeric_literal: '101'
+              end_bracket: )
+          - dot: .
+          - object_reference:
+              naked_identifier: first_name
+          - assignment_operator: :=
+          - expression:
+              quoted_literal: "'John'"
+      - statement_terminator: ;
+      - statement:
+          assignment_segment_statement:
+          - object_reference:
+              naked_identifier: l_employees
+          - bracketed:
+              start_bracket: (
+              numeric_literal: '101'
+              end_bracket: )
+          - dot: .
+          - object_reference:
+              naked_identifier: last_name
+          - assignment_operator: :=
+          - expression:
+              quoted_literal: "'Doe'"
+      - statement_terminator: ;
+      - statement:
+          assignment_segment_statement:
+          - object_reference:
+              naked_identifier: l_employees
+          - bracketed:
+              start_bracket: (
+              numeric_literal: '101'
+              end_bracket: )
+          - dot: .
+          - object_reference:
+              naked_identifier: salary
+          - assignment_operator: :=
+          - expression:
+              numeric_literal: '50000'
+      - statement_terminator: ;
+      - statement:
+          assignment_segment_statement:
+          - object_reference:
+              naked_identifier: l_employees
+          - bracketed:
+              start_bracket: (
+              numeric_literal: '102'
+              end_bracket: )
+          - dot: .
+          - object_reference:
+              naked_identifier: employee_id
+          - assignment_operator: :=
+          - expression:
+              numeric_literal: '102'
+      - statement_terminator: ;
+      - statement:
+          assignment_segment_statement:
+          - object_reference:
+              naked_identifier: l_employees
+          - bracketed:
+              start_bracket: (
+              numeric_literal: '102'
+              end_bracket: )
+          - dot: .
+          - object_reference:
+              naked_identifier: first_name
+          - assignment_operator: :=
+          - expression:
+              quoted_literal: "'Jane'"
+      - statement_terminator: ;
+      - statement:
+          assignment_segment_statement:
+          - object_reference:
+              naked_identifier: l_employees
+          - bracketed:
+              start_bracket: (
+              numeric_literal: '102'
+              end_bracket: )
+          - dot: .
+          - object_reference:
+              naked_identifier: last_name
+          - assignment_operator: :=
+          - expression:
+              quoted_literal: "'Smith'"
+      - statement_terminator: ;
+      - statement:
+          assignment_segment_statement:
+          - object_reference:
+              naked_identifier: l_employees
+          - bracketed:
+              start_bracket: (
+              numeric_literal: '102'
+              end_bracket: )
+          - dot: .
+          - object_reference:
+              naked_identifier: salary
+          - assignment_operator: :=
+          - expression:
+              numeric_literal: '60000'
+      - statement_terminator: ;
+      - statement:
+          function:
+            function_name:
+              naked_identifier: DBMS_OUTPUT
+              dot: .
+              function_name_identifier: PUT_LINE
+            function_contents:
+              bracketed:
+              - start_bracket: (
+              - expression:
+                  quoted_literal: "'Employee 101: '"
+                  binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                  object_reference:
+                    naked_identifier: l_employees
+                  bracketed:
+                    start_bracket: (
+                    numeric_literal: '101'
+                    end_bracket: )
+                  dot: .
+              - expression:
+                - column_reference:
+                    naked_identifier: first_name
+                - binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                - quoted_literal: "' '"
+                - binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                - object_reference:
+                    naked_identifier: l_employees
+                - bracketed:
+                    start_bracket: (
+                    numeric_literal: '101'
+                    end_bracket: )
+                - dot: .
+              - expression:
+                  column_reference:
+                    naked_identifier: last_name
+              - end_bracket: )
+      - statement_terminator: ;
+      - statement:
+          function:
+            function_name:
+              naked_identifier: DBMS_OUTPUT
+              dot: .
+              function_name_identifier: PUT_LINE
+            function_contents:
+              bracketed:
+              - start_bracket: (
+              - expression:
+                  quoted_literal: "'Employee 102 Salary: '"
+                  binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                  object_reference:
+                    naked_identifier: l_employees
+                  bracketed:
+                    start_bracket: (
+                    numeric_literal: '102'
+                    end_bracket: )
+                  dot: .
+              - expression:
+                  column_reference:
+                    naked_identifier: salary
+              - end_bracket: )
+      - statement_terminator: ;
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /

--- a/test/fixtures/dialects/oracle/column_type.yml
+++ b/test/fixtures/dialects/oracle/column_type.yml
@@ -3,108 +3,112 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 6a205f062ed52d5d50e54df28b7c979c8aec3d3ea54aabbd3f1f46ac16cdbc5a
+_hash: 88b0bfd64d491300a9003165885d6cb553ae251e14d10662a4ca44be6fee8bdb
 file:
-- statement:
-    begin_end_block:
-    - declare_segment:
-        keyword: DECLARE
-        naked_identifier: surname
-        column_type_reference:
-          column_reference:
-          - naked_identifier: employees
-          - dot: .
-          - naked_identifier: last_name
-          binary_operator: '%'
-          keyword: TYPE
-        statement_terminator: ;
-    - keyword: BEGIN
-    - statement:
-        function:
-          function_name:
-            naked_identifier: DBMS_OUTPUT
-            dot: .
-            function_name_identifier: PUT_LINE
-          function_contents:
-            bracketed:
-              start_bracket: (
-              expression:
-                quoted_literal: "'surname='"
-                binary_operator:
-                - pipe: '|'
-                - pipe: '|'
-                column_reference:
-                  naked_identifier: surname
-              end_bracket: )
-    - statement_terminator: ;
-    - keyword: END
-- statement_terminator: ;
-- statement_terminator: /
-- statement:
-    begin_end_block:
-    - declare_segment:
-      - keyword: DECLARE
-      - naked_identifier: name
-      - data_type:
-          data_type_identifier: VARCHAR
-          bracketed_arguments:
-            bracketed:
-              start_bracket: (
-              numeric_literal: '25'
-              end_bracket: )
-      - keyword: NOT
-      - keyword: 'NULL'
-      - assignment_operator: :=
-      - expression:
-          quoted_literal: "'Smith'"
+- batch:
+    statement:
+      begin_end_block:
+      - declare_segment:
+          keyword: DECLARE
+          naked_identifier: surname
+          column_type_reference:
+            column_reference:
+            - naked_identifier: employees
+            - dot: .
+            - naked_identifier: last_name
+            binary_operator: '%'
+            keyword: TYPE
+          statement_terminator: ;
+      - keyword: BEGIN
+      - statement:
+          function:
+            function_name:
+              naked_identifier: DBMS_OUTPUT
+              dot: .
+              function_name_identifier: PUT_LINE
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  quoted_literal: "'surname='"
+                  binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                  column_reference:
+                    naked_identifier: surname
+                end_bracket: )
       - statement_terminator: ;
-      - naked_identifier: surname
-      - column_type_reference:
-          column_reference:
-            naked_identifier: name
-          binary_operator: '%'
-          keyword: TYPE
-      - assignment_operator: :=
-      - expression:
-          quoted_literal: "'Jones'"
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      begin_end_block:
+      - declare_segment:
+        - keyword: DECLARE
+        - naked_identifier: name
+        - data_type:
+            data_type_identifier: VARCHAR
+            bracketed_arguments:
+              bracketed:
+                start_bracket: (
+                numeric_literal: '25'
+                end_bracket: )
+        - keyword: NOT
+        - keyword: 'NULL'
+        - assignment_operator: :=
+        - expression:
+            quoted_literal: "'Smith'"
+        - statement_terminator: ;
+        - naked_identifier: surname
+        - column_type_reference:
+            column_reference:
+              naked_identifier: name
+            binary_operator: '%'
+            keyword: TYPE
+        - assignment_operator: :=
+        - expression:
+            quoted_literal: "'Jones'"
+        - statement_terminator: ;
+      - keyword: BEGIN
+      - statement:
+          function:
+            function_name:
+              naked_identifier: DBMS_OUTPUT
+              dot: .
+              function_name_identifier: PUT_LINE
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  quoted_literal: "'name='"
+                  binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                  column_reference:
+                    naked_identifier: name
+                end_bracket: )
       - statement_terminator: ;
-    - keyword: BEGIN
-    - statement:
-        function:
-          function_name:
-            naked_identifier: DBMS_OUTPUT
-            dot: .
-            function_name_identifier: PUT_LINE
-          function_contents:
-            bracketed:
-              start_bracket: (
-              expression:
-                quoted_literal: "'name='"
-                binary_operator:
-                - pipe: '|'
-                - pipe: '|'
-                column_reference:
-                  naked_identifier: name
-              end_bracket: )
-    - statement_terminator: ;
-    - statement:
-        function:
-          function_name:
-            naked_identifier: DBMS_OUTPUT
-            dot: .
-            function_name_identifier: PUT_LINE
-          function_contents:
-            bracketed:
-              start_bracket: (
-              expression:
-                quoted_literal: "'surname='"
-                binary_operator:
-                - pipe: '|'
-                - pipe: '|'
-                column_reference:
-                  naked_identifier: surname
-              end_bracket: )
-    - statement_terminator: ;
-    - keyword: END
-- statement_terminator: ;
-- statement_terminator: /
+      - statement:
+          function:
+            function_name:
+              naked_identifier: DBMS_OUTPUT
+              dot: .
+              function_name_identifier: PUT_LINE
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  quoted_literal: "'surname='"
+                  binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                  column_reference:
+                    naked_identifier: surname
+                end_bracket: )
+      - statement_terminator: ;
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /

--- a/test/fixtures/dialects/oracle/column_value.yml
+++ b/test/fixtures/dialects/oracle/column_value.yml
@@ -3,38 +3,39 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 27978468b93e9dba77b130443f65ee299dd445cf77d0644ba5f3bfacf393db49
+_hash: cb7072455c5275ed4d5485ed0d568b9f0814888076e30496752e5d415269b5b8
 file:
-  statement:
-    select_statement:
-      select_clause:
-        keyword: SELECT
-        select_clause_element:
-          bare_function: column_value
-          alias_expression:
-            alias_operator:
-              keyword: AS
-            naked_identifier: mnth
-      from_clause:
-        keyword: FROM
-        from_expression:
-          from_expression_element:
-            table_expression:
-              function:
-                function_name:
-                  naked_identifier: sys
-                  dot: .
-                  function_name_identifier: dbms_debug_vc2coll
-                function_contents:
-                  bracketed:
-                  - start_bracket: (
-                  - expression:
-                      quoted_literal: "'01'"
-                  - comma: ','
-                  - expression:
-                      quoted_literal: "'05'"
-                  - comma: ','
-                  - expression:
-                      quoted_literal: "'09'"
-                  - end_bracket: )
-  statement_terminator: ;
+  batch:
+    statement:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            bare_function: column_value
+            alias_expression:
+              alias_operator:
+                keyword: AS
+              naked_identifier: mnth
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                function:
+                  function_name:
+                    naked_identifier: sys
+                    dot: .
+                    function_name_identifier: dbms_debug_vc2coll
+                  function_contents:
+                    bracketed:
+                    - start_bracket: (
+                    - expression:
+                        quoted_literal: "'01'"
+                    - comma: ','
+                    - expression:
+                        quoted_literal: "'05'"
+                    - comma: ','
+                    - expression:
+                        quoted_literal: "'09'"
+                    - end_bracket: )
+    statement_terminator: ;

--- a/test/fixtures/dialects/oracle/comment.yml
+++ b/test/fixtures/dialects/oracle/comment.yml
@@ -3,58 +3,59 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 60c4002a0a46717b7f7585fd94f08af0d21c73b1481783df59889ef0cdda8c50
+_hash: 0767f714ec5fb433044abfc2d78a122198b95864b637a804a24f9700dc0ec481
 file:
-- statement:
-    comment_statement:
-    - keyword: COMMENT
-    - keyword: 'ON'
-    - keyword: COLUMN
-    - column_reference:
-      - naked_identifier: employees
-      - dot: .
-      - naked_identifier: job_id
-    - keyword: IS
-    - quoted_literal: "'abbreviated job title'"
-- statement_terminator: ;
-- statement:
-    comment_statement:
-    - keyword: COMMENT
-    - keyword: 'ON'
-    - keyword: TABLE
-    - table_reference:
-        naked_identifier: employees
-    - keyword: IS
-    - quoted_literal: "'employees table'"
-- statement_terminator: ;
-- statement:
-    comment_statement:
-    - keyword: COMMENT
-    - keyword: 'ON'
-    - keyword: INDEXTYPE
-    - indextype_reference:
-        naked_identifier: employees_indextype
-    - keyword: IS
-    - quoted_literal: "'employees indextype'"
-- statement_terminator: ;
-- statement:
-    comment_statement:
-    - keyword: COMMENT
-    - keyword: 'ON'
-    - keyword: OPERATOR
-    - object_reference:
-        naked_identifier: employees_operator
-    - keyword: IS
-    - quoted_literal: "'employees operator'"
-- statement_terminator: ;
-- statement:
-    comment_statement:
-    - keyword: COMMENT
-    - keyword: 'ON'
-    - keyword: MATERIALIZED
-    - keyword: VIEW
-    - table_reference:
-        naked_identifier: employees_mv
-    - keyword: IS
-    - quoted_literal: "'employees materialized view'"
-- statement_terminator: ;
+  batch:
+  - statement:
+      comment_statement:
+      - keyword: COMMENT
+      - keyword: 'ON'
+      - keyword: COLUMN
+      - column_reference:
+        - naked_identifier: employees
+        - dot: .
+        - naked_identifier: job_id
+      - keyword: IS
+      - quoted_literal: "'abbreviated job title'"
+  - statement_terminator: ;
+  - statement:
+      comment_statement:
+      - keyword: COMMENT
+      - keyword: 'ON'
+      - keyword: TABLE
+      - table_reference:
+          naked_identifier: employees
+      - keyword: IS
+      - quoted_literal: "'employees table'"
+  - statement_terminator: ;
+  - statement:
+      comment_statement:
+      - keyword: COMMENT
+      - keyword: 'ON'
+      - keyword: INDEXTYPE
+      - indextype_reference:
+          naked_identifier: employees_indextype
+      - keyword: IS
+      - quoted_literal: "'employees indextype'"
+  - statement_terminator: ;
+  - statement:
+      comment_statement:
+      - keyword: COMMENT
+      - keyword: 'ON'
+      - keyword: OPERATOR
+      - object_reference:
+          naked_identifier: employees_operator
+      - keyword: IS
+      - quoted_literal: "'employees operator'"
+  - statement_terminator: ;
+  - statement:
+      comment_statement:
+      - keyword: COMMENT
+      - keyword: 'ON'
+      - keyword: MATERIALIZED
+      - keyword: VIEW
+      - table_reference:
+          naked_identifier: employees_mv
+      - keyword: IS
+      - quoted_literal: "'employees materialized view'"
+  - statement_terminator: ;

--- a/test/fixtures/dialects/oracle/comparison_operators_with_space.yml
+++ b/test/fixtures/dialects/oracle/comparison_operators_with_space.yml
@@ -3,71 +3,72 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 70bbe6d19831c69c75359a6098c6a2cff155fcbddf2ebfbb444909ff2e756898
+_hash: 021d760ae57d0fdbb9a7719d609e18e6a1bbfc5d7bf8ae5bb9e1b64f8bb0981c
 file:
-- statement:
-    select_statement:
-      select_clause:
-        keyword: select
-        select_clause_element:
-          numeric_literal: '1'
-      from_clause:
-        keyword: from
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: dual
-      where_clause:
-        keyword: where
-        expression:
-        - numeric_literal: '3'
-        - comparison_operator:
-          - raw_comparison_operator: <
-          - raw_comparison_operator: '='
-        - numeric_literal: '5'
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-        keyword: select
-        select_clause_element:
-          numeric_literal: '1'
-      from_clause:
-        keyword: from
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: dual
-      where_clause:
-        keyword: where
-        expression:
-        - numeric_literal: '4'
-        - comparison_operator:
-          - raw_comparison_operator: '>'
-          - raw_comparison_operator: '='
-        - numeric_literal: '2'
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-        keyword: select
-        select_clause_element:
-          numeric_literal: '1'
-      from_clause:
-        keyword: from
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: dual
-      where_clause:
-        keyword: where
-        expression:
-        - numeric_literal: '1'
-        - comparison_operator:
-          - raw_comparison_operator: '!'
-          - raw_comparison_operator: '='
-        - numeric_literal: '3'
-- statement_terminator: ;
+  batch:
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: select
+          select_clause_element:
+            numeric_literal: '1'
+        from_clause:
+          keyword: from
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: dual
+        where_clause:
+          keyword: where
+          expression:
+          - numeric_literal: '3'
+          - comparison_operator:
+            - raw_comparison_operator: <
+            - raw_comparison_operator: '='
+          - numeric_literal: '5'
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: select
+          select_clause_element:
+            numeric_literal: '1'
+        from_clause:
+          keyword: from
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: dual
+        where_clause:
+          keyword: where
+          expression:
+          - numeric_literal: '4'
+          - comparison_operator:
+            - raw_comparison_operator: '>'
+            - raw_comparison_operator: '='
+          - numeric_literal: '2'
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: select
+          select_clause_element:
+            numeric_literal: '1'
+        from_clause:
+          keyword: from
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: dual
+        where_clause:
+          keyword: where
+          expression:
+          - numeric_literal: '1'
+          - comparison_operator:
+            - raw_comparison_operator: '!'
+            - raw_comparison_operator: '='
+          - numeric_literal: '3'
+  - statement_terminator: ;

--- a/test/fixtures/dialects/oracle/continue.yml
+++ b/test/fixtures/dialects/oracle/continue.yml
@@ -3,276 +3,280 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 66c1d78a739302ac039e3efad57ad888fc3287f0f1299d165d48b6e42d4b064c
+_hash: 2f74899e9685a4ac044e6ac8444225d74dec0995978f578435ac0097d381fa49
 file:
-- statement:
-    begin_end_block:
-    - declare_segment:
-        keyword: DECLARE
-        naked_identifier: x
-        data_type:
-          data_type_identifier: NUMBER
-        assignment_operator: :=
-        expression:
-          numeric_literal: '0'
-        statement_terminator: ;
-    - keyword: BEGIN
-    - statement:
-        loop_statement:
-        - keyword: LOOP
-        - statement:
-            function:
-              function_name:
-                naked_identifier: DBMS_OUTPUT
-                dot: .
-                function_name_identifier: PUT_LINE
-              function_contents:
-                bracketed:
-                  start_bracket: (
-                  expression:
-                    quoted_literal: "'Inside loop:  x = '"
-                    binary_operator:
-                    - pipe: '|'
-                    - pipe: '|'
-                    function:
-                      function_name:
-                        function_name_identifier: TO_CHAR
-                      function_contents:
-                        bracketed:
-                          start_bracket: (
-                          expression:
-                            column_reference:
-                              naked_identifier: x
-                          end_bracket: )
-                  end_bracket: )
-        - statement_terminator: ;
-        - statement:
-            assignment_segment_statement:
-              object_reference:
-                naked_identifier: x
-              assignment_operator: :=
-              expression:
-                column_reference:
+- batch:
+    statement:
+      begin_end_block:
+      - declare_segment:
+          keyword: DECLARE
+          naked_identifier: x
+          data_type:
+            data_type_identifier: NUMBER
+          assignment_operator: :=
+          expression:
+            numeric_literal: '0'
+          statement_terminator: ;
+      - keyword: BEGIN
+      - statement:
+          loop_statement:
+          - keyword: LOOP
+          - statement:
+              function:
+                function_name:
+                  naked_identifier: DBMS_OUTPUT
+                  dot: .
+                  function_name_identifier: PUT_LINE
+                function_contents:
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                      quoted_literal: "'Inside loop:  x = '"
+                      binary_operator:
+                      - pipe: '|'
+                      - pipe: '|'
+                      function:
+                        function_name:
+                          function_name_identifier: TO_CHAR
+                        function_contents:
+                          bracketed:
+                            start_bracket: (
+                            expression:
+                              column_reference:
+                                naked_identifier: x
+                            end_bracket: )
+                    end_bracket: )
+          - statement_terminator: ;
+          - statement:
+              assignment_segment_statement:
+                object_reference:
                   naked_identifier: x
-                binary_operator: +
-                numeric_literal: '1'
-        - statement_terminator: ;
-        - statement:
-            if_then_statement:
-            - if_clause:
+                assignment_operator: :=
+                expression:
+                  column_reference:
+                    naked_identifier: x
+                  binary_operator: +
+                  numeric_literal: '1'
+          - statement_terminator: ;
+          - statement:
+              if_then_statement:
+              - if_clause:
+                - keyword: IF
+                - expression:
+                    column_reference:
+                      naked_identifier: x
+                    comparison_operator:
+                      raw_comparison_operator: <
+                    numeric_literal: '3'
+                - keyword: THEN
+              - statement:
+                  continue_statement:
+                    keyword: CONTINUE
+              - statement_terminator: ;
+              - keyword: END
               - keyword: IF
+          - statement_terminator: ;
+          - statement:
+              function:
+                function_name:
+                  naked_identifier: DBMS_OUTPUT
+                  dot: .
+                  function_name_identifier: PUT_LINE
+                function_contents:
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                      quoted_literal: "'Inside loop, after CONTINUE:  x = '"
+                      binary_operator:
+                      - pipe: '|'
+                      - pipe: '|'
+                      function:
+                        function_name:
+                          function_name_identifier: TO_CHAR
+                        function_contents:
+                          bracketed:
+                            start_bracket: (
+                            expression:
+                              column_reference:
+                                naked_identifier: x
+                            end_bracket: )
+                    end_bracket: )
+          - statement_terminator: ;
+          - statement:
+              exit_statement:
+              - keyword: EXIT
+              - keyword: WHEN
+              - expression:
+                  column_reference:
+                    naked_identifier: x
+                  comparison_operator:
+                    raw_comparison_operator: '='
+                  numeric_literal: '5'
+          - statement_terminator: ;
+          - keyword: END
+          - keyword: LOOP
+      - statement_terminator: ;
+      - statement:
+          function:
+            function_name:
+              naked_identifier: DBMS_OUTPUT
+              dot: .
+              function_name_identifier: PUT_LINE
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  quoted_literal: "' After loop:  x = '"
+                  binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                  function:
+                    function_name:
+                      function_name_identifier: TO_CHAR
+                    function_contents:
+                      bracketed:
+                        start_bracket: (
+                        expression:
+                          column_reference:
+                            naked_identifier: x
+                        end_bracket: )
+                end_bracket: )
+      - statement_terminator: ;
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      begin_end_block:
+      - declare_segment:
+          keyword: DECLARE
+          naked_identifier: x
+          data_type:
+            data_type_identifier: NUMBER
+          assignment_operator: :=
+          expression:
+            numeric_literal: '0'
+          statement_terminator: ;
+      - keyword: BEGIN
+      - statement:
+          loop_statement:
+          - keyword: LOOP
+          - statement:
+              function:
+                function_name:
+                  naked_identifier: DBMS_OUTPUT
+                  dot: .
+                  function_name_identifier: PUT_LINE
+                function_contents:
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                      quoted_literal: "'Inside loop:  x = '"
+                      binary_operator:
+                      - pipe: '|'
+                      - pipe: '|'
+                      function:
+                        function_name:
+                          function_name_identifier: TO_CHAR
+                        function_contents:
+                          bracketed:
+                            start_bracket: (
+                            expression:
+                              column_reference:
+                                naked_identifier: x
+                            end_bracket: )
+                    end_bracket: )
+          - statement_terminator: ;
+          - statement:
+              assignment_segment_statement:
+                object_reference:
+                  naked_identifier: x
+                assignment_operator: :=
+                expression:
+                  column_reference:
+                    naked_identifier: x
+                  binary_operator: +
+                  numeric_literal: '1'
+          - statement_terminator: ;
+          - statement:
+              continue_statement:
+              - keyword: CONTINUE
+              - keyword: WHEN
               - expression:
                   column_reference:
                     naked_identifier: x
                   comparison_operator:
                     raw_comparison_operator: <
                   numeric_literal: '3'
-              - keyword: THEN
-            - statement:
-                continue_statement:
-                  keyword: CONTINUE
-            - statement_terminator: ;
-            - keyword: END
-            - keyword: IF
-        - statement_terminator: ;
-        - statement:
-            function:
-              function_name:
-                naked_identifier: DBMS_OUTPUT
-                dot: .
-                function_name_identifier: PUT_LINE
-              function_contents:
-                bracketed:
-                  start_bracket: (
-                  expression:
-                    quoted_literal: "'Inside loop, after CONTINUE:  x = '"
-                    binary_operator:
-                    - pipe: '|'
-                    - pipe: '|'
-                    function:
-                      function_name:
-                        function_name_identifier: TO_CHAR
-                      function_contents:
-                        bracketed:
-                          start_bracket: (
-                          expression:
-                            column_reference:
-                              naked_identifier: x
-                          end_bracket: )
-                  end_bracket: )
-        - statement_terminator: ;
-        - statement:
-            exit_statement:
-            - keyword: EXIT
-            - keyword: WHEN
-            - expression:
-                column_reference:
-                  naked_identifier: x
-                comparison_operator:
-                  raw_comparison_operator: '='
-                numeric_literal: '5'
-        - statement_terminator: ;
-        - keyword: END
-        - keyword: LOOP
-    - statement_terminator: ;
-    - statement:
-        function:
-          function_name:
-            naked_identifier: DBMS_OUTPUT
-            dot: .
-            function_name_identifier: PUT_LINE
-          function_contents:
-            bracketed:
-              start_bracket: (
-              expression:
-                quoted_literal: "' After loop:  x = '"
-                binary_operator:
-                - pipe: '|'
-                - pipe: '|'
-                function:
-                  function_name:
-                    function_name_identifier: TO_CHAR
-                  function_contents:
-                    bracketed:
-                      start_bracket: (
-                      expression:
-                        column_reference:
-                          naked_identifier: x
-                      end_bracket: )
-              end_bracket: )
-    - statement_terminator: ;
-    - keyword: END
-- statement_terminator: ;
-- statement_terminator: /
-- statement:
-    begin_end_block:
-    - declare_segment:
-        keyword: DECLARE
-        naked_identifier: x
-        data_type:
-          data_type_identifier: NUMBER
-        assignment_operator: :=
-        expression:
-          numeric_literal: '0'
-        statement_terminator: ;
-    - keyword: BEGIN
-    - statement:
-        loop_statement:
-        - keyword: LOOP
-        - statement:
-            function:
-              function_name:
-                naked_identifier: DBMS_OUTPUT
-                dot: .
-                function_name_identifier: PUT_LINE
-              function_contents:
-                bracketed:
-                  start_bracket: (
-                  expression:
-                    quoted_literal: "'Inside loop:  x = '"
-                    binary_operator:
-                    - pipe: '|'
-                    - pipe: '|'
-                    function:
-                      function_name:
-                        function_name_identifier: TO_CHAR
-                      function_contents:
-                        bracketed:
-                          start_bracket: (
-                          expression:
-                            column_reference:
-                              naked_identifier: x
-                          end_bracket: )
-                  end_bracket: )
-        - statement_terminator: ;
-        - statement:
-            assignment_segment_statement:
-              object_reference:
-                naked_identifier: x
-              assignment_operator: :=
-              expression:
-                column_reference:
-                  naked_identifier: x
-                binary_operator: +
-                numeric_literal: '1'
-        - statement_terminator: ;
-        - statement:
-            continue_statement:
-            - keyword: CONTINUE
-            - keyword: WHEN
-            - expression:
-                column_reference:
-                  naked_identifier: x
-                comparison_operator:
-                  raw_comparison_operator: <
-                numeric_literal: '3'
-        - statement_terminator: ;
-        - statement:
-            function:
-              function_name:
-                naked_identifier: DBMS_OUTPUT
-                dot: .
-                function_name_identifier: PUT_LINE
-              function_contents:
-                bracketed:
-                  start_bracket: (
-                  expression:
-                    quoted_literal: "'Inside loop, after CONTINUE:  x = '"
-                    binary_operator:
-                    - pipe: '|'
-                    - pipe: '|'
-                    function:
-                      function_name:
-                        function_name_identifier: TO_CHAR
-                      function_contents:
-                        bracketed:
-                          start_bracket: (
-                          expression:
-                            column_reference:
-                              naked_identifier: x
-                          end_bracket: )
-                  end_bracket: )
-        - statement_terminator: ;
-        - statement:
-            exit_statement:
-            - keyword: EXIT
-            - keyword: WHEN
-            - expression:
-                column_reference:
-                  naked_identifier: x
-                comparison_operator:
-                  raw_comparison_operator: '='
-                numeric_literal: '5'
-        - statement_terminator: ;
-        - keyword: END
-        - keyword: LOOP
-    - statement_terminator: ;
-    - statement:
-        function:
-          function_name:
-            naked_identifier: DBMS_OUTPUT
-            dot: .
-            function_name_identifier: PUT_LINE
-          function_contents:
-            bracketed:
-              start_bracket: (
-              expression:
-                quoted_literal: "' After loop:  x = '"
-                binary_operator:
-                - pipe: '|'
-                - pipe: '|'
-                function:
-                  function_name:
-                    function_name_identifier: TO_CHAR
-                  function_contents:
-                    bracketed:
-                      start_bracket: (
-                      expression:
-                        column_reference:
-                          naked_identifier: x
-                      end_bracket: )
-              end_bracket: )
-    - statement_terminator: ;
-    - keyword: END
-- statement_terminator: ;
-- statement_terminator: /
+          - statement_terminator: ;
+          - statement:
+              function:
+                function_name:
+                  naked_identifier: DBMS_OUTPUT
+                  dot: .
+                  function_name_identifier: PUT_LINE
+                function_contents:
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                      quoted_literal: "'Inside loop, after CONTINUE:  x = '"
+                      binary_operator:
+                      - pipe: '|'
+                      - pipe: '|'
+                      function:
+                        function_name:
+                          function_name_identifier: TO_CHAR
+                        function_contents:
+                          bracketed:
+                            start_bracket: (
+                            expression:
+                              column_reference:
+                                naked_identifier: x
+                            end_bracket: )
+                    end_bracket: )
+          - statement_terminator: ;
+          - statement:
+              exit_statement:
+              - keyword: EXIT
+              - keyword: WHEN
+              - expression:
+                  column_reference:
+                    naked_identifier: x
+                  comparison_operator:
+                    raw_comparison_operator: '='
+                  numeric_literal: '5'
+          - statement_terminator: ;
+          - keyword: END
+          - keyword: LOOP
+      - statement_terminator: ;
+      - statement:
+          function:
+            function_name:
+              naked_identifier: DBMS_OUTPUT
+              dot: .
+              function_name_identifier: PUT_LINE
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  quoted_literal: "' After loop:  x = '"
+                  binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                  function:
+                    function_name:
+                      function_name_identifier: TO_CHAR
+                    function_contents:
+                      bracketed:
+                        start_bracket: (
+                        expression:
+                          column_reference:
+                            naked_identifier: x
+                        end_bracket: )
+                end_bracket: )
+      - statement_terminator: ;
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /

--- a/test/fixtures/dialects/oracle/create_database_link.yml
+++ b/test/fixtures/dialects/oracle/create_database_link.yml
@@ -3,52 +3,53 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 62114f25ffce8ea134fb6398e5e7eeb35b12863a419f2d62040cc6d6e5057778
+_hash: 0fda06607118ed643b1804c466cde2b92e172bd30f2a0eda618b0cad7d2ff031
 file:
-- statement:
-    create_database_link_statement:
-    - keyword: CREATE
-    - keyword: PUBLIC
-    - keyword: DATABASE
-    - keyword: LINK
-    - database_link_reference:
-        naked_identifier: remote
-    - keyword: USING
-    - quoted_identifier: "'remote'"
-- statement_terminator: ;
-- statement:
-    create_database_link_statement:
-    - keyword: CREATE
-    - keyword: DATABASE
-    - keyword: LINK
-    - database_link_reference:
-        naked_identifier: local
-    - keyword: CONNECT
-    - keyword: TO
-    - role_reference:
-        naked_identifier: hr
-    - keyword: IDENTIFIED
-    - keyword: BY
-    - naked_identifier: password
-    - keyword: USING
-    - quoted_identifier: "'local'"
-- statement_terminator: ;
-- statement:
-    create_database_link_statement:
-    - keyword: CREATE
-    - keyword: DATABASE
-    - keyword: LINK
-    - database_link_reference:
-      - naked_identifier: remote
-      - dot: .
-      - naked_identifier: us
-      - dot: .
-      - naked_identifier: example
-      - dot: .
-      - naked_identifier: com
-    - keyword: CONNECT
-    - keyword: TO
-    - keyword: CURRENT_USER
-    - keyword: USING
-    - quoted_identifier: "'remote'"
-- statement_terminator: ;
+  batch:
+  - statement:
+      create_database_link_statement:
+      - keyword: CREATE
+      - keyword: PUBLIC
+      - keyword: DATABASE
+      - keyword: LINK
+      - database_link_reference:
+          naked_identifier: remote
+      - keyword: USING
+      - quoted_identifier: "'remote'"
+  - statement_terminator: ;
+  - statement:
+      create_database_link_statement:
+      - keyword: CREATE
+      - keyword: DATABASE
+      - keyword: LINK
+      - database_link_reference:
+          naked_identifier: local
+      - keyword: CONNECT
+      - keyword: TO
+      - role_reference:
+          naked_identifier: hr
+      - keyword: IDENTIFIED
+      - keyword: BY
+      - naked_identifier: password
+      - keyword: USING
+      - quoted_identifier: "'local'"
+  - statement_terminator: ;
+  - statement:
+      create_database_link_statement:
+      - keyword: CREATE
+      - keyword: DATABASE
+      - keyword: LINK
+      - database_link_reference:
+        - naked_identifier: remote
+        - dot: .
+        - naked_identifier: us
+        - dot: .
+        - naked_identifier: example
+        - dot: .
+        - naked_identifier: com
+      - keyword: CONNECT
+      - keyword: TO
+      - keyword: CURRENT_USER
+      - keyword: USING
+      - quoted_identifier: "'remote'"
+  - statement_terminator: ;

--- a/test/fixtures/dialects/oracle/create_function.yml
+++ b/test/fixtures/dialects/oracle/create_function.yml
@@ -3,487 +3,502 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 0f67ffa2e8c994aed93dac9af58387241f5ed38de40507287eb5b96e8efb0994
+_hash: 230b371ef56f7f00f959006d83d10674ef97d677c7a1e8be8ebad27162afed9a
 file:
-- statement:
-    create_function_statement:
-    - keyword: CREATE
-    - keyword: FUNCTION
-    - keyword: IF
-    - keyword: NOT
-    - keyword: EXISTS
-    - function_name:
-        function_name_identifier: get_bal
-    - function_parameter_list:
-        bracketed:
-          start_bracket: (
-          parameter: acc_no
-          keyword: IN
-          data_type:
-            data_type_identifier: NUMBER
-          end_bracket: )
-    - keyword: RETURN
-    - data_type:
-        data_type_identifier: NUMBER
-    - keyword: IS
-    - declare_segment:
-        naked_identifier: acc_bal
-        data_type:
-          data_type_identifier: NUMBER
-          bracketed_arguments:
-            bracketed:
-            - start_bracket: (
-            - numeric_literal: '11'
-            - comma: ','
-            - numeric_literal: '2'
-            - end_bracket: )
-        statement_terminator: ;
-    - begin_end_block:
-      - keyword: BEGIN
-      - statement:
-          select_statement:
-            select_clause:
-              keyword: SELECT
-              select_clause_element:
-                column_reference:
-                  naked_identifier: order_total
-            into_clause:
-              keyword: INTO
-              naked_identifier: acc_bal
-            from_clause:
-              keyword: FROM
-              from_expression:
-                from_expression_element:
-                  table_expression:
-                    table_reference:
-                      naked_identifier: orders
-            where_clause:
-              keyword: WHERE
-              expression:
-              - column_reference:
-                  naked_identifier: customer_id
-              - comparison_operator:
-                  raw_comparison_operator: '='
-              - column_reference:
-                  naked_identifier: acc_no
-      - statement_terminator: ;
-      - statement:
-          function:
-            function_name:
-              function_name_identifier: RETURN
-            function_contents:
-              bracketed:
-                start_bracket: (
-                expression:
-                  column_reference:
-                    naked_identifier: acc_bal
-                end_bracket: )
-      - statement_terminator: ;
-      - keyword: END
-    - statement_terminator: ;
-    - statement_terminator: /
-- statement:
-    create_function_statement:
-    - keyword: CREATE
-    - keyword: OR
-    - keyword: REPLACE
-    - keyword: FUNCTION
-    - function_name:
-        function_name_identifier: text_length
-    - function_parameter_list:
-        bracketed:
-          start_bracket: (
-          parameter: a
-          data_type:
-            data_type_identifier: CLOB
-          end_bracket: )
-    - keyword: RETURN
-    - data_type:
-        data_type_identifier: NUMBER
-    - keyword: DETERMINISTIC
-    - keyword: IS
-    - begin_end_block:
-      - keyword: BEGIN
-      - statement:
-          return_statement:
-            keyword: RETURN
-            expression:
-              function:
-                function_name:
-                  naked_identifier: DBMS_LOB
-                  dot: .
-                  function_name_identifier: GETLENGTH
-                function_contents:
-                  bracketed:
-                    start_bracket: (
-                    expression:
-                      column_reference:
-                        naked_identifier: a
-                    end_bracket: )
-      - statement_terminator: ;
-      - keyword: END
-    - statement_terminator: ;
-    - statement_terminator: /
-- statement:
-    begin_end_block:
-    - declare_segment:
-        keyword: DECLARE
-        create_function_statement:
-        - keyword: FUNCTION
-        - function_name:
-            function_name_identifier: square
-        - function_parameter_list:
-            bracketed:
-              start_bracket: (
-              parameter: original
-              data_type:
-                data_type_identifier: NUMBER
-              end_bracket: )
-        - keyword: RETURN
-        - data_type:
-            data_type_identifier: NUMBER
-        - keyword: AS
-        - declare_segment:
-            naked_identifier: original_squared
+- batch:
+    statement:
+      create_function_statement:
+      - keyword: CREATE
+      - keyword: FUNCTION
+      - keyword: IF
+      - keyword: NOT
+      - keyword: EXISTS
+      - function_name:
+          function_name_identifier: get_bal
+      - function_parameter_list:
+          bracketed:
+            start_bracket: (
+            parameter: acc_no
+            keyword: IN
             data_type:
               data_type_identifier: NUMBER
-            statement_terminator: ;
-        - begin_end_block:
-          - keyword: BEGIN
-          - statement:
-              assignment_segment_statement:
-                object_reference:
-                  naked_identifier: original_squared
-                assignment_operator: :=
-                expression:
-                - column_reference:
-                    naked_identifier: original
-                - binary_operator: '*'
-                - column_reference:
-                    naked_identifier: original
-          - statement_terminator: ;
-          - statement:
-              return_statement:
-                keyword: RETURN
-                expression:
+            end_bracket: )
+      - keyword: RETURN
+      - data_type:
+          data_type_identifier: NUMBER
+      - keyword: IS
+      - declare_segment:
+          naked_identifier: acc_bal
+          data_type:
+            data_type_identifier: NUMBER
+            bracketed_arguments:
+              bracketed:
+              - start_bracket: (
+              - numeric_literal: '11'
+              - comma: ','
+              - numeric_literal: '2'
+              - end_bracket: )
+          statement_terminator: ;
+      - begin_end_block:
+        - keyword: BEGIN
+        - statement:
+            select_statement:
+              select_clause:
+                keyword: SELECT
+                select_clause_element:
                   column_reference:
-                    naked_identifier: original_squared
-          - statement_terminator: ;
-          - keyword: END
+                    naked_identifier: order_total
+              into_clause:
+                keyword: INTO
+                naked_identifier: acc_bal
+              from_clause:
+                keyword: FROM
+                from_expression:
+                  from_expression_element:
+                    table_expression:
+                      table_reference:
+                        naked_identifier: orders
+              where_clause:
+                keyword: WHERE
+                expression:
+                - column_reference:
+                    naked_identifier: customer_id
+                - comparison_operator:
+                    raw_comparison_operator: '='
+                - column_reference:
+                    naked_identifier: acc_no
         - statement_terminator: ;
-    - keyword: BEGIN
-    - statement:
-        function:
-          function_name:
-            naked_identifier: DBMS_OUTPUT
-            dot: .
-            function_name_identifier: PUT_LINE
-          function_contents:
-            bracketed:
-              start_bracket: (
-              expression:
-                function:
-                  function_name:
-                    function_name_identifier: square
-                  function_contents:
-                    bracketed:
-                      start_bracket: (
-                      expression:
-                        numeric_literal: '100'
-                      end_bracket: )
-              end_bracket: )
-    - statement_terminator: ;
-    - keyword: END
-- statement_terminator: ;
-- statement_terminator: /
-- statement:
-    begin_end_block:
-    - declare_segment:
-        keyword: DECLARE
-        naked_identifier: x
-        data_type:
-          data_type_identifier: INTEGER
-        statement_terminator: ;
-        create_function_statement:
-        - keyword: FUNCTION
-        - function_name:
-            function_name_identifier: f
-        - function_parameter_list:
-            bracketed:
-              start_bracket: (
-              parameter: n
-              data_type:
-                data_type_identifier: INTEGER
-              end_bracket: )
-        - keyword: RETURN
-        - data_type:
-            data_type_identifier: INTEGER
-        - keyword: IS
-        - begin_end_block:
-          - keyword: BEGIN
-          - statement:
-              function:
-                function_name:
-                  function_name_identifier: RETURN
-                function_contents:
-                  bracketed:
-                    start_bracket: (
-                    expression:
-                    - column_reference:
-                        naked_identifier: n
-                    - binary_operator: '*'
-                    - column_reference:
-                        naked_identifier: n
-                    end_bracket: )
-          - statement_terminator: ;
-          - keyword: END
-        - statement_terminator: ;
-    - keyword: BEGIN
-    - statement:
-        function:
-          function_name:
-            naked_identifier: DBMS_OUTPUT
-            dot: .
-            function_name_identifier: PUT_LINE
-          function_contents:
-            bracketed:
-              start_bracket: (
-              expression:
-              - quoted_literal: "'f returns '"
-              - binary_operator:
-                - pipe: '|'
-                - pipe: '|'
-              - function:
-                  function_name:
-                    function_name_identifier: f
-                  function_contents:
-                    bracketed:
-                      start_bracket: (
-                      expression:
-                        numeric_literal: '2'
-                      end_bracket: )
-              - binary_operator:
-                - pipe: '|'
-                - pipe: '|'
-              - quoted_literal: "'. Execution returns here (1).'"
-              end_bracket: )
-    - statement_terminator: ;
-    - statement:
-        assignment_segment_statement:
-          object_reference:
-            naked_identifier: x
-          assignment_operator: :=
-          expression:
+        - statement:
             function:
               function_name:
-                function_name_identifier: f
+                function_name_identifier: RETURN
               function_contents:
                 bracketed:
                   start_bracket: (
                   expression:
-                    numeric_literal: '2'
+                    column_reference:
+                      naked_identifier: acc_bal
                   end_bracket: )
-    - statement_terminator: ;
-    - statement:
-        function:
-          function_name:
-            naked_identifier: DBMS_OUTPUT
-            dot: .
-            function_name_identifier: PUT_LINE
-          function_contents:
-            bracketed:
-              start_bracket: (
+        - statement_terminator: ;
+        - keyword: END
+      - statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      create_function_statement:
+      - keyword: CREATE
+      - keyword: OR
+      - keyword: REPLACE
+      - keyword: FUNCTION
+      - function_name:
+          function_name_identifier: text_length
+      - function_parameter_list:
+          bracketed:
+            start_bracket: (
+            parameter: a
+            data_type:
+              data_type_identifier: CLOB
+            end_bracket: )
+      - keyword: RETURN
+      - data_type:
+          data_type_identifier: NUMBER
+      - keyword: DETERMINISTIC
+      - keyword: IS
+      - begin_end_block:
+        - keyword: BEGIN
+        - statement:
+            return_statement:
+              keyword: RETURN
               expression:
-                quoted_literal: "'Execution returns here (2).'"
-              end_bracket: )
-    - statement_terminator: ;
-    - keyword: END
-- statement_terminator: ;
-- statement_terminator: /
-- statement:
-    begin_end_block:
-    - declare_segment:
-      - create_function_statement:
-        - keyword: CREATE
-        - keyword: OR
-        - keyword: REPLACE
-        - keyword: FUNCTION
-        - function_name:
-            function_name_identifier: f
-        - function_parameter_list:
-            bracketed:
-              start_bracket: (
-              parameter: n
-              data_type:
-                data_type_identifier: INTEGER
-              end_bracket: )
-        - keyword: RETURN
-        - data_type:
-            data_type_identifier: INTEGER
-        - keyword: AUTHID
-        - keyword: DEFINER
-        - keyword: IS
-        - begin_end_block:
-          - keyword: BEGIN
-          - statement:
-              if_then_statement:
-              - if_clause:
-                - keyword: IF
-                - expression:
-                    column_reference:
-                      naked_identifier: n
-                    comparison_operator:
-                      raw_comparison_operator: '='
-                    numeric_literal: '0'
-                - keyword: THEN
-              - statement:
-                  return_statement:
-                    keyword: RETURN
-                    expression:
-                      numeric_literal: '1'
-              - statement_terminator: ;
-              - keyword: ELSIF
-              - expression:
-                  column_reference:
-                    naked_identifier: n
-                  comparison_operator:
-                    raw_comparison_operator: '='
-                  numeric_literal: '1'
-              - keyword: THEN
-              - statement:
-                  return_statement:
-                    keyword: RETURN
-                    expression:
-                      column_reference:
-                        naked_identifier: n
-              - statement_terminator: ;
-              - keyword: END
-              - keyword: IF
-          - statement_terminator: ;
-          - keyword: END
+                function:
+                  function_name:
+                    naked_identifier: DBMS_LOB
+                    dot: .
+                    function_name_identifier: GETLENGTH
+                  function_contents:
+                    bracketed:
+                      start_bracket: (
+                      expression:
+                        column_reference:
+                          naked_identifier: a
+                      end_bracket: )
         - statement_terminator: ;
-        - statement_terminator: /
-      - create_function_statement:
-        - keyword: CREATE
-        - keyword: OR
-        - keyword: REPLACE
-        - keyword: FUNCTION
-        - function_name:
-            function_name_identifier: f
-        - function_parameter_list:
-            bracketed:
-              start_bracket: (
-              parameter: n
+        - keyword: END
+      - statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      begin_end_block:
+      - declare_segment:
+          keyword: DECLARE
+          create_function_statement:
+          - keyword: FUNCTION
+          - function_name:
+              function_name_identifier: square
+          - function_parameter_list:
+              bracketed:
+                start_bracket: (
+                parameter: original
+                data_type:
+                  data_type_identifier: NUMBER
+                end_bracket: )
+          - keyword: RETURN
+          - data_type:
+              data_type_identifier: NUMBER
+          - keyword: AS
+          - declare_segment:
+              naked_identifier: original_squared
               data_type:
-                data_type_identifier: INTEGER
-              end_bracket: )
-        - keyword: RETURN
-        - data_type:
-            data_type_identifier: INTEGER
-        - keyword: AUTHID
-        - keyword: DEFINER
-        - keyword: IS
-        - begin_end_block:
-          - keyword: BEGIN
-          - statement:
-              if_then_statement:
-              - if_clause:
-                - keyword: IF
-                - expression:
+                data_type_identifier: NUMBER
+              statement_terminator: ;
+          - begin_end_block:
+            - keyword: BEGIN
+            - statement:
+                assignment_segment_statement:
+                  object_reference:
+                    naked_identifier: original_squared
+                  assignment_operator: :=
+                  expression:
+                  - column_reference:
+                      naked_identifier: original
+                  - binary_operator: '*'
+                  - column_reference:
+                      naked_identifier: original
+            - statement_terminator: ;
+            - statement:
+                return_statement:
+                  keyword: RETURN
+                  expression:
                     column_reference:
-                      naked_identifier: n
-                    comparison_operator:
-                      raw_comparison_operator: '='
-                    numeric_literal: '0'
-                - keyword: THEN
-              - statement:
-                  return_statement:
-                    keyword: RETURN
-                    expression:
-                      numeric_literal: '1'
-              - statement_terminator: ;
-              - keyword: ELSIF
-              - expression:
-                  column_reference:
-                    naked_identifier: n
-                  comparison_operator:
-                    raw_comparison_operator: '='
-                  numeric_literal: '1'
-              - keyword: THEN
-              - statement:
-                  return_statement:
-                    keyword: RETURN
-                    expression:
-                      column_reference:
-                        naked_identifier: n
-              - statement_terminator: ;
-              - keyword: ELSE
-              - statement:
-                  return_statement:
-                    keyword: RETURN
-                    expression:
-                    - column_reference:
-                        naked_identifier: n
-                    - binary_operator: '*'
-                    - column_reference:
-                        naked_identifier: n
-              - statement_terminator: ;
-              - keyword: END
-              - keyword: IF
+                      naked_identifier: original_squared
+            - statement_terminator: ;
+            - keyword: END
           - statement_terminator: ;
-          - keyword: END
-        - statement_terminator: ;
-        - statement_terminator: /
-    - keyword: BEGIN
-    - statement:
-        for_loop_statement:
-        - keyword: FOR
-        - naked_identifier: i
-        - keyword: IN
-        - numeric_literal: '0'
-        - dot: .
-        - dot: .
-        - numeric_literal: '3'
-        - loop_statement:
-          - keyword: LOOP
-          - statement:
+      - keyword: BEGIN
+      - statement:
+          function:
+            function_name:
+              naked_identifier: DBMS_OUTPUT
+              dot: .
+              function_name_identifier: PUT_LINE
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  function:
+                    function_name:
+                      function_name_identifier: square
+                    function_contents:
+                      bracketed:
+                        start_bracket: (
+                        expression:
+                          numeric_literal: '100'
+                        end_bracket: )
+                end_bracket: )
+      - statement_terminator: ;
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      begin_end_block:
+      - declare_segment:
+          keyword: DECLARE
+          naked_identifier: x
+          data_type:
+            data_type_identifier: INTEGER
+          statement_terminator: ;
+          create_function_statement:
+          - keyword: FUNCTION
+          - function_name:
+              function_name_identifier: f
+          - function_parameter_list:
+              bracketed:
+                start_bracket: (
+                parameter: n
+                data_type:
+                  data_type_identifier: INTEGER
+                end_bracket: )
+          - keyword: RETURN
+          - data_type:
+              data_type_identifier: INTEGER
+          - keyword: IS
+          - begin_end_block:
+            - keyword: BEGIN
+            - statement:
+                function:
+                  function_name:
+                    function_name_identifier: RETURN
+                  function_contents:
+                    bracketed:
+                      start_bracket: (
+                      expression:
+                      - column_reference:
+                          naked_identifier: n
+                      - binary_operator: '*'
+                      - column_reference:
+                          naked_identifier: n
+                      end_bracket: )
+            - statement_terminator: ;
+            - keyword: END
+          - statement_terminator: ;
+      - keyword: BEGIN
+      - statement:
+          function:
+            function_name:
+              naked_identifier: DBMS_OUTPUT
+              dot: .
+              function_name_identifier: PUT_LINE
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                - quoted_literal: "'f returns '"
+                - binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                - function:
+                    function_name:
+                      function_name_identifier: f
+                    function_contents:
+                      bracketed:
+                        start_bracket: (
+                        expression:
+                          numeric_literal: '2'
+                        end_bracket: )
+                - binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                - quoted_literal: "'. Execution returns here (1).'"
+                end_bracket: )
+      - statement_terminator: ;
+      - statement:
+          assignment_segment_statement:
+            object_reference:
+              naked_identifier: x
+            assignment_operator: :=
+            expression:
               function:
                 function_name:
-                  naked_identifier: DBMS_OUTPUT
-                  dot: .
-                  function_name_identifier: PUT_LINE
+                  function_name_identifier: f
                 function_contents:
                   bracketed:
                     start_bracket: (
                     expression:
-                    - quoted_literal: "'f('"
-                    - binary_operator:
-                      - pipe: '|'
-                      - pipe: '|'
-                    - column_reference:
-                        naked_identifier: i
-                    - binary_operator:
-                      - pipe: '|'
-                      - pipe: '|'
-                    - quoted_literal: "') = '"
-                    - binary_operator:
-                      - pipe: '|'
-                      - pipe: '|'
-                    - function:
-                        function_name:
-                          function_name_identifier: f
-                        function_contents:
-                          bracketed:
-                            start_bracket: (
-                            expression:
-                              column_reference:
-                                naked_identifier: i
-                            end_bracket: )
+                      numeric_literal: '2'
                     end_bracket: )
-          - statement_terminator: ;
-          - keyword: END
-          - keyword: LOOP
-    - statement_terminator: ;
-    - keyword: END
-- statement_terminator: ;
-- statement_terminator: /
+      - statement_terminator: ;
+      - statement:
+          function:
+            function_name:
+              naked_identifier: DBMS_OUTPUT
+              dot: .
+              function_name_identifier: PUT_LINE
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  quoted_literal: "'Execution returns here (2).'"
+                end_bracket: )
+      - statement_terminator: ;
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      create_function_statement:
+      - keyword: CREATE
+      - keyword: OR
+      - keyword: REPLACE
+      - keyword: FUNCTION
+      - function_name:
+          function_name_identifier: f
+      - function_parameter_list:
+          bracketed:
+            start_bracket: (
+            parameter: n
+            data_type:
+              data_type_identifier: INTEGER
+            end_bracket: )
+      - keyword: RETURN
+      - data_type:
+          data_type_identifier: INTEGER
+      - keyword: AUTHID
+      - keyword: DEFINER
+      - keyword: IS
+      - begin_end_block:
+        - keyword: BEGIN
+        - statement:
+            if_then_statement:
+            - if_clause:
+              - keyword: IF
+              - expression:
+                  column_reference:
+                    naked_identifier: n
+                  comparison_operator:
+                    raw_comparison_operator: '='
+                  numeric_literal: '0'
+              - keyword: THEN
+            - statement:
+                return_statement:
+                  keyword: RETURN
+                  expression:
+                    numeric_literal: '1'
+            - statement_terminator: ;
+            - keyword: ELSIF
+            - expression:
+                column_reference:
+                  naked_identifier: n
+                comparison_operator:
+                  raw_comparison_operator: '='
+                numeric_literal: '1'
+            - keyword: THEN
+            - statement:
+                return_statement:
+                  keyword: RETURN
+                  expression:
+                    column_reference:
+                      naked_identifier: n
+            - statement_terminator: ;
+            - keyword: END
+            - keyword: IF
+        - statement_terminator: ;
+        - keyword: END
+      - statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      create_function_statement:
+      - keyword: CREATE
+      - keyword: OR
+      - keyword: REPLACE
+      - keyword: FUNCTION
+      - function_name:
+          function_name_identifier: f
+      - function_parameter_list:
+          bracketed:
+            start_bracket: (
+            parameter: n
+            data_type:
+              data_type_identifier: INTEGER
+            end_bracket: )
+      - keyword: RETURN
+      - data_type:
+          data_type_identifier: INTEGER
+      - keyword: AUTHID
+      - keyword: DEFINER
+      - keyword: IS
+      - begin_end_block:
+        - keyword: BEGIN
+        - statement:
+            if_then_statement:
+            - if_clause:
+              - keyword: IF
+              - expression:
+                  column_reference:
+                    naked_identifier: n
+                  comparison_operator:
+                    raw_comparison_operator: '='
+                  numeric_literal: '0'
+              - keyword: THEN
+            - statement:
+                return_statement:
+                  keyword: RETURN
+                  expression:
+                    numeric_literal: '1'
+            - statement_terminator: ;
+            - keyword: ELSIF
+            - expression:
+                column_reference:
+                  naked_identifier: n
+                comparison_operator:
+                  raw_comparison_operator: '='
+                numeric_literal: '1'
+            - keyword: THEN
+            - statement:
+                return_statement:
+                  keyword: RETURN
+                  expression:
+                    column_reference:
+                      naked_identifier: n
+            - statement_terminator: ;
+            - keyword: ELSE
+            - statement:
+                return_statement:
+                  keyword: RETURN
+                  expression:
+                  - column_reference:
+                      naked_identifier: n
+                  - binary_operator: '*'
+                  - column_reference:
+                      naked_identifier: n
+            - statement_terminator: ;
+            - keyword: END
+            - keyword: IF
+        - statement_terminator: ;
+        - keyword: END
+      - statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      begin_end_block:
+      - keyword: BEGIN
+      - statement:
+          for_loop_statement:
+          - keyword: FOR
+          - naked_identifier: i
+          - keyword: IN
+          - numeric_literal: '0'
+          - dot: .
+          - dot: .
+          - numeric_literal: '3'
+          - loop_statement:
+            - keyword: LOOP
+            - statement:
+                function:
+                  function_name:
+                    naked_identifier: DBMS_OUTPUT
+                    dot: .
+                    function_name_identifier: PUT_LINE
+                  function_contents:
+                    bracketed:
+                      start_bracket: (
+                      expression:
+                      - quoted_literal: "'f('"
+                      - binary_operator:
+                        - pipe: '|'
+                        - pipe: '|'
+                      - column_reference:
+                          naked_identifier: i
+                      - binary_operator:
+                        - pipe: '|'
+                        - pipe: '|'
+                      - quoted_literal: "') = '"
+                      - binary_operator:
+                        - pipe: '|'
+                        - pipe: '|'
+                      - function:
+                          function_name:
+                            function_name_identifier: f
+                          function_contents:
+                            bracketed:
+                              start_bracket: (
+                              expression:
+                                column_reference:
+                                  naked_identifier: i
+                              end_bracket: )
+                      end_bracket: )
+            - statement_terminator: ;
+            - keyword: END
+            - keyword: LOOP
+      - statement_terminator: ;
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /

--- a/test/fixtures/dialects/oracle/create_package.yml
+++ b/test/fixtures/dialects/oracle/create_package.yml
@@ -3,957 +3,967 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 6ee752d3a5f76c7b13890c7ecd7d879e9d66af58a9191f4c57c5ea6304a29fd6
+_hash: fc14160aea895797e6e18c634c0e3559a1dcc8970608df056e815ae1b97012f3
 file:
-- statement:
-    create_package_statement:
-    - keyword: CREATE
-    - keyword: PACKAGE
-    - keyword: IF
-    - keyword: NOT
-    - keyword: EXISTS
-    - package_reference:
-        naked_identifier: emp_mgmt
-    - keyword: AS
-    - declare_segment:
-      - create_function_statement:
-        - keyword: FUNCTION
-        - function_name:
-            function_name_identifier: hire
-        - function_parameter_list:
-            bracketed:
-            - start_bracket: (
-            - parameter: last_name
-            - data_type:
-                data_type_identifier: VARCHAR2
-            - comma: ','
-            - parameter: job_id
-            - data_type:
-                data_type_identifier: VARCHAR2
-            - comma: ','
-            - parameter: manager_id
-            - data_type:
-                data_type_identifier: NUMBER
-            - comma: ','
-            - parameter: salary
-            - data_type:
-                data_type_identifier: NUMBER
-            - comma: ','
-            - parameter: commission_pct
-            - data_type:
-                data_type_identifier: NUMBER
-            - comma: ','
-            - parameter: department_id
-            - data_type:
-                data_type_identifier: NUMBER
-            - end_bracket: )
-        - keyword: RETURN
-        - data_type:
-            data_type_identifier: NUMBER
-        - statement_terminator: ;
-      - create_function_statement:
-        - keyword: FUNCTION
-        - function_name:
-            function_name_identifier: create_dept
-        - function_parameter_list:
-            bracketed:
-            - start_bracket: (
-            - parameter: department_id
-            - data_type:
-                data_type_identifier: NUMBER
-            - comma: ','
-            - parameter: location_id
-            - data_type:
-                data_type_identifier: NUMBER
-            - end_bracket: )
-        - keyword: RETURN
-        - data_type:
-            data_type_identifier: NUMBER
-        - statement_terminator: ;
-      - create_procedure_statement:
-          keyword: PROCEDURE
-          function_name:
-            function_name_identifier: remove_emp
-          function_parameter_list:
-            bracketed:
-              start_bracket: (
-              parameter: employee_id
-              data_type:
-                data_type_identifier: NUMBER
-              end_bracket: )
-          statement_terminator: ;
-      - create_procedure_statement:
-          keyword: PROCEDURE
-          function_name:
-            function_name_identifier: remove_dept
-          function_parameter_list:
-            bracketed:
-              start_bracket: (
-              parameter: department_id
-              data_type:
-                data_type_identifier: NUMBER
-              end_bracket: )
-          statement_terminator: ;
-      - create_procedure_statement:
-          keyword: PROCEDURE
-          function_name:
-            function_name_identifier: increase_sal
-          function_parameter_list:
-            bracketed:
-            - start_bracket: (
-            - parameter: employee_id
-            - data_type:
-                data_type_identifier: NUMBER
-            - comma: ','
-            - parameter: salary_incr
-            - data_type:
-                data_type_identifier: NUMBER
-            - end_bracket: )
-          statement_terminator: ;
-      - create_procedure_statement:
-          keyword: PROCEDURE
-          function_name:
-            function_name_identifier: increase_comm
-          function_parameter_list:
-            bracketed:
-            - start_bracket: (
-            - parameter: employee_id
-            - data_type:
-                data_type_identifier: NUMBER
-            - comma: ','
-            - parameter: comm_incr
-            - data_type:
-                data_type_identifier: NUMBER
-            - end_bracket: )
-          statement_terminator: ;
-      - naked_identifier: no_comm
-      - data_type:
-          data_type_identifier: EXCEPTION
-      - statement_terminator: ;
-      - naked_identifier: no_sal
-      - data_type:
-          data_type_identifier: EXCEPTION
-      - statement_terminator: ;
-    - keyword: END
-    - package_reference:
-        naked_identifier: emp_mgmt
-- statement_terminator: ;
-- statement_terminator: /
-- statement:
-    create_package_statement:
-    - keyword: CREATE
-    - keyword: OR
-    - keyword: REPLACE
-    - keyword: PACKAGE
-    - keyword: BODY
-    - package_reference:
-        naked_identifier: emp_mgmt
-    - keyword: AS
-    - declare_segment:
-      - naked_identifier: tot_emps
-      - data_type:
-          data_type_identifier: NUMBER
-      - statement_terminator: ;
-      - naked_identifier: tot_depts
-      - data_type:
-          data_type_identifier: NUMBER
-      - statement_terminator: ;
-      - create_function_statement:
-        - keyword: FUNCTION
-        - function_name:
-            function_name_identifier: hire
-        - function_parameter_list:
-            bracketed:
-            - start_bracket: (
-            - parameter: last_name
-            - data_type:
-                data_type_identifier: VARCHAR2
-            - comma: ','
-            - parameter: job_id
-            - data_type:
-                data_type_identifier: VARCHAR2
-            - comma: ','
-            - parameter: manager_id
-            - data_type:
-                data_type_identifier: NUMBER
-            - comma: ','
-            - parameter: salary
-            - data_type:
-                data_type_identifier: NUMBER
-            - comma: ','
-            - parameter: commission_pct
-            - data_type:
-                data_type_identifier: NUMBER
-            - comma: ','
-            - parameter: department_id
-            - data_type:
-                data_type_identifier: NUMBER
-            - end_bracket: )
-        - keyword: RETURN
-        - data_type:
-            data_type_identifier: NUMBER
-        - keyword: IS
-        - declare_segment:
-            naked_identifier: new_empno
-            data_type:
+- batch:
+    statement:
+      create_package_statement:
+      - keyword: CREATE
+      - keyword: PACKAGE
+      - keyword: IF
+      - keyword: NOT
+      - keyword: EXISTS
+      - package_reference:
+          naked_identifier: emp_mgmt
+      - keyword: AS
+      - declare_segment:
+        - create_function_statement:
+          - keyword: FUNCTION
+          - function_name:
+              function_name_identifier: hire
+          - function_parameter_list:
+              bracketed:
+              - start_bracket: (
+              - parameter: last_name
+              - data_type:
+                  data_type_identifier: VARCHAR2
+              - comma: ','
+              - parameter: job_id
+              - data_type:
+                  data_type_identifier: VARCHAR2
+              - comma: ','
+              - parameter: manager_id
+              - data_type:
+                  data_type_identifier: NUMBER
+              - comma: ','
+              - parameter: salary
+              - data_type:
+                  data_type_identifier: NUMBER
+              - comma: ','
+              - parameter: commission_pct
+              - data_type:
+                  data_type_identifier: NUMBER
+              - comma: ','
+              - parameter: department_id
+              - data_type:
+                  data_type_identifier: NUMBER
+              - end_bracket: )
+          - keyword: RETURN
+          - data_type:
               data_type_identifier: NUMBER
-            statement_terminator: ;
-        - begin_end_block:
-          - keyword: BEGIN
-          - statement:
-              select_statement:
-                select_clause:
-                  keyword: SELECT
-                  select_clause_element:
-                    column_reference:
-                    - naked_identifier: employees_seq
-                    - dot: .
-                    - naked_identifier: NEXTVAL
-                into_clause:
-                  keyword: INTO
-                  naked_identifier: new_empno
-                from_clause:
-                  keyword: FROM
-                  from_expression:
-                    from_expression_element:
-                      table_expression:
-                        table_reference:
-                          naked_identifier: DUAL
           - statement_terminator: ;
-          - statement:
-              insert_statement:
-              - keyword: INSERT
-              - keyword: INTO
-              - table_reference:
-                  naked_identifier: employees
-              - values_clause:
-                  keyword: VALUES
-                  bracketed:
-                  - start_bracket: (
-                  - expression:
+        - create_function_statement:
+          - keyword: FUNCTION
+          - function_name:
+              function_name_identifier: create_dept
+          - function_parameter_list:
+              bracketed:
+              - start_bracket: (
+              - parameter: department_id
+              - data_type:
+                  data_type_identifier: NUMBER
+              - comma: ','
+              - parameter: location_id
+              - data_type:
+                  data_type_identifier: NUMBER
+              - end_bracket: )
+          - keyword: RETURN
+          - data_type:
+              data_type_identifier: NUMBER
+          - statement_terminator: ;
+        - create_procedure_statement:
+            keyword: PROCEDURE
+            function_name:
+              function_name_identifier: remove_emp
+            function_parameter_list:
+              bracketed:
+                start_bracket: (
+                parameter: employee_id
+                data_type:
+                  data_type_identifier: NUMBER
+                end_bracket: )
+            statement_terminator: ;
+        - create_procedure_statement:
+            keyword: PROCEDURE
+            function_name:
+              function_name_identifier: remove_dept
+            function_parameter_list:
+              bracketed:
+                start_bracket: (
+                parameter: department_id
+                data_type:
+                  data_type_identifier: NUMBER
+                end_bracket: )
+            statement_terminator: ;
+        - create_procedure_statement:
+            keyword: PROCEDURE
+            function_name:
+              function_name_identifier: increase_sal
+            function_parameter_list:
+              bracketed:
+              - start_bracket: (
+              - parameter: employee_id
+              - data_type:
+                  data_type_identifier: NUMBER
+              - comma: ','
+              - parameter: salary_incr
+              - data_type:
+                  data_type_identifier: NUMBER
+              - end_bracket: )
+            statement_terminator: ;
+        - create_procedure_statement:
+            keyword: PROCEDURE
+            function_name:
+              function_name_identifier: increase_comm
+            function_parameter_list:
+              bracketed:
+              - start_bracket: (
+              - parameter: employee_id
+              - data_type:
+                  data_type_identifier: NUMBER
+              - comma: ','
+              - parameter: comm_incr
+              - data_type:
+                  data_type_identifier: NUMBER
+              - end_bracket: )
+            statement_terminator: ;
+        - naked_identifier: no_comm
+        - data_type:
+            data_type_identifier: EXCEPTION
+        - statement_terminator: ;
+        - naked_identifier: no_sal
+        - data_type:
+            data_type_identifier: EXCEPTION
+        - statement_terminator: ;
+      - keyword: END
+      - package_reference:
+          naked_identifier: emp_mgmt
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      create_package_statement:
+      - keyword: CREATE
+      - keyword: OR
+      - keyword: REPLACE
+      - keyword: PACKAGE
+      - keyword: BODY
+      - package_reference:
+          naked_identifier: emp_mgmt
+      - keyword: AS
+      - declare_segment:
+        - naked_identifier: tot_emps
+        - data_type:
+            data_type_identifier: NUMBER
+        - statement_terminator: ;
+        - naked_identifier: tot_depts
+        - data_type:
+            data_type_identifier: NUMBER
+        - statement_terminator: ;
+        - create_function_statement:
+          - keyword: FUNCTION
+          - function_name:
+              function_name_identifier: hire
+          - function_parameter_list:
+              bracketed:
+              - start_bracket: (
+              - parameter: last_name
+              - data_type:
+                  data_type_identifier: VARCHAR2
+              - comma: ','
+              - parameter: job_id
+              - data_type:
+                  data_type_identifier: VARCHAR2
+              - comma: ','
+              - parameter: manager_id
+              - data_type:
+                  data_type_identifier: NUMBER
+              - comma: ','
+              - parameter: salary
+              - data_type:
+                  data_type_identifier: NUMBER
+              - comma: ','
+              - parameter: commission_pct
+              - data_type:
+                  data_type_identifier: NUMBER
+              - comma: ','
+              - parameter: department_id
+              - data_type:
+                  data_type_identifier: NUMBER
+              - end_bracket: )
+          - keyword: RETURN
+          - data_type:
+              data_type_identifier: NUMBER
+          - keyword: IS
+          - declare_segment:
+              naked_identifier: new_empno
+              data_type:
+                data_type_identifier: NUMBER
+              statement_terminator: ;
+          - begin_end_block:
+            - keyword: BEGIN
+            - statement:
+                select_statement:
+                  select_clause:
+                    keyword: SELECT
+                    select_clause_element:
                       column_reference:
-                        naked_identifier: new_empno
-                  - comma: ','
-                  - quoted_literal: "'First'"
-                  - comma: ','
-                  - quoted_literal: "'Last'"
-                  - comma: ','
-                  - quoted_literal: "'first.example@example.com'"
-                  - comma: ','
-                  - quoted_literal: "'(415)555-0100'"
-                  - comma: ','
-                  - expression:
+                      - naked_identifier: employees_seq
+                      - dot: .
+                      - naked_identifier: NEXTVAL
+                  into_clause:
+                    keyword: INTO
+                    naked_identifier: new_empno
+                  from_clause:
+                    keyword: FROM
+                    from_expression:
+                      from_expression_element:
+                        table_expression:
+                          table_reference:
+                            naked_identifier: DUAL
+            - statement_terminator: ;
+            - statement:
+                insert_statement:
+                - keyword: INSERT
+                - keyword: INTO
+                - table_reference:
+                    naked_identifier: employees
+                - values_clause:
+                    keyword: VALUES
+                    bracketed:
+                    - start_bracket: (
+                    - expression:
+                        column_reference:
+                          naked_identifier: new_empno
+                    - comma: ','
+                    - quoted_literal: "'First'"
+                    - comma: ','
+                    - quoted_literal: "'Last'"
+                    - comma: ','
+                    - quoted_literal: "'first.example@example.com'"
+                    - comma: ','
+                    - quoted_literal: "'(415)555-0100'"
+                    - comma: ','
+                    - expression:
+                        function:
+                          function_name:
+                            function_name_identifier: TO_DATE
+                          function_contents:
+                            bracketed:
+                            - start_bracket: (
+                            - expression:
+                                quoted_literal: "'18-JUN-2002'"
+                            - comma: ','
+                            - expression:
+                                quoted_literal: "'DD-MON-YYYY'"
+                            - end_bracket: )
+                    - comma: ','
+                    - quoted_literal: "'IT_PROG'"
+                    - comma: ','
+                    - numeric_literal: '90000000'
+                    - comma: ','
+                    - numeric_literal: '00'
+                    - comma: ','
+                    - numeric_literal: '100'
+                    - comma: ','
+                    - numeric_literal: '110'
+                    - end_bracket: )
+            - statement_terminator: ;
+            - statement:
+                assignment_segment_statement:
+                  object_reference:
+                    naked_identifier: tot_emps
+                  assignment_operator: :=
+                  expression:
+                    column_reference:
+                      naked_identifier: tot_emps
+                    binary_operator: +
+                    numeric_literal: '1'
+            - statement_terminator: ;
+            - statement:
+                function:
+                  function_name:
+                    function_name_identifier: RETURN
+                  function_contents:
+                    bracketed:
+                      start_bracket: (
+                      expression:
+                        column_reference:
+                          naked_identifier: new_empno
+                      end_bracket: )
+            - statement_terminator: ;
+            - keyword: END
+          - statement_terminator: ;
+        - create_function_statement:
+          - keyword: FUNCTION
+          - function_name:
+              function_name_identifier: create_dept
+          - function_parameter_list:
+              bracketed:
+              - start_bracket: (
+              - parameter: department_id
+              - data_type:
+                  data_type_identifier: NUMBER
+              - comma: ','
+              - parameter: location_id
+              - data_type:
+                  data_type_identifier: NUMBER
+              - end_bracket: )
+          - keyword: RETURN
+          - data_type:
+              data_type_identifier: NUMBER
+          - keyword: IS
+          - declare_segment:
+              naked_identifier: new_deptno
+              data_type:
+                data_type_identifier: NUMBER
+              statement_terminator: ;
+          - begin_end_block:
+            - keyword: BEGIN
+            - statement:
+                select_statement:
+                  select_clause:
+                    keyword: SELECT
+                    select_clause_element:
+                      column_reference:
+                      - naked_identifier: departments_seq
+                      - dot: .
+                      - naked_identifier: NEXTVAL
+                  into_clause:
+                    keyword: INTO
+                    naked_identifier: new_deptno
+                  from_clause:
+                    keyword: FROM
+                    from_expression:
+                      from_expression_element:
+                        table_expression:
+                          table_reference:
+                            naked_identifier: dual
+            - statement_terminator: ;
+            - statement:
+                insert_statement:
+                - keyword: INSERT
+                - keyword: INTO
+                - table_reference:
+                    naked_identifier: departments
+                - values_clause:
+                    keyword: VALUES
+                    bracketed:
+                    - start_bracket: (
+                    - expression:
+                        column_reference:
+                          naked_identifier: new_deptno
+                    - comma: ','
+                    - quoted_literal: "'department name'"
+                    - comma: ','
+                    - numeric_literal: '100'
+                    - comma: ','
+                    - numeric_literal: '1700'
+                    - end_bracket: )
+            - statement_terminator: ;
+            - statement:
+                assignment_segment_statement:
+                  object_reference:
+                    naked_identifier: tot_depts
+                  assignment_operator: :=
+                  expression:
+                    column_reference:
+                      naked_identifier: tot_depts
+                    binary_operator: +
+                    numeric_literal: '1'
+            - statement_terminator: ;
+            - statement:
+                function:
+                  function_name:
+                    function_name_identifier: RETURN
+                  function_contents:
+                    bracketed:
+                      start_bracket: (
+                      expression:
+                        column_reference:
+                          naked_identifier: new_deptno
+                      end_bracket: )
+            - statement_terminator: ;
+            - keyword: END
+          - statement_terminator: ;
+        - create_procedure_statement:
+          - keyword: PROCEDURE
+          - function_name:
+              function_name_identifier: remove_emp
+          - function_parameter_list:
+              bracketed:
+                start_bracket: (
+                parameter: employee_id
+                data_type:
+                  data_type_identifier: NUMBER
+                end_bracket: )
+          - keyword: IS
+          - begin_end_block:
+            - keyword: BEGIN
+            - statement:
+                delete_statement:
+                  keyword: DELETE
+                  from_clause:
+                    keyword: FROM
+                    from_expression:
+                      from_expression_element:
+                        table_expression:
+                          table_reference:
+                            naked_identifier: employees
+                  where_clause:
+                    keyword: WHERE
+                    expression:
+                    - column_reference:
+                      - naked_identifier: employees
+                      - dot: .
+                      - naked_identifier: employee_id
+                    - comparison_operator:
+                        raw_comparison_operator: '='
+                    - column_reference:
+                      - naked_identifier: remove_emp
+                      - dot: .
+                      - naked_identifier: employee_id
+            - statement_terminator: ;
+            - statement:
+                assignment_segment_statement:
+                  object_reference:
+                    naked_identifier: tot_emps
+                  assignment_operator: :=
+                  expression:
+                    column_reference:
+                      naked_identifier: tot_emps
+                    binary_operator: '-'
+                    numeric_literal: '1'
+            - statement_terminator: ;
+            - keyword: END
+          - statement_terminator: ;
+        - create_procedure_statement:
+          - keyword: PROCEDURE
+          - function_name:
+              function_name_identifier: remove_dept
+          - function_parameter_list:
+              bracketed:
+                start_bracket: (
+                parameter: department_id
+                data_type:
+                  data_type_identifier: NUMBER
+                end_bracket: )
+          - keyword: IS
+          - begin_end_block:
+            - keyword: BEGIN
+            - statement:
+                delete_statement:
+                  keyword: DELETE
+                  from_clause:
+                    keyword: FROM
+                    from_expression:
+                      from_expression_element:
+                        table_expression:
+                          table_reference:
+                            naked_identifier: departments
+                  where_clause:
+                    keyword: WHERE
+                    expression:
+                    - column_reference:
+                      - naked_identifier: departments
+                      - dot: .
+                      - naked_identifier: department_id
+                    - comparison_operator:
+                        raw_comparison_operator: '='
+                    - column_reference:
+                      - naked_identifier: remove_dept
+                      - dot: .
+                      - naked_identifier: department_id
+            - statement_terminator: ;
+            - statement:
+                assignment_segment_statement:
+                  object_reference:
+                    naked_identifier: tot_depts
+                  assignment_operator: :=
+                  expression:
+                    column_reference:
+                      naked_identifier: tot_depts
+                    binary_operator: '-'
+                    numeric_literal: '1'
+            - statement_terminator: ;
+            - statement:
+                select_statement:
+                  select_clause:
+                    keyword: SELECT
+                    select_clause_element:
                       function:
                         function_name:
-                          function_name_identifier: TO_DATE
+                          function_name_identifier: COUNT
                         function_contents:
                           bracketed:
-                          - start_bracket: (
-                          - expression:
-                              quoted_literal: "'18-JUN-2002'"
-                          - comma: ','
-                          - expression:
-                              quoted_literal: "'DD-MON-YYYY'"
-                          - end_bracket: )
-                  - comma: ','
-                  - quoted_literal: "'IT_PROG'"
-                  - comma: ','
-                  - numeric_literal: '90000000'
-                  - comma: ','
-                  - numeric_literal: '00'
-                  - comma: ','
-                  - numeric_literal: '100'
-                  - comma: ','
-                  - numeric_literal: '110'
-                  - end_bracket: )
-          - statement_terminator: ;
-          - statement:
-              assignment_segment_statement:
-                object_reference:
-                  naked_identifier: tot_emps
-                assignment_operator: :=
-                expression:
-                  column_reference:
+                            start_bracket: (
+                            star: '*'
+                            end_bracket: )
+                  into_clause:
+                    keyword: INTO
                     naked_identifier: tot_emps
-                  binary_operator: +
-                  numeric_literal: '1'
+                  from_clause:
+                    keyword: FROM
+                    from_expression:
+                      from_expression_element:
+                        table_expression:
+                          table_reference:
+                            naked_identifier: employees
+            - statement_terminator: ;
+            - keyword: END
           - statement_terminator: ;
-          - statement:
-              function:
-                function_name:
-                  function_name_identifier: RETURN
-                function_contents:
-                  bracketed:
-                    start_bracket: (
-                    expression:
+        - create_procedure_statement:
+          - keyword: PROCEDURE
+          - function_name:
+              function_name_identifier: increase_sal
+          - function_parameter_list:
+              bracketed:
+              - start_bracket: (
+              - parameter: employee_id
+              - data_type:
+                  data_type_identifier: NUMBER
+              - comma: ','
+              - parameter: salary_incr
+              - data_type:
+                  data_type_identifier: NUMBER
+              - end_bracket: )
+          - keyword: IS
+          - declare_segment:
+              naked_identifier: curr_sal
+              data_type:
+                data_type_identifier: NUMBER
+              statement_terminator: ;
+          - begin_end_block:
+            - keyword: BEGIN
+            - statement:
+                select_statement:
+                  select_clause:
+                    keyword: SELECT
+                    select_clause_element:
                       column_reference:
-                        naked_identifier: new_empno
-                    end_bracket: )
-          - statement_terminator: ;
-          - keyword: END
-        - statement_terminator: ;
-      - create_function_statement:
-        - keyword: FUNCTION
-        - function_name:
-            function_name_identifier: create_dept
-        - function_parameter_list:
-            bracketed:
-            - start_bracket: (
-            - parameter: department_id
-            - data_type:
-                data_type_identifier: NUMBER
-            - comma: ','
-            - parameter: location_id
-            - data_type:
-                data_type_identifier: NUMBER
-            - end_bracket: )
-        - keyword: RETURN
-        - data_type:
-            data_type_identifier: NUMBER
-        - keyword: IS
-        - declare_segment:
-            naked_identifier: new_deptno
-            data_type:
-              data_type_identifier: NUMBER
-            statement_terminator: ;
-        - begin_end_block:
-          - keyword: BEGIN
-          - statement:
-              select_statement:
-                select_clause:
-                  keyword: SELECT
-                  select_clause_element:
-                    column_reference:
-                    - naked_identifier: departments_seq
-                    - dot: .
-                    - naked_identifier: NEXTVAL
-                into_clause:
-                  keyword: INTO
-                  naked_identifier: new_deptno
-                from_clause:
-                  keyword: FROM
-                  from_expression:
-                    from_expression_element:
-                      table_expression:
-                        table_reference:
-                          naked_identifier: dual
-          - statement_terminator: ;
-          - statement:
-              insert_statement:
-              - keyword: INSERT
-              - keyword: INTO
-              - table_reference:
-                  naked_identifier: departments
-              - values_clause:
-                  keyword: VALUES
-                  bracketed:
-                  - start_bracket: (
+                        naked_identifier: salary
+                  into_clause:
+                    keyword: INTO
+                    naked_identifier: curr_sal
+                  from_clause:
+                    keyword: FROM
+                    from_expression:
+                      from_expression_element:
+                        table_expression:
+                          table_reference:
+                            naked_identifier: employees
+                  where_clause:
+                    keyword: WHERE
+                    expression:
+                    - column_reference:
+                      - naked_identifier: employees
+                      - dot: .
+                      - naked_identifier: employee_id
+                    - comparison_operator:
+                        raw_comparison_operator: '='
+                    - column_reference:
+                      - naked_identifier: increase_sal
+                      - dot: .
+                      - naked_identifier: employee_id
+            - statement_terminator: ;
+            - statement:
+                if_then_statement:
+                - if_clause:
+                  - keyword: IF
                   - expression:
                       column_reference:
-                        naked_identifier: new_deptno
-                  - comma: ','
-                  - quoted_literal: "'department name'"
-                  - comma: ','
-                  - numeric_literal: '100'
-                  - comma: ','
-                  - numeric_literal: '1700'
-                  - end_bracket: )
+                        naked_identifier: curr_sal
+                      keyword: IS
+                      null_literal: 'NULL'
+                  - keyword: THEN
+                - statement:
+                    raise_statement:
+                      keyword: RAISE
+                      naked_identifier: no_sal
+                - statement_terminator: ;
+                - keyword: ELSE
+                - statement:
+                    update_statement:
+                      keyword: UPDATE
+                      table_reference:
+                        naked_identifier: employees
+                      set_clause_list:
+                        keyword: SET
+                        set_clause:
+                          column_reference:
+                            naked_identifier: salary
+                          comparison_operator:
+                            raw_comparison_operator: '='
+                          expression:
+                          - column_reference:
+                              naked_identifier: salary
+                          - binary_operator: +
+                          - column_reference:
+                              naked_identifier: salary_incr
+                      where_clause:
+                        keyword: WHERE
+                        expression:
+                        - column_reference:
+                            naked_identifier: employee_id
+                        - comparison_operator:
+                            raw_comparison_operator: '='
+                        - column_reference:
+                            naked_identifier: employee_id
+                - statement_terminator: ;
+                - keyword: END
+                - keyword: IF
+            - statement_terminator: ;
+            - keyword: END
           - statement_terminator: ;
-          - statement:
-              assignment_segment_statement:
-                object_reference:
-                  naked_identifier: tot_depts
-                assignment_operator: :=
-                expression:
-                  column_reference:
-                    naked_identifier: tot_depts
-                  binary_operator: +
-                  numeric_literal: '1'
-          - statement_terminator: ;
-          - statement:
-              function:
-                function_name:
-                  function_name_identifier: RETURN
-                function_contents:
-                  bracketed:
-                    start_bracket: (
-                    expression:
+        - create_procedure_statement:
+          - keyword: PROCEDURE
+          - function_name:
+              function_name_identifier: increase_comm
+          - function_parameter_list:
+              bracketed:
+              - start_bracket: (
+              - parameter: employee_id
+              - data_type:
+                  data_type_identifier: NUMBER
+              - comma: ','
+              - parameter: comm_incr
+              - data_type:
+                  data_type_identifier: NUMBER
+              - end_bracket: )
+          - keyword: IS
+          - declare_segment:
+              naked_identifier: curr_comm
+              data_type:
+                data_type_identifier: NUMBER
+              statement_terminator: ;
+          - begin_end_block:
+            - keyword: BEGIN
+            - statement:
+                select_statement:
+                  select_clause:
+                    keyword: SELECT
+                    select_clause_element:
                       column_reference:
-                        naked_identifier: new_deptno
-                    end_bracket: )
+                        naked_identifier: commission_pct
+                  into_clause:
+                    keyword: INTO
+                    naked_identifier: curr_comm
+                  from_clause:
+                    keyword: FROM
+                    from_expression:
+                      from_expression_element:
+                        table_expression:
+                          table_reference:
+                            naked_identifier: employees
+                  where_clause:
+                    keyword: WHERE
+                    expression:
+                    - column_reference:
+                      - naked_identifier: employees
+                      - dot: .
+                      - naked_identifier: employee_id
+                    - comparison_operator:
+                        raw_comparison_operator: '='
+                    - column_reference:
+                      - naked_identifier: increase_comm
+                      - dot: .
+                      - naked_identifier: employee_id
+            - statement_terminator: ;
+            - statement:
+                if_then_statement:
+                - if_clause:
+                  - keyword: IF
+                  - expression:
+                      column_reference:
+                        naked_identifier: curr_comm
+                      keyword: IS
+                      null_literal: 'NULL'
+                  - keyword: THEN
+                - statement:
+                    raise_statement:
+                      keyword: RAISE
+                      naked_identifier: no_comm
+                - statement_terminator: ;
+                - keyword: ELSE
+                - statement:
+                    update_statement:
+                      keyword: UPDATE
+                      table_reference:
+                        naked_identifier: employees
+                      set_clause_list:
+                        keyword: SET
+                        set_clause:
+                          column_reference:
+                            naked_identifier: commission_pct
+                          comparison_operator:
+                            raw_comparison_operator: '='
+                          expression:
+                          - column_reference:
+                              naked_identifier: commission_pct
+                          - binary_operator: +
+                          - column_reference:
+                              naked_identifier: comm_incr
+                - statement_terminator: ;
+                - keyword: END
+                - keyword: IF
+            - statement_terminator: ;
+            - keyword: END
           - statement_terminator: ;
-          - keyword: END
-        - statement_terminator: ;
-      - create_procedure_statement:
-        - keyword: PROCEDURE
-        - function_name:
-            function_name_identifier: remove_emp
-        - function_parameter_list:
-            bracketed:
-              start_bracket: (
-              parameter: employee_id
+      - keyword: END
+      - package_reference:
+          naked_identifier: emp_mgmt
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      create_package_statement:
+      - keyword: CREATE
+      - keyword: OR
+      - keyword: REPLACE
+      - keyword: PACKAGE
+      - package_reference:
+          naked_identifier: test_package
+      - keyword: IS
+      - declare_segment:
+          create_function_statement:
+          - keyword: FUNCTION
+          - function_name:
+              function_name_identifier: any_function_with_result_cache
+          - keyword: RETURN
+          - data_type:
+              data_type_identifier: VARCHAR2
+          - keyword: RESULT_CACHE
+          - statement_terminator: ;
+      - keyword: END
+      - package_reference:
+          naked_identifier: test_package
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      create_package_statement:
+      - keyword: CREATE
+      - keyword: PACKAGE
+      - package_reference:
+          naked_identifier: skip_col_pkg
+      - keyword: AS
+      - declare_segment:
+        - create_function_statement:
+          - keyword: FUNCTION
+          - function_name:
+              function_name_identifier: skip_col
+          - function_parameter_list:
+              bracketed:
+              - start_bracket: (
+              - parameter: tab
+              - data_type:
+                  data_type_identifier: TABLE
+              - comma: ','
+              - parameter: col
+              - data_type:
+                  data_type_identifier: COLUMNS
+              - end_bracket: )
+          - keyword: RETURN
+          - data_type:
+              data_type_identifier: TABLE
+          - keyword: PIPELINED
+          - keyword: ROW
+          - keyword: POLYMORPHIC
+          - keyword: USING
+          - object_reference:
+              naked_identifier: skip_col_pkg
+          - statement_terminator: ;
+        - create_function_statement:
+          - keyword: FUNCTION
+          - function_name:
+              function_name_identifier: describe
+          - function_parameter_list:
+              bracketed:
+              - start_bracket: (
+              - parameter: tab
+              - keyword: IN
+              - keyword: OUT
+              - data_type:
+                  naked_identifier: DBMS_TF
+                  dot: .
+                  data_type_identifier: TABLE_T
+              - comma: ','
+              - parameter: col
+              - data_type:
+                  naked_identifier: DBMS_TF
+                  dot: .
+                  data_type_identifier: COLUMNS_T
+              - end_bracket: )
+          - keyword: RETURN
+          - data_type:
+              naked_identifier: DBMS_TF
+              dot: .
+              data_type_identifier: DESCRIBE_T
+          - statement_terminator: ;
+        - create_function_statement:
+          - keyword: FUNCTION
+          - function_name:
+              function_name_identifier: skip_col
+          - function_parameter_list:
+              bracketed:
+              - start_bracket: (
+              - parameter: tab
+              - data_type:
+                  data_type_identifier: TABLE
+              - comma: ','
+              - parameter: type_name
+              - data_type:
+                  data_type_identifier: VARCHAR2
+              - comma: ','
+              - parameter: flip
+              - data_type:
+                  data_type_identifier: VARCHAR2
+              - keyword: DEFAULT
+              - expression:
+                  quoted_literal: "'False'"
+              - end_bracket: )
+          - keyword: RETURN
+          - data_type:
+              data_type_identifier: TABLE
+          - keyword: PIPELINED
+          - keyword: ROW
+          - keyword: POLYMORPHIC
+          - keyword: USING
+          - object_reference:
+              naked_identifier: skip_col_pkg
+          - statement_terminator: ;
+        - create_function_statement:
+          - keyword: FUNCTION
+          - function_name:
+              function_name_identifier: describe
+          - function_parameter_list:
+              bracketed:
+              - start_bracket: (
+              - parameter: tab
+              - keyword: IN
+              - keyword: OUT
+              - data_type:
+                  naked_identifier: DBMS_TF
+                  dot: .
+                  data_type_identifier: TABLE_T
+              - comma: ','
+              - parameter: type_name
+              - data_type:
+                  data_type_identifier: VARCHAR2
+              - comma: ','
+              - parameter: flip
+              - data_type:
+                  data_type_identifier: VARCHAR2
+              - keyword: DEFAULT
+              - expression:
+                  quoted_literal: "'False'"
+              - end_bracket: )
+          - keyword: RETURN
+          - data_type:
+              naked_identifier: DBMS_TF
+              dot: .
+              data_type_identifier: DESCRIBE_T
+          - statement_terminator: ;
+      - keyword: END
+      - package_reference:
+          naked_identifier: skip_col_pkg
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      create_package_statement:
+      - keyword: CREATE
+      - keyword: OR
+      - keyword: REPLACE
+      - keyword: PACKAGE
+      - keyword: BODY
+      - package_reference:
+          naked_identifier: test_package
+      - keyword: IS
+      - declare_segment:
+          create_function_statement:
+          - keyword: FUNCTION
+          - function_name:
+              function_name_identifier: test_function
+          - keyword: RETURN
+          - data_type:
+              data_type_identifier: VARCHAR2
+          - keyword: IS
+          - declare_segment:
+              naked_identifier: var_1
               data_type:
                 data_type_identifier: NUMBER
-              end_bracket: )
-        - keyword: IS
-        - begin_end_block:
-          - keyword: BEGIN
-          - statement:
-              delete_statement:
-                keyword: DELETE
-                from_clause:
-                  keyword: FROM
-                  from_expression:
-                    from_expression_element:
-                      table_expression:
-                        table_reference:
-                          naked_identifier: employees
-                where_clause:
-                  keyword: WHERE
-                  expression:
-                  - column_reference:
-                    - naked_identifier: employees
-                    - dot: .
-                    - naked_identifier: employee_id
-                  - comparison_operator:
-                      raw_comparison_operator: '='
-                  - column_reference:
-                    - naked_identifier: remove_emp
-                    - dot: .
-                    - naked_identifier: employee_id
-          - statement_terminator: ;
-          - statement:
-              assignment_segment_statement:
-                object_reference:
-                  naked_identifier: tot_emps
-                assignment_operator: :=
-                expression:
-                  column_reference:
-                    naked_identifier: tot_emps
-                  binary_operator: '-'
-                  numeric_literal: '1'
-          - statement_terminator: ;
-          - keyword: END
-        - statement_terminator: ;
-      - create_procedure_statement:
-        - keyword: PROCEDURE
-        - function_name:
-            function_name_identifier: remove_dept
-        - function_parameter_list:
-            bracketed:
-              start_bracket: (
-              parameter: department_id
-              data_type:
-                data_type_identifier: NUMBER
-              end_bracket: )
-        - keyword: IS
-        - begin_end_block:
-          - keyword: BEGIN
-          - statement:
-              delete_statement:
-                keyword: DELETE
-                from_clause:
-                  keyword: FROM
-                  from_expression:
-                    from_expression_element:
-                      table_expression:
-                        table_reference:
-                          naked_identifier: departments
-                where_clause:
-                  keyword: WHERE
-                  expression:
-                  - column_reference:
-                    - naked_identifier: departments
-                    - dot: .
-                    - naked_identifier: department_id
-                  - comparison_operator:
-                      raw_comparison_operator: '='
-                  - column_reference:
-                    - naked_identifier: remove_dept
-                    - dot: .
-                    - naked_identifier: department_id
-          - statement_terminator: ;
-          - statement:
-              assignment_segment_statement:
-                object_reference:
-                  naked_identifier: tot_depts
-                assignment_operator: :=
-                expression:
-                  column_reference:
-                    naked_identifier: tot_depts
-                  binary_operator: '-'
-                  numeric_literal: '1'
-          - statement_terminator: ;
-          - statement:
-              select_statement:
-                select_clause:
-                  keyword: SELECT
-                  select_clause_element:
+              assignment_operator: :=
+              expression:
+                numeric_literal: '0'
+              statement_terminator: ;
+          - begin_end_block:
+            - keyword: BEGIN
+            - statement:
+                begin_end_block:
+                - keyword: BEGIN
+                - statement:
+                    select_statement:
+                      select_clause:
+                        keyword: SELECT
+                        select_clause_element:
+                          numeric_literal: '1'
+                      into_clause:
+                        keyword: INTO
+                        naked_identifier: var_1
+                      from_clause:
+                        keyword: FROM
+                        from_expression:
+                          from_expression_element:
+                            table_expression:
+                              table_reference:
+                                naked_identifier: DUAL
+                - statement_terminator: ;
+                - keyword: EXCEPTION
+                - keyword: WHEN
+                - naked_identifier: NO_DATA_FOUND
+                - keyword: THEN
+                - statement:
+                    assignment_segment_statement:
+                      object_reference:
+                        naked_identifier: var_1
+                      assignment_operator: :=
+                      expression:
+                        numeric_literal: '0'
+                - statement_terminator: ;
+                - keyword: WHEN
+                - keyword: OTHERS
+                - keyword: THEN
+                - statement:
                     function:
                       function_name:
-                        function_name_identifier: COUNT
+                        naked_identifier: logger
+                        dot: .
+                        function_name_identifier: log_error
                       function_contents:
                         bracketed:
                           start_bracket: (
-                          star: '*'
+                          expression:
+                            quoted_literal: "'Unhandled Exception'"
                           end_bracket: )
-                into_clause:
-                  keyword: INTO
-                  naked_identifier: tot_emps
-                from_clause:
-                  keyword: FROM
-                  from_expression:
-                    from_expression_element:
-                      table_expression:
-                        table_reference:
-                          naked_identifier: employees
+                - statement_terminator: ;
+                - statement:
+                    raise_statement:
+                      keyword: RAISE
+                - statement_terminator: ;
+                - keyword: END
+            - statement_terminator: ;
+            - keyword: END
+            - object_reference:
+                naked_identifier: test_function
           - statement_terminator: ;
-          - keyword: END
-        - statement_terminator: ;
-      - create_procedure_statement:
-        - keyword: PROCEDURE
-        - function_name:
-            function_name_identifier: increase_sal
-        - function_parameter_list:
-            bracketed:
-            - start_bracket: (
-            - parameter: employee_id
-            - data_type:
-                data_type_identifier: NUMBER
-            - comma: ','
-            - parameter: salary_incr
-            - data_type:
-                data_type_identifier: NUMBER
-            - end_bracket: )
-        - keyword: IS
-        - declare_segment:
-            naked_identifier: curr_sal
-            data_type:
-              data_type_identifier: NUMBER
-            statement_terminator: ;
-        - begin_end_block:
-          - keyword: BEGIN
-          - statement:
-              select_statement:
-                select_clause:
-                  keyword: SELECT
-                  select_clause_element:
-                    column_reference:
-                      naked_identifier: salary
-                into_clause:
-                  keyword: INTO
-                  naked_identifier: curr_sal
-                from_clause:
-                  keyword: FROM
-                  from_expression:
-                    from_expression_element:
-                      table_expression:
-                        table_reference:
-                          naked_identifier: employees
-                where_clause:
-                  keyword: WHERE
-                  expression:
-                  - column_reference:
-                    - naked_identifier: employees
-                    - dot: .
-                    - naked_identifier: employee_id
-                  - comparison_operator:
-                      raw_comparison_operator: '='
-                  - column_reference:
-                    - naked_identifier: increase_sal
-                    - dot: .
-                    - naked_identifier: employee_id
-          - statement_terminator: ;
-          - statement:
-              if_then_statement:
-              - if_clause:
-                - keyword: IF
-                - expression:
-                    column_reference:
-                      naked_identifier: curr_sal
-                    keyword: IS
-                    null_literal: 'NULL'
-                - keyword: THEN
-              - statement:
-                  raise_statement:
-                    keyword: RAISE
-                    naked_identifier: no_sal
-              - statement_terminator: ;
-              - keyword: ELSE
-              - statement:
-                  update_statement:
-                    keyword: UPDATE
-                    table_reference:
-                      naked_identifier: employees
-                    set_clause_list:
-                      keyword: SET
-                      set_clause:
-                        column_reference:
-                          naked_identifier: salary
-                        comparison_operator:
-                          raw_comparison_operator: '='
-                        expression:
-                        - column_reference:
-                            naked_identifier: salary
-                        - binary_operator: +
-                        - column_reference:
-                            naked_identifier: salary_incr
-                    where_clause:
-                      keyword: WHERE
-                      expression:
-                      - column_reference:
-                          naked_identifier: employee_id
-                      - comparison_operator:
-                          raw_comparison_operator: '='
-                      - column_reference:
-                          naked_identifier: employee_id
-              - statement_terminator: ;
-              - keyword: END
-              - keyword: IF
-          - statement_terminator: ;
-          - keyword: END
-        - statement_terminator: ;
-      - create_procedure_statement:
-        - keyword: PROCEDURE
-        - function_name:
-            function_name_identifier: increase_comm
-        - function_parameter_list:
-            bracketed:
-            - start_bracket: (
-            - parameter: employee_id
-            - data_type:
-                data_type_identifier: NUMBER
-            - comma: ','
-            - parameter: comm_incr
-            - data_type:
-                data_type_identifier: NUMBER
-            - end_bracket: )
-        - keyword: IS
-        - declare_segment:
-            naked_identifier: curr_comm
-            data_type:
-              data_type_identifier: NUMBER
-            statement_terminator: ;
-        - begin_end_block:
-          - keyword: BEGIN
-          - statement:
-              select_statement:
-                select_clause:
-                  keyword: SELECT
-                  select_clause_element:
-                    column_reference:
-                      naked_identifier: commission_pct
-                into_clause:
-                  keyword: INTO
-                  naked_identifier: curr_comm
-                from_clause:
-                  keyword: FROM
-                  from_expression:
-                    from_expression_element:
-                      table_expression:
-                        table_reference:
-                          naked_identifier: employees
-                where_clause:
-                  keyword: WHERE
-                  expression:
-                  - column_reference:
-                    - naked_identifier: employees
-                    - dot: .
-                    - naked_identifier: employee_id
-                  - comparison_operator:
-                      raw_comparison_operator: '='
-                  - column_reference:
-                    - naked_identifier: increase_comm
-                    - dot: .
-                    - naked_identifier: employee_id
-          - statement_terminator: ;
-          - statement:
-              if_then_statement:
-              - if_clause:
-                - keyword: IF
-                - expression:
-                    column_reference:
-                      naked_identifier: curr_comm
-                    keyword: IS
-                    null_literal: 'NULL'
-                - keyword: THEN
-              - statement:
-                  raise_statement:
-                    keyword: RAISE
-                    naked_identifier: no_comm
-              - statement_terminator: ;
-              - keyword: ELSE
-              - statement:
-                  update_statement:
-                    keyword: UPDATE
-                    table_reference:
-                      naked_identifier: employees
-                    set_clause_list:
-                      keyword: SET
-                      set_clause:
-                        column_reference:
-                          naked_identifier: commission_pct
-                        comparison_operator:
-                          raw_comparison_operator: '='
-                        expression:
-                        - column_reference:
-                            naked_identifier: commission_pct
-                        - binary_operator: +
-                        - column_reference:
-                            naked_identifier: comm_incr
-              - statement_terminator: ;
-              - keyword: END
-              - keyword: IF
-          - statement_terminator: ;
-          - keyword: END
-        - statement_terminator: ;
-    - keyword: END
-    - package_reference:
-        naked_identifier: emp_mgmt
-- statement_terminator: ;
-- statement_terminator: /
-- statement:
-    create_package_statement:
-    - keyword: CREATE
-    - keyword: OR
-    - keyword: REPLACE
-    - keyword: PACKAGE
-    - package_reference:
-        naked_identifier: test_package
-    - keyword: IS
-    - declare_segment:
-        create_function_statement:
-        - keyword: FUNCTION
-        - function_name:
-            function_name_identifier: any_function_with_result_cache
-        - keyword: RETURN
-        - data_type:
-            data_type_identifier: VARCHAR2
-        - keyword: RESULT_CACHE
-        - statement_terminator: ;
-    - keyword: END
-    - package_reference:
-        naked_identifier: test_package
-- statement_terminator: ;
-- statement_terminator: /
-- statement:
-    create_package_statement:
-    - keyword: CREATE
-    - keyword: PACKAGE
-    - package_reference:
-        naked_identifier: skip_col_pkg
-    - keyword: AS
-    - declare_segment:
-      - create_function_statement:
-        - keyword: FUNCTION
-        - function_name:
-            function_name_identifier: skip_col
-        - function_parameter_list:
-            bracketed:
-            - start_bracket: (
-            - parameter: tab
-            - data_type:
-                data_type_identifier: TABLE
-            - comma: ','
-            - parameter: col
-            - data_type:
-                data_type_identifier: COLUMNS
-            - end_bracket: )
-        - keyword: RETURN
-        - data_type:
-            data_type_identifier: TABLE
-        - keyword: PIPELINED
-        - keyword: ROW
-        - keyword: POLYMORPHIC
-        - keyword: USING
-        - object_reference:
-            naked_identifier: skip_col_pkg
-        - statement_terminator: ;
-      - create_function_statement:
-        - keyword: FUNCTION
-        - function_name:
-            function_name_identifier: describe
-        - function_parameter_list:
-            bracketed:
-            - start_bracket: (
-            - parameter: tab
-            - keyword: IN
-            - keyword: OUT
-            - data_type:
-                naked_identifier: DBMS_TF
-                dot: .
-                data_type_identifier: TABLE_T
-            - comma: ','
-            - parameter: col
-            - data_type:
-                naked_identifier: DBMS_TF
-                dot: .
-                data_type_identifier: COLUMNS_T
-            - end_bracket: )
-        - keyword: RETURN
-        - data_type:
-            naked_identifier: DBMS_TF
-            dot: .
-            data_type_identifier: DESCRIBE_T
-        - statement_terminator: ;
-      - create_function_statement:
-        - keyword: FUNCTION
-        - function_name:
-            function_name_identifier: skip_col
-        - function_parameter_list:
-            bracketed:
-            - start_bracket: (
-            - parameter: tab
-            - data_type:
-                data_type_identifier: TABLE
-            - comma: ','
-            - parameter: type_name
-            - data_type:
-                data_type_identifier: VARCHAR2
-            - comma: ','
-            - parameter: flip
-            - data_type:
-                data_type_identifier: VARCHAR2
-            - keyword: DEFAULT
-            - expression:
-                quoted_literal: "'False'"
-            - end_bracket: )
-        - keyword: RETURN
-        - data_type:
-            data_type_identifier: TABLE
-        - keyword: PIPELINED
-        - keyword: ROW
-        - keyword: POLYMORPHIC
-        - keyword: USING
-        - object_reference:
-            naked_identifier: skip_col_pkg
-        - statement_terminator: ;
-      - create_function_statement:
-        - keyword: FUNCTION
-        - function_name:
-            function_name_identifier: describe
-        - function_parameter_list:
-            bracketed:
-            - start_bracket: (
-            - parameter: tab
-            - keyword: IN
-            - keyword: OUT
-            - data_type:
-                naked_identifier: DBMS_TF
-                dot: .
-                data_type_identifier: TABLE_T
-            - comma: ','
-            - parameter: type_name
-            - data_type:
-                data_type_identifier: VARCHAR2
-            - comma: ','
-            - parameter: flip
-            - data_type:
-                data_type_identifier: VARCHAR2
-            - keyword: DEFAULT
-            - expression:
-                quoted_literal: "'False'"
-            - end_bracket: )
-        - keyword: RETURN
-        - data_type:
-            naked_identifier: DBMS_TF
-            dot: .
-            data_type_identifier: DESCRIBE_T
-        - statement_terminator: ;
-    - keyword: END
-    - package_reference:
-        naked_identifier: skip_col_pkg
-- statement_terminator: ;
-- statement_terminator: /
-- statement:
-    create_package_statement:
-    - keyword: CREATE
-    - keyword: OR
-    - keyword: REPLACE
-    - keyword: PACKAGE
-    - keyword: BODY
-    - package_reference:
-        naked_identifier: test_package
-    - keyword: IS
-    - declare_segment:
-        create_function_statement:
-        - keyword: FUNCTION
-        - function_name:
-            function_name_identifier: test_function
-        - keyword: RETURN
-        - data_type:
-            data_type_identifier: VARCHAR2
-        - keyword: IS
-        - declare_segment:
-            naked_identifier: var_1
-            data_type:
-              data_type_identifier: NUMBER
-            assignment_operator: :=
-            expression:
-              numeric_literal: '0'
-            statement_terminator: ;
-        - begin_end_block:
-          - keyword: BEGIN
-          - statement:
-              begin_end_block:
-              - keyword: BEGIN
-              - statement:
-                  select_statement:
-                    select_clause:
-                      keyword: SELECT
-                      select_clause_element:
-                        numeric_literal: '1'
-                    into_clause:
-                      keyword: INTO
-                      naked_identifier: var_1
-                    from_clause:
-                      keyword: FROM
-                      from_expression:
-                        from_expression_element:
-                          table_expression:
-                            table_reference:
-                              naked_identifier: DUAL
-              - statement_terminator: ;
-              - keyword: EXCEPTION
-              - keyword: WHEN
-              - naked_identifier: NO_DATA_FOUND
-              - keyword: THEN
-              - statement:
-                  assignment_segment_statement:
-                    object_reference:
-                      naked_identifier: var_1
-                    assignment_operator: :=
-                    expression:
-                      numeric_literal: '0'
-              - statement_terminator: ;
-              - keyword: WHEN
-              - keyword: OTHERS
-              - keyword: THEN
-              - statement:
-                  function:
-                    function_name:
-                      naked_identifier: logger
-                      dot: .
-                      function_name_identifier: log_error
-                    function_contents:
-                      bracketed:
-                        start_bracket: (
-                        expression:
-                          quoted_literal: "'Unhandled Exception'"
-                        end_bracket: )
-              - statement_terminator: ;
-              - statement:
-                  raise_statement:
-                    keyword: RAISE
-              - statement_terminator: ;
-              - keyword: END
-          - statement_terminator: ;
-          - keyword: END
-          - object_reference:
-              naked_identifier: test_function
-        - statement_terminator: ;
-    - keyword: END
-    - package_reference:
-        naked_identifier: test_package
-- statement_terminator: ;
-- statement_terminator: /
+      - keyword: END
+      - package_reference:
+          naked_identifier: test_package
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /

--- a/test/fixtures/dialects/oracle/create_procedure.yml
+++ b/test/fixtures/dialects/oracle/create_procedure.yml
@@ -3,584 +3,598 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 35e04399a637d23004021bd8ef4c6b1752c79266805ac0ac258ed75767673f7d
+_hash: 40411257950619d71da8bc7c6593ce9e1df059d414667fd0f58777884ce64011
 file:
-- statement:
-    create_procedure_statement:
-    - keyword: CREATE
-    - keyword: PROCEDURE
-    - keyword: IF
-    - keyword: NOT
-    - keyword: EXISTS
-    - function_name:
-        function_name_identifier: remove_emp
-    - function_parameter_list:
-        bracketed:
-          start_bracket: (
-          parameter: employee_id
+- batch:
+    statement:
+      create_procedure_statement:
+      - keyword: CREATE
+      - keyword: PROCEDURE
+      - keyword: IF
+      - keyword: NOT
+      - keyword: EXISTS
+      - function_name:
+          function_name_identifier: remove_emp
+      - function_parameter_list:
+          bracketed:
+            start_bracket: (
+            parameter: employee_id
+            data_type:
+              data_type_identifier: NUMBER
+            end_bracket: )
+      - keyword: AS
+      - declare_segment:
+          naked_identifier: tot_emps
           data_type:
             data_type_identifier: NUMBER
-          end_bracket: )
-    - keyword: AS
-    - declare_segment:
-        naked_identifier: tot_emps
-        data_type:
-          data_type_identifier: NUMBER
-        statement_terminator: ;
-    - begin_end_block:
-      - keyword: BEGIN
-      - statement:
-          delete_statement:
-            keyword: DELETE
-            from_clause:
-              keyword: FROM
-              from_expression:
-                from_expression_element:
-                  table_expression:
-                    table_reference:
-                      naked_identifier: employees
-            where_clause:
-              keyword: WHERE
-              expression:
-              - column_reference:
-                - naked_identifier: employees
-                - dot: .
-                - naked_identifier: employee_id
-              - comparison_operator:
-                  raw_comparison_operator: '='
-              - column_reference:
-                - naked_identifier: remove_emp
-                - dot: .
-                - naked_identifier: employee_id
-      - statement_terminator: ;
-      - statement:
-          assignment_segment_statement:
-            object_reference:
-              naked_identifier: tot_emps
-            assignment_operator: :=
-            expression:
-              column_reference:
+          statement_terminator: ;
+      - begin_end_block:
+        - keyword: BEGIN
+        - statement:
+            delete_statement:
+              keyword: DELETE
+              from_clause:
+                keyword: FROM
+                from_expression:
+                  from_expression_element:
+                    table_expression:
+                      table_reference:
+                        naked_identifier: employees
+              where_clause:
+                keyword: WHERE
+                expression:
+                - column_reference:
+                  - naked_identifier: employees
+                  - dot: .
+                  - naked_identifier: employee_id
+                - comparison_operator:
+                    raw_comparison_operator: '='
+                - column_reference:
+                  - naked_identifier: remove_emp
+                  - dot: .
+                  - naked_identifier: employee_id
+        - statement_terminator: ;
+        - statement:
+            assignment_segment_statement:
+              object_reference:
                 naked_identifier: tot_emps
-              binary_operator: '-'
-              numeric_literal: '1'
+              assignment_operator: :=
+              expression:
+                column_reference:
+                  naked_identifier: tot_emps
+                binary_operator: '-'
+                numeric_literal: '1'
+        - statement_terminator: ;
+        - keyword: END
       - statement_terminator: ;
-      - keyword: END
-    - statement_terminator: ;
-    - statement_terminator: /
-- statement:
-    create_procedure_statement:
-    - keyword: CREATE
-    - keyword: PROCEDURE
-    - function_name:
-        function_name_identifier: top_protected_proc
-    - keyword: ACCESSIBLE
-    - keyword: BY
-    - bracketed:
-        start_bracket: (
-        keyword: PROCEDURE
-        function_name:
-          function_name_identifier: top_trusted_proc
-        end_bracket: )
-    - keyword: AS
-    - begin_end_block:
-      - keyword: BEGIN
-      - statement:
-          function:
-            function_name:
-              naked_identifier: DBMS_OUTPUT
-              dot: .
-              function_name_identifier: PUT_LINE
-            function_contents:
-              bracketed:
-                start_bracket: (
-                expression:
-                  quoted_literal: "'Processed top_protected_proc.'"
-                end_bracket: )
-      - statement_terminator: ;
-      - keyword: END
-    - statement_terminator: ;
-    - statement_terminator: /
-- statement:
-    create_procedure_statement:
-    - keyword: CREATE
-    - keyword: OR
-    - keyword: REPLACE
-    - keyword: PROCEDURE
-    - function_name:
-        function_name_identifier: p
-    - function_parameter_list:
-        bracketed:
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      create_procedure_statement:
+      - keyword: CREATE
+      - keyword: PROCEDURE
+      - function_name:
+          function_name_identifier: top_protected_proc
+      - keyword: ACCESSIBLE
+      - keyword: BY
+      - bracketed:
           start_bracket: (
-          parameter: x
-          data_type:
-            data_type_identifier: BOOLEAN
+          keyword: PROCEDURE
+          function_name:
+            function_name_identifier: top_trusted_proc
           end_bracket: )
-    - keyword: AUTHID
-    - keyword: DEFINER
-    - keyword: AS
-    - begin_end_block:
-      - keyword: BEGIN
-      - statement:
-          if_then_statement:
-          - if_clause:
-            - keyword: IF
-            - expression:
-                column_reference:
-                  naked_identifier: x
-            - keyword: THEN
-          - statement:
-              function:
-                function_name:
-                  naked_identifier: DBMS_OUTPUT
-                  dot: .
-                  function_name_identifier: PUT_LINE
-                function_contents:
-                  bracketed:
-                    start_bracket: (
-                    expression:
-                      quoted_literal: "'x is true'"
-                    end_bracket: )
-          - statement_terminator: ;
-          - keyword: END
-          - keyword: IF
-      - statement_terminator: ;
-      - keyword: END
-    - statement_terminator: ;
-    - statement_terminator: /
-- statement:
-    create_procedure_statement:
-    - keyword: CREATE
-    - keyword: PROCEDURE
-    - function_name:
-        function_name_identifier: p
-    - function_parameter_list:
-        bracketed:
-        - start_bracket: (
-        - parameter: sales
-        - data_type:
-            data_type_identifier: NUMBER
-        - comma: ','
-        - parameter: quota
-        - data_type:
-            data_type_identifier: NUMBER
-        - comma: ','
-        - parameter: emp_id
-        - data_type:
-            data_type_identifier: NUMBER
-        - end_bracket: )
-    - keyword: IS
-    - declare_segment:
-      - naked_identifier: bonus
-      - data_type:
-          data_type_identifier: NUMBER
-      - assignment_operator: :=
-      - expression:
-          numeric_literal: '0'
-      - statement_terminator: ;
-      - naked_identifier: updated
-      - data_type:
-          data_type_identifier: VARCHAR2
-          bracketed_arguments:
-            bracketed:
-              start_bracket: (
-              numeric_literal: '3'
-              end_bracket: )
-      - assignment_operator: :=
-      - expression:
-          quoted_literal: "'No'"
-      - statement_terminator: ;
-    - begin_end_block:
-      - keyword: BEGIN
-      - statement:
-          if_then_statement:
-          - if_clause:
-            - keyword: IF
-            - expression:
-                column_reference:
-                  naked_identifier: sales
-                comparison_operator:
-                  raw_comparison_operator: '>'
+      - keyword: AS
+      - begin_end_block:
+        - keyword: BEGIN
+        - statement:
+            function:
+              function_name:
+                naked_identifier: DBMS_OUTPUT
+                dot: .
+                function_name_identifier: PUT_LINE
+              function_contents:
                 bracketed:
                   start_bracket: (
                   expression:
-                    column_reference:
-                      naked_identifier: quota
-                    binary_operator: +
-                    numeric_literal: '200'
+                    quoted_literal: "'Processed top_protected_proc.'"
                   end_bracket: )
-            - keyword: THEN
-          - statement:
-              assignment_segment_statement:
-                object_reference:
-                  naked_identifier: bonus
-                assignment_operator: :=
-                expression:
-                  bracketed:
-                    start_bracket: (
-                    expression:
-                    - column_reference:
-                        naked_identifier: sales
-                    - binary_operator: '-'
-                    - column_reference:
-                        naked_identifier: quota
-                    end_bracket: )
-                  binary_operator: /
-                  numeric_literal: '4'
-          - statement_terminator: ;
-          - statement:
-              update_statement:
-                keyword: UPDATE
-                table_reference:
-                  naked_identifier: employees
-                set_clause_list:
-                  keyword: SET
-                  set_clause:
-                    column_reference:
-                      naked_identifier: salary
-                    comparison_operator:
-                      raw_comparison_operator: '='
-                    expression:
-                    - column_reference:
-                        naked_identifier: salary
-                    - binary_operator: +
-                    - column_reference:
-                        naked_identifier: bonus
-                where_clause:
-                  keyword: WHERE
-                  expression:
-                  - column_reference:
-                      naked_identifier: employee_id
-                  - comparison_operator:
-                      raw_comparison_operator: '='
-                  - column_reference:
-                      naked_identifier: emp_id
-          - statement_terminator: ;
-          - statement:
-              assignment_segment_statement:
-                object_reference:
-                  naked_identifier: updated
-                assignment_operator: :=
-                expression:
-                  quoted_literal: "'Yes'"
-          - statement_terminator: ;
-          - keyword: END
-          - keyword: IF
+        - statement_terminator: ;
+        - keyword: END
       - statement_terminator: ;
-      - statement:
-          function:
-            function_name:
-              naked_identifier: DBMS_OUTPUT
-              dot: .
-              function_name_identifier: PUT_LINE
-            function_contents:
-              bracketed:
-                start_bracket: (
-                expression:
-                - quoted_literal: "'Table updated?  '"
-                - binary_operator:
-                  - pipe: '|'
-                  - pipe: '|'
-                - column_reference:
-                    naked_identifier: updated
-                - binary_operator:
-                  - pipe: '|'
-                  - pipe: '|'
-                - quoted_literal: "', '"
-                - binary_operator:
-                  - pipe: '|'
-                  - pipe: '|'
-                - quoted_literal: "'bonus = '"
-                - binary_operator:
-                  - pipe: '|'
-                  - pipe: '|'
-                - column_reference:
-                    naked_identifier: bonus
-                - binary_operator:
-                  - pipe: '|'
-                  - pipe: '|'
-                - quoted_literal: "'.'"
-                end_bracket: )
-      - statement_terminator: ;
-      - keyword: END
-    - statement_terminator: ;
-    - statement_terminator: /
-- statement:
-    create_procedure_statement:
-    - keyword: CREATE
-    - keyword: PROCEDURE
-    - function_name:
-        function_name_identifier: p
-    - function_parameter_list:
-        bracketed:
-        - start_bracket: (
-        - parameter: sales
-        - data_type:
-            data_type_identifier: NUMBER
-        - comma: ','
-        - parameter: quota
-        - data_type:
-            data_type_identifier: NUMBER
-        - comma: ','
-        - parameter: emp_id
-        - data_type:
-            data_type_identifier: NUMBER
-        - end_bracket: )
-    - keyword: IS
-    - declare_segment:
-        naked_identifier: bonus
-        data_type:
-          data_type_identifier: NUMBER
-        assignment_operator: :=
-        expression:
-          numeric_literal: '0'
-        statement_terminator: ;
-    - begin_end_block:
-      - keyword: BEGIN
-      - statement:
-          if_then_statement:
-          - if_clause:
-            - keyword: IF
-            - expression:
-                column_reference:
-                  naked_identifier: sales
-                comparison_operator:
-                  raw_comparison_operator: '>'
-                bracketed:
-                  start_bracket: (
-                  expression:
-                    column_reference:
-                      naked_identifier: quota
-                    binary_operator: +
-                    numeric_literal: '200'
-                  end_bracket: )
-            - keyword: THEN
-          - statement:
-              assignment_segment_statement:
-                object_reference:
-                  naked_identifier: bonus
-                assignment_operator: :=
-                expression:
-                  bracketed:
-                    start_bracket: (
-                    expression:
-                    - column_reference:
-                        naked_identifier: sales
-                    - binary_operator: '-'
-                    - column_reference:
-                        naked_identifier: quota
-                    end_bracket: )
-                  binary_operator: /
-                  numeric_literal: '4'
-          - statement_terminator: ;
-          - keyword: ELSE
-          - statement:
-              if_then_statement:
-              - if_clause:
-                - keyword: IF
-                - expression:
-                  - column_reference:
-                      naked_identifier: sales
-                  - comparison_operator:
-                      raw_comparison_operator: '>'
-                  - column_reference:
-                      naked_identifier: quota
-                - keyword: THEN
-              - statement:
-                  assignment_segment_statement:
-                    object_reference:
-                      naked_identifier: bonus
-                    assignment_operator: :=
-                    expression:
-                      numeric_literal: '50'
-              - statement_terminator: ;
-              - keyword: ELSE
-              - statement:
-                  assignment_segment_statement:
-                    object_reference:
-                      naked_identifier: bonus
-                    assignment_operator: :=
-                    expression:
-                      numeric_literal: '0'
-              - statement_terminator: ;
-              - keyword: END
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      create_procedure_statement:
+      - keyword: CREATE
+      - keyword: OR
+      - keyword: REPLACE
+      - keyword: PROCEDURE
+      - function_name:
+          function_name_identifier: p
+      - function_parameter_list:
+          bracketed:
+            start_bracket: (
+            parameter: x
+            data_type:
+              data_type_identifier: BOOLEAN
+            end_bracket: )
+      - keyword: AUTHID
+      - keyword: DEFINER
+      - keyword: AS
+      - begin_end_block:
+        - keyword: BEGIN
+        - statement:
+            if_then_statement:
+            - if_clause:
               - keyword: IF
-          - statement_terminator: ;
-          - keyword: END
-          - keyword: IF
+              - expression:
+                  column_reference:
+                    naked_identifier: x
+              - keyword: THEN
+            - statement:
+                function:
+                  function_name:
+                    naked_identifier: DBMS_OUTPUT
+                    dot: .
+                    function_name_identifier: PUT_LINE
+                  function_contents:
+                    bracketed:
+                      start_bracket: (
+                      expression:
+                        quoted_literal: "'x is true'"
+                      end_bracket: )
+            - statement_terminator: ;
+            - keyword: END
+            - keyword: IF
+        - statement_terminator: ;
+        - keyword: END
       - statement_terminator: ;
-      - statement:
-          function:
-            function_name:
-              naked_identifier: DBMS_OUTPUT
-              dot: .
-              function_name_identifier: PUT_LINE
-            function_contents:
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      create_procedure_statement:
+      - keyword: CREATE
+      - keyword: PROCEDURE
+      - function_name:
+          function_name_identifier: p
+      - function_parameter_list:
+          bracketed:
+          - start_bracket: (
+          - parameter: sales
+          - data_type:
+              data_type_identifier: NUMBER
+          - comma: ','
+          - parameter: quota
+          - data_type:
+              data_type_identifier: NUMBER
+          - comma: ','
+          - parameter: emp_id
+          - data_type:
+              data_type_identifier: NUMBER
+          - end_bracket: )
+      - keyword: IS
+      - declare_segment:
+        - naked_identifier: bonus
+        - data_type:
+            data_type_identifier: NUMBER
+        - assignment_operator: :=
+        - expression:
+            numeric_literal: '0'
+        - statement_terminator: ;
+        - naked_identifier: updated
+        - data_type:
+            data_type_identifier: VARCHAR2
+            bracketed_arguments:
               bracketed:
                 start_bracket: (
-                expression:
-                  quoted_literal: "'bonus = '"
-                  binary_operator:
-                  - pipe: '|'
-                  - pipe: '|'
-                  column_reference:
-                    naked_identifier: bonus
+                numeric_literal: '3'
                 end_bracket: )
+        - assignment_operator: :=
+        - expression:
+            quoted_literal: "'No'"
+        - statement_terminator: ;
+      - begin_end_block:
+        - keyword: BEGIN
+        - statement:
+            if_then_statement:
+            - if_clause:
+              - keyword: IF
+              - expression:
+                  column_reference:
+                    naked_identifier: sales
+                  comparison_operator:
+                    raw_comparison_operator: '>'
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                      column_reference:
+                        naked_identifier: quota
+                      binary_operator: +
+                      numeric_literal: '200'
+                    end_bracket: )
+              - keyword: THEN
+            - statement:
+                assignment_segment_statement:
+                  object_reference:
+                    naked_identifier: bonus
+                  assignment_operator: :=
+                  expression:
+                    bracketed:
+                      start_bracket: (
+                      expression:
+                      - column_reference:
+                          naked_identifier: sales
+                      - binary_operator: '-'
+                      - column_reference:
+                          naked_identifier: quota
+                      end_bracket: )
+                    binary_operator: /
+                    numeric_literal: '4'
+            - statement_terminator: ;
+            - statement:
+                update_statement:
+                  keyword: UPDATE
+                  table_reference:
+                    naked_identifier: employees
+                  set_clause_list:
+                    keyword: SET
+                    set_clause:
+                      column_reference:
+                        naked_identifier: salary
+                      comparison_operator:
+                        raw_comparison_operator: '='
+                      expression:
+                      - column_reference:
+                          naked_identifier: salary
+                      - binary_operator: +
+                      - column_reference:
+                          naked_identifier: bonus
+                  where_clause:
+                    keyword: WHERE
+                    expression:
+                    - column_reference:
+                        naked_identifier: employee_id
+                    - comparison_operator:
+                        raw_comparison_operator: '='
+                    - column_reference:
+                        naked_identifier: emp_id
+            - statement_terminator: ;
+            - statement:
+                assignment_segment_statement:
+                  object_reference:
+                    naked_identifier: updated
+                  assignment_operator: :=
+                  expression:
+                    quoted_literal: "'Yes'"
+            - statement_terminator: ;
+            - keyword: END
+            - keyword: IF
+        - statement_terminator: ;
+        - statement:
+            function:
+              function_name:
+                naked_identifier: DBMS_OUTPUT
+                dot: .
+                function_name_identifier: PUT_LINE
+              function_contents:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                  - quoted_literal: "'Table updated?  '"
+                  - binary_operator:
+                    - pipe: '|'
+                    - pipe: '|'
+                  - column_reference:
+                      naked_identifier: updated
+                  - binary_operator:
+                    - pipe: '|'
+                    - pipe: '|'
+                  - quoted_literal: "', '"
+                  - binary_operator:
+                    - pipe: '|'
+                    - pipe: '|'
+                  - quoted_literal: "'bonus = '"
+                  - binary_operator:
+                    - pipe: '|'
+                    - pipe: '|'
+                  - column_reference:
+                      naked_identifier: bonus
+                  - binary_operator:
+                    - pipe: '|'
+                    - pipe: '|'
+                  - quoted_literal: "'.'"
+                  end_bracket: )
+        - statement_terminator: ;
+        - keyword: END
       - statement_terminator: ;
-      - statement:
-          update_statement:
-            keyword: UPDATE
-            table_reference:
-              naked_identifier: employees
-            set_clause_list:
-              keyword: SET
-              set_clause:
-                column_reference:
-                  naked_identifier: salary
-                comparison_operator:
-                  raw_comparison_operator: '='
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      create_procedure_statement:
+      - keyword: CREATE
+      - keyword: PROCEDURE
+      - function_name:
+          function_name_identifier: p
+      - function_parameter_list:
+          bracketed:
+          - start_bracket: (
+          - parameter: sales
+          - data_type:
+              data_type_identifier: NUMBER
+          - comma: ','
+          - parameter: quota
+          - data_type:
+              data_type_identifier: NUMBER
+          - comma: ','
+          - parameter: emp_id
+          - data_type:
+              data_type_identifier: NUMBER
+          - end_bracket: )
+      - keyword: IS
+      - declare_segment:
+          naked_identifier: bonus
+          data_type:
+            data_type_identifier: NUMBER
+          assignment_operator: :=
+          expression:
+            numeric_literal: '0'
+          statement_terminator: ;
+      - begin_end_block:
+        - keyword: BEGIN
+        - statement:
+            if_then_statement:
+            - if_clause:
+              - keyword: IF
+              - expression:
+                  column_reference:
+                    naked_identifier: sales
+                  comparison_operator:
+                    raw_comparison_operator: '>'
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                      column_reference:
+                        naked_identifier: quota
+                      binary_operator: +
+                      numeric_literal: '200'
+                    end_bracket: )
+              - keyword: THEN
+            - statement:
+                assignment_segment_statement:
+                  object_reference:
+                    naked_identifier: bonus
+                  assignment_operator: :=
+                  expression:
+                    bracketed:
+                      start_bracket: (
+                      expression:
+                      - column_reference:
+                          naked_identifier: sales
+                      - binary_operator: '-'
+                      - column_reference:
+                          naked_identifier: quota
+                      end_bracket: )
+                    binary_operator: /
+                    numeric_literal: '4'
+            - statement_terminator: ;
+            - keyword: ELSE
+            - statement:
+                if_then_statement:
+                - if_clause:
+                  - keyword: IF
+                  - expression:
+                    - column_reference:
+                        naked_identifier: sales
+                    - comparison_operator:
+                        raw_comparison_operator: '>'
+                    - column_reference:
+                        naked_identifier: quota
+                  - keyword: THEN
+                - statement:
+                    assignment_segment_statement:
+                      object_reference:
+                        naked_identifier: bonus
+                      assignment_operator: :=
+                      expression:
+                        numeric_literal: '50'
+                - statement_terminator: ;
+                - keyword: ELSE
+                - statement:
+                    assignment_segment_statement:
+                      object_reference:
+                        naked_identifier: bonus
+                      assignment_operator: :=
+                      expression:
+                        numeric_literal: '0'
+                - statement_terminator: ;
+                - keyword: END
+                - keyword: IF
+            - statement_terminator: ;
+            - keyword: END
+            - keyword: IF
+        - statement_terminator: ;
+        - statement:
+            function:
+              function_name:
+                naked_identifier: DBMS_OUTPUT
+                dot: .
+                function_name_identifier: PUT_LINE
+              function_contents:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    quoted_literal: "'bonus = '"
+                    binary_operator:
+                    - pipe: '|'
+                    - pipe: '|'
+                    column_reference:
+                      naked_identifier: bonus
+                  end_bracket: )
+        - statement_terminator: ;
+        - statement:
+            update_statement:
+              keyword: UPDATE
+              table_reference:
+                naked_identifier: employees
+              set_clause_list:
+                keyword: SET
+                set_clause:
+                  column_reference:
+                    naked_identifier: salary
+                  comparison_operator:
+                    raw_comparison_operator: '='
+                  expression:
+                  - column_reference:
+                      naked_identifier: salary
+                  - binary_operator: +
+                  - column_reference:
+                      naked_identifier: bonus
+              where_clause:
+                keyword: WHERE
                 expression:
                 - column_reference:
-                    naked_identifier: salary
-                - binary_operator: +
+                    naked_identifier: employee_id
+                - comparison_operator:
+                    raw_comparison_operator: '='
                 - column_reference:
-                    naked_identifier: bonus
-            where_clause:
-              keyword: WHERE
+                    naked_identifier: emp_id
+        - statement_terminator: ;
+        - keyword: END
+      - statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      create_procedure_statement:
+      - keyword: CREATE
+      - keyword: PROCEDURE
+      - function_name:
+          function_name_identifier: create_email
+      - function_parameter_list:
+          bracketed:
+          - start_bracket: (
+          - parameter: name1
+          - data_type:
+              data_type_identifier: VARCHAR2
+          - comma: ','
+          - parameter: name2
+          - data_type:
+              data_type_identifier: VARCHAR2
+          - comma: ','
+          - parameter: company
+          - data_type:
+              data_type_identifier: VARCHAR2
+          - end_bracket: )
+      - keyword: IS
+      - declare_segment:
+          naked_identifier: error_message
+          data_type:
+            data_type_identifier: VARCHAR2
+            bracketed_arguments:
+              bracketed:
+                start_bracket: (
+                numeric_literal: '30'
+                end_bracket: )
+          assignment_operator: :=
+          expression:
+            quoted_literal: "'Email address is too long.'"
+          statement_terminator: ;
+      - begin_end_block:
+        - keyword: BEGIN
+        - statement:
+            assignment_segment_statement:
+              object_reference:
+                naked_identifier: email
+              assignment_operator: :=
               expression:
               - column_reference:
-                  naked_identifier: employee_id
-              - comparison_operator:
-                  raw_comparison_operator: '='
+                  naked_identifier: name1
+              - binary_operator:
+                - pipe: '|'
+                - pipe: '|'
+              - quoted_literal: "'.'"
+              - binary_operator:
+                - pipe: '|'
+                - pipe: '|'
               - column_reference:
-                  naked_identifier: emp_id
+                  naked_identifier: name2
+              - binary_operator:
+                - pipe: '|'
+                - pipe: '|'
+              - quoted_literal: "'@'"
+              - binary_operator:
+                - pipe: '|'
+                - pipe: '|'
+              - column_reference:
+                  naked_identifier: company
+        - statement_terminator: ;
+        - keyword: EXCEPTION
+        - keyword: WHEN
+        - naked_identifier: VALUE_ERROR
+        - keyword: THEN
+        - statement:
+            function:
+              function_name:
+                naked_identifier: DBMS_OUTPUT
+                dot: .
+                function_name_identifier: PUT_LINE
+              function_contents:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    column_reference:
+                      naked_identifier: error_message
+                  end_bracket: )
+        - statement_terminator: ;
+        - keyword: END
       - statement_terminator: ;
-      - keyword: END
-    - statement_terminator: ;
-    - statement_terminator: /
-- statement:
-    create_procedure_statement:
-    - keyword: CREATE
-    - keyword: PROCEDURE
-    - function_name:
-        function_name_identifier: create_email
-    - function_parameter_list:
-        bracketed:
-        - start_bracket: (
-        - parameter: name1
-        - data_type:
-            data_type_identifier: VARCHAR2
-        - comma: ','
-        - parameter: name2
-        - data_type:
-            data_type_identifier: VARCHAR2
-        - comma: ','
-        - parameter: company
-        - data_type:
-            data_type_identifier: VARCHAR2
-        - end_bracket: )
-    - keyword: IS
-    - declare_segment:
-        naked_identifier: error_message
-        data_type:
-          data_type_identifier: VARCHAR2
-          bracketed_arguments:
-            bracketed:
-              start_bracket: (
-              numeric_literal: '30'
-              end_bracket: )
-        assignment_operator: :=
-        expression:
-          quoted_literal: "'Email address is too long.'"
-        statement_terminator: ;
-    - begin_end_block:
-      - keyword: BEGIN
-      - statement:
-          assignment_segment_statement:
-            object_reference:
-              naked_identifier: email
-            assignment_operator: :=
-            expression:
-            - column_reference:
-                naked_identifier: name1
-            - binary_operator:
-              - pipe: '|'
-              - pipe: '|'
-            - quoted_literal: "'.'"
-            - binary_operator:
-              - pipe: '|'
-              - pipe: '|'
-            - column_reference:
-                naked_identifier: name2
-            - binary_operator:
-              - pipe: '|'
-              - pipe: '|'
-            - quoted_literal: "'@'"
-            - binary_operator:
-              - pipe: '|'
-              - pipe: '|'
-            - column_reference:
-                naked_identifier: company
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      create_procedure_statement:
+      - keyword: CREATE
+      - keyword: PROCEDURE
+      - function_name:
+          function_name_identifier: p
+      - keyword: IS
+      - begin_end_block:
+        - keyword: BEGIN
+        - statement:
+            function:
+              function_name:
+                naked_identifier: DBMS_OUTPUT
+                dot: .
+                function_name_identifier: PUT_LINE
+              function_contents:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    quoted_literal: "'Inside p'"
+                  end_bracket: )
+        - statement_terminator: ;
+        - statement:
+            return_statement:
+              keyword: RETURN
+        - statement_terminator: ;
+        - statement:
+            function:
+              function_name:
+                naked_identifier: DBMS_OUTPUT
+                dot: .
+                function_name_identifier: PUT_LINE
+              function_contents:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    quoted_literal: "'Unreachable statement.'"
+                  end_bracket: )
+        - statement_terminator: ;
+        - keyword: END
       - statement_terminator: ;
-      - keyword: EXCEPTION
-      - keyword: WHEN
-      - naked_identifier: VALUE_ERROR
-      - keyword: THEN
-      - statement:
-          function:
-            function_name:
-              naked_identifier: DBMS_OUTPUT
-              dot: .
-              function_name_identifier: PUT_LINE
-            function_contents:
-              bracketed:
-                start_bracket: (
-                expression:
-                  column_reference:
-                    naked_identifier: error_message
-                end_bracket: )
-      - statement_terminator: ;
-      - keyword: END
-    - statement_terminator: ;
-    - statement_terminator: /
-- statement:
-    create_procedure_statement:
-    - keyword: CREATE
-    - keyword: PROCEDURE
-    - function_name:
-        function_name_identifier: p
-    - keyword: IS
-    - begin_end_block:
-      - keyword: BEGIN
-      - statement:
-          function:
-            function_name:
-              naked_identifier: DBMS_OUTPUT
-              dot: .
-              function_name_identifier: PUT_LINE
-            function_contents:
-              bracketed:
-                start_bracket: (
-                expression:
-                  quoted_literal: "'Inside p'"
-                end_bracket: )
-      - statement_terminator: ;
-      - statement:
-          return_statement:
-            keyword: RETURN
-      - statement_terminator: ;
-      - statement:
-          function:
-            function_name:
-              naked_identifier: DBMS_OUTPUT
-              dot: .
-              function_name_identifier: PUT_LINE
-            function_contents:
-              bracketed:
-                start_bracket: (
-                expression:
-                  quoted_literal: "'Unreachable statement.'"
-                end_bracket: )
-      - statement_terminator: ;
-      - keyword: END
-    - statement_terminator: ;
-    - statement_terminator: /
+    slash_buffer_executor:
+      slash: /

--- a/test/fixtures/dialects/oracle/create_sequence.yml
+++ b/test/fixtures/dialects/oracle/create_sequence.yml
@@ -3,41 +3,42 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 0a40d9159b67e8652d7b8b7e98cdc9607afa6d3abac9f020f7ca8690da54b2e2
+_hash: 6a444e4077ce6f0fce9bb8f75083f49f244fedb5c91486f35566ce06d4d44770
 file:
-- statement:
-    create_sequence_statement:
-    - keyword: CREATE
-    - keyword: SEQUENCE
-    - sequence_reference:
-        naked_identifier: TBL_SERVICEALERTMESSAGE_S
-    - create_sequence_options_segment:
-      - keyword: INCREMENT
-      - keyword: BY
-      - numeric_literal: '1'
-    - create_sequence_options_segment:
-      - keyword: START
-      - keyword: WITH
-      - numeric_literal: '1'
-    - create_sequence_options_segment:
-        keyword: NOMAXVALUE
-    - create_sequence_options_segment:
-        keyword: NOCYCLE
-- statement_terminator: ;
-- statement:
-    create_sequence_statement:
-    - keyword: CREATE
-    - keyword: SEQUENCE
-    - sequence_reference:
-        naked_identifier: TBL_SERVICEALERTMESSAGE_S2
-    - create_sequence_options_segment:
-      - keyword: INCREMENT
-      - keyword: BY
-      - numeric_literal: '1'
-    - create_sequence_options_segment:
-        keyword: NOMINVALUE
-    - create_sequence_options_segment:
-        keyword: NOMAXVALUE
-    - create_sequence_options_segment:
-        keyword: NOCYCLE
-- statement_terminator: ;
+  batch:
+  - statement:
+      create_sequence_statement:
+      - keyword: CREATE
+      - keyword: SEQUENCE
+      - sequence_reference:
+          naked_identifier: TBL_SERVICEALERTMESSAGE_S
+      - create_sequence_options_segment:
+        - keyword: INCREMENT
+        - keyword: BY
+        - numeric_literal: '1'
+      - create_sequence_options_segment:
+        - keyword: START
+        - keyword: WITH
+        - numeric_literal: '1'
+      - create_sequence_options_segment:
+          keyword: NOMAXVALUE
+      - create_sequence_options_segment:
+          keyword: NOCYCLE
+  - statement_terminator: ;
+  - statement:
+      create_sequence_statement:
+      - keyword: CREATE
+      - keyword: SEQUENCE
+      - sequence_reference:
+          naked_identifier: TBL_SERVICEALERTMESSAGE_S2
+      - create_sequence_options_segment:
+        - keyword: INCREMENT
+        - keyword: BY
+        - numeric_literal: '1'
+      - create_sequence_options_segment:
+          keyword: NOMINVALUE
+      - create_sequence_options_segment:
+          keyword: NOMAXVALUE
+      - create_sequence_options_segment:
+          keyword: NOCYCLE
+  - statement_terminator: ;

--- a/test/fixtures/dialects/oracle/create_synonym.yml
+++ b/test/fixtures/dialects/oracle/create_synonym.yml
@@ -3,52 +3,53 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 57e08a1f9025170f1510cab53e867730a3129cc88a5e0d88cc3b48f31a27744e
+_hash: 53d09a26157da2f5a32b04191225b5a526e3fb782639ad013276792253ebd87c
 file:
-- statement:
-    create_synonym_statement:
-    - keyword: CREATE
-    - keyword: SYNONYM
-    - object_reference:
-        naked_identifier: offices
-    - keyword: FOR
-    - object_reference:
-      - naked_identifier: hr
-      - dot: .
-      - naked_identifier: locations
-- statement_terminator: ;
-- statement:
-    create_synonym_statement:
-    - keyword: CREATE
-    - keyword: PUBLIC
-    - keyword: SYNONYM
-    - object_reference:
-        naked_identifier: emp_table
-    - keyword: FOR
-    - object_reference:
-      - naked_identifier: hr
-      - dot: .
-      - naked_identifier: employees
-    - at_sign: '@'
-    - database_link_reference:
-      - naked_identifier: remote
-      - dot: .
-      - naked_identifier: us
-      - dot: .
-      - naked_identifier: example
-      - dot: .
-      - naked_identifier: com
-- statement_terminator: ;
-- statement:
-    create_synonym_statement:
-    - keyword: CREATE
-    - keyword: PUBLIC
-    - keyword: SYNONYM
-    - object_reference:
-        naked_identifier: customers
-    - keyword: FOR
-    - object_reference:
-      - naked_identifier: oe
-      - dot: .
-      - naked_identifier: customers
-- statement_terminator: ;
+  batch:
+  - statement:
+      create_synonym_statement:
+      - keyword: CREATE
+      - keyword: SYNONYM
+      - object_reference:
+          naked_identifier: offices
+      - keyword: FOR
+      - object_reference:
+        - naked_identifier: hr
+        - dot: .
+        - naked_identifier: locations
+  - statement_terminator: ;
+  - statement:
+      create_synonym_statement:
+      - keyword: CREATE
+      - keyword: PUBLIC
+      - keyword: SYNONYM
+      - object_reference:
+          naked_identifier: emp_table
+      - keyword: FOR
+      - object_reference:
+        - naked_identifier: hr
+        - dot: .
+        - naked_identifier: employees
+      - at_sign: '@'
+      - database_link_reference:
+        - naked_identifier: remote
+        - dot: .
+        - naked_identifier: us
+        - dot: .
+        - naked_identifier: example
+        - dot: .
+        - naked_identifier: com
+  - statement_terminator: ;
+  - statement:
+      create_synonym_statement:
+      - keyword: CREATE
+      - keyword: PUBLIC
+      - keyword: SYNONYM
+      - object_reference:
+          naked_identifier: customers
+      - keyword: FOR
+      - object_reference:
+        - naked_identifier: oe
+        - dot: .
+        - naked_identifier: customers
+  - statement_terminator: ;

--- a/test/fixtures/dialects/oracle/create_table.yml
+++ b/test/fixtures/dialects/oracle/create_table.yml
@@ -3,215 +3,216 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: d769af0449f931aab8e131f48d87f64c8260b09d944567e1583bb56e388185a1
+_hash: 0e630f7597a0815d878c040812245c192fb49175b56179a0eb01a4635cf299e5
 file:
-- statement:
-    create_table_statement:
-    - keyword: create
-    - keyword: table
-    - table_reference:
-        naked_identifier: tabl#e1
-    - bracketed:
-      - start_bracket: (
-      - column_definition:
-          naked_identifier: c1
-          data_type:
-            data_type_identifier: SMALLINT
-      - comma: ','
-      - column_definition:
-          naked_identifier: c2
-          data_type:
-            data_type_identifier: DATE
-      - end_bracket: )
-- statement_terminator: ;
-- statement:
-    create_table_statement:
-    - keyword: create
-    - keyword: table
-    - table_reference:
-        naked_identifier: table1$
-    - bracketed:
-      - start_bracket: (
-      - column_definition:
-          naked_identifier: c1
-          data_type:
-            data_type_identifier: SMALLINT
-      - comma: ','
-      - column_definition:
-          naked_identifier: c2
-          data_type:
-            data_type_identifier: DATE
-      - end_bracket: )
-- statement_terminator: ;
-- statement:
-    create_table_statement:
-    - keyword: create
-    - keyword: table
-    - table_reference:
-        naked_identifier: tab#le1$
-    - bracketed:
-      - start_bracket: (
-      - column_definition:
-          naked_identifier: c1
-          data_type:
-            data_type_identifier: SMALLINT
-      - comma: ','
-      - column_definition:
-          naked_identifier: c2
-          data_type:
-            data_type_identifier: DATE
-      - end_bracket: )
-- statement_terminator: ;
-- statement:
-    create_table_statement:
-    - keyword: create
-    - keyword: table
-    - table_reference:
-        naked_identifier: tab#le1$
-    - bracketed:
-      - start_bracket: (
-      - column_definition:
-          naked_identifier: c#1
-          data_type:
-            data_type_identifier: SMALLINT
-      - comma: ','
-      - column_definition:
-          naked_identifier: c$2
-          data_type:
-            data_type_identifier: DATE
-      - end_bracket: )
-- statement_terminator: ;
-- statement:
-    create_table_statement:
-    - keyword: CREATE
-    - keyword: TABLE
-    - table_reference:
-        naked_identifier: t1
-    - bracketed:
-        start_bracket: (
-        column_definition:
-        - naked_identifier: id
-        - data_type:
-            data_type_identifier: NUMBER
-        - keyword: GENERATED
-        - keyword: AS
-        - keyword: IDENTITY
-        end_bracket: )
-- statement_terminator: ;
-- statement:
-    create_table_statement:
-    - keyword: CREATE
-    - keyword: TABLE
-    - table_reference:
-        naked_identifier: t2
-    - bracketed:
-        start_bracket: (
-        column_definition:
-        - naked_identifier: id
-        - data_type:
-            data_type_identifier: NUMBER
-        - keyword: GENERATED
-        - keyword: BY
-        - keyword: DEFAULT
-        - keyword: AS
-        - keyword: IDENTITY
-        - bracketed:
-          - start_bracket: (
-          - keyword: START
-          - keyword: WITH
-          - numeric_literal: '100'
-          - keyword: INCREMENT
+  batch:
+  - statement:
+      create_table_statement:
+      - keyword: create
+      - keyword: table
+      - table_reference:
+          naked_identifier: tabl#e1
+      - bracketed:
+        - start_bracket: (
+        - column_definition:
+            naked_identifier: c1
+            data_type:
+              data_type_identifier: SMALLINT
+        - comma: ','
+        - column_definition:
+            naked_identifier: c2
+            data_type:
+              data_type_identifier: DATE
+        - end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      create_table_statement:
+      - keyword: create
+      - keyword: table
+      - table_reference:
+          naked_identifier: table1$
+      - bracketed:
+        - start_bracket: (
+        - column_definition:
+            naked_identifier: c1
+            data_type:
+              data_type_identifier: SMALLINT
+        - comma: ','
+        - column_definition:
+            naked_identifier: c2
+            data_type:
+              data_type_identifier: DATE
+        - end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      create_table_statement:
+      - keyword: create
+      - keyword: table
+      - table_reference:
+          naked_identifier: tab#le1$
+      - bracketed:
+        - start_bracket: (
+        - column_definition:
+            naked_identifier: c1
+            data_type:
+              data_type_identifier: SMALLINT
+        - comma: ','
+        - column_definition:
+            naked_identifier: c2
+            data_type:
+              data_type_identifier: DATE
+        - end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      create_table_statement:
+      - keyword: create
+      - keyword: table
+      - table_reference:
+          naked_identifier: tab#le1$
+      - bracketed:
+        - start_bracket: (
+        - column_definition:
+            naked_identifier: c#1
+            data_type:
+              data_type_identifier: SMALLINT
+        - comma: ','
+        - column_definition:
+            naked_identifier: c$2
+            data_type:
+              data_type_identifier: DATE
+        - end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      create_table_statement:
+      - keyword: CREATE
+      - keyword: TABLE
+      - table_reference:
+          naked_identifier: t1
+      - bracketed:
+          start_bracket: (
+          column_definition:
+          - naked_identifier: id
+          - data_type:
+              data_type_identifier: NUMBER
+          - keyword: GENERATED
+          - keyword: AS
+          - keyword: IDENTITY
+          end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      create_table_statement:
+      - keyword: CREATE
+      - keyword: TABLE
+      - table_reference:
+          naked_identifier: t2
+      - bracketed:
+          start_bracket: (
+          column_definition:
+          - naked_identifier: id
+          - data_type:
+              data_type_identifier: NUMBER
+          - keyword: GENERATED
           - keyword: BY
-          - numeric_literal: '10'
-          - end_bracket: )
-        end_bracket: )
-- statement_terminator: ;
-- statement:
-    create_table_statement:
-    - keyword: CREATE
-    - keyword: TABLE
-    - table_reference:
-        naked_identifier: t3
-    - bracketed:
-        start_bracket: (
-        column_definition:
-          naked_identifier: id
-          data_type:
-            data_type_identifier: NUMBER
-          column_constraint_segment:
           - keyword: DEFAULT
-          - naked_identifier: some_seq
-          - dot: .
-          - keyword: NEXTVAL
-        end_bracket: )
-- statement_terminator: ;
-- statement:
-    create_table_statement:
-    - keyword: CREATE
-    - keyword: TABLE
-    - table_reference:
-        naked_identifier: departments_demo
-    - bracketed:
-      - start_bracket: (
-      - column_definition:
-          naked_identifier: department_id
-          data_type:
-            data_type_identifier: NUMBER
-            bracketed_arguments:
-              bracketed:
-                start_bracket: (
-                numeric_literal: '4'
-                end_bracket: )
-          column_constraint_segment:
-          - keyword: PRIMARY
-          - keyword: KEY
-          keyword: ENABLE
-      - comma: ','
-      - column_definition:
-          naked_identifier: department_name
-          data_type:
-            data_type_identifier: VARCHAR2
-            bracketed_arguments:
-              bracketed:
-                start_bracket: (
-                numeric_literal: '30'
-                end_bracket: )
-          column_constraint_segment:
-          - keyword: CONSTRAINT
-          - object_reference:
-              naked_identifier: dept_name_nn
-          - keyword: NOT
-          - keyword: 'NULL'
-          keyword: DISABLE
-      - comma: ','
-      - column_definition:
-          naked_identifier: manager_id
-          data_type:
-            data_type_identifier: NUMBER
-            bracketed_arguments:
-              bracketed:
-                start_bracket: (
-                numeric_literal: '6'
-                end_bracket: )
-      - comma: ','
-      - column_definition:
-          naked_identifier: location_id
-          data_type:
-            data_type_identifier: NUMBER
-            bracketed_arguments:
-              bracketed:
-                start_bracket: (
-                numeric_literal: '4'
-                end_bracket: )
-      - comma: ','
-      - column_definition:
-          naked_identifier: dn
-          data_type:
-            data_type_identifier: VARCHAR2
-            bracketed_arguments:
-              bracketed:
-                start_bracket: (
-                numeric_literal: '300'
-                end_bracket: )
-      - end_bracket: )
-- statement_terminator: ;
+          - keyword: AS
+          - keyword: IDENTITY
+          - bracketed:
+            - start_bracket: (
+            - keyword: START
+            - keyword: WITH
+            - numeric_literal: '100'
+            - keyword: INCREMENT
+            - keyword: BY
+            - numeric_literal: '10'
+            - end_bracket: )
+          end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      create_table_statement:
+      - keyword: CREATE
+      - keyword: TABLE
+      - table_reference:
+          naked_identifier: t3
+      - bracketed:
+          start_bracket: (
+          column_definition:
+            naked_identifier: id
+            data_type:
+              data_type_identifier: NUMBER
+            column_constraint_segment:
+            - keyword: DEFAULT
+            - naked_identifier: some_seq
+            - dot: .
+            - keyword: NEXTVAL
+          end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      create_table_statement:
+      - keyword: CREATE
+      - keyword: TABLE
+      - table_reference:
+          naked_identifier: departments_demo
+      - bracketed:
+        - start_bracket: (
+        - column_definition:
+            naked_identifier: department_id
+            data_type:
+              data_type_identifier: NUMBER
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  numeric_literal: '4'
+                  end_bracket: )
+            column_constraint_segment:
+            - keyword: PRIMARY
+            - keyword: KEY
+            keyword: ENABLE
+        - comma: ','
+        - column_definition:
+            naked_identifier: department_name
+            data_type:
+              data_type_identifier: VARCHAR2
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  numeric_literal: '30'
+                  end_bracket: )
+            column_constraint_segment:
+            - keyword: CONSTRAINT
+            - object_reference:
+                naked_identifier: dept_name_nn
+            - keyword: NOT
+            - keyword: 'NULL'
+            keyword: DISABLE
+        - comma: ','
+        - column_definition:
+            naked_identifier: manager_id
+            data_type:
+              data_type_identifier: NUMBER
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  numeric_literal: '6'
+                  end_bracket: )
+        - comma: ','
+        - column_definition:
+            naked_identifier: location_id
+            data_type:
+              data_type_identifier: NUMBER
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  numeric_literal: '4'
+                  end_bracket: )
+        - comma: ','
+        - column_definition:
+            naked_identifier: dn
+            data_type:
+              data_type_identifier: VARCHAR2
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  numeric_literal: '300'
+                  end_bracket: )
+        - end_bracket: )
+  - statement_terminator: ;

--- a/test/fixtures/dialects/oracle/create_trigger.yml
+++ b/test/fixtures/dialects/oracle/create_trigger.yml
@@ -3,743 +3,752 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 5ac384e5956234f029ccc05622864d0192b9c6eadc800ff5bad7fbfc82764e02
+_hash: 09932703362d42bf81706716637af4523ce68574d4d6539724089b61842ffed3
 file:
-  statement:
-    create_trigger_statement:
-    - keyword: CREATE
-    - keyword: OR
-    - keyword: REPLACE
-    - keyword: TRIGGER
-    - trigger_reference:
-        naked_identifier: t
-    - keyword: BEFORE
-    - dml_event_clause:
-      - keyword: INSERT
+- batch:
+    statement:
+      create_trigger_statement:
+      - keyword: CREATE
       - keyword: OR
-      - keyword: UPDATE
-      - keyword: OF
-      - column_reference:
-          naked_identifier: salary
-      - comma: ','
-      - column_reference:
-          naked_identifier: department_id
-      - keyword: OR
-      - keyword: DELETE
-      - keyword: 'ON'
-      - table_reference:
-          naked_identifier: employees
-    - statement:
-        begin_end_block:
-        - keyword: BEGIN
-        - statement:
-            case_expression:
-            - keyword: CASE
-            - when_clause:
-              - keyword: WHEN
-              - keyword: INSERTING
-              - keyword: THEN
-              - statement:
-                  function:
-                    function_name:
-                      naked_identifier: DBMS_OUTPUT
-                      dot: .
-                      function_name_identifier: PUT_LINE
-                    function_contents:
-                      bracketed:
-                        start_bracket: (
-                        expression:
-                          quoted_literal: "'Inserting'"
-                        end_bracket: )
-              - statement_terminator: ;
-            - when_clause:
-              - keyword: WHEN
-              - expression:
-                  function:
-                    function_name:
-                      function_name_identifier: UPDATING
-                    function_contents:
-                      bracketed:
-                        start_bracket: (
-                        expression:
-                          quoted_literal: "'salary'"
-                        end_bracket: )
-              - keyword: THEN
-              - statement:
-                  function:
-                    function_name:
-                      naked_identifier: DBMS_OUTPUT
-                      dot: .
-                      function_name_identifier: PUT_LINE
-                    function_contents:
-                      bracketed:
-                        start_bracket: (
-                        expression:
-                          quoted_literal: "'Updating salary'"
-                        end_bracket: )
-              - statement_terminator: ;
-            - when_clause:
-              - keyword: WHEN
-              - expression:
-                  function:
-                    function_name:
-                      function_name_identifier: UPDATING
-                    function_contents:
-                      bracketed:
-                        start_bracket: (
-                        expression:
-                          quoted_literal: "'department_id'"
-                        end_bracket: )
-              - keyword: THEN
-              - statement:
-                  function:
-                    function_name:
-                      naked_identifier: DBMS_OUTPUT
-                      dot: .
-                      function_name_identifier: PUT_LINE
-                    function_contents:
-                      bracketed:
-                        start_bracket: (
-                        expression:
-                          quoted_literal: "'Updating department ID'"
-                        end_bracket: )
-              - statement_terminator: ;
-            - when_clause:
-              - keyword: WHEN
-              - keyword: DELETING
-              - keyword: THEN
-              - statement:
-                  function:
-                    function_name:
-                      naked_identifier: DBMS_OUTPUT
-                      dot: .
-                      function_name_identifier: PUT_LINE
-                    function_contents:
-                      bracketed:
-                        start_bracket: (
-                        expression:
-                          quoted_literal: "'Deleting'"
-                        end_bracket: )
-              - statement_terminator: ;
-            - keyword: END
-            - keyword: CASE
-        - statement_terminator: ;
-        - keyword: END
-    - statement_terminator: ;
-    - statement_terminator: /
-    - statement:
-        create_trigger_statement:
-        - keyword: CREATE
+      - keyword: REPLACE
+      - keyword: TRIGGER
+      - trigger_reference:
+          naked_identifier: t
+      - keyword: BEFORE
+      - dml_event_clause:
+        - keyword: INSERT
         - keyword: OR
-        - keyword: REPLACE
-        - keyword: TRIGGER
-        - trigger_reference:
-            naked_identifier: order_info_insert
-        - keyword: INSTEAD
+        - keyword: UPDATE
         - keyword: OF
-        - dml_event_clause:
-          - keyword: INSERT
-          - keyword: 'ON'
-          - table_reference:
-              naked_identifier: order_info
-        - statement:
-            begin_end_block:
-            - declare_segment:
-              - keyword: DECLARE
-              - naked_identifier: duplicate_info
-              - data_type:
-                  data_type_identifier: EXCEPTION
-              - statement_terminator: ;
-              - keyword: PRAGMA
-              - function:
-                  function_name:
-                    function_name_identifier: EXCEPTION_INIT
-                  function_contents:
-                    bracketed:
-                    - start_bracket: (
-                    - expression:
-                        column_reference:
-                          naked_identifier: duplicate_info
-                    - comma: ','
-                    - expression:
-                        numeric_literal:
-                          sign_indicator: '-'
-                          numeric_literal: '00001'
-                    - end_bracket: )
-              - statement_terminator: ;
-            - keyword: BEGIN
-            - statement:
-                insert_statement:
-                - keyword: INSERT
-                - keyword: INTO
-                - table_reference:
-                    naked_identifier: customers
-                - bracketed:
+        - column_reference:
+            naked_identifier: salary
+        - comma: ','
+        - column_reference:
+            naked_identifier: department_id
+        - keyword: OR
+        - keyword: DELETE
+        - keyword: 'ON'
+        - table_reference:
+            naked_identifier: employees
+      - statement:
+          begin_end_block:
+          - keyword: BEGIN
+          - statement:
+              case_expression:
+              - keyword: CASE
+              - when_clause:
+                - keyword: WHEN
+                - keyword: INSERTING
+                - keyword: THEN
+                - statement:
+                    function:
+                      function_name:
+                        naked_identifier: DBMS_OUTPUT
+                        dot: .
+                        function_name_identifier: PUT_LINE
+                      function_contents:
+                        bracketed:
+                          start_bracket: (
+                          expression:
+                            quoted_literal: "'Inserting'"
+                          end_bracket: )
+                - statement_terminator: ;
+              - when_clause:
+                - keyword: WHEN
+                - expression:
+                    function:
+                      function_name:
+                        function_name_identifier: UPDATING
+                      function_contents:
+                        bracketed:
+                          start_bracket: (
+                          expression:
+                            quoted_literal: "'salary'"
+                          end_bracket: )
+                - keyword: THEN
+                - statement:
+                    function:
+                      function_name:
+                        naked_identifier: DBMS_OUTPUT
+                        dot: .
+                        function_name_identifier: PUT_LINE
+                      function_contents:
+                        bracketed:
+                          start_bracket: (
+                          expression:
+                            quoted_literal: "'Updating salary'"
+                          end_bracket: )
+                - statement_terminator: ;
+              - when_clause:
+                - keyword: WHEN
+                - expression:
+                    function:
+                      function_name:
+                        function_name_identifier: UPDATING
+                      function_contents:
+                        bracketed:
+                          start_bracket: (
+                          expression:
+                            quoted_literal: "'department_id'"
+                          end_bracket: )
+                - keyword: THEN
+                - statement:
+                    function:
+                      function_name:
+                        naked_identifier: DBMS_OUTPUT
+                        dot: .
+                        function_name_identifier: PUT_LINE
+                      function_contents:
+                        bracketed:
+                          start_bracket: (
+                          expression:
+                            quoted_literal: "'Updating department ID'"
+                          end_bracket: )
+                - statement_terminator: ;
+              - when_clause:
+                - keyword: WHEN
+                - keyword: DELETING
+                - keyword: THEN
+                - statement:
+                    function:
+                      function_name:
+                        naked_identifier: DBMS_OUTPUT
+                        dot: .
+                        function_name_identifier: PUT_LINE
+                      function_contents:
+                        bracketed:
+                          start_bracket: (
+                          expression:
+                            quoted_literal: "'Deleting'"
+                          end_bracket: )
+                - statement_terminator: ;
+              - keyword: END
+              - keyword: CASE
+          - statement_terminator: ;
+          - keyword: END
+      - statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      create_trigger_statement:
+      - keyword: CREATE
+      - keyword: OR
+      - keyword: REPLACE
+      - keyword: TRIGGER
+      - trigger_reference:
+          naked_identifier: order_info_insert
+      - keyword: INSTEAD
+      - keyword: OF
+      - dml_event_clause:
+        - keyword: INSERT
+        - keyword: 'ON'
+        - table_reference:
+            naked_identifier: order_info
+      - statement:
+          begin_end_block:
+          - declare_segment:
+            - keyword: DECLARE
+            - naked_identifier: duplicate_info
+            - data_type:
+                data_type_identifier: EXCEPTION
+            - statement_terminator: ;
+            - keyword: PRAGMA
+            - function:
+                function_name:
+                  function_name_identifier: EXCEPTION_INIT
+                function_contents:
+                  bracketed:
                   - start_bracket: (
-                  - column_reference:
+                  - expression:
+                      column_reference:
+                        naked_identifier: duplicate_info
+                  - comma: ','
+                  - expression:
+                      numeric_literal:
+                        sign_indicator: '-'
+                        numeric_literal: '00001'
+                  - end_bracket: )
+            - statement_terminator: ;
+          - keyword: BEGIN
+          - statement:
+              insert_statement:
+              - keyword: INSERT
+              - keyword: INTO
+              - table_reference:
+                  naked_identifier: customers
+              - bracketed:
+                - start_bracket: (
+                - column_reference:
+                    naked_identifier: customer_id
+                - comma: ','
+                - column_reference:
+                    naked_identifier: cust_last_name
+                - comma: ','
+                - column_reference:
+                    naked_identifier: cust_first_name
+                - end_bracket: )
+              - values_clause:
+                  keyword: VALUES
+                  bracketed:
+                  - start_bracket: (
+                  - bind_variable:
+                      colon_delimiter: ':'
+                      trigger_correlation_name:
+                        keyword: new
+                      dot: .
                       naked_identifier: customer_id
                   - comma: ','
-                  - column_reference:
+                  - bind_variable:
+                      colon_delimiter: ':'
+                      trigger_correlation_name:
+                        keyword: new
+                      dot: .
                       naked_identifier: cust_last_name
                   - comma: ','
-                  - column_reference:
+                  - bind_variable:
+                      colon_delimiter: ':'
+                      trigger_correlation_name:
+                        keyword: new
+                      dot: .
                       naked_identifier: cust_first_name
                   - end_bracket: )
-                - values_clause:
-                    keyword: VALUES
-                    bracketed:
-                    - start_bracket: (
-                    - bind_variable:
-                        colon_delimiter: ':'
-                        trigger_correlation_name:
-                          keyword: new
-                        dot: .
-                        naked_identifier: customer_id
-                    - comma: ','
-                    - bind_variable:
-                        colon_delimiter: ':'
-                        trigger_correlation_name:
-                          keyword: new
-                        dot: .
-                        naked_identifier: cust_last_name
-                    - comma: ','
-                    - bind_variable:
-                        colon_delimiter: ':'
-                        trigger_correlation_name:
-                          keyword: new
-                        dot: .
-                        naked_identifier: cust_first_name
-                    - end_bracket: )
-            - statement_terminator: ;
-            - statement:
-                insert_statement:
-                - keyword: INSERT
-                - keyword: INTO
-                - table_reference:
-                    naked_identifier: orders
-                - bracketed:
+          - statement_terminator: ;
+          - statement:
+              insert_statement:
+              - keyword: INSERT
+              - keyword: INTO
+              - table_reference:
+                  naked_identifier: orders
+              - bracketed:
+                - start_bracket: (
+                - column_reference:
+                    naked_identifier: order_id
+                - comma: ','
+                - column_reference:
+                    naked_identifier: order_date
+                - comma: ','
+                - column_reference:
+                    naked_identifier: customer_id
+                - end_bracket: )
+              - values_clause:
+                  keyword: VALUES
+                  bracketed:
                   - start_bracket: (
-                  - column_reference:
+                  - bind_variable:
+                      colon_delimiter: ':'
+                      trigger_correlation_name:
+                        keyword: new
+                      dot: .
                       naked_identifier: order_id
                   - comma: ','
-                  - column_reference:
+                  - bind_variable:
+                      colon_delimiter: ':'
+                      trigger_correlation_name:
+                        keyword: new
+                      dot: .
                       naked_identifier: order_date
                   - comma: ','
-                  - column_reference:
+                  - bind_variable:
+                      colon_delimiter: ':'
+                      trigger_correlation_name:
+                        keyword: new
+                      dot: .
                       naked_identifier: customer_id
                   - end_bracket: )
-                - values_clause:
-                    keyword: VALUES
-                    bracketed:
-                    - start_bracket: (
-                    - bind_variable:
-                        colon_delimiter: ':'
-                        trigger_correlation_name:
-                          keyword: new
-                        dot: .
-                        naked_identifier: order_id
-                    - comma: ','
-                    - bind_variable:
-                        colon_delimiter: ':'
-                        trigger_correlation_name:
-                          keyword: new
-                        dot: .
-                        naked_identifier: order_date
-                    - comma: ','
-                    - bind_variable:
-                        colon_delimiter: ':'
-                        trigger_correlation_name:
-                          keyword: new
-                        dot: .
-                        naked_identifier: customer_id
-                    - end_bracket: )
-            - statement_terminator: ;
-            - keyword: EXCEPTION
-            - keyword: WHEN
-            - naked_identifier: duplicate_info
-            - keyword: THEN
-            - statement:
-                function:
-                  function_name:
-                    function_name_identifier: RAISE_APPLICATION_ERROR
-                  function_contents:
-                    bracketed:
-                    - start_bracket: (
-                    - named_argument:
-                        naked_identifier: num
-                        right_arrow: =>
-                        expression:
-                          numeric_literal:
-                            sign_indicator: '-'
-                            numeric_literal: '20107'
-                    - comma: ','
-                    - named_argument:
-                        naked_identifier: msg
-                        right_arrow: =>
-                        expression:
-                          quoted_literal: "'Duplicate customer or order ID'"
-                    - end_bracket: )
-            - statement_terminator: ;
-            - keyword: END
-            - object_reference:
-                naked_identifier: order_info_insert
-        - statement_terminator: ;
-        - statement_terminator: /
-        - statement:
-            create_trigger_statement:
-            - keyword: CREATE
-            - keyword: OR
-            - keyword: REPLACE
-            - keyword: TRIGGER
-            - trigger_reference:
-                naked_identifier: dept_emplist_tr
-            - keyword: INSTEAD
-            - keyword: OF
-            - dml_event_clause:
+          - statement_terminator: ;
+          - keyword: EXCEPTION
+          - keyword: WHEN
+          - naked_identifier: duplicate_info
+          - keyword: THEN
+          - statement:
+              function:
+                function_name:
+                  function_name_identifier: RAISE_APPLICATION_ERROR
+                function_contents:
+                  bracketed:
+                  - start_bracket: (
+                  - named_argument:
+                      naked_identifier: num
+                      right_arrow: =>
+                      expression:
+                        numeric_literal:
+                          sign_indicator: '-'
+                          numeric_literal: '20107'
+                  - comma: ','
+                  - named_argument:
+                      naked_identifier: msg
+                      right_arrow: =>
+                      expression:
+                        quoted_literal: "'Duplicate customer or order ID'"
+                  - end_bracket: )
+          - statement_terminator: ;
+          - keyword: END
+          - object_reference:
+              naked_identifier: order_info_insert
+      - statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      create_trigger_statement:
+      - keyword: CREATE
+      - keyword: OR
+      - keyword: REPLACE
+      - keyword: TRIGGER
+      - trigger_reference:
+          naked_identifier: dept_emplist_tr
+      - keyword: INSTEAD
+      - keyword: OF
+      - dml_event_clause:
+        - keyword: INSERT
+        - keyword: 'ON'
+        - keyword: NESTED
+        - keyword: TABLE
+        - column_reference:
+            naked_identifier: emplist
+        - keyword: OF
+        - table_reference:
+            naked_identifier: dept_view
+      - referencing_clause:
+        - keyword: REFERENCING
+        - trigger_correlation_name:
+            keyword: NEW
+        - keyword: AS
+        - naked_identifier: Employee
+        - trigger_correlation_name:
+            keyword: PARENT
+        - keyword: AS
+        - naked_identifier: Department
+      - keyword: FOR
+      - keyword: EACH
+      - keyword: ROW
+      - statement:
+          begin_end_block:
+          - keyword: BEGIN
+          - statement:
+              insert_statement:
               - keyword: INSERT
-              - keyword: 'ON'
-              - keyword: NESTED
-              - keyword: TABLE
-              - column_reference:
-                  naked_identifier: emplist
-              - keyword: OF
+              - keyword: INTO
               - table_reference:
-                  naked_identifier: dept_view
-            - referencing_clause:
-              - keyword: REFERENCING
-              - trigger_correlation_name:
-                  keyword: NEW
-              - keyword: AS
-              - naked_identifier: Employee
-              - trigger_correlation_name:
-                  keyword: PARENT
-              - keyword: AS
-              - naked_identifier: Department
-            - keyword: FOR
-            - keyword: EACH
-            - keyword: ROW
-            - statement:
-                begin_end_block:
-                - keyword: BEGIN
-                - statement:
-                    insert_statement:
+                  naked_identifier: employees
+              - bracketed:
+                - start_bracket: (
+                - column_reference:
+                    naked_identifier: employee_id
+                - comma: ','
+                - column_reference:
+                    naked_identifier: last_name
+                - comma: ','
+                - column_reference:
+                    naked_identifier: email
+                - comma: ','
+                - column_reference:
+                    naked_identifier: hire_date
+                - comma: ','
+                - column_reference:
+                    naked_identifier: job_id
+                - comma: ','
+                - column_reference:
+                    naked_identifier: salary
+                - comma: ','
+                - column_reference:
+                    naked_identifier: department_id
+                - end_bracket: )
+              - values_clause:
+                  keyword: VALUES
+                  bracketed:
+                  - start_bracket: (
+                  - sqlplus_variable:
+                    - colon: ':'
+                    - parameter: Employee
+                    - dot: .
+                    - parameter: emp_id
+                  - comma: ','
+                  - sqlplus_variable:
+                    - colon: ':'
+                    - parameter: Employee
+                    - dot: .
+                    - parameter: lastname
+                  - comma: ','
+                  - expression:
+                      sqlplus_variable:
+                      - colon: ':'
+                      - parameter: Employee
+                      - dot: .
+                      - parameter: lastname
+                      binary_operator:
+                      - pipe: '|'
+                      - pipe: '|'
+                      quoted_literal: "'@example.com'"
+                  - comma: ','
+                  - expression:
+                      bare_function: SYSDATE
+                  - comma: ','
+                  - sqlplus_variable:
+                    - colon: ':'
+                    - parameter: Employee
+                    - dot: .
+                    - parameter: job
+                  - comma: ','
+                  - sqlplus_variable:
+                    - colon: ':'
+                    - parameter: Employee
+                    - dot: .
+                    - parameter: sal
+                  - comma: ','
+                  - sqlplus_variable:
+                    - colon: ':'
+                    - parameter: Department
+                    - dot: .
+                    - parameter: department_id
+                  - end_bracket: )
+          - statement_terminator: ;
+          - keyword: END
+      - statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      create_trigger_statement:
+      - keyword: CREATE
+      - keyword: OR
+      - keyword: REPLACE
+      - keyword: TRIGGER
+      - trigger_reference:
+          naked_identifier: maintain_employee_salaries
+      - keyword: FOR
+      - dml_event_clause:
+        - keyword: UPDATE
+        - keyword: OF
+        - column_reference:
+            naked_identifier: salary
+        - keyword: 'ON'
+        - table_reference:
+            naked_identifier: employees
+      - compound_trigger_statement:
+        - keyword: COMPOUND
+        - keyword: TRIGGER
+        - declare_segment:
+          - naked_identifier: threshhold
+          - keyword: CONSTANT
+          - data_type:
+              data_type_identifier: SIMPLE_INTEGER
+          - assignment_operator: :=
+          - expression:
+              numeric_literal: '7'
+          - statement_terminator: ;
+          - collection_type:
+            - keyword: TYPE
+            - naked_identifier: salaries_t
+            - keyword: IS
+            - keyword: TABLE
+            - keyword: OF
+            - row_type_reference:
+                table_reference:
+                  naked_identifier: employee_salaries
+                binary_operator: '%'
+                keyword: ROWTYPE
+            - keyword: INDEX
+            - keyword: BY
+            - data_type:
+                data_type_identifier: SIMPLE_INTEGER
+          - statement_terminator: ;
+          - naked_identifier: salaries
+          - data_type:
+              data_type_identifier: salaries_t
+          - statement_terminator: ;
+          - naked_identifier: idx
+          - data_type:
+              data_type_identifier: SIMPLE_INTEGER
+          - assignment_operator: :=
+          - expression:
+              numeric_literal: '0'
+          - statement_terminator: ;
+          - create_procedure_statement:
+            - keyword: PROCEDURE
+            - function_name:
+                function_name_identifier: flush_array
+            - keyword: IS
+            - declare_segment:
+                naked_identifier: n
+                keyword: CONSTANT
+                data_type:
+                  data_type_identifier: SIMPLE_INTEGER
+                assignment_operator: :=
+                expression:
+                  function:
+                    function_name:
+                      naked_identifier: salaries
+                      dot: .
+                      function_name_identifier: count
+                    function_contents:
+                      bracketed:
+                        start_bracket: (
+                        end_bracket: )
+                statement_terminator: ;
+            - begin_end_block:
+              - keyword: BEGIN
+              - statement:
+                  forall_statement:
+                  - keyword: FORALL
+                  - naked_identifier: j
+                  - keyword: IN
+                  - numeric_literal: '1'
+                  - dot: .
+                  - dot: .
+                  - naked_identifier: n
+                  - insert_statement:
                     - keyword: INSERT
                     - keyword: INTO
                     - table_reference:
-                        naked_identifier: employees
-                    - bracketed:
-                      - start_bracket: (
-                      - column_reference:
-                          naked_identifier: employee_id
-                      - comma: ','
-                      - column_reference:
-                          naked_identifier: last_name
-                      - comma: ','
-                      - column_reference:
-                          naked_identifier: email
-                      - comma: ','
-                      - column_reference:
-                          naked_identifier: hire_date
-                      - comma: ','
-                      - column_reference:
-                          naked_identifier: job_id
-                      - comma: ','
-                      - column_reference:
-                          naked_identifier: salary
-                      - comma: ','
-                      - column_reference:
-                          naked_identifier: department_id
-                      - end_bracket: )
+                        naked_identifier: employee_salaries
                     - values_clause:
                         keyword: VALUES
-                        bracketed:
-                        - start_bracket: (
-                        - sqlplus_variable:
-                          - colon: ':'
-                          - parameter: Employee
-                          - dot: .
-                          - parameter: emp_id
-                        - comma: ','
-                        - sqlplus_variable:
-                          - colon: ':'
-                          - parameter: Employee
-                          - dot: .
-                          - parameter: lastname
-                        - comma: ','
-                        - expression:
-                            sqlplus_variable:
-                            - colon: ':'
-                            - parameter: Employee
-                            - dot: .
-                            - parameter: lastname
-                            binary_operator:
-                            - pipe: '|'
-                            - pipe: '|'
-                            quoted_literal: "'@example.com'"
-                        - comma: ','
-                        - expression:
-                            bare_function: SYSDATE
-                        - comma: ','
-                        - sqlplus_variable:
-                          - colon: ':'
-                          - parameter: Employee
-                          - dot: .
-                          - parameter: job
-                        - comma: ','
-                        - sqlplus_variable:
-                          - colon: ':'
-                          - parameter: Employee
-                          - dot: .
-                          - parameter: sal
-                        - comma: ','
-                        - sqlplus_variable:
-                          - colon: ':'
-                          - parameter: Department
-                          - dot: .
-                          - parameter: department_id
-                        - end_bracket: )
-                - statement_terminator: ;
-                - keyword: END
+                        expression:
+                          function:
+                            function_name:
+                              function_name_identifier: salaries
+                            function_contents:
+                              bracketed:
+                                start_bracket: (
+                                expression:
+                                  column_reference:
+                                    naked_identifier: j
+                                end_bracket: )
+              - statement_terminator: ;
+              - statement:
+                  function:
+                    function_name:
+                      naked_identifier: salaries
+                      dot: .
+                      function_name_identifier: delete
+                    function_contents:
+                      bracketed:
+                        start_bracket: (
+                        end_bracket: )
+              - statement_terminator: ;
+              - statement:
+                  assignment_segment_statement:
+                    object_reference:
+                      naked_identifier: idx
+                    assignment_operator: :=
+                    expression:
+                      numeric_literal: '0'
+              - statement_terminator: ;
+              - statement:
+                  function:
+                    function_name:
+                      naked_identifier: DBMS_OUTPUT
+                      dot: .
+                      function_name_identifier: PUT_LINE
+                    function_contents:
+                      bracketed:
+                        start_bracket: (
+                        expression:
+                        - quoted_literal: "'Flushed '"
+                        - binary_operator:
+                          - pipe: '|'
+                          - pipe: '|'
+                        - column_reference:
+                            naked_identifier: n
+                        - binary_operator:
+                          - pipe: '|'
+                          - pipe: '|'
+                        - quoted_literal: "' rows'"
+                        end_bracket: )
+              - statement_terminator: ;
+              - keyword: END
+              - object_reference:
+                  naked_identifier: flush_array
             - statement_terminator: ;
-            - statement_terminator: /
-            - statement:
-                create_trigger_statement:
-                - keyword: CREATE
-                - keyword: OR
-                - keyword: REPLACE
-                - keyword: TRIGGER
-                - trigger_reference:
-                    naked_identifier: maintain_employee_salaries
-                - keyword: FOR
-                - dml_event_clause:
-                  - keyword: UPDATE
-                  - keyword: OF
+        - timing_point_section:
+          - keyword: AFTER
+          - keyword: EACH
+          - keyword: ROW
+          - keyword: IS
+          - keyword: BEGIN
+          - statement:
+              assignment_segment_statement:
+                object_reference:
+                  naked_identifier: idx
+                assignment_operator: :=
+                expression:
+                  column_reference:
+                    naked_identifier: idx
+                  binary_operator: +
+                  numeric_literal: '1'
+          - statement_terminator: ;
+          - statement:
+              assignment_segment_statement:
+              - object_reference:
+                  naked_identifier: salaries
+              - bracketed:
+                  start_bracket: (
+                  object_reference:
+                    naked_identifier: idx
+                  end_bracket: )
+              - dot: .
+              - object_reference:
+                  naked_identifier: employee_id
+              - assignment_operator: :=
+              - expression:
+                  bind_variable:
+                    colon_delimiter: ':'
+                    trigger_correlation_name:
+                      keyword: NEW
+                    dot: .
+                    naked_identifier: employee_id
+          - statement_terminator: ;
+          - statement:
+              assignment_segment_statement:
+              - object_reference:
+                  naked_identifier: salaries
+              - bracketed:
+                  start_bracket: (
+                  object_reference:
+                    naked_identifier: idx
+                  end_bracket: )
+              - dot: .
+              - object_reference:
+                  naked_identifier: change_date
+              - assignment_operator: :=
+              - expression:
+                  bare_function: SYSTIMESTAMP
+          - statement_terminator: ;
+          - statement:
+              assignment_segment_statement:
+              - object_reference:
+                  naked_identifier: salaries
+              - bracketed:
+                  start_bracket: (
+                  object_reference:
+                    naked_identifier: idx
+                  end_bracket: )
+              - dot: .
+              - object_reference:
+                  naked_identifier: salary
+              - assignment_operator: :=
+              - expression:
+                  bind_variable:
+                    colon_delimiter: ':'
+                    trigger_correlation_name:
+                      keyword: NEW
+                    dot: .
+                    naked_identifier: salary
+          - statement_terminator: ;
+          - statement:
+              if_then_statement:
+              - if_clause:
+                - keyword: IF
+                - expression:
                   - column_reference:
-                      naked_identifier: salary
-                  - keyword: 'ON'
-                  - table_reference:
-                      naked_identifier: employees
-                - compound_trigger_statement:
-                  - keyword: COMPOUND
-                  - keyword: TRIGGER
-                  - declare_segment:
-                    - naked_identifier: threshhold
-                    - keyword: CONSTANT
-                    - data_type:
-                        data_type_identifier: SIMPLE_INTEGER
-                    - assignment_operator: :=
-                    - expression:
-                        numeric_literal: '7'
-                    - statement_terminator: ;
-                    - collection_type:
-                      - keyword: TYPE
-                      - naked_identifier: salaries_t
-                      - keyword: IS
-                      - keyword: TABLE
-                      - keyword: OF
-                      - row_type_reference:
-                          table_reference:
-                            naked_identifier: employee_salaries
-                          binary_operator: '%'
-                          keyword: ROWTYPE
-                      - keyword: INDEX
-                      - keyword: BY
-                      - data_type:
-                          data_type_identifier: SIMPLE_INTEGER
-                    - statement_terminator: ;
-                    - naked_identifier: salaries
-                    - data_type:
-                        data_type_identifier: salaries_t
-                    - statement_terminator: ;
-                    - naked_identifier: idx
-                    - data_type:
-                        data_type_identifier: SIMPLE_INTEGER
-                    - assignment_operator: :=
-                    - expression:
-                        numeric_literal: '0'
-                    - statement_terminator: ;
-                    - create_procedure_statement:
-                      - keyword: PROCEDURE
-                      - function_name:
-                          function_name_identifier: flush_array
-                      - keyword: IS
-                      - declare_segment:
-                          naked_identifier: n
-                          keyword: CONSTANT
-                          data_type:
-                            data_type_identifier: SIMPLE_INTEGER
-                          assignment_operator: :=
-                          expression:
-                            function:
-                              function_name:
-                                naked_identifier: salaries
-                                dot: .
-                                function_name_identifier: count
-                              function_contents:
-                                bracketed:
-                                  start_bracket: (
-                                  end_bracket: )
-                          statement_terminator: ;
-                      - begin_end_block:
-                        - keyword: BEGIN
-                        - statement:
-                            forall_statement:
-                            - keyword: FORALL
-                            - naked_identifier: j
-                            - keyword: IN
-                            - numeric_literal: '1'
-                            - dot: .
-                            - dot: .
-                            - naked_identifier: n
-                            - insert_statement:
-                              - keyword: INSERT
-                              - keyword: INTO
-                              - table_reference:
-                                  naked_identifier: employee_salaries
-                              - values_clause:
-                                  keyword: VALUES
-                                  expression:
-                                    function:
-                                      function_name:
-                                        function_name_identifier: salaries
-                                      function_contents:
-                                        bracketed:
-                                          start_bracket: (
-                                          expression:
-                                            column_reference:
-                                              naked_identifier: j
-                                          end_bracket: )
-                        - statement_terminator: ;
-                        - statement:
-                            function:
-                              function_name:
-                                naked_identifier: salaries
-                                dot: .
-                                function_name_identifier: delete
-                              function_contents:
-                                bracketed:
-                                  start_bracket: (
-                                  end_bracket: )
-                        - statement_terminator: ;
-                        - statement:
-                            assignment_segment_statement:
-                              object_reference:
-                                naked_identifier: idx
-                              assignment_operator: :=
-                              expression:
-                                numeric_literal: '0'
-                        - statement_terminator: ;
-                        - statement:
-                            function:
-                              function_name:
-                                naked_identifier: DBMS_OUTPUT
-                                dot: .
-                                function_name_identifier: PUT_LINE
-                              function_contents:
-                                bracketed:
-                                  start_bracket: (
-                                  expression:
-                                  - quoted_literal: "'Flushed '"
-                                  - binary_operator:
-                                    - pipe: '|'
-                                    - pipe: '|'
-                                  - column_reference:
-                                      naked_identifier: n
-                                  - binary_operator:
-                                    - pipe: '|'
-                                    - pipe: '|'
-                                  - quoted_literal: "' rows'"
-                                  end_bracket: )
-                        - statement_terminator: ;
-                        - keyword: END
-                        - object_reference:
-                            naked_identifier: flush_array
-                      - statement_terminator: ;
-                  - timing_point_section:
-                    - keyword: AFTER
-                    - keyword: EACH
-                    - keyword: ROW
-                    - keyword: IS
-                    - keyword: BEGIN
-                    - statement:
-                        assignment_segment_statement:
-                          object_reference:
-                            naked_identifier: idx
-                          assignment_operator: :=
-                          expression:
-                            column_reference:
-                              naked_identifier: idx
-                            binary_operator: +
-                            numeric_literal: '1'
-                    - statement_terminator: ;
-                    - statement:
-                        assignment_segment_statement:
-                        - object_reference:
-                            naked_identifier: salaries
-                        - bracketed:
-                            start_bracket: (
-                            object_reference:
-                              naked_identifier: idx
-                            end_bracket: )
-                        - dot: .
-                        - object_reference:
-                            naked_identifier: employee_id
-                        - assignment_operator: :=
-                        - expression:
-                            bind_variable:
-                              colon_delimiter: ':'
-                              trigger_correlation_name:
-                                keyword: NEW
-                              dot: .
-                              naked_identifier: employee_id
-                    - statement_terminator: ;
-                    - statement:
-                        assignment_segment_statement:
-                        - object_reference:
-                            naked_identifier: salaries
-                        - bracketed:
-                            start_bracket: (
-                            object_reference:
-                              naked_identifier: idx
-                            end_bracket: )
-                        - dot: .
-                        - object_reference:
-                            naked_identifier: change_date
-                        - assignment_operator: :=
-                        - expression:
-                            bare_function: SYSTIMESTAMP
-                    - statement_terminator: ;
-                    - statement:
-                        assignment_segment_statement:
-                        - object_reference:
-                            naked_identifier: salaries
-                        - bracketed:
-                            start_bracket: (
-                            object_reference:
-                              naked_identifier: idx
-                            end_bracket: )
-                        - dot: .
-                        - object_reference:
-                            naked_identifier: salary
-                        - assignment_operator: :=
-                        - expression:
-                            bind_variable:
-                              colon_delimiter: ':'
-                              trigger_correlation_name:
-                                keyword: NEW
-                              dot: .
-                              naked_identifier: salary
-                    - statement_terminator: ;
-                    - statement:
-                        if_then_statement:
-                        - if_clause:
-                          - keyword: IF
-                          - expression:
-                            - column_reference:
-                                naked_identifier: idx
-                            - comparison_operator:
-                              - raw_comparison_operator: '>'
-                              - raw_comparison_operator: '='
-                            - column_reference:
-                                naked_identifier: threshhold
-                          - keyword: THEN
-                        - statement:
-                            function:
-                              function_name:
-                                function_name_identifier: flush_array
-                              function_contents:
-                                bracketed:
-                                  start_bracket: (
-                                  end_bracket: )
-                        - statement_terminator: ;
-                        - keyword: END
-                        - keyword: IF
-                    - statement_terminator: ;
-                    - keyword: END
-                    - keyword: AFTER
-                    - keyword: EACH
-                    - keyword: ROW
-                    - statement_terminator: ;
-                  - timing_point_section:
-                    - keyword: AFTER
-                    - keyword: STATEMENT
-                    - keyword: IS
-                    - keyword: BEGIN
-                    - statement:
-                        function:
-                          function_name:
-                            function_name_identifier: flush_array
-                          function_contents:
-                            bracketed:
-                              start_bracket: (
-                              end_bracket: )
-                    - statement_terminator: ;
-                    - keyword: END
-                    - keyword: AFTER
-                    - keyword: STATEMENT
-                    - statement_terminator: ;
-                - keyword: END
-                - trigger_reference:
-                    naked_identifier: maintain_employee_salaries
-            - statement_terminator: ;
-            - statement_terminator: /
-            - statement:
-                create_trigger_statement:
-                - keyword: CREATE
-                - keyword: OR
-                - keyword: REPLACE
-                - keyword: TRIGGER
-                - trigger_reference:
-                    naked_identifier: insert_or_update_trigger
-                - keyword: BEFORE
-                - dml_event_clause:
-                  - keyword: INSERT
-                  - keyword: OR
-                  - keyword: UPDATE
-                  - keyword: 'ON'
-                  - table_reference:
-                      naked_identifier: your_table_name
-                - keyword: FOR
-                - keyword: EACH
-                - keyword: ROW
-                - statement:
-                    begin_end_block:
-                    - keyword: BEGIN
-                    - statement:
-                        if_then_statement:
-                        - if_clause:
-                          - keyword: IF
-                          - keyword: INSERTING
-                          - keyword: THEN
-                        - statement:
-                            assignment_segment_statement:
-                              bind_variable:
-                                colon_delimiter: ':'
-                                trigger_correlation_name:
-                                  keyword: new
-                                dot: .
-                                naked_identifier: created_at
-                              assignment_operator: :=
-                              expression:
-                                bare_function: CURRENT_TIMESTAMP
-                        - statement_terminator: ;
-                        - keyword: ELSIF
-                        - keyword: UPDATING
-                        - keyword: THEN
-                        - statement:
-                            assignment_segment_statement:
-                              bind_variable:
-                                colon_delimiter: ':'
-                                trigger_correlation_name:
-                                  keyword: new
-                                dot: .
-                                naked_identifier: updated_at
-                              assignment_operator: :=
-                              expression:
-                                bare_function: CURRENT_TIMESTAMP
-                        - statement_terminator: ;
-                        - keyword: END
-                        - keyword: IF
-                    - statement_terminator: ;
-                    - keyword: END
-                - statement_terminator: ;
+                      naked_identifier: idx
+                  - comparison_operator:
+                    - raw_comparison_operator: '>'
+                    - raw_comparison_operator: '='
+                  - column_reference:
+                      naked_identifier: threshhold
+                - keyword: THEN
+              - statement:
+                  function:
+                    function_name:
+                      function_name_identifier: flush_array
+                    function_contents:
+                      bracketed:
+                        start_bracket: (
+                        end_bracket: )
+              - statement_terminator: ;
+              - keyword: END
+              - keyword: IF
+          - statement_terminator: ;
+          - keyword: END
+          - keyword: AFTER
+          - keyword: EACH
+          - keyword: ROW
+          - statement_terminator: ;
+        - timing_point_section:
+          - keyword: AFTER
+          - keyword: STATEMENT
+          - keyword: IS
+          - keyword: BEGIN
+          - statement:
+              function:
+                function_name:
+                  function_name_identifier: flush_array
+                function_contents:
+                  bracketed:
+                    start_bracket: (
+                    end_bracket: )
+          - statement_terminator: ;
+          - keyword: END
+          - keyword: AFTER
+          - keyword: STATEMENT
+          - statement_terminator: ;
+      - keyword: END
+      - trigger_reference:
+          naked_identifier: maintain_employee_salaries
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      create_trigger_statement:
+      - keyword: CREATE
+      - keyword: OR
+      - keyword: REPLACE
+      - keyword: TRIGGER
+      - trigger_reference:
+          naked_identifier: insert_or_update_trigger
+      - keyword: BEFORE
+      - dml_event_clause:
+        - keyword: INSERT
+        - keyword: OR
+        - keyword: UPDATE
+        - keyword: 'ON'
+        - table_reference:
+            naked_identifier: your_table_name
+      - keyword: FOR
+      - keyword: EACH
+      - keyword: ROW
+      - statement:
+          begin_end_block:
+          - keyword: BEGIN
+          - statement:
+              if_then_statement:
+              - if_clause:
+                - keyword: IF
+                - keyword: INSERTING
+                - keyword: THEN
+              - statement:
+                  assignment_segment_statement:
+                    bind_variable:
+                      colon_delimiter: ':'
+                      trigger_correlation_name:
+                        keyword: new
+                      dot: .
+                      naked_identifier: created_at
+                    assignment_operator: :=
+                    expression:
+                      bare_function: CURRENT_TIMESTAMP
+              - statement_terminator: ;
+              - keyword: ELSIF
+              - keyword: UPDATING
+              - keyword: THEN
+              - statement:
+                  assignment_segment_statement:
+                    bind_variable:
+                      colon_delimiter: ':'
+                      trigger_correlation_name:
+                        keyword: new
+                      dot: .
+                      naked_identifier: updated_at
+                    assignment_operator: :=
+                    expression:
+                      bare_function: CURRENT_TIMESTAMP
+              - statement_terminator: ;
+              - keyword: END
+              - keyword: IF
+          - statement_terminator: ;
+          - keyword: END
+      - statement_terminator: ;

--- a/test/fixtures/dialects/oracle/create_type.yml
+++ b/test/fixtures/dialects/oracle/create_type.yml
@@ -3,487 +3,521 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 077f26cb3da5612a2e421697b9c7a968da02430f65c4908a0d9b8350f61b1234
+_hash: b10c544bc2d8d6374985867e1ba3ea443d29baed3deff5100566623b66301a8d
 file:
-- statement:
-    create_type_statement:
-    - keyword: CREATE
-    - keyword: TYPE
-    - type_reference:
-        naked_identifier: customer_typ_demo
-    - keyword: AS
-    - keyword: OBJECT
-    - bracketed:
-      - start_bracket: (
-      - naked_identifier: customer_id
-      - data_type:
-          data_type_identifier: NUMBER
-          bracketed_arguments:
-            bracketed:
-              start_bracket: (
-              numeric_literal: '6'
-              end_bracket: )
-      - comma: ','
-      - naked_identifier: cust_first_name
-      - data_type:
-          data_type_identifier: VARCHAR2
-          bracketed_arguments:
-            bracketed:
-              start_bracket: (
-              numeric_literal: '20'
-              end_bracket: )
-      - comma: ','
-      - naked_identifier: cust_last_name
-      - data_type:
-          data_type_identifier: VARCHAR2
-          bracketed_arguments:
-            bracketed:
-              start_bracket: (
-              numeric_literal: '20'
-              end_bracket: )
-      - comma: ','
-      - naked_identifier: cust_address
-      - data_type:
-          data_type_identifier: CUST_ADDRESS_TYP
-      - comma: ','
-      - naked_identifier: phone_numbers
-      - data_type:
-          data_type_identifier: PHONE_LIST_TYP
-      - comma: ','
-      - naked_identifier: nls_language
-      - data_type:
-          data_type_identifier: VARCHAR2
-          bracketed_arguments:
-            bracketed:
-              start_bracket: (
-              numeric_literal: '3'
-              end_bracket: )
-      - comma: ','
-      - naked_identifier: nls_territory
-      - data_type:
-          data_type_identifier: VARCHAR2
-          bracketed_arguments:
-            bracketed:
-              start_bracket: (
-              numeric_literal: '30'
-              end_bracket: )
-      - comma: ','
-      - naked_identifier: credit_limit
-      - data_type:
-          data_type_identifier: NUMBER
-          bracketed_arguments:
-            bracketed:
-            - start_bracket: (
-            - numeric_literal: '9'
-            - comma: ','
-            - numeric_literal: '2'
-            - end_bracket: )
-      - comma: ','
-      - naked_identifier: cust_email
-      - data_type:
-          data_type_identifier: VARCHAR2
-          bracketed_arguments:
-            bracketed:
-              start_bracket: (
-              numeric_literal: '30'
-              end_bracket: )
-      - comma: ','
-      - naked_identifier: cust_orders
-      - data_type:
-          data_type_identifier: ORDER_LIST_TYP
-      - end_bracket: )
-- statement_terminator: ;
-- statement_terminator: /
-- statement:
-    create_type_statement:
-    - keyword: CREATE
-    - keyword: TYPE
-    - type_reference:
-        naked_identifier: data_typ1
-    - keyword: AS
-    - keyword: OBJECT
-    - bracketed:
-        start_bracket: (
-        naked_identifier: year
-        data_type:
-          data_type_identifier: NUMBER
-        comma: ','
-        keyword: MEMBER
-        create_function_statement:
-        - keyword: FUNCTION
-        - function_name:
-            function_name_identifier: prod
-        - function_parameter_list:
-            bracketed:
-              start_bracket: (
-              parameter: invent
-              data_type:
-                data_type_identifier: NUMBER
-              end_bracket: )
-        - keyword: RETURN
+- batch:
+    statement:
+      create_type_statement:
+      - keyword: CREATE
+      - keyword: TYPE
+      - type_reference:
+          naked_identifier: customer_typ_demo
+      - keyword: AS
+      - keyword: OBJECT
+      - bracketed:
+        - start_bracket: (
+        - naked_identifier: customer_id
         - data_type:
             data_type_identifier: NUMBER
-        end_bracket: )
-- statement_terminator: ;
-- statement_terminator: /
-- statement:
-    create_type_statement:
-    - keyword: CREATE
-    - keyword: TYPE
-    - type_reference:
-        naked_identifier: corporate_customer_typ_demo
-    - keyword: UNDER
-    - object_reference:
-        naked_identifier: customer_typ
-    - bracketed:
-        start_bracket: (
-        naked_identifier: account_mgr_id
-        data_type:
-          data_type_identifier: NUMBER
-          bracketed_arguments:
-            bracketed:
-              start_bracket: (
-              numeric_literal: '6'
-              end_bracket: )
-        end_bracket: )
-- statement_terminator: ;
-- statement_terminator: /
-- statement:
-    create_type_statement:
-    - keyword: CREATE
-    - keyword: TYPE
-    - type_reference:
-        naked_identifier: person_t
-    - keyword: AS
-    - keyword: OBJECT
-    - bracketed:
-      - start_bracket: (
-      - naked_identifier: name
-      - data_type:
-          data_type_identifier: VARCHAR2
-          bracketed_arguments:
-            bracketed:
-              start_bracket: (
-              numeric_literal: '100'
-              end_bracket: )
-      - comma: ','
-      - naked_identifier: ssn
-      - data_type:
-          data_type_identifier: NUMBER
-      - end_bracket: )
-    - keyword: NOT
-    - keyword: FINAL
-- statement_terminator: ;
-- statement_terminator: /
-- statement:
-    create_type_statement:
-    - keyword: CREATE
-    - keyword: TYPE
-    - type_reference:
-        naked_identifier: employee_t
-    - keyword: UNDER
-    - object_reference:
-        naked_identifier: person_t
-    - bracketed:
-      - start_bracket: (
-      - naked_identifier: department_id
-      - data_type:
-          data_type_identifier: NUMBER
-      - comma: ','
-      - naked_identifier: salary
-      - data_type:
-          data_type_identifier: NUMBER
-      - end_bracket: )
-    - keyword: NOT
-    - keyword: FINAL
-- statement_terminator: ;
-- statement_terminator: /
-- statement:
-    create_type_statement:
-    - keyword: CREATE
-    - keyword: TYPE
-    - type_reference:
-        naked_identifier: part_time_emp_t
-    - keyword: UNDER
-    - object_reference:
-        naked_identifier: employee_t
-    - bracketed:
-        start_bracket: (
-        naked_identifier: num_hrs
-        data_type:
-          data_type_identifier: NUMBER
-        end_bracket: )
-- statement_terminator: ;
-- statement_terminator: /
-- statement:
-    create_type_statement:
-    - keyword: CREATE
-    - keyword: TYPE
-    - type_reference:
-        naked_identifier: phone_list_typ_demo
-    - keyword: AS
-    - keyword: VARRAY
-    - bracketed:
-        start_bracket: (
-        numeric_literal: '5'
-        end_bracket: )
-    - keyword: OF
-    - data_type:
-        data_type_identifier: VARCHAR2
-        bracketed_arguments:
-          bracketed:
-            start_bracket: (
-            numeric_literal: '25'
-            end_bracket: )
-- statement_terminator: ;
-- statement_terminator: /
-- statement:
-    create_type_statement:
-    - keyword: CREATE
-    - keyword: TYPE
-    - keyword: IF
-    - keyword: NOT
-    - keyword: EXISTS
-    - type_reference:
-        naked_identifier: varr_int
-    - keyword: AS
-    - keyword: VARRAY
-    - bracketed:
-        start_bracket: (
-        numeric_literal: '10'
-        end_bracket: )
-    - keyword: OF
-    - bracketed:
-        start_bracket: (
-        data_type:
-          data_type_identifier: PLS_INTEGER
-        end_bracket: )
-    - keyword: NOT
-    - keyword: PERSISTABLE
-- statement_terminator: ;
-- statement_terminator: /
-- statement:
-    create_type_statement:
-    - keyword: CREATE
-    - keyword: TYPE
-    - type_reference:
-        naked_identifier: plsint
-    - keyword: AS
-    - keyword: OBJECT
-    - bracketed:
-        start_bracket: (
-        naked_identifier: I
-        data_type:
-          data_type_identifier: PLS_INTEGER
-        end_bracket: )
-    - keyword: NOT
-    - keyword: PERSISTABLE
-- statement_terminator: ;
-- statement_terminator: /
-- statement:
-    create_type_statement:
-    - keyword: CREATE
-    - keyword: TYPE
-    - type_reference:
-        naked_identifier: tab_plsint
-    - keyword: AS
-    - keyword: TABLE
-    - keyword: OF
-    - bracketed:
-        start_bracket: (
-        data_type:
-          data_type_identifier: PLS_INTEGER
-        end_bracket: )
-    - keyword: NOT
-    - keyword: PERSISTABLE
-- statement_terminator: ;
-- statement_terminator: /
-- statement:
-    create_type_statement:
-    - keyword: CREATE
-    - keyword: TYPE
-    - type_reference:
-        naked_identifier: textdoc_typ
-    - keyword: AS
-    - keyword: OBJECT
-    - bracketed:
-      - start_bracket: (
-      - naked_identifier: document_typ
-      - data_type:
-          data_type_identifier: VARCHAR2
-          bracketed_arguments:
-            bracketed:
-              start_bracket: (
-              numeric_literal: '32'
-              end_bracket: )
-      - comma: ','
-      - naked_identifier: formatted_doc
-      - data_type:
-          data_type_identifier: BLOB
-      - end_bracket: )
-- statement_terminator: ;
-- statement_terminator: /
-- statement:
-    create_type_statement:
-    - keyword: CREATE
-    - keyword: TYPE
-    - type_reference:
-        naked_identifier: textdoc_tab
-    - keyword: AS
-    - keyword: TABLE
-    - keyword: OF
-    - data_type:
-        data_type_identifier: textdoc_typ
-- statement_terminator: ;
-- statement_terminator: /
-- statement:
-    create_type_statement:
-    - keyword: CREATE
-    - keyword: TYPE
-    - type_reference:
-        naked_identifier: cust_address_typ2
-    - keyword: AS
-    - keyword: OBJECT
-    - bracketed:
-      - start_bracket: (
-      - naked_identifier: street_address
-      - data_type:
-          data_type_identifier: VARCHAR2
-          bracketed_arguments:
-            bracketed:
-              start_bracket: (
-              numeric_literal: '40'
-              end_bracket: )
-      - comma: ','
-      - naked_identifier: postal_code
-      - data_type:
-          data_type_identifier: VARCHAR2
-          bracketed_arguments:
-            bracketed:
-              start_bracket: (
-              numeric_literal: '10'
-              end_bracket: )
-      - comma: ','
-      - naked_identifier: city
-      - data_type:
-          data_type_identifier: VARCHAR2
-          bracketed_arguments:
-            bracketed:
-              start_bracket: (
-              numeric_literal: '30'
-              end_bracket: )
-      - comma: ','
-      - naked_identifier: state_province
-      - data_type:
-          data_type_identifier: VARCHAR2
-          bracketed_arguments:
-            bracketed:
-              start_bracket: (
-              numeric_literal: '10'
-              end_bracket: )
-      - comma: ','
-      - naked_identifier: country_id
-      - data_type:
-          data_type_identifier: CHAR
-          bracketed_arguments:
-            bracketed:
-              start_bracket: (
-              numeric_literal: '2'
-              end_bracket: )
-      - comma: ','
-      - naked_identifier: phone
-      - data_type:
-          data_type_identifier: phone_list_typ_demo
-      - end_bracket: )
-- statement_terminator: ;
-- statement_terminator: /
-- statement:
-    create_type_statement:
-    - keyword: CREATE
-    - keyword: TYPE
-    - type_reference:
-        naked_identifier: cust_nt_address_typ
-    - keyword: AS
-    - keyword: TABLE
-    - keyword: OF
-    - data_type:
-        data_type_identifier: cust_address_typ2
-- statement_terminator: ;
-- statement_terminator: /
-- statement:
-    create_type_statement:
-    - keyword: CREATE
-    - keyword: TYPE
-    - type_reference:
-        naked_identifier: demo_typ1
-    - keyword: AS
-    - keyword: OBJECT
-    - bracketed:
-      - start_bracket: (
-      - naked_identifier: a1
-      - data_type:
-          data_type_identifier: NUMBER
-      - comma: ','
-      - naked_identifier: a2
-      - data_type:
-          data_type_identifier: NUMBER
-      - end_bracket: )
-- statement_terminator: ;
-- statement_terminator: /
-- statement:
-    create_type_statement:
-    - keyword: CREATE
-    - keyword: TYPE
-    - type_reference:
-        naked_identifier: demo_typ2
-    - keyword: AS
-    - keyword: OBJECT
-    - bracketed:
-        start_bracket: (
-        naked_identifier: a1
-        data_type:
-          data_type_identifier: NUMBER
-        comma: ','
-        keyword: MEMBER
-        create_function_statement:
-        - keyword: FUNCTION
-        - function_name:
-            function_name_identifier: get_square
-        - keyword: RETURN
+            bracketed_arguments:
+              bracketed:
+                start_bracket: (
+                numeric_literal: '6'
+                end_bracket: )
+        - comma: ','
+        - naked_identifier: cust_first_name
+        - data_type:
+            data_type_identifier: VARCHAR2
+            bracketed_arguments:
+              bracketed:
+                start_bracket: (
+                numeric_literal: '20'
+                end_bracket: )
+        - comma: ','
+        - naked_identifier: cust_last_name
+        - data_type:
+            data_type_identifier: VARCHAR2
+            bracketed_arguments:
+              bracketed:
+                start_bracket: (
+                numeric_literal: '20'
+                end_bracket: )
+        - comma: ','
+        - naked_identifier: cust_address
+        - data_type:
+            data_type_identifier: CUST_ADDRESS_TYP
+        - comma: ','
+        - naked_identifier: phone_numbers
+        - data_type:
+            data_type_identifier: PHONE_LIST_TYP
+        - comma: ','
+        - naked_identifier: nls_language
+        - data_type:
+            data_type_identifier: VARCHAR2
+            bracketed_arguments:
+              bracketed:
+                start_bracket: (
+                numeric_literal: '3'
+                end_bracket: )
+        - comma: ','
+        - naked_identifier: nls_territory
+        - data_type:
+            data_type_identifier: VARCHAR2
+            bracketed_arguments:
+              bracketed:
+                start_bracket: (
+                numeric_literal: '30'
+                end_bracket: )
+        - comma: ','
+        - naked_identifier: credit_limit
         - data_type:
             data_type_identifier: NUMBER
-        end_bracket: )
-- statement_terminator: ;
-- statement_terminator: /
-- statement:
-    create_type_statement:
-    - keyword: CREATE
-    - keyword: OR
-    - keyword: REPLACE
-    - keyword: TYPE
-    - type_reference:
-        naked_identifier: department_t
-    - keyword: AS
-    - keyword: OBJECT
-    - bracketed:
-      - start_bracket: (
-      - naked_identifier: deptno
+            bracketed_arguments:
+              bracketed:
+              - start_bracket: (
+              - numeric_literal: '9'
+              - comma: ','
+              - numeric_literal: '2'
+              - end_bracket: )
+        - comma: ','
+        - naked_identifier: cust_email
+        - data_type:
+            data_type_identifier: VARCHAR2
+            bracketed_arguments:
+              bracketed:
+                start_bracket: (
+                numeric_literal: '30'
+                end_bracket: )
+        - comma: ','
+        - naked_identifier: cust_orders
+        - data_type:
+            data_type_identifier: ORDER_LIST_TYP
+        - end_bracket: )
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      create_type_statement:
+      - keyword: CREATE
+      - keyword: TYPE
+      - type_reference:
+          naked_identifier: data_typ1
+      - keyword: AS
+      - keyword: OBJECT
+      - bracketed:
+          start_bracket: (
+          naked_identifier: year
+          data_type:
+            data_type_identifier: NUMBER
+          comma: ','
+          keyword: MEMBER
+          create_function_statement:
+          - keyword: FUNCTION
+          - function_name:
+              function_name_identifier: prod
+          - function_parameter_list:
+              bracketed:
+                start_bracket: (
+                parameter: invent
+                data_type:
+                  data_type_identifier: NUMBER
+                end_bracket: )
+          - keyword: RETURN
+          - data_type:
+              data_type_identifier: NUMBER
+          end_bracket: )
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      create_type_statement:
+      - keyword: CREATE
+      - keyword: TYPE
+      - type_reference:
+          naked_identifier: corporate_customer_typ_demo
+      - keyword: UNDER
+      - object_reference:
+          naked_identifier: customer_typ
+      - bracketed:
+          start_bracket: (
+          naked_identifier: account_mgr_id
+          data_type:
+            data_type_identifier: NUMBER
+            bracketed_arguments:
+              bracketed:
+                start_bracket: (
+                numeric_literal: '6'
+                end_bracket: )
+          end_bracket: )
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      create_type_statement:
+      - keyword: CREATE
+      - keyword: TYPE
+      - type_reference:
+          naked_identifier: person_t
+      - keyword: AS
+      - keyword: OBJECT
+      - bracketed:
+        - start_bracket: (
+        - naked_identifier: name
+        - data_type:
+            data_type_identifier: VARCHAR2
+            bracketed_arguments:
+              bracketed:
+                start_bracket: (
+                numeric_literal: '100'
+                end_bracket: )
+        - comma: ','
+        - naked_identifier: ssn
+        - data_type:
+            data_type_identifier: NUMBER
+        - end_bracket: )
+      - keyword: NOT
+      - keyword: FINAL
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      create_type_statement:
+      - keyword: CREATE
+      - keyword: TYPE
+      - type_reference:
+          naked_identifier: employee_t
+      - keyword: UNDER
+      - object_reference:
+          naked_identifier: person_t
+      - bracketed:
+        - start_bracket: (
+        - naked_identifier: department_id
+        - data_type:
+            data_type_identifier: NUMBER
+        - comma: ','
+        - naked_identifier: salary
+        - data_type:
+            data_type_identifier: NUMBER
+        - end_bracket: )
+      - keyword: NOT
+      - keyword: FINAL
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      create_type_statement:
+      - keyword: CREATE
+      - keyword: TYPE
+      - type_reference:
+          naked_identifier: part_time_emp_t
+      - keyword: UNDER
+      - object_reference:
+          naked_identifier: employee_t
+      - bracketed:
+          start_bracket: (
+          naked_identifier: num_hrs
+          data_type:
+            data_type_identifier: NUMBER
+          end_bracket: )
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      create_type_statement:
+      - keyword: CREATE
+      - keyword: TYPE
+      - type_reference:
+          naked_identifier: phone_list_typ_demo
+      - keyword: AS
+      - keyword: VARRAY
+      - bracketed:
+          start_bracket: (
+          numeric_literal: '5'
+          end_bracket: )
+      - keyword: OF
       - data_type:
-          data_type_identifier: number
+          data_type_identifier: VARCHAR2
           bracketed_arguments:
             bracketed:
               start_bracket: (
-              numeric_literal: '10'
+              numeric_literal: '25'
               end_bracket: )
-      - comma: ','
-      - naked_identifier: dname
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      create_type_statement:
+      - keyword: CREATE
+      - keyword: TYPE
+      - keyword: IF
+      - keyword: NOT
+      - keyword: EXISTS
+      - type_reference:
+          naked_identifier: varr_int
+      - keyword: AS
+      - keyword: VARRAY
+      - bracketed:
+          start_bracket: (
+          numeric_literal: '10'
+          end_bracket: )
+      - keyword: OF
+      - bracketed:
+          start_bracket: (
+          data_type:
+            data_type_identifier: PLS_INTEGER
+          end_bracket: )
+      - keyword: NOT
+      - keyword: PERSISTABLE
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      create_type_statement:
+      - keyword: CREATE
+      - keyword: TYPE
+      - type_reference:
+          naked_identifier: plsint
+      - keyword: AS
+      - keyword: OBJECT
+      - bracketed:
+          start_bracket: (
+          naked_identifier: I
+          data_type:
+            data_type_identifier: PLS_INTEGER
+          end_bracket: )
+      - keyword: NOT
+      - keyword: PERSISTABLE
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      create_type_statement:
+      - keyword: CREATE
+      - keyword: TYPE
+      - type_reference:
+          naked_identifier: tab_plsint
+      - keyword: AS
+      - keyword: TABLE
+      - keyword: OF
+      - bracketed:
+          start_bracket: (
+          data_type:
+            data_type_identifier: PLS_INTEGER
+          end_bracket: )
+      - keyword: NOT
+      - keyword: PERSISTABLE
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      create_type_statement:
+      - keyword: CREATE
+      - keyword: TYPE
+      - type_reference:
+          naked_identifier: textdoc_typ
+      - keyword: AS
+      - keyword: OBJECT
+      - bracketed:
+        - start_bracket: (
+        - naked_identifier: document_typ
+        - data_type:
+            data_type_identifier: VARCHAR2
+            bracketed_arguments:
+              bracketed:
+                start_bracket: (
+                numeric_literal: '32'
+                end_bracket: )
+        - comma: ','
+        - naked_identifier: formatted_doc
+        - data_type:
+            data_type_identifier: BLOB
+        - end_bracket: )
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      create_type_statement:
+      - keyword: CREATE
+      - keyword: TYPE
+      - type_reference:
+          naked_identifier: textdoc_tab
+      - keyword: AS
+      - keyword: TABLE
+      - keyword: OF
       - data_type:
-          data_type_identifier: CHAR
-          bracketed_arguments:
-            bracketed:
-              start_bracket: (
-              numeric_literal: '30'
-              end_bracket: )
-      - end_bracket: )
-- statement_terminator: ;
-- statement_terminator: /
+          data_type_identifier: textdoc_typ
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      create_type_statement:
+      - keyword: CREATE
+      - keyword: TYPE
+      - type_reference:
+          naked_identifier: cust_address_typ2
+      - keyword: AS
+      - keyword: OBJECT
+      - bracketed:
+        - start_bracket: (
+        - naked_identifier: street_address
+        - data_type:
+            data_type_identifier: VARCHAR2
+            bracketed_arguments:
+              bracketed:
+                start_bracket: (
+                numeric_literal: '40'
+                end_bracket: )
+        - comma: ','
+        - naked_identifier: postal_code
+        - data_type:
+            data_type_identifier: VARCHAR2
+            bracketed_arguments:
+              bracketed:
+                start_bracket: (
+                numeric_literal: '10'
+                end_bracket: )
+        - comma: ','
+        - naked_identifier: city
+        - data_type:
+            data_type_identifier: VARCHAR2
+            bracketed_arguments:
+              bracketed:
+                start_bracket: (
+                numeric_literal: '30'
+                end_bracket: )
+        - comma: ','
+        - naked_identifier: state_province
+        - data_type:
+            data_type_identifier: VARCHAR2
+            bracketed_arguments:
+              bracketed:
+                start_bracket: (
+                numeric_literal: '10'
+                end_bracket: )
+        - comma: ','
+        - naked_identifier: country_id
+        - data_type:
+            data_type_identifier: CHAR
+            bracketed_arguments:
+              bracketed:
+                start_bracket: (
+                numeric_literal: '2'
+                end_bracket: )
+        - comma: ','
+        - naked_identifier: phone
+        - data_type:
+            data_type_identifier: phone_list_typ_demo
+        - end_bracket: )
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      create_type_statement:
+      - keyword: CREATE
+      - keyword: TYPE
+      - type_reference:
+          naked_identifier: cust_nt_address_typ
+      - keyword: AS
+      - keyword: TABLE
+      - keyword: OF
+      - data_type:
+          data_type_identifier: cust_address_typ2
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      create_type_statement:
+      - keyword: CREATE
+      - keyword: TYPE
+      - type_reference:
+          naked_identifier: demo_typ1
+      - keyword: AS
+      - keyword: OBJECT
+      - bracketed:
+        - start_bracket: (
+        - naked_identifier: a1
+        - data_type:
+            data_type_identifier: NUMBER
+        - comma: ','
+        - naked_identifier: a2
+        - data_type:
+            data_type_identifier: NUMBER
+        - end_bracket: )
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      create_type_statement:
+      - keyword: CREATE
+      - keyword: TYPE
+      - type_reference:
+          naked_identifier: demo_typ2
+      - keyword: AS
+      - keyword: OBJECT
+      - bracketed:
+          start_bracket: (
+          naked_identifier: a1
+          data_type:
+            data_type_identifier: NUMBER
+          comma: ','
+          keyword: MEMBER
+          create_function_statement:
+          - keyword: FUNCTION
+          - function_name:
+              function_name_identifier: get_square
+          - keyword: RETURN
+          - data_type:
+              data_type_identifier: NUMBER
+          end_bracket: )
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      create_type_statement:
+      - keyword: CREATE
+      - keyword: OR
+      - keyword: REPLACE
+      - keyword: TYPE
+      - type_reference:
+          naked_identifier: department_t
+      - keyword: AS
+      - keyword: OBJECT
+      - bracketed:
+        - start_bracket: (
+        - naked_identifier: deptno
+        - data_type:
+            data_type_identifier: number
+            bracketed_arguments:
+              bracketed:
+                start_bracket: (
+                numeric_literal: '10'
+                end_bracket: )
+        - comma: ','
+        - naked_identifier: dname
+        - data_type:
+            data_type_identifier: CHAR
+            bracketed_arguments:
+              bracketed:
+                start_bracket: (
+                numeric_literal: '30'
+                end_bracket: )
+        - end_bracket: )
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /

--- a/test/fixtures/dialects/oracle/create_type_body.yml
+++ b/test/fixtures/dialects/oracle/create_type_body.yml
@@ -3,124 +3,128 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: a4ef227d2f94f5b5a3d4eff6bed3d34a22fd7fb0582b725c59676e89c534efca
+_hash: 6ea33a02b369ee6ed39800e2379c99469ece95d170df7ee508568216a85ba498
 file:
-- statement:
-    create_type_body_statement:
-    - keyword: CREATE
-    - keyword: TYPE
-    - keyword: BODY
-    - type_reference:
-        naked_identifier: data_typ1
-    - keyword: IS
-    - keyword: MEMBER
-    - create_function_statement:
-      - keyword: FUNCTION
-      - function_name:
-          function_name_identifier: prod
-      - function_parameter_list:
-          bracketed:
-            start_bracket: (
-            parameter: invent
+- batch:
+    statement:
+      create_type_body_statement:
+      - keyword: CREATE
+      - keyword: TYPE
+      - keyword: BODY
+      - type_reference:
+          naked_identifier: data_typ1
+      - keyword: IS
+      - keyword: MEMBER
+      - create_function_statement:
+        - keyword: FUNCTION
+        - function_name:
+            function_name_identifier: prod
+        - function_parameter_list:
+            bracketed:
+              start_bracket: (
+              parameter: invent
+              data_type:
+                data_type_identifier: NUMBER
+              end_bracket: )
+        - keyword: RETURN
+        - data_type:
+            data_type_identifier: NUMBER
+        - keyword: IS
+        - begin_end_block:
+          - keyword: BEGIN
+          - statement:
+              function:
+                function_name:
+                  function_name_identifier: RETURN
+                function_contents:
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                    - column_reference:
+                        naked_identifier: year
+                    - binary_operator: +
+                    - column_reference:
+                        naked_identifier: invent
+                    end_bracket: )
+          - statement_terminator: ;
+          - keyword: END
+        - statement_terminator: ;
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      create_type_body_statement:
+      - keyword: CREATE
+      - keyword: TYPE
+      - keyword: BODY
+      - type_reference:
+          naked_identifier: demo_typ2
+      - keyword: IS
+      - keyword: MEMBER
+      - create_function_statement:
+        - keyword: FUNCTION
+        - function_name:
+            function_name_identifier: get_square
+        - keyword: RETURN
+        - data_type:
+            data_type_identifier: NUMBER
+        - keyword: IS
+        - declare_segment:
+            naked_identifier: x
             data_type:
               data_type_identifier: NUMBER
-            end_bracket: )
-      - keyword: RETURN
-      - data_type:
-          data_type_identifier: NUMBER
-      - keyword: IS
-      - begin_end_block:
-        - keyword: BEGIN
-        - statement:
-            function:
-              function_name:
-                function_name_identifier: RETURN
-              function_contents:
-                bracketed:
-                  start_bracket: (
-                  expression:
-                  - column_reference:
-                      naked_identifier: year
-                  - binary_operator: +
-                  - column_reference:
-                      naked_identifier: invent
-                  end_bracket: )
+            statement_terminator: ;
+        - begin_end_block:
+          - keyword: BEGIN
+          - statement:
+              select_statement:
+                select_clause:
+                  keyword: SELECT
+                  select_clause_element:
+                    expression:
+                    - column_reference:
+                      - naked_identifier: c
+                      - dot: .
+                      - naked_identifier: col
+                      - dot: .
+                      - naked_identifier: a1
+                    - binary_operator: '*'
+                    - column_reference:
+                      - naked_identifier: c
+                      - dot: .
+                      - naked_identifier: col
+                      - dot: .
+                      - naked_identifier: a1
+                into_clause:
+                  keyword: INTO
+                  naked_identifier: x
+                from_clause:
+                  keyword: FROM
+                  from_expression:
+                    from_expression_element:
+                      table_expression:
+                        table_reference:
+                          naked_identifier: demo_tab2
+                      alias_expression:
+                        naked_identifier: c
+          - statement_terminator: ;
+          - statement:
+              function:
+                function_name:
+                  function_name_identifier: RETURN
+                function_contents:
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                      column_reference:
+                        naked_identifier: x
+                    end_bracket: )
+          - statement_terminator: ;
+          - keyword: END
         - statement_terminator: ;
-        - keyword: END
-      - statement_terminator: ;
-    - keyword: END
-- statement_terminator: ;
-- statement_terminator: /
-- statement:
-    create_type_body_statement:
-    - keyword: CREATE
-    - keyword: TYPE
-    - keyword: BODY
-    - type_reference:
-        naked_identifier: demo_typ2
-    - keyword: IS
-    - keyword: MEMBER
-    - create_function_statement:
-      - keyword: FUNCTION
-      - function_name:
-          function_name_identifier: get_square
-      - keyword: RETURN
-      - data_type:
-          data_type_identifier: NUMBER
-      - keyword: IS
-      - declare_segment:
-          naked_identifier: x
-          data_type:
-            data_type_identifier: NUMBER
-          statement_terminator: ;
-      - begin_end_block:
-        - keyword: BEGIN
-        - statement:
-            select_statement:
-              select_clause:
-                keyword: SELECT
-                select_clause_element:
-                  expression:
-                  - column_reference:
-                    - naked_identifier: c
-                    - dot: .
-                    - naked_identifier: col
-                    - dot: .
-                    - naked_identifier: a1
-                  - binary_operator: '*'
-                  - column_reference:
-                    - naked_identifier: c
-                    - dot: .
-                    - naked_identifier: col
-                    - dot: .
-                    - naked_identifier: a1
-              into_clause:
-                keyword: INTO
-                naked_identifier: x
-              from_clause:
-                keyword: FROM
-                from_expression:
-                  from_expression_element:
-                    table_expression:
-                      table_reference:
-                        naked_identifier: demo_tab2
-                    alias_expression:
-                      naked_identifier: c
-        - statement_terminator: ;
-        - statement:
-            function:
-              function_name:
-                function_name_identifier: RETURN
-              function_contents:
-                bracketed:
-                  start_bracket: (
-                  expression:
-                    column_reference:
-                      naked_identifier: x
-                  end_bracket: )
-        - statement_terminator: ;
-        - keyword: END
-      - statement_terminator: ;
-    - keyword: END
-- statement_terminator: ;
-- statement_terminator: /
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /

--- a/test/fixtures/dialects/oracle/create_user.yml
+++ b/test/fixtures/dialects/oracle/create_user.yml
@@ -3,186 +3,187 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: e21710c455a5d1e432b5e7bdbd8a81f8e133fd2117cea4dd4e9878fefd8af294
+_hash: bc83e1fe6b200b9a278d01129e8c517abaaca80c59062c190cce4c2fa86ba2c3
 file:
-- statement:
-    create_user_statement:
-    - keyword: CREATE
-    - keyword: USER
-    - role_reference:
-        naked_identifier: jsmith
-    - keyword: IDENTIFIED
-    - keyword: EXTERNALLY
-    - keyword: AS
-    - quoted_identifier: '"CN=foo,DNQ=123,SERIAL=234"'
-- statement_terminator: ;
-- statement:
-    create_user_statement:
-    - keyword: CREATE
-    - keyword: USER
-    - role_reference:
-        naked_identifier: tjones
-    - keyword: IDENTIFIED
-    - keyword: EXTERNALLY
-    - keyword: AS
-    - quoted_identifier: '"CN=foo,dnQualifier=123,SERIALNUMER=234"'
-- statement_terminator: ;
-- statement:
-    create_user_statement:
-    - keyword: CREATE
-    - keyword: USER
-    - role_reference:
-        naked_identifier: peter_fitch
-    - keyword: IDENTIFIED
-    - keyword: GLOBALLY
-    - keyword: AS
-    - quoted_identifier: "'AZURE_USER=peter.fitch@example.com'"
-- statement_terminator: ;
-- statement:
-    create_user_statement:
-    - keyword: CREATE
-    - keyword: USER
-    - role_reference:
-        naked_identifier: dba_azure
-    - keyword: IDENTIFIED
-    - keyword: GLOBALLY
-    - keyword: AS
-    - quoted_identifier: "'AZURE_ROLE=AZURE_DBA'"
-- statement_terminator: ;
-- statement:
-    create_user_statement:
-    - keyword: CREATE
-    - keyword: USER
-    - role_reference:
-        naked_identifier: u1
-    - keyword: IDENTIFIED
-    - keyword: BY
-    - naked_identifier: p1
-    - keyword: PROFILE
-    - object_reference:
-        naked_identifier: prof1
-- statement_terminator: ;
-- statement:
-    create_user_statement:
-    - keyword: CREATE
-    - keyword: USER
-    - role_reference:
-        naked_identifier: sidney
-    - keyword: IDENTIFIED
-    - keyword: BY
-    - naked_identifier: out_standing1
-    - keyword: DEFAULT
-    - keyword: TABLESPACE
-    - object_reference:
-        naked_identifier: example
-    - keyword: QUOTA
-    - numeric_literal: '10'
-    - size_prefix: M
-    - keyword: 'ON'
-    - object_reference:
-        naked_identifier: example
-    - keyword: TEMPORARY
-    - keyword: TABLESPACE
-    - object_reference:
-        naked_identifier: temp
-    - keyword: QUOTA
-    - numeric_literal: '5'
-    - size_prefix: M
-    - keyword: 'ON'
-    - object_reference:
-        naked_identifier: system
-    - keyword: PROFILE
-    - object_reference:
-        naked_identifier: app_user
-    - keyword: PASSWORD
-    - keyword: EXPIRE
-- statement_terminator: ;
-- statement:
-    create_user_statement:
-    - keyword: CREATE
-    - keyword: USER
-    - role_reference:
-        naked_identifier: app_user1
-    - keyword: IDENTIFIED
-    - keyword: EXTERNALLY
-    - keyword: DEFAULT
-    - keyword: TABLESPACE
-    - object_reference:
-        naked_identifier: example
-    - keyword: QUOTA
-    - numeric_literal: '5'
-    - size_prefix: M
-    - keyword: 'ON'
-    - object_reference:
-        naked_identifier: example
-    - keyword: PROFILE
-    - object_reference:
-        naked_identifier: app_user
-- statement_terminator: ;
-- statement:
-    create_user_statement:
-    - keyword: CREATE
-    - keyword: USER
-    - role_reference:
-        naked_identifier: ops$external_user
-    - keyword: IDENTIFIED
-    - keyword: EXTERNALLY
-    - keyword: DEFAULT
-    - keyword: TABLESPACE
-    - object_reference:
-        naked_identifier: example
-    - keyword: QUOTA
-    - numeric_literal: '5'
-    - size_prefix: M
-    - keyword: 'ON'
-    - object_reference:
-        naked_identifier: example
-    - keyword: PROFILE
-    - object_reference:
-        naked_identifier: app_user
-- statement_terminator: ;
-- statement:
-    create_user_statement:
-    - keyword: CREATE
-    - keyword: USER
-    - role_reference:
-        naked_identifier: global_user
-    - keyword: IDENTIFIED
-    - keyword: GLOBALLY
-    - keyword: AS
-    - quoted_identifier: "'CN=analyst, OU=division1, O=oracle, C=US'"
-    - keyword: DEFAULT
-    - keyword: TABLESPACE
-    - object_reference:
-        naked_identifier: example
-    - keyword: QUOTA
-    - numeric_literal: '5'
-    - size_prefix: M
-    - keyword: 'ON'
-    - object_reference:
-        naked_identifier: example
-- statement_terminator: ;
-- statement:
-    create_user_statement:
-    - keyword: CREATE
-    - keyword: USER
-    - role_reference:
-        naked_identifier: c##comm_user
-    - keyword: IDENTIFIED
-    - keyword: BY
-    - naked_identifier: comm_pwd
-    - keyword: DEFAULT
-    - keyword: TABLESPACE
-    - object_reference:
-        naked_identifier: example
-    - keyword: QUOTA
-    - numeric_literal: '20'
-    - size_prefix: M
-    - keyword: 'ON'
-    - object_reference:
-        naked_identifier: example
-    - keyword: TEMPORARY
-    - keyword: TABLESPACE
-    - object_reference:
-        naked_identifier: temp_tbs
-- statement_terminator: ;
+  batch:
+  - statement:
+      create_user_statement:
+      - keyword: CREATE
+      - keyword: USER
+      - role_reference:
+          naked_identifier: jsmith
+      - keyword: IDENTIFIED
+      - keyword: EXTERNALLY
+      - keyword: AS
+      - quoted_identifier: '"CN=foo,DNQ=123,SERIAL=234"'
+  - statement_terminator: ;
+  - statement:
+      create_user_statement:
+      - keyword: CREATE
+      - keyword: USER
+      - role_reference:
+          naked_identifier: tjones
+      - keyword: IDENTIFIED
+      - keyword: EXTERNALLY
+      - keyword: AS
+      - quoted_identifier: '"CN=foo,dnQualifier=123,SERIALNUMER=234"'
+  - statement_terminator: ;
+  - statement:
+      create_user_statement:
+      - keyword: CREATE
+      - keyword: USER
+      - role_reference:
+          naked_identifier: peter_fitch
+      - keyword: IDENTIFIED
+      - keyword: GLOBALLY
+      - keyword: AS
+      - quoted_identifier: "'AZURE_USER=peter.fitch@example.com'"
+  - statement_terminator: ;
+  - statement:
+      create_user_statement:
+      - keyword: CREATE
+      - keyword: USER
+      - role_reference:
+          naked_identifier: dba_azure
+      - keyword: IDENTIFIED
+      - keyword: GLOBALLY
+      - keyword: AS
+      - quoted_identifier: "'AZURE_ROLE=AZURE_DBA'"
+  - statement_terminator: ;
+  - statement:
+      create_user_statement:
+      - keyword: CREATE
+      - keyword: USER
+      - role_reference:
+          naked_identifier: u1
+      - keyword: IDENTIFIED
+      - keyword: BY
+      - naked_identifier: p1
+      - keyword: PROFILE
+      - object_reference:
+          naked_identifier: prof1
+  - statement_terminator: ;
+  - statement:
+      create_user_statement:
+      - keyword: CREATE
+      - keyword: USER
+      - role_reference:
+          naked_identifier: sidney
+      - keyword: IDENTIFIED
+      - keyword: BY
+      - naked_identifier: out_standing1
+      - keyword: DEFAULT
+      - keyword: TABLESPACE
+      - object_reference:
+          naked_identifier: example
+      - keyword: QUOTA
+      - numeric_literal: '10'
+      - size_prefix: M
+      - keyword: 'ON'
+      - object_reference:
+          naked_identifier: example
+      - keyword: TEMPORARY
+      - keyword: TABLESPACE
+      - object_reference:
+          naked_identifier: temp
+      - keyword: QUOTA
+      - numeric_literal: '5'
+      - size_prefix: M
+      - keyword: 'ON'
+      - object_reference:
+          naked_identifier: system
+      - keyword: PROFILE
+      - object_reference:
+          naked_identifier: app_user
+      - keyword: PASSWORD
+      - keyword: EXPIRE
+  - statement_terminator: ;
+  - statement:
+      create_user_statement:
+      - keyword: CREATE
+      - keyword: USER
+      - role_reference:
+          naked_identifier: app_user1
+      - keyword: IDENTIFIED
+      - keyword: EXTERNALLY
+      - keyword: DEFAULT
+      - keyword: TABLESPACE
+      - object_reference:
+          naked_identifier: example
+      - keyword: QUOTA
+      - numeric_literal: '5'
+      - size_prefix: M
+      - keyword: 'ON'
+      - object_reference:
+          naked_identifier: example
+      - keyword: PROFILE
+      - object_reference:
+          naked_identifier: app_user
+  - statement_terminator: ;
+  - statement:
+      create_user_statement:
+      - keyword: CREATE
+      - keyword: USER
+      - role_reference:
+          naked_identifier: ops$external_user
+      - keyword: IDENTIFIED
+      - keyword: EXTERNALLY
+      - keyword: DEFAULT
+      - keyword: TABLESPACE
+      - object_reference:
+          naked_identifier: example
+      - keyword: QUOTA
+      - numeric_literal: '5'
+      - size_prefix: M
+      - keyword: 'ON'
+      - object_reference:
+          naked_identifier: example
+      - keyword: PROFILE
+      - object_reference:
+          naked_identifier: app_user
+  - statement_terminator: ;
+  - statement:
+      create_user_statement:
+      - keyword: CREATE
+      - keyword: USER
+      - role_reference:
+          naked_identifier: global_user
+      - keyword: IDENTIFIED
+      - keyword: GLOBALLY
+      - keyword: AS
+      - quoted_identifier: "'CN=analyst, OU=division1, O=oracle, C=US'"
+      - keyword: DEFAULT
+      - keyword: TABLESPACE
+      - object_reference:
+          naked_identifier: example
+      - keyword: QUOTA
+      - numeric_literal: '5'
+      - size_prefix: M
+      - keyword: 'ON'
+      - object_reference:
+          naked_identifier: example
+  - statement_terminator: ;
+  - statement:
+      create_user_statement:
+      - keyword: CREATE
+      - keyword: USER
+      - role_reference:
+          naked_identifier: c##comm_user
+      - keyword: IDENTIFIED
+      - keyword: BY
+      - naked_identifier: comm_pwd
+      - keyword: DEFAULT
+      - keyword: TABLESPACE
+      - object_reference:
+          naked_identifier: example
+      - keyword: QUOTA
+      - numeric_literal: '20'
+      - size_prefix: M
+      - keyword: 'ON'
+      - object_reference:
+          naked_identifier: example
+      - keyword: TEMPORARY
+      - keyword: TABLESPACE
+      - object_reference:
+          naked_identifier: temp_tbs
+  - statement_terminator: ;

--- a/test/fixtures/dialects/oracle/create_view.yml
+++ b/test/fixtures/dialects/oracle/create_view.yml
@@ -3,338 +3,339 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: f00daf451a52a782296944b6de0c981ed0b2d02a3a1c265b1cf9ed09972247a7
+_hash: b6815f531db76686031947110f91ee5ea9920df9576c90539b3ba8eab418df8c
 file:
-- statement:
-    create_view_statement:
-    - keyword: CREATE
-    - keyword: VIEW
-    - table_reference:
-        naked_identifier: NEW_VIEW
-    - keyword: AS
-    - bracketed:
-        start_bracket: (
-        select_statement:
-          select_clause:
-            keyword: select
-            select_clause_element:
-              column_reference:
-                naked_identifier: PERSON_ID
-          from_clause:
-            keyword: from
-            from_expression:
-              from_expression_element:
-                table_expression:
-                  table_reference:
-                    naked_identifier: PERSONS
-                alias_expression:
-                  naked_identifier: p
-        end_bracket: )
-- statement_terminator: ;
-- statement:
-    create_view_statement:
-    - keyword: CREATE
-    - keyword: OR
-    - keyword: REPLACE
-    - keyword: VIEW
-    - table_reference:
-        naked_identifier: NEW_VIEW
-    - keyword: AS
-    - bracketed:
-        start_bracket: (
-        select_statement:
-          select_clause:
-            keyword: select
-            select_clause_element:
-              column_reference:
-                naked_identifier: PERSON_ID
-          from_clause:
-            keyword: from
-            from_expression:
-              from_expression_element:
-                table_expression:
-                  table_reference:
-                    naked_identifier: PERSONS
-                alias_expression:
-                  naked_identifier: p
-        end_bracket: )
-- statement_terminator: ;
-- statement:
-    create_view_statement:
-    - keyword: CREATE
-    - keyword: FORCE
-    - keyword: VIEW
-    - table_reference:
-        naked_identifier: NEW_VIEW
-    - keyword: AS
-    - bracketed:
-        start_bracket: (
-        select_statement:
-          select_clause:
-            keyword: select
-            select_clause_element:
-              column_reference:
-                naked_identifier: PERSON_ID
-          from_clause:
-            keyword: from
-            from_expression:
-              from_expression_element:
-                table_expression:
-                  table_reference:
-                    naked_identifier: PERSONS
-                alias_expression:
-                  naked_identifier: p
-        end_bracket: )
-- statement_terminator: ;
-- statement:
-    create_view_statement:
-    - keyword: CREATE
-    - keyword: 'NO'
-    - keyword: FORCE
-    - keyword: VIEW
-    - table_reference:
-        naked_identifier: NEW_VIEW
-    - keyword: AS
-    - bracketed:
-        start_bracket: (
-        select_statement:
-          select_clause:
-            keyword: select
-            select_clause_element:
-              column_reference:
-                naked_identifier: PERSON_ID
-          from_clause:
-            keyword: from
-            from_expression:
-              from_expression_element:
-                table_expression:
-                  table_reference:
-                    naked_identifier: PERSONS
-                alias_expression:
-                  naked_identifier: p
-        end_bracket: )
-- statement_terminator: ;
-- statement:
-    create_view_statement:
-    - keyword: CREATE
-    - keyword: OR
-    - keyword: REPLACE
-    - keyword: 'NO'
-    - keyword: FORCE
-    - keyword: VIEW
-    - table_reference:
-        naked_identifier: NEW_VIEW
-    - keyword: AS
-    - bracketed:
-        start_bracket: (
-        select_statement:
-          select_clause:
-            keyword: select
-            select_clause_element:
-              column_reference:
-                naked_identifier: PERSON_ID
-          from_clause:
-            keyword: from
-            from_expression:
-              from_expression_element:
-                table_expression:
-                  table_reference:
-                    naked_identifier: PERSONS
-                alias_expression:
-                  naked_identifier: p
-        end_bracket: )
-- statement_terminator: ;
-- statement:
-    create_view_statement:
-    - keyword: CREATE
-    - keyword: EDITIONING
-    - keyword: VIEW
-    - table_reference:
-        naked_identifier: NEW_VIEW
-    - keyword: AS
-    - bracketed:
-        start_bracket: (
-        select_statement:
-          select_clause:
-            keyword: select
-            select_clause_element:
-              column_reference:
-                naked_identifier: PERSON_ID
-          from_clause:
-            keyword: from
-            from_expression:
-              from_expression_element:
-                table_expression:
-                  table_reference:
-                    naked_identifier: PERSONS
-                alias_expression:
-                  naked_identifier: p
-        end_bracket: )
-- statement_terminator: ;
-- statement:
-    create_view_statement:
-    - keyword: CREATE
-    - keyword: EDITIONABLE
-    - keyword: VIEW
-    - table_reference:
-        naked_identifier: NEW_VIEW
-    - keyword: AS
-    - bracketed:
-        start_bracket: (
-        select_statement:
-          select_clause:
-            keyword: select
-            select_clause_element:
-              column_reference:
-                naked_identifier: PERSON_ID
-          from_clause:
-            keyword: from
-            from_expression:
-              from_expression_element:
-                table_expression:
-                  table_reference:
-                    naked_identifier: PERSONS
-                alias_expression:
-                  naked_identifier: p
-        end_bracket: )
-- statement_terminator: ;
-- statement:
-    create_view_statement:
-    - keyword: CREATE
-    - keyword: NONEDITIONABLE
-    - keyword: VIEW
-    - table_reference:
-        naked_identifier: NEW_VIEW
-    - keyword: AS
-    - bracketed:
-        start_bracket: (
-        select_statement:
-          select_clause:
-            keyword: select
-            select_clause_element:
-              column_reference:
-                naked_identifier: PERSON_ID
-          from_clause:
-            keyword: from
-            from_expression:
-              from_expression_element:
-                table_expression:
-                  table_reference:
-                    naked_identifier: PERSONS
-                alias_expression:
-                  naked_identifier: p
-        end_bracket: )
-- statement_terminator: ;
-- statement:
-    create_view_statement:
-    - keyword: CREATE
-    - keyword: EDITIONABLE
-    - keyword: EDITIONING
-    - keyword: VIEW
-    - table_reference:
-        naked_identifier: NEW_VIEW
-    - keyword: AS
-    - bracketed:
-        start_bracket: (
-        select_statement:
-          select_clause:
-            keyword: select
-            select_clause_element:
-              column_reference:
-                naked_identifier: PERSON_ID
-          from_clause:
-            keyword: from
-            from_expression:
-              from_expression_element:
-                table_expression:
-                  table_reference:
-                    naked_identifier: PERSONS
-                alias_expression:
-                  naked_identifier: p
-        end_bracket: )
-- statement_terminator: ;
-- statement:
-    create_view_statement:
-    - keyword: CREATE
-    - keyword: OR
-    - keyword: REPLACE
-    - keyword: EDITIONING
-    - keyword: VIEW
-    - table_reference:
-        naked_identifier: NEW_VIEW
-    - keyword: AS
-    - bracketed:
-        start_bracket: (
-        select_statement:
-          select_clause:
-            keyword: select
-            select_clause_element:
-              column_reference:
-                naked_identifier: PERSON_ID
-          from_clause:
-            keyword: from
-            from_expression:
-              from_expression_element:
-                table_expression:
-                  table_reference:
-                    naked_identifier: PERSONS
-                alias_expression:
-                  naked_identifier: p
-        end_bracket: )
-- statement_terminator: ;
-- statement:
-    create_view_statement:
-    - keyword: CREATE
-    - keyword: MATERIALIZED
-    - keyword: VIEW
-    - table_reference:
-        naked_identifier: NEW_VIEW
-    - keyword: AS
-    - bracketed:
-        start_bracket: (
-        select_statement:
-          select_clause:
-            keyword: select
-            select_clause_element:
-              column_reference:
-                naked_identifier: PERSON_ID
-          from_clause:
-            keyword: from
-            from_expression:
-              from_expression_element:
-                table_expression:
-                  table_reference:
-                    naked_identifier: PERSONS
-                alias_expression:
-                  naked_identifier: p
-        end_bracket: )
-- statement_terminator: ;
-- statement:
-    create_view_statement:
-    - keyword: CREATE
-    - keyword: OR
-    - keyword: REPLACE
-    - keyword: MATERIALIZED
-    - keyword: VIEW
-    - table_reference:
-        naked_identifier: NEW_VIEW
-    - keyword: AS
-    - bracketed:
-        start_bracket: (
-        select_statement:
-          select_clause:
-            keyword: select
-            select_clause_element:
-              column_reference:
-                naked_identifier: PERSON_ID
-          from_clause:
-            keyword: from
-            from_expression:
-              from_expression_element:
-                table_expression:
-                  table_reference:
-                    naked_identifier: PERSONS
-                alias_expression:
-                  naked_identifier: p
-        end_bracket: )
-- statement_terminator: ;
+  batch:
+  - statement:
+      create_view_statement:
+      - keyword: CREATE
+      - keyword: VIEW
+      - table_reference:
+          naked_identifier: NEW_VIEW
+      - keyword: AS
+      - bracketed:
+          start_bracket: (
+          select_statement:
+            select_clause:
+              keyword: select
+              select_clause_element:
+                column_reference:
+                  naked_identifier: PERSON_ID
+            from_clause:
+              keyword: from
+              from_expression:
+                from_expression_element:
+                  table_expression:
+                    table_reference:
+                      naked_identifier: PERSONS
+                  alias_expression:
+                    naked_identifier: p
+          end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      create_view_statement:
+      - keyword: CREATE
+      - keyword: OR
+      - keyword: REPLACE
+      - keyword: VIEW
+      - table_reference:
+          naked_identifier: NEW_VIEW
+      - keyword: AS
+      - bracketed:
+          start_bracket: (
+          select_statement:
+            select_clause:
+              keyword: select
+              select_clause_element:
+                column_reference:
+                  naked_identifier: PERSON_ID
+            from_clause:
+              keyword: from
+              from_expression:
+                from_expression_element:
+                  table_expression:
+                    table_reference:
+                      naked_identifier: PERSONS
+                  alias_expression:
+                    naked_identifier: p
+          end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      create_view_statement:
+      - keyword: CREATE
+      - keyword: FORCE
+      - keyword: VIEW
+      - table_reference:
+          naked_identifier: NEW_VIEW
+      - keyword: AS
+      - bracketed:
+          start_bracket: (
+          select_statement:
+            select_clause:
+              keyword: select
+              select_clause_element:
+                column_reference:
+                  naked_identifier: PERSON_ID
+            from_clause:
+              keyword: from
+              from_expression:
+                from_expression_element:
+                  table_expression:
+                    table_reference:
+                      naked_identifier: PERSONS
+                  alias_expression:
+                    naked_identifier: p
+          end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      create_view_statement:
+      - keyword: CREATE
+      - keyword: 'NO'
+      - keyword: FORCE
+      - keyword: VIEW
+      - table_reference:
+          naked_identifier: NEW_VIEW
+      - keyword: AS
+      - bracketed:
+          start_bracket: (
+          select_statement:
+            select_clause:
+              keyword: select
+              select_clause_element:
+                column_reference:
+                  naked_identifier: PERSON_ID
+            from_clause:
+              keyword: from
+              from_expression:
+                from_expression_element:
+                  table_expression:
+                    table_reference:
+                      naked_identifier: PERSONS
+                  alias_expression:
+                    naked_identifier: p
+          end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      create_view_statement:
+      - keyword: CREATE
+      - keyword: OR
+      - keyword: REPLACE
+      - keyword: 'NO'
+      - keyword: FORCE
+      - keyword: VIEW
+      - table_reference:
+          naked_identifier: NEW_VIEW
+      - keyword: AS
+      - bracketed:
+          start_bracket: (
+          select_statement:
+            select_clause:
+              keyword: select
+              select_clause_element:
+                column_reference:
+                  naked_identifier: PERSON_ID
+            from_clause:
+              keyword: from
+              from_expression:
+                from_expression_element:
+                  table_expression:
+                    table_reference:
+                      naked_identifier: PERSONS
+                  alias_expression:
+                    naked_identifier: p
+          end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      create_view_statement:
+      - keyword: CREATE
+      - keyword: EDITIONING
+      - keyword: VIEW
+      - table_reference:
+          naked_identifier: NEW_VIEW
+      - keyword: AS
+      - bracketed:
+          start_bracket: (
+          select_statement:
+            select_clause:
+              keyword: select
+              select_clause_element:
+                column_reference:
+                  naked_identifier: PERSON_ID
+            from_clause:
+              keyword: from
+              from_expression:
+                from_expression_element:
+                  table_expression:
+                    table_reference:
+                      naked_identifier: PERSONS
+                  alias_expression:
+                    naked_identifier: p
+          end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      create_view_statement:
+      - keyword: CREATE
+      - keyword: EDITIONABLE
+      - keyword: VIEW
+      - table_reference:
+          naked_identifier: NEW_VIEW
+      - keyword: AS
+      - bracketed:
+          start_bracket: (
+          select_statement:
+            select_clause:
+              keyword: select
+              select_clause_element:
+                column_reference:
+                  naked_identifier: PERSON_ID
+            from_clause:
+              keyword: from
+              from_expression:
+                from_expression_element:
+                  table_expression:
+                    table_reference:
+                      naked_identifier: PERSONS
+                  alias_expression:
+                    naked_identifier: p
+          end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      create_view_statement:
+      - keyword: CREATE
+      - keyword: NONEDITIONABLE
+      - keyword: VIEW
+      - table_reference:
+          naked_identifier: NEW_VIEW
+      - keyword: AS
+      - bracketed:
+          start_bracket: (
+          select_statement:
+            select_clause:
+              keyword: select
+              select_clause_element:
+                column_reference:
+                  naked_identifier: PERSON_ID
+            from_clause:
+              keyword: from
+              from_expression:
+                from_expression_element:
+                  table_expression:
+                    table_reference:
+                      naked_identifier: PERSONS
+                  alias_expression:
+                    naked_identifier: p
+          end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      create_view_statement:
+      - keyword: CREATE
+      - keyword: EDITIONABLE
+      - keyword: EDITIONING
+      - keyword: VIEW
+      - table_reference:
+          naked_identifier: NEW_VIEW
+      - keyword: AS
+      - bracketed:
+          start_bracket: (
+          select_statement:
+            select_clause:
+              keyword: select
+              select_clause_element:
+                column_reference:
+                  naked_identifier: PERSON_ID
+            from_clause:
+              keyword: from
+              from_expression:
+                from_expression_element:
+                  table_expression:
+                    table_reference:
+                      naked_identifier: PERSONS
+                  alias_expression:
+                    naked_identifier: p
+          end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      create_view_statement:
+      - keyword: CREATE
+      - keyword: OR
+      - keyword: REPLACE
+      - keyword: EDITIONING
+      - keyword: VIEW
+      - table_reference:
+          naked_identifier: NEW_VIEW
+      - keyword: AS
+      - bracketed:
+          start_bracket: (
+          select_statement:
+            select_clause:
+              keyword: select
+              select_clause_element:
+                column_reference:
+                  naked_identifier: PERSON_ID
+            from_clause:
+              keyword: from
+              from_expression:
+                from_expression_element:
+                  table_expression:
+                    table_reference:
+                      naked_identifier: PERSONS
+                  alias_expression:
+                    naked_identifier: p
+          end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      create_view_statement:
+      - keyword: CREATE
+      - keyword: MATERIALIZED
+      - keyword: VIEW
+      - table_reference:
+          naked_identifier: NEW_VIEW
+      - keyword: AS
+      - bracketed:
+          start_bracket: (
+          select_statement:
+            select_clause:
+              keyword: select
+              select_clause_element:
+                column_reference:
+                  naked_identifier: PERSON_ID
+            from_clause:
+              keyword: from
+              from_expression:
+                from_expression_element:
+                  table_expression:
+                    table_reference:
+                      naked_identifier: PERSONS
+                  alias_expression:
+                    naked_identifier: p
+          end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      create_view_statement:
+      - keyword: CREATE
+      - keyword: OR
+      - keyword: REPLACE
+      - keyword: MATERIALIZED
+      - keyword: VIEW
+      - table_reference:
+          naked_identifier: NEW_VIEW
+      - keyword: AS
+      - bracketed:
+          start_bracket: (
+          select_statement:
+            select_clause:
+              keyword: select
+              select_clause_element:
+                column_reference:
+                  naked_identifier: PERSON_ID
+            from_clause:
+              keyword: from
+              from_expression:
+                from_expression_element:
+                  table_expression:
+                    table_reference:
+                      naked_identifier: PERSONS
+                  alias_expression:
+                    naked_identifier: p
+          end_bracket: )
+  - statement_terminator: ;

--- a/test/fixtures/dialects/oracle/cursor.yml
+++ b/test/fixtures/dialects/oracle/cursor.yml
@@ -3,2482 +3,222 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: d9ed54d452073bf1d4f5ae2bbac40ec0ccef435994959d3f0be6e149002f9c7a
+_hash: c6b985cbfc099cd17a56c27ccc1ff799ffbc5aede6fc832da3c204b59dd2c790
 file:
-- statement:
-    begin_end_block:
-    - declare_segment:
-      - keyword: DECLARE
-      - ref_cursor_type:
-        - keyword: TYPE
-        - naked_identifier: empcurtyp
-        - keyword: IS
-        - keyword: REF
-        - keyword: CURSOR
-        - keyword: RETURN
-        - row_type_reference:
-            table_reference:
-              naked_identifier: employees
+- batch:
+    statement:
+      begin_end_block:
+      - declare_segment:
+        - keyword: DECLARE
+        - ref_cursor_type:
+          - keyword: TYPE
+          - naked_identifier: empcurtyp
+          - keyword: IS
+          - keyword: REF
+          - keyword: CURSOR
+          - keyword: RETURN
+          - row_type_reference:
+              table_reference:
+                naked_identifier: employees
+              binary_operator: '%'
+              keyword: ROWTYPE
+        - statement_terminator: ;
+        - ref_cursor_type:
+          - keyword: TYPE
+          - naked_identifier: genericcurtyp
+          - keyword: IS
+          - keyword: REF
+          - keyword: CURSOR
+        - statement_terminator: ;
+        - naked_identifier: cursor1
+        - data_type:
+            data_type_identifier: empcurtyp
+        - statement_terminator: ;
+        - naked_identifier: cursor2
+        - data_type:
+            data_type_identifier: genericcurtyp
+        - statement_terminator: ;
+        - naked_identifier: my_cursor
+        - data_type:
+            data_type_identifier: SYS_REFCURSOR
+        - statement_terminator: ;
+        - ref_cursor_type:
+          - keyword: TYPE
+          - naked_identifier: deptcurtyp
+          - keyword: IS
+          - keyword: REF
+          - keyword: CURSOR
+          - keyword: RETURN
+          - row_type_reference:
+              table_reference:
+                naked_identifier: departments
+              binary_operator: '%'
+              keyword: ROWTYPE
+        - statement_terminator: ;
+        - naked_identifier: dept_cv
+        - data_type:
+            data_type_identifier: deptcurtyp
+        - statement_terminator: ;
+      - keyword: BEGIN
+      - statement:
+          null_statement:
+            keyword: 'NULL'
+      - statement_terminator: ;
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      begin_end_block:
+      - declare_segment:
+        - keyword: DECLARE
+        - record_type:
+          - keyword: TYPE
+          - naked_identifier: EmpRecTyp
+          - keyword: IS
+          - keyword: RECORD
+          - bracketed:
+            - start_bracket: (
+            - naked_identifier: employee_id
+            - data_type:
+                data_type_identifier: NUMBER
+            - comma: ','
+            - naked_identifier: last_name
+            - data_type:
+                data_type_identifier: VARCHAR2
+                bracketed_arguments:
+                  bracketed:
+                    start_bracket: (
+                    numeric_literal: '25'
+                    end_bracket: )
+            - comma: ','
+            - naked_identifier: salary
+            - data_type:
+                data_type_identifier: NUMBER
+                bracketed_arguments:
+                  bracketed:
+                  - start_bracket: (
+                  - numeric_literal: '8'
+                  - comma: ','
+                  - numeric_literal: '2'
+                  - end_bracket: )
+            - end_bracket: )
+        - statement_terminator: ;
+        - ref_cursor_type:
+          - keyword: TYPE
+          - naked_identifier: EmpCurTyp
+          - keyword: IS
+          - keyword: REF
+          - keyword: CURSOR
+          - keyword: RETURN
+          - object_reference:
+              naked_identifier: EmpRecTyp
+        - statement_terminator: ;
+        - naked_identifier: emp_cv
+        - data_type:
+            data_type_identifier: EmpCurTyp
+        - statement_terminator: ;
+      - keyword: BEGIN
+      - statement:
+          null_statement:
+            keyword: 'NULL'
+      - statement_terminator: ;
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      begin_end_block:
+      - declare_segment:
+        - keyword: DECLARE
+        - naked_identifier: sal
+        - column_type_reference:
+            column_reference:
+            - naked_identifier: employees
+            - dot: .
+            - naked_identifier: salary
             binary_operator: '%'
-            keyword: ROWTYPE
-      - statement_terminator: ;
-      - ref_cursor_type:
-        - keyword: TYPE
-        - naked_identifier: genericcurtyp
-        - keyword: IS
-        - keyword: REF
-        - keyword: CURSOR
-      - statement_terminator: ;
-      - naked_identifier: cursor1
-      - data_type:
-          data_type_identifier: empcurtyp
-      - statement_terminator: ;
-      - naked_identifier: cursor2
-      - data_type:
-          data_type_identifier: genericcurtyp
-      - statement_terminator: ;
-      - naked_identifier: my_cursor
-      - data_type:
-          data_type_identifier: SYS_REFCURSOR
-      - statement_terminator: ;
-      - ref_cursor_type:
-        - keyword: TYPE
-        - naked_identifier: deptcurtyp
-        - keyword: IS
-        - keyword: REF
-        - keyword: CURSOR
-        - keyword: RETURN
-        - row_type_reference:
-            table_reference:
-              naked_identifier: departments
+            keyword: TYPE
+        - statement_terminator: ;
+        - naked_identifier: sal_multiple
+        - column_type_reference:
+            column_reference:
+            - naked_identifier: employees
+            - dot: .
+            - naked_identifier: salary
             binary_operator: '%'
-            keyword: ROWTYPE
+            keyword: TYPE
+        - statement_terminator: ;
+        - naked_identifier: factor
+        - data_type:
+            data_type_identifier: INTEGER
+        - assignment_operator: :=
+        - expression:
+            numeric_literal: '2'
+        - statement_terminator: ;
+        - naked_identifier: cv
+        - data_type:
+            data_type_identifier: SYS_REFCURSOR
+        - statement_terminator: ;
+      - keyword: BEGIN
+      - statement:
+          open_for_statement:
+          - keyword: OPEN
+          - naked_identifier: cv
+          - keyword: FOR
+          - select_statement:
+              select_clause:
+              - keyword: SELECT
+              - select_clause_element:
+                  column_reference:
+                    naked_identifier: salary
+              - comma: ','
+              - select_clause_element:
+                  expression:
+                  - column_reference:
+                      naked_identifier: salary
+                  - binary_operator: '*'
+                  - column_reference:
+                      naked_identifier: factor
+              from_clause:
+                keyword: FROM
+                from_expression:
+                  from_expression_element:
+                    table_expression:
+                      table_reference:
+                        naked_identifier: employees
+              where_clause:
+                keyword: WHERE
+                expression:
+                  column_reference:
+                    naked_identifier: job_id
+                  keyword: LIKE
+                  quoted_literal: "'AD_%'"
       - statement_terminator: ;
-      - naked_identifier: dept_cv
-      - data_type:
-          data_type_identifier: deptcurtyp
-      - statement_terminator: ;
-    - keyword: BEGIN
-    - statement:
-        null_statement:
-          keyword: 'NULL'
-    - statement_terminator: ;
-    - keyword: END
-- statement_terminator: ;
-- statement_terminator: /
-- statement:
-    begin_end_block:
-    - declare_segment:
-      - keyword: DECLARE
-      - record_type:
-        - keyword: TYPE
-        - naked_identifier: EmpRecTyp
-        - keyword: IS
-        - keyword: RECORD
-        - bracketed:
-          - start_bracket: (
-          - naked_identifier: employee_id
-          - data_type:
-              data_type_identifier: NUMBER
-          - comma: ','
-          - naked_identifier: last_name
-          - data_type:
-              data_type_identifier: VARCHAR2
-              bracketed_arguments:
-                bracketed:
-                  start_bracket: (
-                  numeric_literal: '25'
-                  end_bracket: )
-          - comma: ','
-          - naked_identifier: salary
-          - data_type:
-              data_type_identifier: NUMBER
-              bracketed_arguments:
-                bracketed:
-                - start_bracket: (
-                - numeric_literal: '8'
+      - statement:
+          loop_statement:
+          - keyword: LOOP
+          - statement:
+              fetch_statement:
+                keyword: FETCH
+                naked_identifier: cv
+                into_clause:
+                - keyword: INTO
+                - naked_identifier: sal
                 - comma: ','
-                - numeric_literal: '2'
-                - end_bracket: )
-          - end_bracket: )
-      - statement_terminator: ;
-      - ref_cursor_type:
-        - keyword: TYPE
-        - naked_identifier: EmpCurTyp
-        - keyword: IS
-        - keyword: REF
-        - keyword: CURSOR
-        - keyword: RETURN
-        - object_reference:
-            naked_identifier: EmpRecTyp
-      - statement_terminator: ;
-      - naked_identifier: emp_cv
-      - data_type:
-          data_type_identifier: EmpCurTyp
-      - statement_terminator: ;
-    - keyword: BEGIN
-    - statement:
-        null_statement:
-          keyword: 'NULL'
-    - statement_terminator: ;
-    - keyword: END
-- statement_terminator: ;
-- statement_terminator: /
-- statement:
-    begin_end_block:
-    - declare_segment:
-      - keyword: DECLARE
-      - naked_identifier: sal
-      - column_type_reference:
-          column_reference:
-          - naked_identifier: employees
-          - dot: .
-          - naked_identifier: salary
-          binary_operator: '%'
-          keyword: TYPE
-      - statement_terminator: ;
-      - naked_identifier: sal_multiple
-      - column_type_reference:
-          column_reference:
-          - naked_identifier: employees
-          - dot: .
-          - naked_identifier: salary
-          binary_operator: '%'
-          keyword: TYPE
-      - statement_terminator: ;
-      - naked_identifier: factor
-      - data_type:
-          data_type_identifier: INTEGER
-      - assignment_operator: :=
-      - expression:
-          numeric_literal: '2'
-      - statement_terminator: ;
-      - naked_identifier: cv
-      - data_type:
-          data_type_identifier: SYS_REFCURSOR
-      - statement_terminator: ;
-    - keyword: BEGIN
-    - statement:
-        open_for_statement:
-        - keyword: OPEN
-        - naked_identifier: cv
-        - keyword: FOR
-        - select_statement:
-            select_clause:
-            - keyword: SELECT
-            - select_clause_element:
-                column_reference:
-                  naked_identifier: salary
-            - comma: ','
-            - select_clause_element:
-                expression:
-                - column_reference:
-                    naked_identifier: salary
-                - binary_operator: '*'
-                - column_reference:
-                    naked_identifier: factor
-            from_clause:
-              keyword: FROM
-              from_expression:
-                from_expression_element:
-                  table_expression:
-                    table_reference:
-                      naked_identifier: employees
-            where_clause:
-              keyword: WHERE
-              expression:
-                column_reference:
-                  naked_identifier: job_id
-                keyword: LIKE
-                quoted_literal: "'AD_%'"
-    - statement_terminator: ;
-    - statement:
-        loop_statement:
-        - keyword: LOOP
-        - statement:
-            fetch_statement:
-              keyword: FETCH
-              naked_identifier: cv
-              into_clause:
-              - keyword: INTO
-              - naked_identifier: sal
-              - comma: ','
-              - naked_identifier: sal_multiple
-        - statement_terminator: ;
-        - statement:
-            exit_statement:
-            - keyword: EXIT
-            - keyword: WHEN
-            - expression:
-                naked_identifier: cv
-                binary_operator: '%'
-                keyword: NOTFOUND
-        - statement_terminator: ;
-        - statement:
-            function:
-              function_name:
-                naked_identifier: DBMS_OUTPUT
-                dot: .
-                function_name_identifier: PUT_LINE
-              function_contents:
-                bracketed:
-                  start_bracket: (
-                  expression:
-                    quoted_literal: "'factor = '"
-                    binary_operator:
-                    - pipe: '|'
-                    - pipe: '|'
-                    column_reference:
-                      naked_identifier: factor
-                  end_bracket: )
-        - statement_terminator: ;
-        - statement:
-            function:
-              function_name:
-                naked_identifier: DBMS_OUTPUT
-                dot: .
-                function_name_identifier: PUT_LINE
-              function_contents:
-                bracketed:
-                  start_bracket: (
-                  expression:
-                    quoted_literal: "'sal          = '"
-                    binary_operator:
-                    - pipe: '|'
-                    - pipe: '|'
-                    column_reference:
-                      naked_identifier: sal
-                  end_bracket: )
-        - statement_terminator: ;
-        - statement:
-            function:
-              function_name:
-                naked_identifier: DBMS_OUTPUT
-                dot: .
-                function_name_identifier: PUT_LINE
-              function_contents:
-                bracketed:
-                  start_bracket: (
-                  expression:
-                    quoted_literal: "'sal_multiple = '"
-                    binary_operator:
-                    - pipe: '|'
-                    - pipe: '|'
-                    column_reference:
-                      naked_identifier: sal_multiple
-                  end_bracket: )
-        - statement_terminator: ;
-        - statement:
-            assignment_segment_statement:
-              object_reference:
-                naked_identifier: factor
-              assignment_operator: :=
-              expression:
-                column_reference:
-                  naked_identifier: factor
-                binary_operator: +
-                numeric_literal: '1'
-        - statement_terminator: ;
-        - keyword: END
-        - keyword: LOOP
-    - statement_terminator: ;
-    - statement:
-        close_statement:
-          keyword: CLOSE
-          naked_identifier: cv
-    - statement_terminator: ;
-    - keyword: END
-- statement_terminator: ;
-- statement_terminator: /
-- statement:
-    begin_end_block:
-    - declare_segment:
-      - keyword: DECLARE
-      - naked_identifier: sal
-      - column_type_reference:
-          column_reference:
-          - naked_identifier: employees
-          - dot: .
-          - naked_identifier: salary
-          binary_operator: '%'
-          keyword: TYPE
-      - statement_terminator: ;
-      - naked_identifier: sal_multiple
-      - column_type_reference:
-          column_reference:
-          - naked_identifier: employees
-          - dot: .
-          - naked_identifier: salary
-          binary_operator: '%'
-          keyword: TYPE
-      - statement_terminator: ;
-      - naked_identifier: factor
-      - data_type:
-          data_type_identifier: INTEGER
-      - assignment_operator: :=
-      - expression:
-          numeric_literal: '2'
-      - statement_terminator: ;
-      - naked_identifier: cv
-      - data_type:
-          data_type_identifier: SYS_REFCURSOR
-      - statement_terminator: ;
-    - keyword: BEGIN
-    - statement:
-        function:
-          function_name:
-            naked_identifier: DBMS_OUTPUT
-            dot: .
-            function_name_identifier: PUT_LINE
-          function_contents:
-            bracketed:
-              start_bracket: (
-              expression:
-                quoted_literal: "'factor = '"
-                binary_operator:
-                - pipe: '|'
-                - pipe: '|'
-                column_reference:
-                  naked_identifier: factor
-              end_bracket: )
-    - statement_terminator: ;
-    - statement:
-        open_for_statement:
-        - keyword: OPEN
-        - naked_identifier: cv
-        - keyword: FOR
-        - select_statement:
-            select_clause:
-            - keyword: SELECT
-            - select_clause_element:
-                column_reference:
-                  naked_identifier: salary
-            - comma: ','
-            - select_clause_element:
-                expression:
-                - column_reference:
-                    naked_identifier: salary
-                - binary_operator: '*'
-                - column_reference:
-                    naked_identifier: factor
-            from_clause:
-              keyword: FROM
-              from_expression:
-                from_expression_element:
-                  table_expression:
-                    table_reference:
-                      naked_identifier: employees
-            where_clause:
-              keyword: WHERE
-              expression:
-                column_reference:
-                  naked_identifier: job_id
-                keyword: LIKE
-                quoted_literal: "'AD_%'"
-    - statement_terminator: ;
-    - statement:
-        loop_statement:
-        - keyword: LOOP
-        - statement:
-            fetch_statement:
-              keyword: FETCH
-              naked_identifier: cv
-              into_clause:
-              - keyword: INTO
-              - naked_identifier: sal
-              - comma: ','
-              - naked_identifier: sal_multiple
-        - statement_terminator: ;
-        - statement:
-            exit_statement:
-            - keyword: EXIT
-            - keyword: WHEN
-            - expression:
-                naked_identifier: cv
-                binary_operator: '%'
-                keyword: NOTFOUND
-        - statement_terminator: ;
-        - statement:
-            function:
-              function_name:
-                naked_identifier: DBMS_OUTPUT
-                dot: .
-                function_name_identifier: PUT_LINE
-              function_contents:
-                bracketed:
-                  start_bracket: (
-                  expression:
-                    quoted_literal: "'sal          = '"
-                    binary_operator:
-                    - pipe: '|'
-                    - pipe: '|'
-                    column_reference:
-                      naked_identifier: sal
-                  end_bracket: )
-        - statement_terminator: ;
-        - statement:
-            function:
-              function_name:
-                naked_identifier: DBMS_OUTPUT
-                dot: .
-                function_name_identifier: PUT_LINE
-              function_contents:
-                bracketed:
-                  start_bracket: (
-                  expression:
-                    quoted_literal: "'sal_multiple = '"
-                    binary_operator:
-                    - pipe: '|'
-                    - pipe: '|'
-                    column_reference:
-                      naked_identifier: sal_multiple
-                  end_bracket: )
-        - statement_terminator: ;
-        - keyword: END
-        - keyword: LOOP
-    - statement_terminator: ;
-    - statement:
-        assignment_segment_statement:
-          object_reference:
-            naked_identifier: factor
-          assignment_operator: :=
-          expression:
-            column_reference:
-              naked_identifier: factor
-            binary_operator: +
-            numeric_literal: '1'
-    - statement_terminator: ;
-    - statement:
-        function:
-          function_name:
-            naked_identifier: DBMS_OUTPUT
-            dot: .
-            function_name_identifier: PUT_LINE
-          function_contents:
-            bracketed:
-              start_bracket: (
-              expression:
-                quoted_literal: "'factor = '"
-                binary_operator:
-                - pipe: '|'
-                - pipe: '|'
-                column_reference:
-                  naked_identifier: factor
-              end_bracket: )
-    - statement_terminator: ;
-    - statement:
-        open_for_statement:
-        - keyword: OPEN
-        - naked_identifier: cv
-        - keyword: FOR
-        - select_statement:
-            select_clause:
-            - keyword: SELECT
-            - select_clause_element:
-                column_reference:
-                  naked_identifier: salary
-            - comma: ','
-            - select_clause_element:
-                expression:
-                - column_reference:
-                    naked_identifier: salary
-                - binary_operator: '*'
-                - column_reference:
-                    naked_identifier: factor
-            from_clause:
-              keyword: FROM
-              from_expression:
-                from_expression_element:
-                  table_expression:
-                    table_reference:
-                      naked_identifier: employees
-            where_clause:
-              keyword: WHERE
-              expression:
-                column_reference:
-                  naked_identifier: job_id
-                keyword: LIKE
-                quoted_literal: "'AD_%'"
-    - statement_terminator: ;
-    - statement:
-        loop_statement:
-        - keyword: LOOP
-        - statement:
-            fetch_statement:
-              keyword: FETCH
-              naked_identifier: cv
-              into_clause:
-              - keyword: INTO
-              - naked_identifier: sal
-              - comma: ','
-              - naked_identifier: sal_multiple
-        - statement_terminator: ;
-        - statement:
-            exit_statement:
-            - keyword: EXIT
-            - keyword: WHEN
-            - expression:
-                naked_identifier: cv
-                binary_operator: '%'
-                keyword: NOTFOUND
-        - statement_terminator: ;
-        - statement:
-            function:
-              function_name:
-                naked_identifier: DBMS_OUTPUT
-                dot: .
-                function_name_identifier: PUT_LINE
-              function_contents:
-                bracketed:
-                  start_bracket: (
-                  expression:
-                    quoted_literal: "'sal          = '"
-                    binary_operator:
-                    - pipe: '|'
-                    - pipe: '|'
-                    column_reference:
-                      naked_identifier: sal
-                  end_bracket: )
-        - statement_terminator: ;
-        - statement:
-            function:
-              function_name:
-                naked_identifier: DBMS_OUTPUT
-                dot: .
-                function_name_identifier: PUT_LINE
-              function_contents:
-                bracketed:
-                  start_bracket: (
-                  expression:
-                    quoted_literal: "'sal_multiple = '"
-                    binary_operator:
-                    - pipe: '|'
-                    - pipe: '|'
-                    column_reference:
-                      naked_identifier: sal_multiple
-                  end_bracket: )
-        - statement_terminator: ;
-        - keyword: END
-        - keyword: LOOP
-    - statement_terminator: ;
-    - statement:
-        close_statement:
-          keyword: CLOSE
-          naked_identifier: cv
-    - statement_terminator: ;
-    - keyword: END
-- statement_terminator: ;
-- statement_terminator: /
-- statement:
-    begin_end_block:
-    - declare_segment:
-      - keyword: DECLARE
-      - naked_identifier: v1
-      - data_type:
-          naked_identifier: pkg
-          dot: .
-          data_type_identifier: mytab
-      - statement_terminator: ;
-      - naked_identifier: v2
-      - data_type:
-          naked_identifier: pkg
-          dot: .
-          data_type_identifier: rec
-      - statement_terminator: ;
-      - naked_identifier: c1
-      - data_type:
-          data_type_identifier: SYS_REFCURSOR
-      - statement_terminator: ;
-    - keyword: BEGIN
-    - statement:
-        assignment_segment_statement:
-        - object_reference:
-            naked_identifier: v1
-        - bracketed:
-            start_bracket: (
-            numeric_literal: '1'
-            end_bracket: )
-        - dot: .
-        - object_reference:
-            naked_identifier: f1
-        - assignment_operator: :=
-        - expression:
-            numeric_literal: '1'
-    - statement_terminator: ;
-    - statement:
-        assignment_segment_statement:
-        - object_reference:
-            naked_identifier: v1
-        - bracketed:
-            start_bracket: (
-            numeric_literal: '1'
-            end_bracket: )
-        - dot: .
-        - object_reference:
-            naked_identifier: f2
-        - assignment_operator: :=
-        - expression:
-            quoted_literal: "'one'"
-    - statement_terminator: ;
-    - statement:
-        open_for_statement:
-        - keyword: OPEN
-        - naked_identifier: c1
-        - keyword: FOR
-        - select_statement:
-            select_clause:
-              keyword: SELECT
-              select_clause_element:
-                wildcard_expression:
-                  wildcard_identifier:
-                    star: '*'
-            from_clause:
-              keyword: FROM
-              from_expression:
-                from_expression_element:
-                  table_expression:
-                    function:
-                      function_name:
-                        function_name_identifier: TABLE
-                      function_contents:
-                        bracketed:
-                          start_bracket: (
-                          expression:
-                            column_reference:
-                              naked_identifier: v1
-                          end_bracket: )
-    - statement_terminator: ;
-    - statement:
-        fetch_statement:
-          keyword: FETCH
-          naked_identifier: c1
-          into_clause:
-            keyword: INTO
-            naked_identifier: v2
-    - statement_terminator: ;
-    - statement:
-        close_statement:
-          keyword: CLOSE
-          naked_identifier: c1
-    - statement_terminator: ;
-    - statement:
-        function:
-          function_name:
-            naked_identifier: DBMS_OUTPUT
-            dot: .
-            function_name_identifier: PUT_LINE
-          function_contents:
-            bracketed:
-              start_bracket: (
-              expression:
-              - quoted_literal: "'Values in record are '"
-              - binary_operator:
-                - pipe: '|'
-                - pipe: '|'
-              - column_reference:
-                - naked_identifier: v2
-                - dot: .
-                - naked_identifier: f1
-              - binary_operator:
-                - pipe: '|'
-                - pipe: '|'
-              - quoted_literal: "' and '"
-              - binary_operator:
-                - pipe: '|'
-                - pipe: '|'
-              - column_reference:
-                - naked_identifier: v2
-                - dot: .
-                - naked_identifier: f2
-              end_bracket: )
-    - statement_terminator: ;
-    - keyword: END
-- statement_terminator: ;
-- statement_terminator: /
-- statement:
-    begin_end_block:
-    - declare_segment:
-      - keyword: DECLARE
-      - cursor_variable:
-        - keyword: CURSOR
-        - naked_identifier: c1
-        - keyword: RETURN
-        - row_type_reference:
-            table_reference:
-              naked_identifier: departments
-            binary_operator: '%'
-            keyword: ROWTYPE
-        - statement_terminator: ;
-      - cursor_variable:
-        - keyword: CURSOR
-        - naked_identifier: c2
-        - keyword: IS
-        - select_statement:
-            select_clause:
-            - keyword: SELECT
-            - select_clause_element:
-                column_reference:
-                  naked_identifier: employee_id
-            - comma: ','
-            - select_clause_element:
-                column_reference:
-                  naked_identifier: job_id
-            - comma: ','
-            - select_clause_element:
-                column_reference:
-                  naked_identifier: salary
-            from_clause:
-              keyword: FROM
-              from_expression:
-                from_expression_element:
-                  table_expression:
-                    table_reference:
-                      naked_identifier: employees
-            where_clause:
-              keyword: WHERE
-              expression:
-                column_reference:
-                  naked_identifier: salary
-                comparison_operator:
-                  raw_comparison_operator: '>'
-                numeric_literal: '2000'
-        - statement_terminator: ;
-      - cursor_variable:
-        - keyword: CURSOR
-        - naked_identifier: c1
-        - keyword: RETURN
-        - row_type_reference:
-            table_reference:
-              naked_identifier: departments
-            binary_operator: '%'
-            keyword: ROWTYPE
-        - keyword: IS
-        - select_statement:
-            select_clause:
-              keyword: SELECT
-              select_clause_element:
-                wildcard_expression:
-                  wildcard_identifier:
-                    star: '*'
-            from_clause:
-              keyword: FROM
-              from_expression:
-                from_expression_element:
-                  table_expression:
-                    table_reference:
-                      naked_identifier: departments
-            where_clause:
-              keyword: WHERE
-              expression:
-                column_reference:
-                  naked_identifier: department_id
-                comparison_operator:
-                  raw_comparison_operator: '='
-                numeric_literal: '110'
-        - statement_terminator: ;
-      - cursor_variable:
-        - keyword: CURSOR
-        - naked_identifier: c3
-        - keyword: RETURN
-        - row_type_reference:
-            table_reference:
-              naked_identifier: locations
-            binary_operator: '%'
-            keyword: ROWTYPE
-        - statement_terminator: ;
-      - cursor_variable:
-        - keyword: CURSOR
-        - naked_identifier: c3
-        - keyword: IS
-        - select_statement:
-            select_clause:
-              keyword: SELECT
-              select_clause_element:
-                wildcard_expression:
-                  wildcard_identifier:
-                    star: '*'
-            from_clause:
-              keyword: FROM
-              from_expression:
-                from_expression_element:
-                  table_expression:
-                    table_reference:
-                      naked_identifier: locations
-            where_clause:
-              keyword: WHERE
-              expression:
-                column_reference:
-                  naked_identifier: country_id
-                comparison_operator:
-                  raw_comparison_operator: '='
-                quoted_literal: "'JP'"
-        - statement_terminator: ;
-    - keyword: BEGIN
-    - statement:
-        null_statement:
-          keyword: 'NULL'
-    - statement_terminator: ;
-    - keyword: END
-- statement_terminator: ;
-- statement_terminator: /
-- statement:
-    begin_end_block:
-    - declare_segment:
-      - keyword: DECLARE
-      - naked_identifier: sal
-      - column_type_reference:
-          column_reference:
-          - naked_identifier: employees
-          - dot: .
-          - naked_identifier: salary
-          binary_operator: '%'
-          keyword: TYPE
-      - statement_terminator: ;
-      - naked_identifier: sal_multiple
-      - column_type_reference:
-          column_reference:
-          - naked_identifier: employees
-          - dot: .
-          - naked_identifier: salary
-          binary_operator: '%'
-          keyword: TYPE
-      - statement_terminator: ;
-      - naked_identifier: factor
-      - data_type:
-          data_type_identifier: INTEGER
-      - assignment_operator: :=
-      - expression:
-          numeric_literal: '2'
-      - statement_terminator: ;
-      - cursor_variable:
-        - keyword: CURSOR
-        - naked_identifier: c1
-        - keyword: IS
-        - select_statement:
-            select_clause:
-            - keyword: SELECT
-            - select_clause_element:
-                column_reference:
-                  naked_identifier: salary
-            - comma: ','
-            - select_clause_element:
-                expression:
-                - column_reference:
-                    naked_identifier: salary
-                - binary_operator: '*'
-                - column_reference:
-                    naked_identifier: factor
-            from_clause:
-              keyword: FROM
-              from_expression:
-                from_expression_element:
-                  table_expression:
-                    table_reference:
-                      naked_identifier: employees
-            where_clause:
-              keyword: WHERE
-              expression:
-                column_reference:
-                  naked_identifier: job_id
-                keyword: LIKE
-                quoted_literal: "'AD_%'"
-        - statement_terminator: ;
-    - keyword: BEGIN
-    - statement:
-        open_statement:
-          keyword: OPEN
-          naked_identifier: c1
-    - statement_terminator: ;
-    - statement:
-        loop_statement:
-        - keyword: LOOP
-        - statement:
-            fetch_statement:
-              keyword: FETCH
-              naked_identifier: c1
-              into_clause:
-              - keyword: INTO
-              - naked_identifier: sal
-              - comma: ','
-              - naked_identifier: sal_multiple
-        - statement_terminator: ;
-        - statement:
-            exit_statement:
-            - keyword: EXIT
-            - keyword: WHEN
-            - expression:
-                naked_identifier: c1
-                binary_operator: '%'
-                keyword: NOTFOUND
-        - statement_terminator: ;
-        - statement:
-            function:
-              function_name:
-                naked_identifier: DBMS_OUTPUT
-                dot: .
-                function_name_identifier: PUT_LINE
-              function_contents:
-                bracketed:
-                  start_bracket: (
-                  expression:
-                    quoted_literal: "'factor = '"
-                    binary_operator:
-                    - pipe: '|'
-                    - pipe: '|'
-                    column_reference:
-                      naked_identifier: factor
-                  end_bracket: )
-        - statement_terminator: ;
-        - statement:
-            function:
-              function_name:
-                naked_identifier: DBMS_OUTPUT
-                dot: .
-                function_name_identifier: PUT_LINE
-              function_contents:
-                bracketed:
-                  start_bracket: (
-                  expression:
-                    quoted_literal: "'sal          = '"
-                    binary_operator:
-                    - pipe: '|'
-                    - pipe: '|'
-                    column_reference:
-                      naked_identifier: sal
-                  end_bracket: )
-        - statement_terminator: ;
-        - statement:
-            function:
-              function_name:
-                naked_identifier: DBMS_OUTPUT
-                dot: .
-                function_name_identifier: PUT_LINE
-              function_contents:
-                bracketed:
-                  start_bracket: (
-                  expression:
-                    quoted_literal: "'sal_multiple = '"
-                    binary_operator:
-                    - pipe: '|'
-                    - pipe: '|'
-                    column_reference:
-                      naked_identifier: sal_multiple
-                  end_bracket: )
-        - statement_terminator: ;
-        - statement:
-            assignment_segment_statement:
-              object_reference:
-                naked_identifier: factor
-              assignment_operator: :=
-              expression:
-                column_reference:
-                  naked_identifier: factor
-                binary_operator: +
-                numeric_literal: '1'
-        - statement_terminator: ;
-        - keyword: END
-        - keyword: LOOP
-    - statement_terminator: ;
-    - statement:
-        close_statement:
-          keyword: CLOSE
-          naked_identifier: c1
-    - statement_terminator: ;
-    - keyword: END
-- statement_terminator: ;
-- statement_terminator: /
-- statement:
-    begin_end_block:
-    - declare_segment:
-      - keyword: DECLARE
-      - naked_identifier: sal
-      - column_type_reference:
-          column_reference:
-          - naked_identifier: employees
-          - dot: .
-          - naked_identifier: salary
-          binary_operator: '%'
-          keyword: TYPE
-      - statement_terminator: ;
-      - naked_identifier: sal_multiple
-      - column_type_reference:
-          column_reference:
-          - naked_identifier: employees
-          - dot: .
-          - naked_identifier: salary
-          binary_operator: '%'
-          keyword: TYPE
-      - statement_terminator: ;
-      - naked_identifier: factor
-      - data_type:
-          data_type_identifier: INTEGER
-      - assignment_operator: :=
-      - expression:
-          numeric_literal: '2'
-      - statement_terminator: ;
-      - cursor_variable:
-        - keyword: CURSOR
-        - naked_identifier: c1
-        - keyword: IS
-        - select_statement:
-            select_clause:
-            - keyword: SELECT
-            - select_clause_element:
-                column_reference:
-                  naked_identifier: salary
-            - comma: ','
-            - select_clause_element:
-                expression:
-                - column_reference:
-                    naked_identifier: salary
-                - binary_operator: '*'
-                - column_reference:
-                    naked_identifier: factor
-            from_clause:
-              keyword: FROM
-              from_expression:
-                from_expression_element:
-                  table_expression:
-                    table_reference:
-                      naked_identifier: employees
-            where_clause:
-              keyword: WHERE
-              expression:
-                column_reference:
-                  naked_identifier: job_id
-                keyword: LIKE
-                quoted_literal: "'AD_%'"
-        - statement_terminator: ;
-    - keyword: BEGIN
-    - statement:
-        function:
-          function_name:
-            naked_identifier: DBMS_OUTPUT
-            dot: .
-            function_name_identifier: PUT_LINE
-          function_contents:
-            bracketed:
-              start_bracket: (
-              expression:
-                quoted_literal: "'factor = '"
-                binary_operator:
-                - pipe: '|'
-                - pipe: '|'
-                column_reference:
-                  naked_identifier: factor
-              end_bracket: )
-    - statement_terminator: ;
-    - statement:
-        open_statement:
-          keyword: OPEN
-          naked_identifier: c1
-    - statement_terminator: ;
-    - statement:
-        loop_statement:
-        - keyword: LOOP
-        - statement:
-            fetch_statement:
-              keyword: FETCH
-              naked_identifier: c1
-              into_clause:
-              - keyword: INTO
-              - naked_identifier: sal
-              - comma: ','
-              - naked_identifier: sal_multiple
-        - statement_terminator: ;
-        - statement:
-            exit_statement:
-            - keyword: EXIT
-            - keyword: WHEN
-            - expression:
-                naked_identifier: c1
-                binary_operator: '%'
-                keyword: NOTFOUND
-        - statement_terminator: ;
-        - statement:
-            function:
-              function_name:
-                naked_identifier: DBMS_OUTPUT
-                dot: .
-                function_name_identifier: PUT_LINE
-              function_contents:
-                bracketed:
-                  start_bracket: (
-                  expression:
-                    quoted_literal: "'sal          = '"
-                    binary_operator:
-                    - pipe: '|'
-                    - pipe: '|'
-                    column_reference:
-                      naked_identifier: sal
-                  end_bracket: )
-        - statement_terminator: ;
-        - statement:
-            function:
-              function_name:
-                naked_identifier: DBMS_OUTPUT
-                dot: .
-                function_name_identifier: PUT_LINE
-              function_contents:
-                bracketed:
-                  start_bracket: (
-                  expression:
-                    quoted_literal: "'sal_multiple = '"
-                    binary_operator:
-                    - pipe: '|'
-                    - pipe: '|'
-                    column_reference:
-                      naked_identifier: sal_multiple
-                  end_bracket: )
-        - statement_terminator: ;
-        - keyword: END
-        - keyword: LOOP
-    - statement_terminator: ;
-    - statement:
-        close_statement:
-          keyword: CLOSE
-          naked_identifier: c1
-    - statement_terminator: ;
-    - statement:
-        assignment_segment_statement:
-          object_reference:
-            naked_identifier: factor
-          assignment_operator: :=
-          expression:
-            column_reference:
-              naked_identifier: factor
-            binary_operator: +
-            numeric_literal: '1'
-    - statement_terminator: ;
-    - statement:
-        function:
-          function_name:
-            naked_identifier: DBMS_OUTPUT
-            dot: .
-            function_name_identifier: PUT_LINE
-          function_contents:
-            bracketed:
-              start_bracket: (
-              expression:
-                quoted_literal: "'factor = '"
-                binary_operator:
-                - pipe: '|'
-                - pipe: '|'
-                column_reference:
-                  naked_identifier: factor
-              end_bracket: )
-    - statement_terminator: ;
-    - statement:
-        open_statement:
-          keyword: OPEN
-          naked_identifier: c1
-    - statement_terminator: ;
-    - statement:
-        loop_statement:
-        - keyword: LOOP
-        - statement:
-            fetch_statement:
-              keyword: FETCH
-              naked_identifier: c1
-              into_clause:
-              - keyword: INTO
-              - naked_identifier: sal
-              - comma: ','
-              - naked_identifier: sal_multiple
-        - statement_terminator: ;
-        - statement:
-            exit_statement:
-            - keyword: EXIT
-            - keyword: WHEN
-            - expression:
-                naked_identifier: c1
-                binary_operator: '%'
-                keyword: NOTFOUND
-        - statement_terminator: ;
-        - statement:
-            function:
-              function_name:
-                naked_identifier: DBMS_OUTPUT
-                dot: .
-                function_name_identifier: PUT_LINE
-              function_contents:
-                bracketed:
-                  start_bracket: (
-                  expression:
-                    quoted_literal: "'sal          = '"
-                    binary_operator:
-                    - pipe: '|'
-                    - pipe: '|'
-                    column_reference:
-                      naked_identifier: sal
-                  end_bracket: )
-        - statement_terminator: ;
-        - statement:
-            function:
-              function_name:
-                naked_identifier: DBMS_OUTPUT
-                dot: .
-                function_name_identifier: PUT_LINE
-              function_contents:
-                bracketed:
-                  start_bracket: (
-                  expression:
-                    quoted_literal: "'sal_multiple = '"
-                    binary_operator:
-                    - pipe: '|'
-                    - pipe: '|'
-                    column_reference:
-                      naked_identifier: sal_multiple
-                  end_bracket: )
-        - statement_terminator: ;
-        - keyword: END
-        - keyword: LOOP
-    - statement_terminator: ;
-    - statement:
-        close_statement:
-          keyword: CLOSE
-          naked_identifier: c1
-    - statement_terminator: ;
-    - keyword: END
-- statement_terminator: ;
-- statement_terminator: /
-- statement:
-    begin_end_block:
-    - declare_segment:
-        keyword: DECLARE
-        cursor_variable:
-        - keyword: CURSOR
-        - naked_identifier: c1
-        - keyword: IS
-        - select_statement:
-            select_clause:
-            - keyword: SELECT
-            - select_clause_element:
-                column_reference:
-                  naked_identifier: employee_id
-            - comma: ','
-            - select_clause_element:
-                expression:
-                  bracketed:
-                    start_bracket: (
-                    expression:
-                      column_reference:
-                        naked_identifier: salary
-                      binary_operator: '*'
-                      numeric_literal: '0.05'
-                    end_bracket: )
-                alias_expression:
-                  naked_identifier: raisee
-            from_clause:
-              keyword: FROM
-              from_expression:
-                from_expression_element:
-                  table_expression:
-                    table_reference:
-                      naked_identifier: employees
-            where_clause:
-              keyword: WHERE
-              expression:
-                column_reference:
-                  naked_identifier: job_id
-                keyword: LIKE
-                quoted_literal: "'%_MAN'"
-            orderby_clause:
-            - keyword: ORDER
-            - keyword: BY
-            - column_reference:
-                naked_identifier: employee_id
-        - statement_terminator: ;
-        naked_identifier: emp_rec
-        row_type_reference:
-          table_reference:
-            naked_identifier: c1
-          binary_operator: '%'
-          keyword: ROWTYPE
-        statement_terminator: ;
-    - keyword: BEGIN
-    - statement:
-        open_statement:
-          keyword: OPEN
-          naked_identifier: c1
-    - statement_terminator: ;
-    - statement:
-        loop_statement:
-        - keyword: LOOP
-        - statement:
-            fetch_statement:
-              keyword: FETCH
-              naked_identifier: c1
-              into_clause:
-                keyword: INTO
-                naked_identifier: emp_rec
-        - statement_terminator: ;
-        - statement:
-            exit_statement:
-            - keyword: EXIT
-            - keyword: WHEN
-            - expression:
-                naked_identifier: c1
-                binary_operator: '%'
-                keyword: NOTFOUND
-        - statement_terminator: ;
-        - statement:
-            function:
-              function_name:
-                naked_identifier: DBMS_OUTPUT
-                dot: .
-                function_name_identifier: PUT_LINE
-              function_contents:
-                bracketed:
-                  start_bracket: (
-                  expression:
-                  - quoted_literal: "'Raise for employee #'"
-                  - binary_operator:
-                    - pipe: '|'
-                    - pipe: '|'
-                  - column_reference:
-                    - naked_identifier: emp_rec
-                    - dot: .
-                    - naked_identifier: employee_id
-                  - binary_operator:
-                    - pipe: '|'
-                    - pipe: '|'
-                  - quoted_literal: "' is $'"
-                  - binary_operator:
-                    - pipe: '|'
-                    - pipe: '|'
-                  - column_reference:
-                    - naked_identifier: emp_rec
-                    - dot: .
-                    - naked_identifier: raisee
-                  end_bracket: )
-        - statement_terminator: ;
-        - keyword: END
-        - keyword: LOOP
-    - statement_terminator: ;
-    - statement:
-        close_statement:
-          keyword: CLOSE
-          naked_identifier: c1
-    - statement_terminator: ;
-    - keyword: END
-- statement_terminator: ;
-- statement_terminator: /
-- statement:
-    begin_end_block:
-    - declare_segment:
-        keyword: DECLARE
-        cursor_variable:
-        - keyword: CURSOR
-        - naked_identifier: c
-        - function_parameter_list:
-            bracketed:
-            - start_bracket: (
-            - parameter: job
-            - data_type:
-                data_type_identifier: VARCHAR2
-            - comma: ','
-            - parameter: max_sal
-            - data_type:
-                data_type_identifier: NUMBER
-            - end_bracket: )
-        - keyword: IS
-        - select_statement:
-            select_clause:
-            - keyword: SELECT
-            - select_clause_element:
-                column_reference:
-                  naked_identifier: last_name
-            - comma: ','
-            - select_clause_element:
-                column_reference:
-                  naked_identifier: first_name
-            - comma: ','
-            - select_clause_element:
-                expression:
-                  bracketed:
-                    start_bracket: (
-                    expression:
-                    - column_reference:
-                        naked_identifier: salary
-                    - binary_operator: '-'
-                    - column_reference:
-                        naked_identifier: max_sal
-                    end_bracket: )
-                alias_expression:
-                  naked_identifier: overpayment
-            from_clause:
-              keyword: FROM
-              from_expression:
-                from_expression_element:
-                  table_expression:
-                    table_reference:
-                      naked_identifier: employees
-            where_clause:
-              keyword: WHERE
-              expression:
-              - column_reference:
-                  naked_identifier: job_id
-              - comparison_operator:
-                  raw_comparison_operator: '='
-              - column_reference:
-                  naked_identifier: job
-              - binary_operator: AND
-              - column_reference:
-                  naked_identifier: salary
-              - comparison_operator:
-                  raw_comparison_operator: '>'
-              - column_reference:
-                  naked_identifier: max_sal
-            orderby_clause:
-            - keyword: ORDER
-            - keyword: BY
-            - column_reference:
-                naked_identifier: salary
-        - statement_terminator: ;
-        create_procedure_statement:
-        - keyword: PROCEDURE
-        - function_name:
-            function_name_identifier: print_overpaid
-        - keyword: IS
-        - declare_segment:
-          - naked_identifier: last_name_
-          - column_type_reference:
-              column_reference:
-              - naked_identifier: employees
-              - dot: .
-              - naked_identifier: last_name
-              binary_operator: '%'
-              keyword: TYPE
+                - naked_identifier: sal_multiple
           - statement_terminator: ;
-          - naked_identifier: first_name_
-          - column_type_reference:
-              column_reference:
-              - naked_identifier: employees
-              - dot: .
-              - naked_identifier: first_name
-              binary_operator: '%'
-              keyword: TYPE
-          - statement_terminator: ;
-          - naked_identifier: overpayment_
-          - column_type_reference:
-              column_reference:
-              - naked_identifier: employees
-              - dot: .
-              - naked_identifier: salary
-              binary_operator: '%'
-              keyword: TYPE
-          - statement_terminator: ;
-        - begin_end_block:
-          - keyword: BEGIN
           - statement:
-              loop_statement:
-              - keyword: LOOP
-              - statement:
-                  fetch_statement:
-                    keyword: FETCH
-                    naked_identifier: c
-                    into_clause:
-                    - keyword: INTO
-                    - naked_identifier: last_name_
-                    - comma: ','
-                    - naked_identifier: first_name_
-                    - comma: ','
-                    - naked_identifier: overpayment_
-              - statement_terminator: ;
-              - statement:
-                  exit_statement:
-                  - keyword: EXIT
-                  - keyword: WHEN
-                  - expression:
-                      naked_identifier: c
-                      binary_operator: '%'
-                      keyword: NOTFOUND
-              - statement_terminator: ;
-              - statement:
-                  function:
-                    function_name:
-                      naked_identifier: DBMS_OUTPUT
-                      dot: .
-                      function_name_identifier: PUT_LINE
-                    function_contents:
-                      bracketed:
-                        start_bracket: (
-                        expression:
-                        - column_reference:
-                            naked_identifier: last_name_
-                        - binary_operator:
-                          - pipe: '|'
-                          - pipe: '|'
-                        - quoted_literal: "', '"
-                        - binary_operator:
-                          - pipe: '|'
-                          - pipe: '|'
-                        - column_reference:
-                            naked_identifier: first_name_
-                        - binary_operator:
-                          - pipe: '|'
-                          - pipe: '|'
-                        - quoted_literal: "' (by '"
-                        - binary_operator:
-                          - pipe: '|'
-                          - pipe: '|'
-                        - column_reference:
-                            naked_identifier: overpayment_
-                        - binary_operator:
-                          - pipe: '|'
-                          - pipe: '|'
-                        - quoted_literal: "')'"
-                        end_bracket: )
-              - statement_terminator: ;
-              - keyword: END
-              - keyword: LOOP
+              exit_statement:
+              - keyword: EXIT
+              - keyword: WHEN
+              - expression:
+                  naked_identifier: cv
+                  binary_operator: '%'
+                  keyword: NOTFOUND
           - statement_terminator: ;
-          - keyword: END
-          - object_reference:
-              naked_identifier: print_overpaid
-        - statement_terminator: ;
-    - keyword: BEGIN
-    - statement:
-        function:
-          function_name:
-            naked_identifier: DBMS_OUTPUT
-            dot: .
-            function_name_identifier: PUT_LINE
-          function_contents:
-            bracketed:
-              start_bracket: (
-              expression:
-                quoted_literal: "'----------------------'"
-              end_bracket: )
-    - statement_terminator: ;
-    - statement:
-        function:
-          function_name:
-            naked_identifier: DBMS_OUTPUT
-            dot: .
-            function_name_identifier: PUT_LINE
-          function_contents:
-            bracketed:
-              start_bracket: (
-              expression:
-                quoted_literal: "'Overpaid Stock Clerks:'"
-              end_bracket: )
-    - statement_terminator: ;
-    - statement:
-        function:
-          function_name:
-            naked_identifier: DBMS_OUTPUT
-            dot: .
-            function_name_identifier: PUT_LINE
-          function_contents:
-            bracketed:
-              start_bracket: (
-              expression:
-                quoted_literal: "'----------------------'"
-              end_bracket: )
-    - statement_terminator: ;
-    - statement:
-        open_statement:
-          keyword: OPEN
-          naked_identifier: c
-          function_contents:
-            bracketed:
-            - start_bracket: (
-            - expression:
-                quoted_literal: "'ST_CLERK'"
-            - comma: ','
-            - expression:
-                numeric_literal: '5000'
-            - end_bracket: )
-    - statement_terminator: ;
-    - statement:
-        function:
-          function_name:
-            function_name_identifier: print_overpaid
-          function_contents:
-            bracketed:
-              start_bracket: (
-              end_bracket: )
-    - statement_terminator: ;
-    - statement:
-        close_statement:
-          keyword: CLOSE
-          naked_identifier: c
-    - statement_terminator: ;
-    - statement:
-        function:
-          function_name:
-            naked_identifier: DBMS_OUTPUT
-            dot: .
-            function_name_identifier: PUT_LINE
-          function_contents:
-            bracketed:
-              start_bracket: (
-              expression:
-                quoted_literal: "'-------------------------------'"
-              end_bracket: )
-    - statement_terminator: ;
-    - statement:
-        function:
-          function_name:
-            naked_identifier: DBMS_OUTPUT
-            dot: .
-            function_name_identifier: PUT_LINE
-          function_contents:
-            bracketed:
-              start_bracket: (
-              expression:
-                quoted_literal: "'Overpaid Sales Representatives:'"
-              end_bracket: )
-    - statement_terminator: ;
-    - statement:
-        function:
-          function_name:
-            naked_identifier: DBMS_OUTPUT
-            dot: .
-            function_name_identifier: PUT_LINE
-          function_contents:
-            bracketed:
-              start_bracket: (
-              expression:
-                quoted_literal: "'-------------------------------'"
-              end_bracket: )
-    - statement_terminator: ;
-    - statement:
-        open_statement:
-          keyword: OPEN
-          naked_identifier: c
-          function_contents:
-            bracketed:
-            - start_bracket: (
-            - expression:
-                quoted_literal: "'SA_REP'"
-            - comma: ','
-            - expression:
-                numeric_literal: '10000'
-            - end_bracket: )
-    - statement_terminator: ;
-    - statement:
-        function:
-          function_name:
-            function_name_identifier: print_overpaid
-          function_contents:
-            bracketed:
-              start_bracket: (
-              end_bracket: )
-    - statement_terminator: ;
-    - statement:
-        close_statement:
-          keyword: CLOSE
-          naked_identifier: c
-    - statement_terminator: ;
-    - keyword: END
-- statement_terminator: ;
-- statement_terminator: /
-- statement:
-    begin_end_block:
-    - declare_segment:
-        keyword: DECLARE
-        cursor_variable:
-        - keyword: CURSOR
-        - naked_identifier: c
-        - function_parameter_list:
-            bracketed:
-              start_bracket: (
-              parameter: location
-              data_type:
-                data_type_identifier: NUMBER
-              keyword: DEFAULT
-              expression:
-                numeric_literal: '1700'
-              end_bracket: )
-        - keyword: IS
-        - select_statement:
-            select_clause:
-            - keyword: SELECT
-            - select_clause_element:
-                column_reference:
-                - naked_identifier: d
-                - dot: .
-                - naked_identifier: department_name
-            - comma: ','
-            - select_clause_element:
-                column_reference:
-                - naked_identifier: e
-                - dot: .
-                - naked_identifier: last_name
-                alias_expression:
-                  naked_identifier: manager
-            - comma: ','
-            - select_clause_element:
-                column_reference:
-                - naked_identifier: l
-                - dot: .
-                - naked_identifier: city
-            from_clause:
-            - keyword: FROM
-            - from_expression:
-                from_expression_element:
-                  table_expression:
-                    table_reference:
-                      naked_identifier: departments
-                  alias_expression:
-                    naked_identifier: d
-            - comma: ','
-            - from_expression:
-                from_expression_element:
-                  table_expression:
-                    table_reference:
-                      naked_identifier: employees
-                  alias_expression:
-                    naked_identifier: e
-            - comma: ','
-            - from_expression:
-                from_expression_element:
-                  table_expression:
-                    table_reference:
-                      naked_identifier: locations
-                  alias_expression:
-                    naked_identifier: l
-            where_clause:
-              keyword: WHERE
-              expression:
-              - column_reference:
-                - naked_identifier: l
-                - dot: .
-                - naked_identifier: location_id
-              - comparison_operator:
-                  raw_comparison_operator: '='
-              - column_reference:
-                  naked_identifier: location
-              - binary_operator: AND
-              - column_reference:
-                - naked_identifier: l
-                - dot: .
-                - naked_identifier: location_id
-              - comparison_operator:
-                  raw_comparison_operator: '='
-              - column_reference:
-                - naked_identifier: d
-                - dot: .
-                - naked_identifier: location_id
-              - binary_operator: AND
-              - column_reference:
-                - naked_identifier: d
-                - dot: .
-                - naked_identifier: department_id
-              - comparison_operator:
-                  raw_comparison_operator: '='
-              - column_reference:
-                - naked_identifier: e
-                - dot: .
-                - naked_identifier: department_id
-            orderby_clause:
-            - keyword: ORDER
-            - keyword: BY
-            - column_reference:
-              - naked_identifier: d
-              - dot: .
-              - naked_identifier: department_id
-        - statement_terminator: ;
-        create_procedure_statement:
-        - keyword: PROCEDURE
-        - function_name:
-            function_name_identifier: print_depts
-        - keyword: IS
-        - declare_segment:
-          - naked_identifier: dept_name
-          - column_type_reference:
-              column_reference:
-              - naked_identifier: departments
-              - dot: .
-              - naked_identifier: department_name
-              binary_operator: '%'
-              keyword: TYPE
-          - statement_terminator: ;
-          - naked_identifier: mgr_name
-          - column_type_reference:
-              column_reference:
-              - naked_identifier: employees
-              - dot: .
-              - naked_identifier: last_name
-              binary_operator: '%'
-              keyword: TYPE
-          - statement_terminator: ;
-          - naked_identifier: city_name
-          - column_type_reference:
-              column_reference:
-              - naked_identifier: locations
-              - dot: .
-              - naked_identifier: city
-              binary_operator: '%'
-              keyword: TYPE
-          - statement_terminator: ;
-        - begin_end_block:
-          - keyword: BEGIN
-          - statement:
-              loop_statement:
-              - keyword: LOOP
-              - statement:
-                  fetch_statement:
-                    keyword: FETCH
-                    naked_identifier: c
-                    into_clause:
-                    - keyword: INTO
-                    - naked_identifier: dept_name
-                    - comma: ','
-                    - naked_identifier: mgr_name
-                    - comma: ','
-                    - naked_identifier: city_name
-              - statement_terminator: ;
-              - statement:
-                  exit_statement:
-                  - keyword: EXIT
-                  - keyword: WHEN
-                  - expression:
-                      naked_identifier: c
-                      binary_operator: '%'
-                      keyword: NOTFOUND
-              - statement_terminator: ;
-              - statement:
-                  function:
-                    function_name:
-                      naked_identifier: DBMS_OUTPUT
-                      dot: .
-                      function_name_identifier: PUT_LINE
-                    function_contents:
-                      bracketed:
-                        start_bracket: (
-                        expression:
-                        - column_reference:
-                            naked_identifier: dept_name
-                        - binary_operator:
-                          - pipe: '|'
-                          - pipe: '|'
-                        - quoted_literal: "' (Manager: '"
-                        - binary_operator:
-                          - pipe: '|'
-                          - pipe: '|'
-                        - column_reference:
-                            naked_identifier: mgr_name
-                        - binary_operator:
-                          - pipe: '|'
-                          - pipe: '|'
-                        - quoted_literal: "')'"
-                        end_bracket: )
-              - statement_terminator: ;
-              - keyword: END
-              - keyword: LOOP
-          - statement_terminator: ;
-          - keyword: END
-          - object_reference:
-              naked_identifier: print_depts
-        - statement_terminator: ;
-    - keyword: BEGIN
-    - statement:
-        function:
-          function_name:
-            naked_identifier: DBMS_OUTPUT
-            dot: .
-            function_name_identifier: PUT_LINE
-          function_contents:
-            bracketed:
-              start_bracket: (
-              expression:
-                quoted_literal: "'DEPARTMENTS AT HEADQUARTERS:'"
-              end_bracket: )
-    - statement_terminator: ;
-    - statement:
-        function:
-          function_name:
-            naked_identifier: DBMS_OUTPUT
-            dot: .
-            function_name_identifier: PUT_LINE
-          function_contents:
-            bracketed:
-              start_bracket: (
-              expression:
-                quoted_literal: "'--------------------------------'"
-              end_bracket: )
-    - statement_terminator: ;
-    - statement:
-        open_statement:
-          keyword: OPEN
-          naked_identifier: c
-    - statement_terminator: ;
-    - statement:
-        function:
-          function_name:
-            function_name_identifier: print_depts
-          function_contents:
-            bracketed:
-              start_bracket: (
-              end_bracket: )
-    - statement_terminator: ;
-    - statement:
-        function:
-          function_name:
-            naked_identifier: DBMS_OUTPUT
-            dot: .
-            function_name_identifier: PUT_LINE
-          function_contents:
-            bracketed:
-              start_bracket: (
-              expression:
-                quoted_literal: "'--------------------------------'"
-              end_bracket: )
-    - statement_terminator: ;
-    - statement:
-        close_statement:
-          keyword: CLOSE
-          naked_identifier: c
-    - statement_terminator: ;
-    - statement:
-        function:
-          function_name:
-            naked_identifier: DBMS_OUTPUT
-            dot: .
-            function_name_identifier: PUT_LINE
-          function_contents:
-            bracketed:
-              start_bracket: (
-              expression:
-                quoted_literal: "'DEPARTMENTS IN CANADA:'"
-              end_bracket: )
-    - statement_terminator: ;
-    - statement:
-        function:
-          function_name:
-            naked_identifier: DBMS_OUTPUT
-            dot: .
-            function_name_identifier: PUT_LINE
-          function_contents:
-            bracketed:
-              start_bracket: (
-              expression:
-                quoted_literal: "'--------------------------------'"
-              end_bracket: )
-    - statement_terminator: ;
-    - statement:
-        open_statement:
-          keyword: OPEN
-          naked_identifier: c
-          function_contents:
-            bracketed:
-              start_bracket: (
-              expression:
-                numeric_literal: '1800'
-              end_bracket: )
-    - statement_terminator: ;
-    - statement:
-        function:
-          function_name:
-            function_name_identifier: print_depts
-          function_contents:
-            bracketed:
-              start_bracket: (
-              end_bracket: )
-    - statement_terminator: ;
-    - statement:
-        close_statement:
-          keyword: CLOSE
-          naked_identifier: c
-    - statement_terminator: ;
-    - statement:
-        open_statement:
-          keyword: OPEN
-          naked_identifier: c
-          function_contents:
-            bracketed:
-              start_bracket: (
-              expression:
-                numeric_literal: '1900'
-              end_bracket: )
-    - statement_terminator: ;
-    - statement:
-        function:
-          function_name:
-            function_name_identifier: print_depts
-          function_contents:
-            bracketed:
-              start_bracket: (
-              end_bracket: )
-    - statement_terminator: ;
-    - statement:
-        close_statement:
-          keyword: CLOSE
-          naked_identifier: c
-    - statement_terminator: ;
-    - keyword: END
-- statement_terminator: ;
-- statement_terminator: /
-- statement:
-    begin_end_block:
-    - declare_segment:
-        keyword: DECLARE
-        cursor_variable:
-        - keyword: CURSOR
-        - naked_identifier: c
-        - function_parameter_list:
-            bracketed:
-            - start_bracket: (
-            - parameter: job
-            - data_type:
-                data_type_identifier: VARCHAR2
-            - comma: ','
-            - parameter: max_sal
-            - data_type:
-                data_type_identifier: NUMBER
-            - comma: ','
-            - parameter: hired
-            - data_type:
-                data_type_identifier: DATE
-            - keyword: DEFAULT
-            - expression:
-                function:
-                  function_name:
-                    function_name_identifier: TO_DATE
-                  function_contents:
-                    bracketed:
-                    - start_bracket: (
-                    - expression:
-                        quoted_literal: "'31-DEC-1999'"
-                    - comma: ','
-                    - expression:
-                        quoted_literal: "'DD-MON-YYYY'"
-                    - end_bracket: )
-            - end_bracket: )
-        - keyword: IS
-        - select_statement:
-            select_clause:
-            - keyword: SELECT
-            - select_clause_element:
-                column_reference:
-                  naked_identifier: last_name
-            - comma: ','
-            - select_clause_element:
-                column_reference:
-                  naked_identifier: first_name
-            - comma: ','
-            - select_clause_element:
-                expression:
-                  bracketed:
-                    start_bracket: (
-                    expression:
-                    - column_reference:
-                        naked_identifier: salary
-                    - binary_operator: '-'
-                    - column_reference:
-                        naked_identifier: max_sal
-                    end_bracket: )
-                alias_expression:
-                  naked_identifier: overpayment
-            from_clause:
-              keyword: FROM
-              from_expression:
-                from_expression_element:
-                  table_expression:
-                    table_reference:
-                      naked_identifier: employees
-            where_clause:
-              keyword: WHERE
-              expression:
-              - column_reference:
-                  naked_identifier: job_id
-              - comparison_operator:
-                  raw_comparison_operator: '='
-              - column_reference:
-                  naked_identifier: job
-              - binary_operator: AND
-              - column_reference:
-                  naked_identifier: salary
-              - comparison_operator:
-                  raw_comparison_operator: '>'
-              - column_reference:
-                  naked_identifier: max_sal
-              - binary_operator: AND
-              - column_reference:
-                  naked_identifier: hire_date
-              - comparison_operator:
-                  raw_comparison_operator: '>'
-              - column_reference:
-                  naked_identifier: hired
-            orderby_clause:
-            - keyword: ORDER
-            - keyword: BY
-            - column_reference:
-                naked_identifier: salary
-        - statement_terminator: ;
-        create_procedure_statement:
-        - keyword: PROCEDURE
-        - function_name:
-            function_name_identifier: print_overpaid
-        - keyword: IS
-        - declare_segment:
-          - naked_identifier: last_name_
-          - column_type_reference:
-              column_reference:
-              - naked_identifier: employees
-              - dot: .
-              - naked_identifier: last_name
-              binary_operator: '%'
-              keyword: TYPE
-          - statement_terminator: ;
-          - naked_identifier: first_name_
-          - column_type_reference:
-              column_reference:
-              - naked_identifier: employees
-              - dot: .
-              - naked_identifier: first_name
-              binary_operator: '%'
-              keyword: TYPE
-          - statement_terminator: ;
-          - naked_identifier: overpayment_
-          - column_type_reference:
-              column_reference:
-              - naked_identifier: employees
-              - dot: .
-              - naked_identifier: salary
-              binary_operator: '%'
-              keyword: TYPE
-          - statement_terminator: ;
-        - begin_end_block:
-          - keyword: BEGIN
-          - statement:
-              loop_statement:
-              - keyword: LOOP
-              - statement:
-                  fetch_statement:
-                    keyword: FETCH
-                    naked_identifier: c
-                    into_clause:
-                    - keyword: INTO
-                    - naked_identifier: last_name_
-                    - comma: ','
-                    - naked_identifier: first_name_
-                    - comma: ','
-                    - naked_identifier: overpayment_
-              - statement_terminator: ;
-              - statement:
-                  exit_statement:
-                  - keyword: EXIT
-                  - keyword: WHEN
-                  - expression:
-                      naked_identifier: c
-                      binary_operator: '%'
-                      keyword: NOTFOUND
-              - statement_terminator: ;
-              - statement:
-                  function:
-                    function_name:
-                      naked_identifier: DBMS_OUTPUT
-                      dot: .
-                      function_name_identifier: PUT_LINE
-                    function_contents:
-                      bracketed:
-                        start_bracket: (
-                        expression:
-                        - column_reference:
-                            naked_identifier: last_name_
-                        - binary_operator:
-                          - pipe: '|'
-                          - pipe: '|'
-                        - quoted_literal: "', '"
-                        - binary_operator:
-                          - pipe: '|'
-                          - pipe: '|'
-                        - column_reference:
-                            naked_identifier: first_name_
-                        - binary_operator:
-                          - pipe: '|'
-                          - pipe: '|'
-                        - quoted_literal: "' (by '"
-                        - binary_operator:
-                          - pipe: '|'
-                          - pipe: '|'
-                        - column_reference:
-                            naked_identifier: overpayment_
-                        - binary_operator:
-                          - pipe: '|'
-                          - pipe: '|'
-                        - quoted_literal: "')'"
-                        end_bracket: )
-              - statement_terminator: ;
-              - keyword: END
-              - keyword: LOOP
-          - statement_terminator: ;
-          - keyword: END
-          - object_reference:
-              naked_identifier: print_overpaid
-        - statement_terminator: ;
-    - keyword: BEGIN
-    - statement:
-        function:
-          function_name:
-            naked_identifier: DBMS_OUTPUT
-            dot: .
-            function_name_identifier: PUT_LINE
-          function_contents:
-            bracketed:
-              start_bracket: (
-              expression:
-                quoted_literal: "'-------------------------------'"
-              end_bracket: )
-    - statement_terminator: ;
-    - statement:
-        function:
-          function_name:
-            naked_identifier: DBMS_OUTPUT
-            dot: .
-            function_name_identifier: PUT_LINE
-          function_contents:
-            bracketed:
-              start_bracket: (
-              expression:
-                quoted_literal: "'Overpaid Sales Representatives:'"
-              end_bracket: )
-    - statement_terminator: ;
-    - statement:
-        function:
-          function_name:
-            naked_identifier: DBMS_OUTPUT
-            dot: .
-            function_name_identifier: PUT_LINE
-          function_contents:
-            bracketed:
-              start_bracket: (
-              expression:
-                quoted_literal: "'-------------------------------'"
-              end_bracket: )
-    - statement_terminator: ;
-    - statement:
-        open_statement:
-          keyword: OPEN
-          naked_identifier: c
-          function_contents:
-            bracketed:
-            - start_bracket: (
-            - expression:
-                quoted_literal: "'SA_REP'"
-            - comma: ','
-            - expression:
-                numeric_literal: '10000'
-            - end_bracket: )
-    - statement_terminator: ;
-    - statement:
-        function:
-          function_name:
-            function_name_identifier: print_overpaid
-          function_contents:
-            bracketed:
-              start_bracket: (
-              end_bracket: )
-    - statement_terminator: ;
-    - statement:
-        close_statement:
-          keyword: CLOSE
-          naked_identifier: c
-    - statement_terminator: ;
-    - statement:
-        function:
-          function_name:
-            naked_identifier: DBMS_OUTPUT
-            dot: .
-            function_name_identifier: PUT_LINE
-          function_contents:
-            bracketed:
-              start_bracket: (
-              expression:
-                quoted_literal: "'------------------------------------------------'"
-              end_bracket: )
-    - statement_terminator: ;
-    - statement:
-        function:
-          function_name:
-            naked_identifier: DBMS_OUTPUT
-            dot: .
-            function_name_identifier: PUT_LINE
-          function_contents:
-            bracketed:
-              start_bracket: (
-              expression:
-                quoted_literal: "'Overpaid Sales Representatives Hired After 2014:'"
-              end_bracket: )
-    - statement_terminator: ;
-    - statement:
-        function:
-          function_name:
-            naked_identifier: DBMS_OUTPUT
-            dot: .
-            function_name_identifier: PUT_LINE
-          function_contents:
-            bracketed:
-              start_bracket: (
-              expression:
-                quoted_literal: "'------------------------------------------------'"
-              end_bracket: )
-    - statement_terminator: ;
-    - statement:
-        open_statement:
-          keyword: OPEN
-          naked_identifier: c
-          function_contents:
-            bracketed:
-            - start_bracket: (
-            - expression:
-                quoted_literal: "'SA_REP'"
-            - comma: ','
-            - expression:
-                numeric_literal: '10000'
-            - comma: ','
-            - expression:
-                function:
-                  function_name:
-                    function_name_identifier: TO_DATE
-                  function_contents:
-                    bracketed:
-                    - start_bracket: (
-                    - expression:
-                        quoted_literal: "'31-DEC-2014'"
-                    - comma: ','
-                    - expression:
-                        quoted_literal: "'DD-MON-YYYY'"
-                    - end_bracket: )
-            - end_bracket: )
-    - statement_terminator: ;
-    - statement:
-        function:
-          function_name:
-            function_name_identifier: print_overpaid
-          function_contents:
-            bracketed:
-              start_bracket: (
-              end_bracket: )
-    - statement_terminator: ;
-    - statement:
-        close_statement:
-          keyword: CLOSE
-          naked_identifier: c
-    - statement_terminator: ;
-    - keyword: END
-- statement_terminator: ;
-- statement_terminator: /
-- statement:
-    begin_end_block:
-    - declare_segment:
-        keyword: DECLARE
-        cursor_variable:
-        - keyword: CURSOR
-        - naked_identifier: c1
-        - keyword: IS
-        - select_statement:
-            select_clause:
-            - keyword: SELECT
-            - select_clause_element:
-                column_reference:
-                - naked_identifier: t1
-                - dot: .
-                - naked_identifier: department_id
-            - comma: ','
-            - select_clause_element:
-                column_reference:
-                  naked_identifier: department_name
-            - comma: ','
-            - select_clause_element:
-                column_reference:
-                  naked_identifier: staff
-            from_clause:
-            - keyword: FROM
-            - from_expression:
-                from_expression_element:
-                  table_expression:
-                    table_reference:
-                      naked_identifier: departments
-                  alias_expression:
-                    naked_identifier: t1
-            - comma: ','
-            - from_expression:
-                from_expression_element:
-                  table_expression:
-                    bracketed:
-                      start_bracket: (
-                      select_statement:
-                        select_clause:
-                        - keyword: SELECT
-                        - select_clause_element:
-                            column_reference:
-                              naked_identifier: department_id
-                        - comma: ','
-                        - select_clause_element:
-                            function:
-                              function_name:
-                                function_name_identifier: COUNT
-                              function_contents:
-                                bracketed:
-                                  start_bracket: (
-                                  star: '*'
-                                  end_bracket: )
-                            alias_expression:
-                              alias_operator:
-                                keyword: AS
-                              naked_identifier: staff
-                        from_clause:
-                          keyword: FROM
-                          from_expression:
-                            from_expression_element:
-                              table_expression:
-                                table_reference:
-                                  naked_identifier: employees
-                        groupby_clause:
-                        - keyword: GROUP
-                        - keyword: BY
-                        - column_reference:
-                            naked_identifier: department_id
-                      end_bracket: )
-                  alias_expression:
-                    naked_identifier: t2
-            where_clause:
-              keyword: WHERE
-              expression:
-                bracketed:
-                  start_bracket: (
-                  expression:
-                  - column_reference:
-                    - naked_identifier: t1
-                    - dot: .
-                    - naked_identifier: department_id
-                  - comparison_operator:
-                      raw_comparison_operator: '='
-                  - column_reference:
-                    - naked_identifier: t2
-                    - dot: .
-                    - naked_identifier: department_id
-                  end_bracket: )
-                binary_operator: AND
-                column_reference:
-                  naked_identifier: staff
-                comparison_operator:
-                - raw_comparison_operator: '>'
-                - raw_comparison_operator: '='
-                numeric_literal: '5'
-            orderby_clause:
-            - keyword: ORDER
-            - keyword: BY
-            - column_reference:
-                naked_identifier: staff
-        - statement_terminator: ;
-    - keyword: BEGIN
-    - statement:
-        for_loop_statement:
-        - keyword: FOR
-        - naked_identifier: dept
-        - keyword: IN
-        - expression:
-            column_reference:
-              naked_identifier: c1
-        - loop_statement:
-          - keyword: LOOP
           - statement:
               function:
                 function_name:
@@ -2489,213 +229,2225 @@ file:
                   bracketed:
                     start_bracket: (
                     expression:
-                    - quoted_literal: "'Department = '"
-                    - binary_operator:
-                      - pipe: '|'
-                      - pipe: '|'
-                    - column_reference:
-                      - naked_identifier: dept
-                      - dot: .
-                      - naked_identifier: department_name
-                    - binary_operator:
-                      - pipe: '|'
-                      - pipe: '|'
-                    - quoted_literal: "', staff = '"
-                    - binary_operator:
-                      - pipe: '|'
-                      - pipe: '|'
-                    - column_reference:
-                      - naked_identifier: dept
-                      - dot: .
-                      - naked_identifier: staff
-                    end_bracket: )
-          - statement_terminator: ;
-          - keyword: END
-          - keyword: LOOP
-    - statement_terminator: ;
-    - keyword: END
-- statement_terminator: ;
-- statement_terminator: /
-- statement:
-    begin_end_block:
-    - declare_segment:
-        keyword: DECLARE
-        cursor_variable:
-        - keyword: CURSOR
-        - naked_identifier: c1
-        - keyword: IS
-        - select_statement:
-            select_clause:
-            - keyword: SELECT
-            - select_clause_element:
-                column_reference:
-                  naked_identifier: department_id
-            - comma: ','
-            - select_clause_element:
-                column_reference:
-                  naked_identifier: last_name
-            - comma: ','
-            - select_clause_element:
-                column_reference:
-                  naked_identifier: salary
-            from_clause:
-              keyword: FROM
-              from_expression:
-                from_expression_element:
-                  table_expression:
-                    table_reference:
-                      naked_identifier: employees
-                  alias_expression:
-                    naked_identifier: t
-            where_clause:
-              keyword: WHERE
-              expression:
-                column_reference:
-                  naked_identifier: salary
-                comparison_operator:
-                  raw_comparison_operator: '>'
-                bracketed:
-                  start_bracket: (
-                  expression:
-                    select_statement:
-                      select_clause:
-                        keyword: SELECT
-                        select_clause_element:
-                          function:
-                            function_name:
-                              function_name_identifier: AVG
-                            function_contents:
-                              bracketed:
-                                start_bracket: (
-                                expression:
-                                  column_reference:
-                                    naked_identifier: salary
-                                end_bracket: )
-                      from_clause:
-                        keyword: FROM
-                        from_expression:
-                          from_expression_element:
-                            table_expression:
-                              table_reference:
-                                naked_identifier: employees
-                      where_clause:
-                        keyword: WHERE
-                        expression:
-                        - column_reference:
-                          - naked_identifier: t
-                          - dot: .
-                          - naked_identifier: department_id
-                        - comparison_operator:
-                            raw_comparison_operator: '='
-                        - column_reference:
-                            naked_identifier: department_id
-                  end_bracket: )
-            orderby_clause:
-            - keyword: ORDER
-            - keyword: BY
-            - column_reference:
-                naked_identifier: department_id
-            - comma: ','
-            - column_reference:
-                naked_identifier: last_name
-        - statement_terminator: ;
-    - keyword: BEGIN
-    - statement:
-        for_loop_statement:
-        - keyword: FOR
-        - naked_identifier: person
-        - keyword: IN
-        - expression:
-            column_reference:
-              naked_identifier: c1
-        - loop_statement:
-          - keyword: LOOP
-          - statement:
-              function:
-                function_name:
-                  naked_identifier: DBMS_OUTPUT
-                  dot: .
-                  function_name_identifier: PUT_LINE
-                function_contents:
-                  bracketed:
-                    start_bracket: (
-                    expression:
-                      quoted_literal: "'Making above-average salary = '"
+                      quoted_literal: "'factor = '"
                       binary_operator:
                       - pipe: '|'
                       - pipe: '|'
                       column_reference:
-                      - naked_identifier: person
-                      - dot: .
-                      - naked_identifier: last_name
+                        naked_identifier: factor
+                    end_bracket: )
+          - statement_terminator: ;
+          - statement:
+              function:
+                function_name:
+                  naked_identifier: DBMS_OUTPUT
+                  dot: .
+                  function_name_identifier: PUT_LINE
+                function_contents:
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                      quoted_literal: "'sal          = '"
+                      binary_operator:
+                      - pipe: '|'
+                      - pipe: '|'
+                      column_reference:
+                        naked_identifier: sal
+                    end_bracket: )
+          - statement_terminator: ;
+          - statement:
+              function:
+                function_name:
+                  naked_identifier: DBMS_OUTPUT
+                  dot: .
+                  function_name_identifier: PUT_LINE
+                function_contents:
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                      quoted_literal: "'sal_multiple = '"
+                      binary_operator:
+                      - pipe: '|'
+                      - pipe: '|'
+                      column_reference:
+                        naked_identifier: sal_multiple
+                    end_bracket: )
+          - statement_terminator: ;
+          - statement:
+              assignment_segment_statement:
+                object_reference:
+                  naked_identifier: factor
+                assignment_operator: :=
+                expression:
+                  column_reference:
+                    naked_identifier: factor
+                  binary_operator: +
+                  numeric_literal: '1'
+          - statement_terminator: ;
+          - keyword: END
+          - keyword: LOOP
+      - statement_terminator: ;
+      - statement:
+          close_statement:
+            keyword: CLOSE
+            naked_identifier: cv
+      - statement_terminator: ;
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      begin_end_block:
+      - declare_segment:
+        - keyword: DECLARE
+        - naked_identifier: sal
+        - column_type_reference:
+            column_reference:
+            - naked_identifier: employees
+            - dot: .
+            - naked_identifier: salary
+            binary_operator: '%'
+            keyword: TYPE
+        - statement_terminator: ;
+        - naked_identifier: sal_multiple
+        - column_type_reference:
+            column_reference:
+            - naked_identifier: employees
+            - dot: .
+            - naked_identifier: salary
+            binary_operator: '%'
+            keyword: TYPE
+        - statement_terminator: ;
+        - naked_identifier: factor
+        - data_type:
+            data_type_identifier: INTEGER
+        - assignment_operator: :=
+        - expression:
+            numeric_literal: '2'
+        - statement_terminator: ;
+        - naked_identifier: cv
+        - data_type:
+            data_type_identifier: SYS_REFCURSOR
+        - statement_terminator: ;
+      - keyword: BEGIN
+      - statement:
+          function:
+            function_name:
+              naked_identifier: DBMS_OUTPUT
+              dot: .
+              function_name_identifier: PUT_LINE
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  quoted_literal: "'factor = '"
+                  binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                  column_reference:
+                    naked_identifier: factor
+                end_bracket: )
+      - statement_terminator: ;
+      - statement:
+          open_for_statement:
+          - keyword: OPEN
+          - naked_identifier: cv
+          - keyword: FOR
+          - select_statement:
+              select_clause:
+              - keyword: SELECT
+              - select_clause_element:
+                  column_reference:
+                    naked_identifier: salary
+              - comma: ','
+              - select_clause_element:
+                  expression:
+                  - column_reference:
+                      naked_identifier: salary
+                  - binary_operator: '*'
+                  - column_reference:
+                      naked_identifier: factor
+              from_clause:
+                keyword: FROM
+                from_expression:
+                  from_expression_element:
+                    table_expression:
+                      table_reference:
+                        naked_identifier: employees
+              where_clause:
+                keyword: WHERE
+                expression:
+                  column_reference:
+                    naked_identifier: job_id
+                  keyword: LIKE
+                  quoted_literal: "'AD_%'"
+      - statement_terminator: ;
+      - statement:
+          loop_statement:
+          - keyword: LOOP
+          - statement:
+              fetch_statement:
+                keyword: FETCH
+                naked_identifier: cv
+                into_clause:
+                - keyword: INTO
+                - naked_identifier: sal
+                - comma: ','
+                - naked_identifier: sal_multiple
+          - statement_terminator: ;
+          - statement:
+              exit_statement:
+              - keyword: EXIT
+              - keyword: WHEN
+              - expression:
+                  naked_identifier: cv
+                  binary_operator: '%'
+                  keyword: NOTFOUND
+          - statement_terminator: ;
+          - statement:
+              function:
+                function_name:
+                  naked_identifier: DBMS_OUTPUT
+                  dot: .
+                  function_name_identifier: PUT_LINE
+                function_contents:
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                      quoted_literal: "'sal          = '"
+                      binary_operator:
+                      - pipe: '|'
+                      - pipe: '|'
+                      column_reference:
+                        naked_identifier: sal
+                    end_bracket: )
+          - statement_terminator: ;
+          - statement:
+              function:
+                function_name:
+                  naked_identifier: DBMS_OUTPUT
+                  dot: .
+                  function_name_identifier: PUT_LINE
+                function_contents:
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                      quoted_literal: "'sal_multiple = '"
+                      binary_operator:
+                      - pipe: '|'
+                      - pipe: '|'
+                      column_reference:
+                        naked_identifier: sal_multiple
                     end_bracket: )
           - statement_terminator: ;
           - keyword: END
           - keyword: LOOP
-    - statement_terminator: ;
-    - keyword: END
-- statement_terminator: ;
-- statement_terminator: /
-- statement:
-    begin_end_block:
-    - declare_segment:
-      - keyword: DECLARE
-      - ref_cursor_type:
-        - keyword: TYPE
-        - naked_identifier: emp_cur_typ
-        - keyword: IS
-        - keyword: REF
-        - keyword: CURSOR
       - statement_terminator: ;
-      - naked_identifier: emp_cur
-      - data_type:
-          data_type_identifier: emp_cur_typ
+      - statement:
+          assignment_segment_statement:
+            object_reference:
+              naked_identifier: factor
+            assignment_operator: :=
+            expression:
+              column_reference:
+                naked_identifier: factor
+              binary_operator: +
+              numeric_literal: '1'
       - statement_terminator: ;
-      - naked_identifier: dept_name
-      - column_type_reference:
-          column_reference:
-          - naked_identifier: departments
-          - dot: .
-          - naked_identifier: department_name
-          binary_operator: '%'
-          keyword: TYPE
+      - statement:
+          function:
+            function_name:
+              naked_identifier: DBMS_OUTPUT
+              dot: .
+              function_name_identifier: PUT_LINE
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  quoted_literal: "'factor = '"
+                  binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                  column_reference:
+                    naked_identifier: factor
+                end_bracket: )
       - statement_terminator: ;
-      - naked_identifier: emp_name
-      - column_type_reference:
-          column_reference:
-          - naked_identifier: employees
-          - dot: .
-          - naked_identifier: last_name
-          binary_operator: '%'
-          keyword: TYPE
+      - statement:
+          open_for_statement:
+          - keyword: OPEN
+          - naked_identifier: cv
+          - keyword: FOR
+          - select_statement:
+              select_clause:
+              - keyword: SELECT
+              - select_clause_element:
+                  column_reference:
+                    naked_identifier: salary
+              - comma: ','
+              - select_clause_element:
+                  expression:
+                  - column_reference:
+                      naked_identifier: salary
+                  - binary_operator: '*'
+                  - column_reference:
+                      naked_identifier: factor
+              from_clause:
+                keyword: FROM
+                from_expression:
+                  from_expression_element:
+                    table_expression:
+                      table_reference:
+                        naked_identifier: employees
+              where_clause:
+                keyword: WHERE
+                expression:
+                  column_reference:
+                    naked_identifier: job_id
+                  keyword: LIKE
+                  quoted_literal: "'AD_%'"
       - statement_terminator: ;
-      - cursor_variable:
-        - keyword: CURSOR
+      - statement:
+          loop_statement:
+          - keyword: LOOP
+          - statement:
+              fetch_statement:
+                keyword: FETCH
+                naked_identifier: cv
+                into_clause:
+                - keyword: INTO
+                - naked_identifier: sal
+                - comma: ','
+                - naked_identifier: sal_multiple
+          - statement_terminator: ;
+          - statement:
+              exit_statement:
+              - keyword: EXIT
+              - keyword: WHEN
+              - expression:
+                  naked_identifier: cv
+                  binary_operator: '%'
+                  keyword: NOTFOUND
+          - statement_terminator: ;
+          - statement:
+              function:
+                function_name:
+                  naked_identifier: DBMS_OUTPUT
+                  dot: .
+                  function_name_identifier: PUT_LINE
+                function_contents:
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                      quoted_literal: "'sal          = '"
+                      binary_operator:
+                      - pipe: '|'
+                      - pipe: '|'
+                      column_reference:
+                        naked_identifier: sal
+                    end_bracket: )
+          - statement_terminator: ;
+          - statement:
+              function:
+                function_name:
+                  naked_identifier: DBMS_OUTPUT
+                  dot: .
+                  function_name_identifier: PUT_LINE
+                function_contents:
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                      quoted_literal: "'sal_multiple = '"
+                      binary_operator:
+                      - pipe: '|'
+                      - pipe: '|'
+                      column_reference:
+                        naked_identifier: sal_multiple
+                    end_bracket: )
+          - statement_terminator: ;
+          - keyword: END
+          - keyword: LOOP
+      - statement_terminator: ;
+      - statement:
+          close_statement:
+            keyword: CLOSE
+            naked_identifier: cv
+      - statement_terminator: ;
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      begin_end_block:
+      - declare_segment:
+        - keyword: DECLARE
+        - naked_identifier: v1
+        - data_type:
+            naked_identifier: pkg
+            dot: .
+            data_type_identifier: mytab
+        - statement_terminator: ;
+        - naked_identifier: v2
+        - data_type:
+            naked_identifier: pkg
+            dot: .
+            data_type_identifier: rec
+        - statement_terminator: ;
         - naked_identifier: c1
-        - keyword: IS
-        - select_statement:
-            select_clause:
-            - keyword: SELECT
-            - select_clause_element:
-                column_reference:
-                  naked_identifier: department_name
-            - comma: ','
-            - select_clause_element:
-                function:
-                  function_name:
-                    function_name_identifier: CURSOR
-                  function_contents:
+        - data_type:
+            data_type_identifier: SYS_REFCURSOR
+        - statement_terminator: ;
+      - keyword: BEGIN
+      - statement:
+          assignment_segment_statement:
+          - object_reference:
+              naked_identifier: v1
+          - bracketed:
+              start_bracket: (
+              numeric_literal: '1'
+              end_bracket: )
+          - dot: .
+          - object_reference:
+              naked_identifier: f1
+          - assignment_operator: :=
+          - expression:
+              numeric_literal: '1'
+      - statement_terminator: ;
+      - statement:
+          assignment_segment_statement:
+          - object_reference:
+              naked_identifier: v1
+          - bracketed:
+              start_bracket: (
+              numeric_literal: '1'
+              end_bracket: )
+          - dot: .
+          - object_reference:
+              naked_identifier: f2
+          - assignment_operator: :=
+          - expression:
+              quoted_literal: "'one'"
+      - statement_terminator: ;
+      - statement:
+          open_for_statement:
+          - keyword: OPEN
+          - naked_identifier: c1
+          - keyword: FOR
+          - select_statement:
+              select_clause:
+                keyword: SELECT
+                select_clause_element:
+                  wildcard_expression:
+                    wildcard_identifier:
+                      star: '*'
+              from_clause:
+                keyword: FROM
+                from_expression:
+                  from_expression_element:
+                    table_expression:
+                      function:
+                        function_name:
+                          function_name_identifier: TABLE
+                        function_contents:
+                          bracketed:
+                            start_bracket: (
+                            expression:
+                              column_reference:
+                                naked_identifier: v1
+                            end_bracket: )
+      - statement_terminator: ;
+      - statement:
+          fetch_statement:
+            keyword: FETCH
+            naked_identifier: c1
+            into_clause:
+              keyword: INTO
+              naked_identifier: v2
+      - statement_terminator: ;
+      - statement:
+          close_statement:
+            keyword: CLOSE
+            naked_identifier: c1
+      - statement_terminator: ;
+      - statement:
+          function:
+            function_name:
+              naked_identifier: DBMS_OUTPUT
+              dot: .
+              function_name_identifier: PUT_LINE
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                - quoted_literal: "'Values in record are '"
+                - binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                - column_reference:
+                  - naked_identifier: v2
+                  - dot: .
+                  - naked_identifier: f1
+                - binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                - quoted_literal: "' and '"
+                - binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                - column_reference:
+                  - naked_identifier: v2
+                  - dot: .
+                  - naked_identifier: f2
+                end_bracket: )
+      - statement_terminator: ;
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      begin_end_block:
+      - declare_segment:
+        - keyword: DECLARE
+        - cursor_variable:
+          - keyword: CURSOR
+          - naked_identifier: c1
+          - keyword: RETURN
+          - row_type_reference:
+              table_reference:
+                naked_identifier: departments
+              binary_operator: '%'
+              keyword: ROWTYPE
+          - statement_terminator: ;
+        - cursor_variable:
+          - keyword: CURSOR
+          - naked_identifier: c2
+          - keyword: IS
+          - select_statement:
+              select_clause:
+              - keyword: SELECT
+              - select_clause_element:
+                  column_reference:
+                    naked_identifier: employee_id
+              - comma: ','
+              - select_clause_element:
+                  column_reference:
+                    naked_identifier: job_id
+              - comma: ','
+              - select_clause_element:
+                  column_reference:
+                    naked_identifier: salary
+              from_clause:
+                keyword: FROM
+                from_expression:
+                  from_expression_element:
+                    table_expression:
+                      table_reference:
+                        naked_identifier: employees
+              where_clause:
+                keyword: WHERE
+                expression:
+                  column_reference:
+                    naked_identifier: salary
+                  comparison_operator:
+                    raw_comparison_operator: '>'
+                  numeric_literal: '2000'
+          - statement_terminator: ;
+        - cursor_variable:
+          - keyword: CURSOR
+          - naked_identifier: c1
+          - keyword: RETURN
+          - row_type_reference:
+              table_reference:
+                naked_identifier: departments
+              binary_operator: '%'
+              keyword: ROWTYPE
+          - keyword: IS
+          - select_statement:
+              select_clause:
+                keyword: SELECT
+                select_clause_element:
+                  wildcard_expression:
+                    wildcard_identifier:
+                      star: '*'
+              from_clause:
+                keyword: FROM
+                from_expression:
+                  from_expression_element:
+                    table_expression:
+                      table_reference:
+                        naked_identifier: departments
+              where_clause:
+                keyword: WHERE
+                expression:
+                  column_reference:
+                    naked_identifier: department_id
+                  comparison_operator:
+                    raw_comparison_operator: '='
+                  numeric_literal: '110'
+          - statement_terminator: ;
+        - cursor_variable:
+          - keyword: CURSOR
+          - naked_identifier: c3
+          - keyword: RETURN
+          - row_type_reference:
+              table_reference:
+                naked_identifier: locations
+              binary_operator: '%'
+              keyword: ROWTYPE
+          - statement_terminator: ;
+        - cursor_variable:
+          - keyword: CURSOR
+          - naked_identifier: c3
+          - keyword: IS
+          - select_statement:
+              select_clause:
+                keyword: SELECT
+                select_clause_element:
+                  wildcard_expression:
+                    wildcard_identifier:
+                      star: '*'
+              from_clause:
+                keyword: FROM
+                from_expression:
+                  from_expression_element:
+                    table_expression:
+                      table_reference:
+                        naked_identifier: locations
+              where_clause:
+                keyword: WHERE
+                expression:
+                  column_reference:
+                    naked_identifier: country_id
+                  comparison_operator:
+                    raw_comparison_operator: '='
+                  quoted_literal: "'JP'"
+          - statement_terminator: ;
+      - keyword: BEGIN
+      - statement:
+          null_statement:
+            keyword: 'NULL'
+      - statement_terminator: ;
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      begin_end_block:
+      - declare_segment:
+        - keyword: DECLARE
+        - naked_identifier: sal
+        - column_type_reference:
+            column_reference:
+            - naked_identifier: employees
+            - dot: .
+            - naked_identifier: salary
+            binary_operator: '%'
+            keyword: TYPE
+        - statement_terminator: ;
+        - naked_identifier: sal_multiple
+        - column_type_reference:
+            column_reference:
+            - naked_identifier: employees
+            - dot: .
+            - naked_identifier: salary
+            binary_operator: '%'
+            keyword: TYPE
+        - statement_terminator: ;
+        - naked_identifier: factor
+        - data_type:
+            data_type_identifier: INTEGER
+        - assignment_operator: :=
+        - expression:
+            numeric_literal: '2'
+        - statement_terminator: ;
+        - cursor_variable:
+          - keyword: CURSOR
+          - naked_identifier: c1
+          - keyword: IS
+          - select_statement:
+              select_clause:
+              - keyword: SELECT
+              - select_clause_element:
+                  column_reference:
+                    naked_identifier: salary
+              - comma: ','
+              - select_clause_element:
+                  expression:
+                  - column_reference:
+                      naked_identifier: salary
+                  - binary_operator: '*'
+                  - column_reference:
+                      naked_identifier: factor
+              from_clause:
+                keyword: FROM
+                from_expression:
+                  from_expression_element:
+                    table_expression:
+                      table_reference:
+                        naked_identifier: employees
+              where_clause:
+                keyword: WHERE
+                expression:
+                  column_reference:
+                    naked_identifier: job_id
+                  keyword: LIKE
+                  quoted_literal: "'AD_%'"
+          - statement_terminator: ;
+      - keyword: BEGIN
+      - statement:
+          open_statement:
+            keyword: OPEN
+            naked_identifier: c1
+      - statement_terminator: ;
+      - statement:
+          loop_statement:
+          - keyword: LOOP
+          - statement:
+              fetch_statement:
+                keyword: FETCH
+                naked_identifier: c1
+                into_clause:
+                - keyword: INTO
+                - naked_identifier: sal
+                - comma: ','
+                - naked_identifier: sal_multiple
+          - statement_terminator: ;
+          - statement:
+              exit_statement:
+              - keyword: EXIT
+              - keyword: WHEN
+              - expression:
+                  naked_identifier: c1
+                  binary_operator: '%'
+                  keyword: NOTFOUND
+          - statement_terminator: ;
+          - statement:
+              function:
+                function_name:
+                  naked_identifier: DBMS_OUTPUT
+                  dot: .
+                  function_name_identifier: PUT_LINE
+                function_contents:
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                      quoted_literal: "'factor = '"
+                      binary_operator:
+                      - pipe: '|'
+                      - pipe: '|'
+                      column_reference:
+                        naked_identifier: factor
+                    end_bracket: )
+          - statement_terminator: ;
+          - statement:
+              function:
+                function_name:
+                  naked_identifier: DBMS_OUTPUT
+                  dot: .
+                  function_name_identifier: PUT_LINE
+                function_contents:
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                      quoted_literal: "'sal          = '"
+                      binary_operator:
+                      - pipe: '|'
+                      - pipe: '|'
+                      column_reference:
+                        naked_identifier: sal
+                    end_bracket: )
+          - statement_terminator: ;
+          - statement:
+              function:
+                function_name:
+                  naked_identifier: DBMS_OUTPUT
+                  dot: .
+                  function_name_identifier: PUT_LINE
+                function_contents:
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                      quoted_literal: "'sal_multiple = '"
+                      binary_operator:
+                      - pipe: '|'
+                      - pipe: '|'
+                      column_reference:
+                        naked_identifier: sal_multiple
+                    end_bracket: )
+          - statement_terminator: ;
+          - statement:
+              assignment_segment_statement:
+                object_reference:
+                  naked_identifier: factor
+                assignment_operator: :=
+                expression:
+                  column_reference:
+                    naked_identifier: factor
+                  binary_operator: +
+                  numeric_literal: '1'
+          - statement_terminator: ;
+          - keyword: END
+          - keyword: LOOP
+      - statement_terminator: ;
+      - statement:
+          close_statement:
+            keyword: CLOSE
+            naked_identifier: c1
+      - statement_terminator: ;
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      begin_end_block:
+      - declare_segment:
+        - keyword: DECLARE
+        - naked_identifier: sal
+        - column_type_reference:
+            column_reference:
+            - naked_identifier: employees
+            - dot: .
+            - naked_identifier: salary
+            binary_operator: '%'
+            keyword: TYPE
+        - statement_terminator: ;
+        - naked_identifier: sal_multiple
+        - column_type_reference:
+            column_reference:
+            - naked_identifier: employees
+            - dot: .
+            - naked_identifier: salary
+            binary_operator: '%'
+            keyword: TYPE
+        - statement_terminator: ;
+        - naked_identifier: factor
+        - data_type:
+            data_type_identifier: INTEGER
+        - assignment_operator: :=
+        - expression:
+            numeric_literal: '2'
+        - statement_terminator: ;
+        - cursor_variable:
+          - keyword: CURSOR
+          - naked_identifier: c1
+          - keyword: IS
+          - select_statement:
+              select_clause:
+              - keyword: SELECT
+              - select_clause_element:
+                  column_reference:
+                    naked_identifier: salary
+              - comma: ','
+              - select_clause_element:
+                  expression:
+                  - column_reference:
+                      naked_identifier: salary
+                  - binary_operator: '*'
+                  - column_reference:
+                      naked_identifier: factor
+              from_clause:
+                keyword: FROM
+                from_expression:
+                  from_expression_element:
+                    table_expression:
+                      table_reference:
+                        naked_identifier: employees
+              where_clause:
+                keyword: WHERE
+                expression:
+                  column_reference:
+                    naked_identifier: job_id
+                  keyword: LIKE
+                  quoted_literal: "'AD_%'"
+          - statement_terminator: ;
+      - keyword: BEGIN
+      - statement:
+          function:
+            function_name:
+              naked_identifier: DBMS_OUTPUT
+              dot: .
+              function_name_identifier: PUT_LINE
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  quoted_literal: "'factor = '"
+                  binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                  column_reference:
+                    naked_identifier: factor
+                end_bracket: )
+      - statement_terminator: ;
+      - statement:
+          open_statement:
+            keyword: OPEN
+            naked_identifier: c1
+      - statement_terminator: ;
+      - statement:
+          loop_statement:
+          - keyword: LOOP
+          - statement:
+              fetch_statement:
+                keyword: FETCH
+                naked_identifier: c1
+                into_clause:
+                - keyword: INTO
+                - naked_identifier: sal
+                - comma: ','
+                - naked_identifier: sal_multiple
+          - statement_terminator: ;
+          - statement:
+              exit_statement:
+              - keyword: EXIT
+              - keyword: WHEN
+              - expression:
+                  naked_identifier: c1
+                  binary_operator: '%'
+                  keyword: NOTFOUND
+          - statement_terminator: ;
+          - statement:
+              function:
+                function_name:
+                  naked_identifier: DBMS_OUTPUT
+                  dot: .
+                  function_name_identifier: PUT_LINE
+                function_contents:
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                      quoted_literal: "'sal          = '"
+                      binary_operator:
+                      - pipe: '|'
+                      - pipe: '|'
+                      column_reference:
+                        naked_identifier: sal
+                    end_bracket: )
+          - statement_terminator: ;
+          - statement:
+              function:
+                function_name:
+                  naked_identifier: DBMS_OUTPUT
+                  dot: .
+                  function_name_identifier: PUT_LINE
+                function_contents:
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                      quoted_literal: "'sal_multiple = '"
+                      binary_operator:
+                      - pipe: '|'
+                      - pipe: '|'
+                      column_reference:
+                        naked_identifier: sal_multiple
+                    end_bracket: )
+          - statement_terminator: ;
+          - keyword: END
+          - keyword: LOOP
+      - statement_terminator: ;
+      - statement:
+          close_statement:
+            keyword: CLOSE
+            naked_identifier: c1
+      - statement_terminator: ;
+      - statement:
+          assignment_segment_statement:
+            object_reference:
+              naked_identifier: factor
+            assignment_operator: :=
+            expression:
+              column_reference:
+                naked_identifier: factor
+              binary_operator: +
+              numeric_literal: '1'
+      - statement_terminator: ;
+      - statement:
+          function:
+            function_name:
+              naked_identifier: DBMS_OUTPUT
+              dot: .
+              function_name_identifier: PUT_LINE
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  quoted_literal: "'factor = '"
+                  binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                  column_reference:
+                    naked_identifier: factor
+                end_bracket: )
+      - statement_terminator: ;
+      - statement:
+          open_statement:
+            keyword: OPEN
+            naked_identifier: c1
+      - statement_terminator: ;
+      - statement:
+          loop_statement:
+          - keyword: LOOP
+          - statement:
+              fetch_statement:
+                keyword: FETCH
+                naked_identifier: c1
+                into_clause:
+                - keyword: INTO
+                - naked_identifier: sal
+                - comma: ','
+                - naked_identifier: sal_multiple
+          - statement_terminator: ;
+          - statement:
+              exit_statement:
+              - keyword: EXIT
+              - keyword: WHEN
+              - expression:
+                  naked_identifier: c1
+                  binary_operator: '%'
+                  keyword: NOTFOUND
+          - statement_terminator: ;
+          - statement:
+              function:
+                function_name:
+                  naked_identifier: DBMS_OUTPUT
+                  dot: .
+                  function_name_identifier: PUT_LINE
+                function_contents:
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                      quoted_literal: "'sal          = '"
+                      binary_operator:
+                      - pipe: '|'
+                      - pipe: '|'
+                      column_reference:
+                        naked_identifier: sal
+                    end_bracket: )
+          - statement_terminator: ;
+          - statement:
+              function:
+                function_name:
+                  naked_identifier: DBMS_OUTPUT
+                  dot: .
+                  function_name_identifier: PUT_LINE
+                function_contents:
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                      quoted_literal: "'sal_multiple = '"
+                      binary_operator:
+                      - pipe: '|'
+                      - pipe: '|'
+                      column_reference:
+                        naked_identifier: sal_multiple
+                    end_bracket: )
+          - statement_terminator: ;
+          - keyword: END
+          - keyword: LOOP
+      - statement_terminator: ;
+      - statement:
+          close_statement:
+            keyword: CLOSE
+            naked_identifier: c1
+      - statement_terminator: ;
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      begin_end_block:
+      - declare_segment:
+          keyword: DECLARE
+          cursor_variable:
+          - keyword: CURSOR
+          - naked_identifier: c1
+          - keyword: IS
+          - select_statement:
+              select_clause:
+              - keyword: SELECT
+              - select_clause_element:
+                  column_reference:
+                    naked_identifier: employee_id
+              - comma: ','
+              - select_clause_element:
+                  expression:
                     bracketed:
                       start_bracket: (
                       expression:
+                        column_reference:
+                          naked_identifier: salary
+                        binary_operator: '*'
+                        numeric_literal: '0.05'
+                      end_bracket: )
+                  alias_expression:
+                    naked_identifier: raisee
+              from_clause:
+                keyword: FROM
+                from_expression:
+                  from_expression_element:
+                    table_expression:
+                      table_reference:
+                        naked_identifier: employees
+              where_clause:
+                keyword: WHERE
+                expression:
+                  column_reference:
+                    naked_identifier: job_id
+                  keyword: LIKE
+                  quoted_literal: "'%_MAN'"
+              orderby_clause:
+              - keyword: ORDER
+              - keyword: BY
+              - column_reference:
+                  naked_identifier: employee_id
+          - statement_terminator: ;
+          naked_identifier: emp_rec
+          row_type_reference:
+            table_reference:
+              naked_identifier: c1
+            binary_operator: '%'
+            keyword: ROWTYPE
+          statement_terminator: ;
+      - keyword: BEGIN
+      - statement:
+          open_statement:
+            keyword: OPEN
+            naked_identifier: c1
+      - statement_terminator: ;
+      - statement:
+          loop_statement:
+          - keyword: LOOP
+          - statement:
+              fetch_statement:
+                keyword: FETCH
+                naked_identifier: c1
+                into_clause:
+                  keyword: INTO
+                  naked_identifier: emp_rec
+          - statement_terminator: ;
+          - statement:
+              exit_statement:
+              - keyword: EXIT
+              - keyword: WHEN
+              - expression:
+                  naked_identifier: c1
+                  binary_operator: '%'
+                  keyword: NOTFOUND
+          - statement_terminator: ;
+          - statement:
+              function:
+                function_name:
+                  naked_identifier: DBMS_OUTPUT
+                  dot: .
+                  function_name_identifier: PUT_LINE
+                function_contents:
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                    - quoted_literal: "'Raise for employee #'"
+                    - binary_operator:
+                      - pipe: '|'
+                      - pipe: '|'
+                    - column_reference:
+                      - naked_identifier: emp_rec
+                      - dot: .
+                      - naked_identifier: employee_id
+                    - binary_operator:
+                      - pipe: '|'
+                      - pipe: '|'
+                    - quoted_literal: "' is $'"
+                    - binary_operator:
+                      - pipe: '|'
+                      - pipe: '|'
+                    - column_reference:
+                      - naked_identifier: emp_rec
+                      - dot: .
+                      - naked_identifier: raisee
+                    end_bracket: )
+          - statement_terminator: ;
+          - keyword: END
+          - keyword: LOOP
+      - statement_terminator: ;
+      - statement:
+          close_statement:
+            keyword: CLOSE
+            naked_identifier: c1
+      - statement_terminator: ;
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      begin_end_block:
+      - declare_segment:
+          keyword: DECLARE
+          cursor_variable:
+          - keyword: CURSOR
+          - naked_identifier: c
+          - function_parameter_list:
+              bracketed:
+              - start_bracket: (
+              - parameter: job
+              - data_type:
+                  data_type_identifier: VARCHAR2
+              - comma: ','
+              - parameter: max_sal
+              - data_type:
+                  data_type_identifier: NUMBER
+              - end_bracket: )
+          - keyword: IS
+          - select_statement:
+              select_clause:
+              - keyword: SELECT
+              - select_clause_element:
+                  column_reference:
+                    naked_identifier: last_name
+              - comma: ','
+              - select_clause_element:
+                  column_reference:
+                    naked_identifier: first_name
+              - comma: ','
+              - select_clause_element:
+                  expression:
+                    bracketed:
+                      start_bracket: (
+                      expression:
+                      - column_reference:
+                          naked_identifier: salary
+                      - binary_operator: '-'
+                      - column_reference:
+                          naked_identifier: max_sal
+                      end_bracket: )
+                  alias_expression:
+                    naked_identifier: overpayment
+              from_clause:
+                keyword: FROM
+                from_expression:
+                  from_expression_element:
+                    table_expression:
+                      table_reference:
+                        naked_identifier: employees
+              where_clause:
+                keyword: WHERE
+                expression:
+                - column_reference:
+                    naked_identifier: job_id
+                - comparison_operator:
+                    raw_comparison_operator: '='
+                - column_reference:
+                    naked_identifier: job
+                - binary_operator: AND
+                - column_reference:
+                    naked_identifier: salary
+                - comparison_operator:
+                    raw_comparison_operator: '>'
+                - column_reference:
+                    naked_identifier: max_sal
+              orderby_clause:
+              - keyword: ORDER
+              - keyword: BY
+              - column_reference:
+                  naked_identifier: salary
+          - statement_terminator: ;
+          create_procedure_statement:
+          - keyword: PROCEDURE
+          - function_name:
+              function_name_identifier: print_overpaid
+          - keyword: IS
+          - declare_segment:
+            - naked_identifier: last_name_
+            - column_type_reference:
+                column_reference:
+                - naked_identifier: employees
+                - dot: .
+                - naked_identifier: last_name
+                binary_operator: '%'
+                keyword: TYPE
+            - statement_terminator: ;
+            - naked_identifier: first_name_
+            - column_type_reference:
+                column_reference:
+                - naked_identifier: employees
+                - dot: .
+                - naked_identifier: first_name
+                binary_operator: '%'
+                keyword: TYPE
+            - statement_terminator: ;
+            - naked_identifier: overpayment_
+            - column_type_reference:
+                column_reference:
+                - naked_identifier: employees
+                - dot: .
+                - naked_identifier: salary
+                binary_operator: '%'
+                keyword: TYPE
+            - statement_terminator: ;
+          - begin_end_block:
+            - keyword: BEGIN
+            - statement:
+                loop_statement:
+                - keyword: LOOP
+                - statement:
+                    fetch_statement:
+                      keyword: FETCH
+                      naked_identifier: c
+                      into_clause:
+                      - keyword: INTO
+                      - naked_identifier: last_name_
+                      - comma: ','
+                      - naked_identifier: first_name_
+                      - comma: ','
+                      - naked_identifier: overpayment_
+                - statement_terminator: ;
+                - statement:
+                    exit_statement:
+                    - keyword: EXIT
+                    - keyword: WHEN
+                    - expression:
+                        naked_identifier: c
+                        binary_operator: '%'
+                        keyword: NOTFOUND
+                - statement_terminator: ;
+                - statement:
+                    function:
+                      function_name:
+                        naked_identifier: DBMS_OUTPUT
+                        dot: .
+                        function_name_identifier: PUT_LINE
+                      function_contents:
+                        bracketed:
+                          start_bracket: (
+                          expression:
+                          - column_reference:
+                              naked_identifier: last_name_
+                          - binary_operator:
+                            - pipe: '|'
+                            - pipe: '|'
+                          - quoted_literal: "', '"
+                          - binary_operator:
+                            - pipe: '|'
+                            - pipe: '|'
+                          - column_reference:
+                              naked_identifier: first_name_
+                          - binary_operator:
+                            - pipe: '|'
+                            - pipe: '|'
+                          - quoted_literal: "' (by '"
+                          - binary_operator:
+                            - pipe: '|'
+                            - pipe: '|'
+                          - column_reference:
+                              naked_identifier: overpayment_
+                          - binary_operator:
+                            - pipe: '|'
+                            - pipe: '|'
+                          - quoted_literal: "')'"
+                          end_bracket: )
+                - statement_terminator: ;
+                - keyword: END
+                - keyword: LOOP
+            - statement_terminator: ;
+            - keyword: END
+            - object_reference:
+                naked_identifier: print_overpaid
+          - statement_terminator: ;
+      - keyword: BEGIN
+      - statement:
+          function:
+            function_name:
+              naked_identifier: DBMS_OUTPUT
+              dot: .
+              function_name_identifier: PUT_LINE
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  quoted_literal: "'----------------------'"
+                end_bracket: )
+      - statement_terminator: ;
+      - statement:
+          function:
+            function_name:
+              naked_identifier: DBMS_OUTPUT
+              dot: .
+              function_name_identifier: PUT_LINE
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  quoted_literal: "'Overpaid Stock Clerks:'"
+                end_bracket: )
+      - statement_terminator: ;
+      - statement:
+          function:
+            function_name:
+              naked_identifier: DBMS_OUTPUT
+              dot: .
+              function_name_identifier: PUT_LINE
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  quoted_literal: "'----------------------'"
+                end_bracket: )
+      - statement_terminator: ;
+      - statement:
+          open_statement:
+            keyword: OPEN
+            naked_identifier: c
+            function_contents:
+              bracketed:
+              - start_bracket: (
+              - expression:
+                  quoted_literal: "'ST_CLERK'"
+              - comma: ','
+              - expression:
+                  numeric_literal: '5000'
+              - end_bracket: )
+      - statement_terminator: ;
+      - statement:
+          function:
+            function_name:
+              function_name_identifier: print_overpaid
+            function_contents:
+              bracketed:
+                start_bracket: (
+                end_bracket: )
+      - statement_terminator: ;
+      - statement:
+          close_statement:
+            keyword: CLOSE
+            naked_identifier: c
+      - statement_terminator: ;
+      - statement:
+          function:
+            function_name:
+              naked_identifier: DBMS_OUTPUT
+              dot: .
+              function_name_identifier: PUT_LINE
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  quoted_literal: "'-------------------------------'"
+                end_bracket: )
+      - statement_terminator: ;
+      - statement:
+          function:
+            function_name:
+              naked_identifier: DBMS_OUTPUT
+              dot: .
+              function_name_identifier: PUT_LINE
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  quoted_literal: "'Overpaid Sales Representatives:'"
+                end_bracket: )
+      - statement_terminator: ;
+      - statement:
+          function:
+            function_name:
+              naked_identifier: DBMS_OUTPUT
+              dot: .
+              function_name_identifier: PUT_LINE
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  quoted_literal: "'-------------------------------'"
+                end_bracket: )
+      - statement_terminator: ;
+      - statement:
+          open_statement:
+            keyword: OPEN
+            naked_identifier: c
+            function_contents:
+              bracketed:
+              - start_bracket: (
+              - expression:
+                  quoted_literal: "'SA_REP'"
+              - comma: ','
+              - expression:
+                  numeric_literal: '10000'
+              - end_bracket: )
+      - statement_terminator: ;
+      - statement:
+          function:
+            function_name:
+              function_name_identifier: print_overpaid
+            function_contents:
+              bracketed:
+                start_bracket: (
+                end_bracket: )
+      - statement_terminator: ;
+      - statement:
+          close_statement:
+            keyword: CLOSE
+            naked_identifier: c
+      - statement_terminator: ;
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      begin_end_block:
+      - declare_segment:
+          keyword: DECLARE
+          cursor_variable:
+          - keyword: CURSOR
+          - naked_identifier: c
+          - function_parameter_list:
+              bracketed:
+                start_bracket: (
+                parameter: location
+                data_type:
+                  data_type_identifier: NUMBER
+                keyword: DEFAULT
+                expression:
+                  numeric_literal: '1700'
+                end_bracket: )
+          - keyword: IS
+          - select_statement:
+              select_clause:
+              - keyword: SELECT
+              - select_clause_element:
+                  column_reference:
+                  - naked_identifier: d
+                  - dot: .
+                  - naked_identifier: department_name
+              - comma: ','
+              - select_clause_element:
+                  column_reference:
+                  - naked_identifier: e
+                  - dot: .
+                  - naked_identifier: last_name
+                  alias_expression:
+                    naked_identifier: manager
+              - comma: ','
+              - select_clause_element:
+                  column_reference:
+                  - naked_identifier: l
+                  - dot: .
+                  - naked_identifier: city
+              from_clause:
+              - keyword: FROM
+              - from_expression:
+                  from_expression_element:
+                    table_expression:
+                      table_reference:
+                        naked_identifier: departments
+                    alias_expression:
+                      naked_identifier: d
+              - comma: ','
+              - from_expression:
+                  from_expression_element:
+                    table_expression:
+                      table_reference:
+                        naked_identifier: employees
+                    alias_expression:
+                      naked_identifier: e
+              - comma: ','
+              - from_expression:
+                  from_expression_element:
+                    table_expression:
+                      table_reference:
+                        naked_identifier: locations
+                    alias_expression:
+                      naked_identifier: l
+              where_clause:
+                keyword: WHERE
+                expression:
+                - column_reference:
+                  - naked_identifier: l
+                  - dot: .
+                  - naked_identifier: location_id
+                - comparison_operator:
+                    raw_comparison_operator: '='
+                - column_reference:
+                    naked_identifier: location
+                - binary_operator: AND
+                - column_reference:
+                  - naked_identifier: l
+                  - dot: .
+                  - naked_identifier: location_id
+                - comparison_operator:
+                    raw_comparison_operator: '='
+                - column_reference:
+                  - naked_identifier: d
+                  - dot: .
+                  - naked_identifier: location_id
+                - binary_operator: AND
+                - column_reference:
+                  - naked_identifier: d
+                  - dot: .
+                  - naked_identifier: department_id
+                - comparison_operator:
+                    raw_comparison_operator: '='
+                - column_reference:
+                  - naked_identifier: e
+                  - dot: .
+                  - naked_identifier: department_id
+              orderby_clause:
+              - keyword: ORDER
+              - keyword: BY
+              - column_reference:
+                - naked_identifier: d
+                - dot: .
+                - naked_identifier: department_id
+          - statement_terminator: ;
+          create_procedure_statement:
+          - keyword: PROCEDURE
+          - function_name:
+              function_name_identifier: print_depts
+          - keyword: IS
+          - declare_segment:
+            - naked_identifier: dept_name
+            - column_type_reference:
+                column_reference:
+                - naked_identifier: departments
+                - dot: .
+                - naked_identifier: department_name
+                binary_operator: '%'
+                keyword: TYPE
+            - statement_terminator: ;
+            - naked_identifier: mgr_name
+            - column_type_reference:
+                column_reference:
+                - naked_identifier: employees
+                - dot: .
+                - naked_identifier: last_name
+                binary_operator: '%'
+                keyword: TYPE
+            - statement_terminator: ;
+            - naked_identifier: city_name
+            - column_type_reference:
+                column_reference:
+                - naked_identifier: locations
+                - dot: .
+                - naked_identifier: city
+                binary_operator: '%'
+                keyword: TYPE
+            - statement_terminator: ;
+          - begin_end_block:
+            - keyword: BEGIN
+            - statement:
+                loop_statement:
+                - keyword: LOOP
+                - statement:
+                    fetch_statement:
+                      keyword: FETCH
+                      naked_identifier: c
+                      into_clause:
+                      - keyword: INTO
+                      - naked_identifier: dept_name
+                      - comma: ','
+                      - naked_identifier: mgr_name
+                      - comma: ','
+                      - naked_identifier: city_name
+                - statement_terminator: ;
+                - statement:
+                    exit_statement:
+                    - keyword: EXIT
+                    - keyword: WHEN
+                    - expression:
+                        naked_identifier: c
+                        binary_operator: '%'
+                        keyword: NOTFOUND
+                - statement_terminator: ;
+                - statement:
+                    function:
+                      function_name:
+                        naked_identifier: DBMS_OUTPUT
+                        dot: .
+                        function_name_identifier: PUT_LINE
+                      function_contents:
+                        bracketed:
+                          start_bracket: (
+                          expression:
+                          - column_reference:
+                              naked_identifier: dept_name
+                          - binary_operator:
+                            - pipe: '|'
+                            - pipe: '|'
+                          - quoted_literal: "' (Manager: '"
+                          - binary_operator:
+                            - pipe: '|'
+                            - pipe: '|'
+                          - column_reference:
+                              naked_identifier: mgr_name
+                          - binary_operator:
+                            - pipe: '|'
+                            - pipe: '|'
+                          - quoted_literal: "')'"
+                          end_bracket: )
+                - statement_terminator: ;
+                - keyword: END
+                - keyword: LOOP
+            - statement_terminator: ;
+            - keyword: END
+            - object_reference:
+                naked_identifier: print_depts
+          - statement_terminator: ;
+      - keyword: BEGIN
+      - statement:
+          function:
+            function_name:
+              naked_identifier: DBMS_OUTPUT
+              dot: .
+              function_name_identifier: PUT_LINE
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  quoted_literal: "'DEPARTMENTS AT HEADQUARTERS:'"
+                end_bracket: )
+      - statement_terminator: ;
+      - statement:
+          function:
+            function_name:
+              naked_identifier: DBMS_OUTPUT
+              dot: .
+              function_name_identifier: PUT_LINE
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  quoted_literal: "'--------------------------------'"
+                end_bracket: )
+      - statement_terminator: ;
+      - statement:
+          open_statement:
+            keyword: OPEN
+            naked_identifier: c
+      - statement_terminator: ;
+      - statement:
+          function:
+            function_name:
+              function_name_identifier: print_depts
+            function_contents:
+              bracketed:
+                start_bracket: (
+                end_bracket: )
+      - statement_terminator: ;
+      - statement:
+          function:
+            function_name:
+              naked_identifier: DBMS_OUTPUT
+              dot: .
+              function_name_identifier: PUT_LINE
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  quoted_literal: "'--------------------------------'"
+                end_bracket: )
+      - statement_terminator: ;
+      - statement:
+          close_statement:
+            keyword: CLOSE
+            naked_identifier: c
+      - statement_terminator: ;
+      - statement:
+          function:
+            function_name:
+              naked_identifier: DBMS_OUTPUT
+              dot: .
+              function_name_identifier: PUT_LINE
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  quoted_literal: "'DEPARTMENTS IN CANADA:'"
+                end_bracket: )
+      - statement_terminator: ;
+      - statement:
+          function:
+            function_name:
+              naked_identifier: DBMS_OUTPUT
+              dot: .
+              function_name_identifier: PUT_LINE
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  quoted_literal: "'--------------------------------'"
+                end_bracket: )
+      - statement_terminator: ;
+      - statement:
+          open_statement:
+            keyword: OPEN
+            naked_identifier: c
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  numeric_literal: '1800'
+                end_bracket: )
+      - statement_terminator: ;
+      - statement:
+          function:
+            function_name:
+              function_name_identifier: print_depts
+            function_contents:
+              bracketed:
+                start_bracket: (
+                end_bracket: )
+      - statement_terminator: ;
+      - statement:
+          close_statement:
+            keyword: CLOSE
+            naked_identifier: c
+      - statement_terminator: ;
+      - statement:
+          open_statement:
+            keyword: OPEN
+            naked_identifier: c
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  numeric_literal: '1900'
+                end_bracket: )
+      - statement_terminator: ;
+      - statement:
+          function:
+            function_name:
+              function_name_identifier: print_depts
+            function_contents:
+              bracketed:
+                start_bracket: (
+                end_bracket: )
+      - statement_terminator: ;
+      - statement:
+          close_statement:
+            keyword: CLOSE
+            naked_identifier: c
+      - statement_terminator: ;
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      begin_end_block:
+      - declare_segment:
+          keyword: DECLARE
+          cursor_variable:
+          - keyword: CURSOR
+          - naked_identifier: c
+          - function_parameter_list:
+              bracketed:
+              - start_bracket: (
+              - parameter: job
+              - data_type:
+                  data_type_identifier: VARCHAR2
+              - comma: ','
+              - parameter: max_sal
+              - data_type:
+                  data_type_identifier: NUMBER
+              - comma: ','
+              - parameter: hired
+              - data_type:
+                  data_type_identifier: DATE
+              - keyword: DEFAULT
+              - expression:
+                  function:
+                    function_name:
+                      function_name_identifier: TO_DATE
+                    function_contents:
+                      bracketed:
+                      - start_bracket: (
+                      - expression:
+                          quoted_literal: "'31-DEC-1999'"
+                      - comma: ','
+                      - expression:
+                          quoted_literal: "'DD-MON-YYYY'"
+                      - end_bracket: )
+              - end_bracket: )
+          - keyword: IS
+          - select_statement:
+              select_clause:
+              - keyword: SELECT
+              - select_clause_element:
+                  column_reference:
+                    naked_identifier: last_name
+              - comma: ','
+              - select_clause_element:
+                  column_reference:
+                    naked_identifier: first_name
+              - comma: ','
+              - select_clause_element:
+                  expression:
+                    bracketed:
+                      start_bracket: (
+                      expression:
+                      - column_reference:
+                          naked_identifier: salary
+                      - binary_operator: '-'
+                      - column_reference:
+                          naked_identifier: max_sal
+                      end_bracket: )
+                  alias_expression:
+                    naked_identifier: overpayment
+              from_clause:
+                keyword: FROM
+                from_expression:
+                  from_expression_element:
+                    table_expression:
+                      table_reference:
+                        naked_identifier: employees
+              where_clause:
+                keyword: WHERE
+                expression:
+                - column_reference:
+                    naked_identifier: job_id
+                - comparison_operator:
+                    raw_comparison_operator: '='
+                - column_reference:
+                    naked_identifier: job
+                - binary_operator: AND
+                - column_reference:
+                    naked_identifier: salary
+                - comparison_operator:
+                    raw_comparison_operator: '>'
+                - column_reference:
+                    naked_identifier: max_sal
+                - binary_operator: AND
+                - column_reference:
+                    naked_identifier: hire_date
+                - comparison_operator:
+                    raw_comparison_operator: '>'
+                - column_reference:
+                    naked_identifier: hired
+              orderby_clause:
+              - keyword: ORDER
+              - keyword: BY
+              - column_reference:
+                  naked_identifier: salary
+          - statement_terminator: ;
+          create_procedure_statement:
+          - keyword: PROCEDURE
+          - function_name:
+              function_name_identifier: print_overpaid
+          - keyword: IS
+          - declare_segment:
+            - naked_identifier: last_name_
+            - column_type_reference:
+                column_reference:
+                - naked_identifier: employees
+                - dot: .
+                - naked_identifier: last_name
+                binary_operator: '%'
+                keyword: TYPE
+            - statement_terminator: ;
+            - naked_identifier: first_name_
+            - column_type_reference:
+                column_reference:
+                - naked_identifier: employees
+                - dot: .
+                - naked_identifier: first_name
+                binary_operator: '%'
+                keyword: TYPE
+            - statement_terminator: ;
+            - naked_identifier: overpayment_
+            - column_type_reference:
+                column_reference:
+                - naked_identifier: employees
+                - dot: .
+                - naked_identifier: salary
+                binary_operator: '%'
+                keyword: TYPE
+            - statement_terminator: ;
+          - begin_end_block:
+            - keyword: BEGIN
+            - statement:
+                loop_statement:
+                - keyword: LOOP
+                - statement:
+                    fetch_statement:
+                      keyword: FETCH
+                      naked_identifier: c
+                      into_clause:
+                      - keyword: INTO
+                      - naked_identifier: last_name_
+                      - comma: ','
+                      - naked_identifier: first_name_
+                      - comma: ','
+                      - naked_identifier: overpayment_
+                - statement_terminator: ;
+                - statement:
+                    exit_statement:
+                    - keyword: EXIT
+                    - keyword: WHEN
+                    - expression:
+                        naked_identifier: c
+                        binary_operator: '%'
+                        keyword: NOTFOUND
+                - statement_terminator: ;
+                - statement:
+                    function:
+                      function_name:
+                        naked_identifier: DBMS_OUTPUT
+                        dot: .
+                        function_name_identifier: PUT_LINE
+                      function_contents:
+                        bracketed:
+                          start_bracket: (
+                          expression:
+                          - column_reference:
+                              naked_identifier: last_name_
+                          - binary_operator:
+                            - pipe: '|'
+                            - pipe: '|'
+                          - quoted_literal: "', '"
+                          - binary_operator:
+                            - pipe: '|'
+                            - pipe: '|'
+                          - column_reference:
+                              naked_identifier: first_name_
+                          - binary_operator:
+                            - pipe: '|'
+                            - pipe: '|'
+                          - quoted_literal: "' (by '"
+                          - binary_operator:
+                            - pipe: '|'
+                            - pipe: '|'
+                          - column_reference:
+                              naked_identifier: overpayment_
+                          - binary_operator:
+                            - pipe: '|'
+                            - pipe: '|'
+                          - quoted_literal: "')'"
+                          end_bracket: )
+                - statement_terminator: ;
+                - keyword: END
+                - keyword: LOOP
+            - statement_terminator: ;
+            - keyword: END
+            - object_reference:
+                naked_identifier: print_overpaid
+          - statement_terminator: ;
+      - keyword: BEGIN
+      - statement:
+          function:
+            function_name:
+              naked_identifier: DBMS_OUTPUT
+              dot: .
+              function_name_identifier: PUT_LINE
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  quoted_literal: "'-------------------------------'"
+                end_bracket: )
+      - statement_terminator: ;
+      - statement:
+          function:
+            function_name:
+              naked_identifier: DBMS_OUTPUT
+              dot: .
+              function_name_identifier: PUT_LINE
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  quoted_literal: "'Overpaid Sales Representatives:'"
+                end_bracket: )
+      - statement_terminator: ;
+      - statement:
+          function:
+            function_name:
+              naked_identifier: DBMS_OUTPUT
+              dot: .
+              function_name_identifier: PUT_LINE
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  quoted_literal: "'-------------------------------'"
+                end_bracket: )
+      - statement_terminator: ;
+      - statement:
+          open_statement:
+            keyword: OPEN
+            naked_identifier: c
+            function_contents:
+              bracketed:
+              - start_bracket: (
+              - expression:
+                  quoted_literal: "'SA_REP'"
+              - comma: ','
+              - expression:
+                  numeric_literal: '10000'
+              - end_bracket: )
+      - statement_terminator: ;
+      - statement:
+          function:
+            function_name:
+              function_name_identifier: print_overpaid
+            function_contents:
+              bracketed:
+                start_bracket: (
+                end_bracket: )
+      - statement_terminator: ;
+      - statement:
+          close_statement:
+            keyword: CLOSE
+            naked_identifier: c
+      - statement_terminator: ;
+      - statement:
+          function:
+            function_name:
+              naked_identifier: DBMS_OUTPUT
+              dot: .
+              function_name_identifier: PUT_LINE
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  quoted_literal: "'------------------------------------------------'"
+                end_bracket: )
+      - statement_terminator: ;
+      - statement:
+          function:
+            function_name:
+              naked_identifier: DBMS_OUTPUT
+              dot: .
+              function_name_identifier: PUT_LINE
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  quoted_literal: "'Overpaid Sales Representatives Hired After 2014:'"
+                end_bracket: )
+      - statement_terminator: ;
+      - statement:
+          function:
+            function_name:
+              naked_identifier: DBMS_OUTPUT
+              dot: .
+              function_name_identifier: PUT_LINE
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  quoted_literal: "'------------------------------------------------'"
+                end_bracket: )
+      - statement_terminator: ;
+      - statement:
+          open_statement:
+            keyword: OPEN
+            naked_identifier: c
+            function_contents:
+              bracketed:
+              - start_bracket: (
+              - expression:
+                  quoted_literal: "'SA_REP'"
+              - comma: ','
+              - expression:
+                  numeric_literal: '10000'
+              - comma: ','
+              - expression:
+                  function:
+                    function_name:
+                      function_name_identifier: TO_DATE
+                    function_contents:
+                      bracketed:
+                      - start_bracket: (
+                      - expression:
+                          quoted_literal: "'31-DEC-2014'"
+                      - comma: ','
+                      - expression:
+                          quoted_literal: "'DD-MON-YYYY'"
+                      - end_bracket: )
+              - end_bracket: )
+      - statement_terminator: ;
+      - statement:
+          function:
+            function_name:
+              function_name_identifier: print_overpaid
+            function_contents:
+              bracketed:
+                start_bracket: (
+                end_bracket: )
+      - statement_terminator: ;
+      - statement:
+          close_statement:
+            keyword: CLOSE
+            naked_identifier: c
+      - statement_terminator: ;
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      begin_end_block:
+      - declare_segment:
+          keyword: DECLARE
+          cursor_variable:
+          - keyword: CURSOR
+          - naked_identifier: c1
+          - keyword: IS
+          - select_statement:
+              select_clause:
+              - keyword: SELECT
+              - select_clause_element:
+                  column_reference:
+                  - naked_identifier: t1
+                  - dot: .
+                  - naked_identifier: department_id
+              - comma: ','
+              - select_clause_element:
+                  column_reference:
+                    naked_identifier: department_name
+              - comma: ','
+              - select_clause_element:
+                  column_reference:
+                    naked_identifier: staff
+              from_clause:
+              - keyword: FROM
+              - from_expression:
+                  from_expression_element:
+                    table_expression:
+                      table_reference:
+                        naked_identifier: departments
+                    alias_expression:
+                      naked_identifier: t1
+              - comma: ','
+              - from_expression:
+                  from_expression_element:
+                    table_expression:
+                      bracketed:
+                        start_bracket: (
                         select_statement:
                           select_clause:
-                            keyword: SELECT
-                            select_clause_element:
+                          - keyword: SELECT
+                          - select_clause_element:
                               column_reference:
-                              - naked_identifier: e
-                              - dot: .
-                              - naked_identifier: last_name
+                                naked_identifier: department_id
+                          - comma: ','
+                          - select_clause_element:
+                              function:
+                                function_name:
+                                  function_name_identifier: COUNT
+                                function_contents:
+                                  bracketed:
+                                    start_bracket: (
+                                    star: '*'
+                                    end_bracket: )
+                              alias_expression:
+                                alias_operator:
+                                  keyword: AS
+                                naked_identifier: staff
                           from_clause:
                             keyword: FROM
                             from_expression:
@@ -2703,119 +2455,55 @@ file:
                                 table_expression:
                                   table_reference:
                                     naked_identifier: employees
-                                alias_expression:
-                                  naked_identifier: e
-                          where_clause:
-                            keyword: WHERE
-                            expression:
-                            - column_reference:
-                              - naked_identifier: e
-                              - dot: .
-                              - naked_identifier: department_id
-                            - comparison_operator:
-                                raw_comparison_operator: '='
-                            - column_reference:
-                              - naked_identifier: d
-                              - dot: .
-                              - naked_identifier: department_id
-                          orderby_clause:
-                          - keyword: ORDER
+                          groupby_clause:
+                          - keyword: GROUP
                           - keyword: BY
                           - column_reference:
-                            - naked_identifier: e
-                            - dot: .
-                            - naked_identifier: last_name
-                      end_bracket: )
-                alias_expression:
-                  naked_identifier: employees
-            from_clause:
-              keyword: FROM
-              from_expression:
-                from_expression_element:
-                  table_expression:
-                    table_reference:
-                      naked_identifier: departments
-                  alias_expression:
-                    naked_identifier: d
-            where_clause:
-              keyword: WHERE
-              expression:
-                column_reference:
-                  naked_identifier: department_name
-                keyword: LIKE
-                quoted_literal: "'A%'"
-            orderby_clause:
-            - keyword: ORDER
-            - keyword: BY
-            - column_reference:
-                naked_identifier: department_name
-        - statement_terminator: ;
-    - keyword: BEGIN
-    - statement:
-        open_statement:
-          keyword: OPEN
-          naked_identifier: c1
-    - statement_terminator: ;
-    - statement:
-        loop_statement:
-        - keyword: LOOP
-        - statement:
-            fetch_statement:
-              keyword: FETCH
-              naked_identifier: c1
-              into_clause:
-              - keyword: INTO
-              - naked_identifier: dept_name
-              - comma: ','
-              - naked_identifier: emp_cur
-        - statement_terminator: ;
-        - statement:
-            exit_statement:
-            - keyword: EXIT
-            - keyword: WHEN
-            - expression:
+                              naked_identifier: department_id
+                        end_bracket: )
+                    alias_expression:
+                      naked_identifier: t2
+              where_clause:
+                keyword: WHERE
+                expression:
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                    - column_reference:
+                      - naked_identifier: t1
+                      - dot: .
+                      - naked_identifier: department_id
+                    - comparison_operator:
+                        raw_comparison_operator: '='
+                    - column_reference:
+                      - naked_identifier: t2
+                      - dot: .
+                      - naked_identifier: department_id
+                    end_bracket: )
+                  binary_operator: AND
+                  column_reference:
+                    naked_identifier: staff
+                  comparison_operator:
+                  - raw_comparison_operator: '>'
+                  - raw_comparison_operator: '='
+                  numeric_literal: '5'
+              orderby_clause:
+              - keyword: ORDER
+              - keyword: BY
+              - column_reference:
+                  naked_identifier: staff
+          - statement_terminator: ;
+      - keyword: BEGIN
+      - statement:
+          for_loop_statement:
+          - keyword: FOR
+          - naked_identifier: dept
+          - keyword: IN
+          - expression:
+              column_reference:
                 naked_identifier: c1
-                binary_operator: '%'
-                keyword: NOTFOUND
-        - statement_terminator: ;
-        - statement:
-            function:
-              function_name:
-                naked_identifier: DBMS_OUTPUT
-                dot: .
-                function_name_identifier: PUT_LINE
-              function_contents:
-                bracketed:
-                  start_bracket: (
-                  expression:
-                    quoted_literal: "'Department: '"
-                    binary_operator:
-                    - pipe: '|'
-                    - pipe: '|'
-                    column_reference:
-                      naked_identifier: dept_name
-                  end_bracket: )
-        - statement_terminator: ;
-        - statement:
-            loop_statement:
+          - loop_statement:
             - keyword: LOOP
-            - statement:
-                fetch_statement:
-                  keyword: FETCH
-                  naked_identifier: emp_cur
-                  into_clause:
-                    keyword: INTO
-                    naked_identifier: emp_name
-            - statement_terminator: ;
-            - statement:
-                exit_statement:
-                - keyword: EXIT
-                - keyword: WHEN
-                - expression:
-                    naked_identifier: emp_cur
-                    binary_operator: '%'
-                    keyword: NOTFOUND
-            - statement_terminator: ;
             - statement:
                 function:
                   function_name:
@@ -2826,155 +2514,499 @@ file:
                     bracketed:
                       start_bracket: (
                       expression:
-                        quoted_literal: "'-- Employee: '"
-                        binary_operator:
+                      - quoted_literal: "'Department = '"
+                      - binary_operator:
                         - pipe: '|'
                         - pipe: '|'
-                        column_reference:
-                          naked_identifier: emp_name
+                      - column_reference:
+                        - naked_identifier: dept
+                        - dot: .
+                        - naked_identifier: department_name
+                      - binary_operator:
+                        - pipe: '|'
+                        - pipe: '|'
+                      - quoted_literal: "', staff = '"
+                      - binary_operator:
+                        - pipe: '|'
+                        - pipe: '|'
+                      - column_reference:
+                        - naked_identifier: dept
+                        - dot: .
+                        - naked_identifier: staff
                       end_bracket: )
             - statement_terminator: ;
             - keyword: END
             - keyword: LOOP
-        - statement_terminator: ;
-        - keyword: END
-        - keyword: LOOP
-    - statement_terminator: ;
-    - statement:
-        close_statement:
-          keyword: CLOSE
-          naked_identifier: c1
-    - statement_terminator: ;
-    - keyword: END
-- statement_terminator: ;
-- statement_terminator: /
-- statement:
-    begin_end_block:
-    - declare_segment:
-        keyword: DECLARE
-        cursor_variable:
-        - keyword: CURSOR
-        - naked_identifier: c1
-        - keyword: IS
-        - select_statement:
-          - select_clause:
-              keyword: SELECT
-              select_clause_element:
-                wildcard_expression:
-                  wildcard_identifier:
-                    star: '*'
-          - from_clause:
-              keyword: FROM
-              from_expression:
-                from_expression_element:
-                  table_expression:
-                    table_reference:
-                      naked_identifier: emp
-          - keyword: FOR
-          - keyword: UPDATE
-          - keyword: OF
-          - table_reference:
-              naked_identifier: salary
-          - orderby_clause:
-            - keyword: ORDER
-            - keyword: BY
-            - column_reference:
-                naked_identifier: employee_id
-        - statement_terminator: ;
-        naked_identifier: emp_rec
-        row_type_reference:
-          table_reference:
-            naked_identifier: emp
-          binary_operator: '%'
-          keyword: ROWTYPE
-        statement_terminator: ;
-    - keyword: BEGIN
-    - statement:
-        open_statement:
-          keyword: OPEN
-          naked_identifier: c1
-    - statement_terminator: ;
-    - statement:
-        loop_statement:
-        - keyword: LOOP
-        - statement:
-            fetch_statement:
-              keyword: FETCH
-              naked_identifier: c1
-              into_clause:
-                keyword: INTO
-                naked_identifier: emp_rec
-        - statement_terminator: ;
-        - statement:
-            exit_statement:
-            - keyword: EXIT
-            - keyword: WHEN
-            - expression:
-                naked_identifier: c1
-                binary_operator: '%'
-                keyword: NOTFOUND
-        - statement_terminator: ;
-        - statement:
-            function:
-              function_name:
-                naked_identifier: DBMS_OUTPUT
-                dot: .
-                function_name_identifier: PUT_LINE
-              function_contents:
-                bracketed:
-                  start_bracket: (
-                  expression:
-                    quoted_literal: "'emp_rec.employee_id = '"
-                    binary_operator:
-                    - pipe: '|'
-                    - pipe: '|'
-                    function:
-                      function_name:
-                        function_name_identifier: TO_CHAR
-                      function_contents:
-                        bracketed:
-                          start_bracket: (
-                          expression:
-                            column_reference:
-                            - naked_identifier: emp_rec
-                            - dot: .
-                            - naked_identifier: employee_id
-                          end_bracket: )
-                  end_bracket: )
-        - statement_terminator: ;
-        - statement:
-            update_statement:
-              keyword: UPDATE
-              table_reference:
-                naked_identifier: emp
-              set_clause_list:
-                keyword: SET
-                set_clause:
+      - statement_terminator: ;
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      begin_end_block:
+      - declare_segment:
+          keyword: DECLARE
+          cursor_variable:
+          - keyword: CURSOR
+          - naked_identifier: c1
+          - keyword: IS
+          - select_statement:
+              select_clause:
+              - keyword: SELECT
+              - select_clause_element:
+                  column_reference:
+                    naked_identifier: department_id
+              - comma: ','
+              - select_clause_element:
+                  column_reference:
+                    naked_identifier: last_name
+              - comma: ','
+              - select_clause_element:
                   column_reference:
                     naked_identifier: salary
-                  comparison_operator:
-                    raw_comparison_operator: '='
-                  expression:
-                    column_reference:
-                      naked_identifier: salary
-                    binary_operator: '*'
-                    numeric_literal: '1.05'
+              from_clause:
+                keyword: FROM
+                from_expression:
+                  from_expression_element:
+                    table_expression:
+                      table_reference:
+                        naked_identifier: employees
+                    alias_expression:
+                      naked_identifier: t
               where_clause:
                 keyword: WHERE
                 expression:
                   column_reference:
-                    naked_identifier: employee_id
+                    naked_identifier: salary
                   comparison_operator:
-                    raw_comparison_operator: '='
-                  numeric_literal: '105'
+                    raw_comparison_operator: '>'
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                      select_statement:
+                        select_clause:
+                          keyword: SELECT
+                          select_clause_element:
+                            function:
+                              function_name:
+                                function_name_identifier: AVG
+                              function_contents:
+                                bracketed:
+                                  start_bracket: (
+                                  expression:
+                                    column_reference:
+                                      naked_identifier: salary
+                                  end_bracket: )
+                        from_clause:
+                          keyword: FROM
+                          from_expression:
+                            from_expression_element:
+                              table_expression:
+                                table_reference:
+                                  naked_identifier: employees
+                        where_clause:
+                          keyword: WHERE
+                          expression:
+                          - column_reference:
+                            - naked_identifier: t
+                            - dot: .
+                            - naked_identifier: department_id
+                          - comparison_operator:
+                              raw_comparison_operator: '='
+                          - column_reference:
+                              naked_identifier: department_id
+                    end_bracket: )
+              orderby_clause:
+              - keyword: ORDER
+              - keyword: BY
+              - column_reference:
+                  naked_identifier: department_id
+              - comma: ','
+              - column_reference:
+                  naked_identifier: last_name
+          - statement_terminator: ;
+      - keyword: BEGIN
+      - statement:
+          for_loop_statement:
+          - keyword: FOR
+          - naked_identifier: person
+          - keyword: IN
+          - expression:
+              column_reference:
+                naked_identifier: c1
+          - loop_statement:
+            - keyword: LOOP
+            - statement:
+                function:
+                  function_name:
+                    naked_identifier: DBMS_OUTPUT
+                    dot: .
+                    function_name_identifier: PUT_LINE
+                  function_contents:
+                    bracketed:
+                      start_bracket: (
+                      expression:
+                        quoted_literal: "'Making above-average salary = '"
+                        binary_operator:
+                        - pipe: '|'
+                        - pipe: '|'
+                        column_reference:
+                        - naked_identifier: person
+                        - dot: .
+                        - naked_identifier: last_name
+                      end_bracket: )
+            - statement_terminator: ;
+            - keyword: END
+            - keyword: LOOP
+      - statement_terminator: ;
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      begin_end_block:
+      - declare_segment:
+        - keyword: DECLARE
+        - ref_cursor_type:
+          - keyword: TYPE
+          - naked_identifier: emp_cur_typ
+          - keyword: IS
+          - keyword: REF
+          - keyword: CURSOR
         - statement_terminator: ;
-        - statement:
-            transaction_statement:
-              keyword: COMMIT
+        - naked_identifier: emp_cur
+        - data_type:
+            data_type_identifier: emp_cur_typ
         - statement_terminator: ;
-        - keyword: END
-        - keyword: LOOP
-    - statement_terminator: ;
-    - keyword: END
-- statement_terminator: ;
-- statement_terminator: /
+        - naked_identifier: dept_name
+        - column_type_reference:
+            column_reference:
+            - naked_identifier: departments
+            - dot: .
+            - naked_identifier: department_name
+            binary_operator: '%'
+            keyword: TYPE
+        - statement_terminator: ;
+        - naked_identifier: emp_name
+        - column_type_reference:
+            column_reference:
+            - naked_identifier: employees
+            - dot: .
+            - naked_identifier: last_name
+            binary_operator: '%'
+            keyword: TYPE
+        - statement_terminator: ;
+        - cursor_variable:
+          - keyword: CURSOR
+          - naked_identifier: c1
+          - keyword: IS
+          - select_statement:
+              select_clause:
+              - keyword: SELECT
+              - select_clause_element:
+                  column_reference:
+                    naked_identifier: department_name
+              - comma: ','
+              - select_clause_element:
+                  function:
+                    function_name:
+                      function_name_identifier: CURSOR
+                    function_contents:
+                      bracketed:
+                        start_bracket: (
+                        expression:
+                          select_statement:
+                            select_clause:
+                              keyword: SELECT
+                              select_clause_element:
+                                column_reference:
+                                - naked_identifier: e
+                                - dot: .
+                                - naked_identifier: last_name
+                            from_clause:
+                              keyword: FROM
+                              from_expression:
+                                from_expression_element:
+                                  table_expression:
+                                    table_reference:
+                                      naked_identifier: employees
+                                  alias_expression:
+                                    naked_identifier: e
+                            where_clause:
+                              keyword: WHERE
+                              expression:
+                              - column_reference:
+                                - naked_identifier: e
+                                - dot: .
+                                - naked_identifier: department_id
+                              - comparison_operator:
+                                  raw_comparison_operator: '='
+                              - column_reference:
+                                - naked_identifier: d
+                                - dot: .
+                                - naked_identifier: department_id
+                            orderby_clause:
+                            - keyword: ORDER
+                            - keyword: BY
+                            - column_reference:
+                              - naked_identifier: e
+                              - dot: .
+                              - naked_identifier: last_name
+                        end_bracket: )
+                  alias_expression:
+                    naked_identifier: employees
+              from_clause:
+                keyword: FROM
+                from_expression:
+                  from_expression_element:
+                    table_expression:
+                      table_reference:
+                        naked_identifier: departments
+                    alias_expression:
+                      naked_identifier: d
+              where_clause:
+                keyword: WHERE
+                expression:
+                  column_reference:
+                    naked_identifier: department_name
+                  keyword: LIKE
+                  quoted_literal: "'A%'"
+              orderby_clause:
+              - keyword: ORDER
+              - keyword: BY
+              - column_reference:
+                  naked_identifier: department_name
+          - statement_terminator: ;
+      - keyword: BEGIN
+      - statement:
+          open_statement:
+            keyword: OPEN
+            naked_identifier: c1
+      - statement_terminator: ;
+      - statement:
+          loop_statement:
+          - keyword: LOOP
+          - statement:
+              fetch_statement:
+                keyword: FETCH
+                naked_identifier: c1
+                into_clause:
+                - keyword: INTO
+                - naked_identifier: dept_name
+                - comma: ','
+                - naked_identifier: emp_cur
+          - statement_terminator: ;
+          - statement:
+              exit_statement:
+              - keyword: EXIT
+              - keyword: WHEN
+              - expression:
+                  naked_identifier: c1
+                  binary_operator: '%'
+                  keyword: NOTFOUND
+          - statement_terminator: ;
+          - statement:
+              function:
+                function_name:
+                  naked_identifier: DBMS_OUTPUT
+                  dot: .
+                  function_name_identifier: PUT_LINE
+                function_contents:
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                      quoted_literal: "'Department: '"
+                      binary_operator:
+                      - pipe: '|'
+                      - pipe: '|'
+                      column_reference:
+                        naked_identifier: dept_name
+                    end_bracket: )
+          - statement_terminator: ;
+          - statement:
+              loop_statement:
+              - keyword: LOOP
+              - statement:
+                  fetch_statement:
+                    keyword: FETCH
+                    naked_identifier: emp_cur
+                    into_clause:
+                      keyword: INTO
+                      naked_identifier: emp_name
+              - statement_terminator: ;
+              - statement:
+                  exit_statement:
+                  - keyword: EXIT
+                  - keyword: WHEN
+                  - expression:
+                      naked_identifier: emp_cur
+                      binary_operator: '%'
+                      keyword: NOTFOUND
+              - statement_terminator: ;
+              - statement:
+                  function:
+                    function_name:
+                      naked_identifier: DBMS_OUTPUT
+                      dot: .
+                      function_name_identifier: PUT_LINE
+                    function_contents:
+                      bracketed:
+                        start_bracket: (
+                        expression:
+                          quoted_literal: "'-- Employee: '"
+                          binary_operator:
+                          - pipe: '|'
+                          - pipe: '|'
+                          column_reference:
+                            naked_identifier: emp_name
+                        end_bracket: )
+              - statement_terminator: ;
+              - keyword: END
+              - keyword: LOOP
+          - statement_terminator: ;
+          - keyword: END
+          - keyword: LOOP
+      - statement_terminator: ;
+      - statement:
+          close_statement:
+            keyword: CLOSE
+            naked_identifier: c1
+      - statement_terminator: ;
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      begin_end_block:
+      - declare_segment:
+          keyword: DECLARE
+          cursor_variable:
+          - keyword: CURSOR
+          - naked_identifier: c1
+          - keyword: IS
+          - select_statement:
+            - select_clause:
+                keyword: SELECT
+                select_clause_element:
+                  wildcard_expression:
+                    wildcard_identifier:
+                      star: '*'
+            - from_clause:
+                keyword: FROM
+                from_expression:
+                  from_expression_element:
+                    table_expression:
+                      table_reference:
+                        naked_identifier: emp
+            - keyword: FOR
+            - keyword: UPDATE
+            - keyword: OF
+            - table_reference:
+                naked_identifier: salary
+            - orderby_clause:
+              - keyword: ORDER
+              - keyword: BY
+              - column_reference:
+                  naked_identifier: employee_id
+          - statement_terminator: ;
+          naked_identifier: emp_rec
+          row_type_reference:
+            table_reference:
+              naked_identifier: emp
+            binary_operator: '%'
+            keyword: ROWTYPE
+          statement_terminator: ;
+      - keyword: BEGIN
+      - statement:
+          open_statement:
+            keyword: OPEN
+            naked_identifier: c1
+      - statement_terminator: ;
+      - statement:
+          loop_statement:
+          - keyword: LOOP
+          - statement:
+              fetch_statement:
+                keyword: FETCH
+                naked_identifier: c1
+                into_clause:
+                  keyword: INTO
+                  naked_identifier: emp_rec
+          - statement_terminator: ;
+          - statement:
+              exit_statement:
+              - keyword: EXIT
+              - keyword: WHEN
+              - expression:
+                  naked_identifier: c1
+                  binary_operator: '%'
+                  keyword: NOTFOUND
+          - statement_terminator: ;
+          - statement:
+              function:
+                function_name:
+                  naked_identifier: DBMS_OUTPUT
+                  dot: .
+                  function_name_identifier: PUT_LINE
+                function_contents:
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                      quoted_literal: "'emp_rec.employee_id = '"
+                      binary_operator:
+                      - pipe: '|'
+                      - pipe: '|'
+                      function:
+                        function_name:
+                          function_name_identifier: TO_CHAR
+                        function_contents:
+                          bracketed:
+                            start_bracket: (
+                            expression:
+                              column_reference:
+                              - naked_identifier: emp_rec
+                              - dot: .
+                              - naked_identifier: employee_id
+                            end_bracket: )
+                    end_bracket: )
+          - statement_terminator: ;
+          - statement:
+              update_statement:
+                keyword: UPDATE
+                table_reference:
+                  naked_identifier: emp
+                set_clause_list:
+                  keyword: SET
+                  set_clause:
+                    column_reference:
+                      naked_identifier: salary
+                    comparison_operator:
+                      raw_comparison_operator: '='
+                    expression:
+                      column_reference:
+                        naked_identifier: salary
+                      binary_operator: '*'
+                      numeric_literal: '1.05'
+                where_clause:
+                  keyword: WHERE
+                  expression:
+                    column_reference:
+                      naked_identifier: employee_id
+                    comparison_operator:
+                      raw_comparison_operator: '='
+                    numeric_literal: '105'
+          - statement_terminator: ;
+          - statement:
+              transaction_statement:
+                keyword: COMMIT
+          - statement_terminator: ;
+          - keyword: END
+          - keyword: LOOP
+      - statement_terminator: ;
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /

--- a/test/fixtures/dialects/oracle/database_link.yml
+++ b/test/fixtures/dialects/oracle/database_link.yml
@@ -3,106 +3,107 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 5d58dab8c810a69405689c1ac6eb6f0416b3389c1901c5a08601b0f41ed0d2d4
+_hash: fd1454a1c29738768fc3651822fac209cfe5d7c2d5b85ffff9d10b760fc02d3e
 file:
-- statement:
-    select_statement:
-      select_clause:
-        keyword: select
-        select_clause_element:
-          wildcard_expression:
-            wildcard_identifier:
-              star: '*'
-      from_clause:
-        keyword: from
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-              - naked_identifier: foo
-              - at_sign: '@'
-              - naked_identifier: bar
-      where_clause:
-        keyword: where
-        expression:
-        - numeric_literal: '1'
-        - comparison_operator:
-            raw_comparison_operator: '='
-        - numeric_literal: '1'
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-        keyword: select
-        select_clause_element:
-          column_reference:
-          - naked_identifier: baz
-          - dot: .
-          - naked_identifier: name
-      from_clause:
-        keyword: from
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-              - naked_identifier: foo
-              - at_sign: '@'
-              - naked_identifier: bar
-            alias_expression:
-              naked_identifier: baz
-      where_clause:
-        keyword: where
-        expression:
-        - numeric_literal: '1'
-        - comparison_operator:
-            raw_comparison_operator: '='
-        - numeric_literal: '1'
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-        keyword: select
-        select_clause_element:
-          function:
-            function_name:
-            - function_name_identifier: function_a
-            - at_sign: '@'
-            - function_name_identifier: orcl
-            function_contents:
-              bracketed:
-                start_bracket: (
-                end_bracket: )
-      from_clause:
-        keyword: from
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: dual
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-        keyword: select
-        select_clause_element:
-          function:
-            function_name:
-            - naked_identifier: pkg_test
+  batch:
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: select
+          select_clause_element:
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+        from_clause:
+          keyword: from
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                - naked_identifier: foo
+                - at_sign: '@'
+                - naked_identifier: bar
+        where_clause:
+          keyword: where
+          expression:
+          - numeric_literal: '1'
+          - comparison_operator:
+              raw_comparison_operator: '='
+          - numeric_literal: '1'
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: select
+          select_clause_element:
+            column_reference:
+            - naked_identifier: baz
             - dot: .
-            - function_name_identifier: function_a
-            - at_sign: '@'
-            - function_name_identifier: orcl
-            function_contents:
-              bracketed:
-                start_bracket: (
-                expression:
-                  numeric_literal: '1'
-                end_bracket: )
-      from_clause:
-        keyword: from
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: dual
-- statement_terminator: ;
+            - naked_identifier: name
+        from_clause:
+          keyword: from
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                - naked_identifier: foo
+                - at_sign: '@'
+                - naked_identifier: bar
+              alias_expression:
+                naked_identifier: baz
+        where_clause:
+          keyword: where
+          expression:
+          - numeric_literal: '1'
+          - comparison_operator:
+              raw_comparison_operator: '='
+          - numeric_literal: '1'
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: select
+          select_clause_element:
+            function:
+              function_name:
+              - function_name_identifier: function_a
+              - at_sign: '@'
+              - function_name_identifier: orcl
+              function_contents:
+                bracketed:
+                  start_bracket: (
+                  end_bracket: )
+        from_clause:
+          keyword: from
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: dual
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: select
+          select_clause_element:
+            function:
+              function_name:
+              - naked_identifier: pkg_test
+              - dot: .
+              - function_name_identifier: function_a
+              - at_sign: '@'
+              - function_name_identifier: orcl
+              function_contents:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    numeric_literal: '1'
+                  end_bracket: )
+        from_clause:
+          keyword: from
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: dual
+  - statement_terminator: ;

--- a/test/fixtures/dialects/oracle/drop_database_link.yml
+++ b/test/fixtures/dialects/oracle/drop_database_link.yml
@@ -3,14 +3,15 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: cd2b45a05673ea8ae060bc0b360ea73dd314c17734a7cde396a086870c655b86
+_hash: a49a24933e3de7949314b74bf6e6b7803a665a06441effd04526bd910ed57c15
 file:
-  statement:
-    drop_database_link_statement:
-    - keyword: DROP
-    - keyword: PUBLIC
-    - keyword: DATABASE
-    - keyword: LINK
-    - database_link_reference:
-        naked_identifier: remote
-  statement_terminator: ;
+  batch:
+    statement:
+      drop_database_link_statement:
+      - keyword: DROP
+      - keyword: PUBLIC
+      - keyword: DATABASE
+      - keyword: LINK
+      - database_link_reference:
+          naked_identifier: remote
+    statement_terminator: ;

--- a/test/fixtures/dialects/oracle/drop_package.yml
+++ b/test/fixtures/dialects/oracle/drop_package.yml
@@ -3,12 +3,13 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: ad95a8c4c861de157b9cb1474c0e529c48b47f70c9cd28001f56c0c54f9f33f3
+_hash: d9c280cfa83ab7cda746de679bcdab3c75ee000396570e8bc2ebb37f46d8c74f
 file:
-  statement:
-    drop_package_statement:
-    - keyword: DROP
-    - keyword: PACKAGE
-    - package_reference:
-        naked_identifier: emp_mgmt
-  statement_terminator: ;
+  batch:
+    statement:
+      drop_package_statement:
+      - keyword: DROP
+      - keyword: PACKAGE
+      - package_reference:
+          naked_identifier: emp_mgmt
+    statement_terminator: ;

--- a/test/fixtures/dialects/oracle/drop_procedure.yml
+++ b/test/fixtures/dialects/oracle/drop_procedure.yml
@@ -3,14 +3,15 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 11d2b406537784262f8d1ff4dcf1f7d7ca200480a0f958c6387e9d990db0a493
+_hash: b3316184bb4a2c37aa99f80e55d770015fe3d9cdec33983c88e26209aa19d2b2
 file:
-  statement:
-    drop_procedure_statement:
-    - keyword: DROP
-    - keyword: PROCEDURE
-    - function_name:
-        naked_identifier: hr
-        dot: .
-        function_name_identifier: remove_emp
-  statement_terminator: ;
+  batch:
+    statement:
+      drop_procedure_statement:
+      - keyword: DROP
+      - keyword: PROCEDURE
+      - function_name:
+          naked_identifier: hr
+          dot: .
+          function_name_identifier: remove_emp
+    statement_terminator: ;

--- a/test/fixtures/dialects/oracle/drop_synonym.yml
+++ b/test/fixtures/dialects/oracle/drop_synonym.yml
@@ -3,13 +3,14 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 79b866073c56f7d9e2ad925ad86ae3698729de575fcbd02d19318ac7f35546cd
+_hash: af84de3d2ae7f6cc4e003d1df3a2727eba72f1caa6d6fe1a2263368aa3d6926e
 file:
-  statement:
-    drop_synonym_statement:
-    - keyword: DROP
-    - keyword: PUBLIC
-    - keyword: SYNONYM
-    - object_reference:
-        naked_identifier: customers
-  statement_terminator: ;
+  batch:
+    statement:
+      drop_synonym_statement:
+      - keyword: DROP
+      - keyword: PUBLIC
+      - keyword: SYNONYM
+      - object_reference:
+          naked_identifier: customers
+    statement_terminator: ;

--- a/test/fixtures/dialects/oracle/drop_table.yml
+++ b/test/fixtures/dialects/oracle/drop_table.yml
@@ -3,38 +3,39 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: db58b5ebc6efad7ee53b2673aefe4004241b0b3f282079aa6e02b48745243b16
+_hash: dafc41aabaed6856946dec8bfd9cfbcfa5e23f12d047c789c69af0b113610bb2
 file:
-- statement:
-    drop_table_statement:
-    - keyword: DROP
-    - keyword: TABLE
-    - table_reference:
-      - naked_identifier: foo
-      - dot: .
-      - naked_identifier: bar
-    - keyword: CASCADE
-    - keyword: CONSTRAINTS
-    - keyword: PURGE
-- statement_terminator: ;
-- statement:
-    drop_table_statement:
-    - keyword: DROP
-    - keyword: TABLE
-    - table_reference:
-      - naked_identifier: foo
-      - dot: .
-      - naked_identifier: bar
-    - keyword: CASCADE
-    - keyword: CONSTRAINTS
-- statement_terminator: ;
-- statement:
-    drop_table_statement:
-    - keyword: DROP
-    - keyword: TABLE
-    - table_reference:
-      - naked_identifier: foo
-      - dot: .
-      - naked_identifier: bar
-    - keyword: PURGE
-- statement_terminator: ;
+  batch:
+  - statement:
+      drop_table_statement:
+      - keyword: DROP
+      - keyword: TABLE
+      - table_reference:
+        - naked_identifier: foo
+        - dot: .
+        - naked_identifier: bar
+      - keyword: CASCADE
+      - keyword: CONSTRAINTS
+      - keyword: PURGE
+  - statement_terminator: ;
+  - statement:
+      drop_table_statement:
+      - keyword: DROP
+      - keyword: TABLE
+      - table_reference:
+        - naked_identifier: foo
+        - dot: .
+        - naked_identifier: bar
+      - keyword: CASCADE
+      - keyword: CONSTRAINTS
+  - statement_terminator: ;
+  - statement:
+      drop_table_statement:
+      - keyword: DROP
+      - keyword: TABLE
+      - table_reference:
+        - naked_identifier: foo
+        - dot: .
+        - naked_identifier: bar
+      - keyword: PURGE
+  - statement_terminator: ;

--- a/test/fixtures/dialects/oracle/drop_type.yml
+++ b/test/fixtures/dialects/oracle/drop_type.yml
@@ -3,23 +3,24 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 12cc8c15b864c7b5b34bc9f57d9be238033e44de56a382c618f704c9d757d1cb
+_hash: 6c282050944d7687d915164083a047afe5b273f11948a6e14984b9e45b96b6dc
 file:
-- statement:
-    drop_type_statement:
-    - keyword: DROP
-    - keyword: TYPE
-    - keyword: IF
-    - keyword: EXISTS
-    - object_reference:
-        naked_identifier: person_t
-    - keyword: FORCE
-- statement_terminator: ;
-- statement:
-    drop_type_statement:
-    - keyword: DROP
-    - keyword: TYPE
-    - keyword: BODY
-    - object_reference:
-        naked_identifier: data_typ1
-- statement_terminator: ;
+  batch:
+  - statement:
+      drop_type_statement:
+      - keyword: DROP
+      - keyword: TYPE
+      - keyword: IF
+      - keyword: EXISTS
+      - object_reference:
+          naked_identifier: person_t
+      - keyword: FORCE
+  - statement_terminator: ;
+  - statement:
+      drop_type_statement:
+      - keyword: DROP
+      - keyword: TYPE
+      - keyword: BODY
+      - object_reference:
+          naked_identifier: data_typ1
+  - statement_terminator: ;

--- a/test/fixtures/dialects/oracle/exception_indentation.yml
+++ b/test/fixtures/dialects/oracle/exception_indentation.yml
@@ -3,173 +3,174 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: b6c7f18ae6e069bcd5c04d9953eda1a1035cacd33c1a0cfb81f52e1e202a9b45
+_hash: a71dfc33c4448d07e9153eab909f88acea3eceefee21e017f90d7eccb59bbf3d
 file:
-- statement:
-    begin_end_block:
-    - keyword: BEGIN
-    - statement:
-        select_statement:
-          select_clause:
-            keyword: SELECT
-            select_clause_element:
-              numeric_literal: '1'
-          from_clause:
-            keyword: FROM
-            from_expression:
-              from_expression_element:
-                table_expression:
-                  table_reference:
-                    naked_identifier: dual
-    - statement_terminator: ;
-    - keyword: EXCEPTION
-    - keyword: WHEN
-    - naked_identifier: no_data_found
-    - keyword: THEN
-    - statement:
-        function:
-          function_name:
-            naked_identifier: DBMS_OUTPUT
-            dot: .
-            function_name_identifier: PUT_LINE
-          function_contents:
-            bracketed:
-              start_bracket: (
-              expression:
-                quoted_literal: "'No data'"
-              end_bracket: )
-    - statement_terminator: ;
-    - keyword: WHEN
-    - keyword: OTHERS
-    - keyword: THEN
-    - statement:
-        function:
-          function_name:
-            naked_identifier: DBMS_OUTPUT
-            dot: .
-            function_name_identifier: PUT_LINE
-          function_contents:
-            bracketed:
-              start_bracket: (
-              expression:
-                quoted_literal: "'Error'"
-              end_bracket: )
-    - statement_terminator: ;
-    - keyword: END
-- statement_terminator: ;
-- statement:
-    begin_end_block:
-    - declare_segment:
-        keyword: DECLARE
-        naked_identifier: v_value
-        data_type:
-          data_type_identifier: NUMBER
-        statement_terminator: ;
-    - keyword: BEGIN
-    - statement:
-        begin_end_block:
-        - keyword: BEGIN
-        - statement:
-            assignment_segment_statement:
-              object_reference:
-                naked_identifier: v_value
-              assignment_operator: :=
-              expression:
+  batch:
+  - statement:
+      begin_end_block:
+      - keyword: BEGIN
+      - statement:
+          select_statement:
+            select_clause:
+              keyword: SELECT
+              select_clause_element:
                 numeric_literal: '1'
-        - statement_terminator: ;
-        - keyword: EXCEPTION
-        - keyword: WHEN
-        - keyword: OTHERS
-        - keyword: THEN
-        - statement:
-            function:
-              function_name:
-                naked_identifier: DBMS_OUTPUT
-                dot: .
-                function_name_identifier: PUT_LINE
-              function_contents:
-                bracketed:
-                  start_bracket: (
-                  expression:
-                    quoted_literal: "'Inner exception'"
-                  end_bracket: )
-        - statement_terminator: ;
-        - keyword: END
-    - statement_terminator: ;
-    - keyword: EXCEPTION
-    - keyword: WHEN
-    - keyword: OTHERS
-    - keyword: THEN
-    - statement:
-        function:
-          function_name:
-            naked_identifier: DBMS_OUTPUT
-            dot: .
-            function_name_identifier: PUT_LINE
-          function_contents:
-            bracketed:
-              start_bracket: (
-              expression:
-                quoted_literal: "'Outer exception'"
-              end_bracket: )
-    - statement_terminator: ;
-    - keyword: END
-- statement_terminator: ;
-- statement:
-    begin_end_block:
-    - keyword: BEGIN
-    - statement:
-        null_statement:
-          keyword: 'NULL'
-    - statement_terminator: ;
-    - keyword: EXCEPTION
-    - keyword: WHEN
-    - naked_identifier: zero_divide
-    - keyword: THEN
-    - statement:
-        function:
-          function_name:
-            naked_identifier: DBMS_OUTPUT
-            dot: .
-            function_name_identifier: PUT_LINE
-          function_contents:
-            bracketed:
-              start_bracket: (
-              expression:
-                quoted_literal: "'Division by zero'"
-              end_bracket: )
-    - statement_terminator: ;
-    - keyword: WHEN
-    - naked_identifier: invalid_number
-    - keyword: THEN
-    - statement:
-        function:
-          function_name:
-            naked_identifier: DBMS_OUTPUT
-            dot: .
-            function_name_identifier: PUT_LINE
-          function_contents:
-            bracketed:
-              start_bracket: (
-              expression:
-                quoted_literal: "'Invalid number'"
-              end_bracket: )
-    - statement_terminator: ;
-    - keyword: WHEN
-    - keyword: OTHERS
-    - keyword: THEN
-    - statement:
-        function:
-          function_name:
-            naked_identifier: DBMS_OUTPUT
-            dot: .
-            function_name_identifier: PUT_LINE
-          function_contents:
-            bracketed:
-              start_bracket: (
-              expression:
-                quoted_literal: "'Other error'"
-              end_bracket: )
-    - statement_terminator: ;
-    - keyword: END
-- statement_terminator: ;
+            from_clause:
+              keyword: FROM
+              from_expression:
+                from_expression_element:
+                  table_expression:
+                    table_reference:
+                      naked_identifier: dual
+      - statement_terminator: ;
+      - keyword: EXCEPTION
+      - keyword: WHEN
+      - naked_identifier: no_data_found
+      - keyword: THEN
+      - statement:
+          function:
+            function_name:
+              naked_identifier: DBMS_OUTPUT
+              dot: .
+              function_name_identifier: PUT_LINE
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  quoted_literal: "'No data'"
+                end_bracket: )
+      - statement_terminator: ;
+      - keyword: WHEN
+      - keyword: OTHERS
+      - keyword: THEN
+      - statement:
+          function:
+            function_name:
+              naked_identifier: DBMS_OUTPUT
+              dot: .
+              function_name_identifier: PUT_LINE
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  quoted_literal: "'Error'"
+                end_bracket: )
+      - statement_terminator: ;
+      - keyword: END
+  - statement_terminator: ;
+  - statement:
+      begin_end_block:
+      - declare_segment:
+          keyword: DECLARE
+          naked_identifier: v_value
+          data_type:
+            data_type_identifier: NUMBER
+          statement_terminator: ;
+      - keyword: BEGIN
+      - statement:
+          begin_end_block:
+          - keyword: BEGIN
+          - statement:
+              assignment_segment_statement:
+                object_reference:
+                  naked_identifier: v_value
+                assignment_operator: :=
+                expression:
+                  numeric_literal: '1'
+          - statement_terminator: ;
+          - keyword: EXCEPTION
+          - keyword: WHEN
+          - keyword: OTHERS
+          - keyword: THEN
+          - statement:
+              function:
+                function_name:
+                  naked_identifier: DBMS_OUTPUT
+                  dot: .
+                  function_name_identifier: PUT_LINE
+                function_contents:
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                      quoted_literal: "'Inner exception'"
+                    end_bracket: )
+          - statement_terminator: ;
+          - keyword: END
+      - statement_terminator: ;
+      - keyword: EXCEPTION
+      - keyword: WHEN
+      - keyword: OTHERS
+      - keyword: THEN
+      - statement:
+          function:
+            function_name:
+              naked_identifier: DBMS_OUTPUT
+              dot: .
+              function_name_identifier: PUT_LINE
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  quoted_literal: "'Outer exception'"
+                end_bracket: )
+      - statement_terminator: ;
+      - keyword: END
+  - statement_terminator: ;
+  - statement:
+      begin_end_block:
+      - keyword: BEGIN
+      - statement:
+          null_statement:
+            keyword: 'NULL'
+      - statement_terminator: ;
+      - keyword: EXCEPTION
+      - keyword: WHEN
+      - naked_identifier: zero_divide
+      - keyword: THEN
+      - statement:
+          function:
+            function_name:
+              naked_identifier: DBMS_OUTPUT
+              dot: .
+              function_name_identifier: PUT_LINE
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  quoted_literal: "'Division by zero'"
+                end_bracket: )
+      - statement_terminator: ;
+      - keyword: WHEN
+      - naked_identifier: invalid_number
+      - keyword: THEN
+      - statement:
+          function:
+            function_name:
+              naked_identifier: DBMS_OUTPUT
+              dot: .
+              function_name_identifier: PUT_LINE
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  quoted_literal: "'Invalid number'"
+                end_bracket: )
+      - statement_terminator: ;
+      - keyword: WHEN
+      - keyword: OTHERS
+      - keyword: THEN
+      - statement:
+          function:
+            function_name:
+              naked_identifier: DBMS_OUTPUT
+              dot: .
+              function_name_identifier: PUT_LINE
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  quoted_literal: "'Other error'"
+                end_bracket: )
+      - statement_terminator: ;
+      - keyword: END
+  - statement_terminator: ;

--- a/test/fixtures/dialects/oracle/execute_immediate_patterns.yml
+++ b/test/fixtures/dialects/oracle/execute_immediate_patterns.yml
@@ -3,1034 +3,1057 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: d8584251efc41769083ef088772f0b6fbecdee8c20df19a9f337a33555f7e7c6
+_hash: 67c2be6346dd96263b85a4d9fad479f70dcf1622264e37f5085e2ba0626d40ee
 file:
-- statement:
-    begin_end_block:
-    - declare_segment:
-      - keyword: DECLARE
-      - naked_identifier: constraint_name
-      - data_type:
-          data_type_identifier: VARCHAR2
-          bracketed_arguments:
-            bracketed:
-              start_bracket: (
-              numeric_literal: '255'
-              end_bracket: )
+- batch:
+    statement:
+      begin_end_block:
+      - declare_segment:
+        - keyword: DECLARE
+        - naked_identifier: constraint_name
+        - data_type:
+            data_type_identifier: VARCHAR2
+            bracketed_arguments:
+              bracketed:
+                start_bracket: (
+                numeric_literal: '255'
+                end_bracket: )
+        - statement_terminator: ;
+        - naked_identifier: result_var
+        - data_type:
+            data_type_identifier: NUMBER
+        - statement_terminator: ;
+        - naked_identifier: table_name
+        - data_type:
+            data_type_identifier: VARCHAR2
+            bracketed_arguments:
+              bracketed:
+                start_bracket: (
+                numeric_literal: '100'
+                end_bracket: )
+        - assignment_operator: :=
+        - expression:
+            quoted_literal: "'MY_TABLE'"
+        - statement_terminator: ;
+      - keyword: BEGIN
+      - statement:
+          select_statement:
+            select_clause:
+              keyword: SELECT
+              select_clause_element:
+                column_reference:
+                  naked_identifier: constraint_name
+            into_clause:
+              keyword: INTO
+              naked_identifier: constraint_name
+            from_clause:
+              keyword: FROM
+              from_expression:
+                from_expression_element:
+                  table_expression:
+                    table_reference:
+                      naked_identifier: user_constraints
+            where_clause:
+              keyword: WHERE
+              expression:
+              - column_reference:
+                  naked_identifier: table_name
+              - comparison_operator:
+                  raw_comparison_operator: '='
+              - quoted_literal: "'MY_TABLE'"
+              - binary_operator: AND
+              - column_reference:
+                  naked_identifier: constraint_type
+              - comparison_operator:
+                  raw_comparison_operator: '='
+              - quoted_literal: "'C'"
+              - binary_operator: AND
+              - column_reference:
+                  naked_identifier: search_condition_vc
+              - keyword: LIKE
+              - quoted_literal: "'MY_CONDITION%'"
       - statement_terminator: ;
-      - naked_identifier: result_var
-      - data_type:
-          data_type_identifier: NUMBER
-      - statement_terminator: ;
-      - naked_identifier: table_name
-      - data_type:
-          data_type_identifier: VARCHAR2
-          bracketed_arguments:
-            bracketed:
-              start_bracket: (
-              numeric_literal: '100'
-              end_bracket: )
-      - assignment_operator: :=
-      - expression:
-          quoted_literal: "'MY_TABLE'"
-      - statement_terminator: ;
-    - keyword: BEGIN
-    - statement:
-        select_statement:
-          select_clause:
-            keyword: SELECT
-            select_clause_element:
-              column_reference:
-                naked_identifier: constraint_name
-          into_clause:
-            keyword: INTO
-            naked_identifier: constraint_name
-          from_clause:
-            keyword: FROM
-            from_expression:
-              from_expression_element:
-                table_expression:
-                  table_reference:
-                    naked_identifier: user_constraints
-          where_clause:
-            keyword: WHERE
-            expression:
+      - statement:
+          execute_immediate_statement:
+          - keyword: EXECUTE
+          - keyword: IMMEDIATE
+          - expression:
+            - quoted_literal: "'ALTER TABLE '"
+            - binary_operator:
+              - pipe: '|'
+              - pipe: '|'
             - column_reference:
                 naked_identifier: table_name
-            - comparison_operator:
-                raw_comparison_operator: '='
-            - quoted_literal: "'MY_TABLE'"
-            - binary_operator: AND
+            - binary_operator:
+              - pipe: '|'
+              - pipe: '|'
+            - quoted_literal: "' DROP CONSTRAINT '"
+            - binary_operator:
+              - pipe: '|'
+              - pipe: '|'
             - column_reference:
-                naked_identifier: constraint_type
-            - comparison_operator:
-                raw_comparison_operator: '='
-            - quoted_literal: "'C'"
-            - binary_operator: AND
-            - column_reference:
-                naked_identifier: search_condition_vc
-            - keyword: LIKE
-            - quoted_literal: "'MY_CONDITION%'"
-    - statement_terminator: ;
-    - statement:
-        execute_immediate_statement:
-        - keyword: EXECUTE
-        - keyword: IMMEDIATE
-        - expression:
-          - quoted_literal: "'ALTER TABLE '"
-          - binary_operator:
-            - pipe: '|'
-            - pipe: '|'
-          - column_reference:
-              naked_identifier: table_name
-          - binary_operator:
-            - pipe: '|'
-            - pipe: '|'
-          - quoted_literal: "' DROP CONSTRAINT '"
-          - binary_operator:
-            - pipe: '|'
-            - pipe: '|'
-          - column_reference:
-              naked_identifier: constraint_name
-    - statement_terminator: ;
-    - statement:
-        execute_immediate_statement:
-        - keyword: EXECUTE
-        - keyword: IMMEDIATE
-        - expression:
-            quoted_literal: "'ALTER TABLE MY_TABLE2 DROP CONSTRAINT '"
-            binary_operator:
-            - pipe: '|'
-            - pipe: '|'
-            column_reference:
-              naked_identifier: constraint_name
-    - statement_terminator: ;
-    - statement:
-        execute_immediate_statement:
-        - keyword: EXECUTE
-        - keyword: IMMEDIATE
-        - expression:
-            quoted_literal: "'SELECT COUNT(*) FROM '"
-            binary_operator:
-            - pipe: '|'
-            - pipe: '|'
-            column_reference:
-              naked_identifier: table_name
-        - into_clause:
-            keyword: INTO
-            naked_identifier: result_var
-    - statement_terminator: ;
-    - statement:
-        execute_immediate_statement:
-        - keyword: EXECUTE
-        - keyword: IMMEDIATE
-        - expression:
-            quoted_literal: "'INSERT INTO MY_TABLE3 VALUES (:1, :2)'"
-        - keyword: USING
-        - expression:
-            column_reference:
-              naked_identifier: constraint_name
-        - comma: ','
-        - expression:
-            column_reference:
+                naked_identifier: constraint_name
+      - statement_terminator: ;
+      - statement:
+          execute_immediate_statement:
+          - keyword: EXECUTE
+          - keyword: IMMEDIATE
+          - expression:
+              quoted_literal: "'ALTER TABLE MY_TABLE2 DROP CONSTRAINT '"
+              binary_operator:
+              - pipe: '|'
+              - pipe: '|'
+              column_reference:
+                naked_identifier: constraint_name
+      - statement_terminator: ;
+      - statement:
+          execute_immediate_statement:
+          - keyword: EXECUTE
+          - keyword: IMMEDIATE
+          - expression:
+              quoted_literal: "'SELECT COUNT(*) FROM '"
+              binary_operator:
+              - pipe: '|'
+              - pipe: '|'
+              column_reference:
+                naked_identifier: table_name
+          - into_clause:
+              keyword: INTO
               naked_identifier: result_var
-    - statement_terminator: ;
-    - statement:
-        execute_immediate_statement:
-        - keyword: EXECUTE
-        - keyword: IMMEDIATE
+      - statement_terminator: ;
+      - statement:
+          execute_immediate_statement:
+          - keyword: EXECUTE
+          - keyword: IMMEDIATE
+          - expression:
+              quoted_literal: "'INSERT INTO MY_TABLE3 VALUES (:1, :2)'"
+          - keyword: USING
+          - expression:
+              column_reference:
+                naked_identifier: constraint_name
+          - comma: ','
+          - expression:
+              column_reference:
+                naked_identifier: result_var
+      - statement_terminator: ;
+      - statement:
+          execute_immediate_statement:
+          - keyword: EXECUTE
+          - keyword: IMMEDIATE
+          - expression:
+              quoted_literal: "'DROP TABLE MY_TABLE'"
+      - statement_terminator: ;
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      begin_end_block:
+      - declare_segment:
+        - keyword: DECLARE
+        - naked_identifier: a
+        - data_type:
+            data_type_identifier: NUMBER
+        - assignment_operator: :=
         - expression:
-            quoted_literal: "'DROP TABLE MY_TABLE'"
-    - statement_terminator: ;
-    - keyword: END
-- statement_terminator: ;
-- statement_terminator: /
-- statement:
-    begin_end_block:
-    - declare_segment:
-      - keyword: DECLARE
-      - naked_identifier: a
-      - data_type:
-          data_type_identifier: NUMBER
-      - assignment_operator: :=
-      - expression:
-          numeric_literal: '4'
-      - statement_terminator: ;
-      - naked_identifier: b
-      - data_type:
-          data_type_identifier: NUMBER
-      - assignment_operator: :=
-      - expression:
-          numeric_literal: '7'
-      - statement_terminator: ;
-      - naked_identifier: plsql_block
-      - data_type:
-          data_type_identifier: VARCHAR2
-          bracketed_arguments:
-            bracketed:
-              start_bracket: (
-              numeric_literal: '100'
-              end_bracket: )
-      - statement_terminator: ;
-    - keyword: BEGIN
-    - statement:
-        assignment_segment_statement:
-          object_reference:
-            naked_identifier: plsql_block
-          assignment_operator: :=
-          expression:
-            quoted_literal: "'BEGIN calc_stats(:x, :x, :y, :x); END;'"
-    - statement_terminator: ;
-    - statement:
-        execute_immediate_statement:
-        - keyword: EXECUTE
-        - keyword: IMMEDIATE
+            numeric_literal: '4'
+        - statement_terminator: ;
+        - naked_identifier: b
+        - data_type:
+            data_type_identifier: NUMBER
+        - assignment_operator: :=
         - expression:
-            column_reference:
+            numeric_literal: '7'
+        - statement_terminator: ;
+        - naked_identifier: plsql_block
+        - data_type:
+            data_type_identifier: VARCHAR2
+            bracketed_arguments:
+              bracketed:
+                start_bracket: (
+                numeric_literal: '100'
+                end_bracket: )
+        - statement_terminator: ;
+      - keyword: BEGIN
+      - statement:
+          assignment_segment_statement:
+            object_reference:
               naked_identifier: plsql_block
-        - keyword: USING
-        - expression:
-            column_reference:
-              naked_identifier: a
-        - comma: ','
-        - expression:
-            column_reference:
-              naked_identifier: b
-    - statement_terminator: ;
-    - keyword: END
-- statement_terminator: ;
-- statement_terminator: /
-- statement:
-    begin_end_block:
-    - declare_segment:
-        keyword: DECLARE
-        naked_identifier: a_null
-        data_type:
-          data_type_identifier: CHAR
-          bracketed_arguments:
-            bracketed:
-              start_bracket: (
-              numeric_literal: '1'
-              end_bracket: )
-        statement_terminator: ;
-    - keyword: BEGIN
-    - statement:
-        execute_immediate_statement:
-        - keyword: EXECUTE
-        - keyword: IMMEDIATE
-        - expression:
-            quoted_literal: "'UPDATE employees_temp SET commission_pct = :x'"
-        - keyword: USING
-        - expression:
-            column_reference:
-              naked_identifier: a_null
-    - statement_terminator: ;
-    - keyword: END
-- statement_terminator: ;
-- statement_terminator: /
-- statement:
-    begin_end_block:
-    - declare_segment:
-      - keyword: DECLARE
-      - naked_identifier: plsql_block
-      - data_type:
-          data_type_identifier: VARCHAR2
-          bracketed_arguments:
-            bracketed:
-              start_bracket: (
-              numeric_literal: '500'
-              end_bracket: )
+            assignment_operator: :=
+            expression:
+              quoted_literal: "'BEGIN calc_stats(:x, :x, :y, :x); END;'"
       - statement_terminator: ;
-      - naked_identifier: new_deptid
-      - data_type:
-          data_type_identifier: NUMBER
-          bracketed_arguments:
-            bracketed:
-              start_bracket: (
-              numeric_literal: '4'
-              end_bracket: )
+      - statement:
+          execute_immediate_statement:
+          - keyword: EXECUTE
+          - keyword: IMMEDIATE
+          - expression:
+              column_reference:
+                naked_identifier: plsql_block
+          - keyword: USING
+          - expression:
+              column_reference:
+                naked_identifier: a
+          - comma: ','
+          - expression:
+              column_reference:
+                naked_identifier: b
       - statement_terminator: ;
-      - naked_identifier: new_dname
-      - data_type:
-          data_type_identifier: VARCHAR2
-          bracketed_arguments:
-            bracketed:
-              start_bracket: (
-              numeric_literal: '30'
-              end_bracket: )
-      - assignment_operator: :=
-      - expression:
-          quoted_literal: "'Advertising'"
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      begin_end_block:
+      - declare_segment:
+          keyword: DECLARE
+          naked_identifier: a_null
+          data_type:
+            data_type_identifier: CHAR
+            bracketed_arguments:
+              bracketed:
+                start_bracket: (
+                numeric_literal: '1'
+                end_bracket: )
+          statement_terminator: ;
+      - keyword: BEGIN
+      - statement:
+          execute_immediate_statement:
+          - keyword: EXECUTE
+          - keyword: IMMEDIATE
+          - expression:
+              quoted_literal: "'UPDATE employees_temp SET commission_pct = :x'"
+          - keyword: USING
+          - expression:
+              column_reference:
+                naked_identifier: a_null
       - statement_terminator: ;
-      - naked_identifier: new_mgrid
-      - data_type:
-          data_type_identifier: NUMBER
-          bracketed_arguments:
-            bracketed:
-              start_bracket: (
-              numeric_literal: '6'
-              end_bracket: )
-      - assignment_operator: :=
-      - expression:
-          numeric_literal: '200'
-      - statement_terminator: ;
-      - naked_identifier: new_locid
-      - data_type:
-          data_type_identifier: NUMBER
-          bracketed_arguments:
-            bracketed:
-              start_bracket: (
-              numeric_literal: '4'
-              end_bracket: )
-      - assignment_operator: :=
-      - expression:
-          numeric_literal: '1700'
-      - statement_terminator: ;
-    - keyword: BEGIN
-    - statement:
-        assignment_segment_statement:
-          object_reference:
-            naked_identifier: plsql_block
-          assignment_operator: :=
-          expression:
-            quoted_literal: "'BEGIN create_dept(:a, :b, :c, :d); END;'"
-    - statement_terminator: ;
-    - statement:
-        execute_immediate_statement:
-        - keyword: EXECUTE
-        - keyword: IMMEDIATE
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      begin_end_block:
+      - declare_segment:
+        - keyword: DECLARE
+        - naked_identifier: plsql_block
+        - data_type:
+            data_type_identifier: VARCHAR2
+            bracketed_arguments:
+              bracketed:
+                start_bracket: (
+                numeric_literal: '500'
+                end_bracket: )
+        - statement_terminator: ;
+        - naked_identifier: new_deptid
+        - data_type:
+            data_type_identifier: NUMBER
+            bracketed_arguments:
+              bracketed:
+                start_bracket: (
+                numeric_literal: '4'
+                end_bracket: )
+        - statement_terminator: ;
+        - naked_identifier: new_dname
+        - data_type:
+            data_type_identifier: VARCHAR2
+            bracketed_arguments:
+              bracketed:
+                start_bracket: (
+                numeric_literal: '30'
+                end_bracket: )
+        - assignment_operator: :=
         - expression:
-            column_reference:
+            quoted_literal: "'Advertising'"
+        - statement_terminator: ;
+        - naked_identifier: new_mgrid
+        - data_type:
+            data_type_identifier: NUMBER
+            bracketed_arguments:
+              bracketed:
+                start_bracket: (
+                numeric_literal: '6'
+                end_bracket: )
+        - assignment_operator: :=
+        - expression:
+            numeric_literal: '200'
+        - statement_terminator: ;
+        - naked_identifier: new_locid
+        - data_type:
+            data_type_identifier: NUMBER
+            bracketed_arguments:
+              bracketed:
+                start_bracket: (
+                numeric_literal: '4'
+                end_bracket: )
+        - assignment_operator: :=
+        - expression:
+            numeric_literal: '1700'
+        - statement_terminator: ;
+      - keyword: BEGIN
+      - statement:
+          assignment_segment_statement:
+            object_reference:
               naked_identifier: plsql_block
-        - keyword: USING
-        - keyword: IN
-        - keyword: OUT
-        - expression:
-            column_reference:
-              naked_identifier: new_deptid
-        - comma: ','
-        - expression:
-            column_reference:
-              naked_identifier: new_dname
-        - comma: ','
-        - expression:
-            column_reference:
-              naked_identifier: new_mgrid
-        - comma: ','
-        - expression:
-            column_reference:
-              naked_identifier: new_locid
-    - statement_terminator: ;
-    - keyword: END
-- statement_terminator: ;
-- statement_terminator: /
-- statement:
-    begin_end_block:
-    - declare_segment:
-      - keyword: DECLARE
-      - naked_identifier: dyn_stmt
-      - data_type:
-          data_type_identifier: VARCHAR2
-          bracketed_arguments:
-            bracketed:
-              start_bracket: (
-              numeric_literal: '200'
-              end_bracket: )
+            assignment_operator: :=
+            expression:
+              quoted_literal: "'BEGIN create_dept(:a, :b, :c, :d); END;'"
       - statement_terminator: ;
-      - naked_identifier: b
-      - data_type:
-          data_type_identifier: BOOLEAN
-      - assignment_operator: :=
-      - expression:
-          boolean_literal: 'TRUE'
+      - statement:
+          execute_immediate_statement:
+          - keyword: EXECUTE
+          - keyword: IMMEDIATE
+          - expression:
+              column_reference:
+                naked_identifier: plsql_block
+          - keyword: USING
+          - keyword: IN
+          - keyword: OUT
+          - expression:
+              column_reference:
+                naked_identifier: new_deptid
+          - comma: ','
+          - expression:
+              column_reference:
+                naked_identifier: new_dname
+          - comma: ','
+          - expression:
+              column_reference:
+                naked_identifier: new_mgrid
+          - comma: ','
+          - expression:
+              column_reference:
+                naked_identifier: new_locid
       - statement_terminator: ;
-    - keyword: BEGIN
-    - statement:
-        assignment_segment_statement:
-          object_reference:
-            naked_identifier: dyn_stmt
-          assignment_operator: :=
-          expression:
-            quoted_literal: "'BEGIN p(:x); END;'"
-    - statement_terminator: ;
-    - statement:
-        execute_immediate_statement:
-        - keyword: EXECUTE
-        - keyword: IMMEDIATE
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      begin_end_block:
+      - declare_segment:
+        - keyword: DECLARE
+        - naked_identifier: dyn_stmt
+        - data_type:
+            data_type_identifier: VARCHAR2
+            bracketed_arguments:
+              bracketed:
+                start_bracket: (
+                numeric_literal: '200'
+                end_bracket: )
+        - statement_terminator: ;
+        - naked_identifier: b
+        - data_type:
+            data_type_identifier: BOOLEAN
+        - assignment_operator: :=
         - expression:
-            column_reference:
+            boolean_literal: 'TRUE'
+        - statement_terminator: ;
+      - keyword: BEGIN
+      - statement:
+          assignment_segment_statement:
+            object_reference:
               naked_identifier: dyn_stmt
-        - keyword: USING
-        - expression:
-            column_reference:
-              naked_identifier: b
-    - statement_terminator: ;
-    - keyword: END
-- statement_terminator: ;
-- statement_terminator: /
-- statement:
-    begin_end_block:
-    - declare_segment:
-      - keyword: DECLARE
-      - naked_identifier: r
-      - data_type:
-          naked_identifier: pkg
-          dot: .
-          data_type_identifier: rec
+            assignment_operator: :=
+            expression:
+              quoted_literal: "'BEGIN p(:x); END;'"
       - statement_terminator: ;
-      - naked_identifier: dyn_str
-      - data_type:
-          data_type_identifier: VARCHAR2
-          bracketed_arguments:
-            bracketed:
-              start_bracket: (
-              numeric_literal: '3000'
-              end_bracket: )
+      - statement:
+          execute_immediate_statement:
+          - keyword: EXECUTE
+          - keyword: IMMEDIATE
+          - expression:
+              column_reference:
+                naked_identifier: dyn_stmt
+          - keyword: USING
+          - expression:
+              column_reference:
+                naked_identifier: b
       - statement_terminator: ;
-    - keyword: BEGIN
-    - statement:
-        assignment_segment_statement:
-          object_reference:
-            naked_identifier: dyn_str
-          assignment_operator: :=
-          expression:
-            quoted_literal: "'BEGIN pkg.p(:x, 6, 8); END;'"
-    - statement_terminator: ;
-    - statement:
-        execute_immediate_statement:
-        - keyword: EXECUTE
-        - keyword: IMMEDIATE
-        - expression:
-            column_reference:
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      begin_end_block:
+      - declare_segment:
+        - keyword: DECLARE
+        - naked_identifier: r
+        - data_type:
+            naked_identifier: pkg
+            dot: .
+            data_type_identifier: rec
+        - statement_terminator: ;
+        - naked_identifier: dyn_str
+        - data_type:
+            data_type_identifier: VARCHAR2
+            bracketed_arguments:
+              bracketed:
+                start_bracket: (
+                numeric_literal: '3000'
+                end_bracket: )
+        - statement_terminator: ;
+      - keyword: BEGIN
+      - statement:
+          assignment_segment_statement:
+            object_reference:
               naked_identifier: dyn_str
-        - keyword: USING
-        - keyword: OUT
+            assignment_operator: :=
+            expression:
+              quoted_literal: "'BEGIN pkg.p(:x, 6, 8); END;'"
+      - statement_terminator: ;
+      - statement:
+          execute_immediate_statement:
+          - keyword: EXECUTE
+          - keyword: IMMEDIATE
+          - expression:
+              column_reference:
+                naked_identifier: dyn_str
+          - keyword: USING
+          - keyword: OUT
+          - expression:
+              column_reference:
+                naked_identifier: r
+      - statement_terminator: ;
+      - statement:
+          function:
+            function_name:
+              naked_identifier: DBMS_OUTPUT
+              dot: .
+              function_name_identifier: PUT_LINE
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  quoted_literal: "'r.n1 = '"
+                  binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                  column_reference:
+                  - naked_identifier: r
+                  - dot: .
+                  - naked_identifier: n1
+                end_bracket: )
+      - statement_terminator: ;
+      - statement:
+          function:
+            function_name:
+              naked_identifier: DBMS_OUTPUT
+              dot: .
+              function_name_identifier: PUT_LINE
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  quoted_literal: "'r.n2 = '"
+                  binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                  column_reference:
+                  - naked_identifier: r
+                  - dot: .
+                  - naked_identifier: n2
+                end_bracket: )
+      - statement_terminator: ;
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      begin_end_block:
+      - declare_segment:
+        - keyword: DECLARE
+        - naked_identifier: emp_count
+        - data_type:
+            data_type_identifier: NUMBER
+        - statement_terminator: ;
+        - naked_identifier: dept_id
+        - data_type:
+            data_type_identifier: NUMBER
+        - assignment_operator: :=
         - expression:
-            column_reference:
-              naked_identifier: r
-    - statement_terminator: ;
-    - statement:
-        function:
-          function_name:
-            naked_identifier: DBMS_OUTPUT
-            dot: .
-            function_name_identifier: PUT_LINE
-          function_contents:
-            bracketed:
-              start_bracket: (
-              expression:
-                quoted_literal: "'r.n1 = '"
-                binary_operator:
-                - pipe: '|'
-                - pipe: '|'
-                column_reference:
-                - naked_identifier: r
-                - dot: .
-                - naked_identifier: n1
-              end_bracket: )
-    - statement_terminator: ;
-    - statement:
-        function:
-          function_name:
-            naked_identifier: DBMS_OUTPUT
-            dot: .
-            function_name_identifier: PUT_LINE
-          function_contents:
-            bracketed:
-              start_bracket: (
-              expression:
-                quoted_literal: "'r.n2 = '"
-                binary_operator:
-                - pipe: '|'
-                - pipe: '|'
-                column_reference:
-                - naked_identifier: r
-                - dot: .
-                - naked_identifier: n2
-              end_bracket: )
-    - statement_terminator: ;
-    - keyword: END
-- statement_terminator: ;
-- statement_terminator: /
-- statement:
-    begin_end_block:
-    - declare_segment:
-      - keyword: DECLARE
-      - naked_identifier: emp_count
-      - data_type:
-          data_type_identifier: NUMBER
-      - statement_terminator: ;
-      - naked_identifier: dept_id
-      - data_type:
-          data_type_identifier: NUMBER
-      - assignment_operator: :=
-      - expression:
-          numeric_literal: '10'
-      - statement_terminator: ;
-      - naked_identifier: min_salary
-      - data_type:
-          data_type_identifier: NUMBER
-      - assignment_operator: :=
-      - expression:
-          numeric_literal: '5000'
-      - statement_terminator: ;
-      - naked_identifier: dynamic_query
-      - data_type:
-          data_type_identifier: VARCHAR2
-          bracketed_arguments:
-            bracketed:
-              start_bracket: (
-              numeric_literal: '500'
-              end_bracket: )
-      - statement_terminator: ;
-    - keyword: BEGIN
-    - statement:
-        assignment_segment_statement:
-          object_reference:
-            naked_identifier: dynamic_query
-          assignment_operator: :=
-          expression:
-          - quoted_literal: "'SELECT COUNT(*) '"
-          - binary_operator:
-            - pipe: '|'
-            - pipe: '|'
-          - quoted_literal: "'FROM employees '"
-          - binary_operator:
-            - pipe: '|'
-            - pipe: '|'
-          - quoted_literal: "'WHERE department_id = :dept_id '"
-          - binary_operator:
-            - pipe: '|'
-            - pipe: '|'
-          - quoted_literal: "'AND salary >= :min_salary'"
-    - statement_terminator: ;
-    - statement:
-        execute_immediate_statement:
-        - keyword: EXECUTE
-        - keyword: IMMEDIATE
+            numeric_literal: '10'
+        - statement_terminator: ;
+        - naked_identifier: min_salary
+        - data_type:
+            data_type_identifier: NUMBER
+        - assignment_operator: :=
         - expression:
-            column_reference:
+            numeric_literal: '5000'
+        - statement_terminator: ;
+        - naked_identifier: dynamic_query
+        - data_type:
+            data_type_identifier: VARCHAR2
+            bracketed_arguments:
+              bracketed:
+                start_bracket: (
+                numeric_literal: '500'
+                end_bracket: )
+        - statement_terminator: ;
+      - keyword: BEGIN
+      - statement:
+          assignment_segment_statement:
+            object_reference:
               naked_identifier: dynamic_query
-        - into_clause:
-            keyword: INTO
-            naked_identifier: emp_count
-        - keyword: USING
-        - expression:
-            column_reference:
-              naked_identifier: dept_id
-        - comma: ','
-        - expression:
-            column_reference:
-              naked_identifier: min_salary
-    - statement_terminator: ;
-    - statement:
-        function:
-          function_name:
-            naked_identifier: DBMS_OUTPUT
-            dot: .
-            function_name_identifier: PUT_LINE
-          function_contents:
-            bracketed:
-              start_bracket: (
-              expression:
-                quoted_literal: "'Total employees found: '"
-                binary_operator:
-                - pipe: '|'
-                - pipe: '|'
-                column_reference:
-                  naked_identifier: emp_count
-              end_bracket: )
-    - statement_terminator: ;
-    - keyword: END
-- statement_terminator: ;
-- statement_terminator: /
-- statement:
-    begin_end_block:
-    - declare_segment:
-      - keyword: DECLARE
-      - naked_identifier: emp_ids
-      - data_type:
-          naked_identifier: DBMS_SQL
-          dot: .
-          data_type_identifier: NUMBER_TABLE
+            assignment_operator: :=
+            expression:
+            - quoted_literal: "'SELECT COUNT(*) '"
+            - binary_operator:
+              - pipe: '|'
+              - pipe: '|'
+            - quoted_literal: "'FROM employees '"
+            - binary_operator:
+              - pipe: '|'
+              - pipe: '|'
+            - quoted_literal: "'WHERE department_id = :dept_id '"
+            - binary_operator:
+              - pipe: '|'
+              - pipe: '|'
+            - quoted_literal: "'AND salary >= :min_salary'"
       - statement_terminator: ;
-      - naked_identifier: emp_names
-      - data_type:
-          naked_identifier: DBMS_SQL
-          dot: .
-          data_type_identifier: VARCHAR2_TABLE
-      - statement_terminator: ;
-      - naked_identifier: dept_id
-      - data_type:
-          data_type_identifier: NUMBER
-      - assignment_operator: :=
-      - expression:
-          numeric_literal: '20'
-      - statement_terminator: ;
-      - naked_identifier: dynamic_query
-      - data_type:
-          data_type_identifier: VARCHAR2
-          bracketed_arguments:
-            bracketed:
-              start_bracket: (
-              numeric_literal: '500'
-              end_bracket: )
-      - statement_terminator: ;
-    - keyword: BEGIN
-    - statement:
-        assignment_segment_statement:
-          object_reference:
-            naked_identifier: dynamic_query
-          assignment_operator: :=
-          expression:
-          - quoted_literal: "'SELECT employee_id, first_name '"
-          - binary_operator:
-            - pipe: '|'
-            - pipe: '|'
-          - quoted_literal: "'FROM employees '"
-          - binary_operator:
-            - pipe: '|'
-            - pipe: '|'
-          - quoted_literal: "'WHERE department_id = :dept_id '"
-          - binary_operator:
-            - pipe: '|'
-            - pipe: '|'
-          - quoted_literal: "'AND rownum <= 10'"
-    - statement_terminator: ;
-    - statement:
-        execute_immediate_statement:
-        - keyword: EXECUTE
-        - keyword: IMMEDIATE
-        - expression:
-            column_reference:
-              naked_identifier: dynamic_query
-        - bulk_collect_into_clause:
-          - keyword: BULK
-          - keyword: COLLECT
-          - keyword: INTO
-          - naked_identifier: emp_ids
+      - statement:
+          execute_immediate_statement:
+          - keyword: EXECUTE
+          - keyword: IMMEDIATE
+          - expression:
+              column_reference:
+                naked_identifier: dynamic_query
+          - into_clause:
+              keyword: INTO
+              naked_identifier: emp_count
+          - keyword: USING
+          - expression:
+              column_reference:
+                naked_identifier: dept_id
           - comma: ','
-          - naked_identifier: emp_names
-        - keyword: USING
-        - expression:
-            column_reference:
-              naked_identifier: dept_id
-    - statement_terminator: ;
-    - statement:
-        for_loop_statement:
-        - keyword: FOR
-        - naked_identifier: i
-        - keyword: IN
-        - numeric_literal: '1'
-        - dot: .
-        - dot: .
+          - expression:
+              column_reference:
+                naked_identifier: min_salary
+      - statement_terminator: ;
+      - statement:
+          function:
+            function_name:
+              naked_identifier: DBMS_OUTPUT
+              dot: .
+              function_name_identifier: PUT_LINE
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  quoted_literal: "'Total employees found: '"
+                  binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                  column_reference:
+                    naked_identifier: emp_count
+                end_bracket: )
+      - statement_terminator: ;
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      begin_end_block:
+      - declare_segment:
+        - keyword: DECLARE
         - naked_identifier: emp_ids
-        - dot: .
-        - naked_identifier: COUNT
-        - loop_statement:
-          - keyword: LOOP
-          - statement:
-              function:
-                function_name:
-                  naked_identifier: DBMS_OUTPUT
-                  dot: .
-                  function_name_identifier: PUT_LINE
-                function_contents:
-                  bracketed:
-                    start_bracket: (
-                    expression:
-                    - quoted_literal: "'Employee: '"
-                    - binary_operator:
-                      - pipe: '|'
-                      - pipe: '|'
-                    - function:
-                        function_name:
-                          function_name_identifier: emp_names
-                        function_contents:
-                          bracketed:
-                            start_bracket: (
-                            expression:
-                              column_reference:
-                                naked_identifier: i
-                            end_bracket: )
-                    - binary_operator:
-                      - pipe: '|'
-                      - pipe: '|'
-                    - quoted_literal: "' (ID: '"
-                    - binary_operator:
-                      - pipe: '|'
-                      - pipe: '|'
-                    - function:
-                        function_name:
-                          function_name_identifier: emp_ids
-                        function_contents:
-                          bracketed:
-                            start_bracket: (
-                            expression:
-                              column_reference:
-                                naked_identifier: i
-                            end_bracket: )
-                    - binary_operator:
-                      - pipe: '|'
-                      - pipe: '|'
-                    - quoted_literal: "')'"
-                    end_bracket: )
-          - statement_terminator: ;
-          - keyword: END
-          - keyword: LOOP
-    - statement_terminator: ;
-    - statement:
-        function:
-          function_name:
-            naked_identifier: DBMS_OUTPUT
+        - data_type:
+            naked_identifier: DBMS_SQL
             dot: .
-            function_name_identifier: PUT_LINE
-          function_contents:
-            bracketed:
-              start_bracket: (
-              expression:
-                quoted_literal: "'Total employees found: '"
-                binary_operator:
-                - pipe: '|'
-                - pipe: '|'
-                column_reference:
-                - naked_identifier: emp_ids
-                - dot: .
-                - naked_identifier: COUNT
-              end_bracket: )
-    - statement_terminator: ;
-    - keyword: END
-- statement_terminator: ;
-- statement_terminator: /
-- statement:
-    begin_end_block:
-    - declare_segment:
-      - keyword: DECLARE
-      - naked_identifier: updated_ids
-      - data_type:
-          naked_identifier: DBMS_SQL
-          dot: .
-          data_type_identifier: NUMBER_TABLE
-      - statement_terminator: ;
-      - naked_identifier: updated_salaries
-      - data_type:
-          naked_identifier: DBMS_SQL
-          dot: .
-          data_type_identifier: NUMBER_TABLE
-      - statement_terminator: ;
-      - naked_identifier: dept_id
-      - data_type:
-          data_type_identifier: NUMBER
-      - assignment_operator: :=
-      - expression:
-          numeric_literal: '30'
-      - statement_terminator: ;
-      - naked_identifier: salary_increase
-      - data_type:
-          data_type_identifier: NUMBER
-      - assignment_operator: :=
-      - expression:
-          numeric_literal: '500'
-      - statement_terminator: ;
-      - naked_identifier: dynamic_update
-      - data_type:
-          data_type_identifier: VARCHAR2
-          bracketed_arguments:
-            bracketed:
-              start_bracket: (
-              numeric_literal: '500'
-              end_bracket: )
-      - statement_terminator: ;
-    - keyword: BEGIN
-    - statement:
-        assignment_segment_statement:
-          object_reference:
-            naked_identifier: dynamic_update
-          assignment_operator: :=
-          expression:
-          - quoted_literal: "'UPDATE employees '"
-          - binary_operator:
-            - pipe: '|'
-            - pipe: '|'
-          - quoted_literal: "'SET salary = salary + :increase '"
-          - binary_operator:
-            - pipe: '|'
-            - pipe: '|'
-          - quoted_literal: "'WHERE department_id = :dept_id '"
-          - binary_operator:
-            - pipe: '|'
-            - pipe: '|'
-          - quoted_literal: "'AND salary < 8000 '"
-          - binary_operator:
-            - pipe: '|'
-            - pipe: '|'
-          - quoted_literal: "'RETURNING employee_id, salary INTO :ids, :salaries'"
-    - statement_terminator: ;
-    - statement:
-        execute_immediate_statement:
-        - keyword: EXECUTE
-        - keyword: IMMEDIATE
+            data_type_identifier: NUMBER_TABLE
+        - statement_terminator: ;
+        - naked_identifier: emp_names
+        - data_type:
+            naked_identifier: DBMS_SQL
+            dot: .
+            data_type_identifier: VARCHAR2_TABLE
+        - statement_terminator: ;
+        - naked_identifier: dept_id
+        - data_type:
+            data_type_identifier: NUMBER
+        - assignment_operator: :=
         - expression:
-            column_reference:
-              naked_identifier: dynamic_update
-        - keyword: USING
-        - expression:
-            column_reference:
-              naked_identifier: salary_increase
-        - comma: ','
-        - expression:
-            column_reference:
-              naked_identifier: dept_id
-        - keyword: RETURNING
-        - bulk_collect_into_clause:
-          - keyword: BULK
-          - keyword: COLLECT
-          - keyword: INTO
-          - naked_identifier: updated_ids
-          - comma: ','
-          - naked_identifier: updated_salaries
-    - statement_terminator: ;
-    - statement:
-        for_loop_statement:
-        - keyword: FOR
-        - naked_identifier: i
-        - keyword: IN
-        - numeric_literal: '1'
-        - dot: .
-        - dot: .
+            numeric_literal: '20'
+        - statement_terminator: ;
+        - naked_identifier: dynamic_query
+        - data_type:
+            data_type_identifier: VARCHAR2
+            bracketed_arguments:
+              bracketed:
+                start_bracket: (
+                numeric_literal: '500'
+                end_bracket: )
+        - statement_terminator: ;
+      - keyword: BEGIN
+      - statement:
+          assignment_segment_statement:
+            object_reference:
+              naked_identifier: dynamic_query
+            assignment_operator: :=
+            expression:
+            - quoted_literal: "'SELECT employee_id, first_name '"
+            - binary_operator:
+              - pipe: '|'
+              - pipe: '|'
+            - quoted_literal: "'FROM employees '"
+            - binary_operator:
+              - pipe: '|'
+              - pipe: '|'
+            - quoted_literal: "'WHERE department_id = :dept_id '"
+            - binary_operator:
+              - pipe: '|'
+              - pipe: '|'
+            - quoted_literal: "'AND rownum <= 10'"
+      - statement_terminator: ;
+      - statement:
+          execute_immediate_statement:
+          - keyword: EXECUTE
+          - keyword: IMMEDIATE
+          - expression:
+              column_reference:
+                naked_identifier: dynamic_query
+          - bulk_collect_into_clause:
+            - keyword: BULK
+            - keyword: COLLECT
+            - keyword: INTO
+            - naked_identifier: emp_ids
+            - comma: ','
+            - naked_identifier: emp_names
+          - keyword: USING
+          - expression:
+              column_reference:
+                naked_identifier: dept_id
+      - statement_terminator: ;
+      - statement:
+          for_loop_statement:
+          - keyword: FOR
+          - naked_identifier: i
+          - keyword: IN
+          - numeric_literal: '1'
+          - dot: .
+          - dot: .
+          - naked_identifier: emp_ids
+          - dot: .
+          - naked_identifier: COUNT
+          - loop_statement:
+            - keyword: LOOP
+            - statement:
+                function:
+                  function_name:
+                    naked_identifier: DBMS_OUTPUT
+                    dot: .
+                    function_name_identifier: PUT_LINE
+                  function_contents:
+                    bracketed:
+                      start_bracket: (
+                      expression:
+                      - quoted_literal: "'Employee: '"
+                      - binary_operator:
+                        - pipe: '|'
+                        - pipe: '|'
+                      - function:
+                          function_name:
+                            function_name_identifier: emp_names
+                          function_contents:
+                            bracketed:
+                              start_bracket: (
+                              expression:
+                                column_reference:
+                                  naked_identifier: i
+                              end_bracket: )
+                      - binary_operator:
+                        - pipe: '|'
+                        - pipe: '|'
+                      - quoted_literal: "' (ID: '"
+                      - binary_operator:
+                        - pipe: '|'
+                        - pipe: '|'
+                      - function:
+                          function_name:
+                            function_name_identifier: emp_ids
+                          function_contents:
+                            bracketed:
+                              start_bracket: (
+                              expression:
+                                column_reference:
+                                  naked_identifier: i
+                              end_bracket: )
+                      - binary_operator:
+                        - pipe: '|'
+                        - pipe: '|'
+                      - quoted_literal: "')'"
+                      end_bracket: )
+            - statement_terminator: ;
+            - keyword: END
+            - keyword: LOOP
+      - statement_terminator: ;
+      - statement:
+          function:
+            function_name:
+              naked_identifier: DBMS_OUTPUT
+              dot: .
+              function_name_identifier: PUT_LINE
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  quoted_literal: "'Total employees found: '"
+                  binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                  column_reference:
+                  - naked_identifier: emp_ids
+                  - dot: .
+                  - naked_identifier: COUNT
+                end_bracket: )
+      - statement_terminator: ;
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      begin_end_block:
+      - declare_segment:
+        - keyword: DECLARE
         - naked_identifier: updated_ids
-        - dot: .
-        - naked_identifier: COUNT
-        - loop_statement:
-          - keyword: LOOP
-          - statement:
-              function:
-                function_name:
-                  naked_identifier: DBMS_OUTPUT
-                  dot: .
-                  function_name_identifier: PUT_LINE
-                function_contents:
-                  bracketed:
-                    start_bracket: (
-                    expression:
-                    - quoted_literal: "'Updated employee ID: '"
-                    - binary_operator:
-                      - pipe: '|'
-                      - pipe: '|'
-                    - function:
-                        function_name:
-                          function_name_identifier: updated_ids
-                        function_contents:
-                          bracketed:
-                            start_bracket: (
-                            expression:
-                              column_reference:
-                                naked_identifier: i
-                            end_bracket: )
-                    - binary_operator:
-                      - pipe: '|'
-                      - pipe: '|'
-                    - quoted_literal: "', New salary: '"
-                    - binary_operator:
-                      - pipe: '|'
-                      - pipe: '|'
-                    - function:
-                        function_name:
-                          function_name_identifier: updated_salaries
-                        function_contents:
-                          bracketed:
-                            start_bracket: (
-                            expression:
-                              column_reference:
-                                naked_identifier: i
-                            end_bracket: )
-                    end_bracket: )
-          - statement_terminator: ;
-          - keyword: END
-          - keyword: LOOP
-    - statement_terminator: ;
-    - keyword: END
-- statement_terminator: ;
-- statement_terminator: /
-- statement:
-    begin_end_block:
-    - declare_segment:
-      - keyword: DECLARE
-      - naked_identifier: emp_id
-      - data_type:
-          data_type_identifier: NUMBER
-      - statement_terminator: ;
-      - naked_identifier: emp_salary
-      - data_type:
-          data_type_identifier: NUMBER
-      - statement_terminator: ;
-      - naked_identifier: dynamic_delete
-      - data_type:
-          data_type_identifier: VARCHAR2
-          bracketed_arguments:
-            bracketed:
-              start_bracket: (
-              numeric_literal: '500'
-              end_bracket: )
-      - statement_terminator: ;
-    - keyword: BEGIN
-    - statement:
-        assignment_segment_statement:
-          object_reference:
-            naked_identifier: dynamic_delete
-          assignment_operator: :=
-          expression:
-          - quoted_literal: "'DELETE FROM temp_employees '"
-          - binary_operator:
-            - pipe: '|'
-            - pipe: '|'
-          - quoted_literal: "'WHERE employee_id = :emp_id '"
-          - binary_operator:
-            - pipe: '|'
-            - pipe: '|'
-          - quoted_literal: "'RETURNING employee_id, salary INTO :id, :sal'"
-    - statement_terminator: ;
-    - statement:
-        execute_immediate_statement:
-        - keyword: EXECUTE
-        - keyword: IMMEDIATE
-        - expression:
-            column_reference:
-              naked_identifier: dynamic_delete
-        - keyword: USING
-        - expression:
-            numeric_literal: '100'
-        - keyword: RETURN
-        - into_clause:
-          - keyword: INTO
-          - naked_identifier: emp_id
-          - comma: ','
-          - naked_identifier: emp_salary
-    - statement_terminator: ;
-    - statement:
-        function:
-          function_name:
-            naked_identifier: DBMS_OUTPUT
+        - data_type:
+            naked_identifier: DBMS_SQL
             dot: .
-            function_name_identifier: PUT_LINE
-          function_contents:
-            bracketed:
-              start_bracket: (
-              expression:
-              - quoted_literal: "'Deleted employee ID: '"
-              - binary_operator:
-                - pipe: '|'
-                - pipe: '|'
-              - column_reference:
-                  naked_identifier: emp_id
-              - binary_operator:
-                - pipe: '|'
-                - pipe: '|'
-              - quoted_literal: "', Salary was: '"
-              - binary_operator:
-                - pipe: '|'
-                - pipe: '|'
-              - column_reference:
-                  naked_identifier: emp_salary
-              end_bracket: )
-    - statement_terminator: ;
-    - keyword: END
-- statement_terminator: ;
-- statement_terminator: /
-- statement:
-    begin_end_block:
-    - declare_segment:
-      - keyword: DECLARE
-      - naked_identifier: old_name
-      - data_type:
-          data_type_identifier: VARCHAR2
-          bracketed_arguments:
-            bracketed:
-              start_bracket: (
-              numeric_literal: '100'
-              end_bracket: )
-      - statement_terminator: ;
-      - naked_identifier: new_salary
-      - data_type:
-          data_type_identifier: NUMBER
-      - statement_terminator: ;
-      - naked_identifier: dynamic_update
-      - data_type:
-          data_type_identifier: VARCHAR2
-          bracketed_arguments:
-            bracketed:
-              start_bracket: (
-              numeric_literal: '500'
-              end_bracket: )
-      - statement_terminator: ;
-    - keyword: BEGIN
-    - statement:
-        assignment_segment_statement:
-          object_reference:
-            naked_identifier: dynamic_update
-          assignment_operator: :=
-          expression:
-          - quoted_literal: "'UPDATE employees '"
-          - binary_operator:
-            - pipe: '|'
-            - pipe: '|'
-          - quoted_literal: "'SET first_name = :new_name, salary = salary * 1.1 '"
-          - binary_operator:
-            - pipe: '|'
-            - pipe: '|'
-          - quoted_literal: "'WHERE employee_id = :emp_id '"
-          - binary_operator:
-            - pipe: '|'
-            - pipe: '|'
-          - quoted_literal: "'RETURNING first_name, salary INTO :name, :sal'"
-    - statement_terminator: ;
-    - statement:
-        execute_immediate_statement:
-        - keyword: EXECUTE
-        - keyword: IMMEDIATE
+            data_type_identifier: NUMBER_TABLE
+        - statement_terminator: ;
+        - naked_identifier: updated_salaries
+        - data_type:
+            naked_identifier: DBMS_SQL
+            dot: .
+            data_type_identifier: NUMBER_TABLE
+        - statement_terminator: ;
+        - naked_identifier: dept_id
+        - data_type:
+            data_type_identifier: NUMBER
+        - assignment_operator: :=
         - expression:
-            column_reference:
+            numeric_literal: '30'
+        - statement_terminator: ;
+        - naked_identifier: salary_increase
+        - data_type:
+            data_type_identifier: NUMBER
+        - assignment_operator: :=
+        - expression:
+            numeric_literal: '500'
+        - statement_terminator: ;
+        - naked_identifier: dynamic_update
+        - data_type:
+            data_type_identifier: VARCHAR2
+            bracketed_arguments:
+              bracketed:
+                start_bracket: (
+                numeric_literal: '500'
+                end_bracket: )
+        - statement_terminator: ;
+      - keyword: BEGIN
+      - statement:
+          assignment_segment_statement:
+            object_reference:
               naked_identifier: dynamic_update
-        - keyword: USING
-        - expression:
-            quoted_literal: "'John'"
-        - comma: ','
-        - expression:
-            numeric_literal: '101'
-        - keyword: RETURNING
-        - into_clause:
-          - keyword: INTO
-          - naked_identifier: old_name
+            assignment_operator: :=
+            expression:
+            - quoted_literal: "'UPDATE employees '"
+            - binary_operator:
+              - pipe: '|'
+              - pipe: '|'
+            - quoted_literal: "'SET salary = salary + :increase '"
+            - binary_operator:
+              - pipe: '|'
+              - pipe: '|'
+            - quoted_literal: "'WHERE department_id = :dept_id '"
+            - binary_operator:
+              - pipe: '|'
+              - pipe: '|'
+            - quoted_literal: "'AND salary < 8000 '"
+            - binary_operator:
+              - pipe: '|'
+              - pipe: '|'
+            - quoted_literal: "'RETURNING employee_id, salary INTO :ids, :salaries'"
+      - statement_terminator: ;
+      - statement:
+          execute_immediate_statement:
+          - keyword: EXECUTE
+          - keyword: IMMEDIATE
+          - expression:
+              column_reference:
+                naked_identifier: dynamic_update
+          - keyword: USING
+          - expression:
+              column_reference:
+                naked_identifier: salary_increase
           - comma: ','
-          - naked_identifier: new_salary
-    - statement_terminator: ;
-    - statement:
-        function:
-          function_name:
-            naked_identifier: DBMS_OUTPUT
-            dot: .
-            function_name_identifier: PUT_LINE
-          function_contents:
-            bracketed:
-              start_bracket: (
-              expression:
-              - quoted_literal: "'Updated employee: '"
-              - binary_operator:
-                - pipe: '|'
-                - pipe: '|'
-              - column_reference:
-                  naked_identifier: old_name
-              - binary_operator:
-                - pipe: '|'
-                - pipe: '|'
-              - quoted_literal: "', New salary: '"
-              - binary_operator:
-                - pipe: '|'
-                - pipe: '|'
-              - column_reference:
-                  naked_identifier: new_salary
-              end_bracket: )
-    - statement_terminator: ;
-    - keyword: END
-- statement_terminator: ;
-- statement_terminator: /
+          - expression:
+              column_reference:
+                naked_identifier: dept_id
+          - keyword: RETURNING
+          - bulk_collect_into_clause:
+            - keyword: BULK
+            - keyword: COLLECT
+            - keyword: INTO
+            - naked_identifier: updated_ids
+            - comma: ','
+            - naked_identifier: updated_salaries
+      - statement_terminator: ;
+      - statement:
+          for_loop_statement:
+          - keyword: FOR
+          - naked_identifier: i
+          - keyword: IN
+          - numeric_literal: '1'
+          - dot: .
+          - dot: .
+          - naked_identifier: updated_ids
+          - dot: .
+          - naked_identifier: COUNT
+          - loop_statement:
+            - keyword: LOOP
+            - statement:
+                function:
+                  function_name:
+                    naked_identifier: DBMS_OUTPUT
+                    dot: .
+                    function_name_identifier: PUT_LINE
+                  function_contents:
+                    bracketed:
+                      start_bracket: (
+                      expression:
+                      - quoted_literal: "'Updated employee ID: '"
+                      - binary_operator:
+                        - pipe: '|'
+                        - pipe: '|'
+                      - function:
+                          function_name:
+                            function_name_identifier: updated_ids
+                          function_contents:
+                            bracketed:
+                              start_bracket: (
+                              expression:
+                                column_reference:
+                                  naked_identifier: i
+                              end_bracket: )
+                      - binary_operator:
+                        - pipe: '|'
+                        - pipe: '|'
+                      - quoted_literal: "', New salary: '"
+                      - binary_operator:
+                        - pipe: '|'
+                        - pipe: '|'
+                      - function:
+                          function_name:
+                            function_name_identifier: updated_salaries
+                          function_contents:
+                            bracketed:
+                              start_bracket: (
+                              expression:
+                                column_reference:
+                                  naked_identifier: i
+                              end_bracket: )
+                      end_bracket: )
+            - statement_terminator: ;
+            - keyword: END
+            - keyword: LOOP
+      - statement_terminator: ;
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      begin_end_block:
+      - declare_segment:
+        - keyword: DECLARE
+        - naked_identifier: emp_id
+        - data_type:
+            data_type_identifier: NUMBER
+        - statement_terminator: ;
+        - naked_identifier: emp_salary
+        - data_type:
+            data_type_identifier: NUMBER
+        - statement_terminator: ;
+        - naked_identifier: dynamic_delete
+        - data_type:
+            data_type_identifier: VARCHAR2
+            bracketed_arguments:
+              bracketed:
+                start_bracket: (
+                numeric_literal: '500'
+                end_bracket: )
+        - statement_terminator: ;
+      - keyword: BEGIN
+      - statement:
+          assignment_segment_statement:
+            object_reference:
+              naked_identifier: dynamic_delete
+            assignment_operator: :=
+            expression:
+            - quoted_literal: "'DELETE FROM temp_employees '"
+            - binary_operator:
+              - pipe: '|'
+              - pipe: '|'
+            - quoted_literal: "'WHERE employee_id = :emp_id '"
+            - binary_operator:
+              - pipe: '|'
+              - pipe: '|'
+            - quoted_literal: "'RETURNING employee_id, salary INTO :id, :sal'"
+      - statement_terminator: ;
+      - statement:
+          execute_immediate_statement:
+          - keyword: EXECUTE
+          - keyword: IMMEDIATE
+          - expression:
+              column_reference:
+                naked_identifier: dynamic_delete
+          - keyword: USING
+          - expression:
+              numeric_literal: '100'
+          - keyword: RETURN
+          - into_clause:
+            - keyword: INTO
+            - naked_identifier: emp_id
+            - comma: ','
+            - naked_identifier: emp_salary
+      - statement_terminator: ;
+      - statement:
+          function:
+            function_name:
+              naked_identifier: DBMS_OUTPUT
+              dot: .
+              function_name_identifier: PUT_LINE
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                - quoted_literal: "'Deleted employee ID: '"
+                - binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                - column_reference:
+                    naked_identifier: emp_id
+                - binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                - quoted_literal: "', Salary was: '"
+                - binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                - column_reference:
+                    naked_identifier: emp_salary
+                end_bracket: )
+      - statement_terminator: ;
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      begin_end_block:
+      - declare_segment:
+        - keyword: DECLARE
+        - naked_identifier: old_name
+        - data_type:
+            data_type_identifier: VARCHAR2
+            bracketed_arguments:
+              bracketed:
+                start_bracket: (
+                numeric_literal: '100'
+                end_bracket: )
+        - statement_terminator: ;
+        - naked_identifier: new_salary
+        - data_type:
+            data_type_identifier: NUMBER
+        - statement_terminator: ;
+        - naked_identifier: dynamic_update
+        - data_type:
+            data_type_identifier: VARCHAR2
+            bracketed_arguments:
+              bracketed:
+                start_bracket: (
+                numeric_literal: '500'
+                end_bracket: )
+        - statement_terminator: ;
+      - keyword: BEGIN
+      - statement:
+          assignment_segment_statement:
+            object_reference:
+              naked_identifier: dynamic_update
+            assignment_operator: :=
+            expression:
+            - quoted_literal: "'UPDATE employees '"
+            - binary_operator:
+              - pipe: '|'
+              - pipe: '|'
+            - quoted_literal: "'SET first_name = :new_name, salary = salary * 1.1\
+                \ '"
+            - binary_operator:
+              - pipe: '|'
+              - pipe: '|'
+            - quoted_literal: "'WHERE employee_id = :emp_id '"
+            - binary_operator:
+              - pipe: '|'
+              - pipe: '|'
+            - quoted_literal: "'RETURNING first_name, salary INTO :name, :sal'"
+      - statement_terminator: ;
+      - statement:
+          execute_immediate_statement:
+          - keyword: EXECUTE
+          - keyword: IMMEDIATE
+          - expression:
+              column_reference:
+                naked_identifier: dynamic_update
+          - keyword: USING
+          - expression:
+              quoted_literal: "'John'"
+          - comma: ','
+          - expression:
+              numeric_literal: '101'
+          - keyword: RETURNING
+          - into_clause:
+            - keyword: INTO
+            - naked_identifier: old_name
+            - comma: ','
+            - naked_identifier: new_salary
+      - statement_terminator: ;
+      - statement:
+          function:
+            function_name:
+              naked_identifier: DBMS_OUTPUT
+              dot: .
+              function_name_identifier: PUT_LINE
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                - quoted_literal: "'Updated employee: '"
+                - binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                - column_reference:
+                    naked_identifier: old_name
+                - binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                - quoted_literal: "', New salary: '"
+                - binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                - column_reference:
+                    naked_identifier: new_salary
+                end_bracket: )
+      - statement_terminator: ;
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /

--- a/test/fixtures/dialects/oracle/exit.yml
+++ b/test/fixtures/dialects/oracle/exit.yml
@@ -3,202 +3,206 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 367bb04bba56b71b2038739edc0ac2132ad46c43b4bdcad62b1f30f9c9a0407a
+_hash: bd93e570600c13d7be128682ec0a06d324f6b01cfb70d7fe47a15de3ddd80d18
 file:
-- statement:
-    begin_end_block:
-    - declare_segment:
-        keyword: DECLARE
-        naked_identifier: x
-        data_type:
-          data_type_identifier: NUMBER
-        assignment_operator: :=
-        expression:
-          numeric_literal: '0'
-        statement_terminator: ;
-    - keyword: BEGIN
-    - statement:
-        loop_statement:
-        - keyword: LOOP
-        - statement:
-            function:
-              function_name:
-                naked_identifier: DBMS_OUTPUT
-                dot: .
-                function_name_identifier: PUT_LINE
-              function_contents:
-                bracketed:
-                  start_bracket: (
-                  expression:
-                    quoted_literal: "'Inside loop:  x = '"
-                    binary_operator:
-                    - pipe: '|'
-                    - pipe: '|'
-                    function:
-                      function_name:
-                        function_name_identifier: TO_CHAR
-                      function_contents:
-                        bracketed:
-                          start_bracket: (
-                          expression:
-                            column_reference:
-                              naked_identifier: x
-                          end_bracket: )
-                  end_bracket: )
-        - statement_terminator: ;
-        - statement:
-            assignment_segment_statement:
-              object_reference:
-                naked_identifier: x
-              assignment_operator: :=
-              expression:
-                column_reference:
+- batch:
+    statement:
+      begin_end_block:
+      - declare_segment:
+          keyword: DECLARE
+          naked_identifier: x
+          data_type:
+            data_type_identifier: NUMBER
+          assignment_operator: :=
+          expression:
+            numeric_literal: '0'
+          statement_terminator: ;
+      - keyword: BEGIN
+      - statement:
+          loop_statement:
+          - keyword: LOOP
+          - statement:
+              function:
+                function_name:
+                  naked_identifier: DBMS_OUTPUT
+                  dot: .
+                  function_name_identifier: PUT_LINE
+                function_contents:
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                      quoted_literal: "'Inside loop:  x = '"
+                      binary_operator:
+                      - pipe: '|'
+                      - pipe: '|'
+                      function:
+                        function_name:
+                          function_name_identifier: TO_CHAR
+                        function_contents:
+                          bracketed:
+                            start_bracket: (
+                            expression:
+                              column_reference:
+                                naked_identifier: x
+                            end_bracket: )
+                    end_bracket: )
+          - statement_terminator: ;
+          - statement:
+              assignment_segment_statement:
+                object_reference:
                   naked_identifier: x
-                binary_operator: +
-                numeric_literal: '1'
-        - statement_terminator: ;
-        - statement:
-            if_then_statement:
-            - if_clause:
+                assignment_operator: :=
+                expression:
+                  column_reference:
+                    naked_identifier: x
+                  binary_operator: +
+                  numeric_literal: '1'
+          - statement_terminator: ;
+          - statement:
+              if_then_statement:
+              - if_clause:
+                - keyword: IF
+                - expression:
+                    column_reference:
+                      naked_identifier: x
+                    comparison_operator:
+                      raw_comparison_operator: '>'
+                    numeric_literal: '3'
+                - keyword: THEN
+              - statement:
+                  exit_statement:
+                    keyword: EXIT
+              - statement_terminator: ;
+              - keyword: END
               - keyword: IF
+          - statement_terminator: ;
+          - keyword: END
+          - keyword: LOOP
+      - statement_terminator: ;
+      - statement:
+          function:
+            function_name:
+              naked_identifier: DBMS_OUTPUT
+              dot: .
+              function_name_identifier: PUT_LINE
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  quoted_literal: "' After loop:  x = '"
+                  binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                  function:
+                    function_name:
+                      function_name_identifier: TO_CHAR
+                    function_contents:
+                      bracketed:
+                        start_bracket: (
+                        expression:
+                          column_reference:
+                            naked_identifier: x
+                        end_bracket: )
+                end_bracket: )
+      - statement_terminator: ;
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      begin_end_block:
+      - declare_segment:
+          keyword: DECLARE
+          naked_identifier: x
+          data_type:
+            data_type_identifier: NUMBER
+          assignment_operator: :=
+          expression:
+            numeric_literal: '0'
+          statement_terminator: ;
+      - keyword: BEGIN
+      - statement:
+          loop_statement:
+          - keyword: LOOP
+          - statement:
+              function:
+                function_name:
+                  naked_identifier: DBMS_OUTPUT
+                  dot: .
+                  function_name_identifier: PUT_LINE
+                function_contents:
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                      quoted_literal: "'Inside loop:  x = '"
+                      binary_operator:
+                      - pipe: '|'
+                      - pipe: '|'
+                      function:
+                        function_name:
+                          function_name_identifier: TO_CHAR
+                        function_contents:
+                          bracketed:
+                            start_bracket: (
+                            expression:
+                              column_reference:
+                                naked_identifier: x
+                            end_bracket: )
+                    end_bracket: )
+          - statement_terminator: ;
+          - statement:
+              assignment_segment_statement:
+                object_reference:
+                  naked_identifier: x
+                assignment_operator: :=
+                expression:
+                  column_reference:
+                    naked_identifier: x
+                  binary_operator: +
+                  numeric_literal: '1'
+          - statement_terminator: ;
+          - statement:
+              exit_statement:
+              - keyword: EXIT
+              - keyword: WHEN
               - expression:
                   column_reference:
                     naked_identifier: x
                   comparison_operator:
                     raw_comparison_operator: '>'
                   numeric_literal: '3'
-              - keyword: THEN
-            - statement:
-                exit_statement:
-                  keyword: EXIT
-            - statement_terminator: ;
-            - keyword: END
-            - keyword: IF
-        - statement_terminator: ;
-        - keyword: END
-        - keyword: LOOP
-    - statement_terminator: ;
-    - statement:
-        function:
-          function_name:
-            naked_identifier: DBMS_OUTPUT
-            dot: .
-            function_name_identifier: PUT_LINE
-          function_contents:
-            bracketed:
-              start_bracket: (
-              expression:
-                quoted_literal: "' After loop:  x = '"
-                binary_operator:
-                - pipe: '|'
-                - pipe: '|'
-                function:
-                  function_name:
-                    function_name_identifier: TO_CHAR
-                  function_contents:
-                    bracketed:
-                      start_bracket: (
-                      expression:
-                        column_reference:
-                          naked_identifier: x
-                      end_bracket: )
-              end_bracket: )
-    - statement_terminator: ;
-    - keyword: END
-- statement_terminator: ;
-- statement_terminator: /
-- statement:
-    begin_end_block:
-    - declare_segment:
-        keyword: DECLARE
-        naked_identifier: x
-        data_type:
-          data_type_identifier: NUMBER
-        assignment_operator: :=
-        expression:
-          numeric_literal: '0'
-        statement_terminator: ;
-    - keyword: BEGIN
-    - statement:
-        loop_statement:
-        - keyword: LOOP
-        - statement:
-            function:
-              function_name:
-                naked_identifier: DBMS_OUTPUT
-                dot: .
-                function_name_identifier: PUT_LINE
-              function_contents:
-                bracketed:
-                  start_bracket: (
-                  expression:
-                    quoted_literal: "'Inside loop:  x = '"
-                    binary_operator:
-                    - pipe: '|'
-                    - pipe: '|'
-                    function:
-                      function_name:
-                        function_name_identifier: TO_CHAR
-                      function_contents:
-                        bracketed:
-                          start_bracket: (
-                          expression:
-                            column_reference:
-                              naked_identifier: x
-                          end_bracket: )
-                  end_bracket: )
-        - statement_terminator: ;
-        - statement:
-            assignment_segment_statement:
-              object_reference:
-                naked_identifier: x
-              assignment_operator: :=
-              expression:
-                column_reference:
-                  naked_identifier: x
-                binary_operator: +
-                numeric_literal: '1'
-        - statement_terminator: ;
-        - statement:
-            exit_statement:
-            - keyword: EXIT
-            - keyword: WHEN
-            - expression:
-                column_reference:
-                  naked_identifier: x
-                comparison_operator:
-                  raw_comparison_operator: '>'
-                numeric_literal: '3'
-        - statement_terminator: ;
-        - keyword: END
-        - keyword: LOOP
-    - statement_terminator: ;
-    - statement:
-        function:
-          function_name:
-            naked_identifier: DBMS_OUTPUT
-            dot: .
-            function_name_identifier: PUT_LINE
-          function_contents:
-            bracketed:
-              start_bracket: (
-              expression:
-                quoted_literal: "'After loop:  x = '"
-                binary_operator:
-                - pipe: '|'
-                - pipe: '|'
-                function:
-                  function_name:
-                    function_name_identifier: TO_CHAR
-                  function_contents:
-                    bracketed:
-                      start_bracket: (
-                      expression:
-                        column_reference:
-                          naked_identifier: x
-                      end_bracket: )
-              end_bracket: )
-    - statement_terminator: ;
-    - keyword: END
-- statement_terminator: ;
-- statement_terminator: /
+          - statement_terminator: ;
+          - keyword: END
+          - keyword: LOOP
+      - statement_terminator: ;
+      - statement:
+          function:
+            function_name:
+              naked_identifier: DBMS_OUTPUT
+              dot: .
+              function_name_identifier: PUT_LINE
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  quoted_literal: "'After loop:  x = '"
+                  binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                  function:
+                    function_name:
+                      function_name_identifier: TO_CHAR
+                    function_contents:
+                      bracketed:
+                        start_bracket: (
+                        expression:
+                          column_reference:
+                            naked_identifier: x
+                        end_bracket: )
+                end_bracket: )
+      - statement_terminator: ;
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /

--- a/test/fixtures/dialects/oracle/fetch.yml
+++ b/test/fixtures/dialects/oracle/fetch.yml
@@ -3,29 +3,1094 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 639812665560931147c217c7a079da17710e6dfcbfdb86b82023ee6f478fc4de
+_hash: 1e77b27479364356fca323db7399f8f8ce901d963ec3bd00b9a5ede25ecddc11
 file:
-- statement:
-    begin_end_block:
-    - declare_segment:
-      - keyword: DECLARE
-      - record_type:
-        - keyword: TYPE
-        - naked_identifier: EmpRecTyp
-        - keyword: IS
-        - keyword: RECORD
-        - bracketed:
-          - start_bracket: (
-          - naked_identifier: emp_id
+- batch:
+    statement:
+      begin_end_block:
+      - declare_segment:
+        - keyword: DECLARE
+        - record_type:
+          - keyword: TYPE
+          - naked_identifier: EmpRecTyp
+          - keyword: IS
+          - keyword: RECORD
+          - bracketed:
+            - start_bracket: (
+            - naked_identifier: emp_id
+            - column_type_reference:
+                column_reference:
+                - naked_identifier: employees
+                - dot: .
+                - naked_identifier: employee_id
+                binary_operator: '%'
+                keyword: TYPE
+            - comma: ','
+            - naked_identifier: salary
+            - column_type_reference:
+                column_reference:
+                - naked_identifier: employees
+                - dot: .
+                - naked_identifier: salary
+                binary_operator: '%'
+                keyword: TYPE
+            - end_bracket: )
+        - statement_terminator: ;
+        - cursor_variable:
+          - keyword: CURSOR
+          - naked_identifier: desc_salary
+          - keyword: RETURN
+          - data_type:
+              data_type_identifier: EmpRecTyp
+          - keyword: IS
+          - select_statement:
+              select_clause:
+              - keyword: SELECT
+              - select_clause_element:
+                  column_reference:
+                    naked_identifier: employee_id
+              - comma: ','
+              - select_clause_element:
+                  column_reference:
+                    naked_identifier: salary
+              from_clause:
+                keyword: FROM
+                from_expression:
+                  from_expression_element:
+                    table_expression:
+                      table_reference:
+                        naked_identifier: employees
+              orderby_clause:
+              - keyword: ORDER
+              - keyword: BY
+              - column_reference:
+                  naked_identifier: salary
+              - keyword: DESC
+          - statement_terminator: ;
+        - naked_identifier: highest_paid_emp
+        - data_type:
+            data_type_identifier: EmpRecTyp
+        - statement_terminator: ;
+        - naked_identifier: next_highest_paid_emp
+        - data_type:
+            data_type_identifier: EmpRecTyp
+        - statement_terminator: ;
+        - create_function_statement:
+          - keyword: FUNCTION
+          - function_name:
+              function_name_identifier: nth_highest_salary
+          - function_parameter_list:
+              bracketed:
+                start_bracket: (
+                parameter: n
+                data_type:
+                  data_type_identifier: INTEGER
+                end_bracket: )
+          - keyword: RETURN
+          - data_type:
+              data_type_identifier: EmpRecTyp
+          - keyword: IS
+          - declare_segment:
+              naked_identifier: emp_rec
+              data_type:
+                data_type_identifier: EmpRecTyp
+              statement_terminator: ;
+          - begin_end_block:
+            - keyword: BEGIN
+            - statement:
+                open_statement:
+                  keyword: OPEN
+                  naked_identifier: desc_salary
+            - statement_terminator: ;
+            - statement:
+                for_loop_statement:
+                - keyword: FOR
+                - naked_identifier: i
+                - keyword: IN
+                - numeric_literal: '1'
+                - dot: .
+                - dot: .
+                - naked_identifier: n
+                - loop_statement:
+                  - keyword: LOOP
+                  - statement:
+                      fetch_statement:
+                        keyword: FETCH
+                        naked_identifier: desc_salary
+                        into_clause:
+                          keyword: INTO
+                          naked_identifier: emp_rec
+                  - statement_terminator: ;
+                  - keyword: END
+                  - keyword: LOOP
+            - statement_terminator: ;
+            - statement:
+                close_statement:
+                  keyword: CLOSE
+                  naked_identifier: desc_salary
+            - statement_terminator: ;
+            - statement:
+                return_statement:
+                  keyword: RETURN
+                  expression:
+                    column_reference:
+                      naked_identifier: emp_rec
+            - statement_terminator: ;
+            - keyword: END
+            - object_reference:
+                naked_identifier: nth_highest_salary
+          - statement_terminator: ;
+      - keyword: BEGIN
+      - statement:
+          assignment_segment_statement:
+            object_reference:
+              naked_identifier: highest_paid_emp
+            assignment_operator: :=
+            expression:
+              function:
+                function_name:
+                  function_name_identifier: nth_highest_salary
+                function_contents:
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                      numeric_literal: '1'
+                    end_bracket: )
+      - statement_terminator: ;
+      - statement:
+          assignment_segment_statement:
+            object_reference:
+              naked_identifier: next_highest_paid_emp
+            assignment_operator: :=
+            expression:
+              function:
+                function_name:
+                  function_name_identifier: nth_highest_salary
+                function_contents:
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                      numeric_literal: '2'
+                    end_bracket: )
+      - statement_terminator: ;
+      - statement:
+          function:
+            function_name:
+              naked_identifier: DBMS_OUTPUT
+              dot: .
+              function_name_identifier: PUT_LINE
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                - quoted_literal: "'Highest Paid: #'"
+                - binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                - column_reference:
+                  - naked_identifier: highest_paid_emp
+                  - dot: .
+                  - naked_identifier: emp_id
+                - binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                - quoted_literal: "', $'"
+                - binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                - column_reference:
+                  - naked_identifier: highest_paid_emp
+                  - dot: .
+                  - naked_identifier: salary
+                end_bracket: )
+      - statement_terminator: ;
+      - statement:
+          function:
+            function_name:
+              naked_identifier: DBMS_OUTPUT
+              dot: .
+              function_name_identifier: PUT_LINE
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                - quoted_literal: "'Next Highest Paid: #'"
+                - binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                - column_reference:
+                  - naked_identifier: next_highest_paid_emp
+                  - dot: .
+                  - naked_identifier: emp_id
+                - binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                - quoted_literal: "', $'"
+                - binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                - column_reference:
+                  - naked_identifier: next_highest_paid_emp
+                  - dot: .
+                  - naked_identifier: salary
+                end_bracket: )
+      - statement_terminator: ;
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      begin_end_block:
+      - declare_segment:
+        - keyword: DECLARE
+        - cursor_variable:
+          - keyword: CURSOR
+          - naked_identifier: c1
+          - keyword: IS
+          - select_statement:
+              select_clause:
+              - keyword: SELECT
+              - select_clause_element:
+                  column_reference:
+                    naked_identifier: last_name
+              - comma: ','
+              - select_clause_element:
+                  column_reference:
+                    naked_identifier: job_id
+              from_clause:
+                keyword: FROM
+                from_expression:
+                  from_expression_element:
+                    table_expression:
+                      table_reference:
+                        naked_identifier: employees
+              where_clause:
+                keyword: WHERE
+                expression:
+                  function:
+                    function_name:
+                      function_name_identifier: REGEXP_LIKE
+                    function_contents:
+                      bracketed:
+                      - start_bracket: (
+                      - expression:
+                          column_reference:
+                            naked_identifier: job_id
+                      - comma: ','
+                      - expression:
+                          quoted_literal: "'S[HT]_CLERK'"
+                      - end_bracket: )
+              orderby_clause:
+              - keyword: ORDER
+              - keyword: BY
+              - column_reference:
+                  naked_identifier: last_name
+          - statement_terminator: ;
+        - naked_identifier: v_lastname
+        - column_type_reference:
+            column_reference:
+            - naked_identifier: employees
+            - dot: .
+            - naked_identifier: last_name
+            binary_operator: '%'
+            keyword: TYPE
+        - statement_terminator: ;
+        - naked_identifier: v_jobid
+        - column_type_reference:
+            column_reference:
+            - naked_identifier: employees
+            - dot: .
+            - naked_identifier: job_id
+            binary_operator: '%'
+            keyword: TYPE
+        - statement_terminator: ;
+        - cursor_variable:
+          - keyword: CURSOR
+          - naked_identifier: c2
+          - keyword: IS
+          - select_statement:
+              select_clause:
+                keyword: SELECT
+                select_clause_element:
+                  wildcard_expression:
+                    wildcard_identifier:
+                      star: '*'
+              from_clause:
+                keyword: FROM
+                from_expression:
+                  from_expression_element:
+                    table_expression:
+                      table_reference:
+                        naked_identifier: employees
+              where_clause:
+                keyword: WHERE
+                expression:
+                  function:
+                    function_name:
+                      function_name_identifier: REGEXP_LIKE
+                    function_contents:
+                      bracketed:
+                      - start_bracket: (
+                      - expression:
+                          column_reference:
+                            naked_identifier: job_id
+                      - comma: ','
+                      - expression:
+                          quoted_literal: "'[ACADFIMKSA]_M[ANGR]'"
+                      - end_bracket: )
+              orderby_clause:
+              - keyword: ORDER
+              - keyword: BY
+              - column_reference:
+                  naked_identifier: job_id
+          - statement_terminator: ;
+        - naked_identifier: v_employees
+        - row_type_reference:
+            table_reference:
+              naked_identifier: employees
+            binary_operator: '%'
+            keyword: ROWTYPE
+        - statement_terminator: ;
+      - keyword: BEGIN
+      - statement:
+          open_statement:
+            keyword: OPEN
+            naked_identifier: c1
+      - statement_terminator: ;
+      - statement:
+          loop_statement:
+          - keyword: LOOP
+          - statement:
+              fetch_statement:
+                keyword: FETCH
+                naked_identifier: c1
+                into_clause:
+                - keyword: INTO
+                - naked_identifier: v_lastname
+                - comma: ','
+                - naked_identifier: v_jobid
+          - statement_terminator: ;
+          - statement:
+              exit_statement:
+              - keyword: EXIT
+              - keyword: WHEN
+              - expression:
+                  naked_identifier: c1
+                  binary_operator: '%'
+                  keyword: NOTFOUND
+          - statement_terminator: ;
+          - statement:
+              function:
+                function_name:
+                  naked_identifier: DBMS_OUTPUT
+                  dot: .
+                  function_name_identifier: PUT_LINE
+                function_contents:
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                      function:
+                        function_name:
+                          function_name_identifier: RPAD
+                        function_contents:
+                          bracketed:
+                          - start_bracket: (
+                          - expression:
+                              column_reference:
+                                naked_identifier: v_lastname
+                          - comma: ','
+                          - expression:
+                              numeric_literal: '25'
+                          - comma: ','
+                          - expression:
+                              quoted_literal: "' '"
+                          - end_bracket: )
+                      binary_operator:
+                      - pipe: '|'
+                      - pipe: '|'
+                      column_reference:
+                        naked_identifier: v_jobid
+                    end_bracket: )
+          - statement_terminator: ;
+          - keyword: END
+          - keyword: LOOP
+      - statement_terminator: ;
+      - statement:
+          close_statement:
+            keyword: CLOSE
+            naked_identifier: c1
+      - statement_terminator: ;
+      - statement:
+          function:
+            function_name:
+              naked_identifier: DBMS_OUTPUT
+              dot: .
+              function_name_identifier: PUT_LINE
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  quoted_literal: "'-------------------------------------'"
+                end_bracket: )
+      - statement_terminator: ;
+      - statement:
+          open_statement:
+            keyword: OPEN
+            naked_identifier: c2
+      - statement_terminator: ;
+      - statement:
+          loop_statement:
+          - keyword: LOOP
+          - statement:
+              fetch_statement:
+                keyword: FETCH
+                naked_identifier: c2
+                into_clause:
+                  keyword: INTO
+                  naked_identifier: v_employees
+          - statement_terminator: ;
+          - statement:
+              exit_statement:
+              - keyword: EXIT
+              - keyword: WHEN
+              - expression:
+                  naked_identifier: c2
+                  binary_operator: '%'
+                  keyword: NOTFOUND
+          - statement_terminator: ;
+          - statement:
+              function:
+                function_name:
+                  naked_identifier: DBMS_OUTPUT
+                  dot: .
+                  function_name_identifier: PUT_LINE
+                function_contents:
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                      function:
+                        function_name:
+                          function_name_identifier: RPAD
+                        function_contents:
+                          bracketed:
+                          - start_bracket: (
+                          - expression:
+                              column_reference:
+                              - naked_identifier: v_employees
+                              - dot: .
+                              - naked_identifier: last_name
+                          - comma: ','
+                          - expression:
+                              numeric_literal: '25'
+                          - comma: ','
+                          - expression:
+                              quoted_literal: "' '"
+                          - end_bracket: )
+                      binary_operator:
+                      - pipe: '|'
+                      - pipe: '|'
+                      column_reference:
+                      - naked_identifier: v_employees
+                      - dot: .
+                      - naked_identifier: job_id
+                    end_bracket: )
+          - statement_terminator: ;
+          - keyword: END
+          - keyword: LOOP
+      - statement_terminator: ;
+      - statement:
+          close_statement:
+            keyword: CLOSE
+            naked_identifier: c2
+      - statement_terminator: ;
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      begin_end_block:
+      - declare_segment:
+        - keyword: DECLARE
+        - cursor_variable:
+          - keyword: CURSOR
+          - naked_identifier: c
+          - keyword: IS
+          - select_statement:
+              select_clause:
+              - keyword: SELECT
+              - select_clause_element:
+                  column_reference:
+                  - naked_identifier: e
+                  - dot: .
+                  - naked_identifier: job_id
+              - comma: ','
+              - select_clause_element:
+                  column_reference:
+                  - naked_identifier: j
+                  - dot: .
+                  - naked_identifier: job_title
+              from_clause:
+              - keyword: FROM
+              - from_expression:
+                  from_expression_element:
+                    table_expression:
+                      table_reference:
+                        naked_identifier: employees
+                    alias_expression:
+                      naked_identifier: e
+              - comma: ','
+              - from_expression:
+                  from_expression_element:
+                    table_expression:
+                      table_reference:
+                        naked_identifier: jobs
+                    alias_expression:
+                      naked_identifier: j
+              where_clause:
+                keyword: WHERE
+                expression:
+                - column_reference:
+                  - naked_identifier: e
+                  - dot: .
+                  - naked_identifier: job_id
+                - comparison_operator:
+                    raw_comparison_operator: '='
+                - column_reference:
+                  - naked_identifier: j
+                  - dot: .
+                  - naked_identifier: job_id
+                - binary_operator: AND
+                - column_reference:
+                  - naked_identifier: e
+                  - dot: .
+                  - naked_identifier: manager_id
+                - comparison_operator:
+                    raw_comparison_operator: '='
+                - numeric_literal: '100'
+              orderby_clause:
+              - keyword: ORDER
+              - keyword: BY
+              - column_reference:
+                  naked_identifier: last_name
+          - statement_terminator: ;
+        - naked_identifier: job1
+        - row_type_reference:
+            table_reference:
+              naked_identifier: c
+            binary_operator: '%'
+            keyword: ROWTYPE
+        - statement_terminator: ;
+        - naked_identifier: job2
+        - row_type_reference:
+            table_reference:
+              naked_identifier: c
+            binary_operator: '%'
+            keyword: ROWTYPE
+        - statement_terminator: ;
+        - naked_identifier: job3
+        - row_type_reference:
+            table_reference:
+              naked_identifier: c
+            binary_operator: '%'
+            keyword: ROWTYPE
+        - statement_terminator: ;
+        - naked_identifier: job4
+        - row_type_reference:
+            table_reference:
+              naked_identifier: c
+            binary_operator: '%'
+            keyword: ROWTYPE
+        - statement_terminator: ;
+        - naked_identifier: job5
+        - row_type_reference:
+            table_reference:
+              naked_identifier: c
+            binary_operator: '%'
+            keyword: ROWTYPE
+        - statement_terminator: ;
+      - keyword: BEGIN
+      - statement:
+          open_statement:
+            keyword: OPEN
+            naked_identifier: c
+      - statement_terminator: ;
+      - statement:
+          fetch_statement:
+            keyword: FETCH
+            naked_identifier: c
+            into_clause:
+              keyword: INTO
+              naked_identifier: job1
+      - statement_terminator: ;
+      - statement:
+          fetch_statement:
+            keyword: FETCH
+            naked_identifier: c
+            into_clause:
+              keyword: INTO
+              naked_identifier: job2
+      - statement_terminator: ;
+      - statement:
+          fetch_statement:
+            keyword: FETCH
+            naked_identifier: c
+            into_clause:
+              keyword: INTO
+              naked_identifier: job3
+      - statement_terminator: ;
+      - statement:
+          fetch_statement:
+            keyword: FETCH
+            naked_identifier: c
+            into_clause:
+              keyword: INTO
+              naked_identifier: job4
+      - statement_terminator: ;
+      - statement:
+          fetch_statement:
+            keyword: FETCH
+            naked_identifier: c
+            into_clause:
+              keyword: INTO
+              naked_identifier: job5
+      - statement_terminator: ;
+      - statement:
+          close_statement:
+            keyword: CLOSE
+            naked_identifier: c
+      - statement_terminator: ;
+      - statement:
+          function:
+            function_name:
+              naked_identifier: DBMS_OUTPUT
+              dot: .
+              function_name_identifier: PUT_LINE
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                - column_reference:
+                  - naked_identifier: job1
+                  - dot: .
+                  - naked_identifier: job_title
+                - binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                - quoted_literal: "' ('"
+                - binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                - column_reference:
+                  - naked_identifier: job1
+                  - dot: .
+                  - naked_identifier: job_id
+                - binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                - quoted_literal: "')'"
+                end_bracket: )
+      - statement_terminator: ;
+      - statement:
+          function:
+            function_name:
+              naked_identifier: DBMS_OUTPUT
+              dot: .
+              function_name_identifier: PUT_LINE
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                - column_reference:
+                  - naked_identifier: job2
+                  - dot: .
+                  - naked_identifier: job_title
+                - binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                - quoted_literal: "' ('"
+                - binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                - column_reference:
+                  - naked_identifier: job2
+                  - dot: .
+                  - naked_identifier: job_id
+                - binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                - quoted_literal: "')'"
+                end_bracket: )
+      - statement_terminator: ;
+      - statement:
+          function:
+            function_name:
+              naked_identifier: DBMS_OUTPUT
+              dot: .
+              function_name_identifier: PUT_LINE
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                - column_reference:
+                  - naked_identifier: job3
+                  - dot: .
+                  - naked_identifier: job_title
+                - binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                - quoted_literal: "' ('"
+                - binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                - column_reference:
+                  - naked_identifier: job3
+                  - dot: .
+                  - naked_identifier: job_id
+                - binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                - quoted_literal: "')'"
+                end_bracket: )
+      - statement_terminator: ;
+      - statement:
+          function:
+            function_name:
+              naked_identifier: DBMS_OUTPUT
+              dot: .
+              function_name_identifier: PUT_LINE
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                - column_reference:
+                  - naked_identifier: job4
+                  - dot: .
+                  - naked_identifier: job_title
+                - binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                - quoted_literal: "' ('"
+                - binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                - column_reference:
+                  - naked_identifier: job4
+                  - dot: .
+                  - naked_identifier: job_id
+                - binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                - quoted_literal: "')'"
+                end_bracket: )
+      - statement_terminator: ;
+      - statement:
+          function:
+            function_name:
+              naked_identifier: DBMS_OUTPUT
+              dot: .
+              function_name_identifier: PUT_LINE
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                - column_reference:
+                  - naked_identifier: job5
+                  - dot: .
+                  - naked_identifier: job_title
+                - binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                - quoted_literal: "' ('"
+                - binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                - column_reference:
+                  - naked_identifier: job5
+                  - dot: .
+                  - naked_identifier: job_id
+                - binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                - quoted_literal: "')'"
+                end_bracket: )
+      - statement_terminator: ;
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      begin_end_block:
+      - declare_segment:
+        - keyword: DECLARE
+        - naked_identifier: cv
+        - data_type:
+            data_type_identifier: SYS_REFCURSOR
+        - statement_terminator: ;
+        - naked_identifier: v_lastname
+        - column_type_reference:
+            column_reference:
+            - naked_identifier: employees
+            - dot: .
+            - naked_identifier: last_name
+            binary_operator: '%'
+            keyword: TYPE
+        - statement_terminator: ;
+        - naked_identifier: v_jobid
+        - column_type_reference:
+            column_reference:
+            - naked_identifier: employees
+            - dot: .
+            - naked_identifier: job_id
+            binary_operator: '%'
+            keyword: TYPE
+        - statement_terminator: ;
+        - naked_identifier: query_2
+        - data_type:
+            data_type_identifier: VARCHAR2
+            bracketed_arguments:
+              bracketed:
+                start_bracket: (
+                numeric_literal: '200'
+                end_bracket: )
+        - assignment_operator: :=
+        - expression:
+            quoted_literal: "'SELECT * FROM employees\n    WHERE REGEXP_LIKE (job_id,\
+              \ ''[ACADFIMKSA]_M[ANGR]'')\n    ORDER BY job_id'"
+        - statement_terminator: ;
+        - naked_identifier: v_employees
+        - row_type_reference:
+            table_reference:
+              naked_identifier: employees
+            binary_operator: '%'
+            keyword: ROWTYPE
+        - statement_terminator: ;
+      - keyword: BEGIN
+      - statement:
+          open_for_statement:
+          - keyword: OPEN
+          - naked_identifier: cv
+          - keyword: FOR
+          - select_statement:
+              select_clause:
+              - keyword: SELECT
+              - select_clause_element:
+                  column_reference:
+                    naked_identifier: last_name
+              - comma: ','
+              - select_clause_element:
+                  column_reference:
+                    naked_identifier: job_id
+              from_clause:
+                keyword: FROM
+                from_expression:
+                  from_expression_element:
+                    table_expression:
+                      table_reference:
+                        naked_identifier: employees
+              where_clause:
+                keyword: WHERE
+                expression:
+                  function:
+                    function_name:
+                      function_name_identifier: REGEXP_LIKE
+                    function_contents:
+                      bracketed:
+                      - start_bracket: (
+                      - expression:
+                          column_reference:
+                            naked_identifier: job_id
+                      - comma: ','
+                      - expression:
+                          quoted_literal: "'S[HT]_CLERK'"
+                      - end_bracket: )
+              orderby_clause:
+              - keyword: ORDER
+              - keyword: BY
+              - column_reference:
+                  naked_identifier: last_name
+      - statement_terminator: ;
+      - statement:
+          loop_statement:
+          - keyword: LOOP
+          - statement:
+              fetch_statement:
+                keyword: FETCH
+                naked_identifier: cv
+                into_clause:
+                - keyword: INTO
+                - naked_identifier: v_lastname
+                - comma: ','
+                - naked_identifier: v_jobid
+          - statement_terminator: ;
+          - statement:
+              exit_statement:
+              - keyword: EXIT
+              - keyword: WHEN
+              - expression:
+                  naked_identifier: cv
+                  binary_operator: '%'
+                  keyword: NOTFOUND
+          - statement_terminator: ;
+          - statement:
+              function:
+                function_name:
+                  naked_identifier: DBMS_OUTPUT
+                  dot: .
+                  function_name_identifier: PUT_LINE
+                function_contents:
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                      function:
+                        function_name:
+                          function_name_identifier: RPAD
+                        function_contents:
+                          bracketed:
+                          - start_bracket: (
+                          - expression:
+                              column_reference:
+                                naked_identifier: v_lastname
+                          - comma: ','
+                          - expression:
+                              numeric_literal: '25'
+                          - comma: ','
+                          - expression:
+                              quoted_literal: "' '"
+                          - end_bracket: )
+                      binary_operator:
+                      - pipe: '|'
+                      - pipe: '|'
+                      column_reference:
+                        naked_identifier: v_jobid
+                    end_bracket: )
+          - statement_terminator: ;
+          - keyword: END
+          - keyword: LOOP
+      - statement_terminator: ;
+      - statement:
+          function:
+            function_name:
+              naked_identifier: DBMS_OUTPUT
+              dot: .
+              function_name_identifier: PUT_LINE
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  quoted_literal: "'-------------------------------------'"
+                end_bracket: )
+      - statement_terminator: ;
+      - statement:
+          open_for_statement:
+          - keyword: OPEN
+          - naked_identifier: cv
+          - keyword: FOR
+          - naked_identifier: query_2
+      - statement_terminator: ;
+      - statement:
+          loop_statement:
+          - keyword: LOOP
+          - statement:
+              fetch_statement:
+                keyword: FETCH
+                naked_identifier: cv
+                into_clause:
+                  keyword: INTO
+                  naked_identifier: v_employees
+          - statement_terminator: ;
+          - statement:
+              exit_statement:
+              - keyword: EXIT
+              - keyword: WHEN
+              - expression:
+                  naked_identifier: cv
+                  binary_operator: '%'
+                  keyword: NOTFOUND
+          - statement_terminator: ;
+          - statement:
+              function:
+                function_name:
+                  naked_identifier: DBMS_OUTPUT
+                  dot: .
+                  function_name_identifier: PUT_LINE
+                function_contents:
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                      function:
+                        function_name:
+                          function_name_identifier: RPAD
+                        function_contents:
+                          bracketed:
+                          - start_bracket: (
+                          - expression:
+                              column_reference:
+                              - naked_identifier: v_employees
+                              - dot: .
+                              - naked_identifier: last_name
+                          - comma: ','
+                          - expression:
+                              numeric_literal: '25'
+                          - comma: ','
+                          - expression:
+                              quoted_literal: "' '"
+                          - end_bracket: )
+                      binary_operator:
+                      - pipe: '|'
+                      - pipe: '|'
+                      column_reference:
+                      - naked_identifier: v_employees
+                      - dot: .
+                      - naked_identifier: job_id
+                    end_bracket: )
+          - statement_terminator: ;
+          - keyword: END
+          - keyword: LOOP
+      - statement_terminator: ;
+      - statement:
+          close_statement:
+            keyword: CLOSE
+            naked_identifier: cv
+      - statement_terminator: ;
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      begin_end_block:
+      - declare_segment:
+        - keyword: DECLARE
+        - ref_cursor_type:
+          - keyword: TYPE
+          - naked_identifier: empcurtyp
+          - keyword: IS
+          - keyword: REF
+          - keyword: CURSOR
+        - statement_terminator: ;
+        - collection_type:
+          - keyword: TYPE
+          - naked_identifier: namelist
+          - keyword: IS
+          - keyword: TABLE
+          - keyword: OF
           - column_type_reference:
               column_reference:
               - naked_identifier: employees
               - dot: .
-              - naked_identifier: employee_id
+              - naked_identifier: last_name
               binary_operator: '%'
               keyword: TYPE
-          - comma: ','
-          - naked_identifier: salary
+        - statement_terminator: ;
+        - collection_type:
+          - keyword: TYPE
+          - naked_identifier: sallist
+          - keyword: IS
+          - keyword: TABLE
+          - keyword: OF
           - column_type_reference:
               column_reference:
               - naked_identifier: employees
@@ -33,73 +1098,996 @@ file:
               - naked_identifier: salary
               binary_operator: '%'
               keyword: TYPE
-          - end_bracket: )
-      - statement_terminator: ;
-      - cursor_variable:
-        - keyword: CURSOR
-        - naked_identifier: desc_salary
-        - keyword: RETURN
-        - data_type:
-            data_type_identifier: EmpRecTyp
-        - keyword: IS
-        - select_statement:
-            select_clause:
-            - keyword: SELECT
-            - select_clause_element:
-                column_reference:
-                  naked_identifier: employee_id
-            - comma: ','
-            - select_clause_element:
-                column_reference:
-                  naked_identifier: salary
-            from_clause:
-              keyword: FROM
-              from_expression:
-                from_expression_element:
-                  table_expression:
-                    table_reference:
-                      naked_identifier: employees
-            orderby_clause:
-            - keyword: ORDER
-            - keyword: BY
-            - column_reference:
-                naked_identifier: salary
-            - keyword: DESC
         - statement_terminator: ;
-      - naked_identifier: highest_paid_emp
-      - data_type:
-          data_type_identifier: EmpRecTyp
-      - statement_terminator: ;
-      - naked_identifier: next_highest_paid_emp
-      - data_type:
-          data_type_identifier: EmpRecTyp
-      - statement_terminator: ;
-      - create_function_statement:
-        - keyword: FUNCTION
-        - function_name:
-            function_name_identifier: nth_highest_salary
-        - function_parameter_list:
-            bracketed:
-              start_bracket: (
-              parameter: n
-              data_type:
-                data_type_identifier: INTEGER
-              end_bracket: )
-        - keyword: RETURN
+        - naked_identifier: emp_cv
         - data_type:
-            data_type_identifier: EmpRecTyp
-        - keyword: IS
-        - declare_segment:
-            naked_identifier: emp_rec
-            data_type:
-              data_type_identifier: EmpRecTyp
-            statement_terminator: ;
-        - begin_end_block:
-          - keyword: BEGIN
+            data_type_identifier: empcurtyp
+        - statement_terminator: ;
+        - naked_identifier: names
+        - data_type:
+            data_type_identifier: namelist
+        - statement_terminator: ;
+        - naked_identifier: sals
+        - data_type:
+            data_type_identifier: sallist
+        - statement_terminator: ;
+      - keyword: BEGIN
+      - statement:
+          open_for_statement:
+          - keyword: OPEN
+          - naked_identifier: emp_cv
+          - keyword: FOR
+          - select_statement:
+              select_clause:
+              - keyword: SELECT
+              - select_clause_element:
+                  column_reference:
+                    naked_identifier: last_name
+              - comma: ','
+              - select_clause_element:
+                  column_reference:
+                    naked_identifier: salary
+              from_clause:
+                keyword: FROM
+                from_expression:
+                  from_expression_element:
+                    table_expression:
+                      table_reference:
+                        naked_identifier: employees
+              where_clause:
+                keyword: WHERE
+                expression:
+                  column_reference:
+                    naked_identifier: job_id
+                  comparison_operator:
+                    raw_comparison_operator: '='
+                  quoted_literal: "'SA_REP'"
+              orderby_clause:
+              - keyword: ORDER
+              - keyword: BY
+              - column_reference:
+                  naked_identifier: salary
+              - keyword: DESC
+      - statement_terminator: ;
+      - statement:
+          fetch_statement:
+            keyword: FETCH
+            naked_identifier: emp_cv
+            bulk_collect_into_clause:
+            - keyword: BULK
+            - keyword: COLLECT
+            - keyword: INTO
+            - naked_identifier: names
+            - comma: ','
+            - naked_identifier: sals
+      - statement_terminator: ;
+      - statement:
+          close_statement:
+            keyword: CLOSE
+            naked_identifier: emp_cv
+      - statement_terminator: ;
+      - statement:
+          for_loop_statement:
+          - keyword: FOR
+          - naked_identifier: i
+          - keyword: IN
+          - naked_identifier: names
+          - dot: .
+          - naked_identifier: FIRST
+          - dot: .
+          - dot: .
+          - naked_identifier: names
+          - dot: .
+          - naked_identifier: LAST
+          - loop_statement:
+            - keyword: LOOP
+            - statement:
+                function:
+                  function_name:
+                    naked_identifier: DBMS_OUTPUT
+                    dot: .
+                    function_name_identifier: PUT_LINE
+                  function_contents:
+                    bracketed:
+                      start_bracket: (
+                      expression:
+                      - quoted_literal: "'Name = '"
+                      - binary_operator:
+                        - pipe: '|'
+                        - pipe: '|'
+                      - function:
+                          function_name:
+                            function_name_identifier: names
+                          function_contents:
+                            bracketed:
+                              start_bracket: (
+                              expression:
+                                column_reference:
+                                  naked_identifier: i
+                              end_bracket: )
+                      - binary_operator:
+                        - pipe: '|'
+                        - pipe: '|'
+                      - quoted_literal: "', salary = '"
+                      - binary_operator:
+                        - pipe: '|'
+                        - pipe: '|'
+                      - function:
+                          function_name:
+                            function_name_identifier: sals
+                          function_contents:
+                            bracketed:
+                              start_bracket: (
+                              expression:
+                                column_reference:
+                                  naked_identifier: i
+                              end_bracket: )
+                      end_bracket: )
+            - statement_terminator: ;
+            - keyword: END
+            - keyword: LOOP
+      - statement_terminator: ;
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      begin_end_block:
+      - declare_segment:
+          keyword: DECLARE
+          cursor_variable:
+          - keyword: CURSOR
+          - naked_identifier: c1
+          - keyword: IS
+          - select_statement:
+            - select_clause:
+                keyword: SELECT
+                select_clause_element:
+                  wildcard_expression:
+                    wildcard_identifier:
+                      star: '*'
+            - from_clause:
+                keyword: FROM
+                from_expression:
+                  from_expression_element:
+                    table_expression:
+                      table_reference:
+                        naked_identifier: emp
+            - keyword: FOR
+            - keyword: UPDATE
+            - keyword: OF
+            - table_reference:
+                naked_identifier: salary
+            - orderby_clause:
+              - keyword: ORDER
+              - keyword: BY
+              - column_reference:
+                  naked_identifier: employee_id
+          - statement_terminator: ;
+          naked_identifier: emp_rec
+          row_type_reference:
+            table_reference:
+              naked_identifier: emp
+            binary_operator: '%'
+            keyword: ROWTYPE
+          statement_terminator: ;
+      - keyword: BEGIN
+      - statement:
+          open_statement:
+            keyword: OPEN
+            naked_identifier: c1
+      - statement_terminator: ;
+      - statement:
+          loop_statement:
+          - keyword: LOOP
           - statement:
-              open_statement:
-                keyword: OPEN
-                naked_identifier: desc_salary
+              fetch_statement:
+                keyword: FETCH
+                naked_identifier: c1
+                into_clause:
+                  keyword: INTO
+                  naked_identifier: emp_rec
+          - statement_terminator: ;
+          - statement:
+              exit_statement:
+              - keyword: EXIT
+              - keyword: WHEN
+              - expression:
+                  naked_identifier: c1
+                  binary_operator: '%'
+                  keyword: NOTFOUND
+          - statement_terminator: ;
+          - statement:
+              function:
+                function_name:
+                  naked_identifier: DBMS_OUTPUT
+                  dot: .
+                  function_name_identifier: PUT_LINE
+                function_contents:
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                      quoted_literal: "'emp_rec.employee_id = '"
+                      binary_operator:
+                      - pipe: '|'
+                      - pipe: '|'
+                      function:
+                        function_name:
+                          function_name_identifier: TO_CHAR
+                        function_contents:
+                          bracketed:
+                            start_bracket: (
+                            expression:
+                              column_reference:
+                              - naked_identifier: emp_rec
+                              - dot: .
+                              - naked_identifier: employee_id
+                            end_bracket: )
+                    end_bracket: )
+          - statement_terminator: ;
+          - statement:
+              update_statement:
+                keyword: UPDATE
+                table_reference:
+                  naked_identifier: emp
+                set_clause_list:
+                  keyword: SET
+                  set_clause:
+                    column_reference:
+                      naked_identifier: salary
+                    comparison_operator:
+                      raw_comparison_operator: '='
+                    expression:
+                      column_reference:
+                        naked_identifier: salary
+                      binary_operator: '*'
+                      numeric_literal: '1.05'
+                where_clause:
+                  keyword: WHERE
+                  expression:
+                    column_reference:
+                      naked_identifier: employee_id
+                    comparison_operator:
+                      raw_comparison_operator: '='
+                    numeric_literal: '105'
+          - statement_terminator: ;
+          - statement:
+              transaction_statement:
+                keyword: COMMIT
+          - statement_terminator: ;
+          - keyword: END
+          - keyword: LOOP
+      - statement_terminator: ;
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      begin_end_block:
+      - declare_segment:
+        - keyword: DECLARE
+        - ref_cursor_type:
+          - keyword: TYPE
+          - naked_identifier: EmpCurTyp
+          - keyword: IS
+          - keyword: REF
+          - keyword: CURSOR
+        - statement_terminator: ;
+        - naked_identifier: v_emp_cursor
+        - data_type:
+            data_type_identifier: EmpCurTyp
+        - statement_terminator: ;
+        - naked_identifier: emp_record
+        - row_type_reference:
+            table_reference:
+              naked_identifier: employees
+            binary_operator: '%'
+            keyword: ROWTYPE
+        - statement_terminator: ;
+        - naked_identifier: v_stmt_str
+        - data_type:
+            data_type_identifier: VARCHAR2
+            bracketed_arguments:
+              bracketed:
+                start_bracket: (
+                numeric_literal: '200'
+                end_bracket: )
+        - statement_terminator: ;
+        - naked_identifier: v_e_job
+        - column_type_reference:
+            column_reference:
+            - naked_identifier: employees
+            - dot: .
+            - naked_identifier: job_id
+            binary_operator: '%'
+            keyword: TYPE
+        - statement_terminator: ;
+      - keyword: BEGIN
+      - statement:
+          assignment_segment_statement:
+            object_reference:
+              naked_identifier: v_stmt_str
+            assignment_operator: :=
+            expression:
+              quoted_literal: "'SELECT * FROM employees WHERE job_id = :j'"
+      - statement_terminator: ;
+      - statement:
+          open_for_statement:
+          - keyword: OPEN
+          - naked_identifier: v_emp_cursor
+          - keyword: FOR
+          - naked_identifier: v_stmt_str
+          - keyword: USING
+          - quoted_identifier: "'MANAGER'"
+      - statement_terminator: ;
+      - statement:
+          loop_statement:
+          - keyword: LOOP
+          - statement:
+              fetch_statement:
+                keyword: FETCH
+                naked_identifier: v_emp_cursor
+                into_clause:
+                  keyword: INTO
+                  naked_identifier: emp_record
+          - statement_terminator: ;
+          - statement:
+              exit_statement:
+              - keyword: EXIT
+              - keyword: WHEN
+              - expression:
+                  naked_identifier: v_emp_cursor
+                  binary_operator: '%'
+                  keyword: NOTFOUND
+          - statement_terminator: ;
+          - keyword: END
+          - keyword: LOOP
+      - statement_terminator: ;
+      - statement:
+          close_statement:
+            keyword: CLOSE
+            naked_identifier: v_emp_cursor
+      - statement_terminator: ;
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      begin_end_block:
+      - declare_segment:
+        - keyword: DECLARE
+        - collection_type:
+          - keyword: TYPE
+          - naked_identifier: NameList
+          - keyword: IS
+          - keyword: TABLE
+          - keyword: OF
+          - column_type_reference:
+              column_reference:
+              - naked_identifier: employees
+              - dot: .
+              - naked_identifier: last_name
+              binary_operator: '%'
+              keyword: TYPE
+        - statement_terminator: ;
+        - collection_type:
+          - keyword: TYPE
+          - naked_identifier: SalList
+          - keyword: IS
+          - keyword: TABLE
+          - keyword: OF
+          - column_type_reference:
+              column_reference:
+              - naked_identifier: employees
+              - dot: .
+              - naked_identifier: salary
+              binary_operator: '%'
+              keyword: TYPE
+        - statement_terminator: ;
+        - cursor_variable:
+          - keyword: CURSOR
+          - naked_identifier: c1
+          - keyword: IS
+          - select_statement:
+              select_clause:
+              - keyword: SELECT
+              - select_clause_element:
+                  column_reference:
+                    naked_identifier: last_name
+              - comma: ','
+              - select_clause_element:
+                  column_reference:
+                    naked_identifier: salary
+              from_clause:
+                keyword: FROM
+                from_expression:
+                  from_expression_element:
+                    table_expression:
+                      table_reference:
+                        naked_identifier: employees
+              where_clause:
+                keyword: WHERE
+                expression:
+                  column_reference:
+                    naked_identifier: salary
+                  comparison_operator:
+                    raw_comparison_operator: '>'
+                  numeric_literal: '10000'
+              orderby_clause:
+              - keyword: ORDER
+              - keyword: BY
+              - column_reference:
+                  naked_identifier: last_name
+          - statement_terminator: ;
+        - naked_identifier: names
+        - data_type:
+            data_type_identifier: NameList
+        - statement_terminator: ;
+        - naked_identifier: sals
+        - data_type:
+            data_type_identifier: SalList
+        - statement_terminator: ;
+        - collection_type:
+          - keyword: TYPE
+          - naked_identifier: RecList
+          - keyword: IS
+          - keyword: TABLE
+          - keyword: OF
+          - row_type_reference:
+              table_reference:
+                naked_identifier: c1
+              binary_operator: '%'
+              keyword: ROWTYPE
+        - statement_terminator: ;
+        - naked_identifier: recs
+        - data_type:
+            data_type_identifier: RecList
+        - statement_terminator: ;
+        - naked_identifier: v_limit
+        - data_type:
+            data_type_identifier: PLS_INTEGER
+        - assignment_operator: :=
+        - expression:
+            numeric_literal: '10'
+        - statement_terminator: ;
+        - create_procedure_statement:
+          - keyword: PROCEDURE
+          - function_name:
+              function_name_identifier: print_results
+          - keyword: IS
+          - begin_end_block:
+            - keyword: BEGIN
+            - statement:
+                if_then_statement:
+                - if_clause:
+                  - keyword: IF
+                  - expression:
+                    - column_reference:
+                        naked_identifier: names
+                    - keyword: IS
+                    - null_literal: 'NULL'
+                    - binary_operator: OR
+                    - column_reference:
+                      - naked_identifier: names
+                      - dot: .
+                      - naked_identifier: COUNT
+                    - comparison_operator:
+                        raw_comparison_operator: '='
+                    - numeric_literal: '0'
+                  - keyword: THEN
+                - statement:
+                    function:
+                      function_name:
+                        naked_identifier: DBMS_OUTPUT
+                        dot: .
+                        function_name_identifier: PUT_LINE
+                      function_contents:
+                        bracketed:
+                          start_bracket: (
+                          expression:
+                            quoted_literal: "'No results!'"
+                          end_bracket: )
+                - statement_terminator: ;
+                - keyword: ELSE
+                - statement:
+                    function:
+                      function_name:
+                        naked_identifier: DBMS_OUTPUT
+                        dot: .
+                        function_name_identifier: PUT_LINE
+                      function_contents:
+                        bracketed:
+                          start_bracket: (
+                          expression:
+                            quoted_literal: "'Result: '"
+                          end_bracket: )
+                - statement_terminator: ;
+                - statement:
+                    for_loop_statement:
+                    - keyword: FOR
+                    - naked_identifier: i
+                    - keyword: IN
+                    - naked_identifier: names
+                    - dot: .
+                    - naked_identifier: FIRST
+                    - dot: .
+                    - dot: .
+                    - naked_identifier: names
+                    - dot: .
+                    - naked_identifier: LAST
+                    - loop_statement:
+                      - keyword: LOOP
+                      - statement:
+                          function:
+                            function_name:
+                              naked_identifier: DBMS_OUTPUT
+                              dot: .
+                              function_name_identifier: PUT_LINE
+                            function_contents:
+                              bracketed:
+                                start_bracket: (
+                                expression:
+                                - quoted_literal: "'  Employee '"
+                                - binary_operator:
+                                  - pipe: '|'
+                                  - pipe: '|'
+                                - function:
+                                    function_name:
+                                      function_name_identifier: names
+                                    function_contents:
+                                      bracketed:
+                                        start_bracket: (
+                                        expression:
+                                          column_reference:
+                                            naked_identifier: i
+                                        end_bracket: )
+                                - binary_operator:
+                                  - pipe: '|'
+                                  - pipe: '|'
+                                - quoted_literal: "': $'"
+                                - binary_operator:
+                                  - pipe: '|'
+                                  - pipe: '|'
+                                - function:
+                                    function_name:
+                                      function_name_identifier: sals
+                                    function_contents:
+                                      bracketed:
+                                        start_bracket: (
+                                        expression:
+                                          column_reference:
+                                            naked_identifier: i
+                                        end_bracket: )
+                                end_bracket: )
+                      - statement_terminator: ;
+                      - keyword: END
+                      - keyword: LOOP
+                - statement_terminator: ;
+                - keyword: END
+                - keyword: IF
+            - statement_terminator: ;
+            - keyword: END
+          - statement_terminator: ;
+      - keyword: BEGIN
+      - statement:
+          function:
+            function_name:
+              naked_identifier: DBMS_OUTPUT
+              dot: .
+              function_name_identifier: PUT_LINE
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  quoted_literal: "'--- Processing all results simultaneously ---'"
+                end_bracket: )
+      - statement_terminator: ;
+      - statement:
+          open_statement:
+            keyword: OPEN
+            naked_identifier: c1
+      - statement_terminator: ;
+      - statement:
+          fetch_statement:
+            keyword: FETCH
+            naked_identifier: c1
+            bulk_collect_into_clause:
+            - keyword: BULK
+            - keyword: COLLECT
+            - keyword: INTO
+            - naked_identifier: names
+            - comma: ','
+            - naked_identifier: sals
+      - statement_terminator: ;
+      - statement:
+          close_statement:
+            keyword: CLOSE
+            naked_identifier: c1
+      - statement_terminator: ;
+      - statement:
+          function:
+            function_name:
+              function_name_identifier: print_results
+            function_contents:
+              bracketed:
+                start_bracket: (
+                end_bracket: )
+      - statement_terminator: ;
+      - statement:
+          function:
+            function_name:
+              naked_identifier: DBMS_OUTPUT
+              dot: .
+              function_name_identifier: PUT_LINE
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                - quoted_literal: "'--- Processing '"
+                - binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                - column_reference:
+                    naked_identifier: v_limit
+                - binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                - quoted_literal: "' rows at a time ---'"
+                end_bracket: )
+      - statement_terminator: ;
+      - statement:
+          open_statement:
+            keyword: OPEN
+            naked_identifier: c1
+      - statement_terminator: ;
+      - statement:
+          loop_statement:
+          - keyword: LOOP
+          - statement:
+              fetch_statement:
+              - keyword: FETCH
+              - naked_identifier: c1
+              - bulk_collect_into_clause:
+                - keyword: BULK
+                - keyword: COLLECT
+                - keyword: INTO
+                - naked_identifier: names
+                - comma: ','
+                - naked_identifier: sals
+              - keyword: LIMIT
+              - naked_identifier: v_limit
+          - statement_terminator: ;
+          - statement:
+              exit_statement:
+              - keyword: EXIT
+              - keyword: WHEN
+              - expression:
+                  column_reference:
+                  - naked_identifier: names
+                  - dot: .
+                  - naked_identifier: COUNT
+                  comparison_operator:
+                    raw_comparison_operator: '='
+                  numeric_literal: '0'
+          - statement_terminator: ;
+          - statement:
+              function:
+                function_name:
+                  function_name_identifier: print_results
+                function_contents:
+                  bracketed:
+                    start_bracket: (
+                    end_bracket: )
+          - statement_terminator: ;
+          - keyword: END
+          - keyword: LOOP
+      - statement_terminator: ;
+      - statement:
+          close_statement:
+            keyword: CLOSE
+            naked_identifier: c1
+      - statement_terminator: ;
+      - statement:
+          function:
+            function_name:
+              naked_identifier: DBMS_OUTPUT
+              dot: .
+              function_name_identifier: PUT_LINE
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  quoted_literal: "'--- Fetching records rather than columns ---'"
+                end_bracket: )
+      - statement_terminator: ;
+      - statement:
+          open_statement:
+            keyword: OPEN
+            naked_identifier: c1
+      - statement_terminator: ;
+      - statement:
+          fetch_statement:
+            keyword: FETCH
+            naked_identifier: c1
+            bulk_collect_into_clause:
+            - keyword: BULK
+            - keyword: COLLECT
+            - keyword: INTO
+            - naked_identifier: recs
+      - statement_terminator: ;
+      - statement:
+          for_loop_statement:
+          - keyword: FOR
+          - naked_identifier: i
+          - keyword: IN
+          - naked_identifier: recs
+          - dot: .
+          - naked_identifier: FIRST
+          - dot: .
+          - dot: .
+          - naked_identifier: recs
+          - dot: .
+          - naked_identifier: LAST
+          - loop_statement:
+            - keyword: LOOP
+            - statement:
+                function:
+                  function_name:
+                    naked_identifier: DBMS_OUTPUT
+                    dot: .
+                    function_name_identifier: PUT_LINE
+                  function_contents:
+                    bracketed:
+                      start_bracket: (
+                      expression:
+                        numeric_literal: '1'
+                      end_bracket: )
+            - statement_terminator: ;
+            - keyword: END
+            - keyword: LOOP
+      - statement_terminator: ;
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      begin_end_block:
+      - declare_segment:
+        - keyword: DECLARE
+        - cursor_variable:
+          - keyword: CURSOR
+          - naked_identifier: c1
+          - keyword: IS
+          - select_statement:
+              select_clause:
+              - keyword: SELECT
+              - select_clause_element:
+                  column_reference:
+                    naked_identifier: first_name
+              - comma: ','
+              - select_clause_element:
+                  column_reference:
+                    naked_identifier: last_name
+              - comma: ','
+              - select_clause_element:
+                  column_reference:
+                    naked_identifier: hire_date
+              from_clause:
+                keyword: FROM
+                from_expression:
+                  from_expression_element:
+                    table_expression:
+                      table_reference:
+                        naked_identifier: employees
+          - statement_terminator: ;
+        - collection_type:
+          - keyword: TYPE
+          - naked_identifier: NameSet
+          - keyword: IS
+          - keyword: TABLE
+          - keyword: OF
+          - row_type_reference:
+              table_reference:
+                naked_identifier: c1
+              binary_operator: '%'
+              keyword: ROWTYPE
+        - statement_terminator: ;
+        - naked_identifier: stock_managers
+        - data_type:
+            data_type_identifier: NameSet
+        - statement_terminator: ;
+        - ref_cursor_type:
+          - keyword: TYPE
+          - naked_identifier: cursor_var_type
+          - keyword: is
+          - keyword: REF
+          - keyword: CURSOR
+        - statement_terminator: ;
+        - naked_identifier: cv
+        - data_type:
+            data_type_identifier: cursor_var_type
+        - statement_terminator: ;
+      - keyword: BEGIN
+      - statement:
+          open_for_statement:
+          - keyword: OPEN
+          - naked_identifier: cv
+          - keyword: FOR
+          - select_statement:
+              select_clause:
+              - keyword: SELECT
+              - select_clause_element:
+                  column_reference:
+                    naked_identifier: first_name
+              - comma: ','
+              - select_clause_element:
+                  column_reference:
+                    naked_identifier: last_name
+              - comma: ','
+              - select_clause_element:
+                  column_reference:
+                    naked_identifier: hire_date
+              from_clause:
+                keyword: FROM
+                from_expression:
+                  from_expression_element:
+                    table_expression:
+                      table_reference:
+                        naked_identifier: employees
+              where_clause:
+                keyword: WHERE
+                expression:
+                  column_reference:
+                    naked_identifier: job_id
+                  comparison_operator:
+                    raw_comparison_operator: '='
+                  quoted_literal: "'ST_MAN'"
+              orderby_clause:
+              - keyword: ORDER
+              - keyword: BY
+              - column_reference:
+                  naked_identifier: hire_date
+      - statement_terminator: ;
+      - statement:
+          fetch_statement:
+            keyword: FETCH
+            naked_identifier: cv
+            bulk_collect_into_clause:
+            - keyword: BULK
+            - keyword: COLLECT
+            - keyword: INTO
+            - naked_identifier: stock_managers
+      - statement_terminator: ;
+      - statement:
+          close_statement:
+            keyword: CLOSE
+            naked_identifier: cv
+      - statement_terminator: ;
+      - statement:
+          for_loop_statement:
+          - keyword: FOR
+          - naked_identifier: i
+          - keyword: IN
+          - naked_identifier: stock_managers
+          - dot: .
+          - naked_identifier: FIRST
+          - dot: .
+          - dot: .
+          - naked_identifier: stock_managers
+          - dot: .
+          - naked_identifier: LAST
+          - loop_statement:
+            - keyword: LOOP
+            - statement:
+                function:
+                  function_name:
+                    naked_identifier: DBMS_OUTPUT
+                    dot: .
+                    function_name_identifier: PUT_LINE
+                  function_contents:
+                    bracketed:
+                      start_bracket: (
+                      expression:
+                        numeric_literal: '1'
+                      end_bracket: )
+            - statement_terminator: ;
+            - keyword: END
+            - keyword: LOOP
+      - statement_terminator: ;
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      begin_end_block:
+      - declare_segment:
+        - keyword: DECLARE
+        - collection_type:
+          - keyword: TYPE
+          - naked_identifier: numtab
+          - keyword: IS
+          - keyword: TABLE
+          - keyword: OF
+          - data_type:
+              data_type_identifier: NUMBER
+          - keyword: INDEX
+          - keyword: BY
+          - data_type:
+              data_type_identifier: PLS_INTEGER
+        - statement_terminator: ;
+        - cursor_variable:
+          - keyword: CURSOR
+          - naked_identifier: c1
+          - keyword: IS
+          - select_statement:
+              select_clause:
+                keyword: SELECT
+                select_clause_element:
+                  column_reference:
+                    naked_identifier: employee_id
+              from_clause:
+                keyword: FROM
+                from_expression:
+                  from_expression_element:
+                    table_expression:
+                      table_reference:
+                        naked_identifier: employees
+              where_clause:
+                keyword: WHERE
+                expression:
+                  column_reference:
+                    naked_identifier: department_id
+                  comparison_operator:
+                    raw_comparison_operator: '='
+                  numeric_literal: '80'
+              orderby_clause:
+              - keyword: ORDER
+              - keyword: BY
+              - column_reference:
+                  naked_identifier: employee_id
+          - statement_terminator: ;
+        - naked_identifier: empids
+        - data_type:
+            data_type_identifier: numtab
+        - statement_terminator: ;
+      - keyword: BEGIN
+      - statement:
+          open_statement:
+            keyword: OPEN
+            naked_identifier: c1
+      - statement_terminator: ;
+      - statement:
+          loop_statement:
+          - keyword: LOOP
+          - statement:
+              fetch_statement:
+              - keyword: FETCH
+              - naked_identifier: c1
+              - bulk_collect_into_clause:
+                - keyword: BULK
+                - keyword: COLLECT
+                - keyword: INTO
+                - naked_identifier: empids
+              - keyword: LIMIT
+              - numeric_literal: '10'
+          - statement_terminator: ;
+          - statement:
+              function:
+                function_name:
+                  naked_identifier: DBMS_OUTPUT
+                  dot: .
+                  function_name_identifier: PUT_LINE
+                function_contents:
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                      quoted_literal: "'------- Results from One Bulk Fetch --------'"
+                    end_bracket: )
           - statement_terminator: ;
           - statement:
               for_loop_statement:
@@ -109,2026 +2097,58 @@ file:
               - numeric_literal: '1'
               - dot: .
               - dot: .
-              - naked_identifier: n
+              - naked_identifier: empids
+              - dot: .
+              - naked_identifier: COUNT
               - loop_statement:
                 - keyword: LOOP
                 - statement:
-                    fetch_statement:
-                      keyword: FETCH
-                      naked_identifier: desc_salary
-                      into_clause:
-                        keyword: INTO
-                        naked_identifier: emp_rec
+                    function:
+                      function_name:
+                        naked_identifier: DBMS_OUTPUT
+                        dot: .
+                        function_name_identifier: PUT_LINE
+                      function_contents:
+                        bracketed:
+                          start_bracket: (
+                          expression:
+                            quoted_literal: "'Employee Id: '"
+                            binary_operator:
+                            - pipe: '|'
+                            - pipe: '|'
+                            function:
+                              function_name:
+                                function_name_identifier: empids
+                              function_contents:
+                                bracketed:
+                                  start_bracket: (
+                                  expression:
+                                    column_reference:
+                                      naked_identifier: i
+                                  end_bracket: )
+                          end_bracket: )
                 - statement_terminator: ;
                 - keyword: END
                 - keyword: LOOP
           - statement_terminator: ;
           - statement:
-              close_statement:
-                keyword: CLOSE
-                naked_identifier: desc_salary
-          - statement_terminator: ;
-          - statement:
-              return_statement:
-                keyword: RETURN
-                expression:
-                  column_reference:
-                    naked_identifier: emp_rec
-          - statement_terminator: ;
-          - keyword: END
-          - object_reference:
-              naked_identifier: nth_highest_salary
-        - statement_terminator: ;
-    - keyword: BEGIN
-    - statement:
-        assignment_segment_statement:
-          object_reference:
-            naked_identifier: highest_paid_emp
-          assignment_operator: :=
-          expression:
-            function:
-              function_name:
-                function_name_identifier: nth_highest_salary
-              function_contents:
-                bracketed:
-                  start_bracket: (
-                  expression:
-                    numeric_literal: '1'
-                  end_bracket: )
-    - statement_terminator: ;
-    - statement:
-        assignment_segment_statement:
-          object_reference:
-            naked_identifier: next_highest_paid_emp
-          assignment_operator: :=
-          expression:
-            function:
-              function_name:
-                function_name_identifier: nth_highest_salary
-              function_contents:
-                bracketed:
-                  start_bracket: (
-                  expression:
-                    numeric_literal: '2'
-                  end_bracket: )
-    - statement_terminator: ;
-    - statement:
-        function:
-          function_name:
-            naked_identifier: DBMS_OUTPUT
-            dot: .
-            function_name_identifier: PUT_LINE
-          function_contents:
-            bracketed:
-              start_bracket: (
-              expression:
-              - quoted_literal: "'Highest Paid: #'"
-              - binary_operator:
-                - pipe: '|'
-                - pipe: '|'
-              - column_reference:
-                - naked_identifier: highest_paid_emp
-                - dot: .
-                - naked_identifier: emp_id
-              - binary_operator:
-                - pipe: '|'
-                - pipe: '|'
-              - quoted_literal: "', $'"
-              - binary_operator:
-                - pipe: '|'
-                - pipe: '|'
-              - column_reference:
-                - naked_identifier: highest_paid_emp
-                - dot: .
-                - naked_identifier: salary
-              end_bracket: )
-    - statement_terminator: ;
-    - statement:
-        function:
-          function_name:
-            naked_identifier: DBMS_OUTPUT
-            dot: .
-            function_name_identifier: PUT_LINE
-          function_contents:
-            bracketed:
-              start_bracket: (
-              expression:
-              - quoted_literal: "'Next Highest Paid: #'"
-              - binary_operator:
-                - pipe: '|'
-                - pipe: '|'
-              - column_reference:
-                - naked_identifier: next_highest_paid_emp
-                - dot: .
-                - naked_identifier: emp_id
-              - binary_operator:
-                - pipe: '|'
-                - pipe: '|'
-              - quoted_literal: "', $'"
-              - binary_operator:
-                - pipe: '|'
-                - pipe: '|'
-              - column_reference:
-                - naked_identifier: next_highest_paid_emp
-                - dot: .
-                - naked_identifier: salary
-              end_bracket: )
-    - statement_terminator: ;
-    - keyword: END
-- statement_terminator: ;
-- statement_terminator: /
-- statement:
-    begin_end_block:
-    - declare_segment:
-      - keyword: DECLARE
-      - cursor_variable:
-        - keyword: CURSOR
-        - naked_identifier: c1
-        - keyword: IS
-        - select_statement:
-            select_clause:
-            - keyword: SELECT
-            - select_clause_element:
-                column_reference:
-                  naked_identifier: last_name
-            - comma: ','
-            - select_clause_element:
-                column_reference:
-                  naked_identifier: job_id
-            from_clause:
-              keyword: FROM
-              from_expression:
-                from_expression_element:
-                  table_expression:
-                    table_reference:
-                      naked_identifier: employees
-            where_clause:
-              keyword: WHERE
-              expression:
-                function:
-                  function_name:
-                    function_name_identifier: REGEXP_LIKE
-                  function_contents:
-                    bracketed:
-                    - start_bracket: (
-                    - expression:
-                        column_reference:
-                          naked_identifier: job_id
-                    - comma: ','
-                    - expression:
-                        quoted_literal: "'S[HT]_CLERK'"
-                    - end_bracket: )
-            orderby_clause:
-            - keyword: ORDER
-            - keyword: BY
-            - column_reference:
-                naked_identifier: last_name
-        - statement_terminator: ;
-      - naked_identifier: v_lastname
-      - column_type_reference:
-          column_reference:
-          - naked_identifier: employees
-          - dot: .
-          - naked_identifier: last_name
-          binary_operator: '%'
-          keyword: TYPE
-      - statement_terminator: ;
-      - naked_identifier: v_jobid
-      - column_type_reference:
-          column_reference:
-          - naked_identifier: employees
-          - dot: .
-          - naked_identifier: job_id
-          binary_operator: '%'
-          keyword: TYPE
-      - statement_terminator: ;
-      - cursor_variable:
-        - keyword: CURSOR
-        - naked_identifier: c2
-        - keyword: IS
-        - select_statement:
-            select_clause:
-              keyword: SELECT
-              select_clause_element:
-                wildcard_expression:
-                  wildcard_identifier:
-                    star: '*'
-            from_clause:
-              keyword: FROM
-              from_expression:
-                from_expression_element:
-                  table_expression:
-                    table_reference:
-                      naked_identifier: employees
-            where_clause:
-              keyword: WHERE
-              expression:
-                function:
-                  function_name:
-                    function_name_identifier: REGEXP_LIKE
-                  function_contents:
-                    bracketed:
-                    - start_bracket: (
-                    - expression:
-                        column_reference:
-                          naked_identifier: job_id
-                    - comma: ','
-                    - expression:
-                        quoted_literal: "'[ACADFIMKSA]_M[ANGR]'"
-                    - end_bracket: )
-            orderby_clause:
-            - keyword: ORDER
-            - keyword: BY
-            - column_reference:
-                naked_identifier: job_id
-        - statement_terminator: ;
-      - naked_identifier: v_employees
-      - row_type_reference:
-          table_reference:
-            naked_identifier: employees
-          binary_operator: '%'
-          keyword: ROWTYPE
-      - statement_terminator: ;
-    - keyword: BEGIN
-    - statement:
-        open_statement:
-          keyword: OPEN
-          naked_identifier: c1
-    - statement_terminator: ;
-    - statement:
-        loop_statement:
-        - keyword: LOOP
-        - statement:
-            fetch_statement:
-              keyword: FETCH
-              naked_identifier: c1
-              into_clause:
-              - keyword: INTO
-              - naked_identifier: v_lastname
-              - comma: ','
-              - naked_identifier: v_jobid
-        - statement_terminator: ;
-        - statement:
-            exit_statement:
-            - keyword: EXIT
-            - keyword: WHEN
-            - expression:
-                naked_identifier: c1
-                binary_operator: '%'
-                keyword: NOTFOUND
-        - statement_terminator: ;
-        - statement:
-            function:
-              function_name:
-                naked_identifier: DBMS_OUTPUT
-                dot: .
-                function_name_identifier: PUT_LINE
-              function_contents:
-                bracketed:
-                  start_bracket: (
-                  expression:
-                    function:
-                      function_name:
-                        function_name_identifier: RPAD
-                      function_contents:
-                        bracketed:
-                        - start_bracket: (
-                        - expression:
-                            column_reference:
-                              naked_identifier: v_lastname
-                        - comma: ','
-                        - expression:
-                            numeric_literal: '25'
-                        - comma: ','
-                        - expression:
-                            quoted_literal: "' '"
-                        - end_bracket: )
-                    binary_operator:
-                    - pipe: '|'
-                    - pipe: '|'
-                    column_reference:
-                      naked_identifier: v_jobid
-                  end_bracket: )
-        - statement_terminator: ;
-        - keyword: END
-        - keyword: LOOP
-    - statement_terminator: ;
-    - statement:
-        close_statement:
-          keyword: CLOSE
-          naked_identifier: c1
-    - statement_terminator: ;
-    - statement:
-        function:
-          function_name:
-            naked_identifier: DBMS_OUTPUT
-            dot: .
-            function_name_identifier: PUT_LINE
-          function_contents:
-            bracketed:
-              start_bracket: (
-              expression:
-                quoted_literal: "'-------------------------------------'"
-              end_bracket: )
-    - statement_terminator: ;
-    - statement:
-        open_statement:
-          keyword: OPEN
-          naked_identifier: c2
-    - statement_terminator: ;
-    - statement:
-        loop_statement:
-        - keyword: LOOP
-        - statement:
-            fetch_statement:
-              keyword: FETCH
-              naked_identifier: c2
-              into_clause:
-                keyword: INTO
-                naked_identifier: v_employees
-        - statement_terminator: ;
-        - statement:
-            exit_statement:
-            - keyword: EXIT
-            - keyword: WHEN
-            - expression:
-                naked_identifier: c2
-                binary_operator: '%'
-                keyword: NOTFOUND
-        - statement_terminator: ;
-        - statement:
-            function:
-              function_name:
-                naked_identifier: DBMS_OUTPUT
-                dot: .
-                function_name_identifier: PUT_LINE
-              function_contents:
-                bracketed:
-                  start_bracket: (
-                  expression:
-                    function:
-                      function_name:
-                        function_name_identifier: RPAD
-                      function_contents:
-                        bracketed:
-                        - start_bracket: (
-                        - expression:
-                            column_reference:
-                            - naked_identifier: v_employees
-                            - dot: .
-                            - naked_identifier: last_name
-                        - comma: ','
-                        - expression:
-                            numeric_literal: '25'
-                        - comma: ','
-                        - expression:
-                            quoted_literal: "' '"
-                        - end_bracket: )
-                    binary_operator:
-                    - pipe: '|'
-                    - pipe: '|'
-                    column_reference:
-                    - naked_identifier: v_employees
-                    - dot: .
-                    - naked_identifier: job_id
-                  end_bracket: )
-        - statement_terminator: ;
-        - keyword: END
-        - keyword: LOOP
-    - statement_terminator: ;
-    - statement:
-        close_statement:
-          keyword: CLOSE
-          naked_identifier: c2
-    - statement_terminator: ;
-    - keyword: END
-- statement_terminator: ;
-- statement_terminator: /
-- statement:
-    begin_end_block:
-    - declare_segment:
-      - keyword: DECLARE
-      - cursor_variable:
-        - keyword: CURSOR
-        - naked_identifier: c
-        - keyword: IS
-        - select_statement:
-            select_clause:
-            - keyword: SELECT
-            - select_clause_element:
-                column_reference:
-                - naked_identifier: e
-                - dot: .
-                - naked_identifier: job_id
-            - comma: ','
-            - select_clause_element:
-                column_reference:
-                - naked_identifier: j
-                - dot: .
-                - naked_identifier: job_title
-            from_clause:
-            - keyword: FROM
-            - from_expression:
-                from_expression_element:
-                  table_expression:
-                    table_reference:
-                      naked_identifier: employees
-                  alias_expression:
-                    naked_identifier: e
-            - comma: ','
-            - from_expression:
-                from_expression_element:
-                  table_expression:
-                    table_reference:
-                      naked_identifier: jobs
-                  alias_expression:
-                    naked_identifier: j
-            where_clause:
-              keyword: WHERE
-              expression:
-              - column_reference:
-                - naked_identifier: e
-                - dot: .
-                - naked_identifier: job_id
-              - comparison_operator:
-                  raw_comparison_operator: '='
-              - column_reference:
-                - naked_identifier: j
-                - dot: .
-                - naked_identifier: job_id
-              - binary_operator: AND
-              - column_reference:
-                - naked_identifier: e
-                - dot: .
-                - naked_identifier: manager_id
-              - comparison_operator:
-                  raw_comparison_operator: '='
-              - numeric_literal: '100'
-            orderby_clause:
-            - keyword: ORDER
-            - keyword: BY
-            - column_reference:
-                naked_identifier: last_name
-        - statement_terminator: ;
-      - naked_identifier: job1
-      - row_type_reference:
-          table_reference:
-            naked_identifier: c
-          binary_operator: '%'
-          keyword: ROWTYPE
-      - statement_terminator: ;
-      - naked_identifier: job2
-      - row_type_reference:
-          table_reference:
-            naked_identifier: c
-          binary_operator: '%'
-          keyword: ROWTYPE
-      - statement_terminator: ;
-      - naked_identifier: job3
-      - row_type_reference:
-          table_reference:
-            naked_identifier: c
-          binary_operator: '%'
-          keyword: ROWTYPE
-      - statement_terminator: ;
-      - naked_identifier: job4
-      - row_type_reference:
-          table_reference:
-            naked_identifier: c
-          binary_operator: '%'
-          keyword: ROWTYPE
-      - statement_terminator: ;
-      - naked_identifier: job5
-      - row_type_reference:
-          table_reference:
-            naked_identifier: c
-          binary_operator: '%'
-          keyword: ROWTYPE
-      - statement_terminator: ;
-    - keyword: BEGIN
-    - statement:
-        open_statement:
-          keyword: OPEN
-          naked_identifier: c
-    - statement_terminator: ;
-    - statement:
-        fetch_statement:
-          keyword: FETCH
-          naked_identifier: c
-          into_clause:
-            keyword: INTO
-            naked_identifier: job1
-    - statement_terminator: ;
-    - statement:
-        fetch_statement:
-          keyword: FETCH
-          naked_identifier: c
-          into_clause:
-            keyword: INTO
-            naked_identifier: job2
-    - statement_terminator: ;
-    - statement:
-        fetch_statement:
-          keyword: FETCH
-          naked_identifier: c
-          into_clause:
-            keyword: INTO
-            naked_identifier: job3
-    - statement_terminator: ;
-    - statement:
-        fetch_statement:
-          keyword: FETCH
-          naked_identifier: c
-          into_clause:
-            keyword: INTO
-            naked_identifier: job4
-    - statement_terminator: ;
-    - statement:
-        fetch_statement:
-          keyword: FETCH
-          naked_identifier: c
-          into_clause:
-            keyword: INTO
-            naked_identifier: job5
-    - statement_terminator: ;
-    - statement:
-        close_statement:
-          keyword: CLOSE
-          naked_identifier: c
-    - statement_terminator: ;
-    - statement:
-        function:
-          function_name:
-            naked_identifier: DBMS_OUTPUT
-            dot: .
-            function_name_identifier: PUT_LINE
-          function_contents:
-            bracketed:
-              start_bracket: (
-              expression:
-              - column_reference:
-                - naked_identifier: job1
-                - dot: .
-                - naked_identifier: job_title
-              - binary_operator:
-                - pipe: '|'
-                - pipe: '|'
-              - quoted_literal: "' ('"
-              - binary_operator:
-                - pipe: '|'
-                - pipe: '|'
-              - column_reference:
-                - naked_identifier: job1
-                - dot: .
-                - naked_identifier: job_id
-              - binary_operator:
-                - pipe: '|'
-                - pipe: '|'
-              - quoted_literal: "')'"
-              end_bracket: )
-    - statement_terminator: ;
-    - statement:
-        function:
-          function_name:
-            naked_identifier: DBMS_OUTPUT
-            dot: .
-            function_name_identifier: PUT_LINE
-          function_contents:
-            bracketed:
-              start_bracket: (
-              expression:
-              - column_reference:
-                - naked_identifier: job2
-                - dot: .
-                - naked_identifier: job_title
-              - binary_operator:
-                - pipe: '|'
-                - pipe: '|'
-              - quoted_literal: "' ('"
-              - binary_operator:
-                - pipe: '|'
-                - pipe: '|'
-              - column_reference:
-                - naked_identifier: job2
-                - dot: .
-                - naked_identifier: job_id
-              - binary_operator:
-                - pipe: '|'
-                - pipe: '|'
-              - quoted_literal: "')'"
-              end_bracket: )
-    - statement_terminator: ;
-    - statement:
-        function:
-          function_name:
-            naked_identifier: DBMS_OUTPUT
-            dot: .
-            function_name_identifier: PUT_LINE
-          function_contents:
-            bracketed:
-              start_bracket: (
-              expression:
-              - column_reference:
-                - naked_identifier: job3
-                - dot: .
-                - naked_identifier: job_title
-              - binary_operator:
-                - pipe: '|'
-                - pipe: '|'
-              - quoted_literal: "' ('"
-              - binary_operator:
-                - pipe: '|'
-                - pipe: '|'
-              - column_reference:
-                - naked_identifier: job3
-                - dot: .
-                - naked_identifier: job_id
-              - binary_operator:
-                - pipe: '|'
-                - pipe: '|'
-              - quoted_literal: "')'"
-              end_bracket: )
-    - statement_terminator: ;
-    - statement:
-        function:
-          function_name:
-            naked_identifier: DBMS_OUTPUT
-            dot: .
-            function_name_identifier: PUT_LINE
-          function_contents:
-            bracketed:
-              start_bracket: (
-              expression:
-              - column_reference:
-                - naked_identifier: job4
-                - dot: .
-                - naked_identifier: job_title
-              - binary_operator:
-                - pipe: '|'
-                - pipe: '|'
-              - quoted_literal: "' ('"
-              - binary_operator:
-                - pipe: '|'
-                - pipe: '|'
-              - column_reference:
-                - naked_identifier: job4
-                - dot: .
-                - naked_identifier: job_id
-              - binary_operator:
-                - pipe: '|'
-                - pipe: '|'
-              - quoted_literal: "')'"
-              end_bracket: )
-    - statement_terminator: ;
-    - statement:
-        function:
-          function_name:
-            naked_identifier: DBMS_OUTPUT
-            dot: .
-            function_name_identifier: PUT_LINE
-          function_contents:
-            bracketed:
-              start_bracket: (
-              expression:
-              - column_reference:
-                - naked_identifier: job5
-                - dot: .
-                - naked_identifier: job_title
-              - binary_operator:
-                - pipe: '|'
-                - pipe: '|'
-              - quoted_literal: "' ('"
-              - binary_operator:
-                - pipe: '|'
-                - pipe: '|'
-              - column_reference:
-                - naked_identifier: job5
-                - dot: .
-                - naked_identifier: job_id
-              - binary_operator:
-                - pipe: '|'
-                - pipe: '|'
-              - quoted_literal: "')'"
-              end_bracket: )
-    - statement_terminator: ;
-    - keyword: END
-- statement_terminator: ;
-- statement_terminator: /
-- statement:
-    begin_end_block:
-    - declare_segment:
-      - keyword: DECLARE
-      - naked_identifier: cv
-      - data_type:
-          data_type_identifier: SYS_REFCURSOR
-      - statement_terminator: ;
-      - naked_identifier: v_lastname
-      - column_type_reference:
-          column_reference:
-          - naked_identifier: employees
-          - dot: .
-          - naked_identifier: last_name
-          binary_operator: '%'
-          keyword: TYPE
-      - statement_terminator: ;
-      - naked_identifier: v_jobid
-      - column_type_reference:
-          column_reference:
-          - naked_identifier: employees
-          - dot: .
-          - naked_identifier: job_id
-          binary_operator: '%'
-          keyword: TYPE
-      - statement_terminator: ;
-      - naked_identifier: query_2
-      - data_type:
-          data_type_identifier: VARCHAR2
-          bracketed_arguments:
-            bracketed:
-              start_bracket: (
-              numeric_literal: '200'
-              end_bracket: )
-      - assignment_operator: :=
-      - expression:
-          quoted_literal: "'SELECT * FROM employees\n    WHERE REGEXP_LIKE (job_id,\
-            \ ''[ACADFIMKSA]_M[ANGR]'')\n    ORDER BY job_id'"
-      - statement_terminator: ;
-      - naked_identifier: v_employees
-      - row_type_reference:
-          table_reference:
-            naked_identifier: employees
-          binary_operator: '%'
-          keyword: ROWTYPE
-      - statement_terminator: ;
-    - keyword: BEGIN
-    - statement:
-        open_for_statement:
-        - keyword: OPEN
-        - naked_identifier: cv
-        - keyword: FOR
-        - select_statement:
-            select_clause:
-            - keyword: SELECT
-            - select_clause_element:
-                column_reference:
-                  naked_identifier: last_name
-            - comma: ','
-            - select_clause_element:
-                column_reference:
-                  naked_identifier: job_id
-            from_clause:
-              keyword: FROM
-              from_expression:
-                from_expression_element:
-                  table_expression:
-                    table_reference:
-                      naked_identifier: employees
-            where_clause:
-              keyword: WHERE
-              expression:
-                function:
-                  function_name:
-                    function_name_identifier: REGEXP_LIKE
-                  function_contents:
-                    bracketed:
-                    - start_bracket: (
-                    - expression:
-                        column_reference:
-                          naked_identifier: job_id
-                    - comma: ','
-                    - expression:
-                        quoted_literal: "'S[HT]_CLERK'"
-                    - end_bracket: )
-            orderby_clause:
-            - keyword: ORDER
-            - keyword: BY
-            - column_reference:
-                naked_identifier: last_name
-    - statement_terminator: ;
-    - statement:
-        loop_statement:
-        - keyword: LOOP
-        - statement:
-            fetch_statement:
-              keyword: FETCH
-              naked_identifier: cv
-              into_clause:
-              - keyword: INTO
-              - naked_identifier: v_lastname
-              - comma: ','
-              - naked_identifier: v_jobid
-        - statement_terminator: ;
-        - statement:
-            exit_statement:
-            - keyword: EXIT
-            - keyword: WHEN
-            - expression:
-                naked_identifier: cv
-                binary_operator: '%'
-                keyword: NOTFOUND
-        - statement_terminator: ;
-        - statement:
-            function:
-              function_name:
-                naked_identifier: DBMS_OUTPUT
-                dot: .
-                function_name_identifier: PUT_LINE
-              function_contents:
-                bracketed:
-                  start_bracket: (
-                  expression:
-                    function:
-                      function_name:
-                        function_name_identifier: RPAD
-                      function_contents:
-                        bracketed:
-                        - start_bracket: (
-                        - expression:
-                            column_reference:
-                              naked_identifier: v_lastname
-                        - comma: ','
-                        - expression:
-                            numeric_literal: '25'
-                        - comma: ','
-                        - expression:
-                            quoted_literal: "' '"
-                        - end_bracket: )
-                    binary_operator:
-                    - pipe: '|'
-                    - pipe: '|'
-                    column_reference:
-                      naked_identifier: v_jobid
-                  end_bracket: )
-        - statement_terminator: ;
-        - keyword: END
-        - keyword: LOOP
-    - statement_terminator: ;
-    - statement:
-        function:
-          function_name:
-            naked_identifier: DBMS_OUTPUT
-            dot: .
-            function_name_identifier: PUT_LINE
-          function_contents:
-            bracketed:
-              start_bracket: (
-              expression:
-                quoted_literal: "'-------------------------------------'"
-              end_bracket: )
-    - statement_terminator: ;
-    - statement:
-        open_for_statement:
-        - keyword: OPEN
-        - naked_identifier: cv
-        - keyword: FOR
-        - naked_identifier: query_2
-    - statement_terminator: ;
-    - statement:
-        loop_statement:
-        - keyword: LOOP
-        - statement:
-            fetch_statement:
-              keyword: FETCH
-              naked_identifier: cv
-              into_clause:
-                keyword: INTO
-                naked_identifier: v_employees
-        - statement_terminator: ;
-        - statement:
-            exit_statement:
-            - keyword: EXIT
-            - keyword: WHEN
-            - expression:
-                naked_identifier: cv
-                binary_operator: '%'
-                keyword: NOTFOUND
-        - statement_terminator: ;
-        - statement:
-            function:
-              function_name:
-                naked_identifier: DBMS_OUTPUT
-                dot: .
-                function_name_identifier: PUT_LINE
-              function_contents:
-                bracketed:
-                  start_bracket: (
-                  expression:
-                    function:
-                      function_name:
-                        function_name_identifier: RPAD
-                      function_contents:
-                        bracketed:
-                        - start_bracket: (
-                        - expression:
-                            column_reference:
-                            - naked_identifier: v_employees
-                            - dot: .
-                            - naked_identifier: last_name
-                        - comma: ','
-                        - expression:
-                            numeric_literal: '25'
-                        - comma: ','
-                        - expression:
-                            quoted_literal: "' '"
-                        - end_bracket: )
-                    binary_operator:
-                    - pipe: '|'
-                    - pipe: '|'
-                    column_reference:
-                    - naked_identifier: v_employees
-                    - dot: .
-                    - naked_identifier: job_id
-                  end_bracket: )
-        - statement_terminator: ;
-        - keyword: END
-        - keyword: LOOP
-    - statement_terminator: ;
-    - statement:
-        close_statement:
-          keyword: CLOSE
-          naked_identifier: cv
-    - statement_terminator: ;
-    - keyword: END
-- statement_terminator: ;
-- statement_terminator: /
-- statement:
-    begin_end_block:
-    - declare_segment:
-      - keyword: DECLARE
-      - ref_cursor_type:
-        - keyword: TYPE
-        - naked_identifier: empcurtyp
-        - keyword: IS
-        - keyword: REF
-        - keyword: CURSOR
-      - statement_terminator: ;
-      - collection_type:
-        - keyword: TYPE
-        - naked_identifier: namelist
-        - keyword: IS
-        - keyword: TABLE
-        - keyword: OF
-        - column_type_reference:
-            column_reference:
-            - naked_identifier: employees
-            - dot: .
-            - naked_identifier: last_name
-            binary_operator: '%'
-            keyword: TYPE
-      - statement_terminator: ;
-      - collection_type:
-        - keyword: TYPE
-        - naked_identifier: sallist
-        - keyword: IS
-        - keyword: TABLE
-        - keyword: OF
-        - column_type_reference:
-            column_reference:
-            - naked_identifier: employees
-            - dot: .
-            - naked_identifier: salary
-            binary_operator: '%'
-            keyword: TYPE
-      - statement_terminator: ;
-      - naked_identifier: emp_cv
-      - data_type:
-          data_type_identifier: empcurtyp
-      - statement_terminator: ;
-      - naked_identifier: names
-      - data_type:
-          data_type_identifier: namelist
-      - statement_terminator: ;
-      - naked_identifier: sals
-      - data_type:
-          data_type_identifier: sallist
-      - statement_terminator: ;
-    - keyword: BEGIN
-    - statement:
-        open_for_statement:
-        - keyword: OPEN
-        - naked_identifier: emp_cv
-        - keyword: FOR
-        - select_statement:
-            select_clause:
-            - keyword: SELECT
-            - select_clause_element:
-                column_reference:
-                  naked_identifier: last_name
-            - comma: ','
-            - select_clause_element:
-                column_reference:
-                  naked_identifier: salary
-            from_clause:
-              keyword: FROM
-              from_expression:
-                from_expression_element:
-                  table_expression:
-                    table_reference:
-                      naked_identifier: employees
-            where_clause:
-              keyword: WHERE
-              expression:
-                column_reference:
-                  naked_identifier: job_id
-                comparison_operator:
-                  raw_comparison_operator: '='
-                quoted_literal: "'SA_REP'"
-            orderby_clause:
-            - keyword: ORDER
-            - keyword: BY
-            - column_reference:
-                naked_identifier: salary
-            - keyword: DESC
-    - statement_terminator: ;
-    - statement:
-        fetch_statement:
-          keyword: FETCH
-          naked_identifier: emp_cv
-          bulk_collect_into_clause:
-          - keyword: BULK
-          - keyword: COLLECT
-          - keyword: INTO
-          - naked_identifier: names
-          - comma: ','
-          - naked_identifier: sals
-    - statement_terminator: ;
-    - statement:
-        close_statement:
-          keyword: CLOSE
-          naked_identifier: emp_cv
-    - statement_terminator: ;
-    - statement:
-        for_loop_statement:
-        - keyword: FOR
-        - naked_identifier: i
-        - keyword: IN
-        - naked_identifier: names
-        - dot: .
-        - naked_identifier: FIRST
-        - dot: .
-        - dot: .
-        - naked_identifier: names
-        - dot: .
-        - naked_identifier: LAST
-        - loop_statement:
-          - keyword: LOOP
-          - statement:
-              function:
-                function_name:
-                  naked_identifier: DBMS_OUTPUT
-                  dot: .
-                  function_name_identifier: PUT_LINE
-                function_contents:
-                  bracketed:
-                    start_bracket: (
-                    expression:
-                    - quoted_literal: "'Name = '"
-                    - binary_operator:
-                      - pipe: '|'
-                      - pipe: '|'
-                    - function:
-                        function_name:
-                          function_name_identifier: names
-                        function_contents:
-                          bracketed:
-                            start_bracket: (
-                            expression:
-                              column_reference:
-                                naked_identifier: i
-                            end_bracket: )
-                    - binary_operator:
-                      - pipe: '|'
-                      - pipe: '|'
-                    - quoted_literal: "', salary = '"
-                    - binary_operator:
-                      - pipe: '|'
-                      - pipe: '|'
-                    - function:
-                        function_name:
-                          function_name_identifier: sals
-                        function_contents:
-                          bracketed:
-                            start_bracket: (
-                            expression:
-                              column_reference:
-                                naked_identifier: i
-                            end_bracket: )
-                    end_bracket: )
+              exit_statement:
+              - keyword: EXIT
+              - keyword: WHEN
+              - expression:
+                  naked_identifier: c1
+                  binary_operator: '%'
+                  keyword: NOTFOUND
           - statement_terminator: ;
           - keyword: END
           - keyword: LOOP
-    - statement_terminator: ;
-    - keyword: END
-- statement_terminator: ;
-- statement_terminator: /
-- statement:
-    begin_end_block:
-    - declare_segment:
-        keyword: DECLARE
-        cursor_variable:
-        - keyword: CURSOR
-        - naked_identifier: c1
-        - keyword: IS
-        - select_statement:
-          - select_clause:
-              keyword: SELECT
-              select_clause_element:
-                wildcard_expression:
-                  wildcard_identifier:
-                    star: '*'
-          - from_clause:
-              keyword: FROM
-              from_expression:
-                from_expression_element:
-                  table_expression:
-                    table_reference:
-                      naked_identifier: emp
-          - keyword: FOR
-          - keyword: UPDATE
-          - keyword: OF
-          - table_reference:
-              naked_identifier: salary
-          - orderby_clause:
-            - keyword: ORDER
-            - keyword: BY
-            - column_reference:
-                naked_identifier: employee_id
-        - statement_terminator: ;
-        naked_identifier: emp_rec
-        row_type_reference:
-          table_reference:
-            naked_identifier: emp
-          binary_operator: '%'
-          keyword: ROWTYPE
-        statement_terminator: ;
-    - keyword: BEGIN
-    - statement:
-        open_statement:
-          keyword: OPEN
-          naked_identifier: c1
-    - statement_terminator: ;
-    - statement:
-        loop_statement:
-        - keyword: LOOP
-        - statement:
-            fetch_statement:
-              keyword: FETCH
-              naked_identifier: c1
-              into_clause:
-                keyword: INTO
-                naked_identifier: emp_rec
-        - statement_terminator: ;
-        - statement:
-            exit_statement:
-            - keyword: EXIT
-            - keyword: WHEN
-            - expression:
-                naked_identifier: c1
-                binary_operator: '%'
-                keyword: NOTFOUND
-        - statement_terminator: ;
-        - statement:
-            function:
-              function_name:
-                naked_identifier: DBMS_OUTPUT
-                dot: .
-                function_name_identifier: PUT_LINE
-              function_contents:
-                bracketed:
-                  start_bracket: (
-                  expression:
-                    quoted_literal: "'emp_rec.employee_id = '"
-                    binary_operator:
-                    - pipe: '|'
-                    - pipe: '|'
-                    function:
-                      function_name:
-                        function_name_identifier: TO_CHAR
-                      function_contents:
-                        bracketed:
-                          start_bracket: (
-                          expression:
-                            column_reference:
-                            - naked_identifier: emp_rec
-                            - dot: .
-                            - naked_identifier: employee_id
-                          end_bracket: )
-                  end_bracket: )
-        - statement_terminator: ;
-        - statement:
-            update_statement:
-              keyword: UPDATE
-              table_reference:
-                naked_identifier: emp
-              set_clause_list:
-                keyword: SET
-                set_clause:
-                  column_reference:
-                    naked_identifier: salary
-                  comparison_operator:
-                    raw_comparison_operator: '='
-                  expression:
-                    column_reference:
-                      naked_identifier: salary
-                    binary_operator: '*'
-                    numeric_literal: '1.05'
-              where_clause:
-                keyword: WHERE
-                expression:
-                  column_reference:
-                    naked_identifier: employee_id
-                  comparison_operator:
-                    raw_comparison_operator: '='
-                  numeric_literal: '105'
-        - statement_terminator: ;
-        - statement:
-            transaction_statement:
-              keyword: COMMIT
-        - statement_terminator: ;
-        - keyword: END
-        - keyword: LOOP
-    - statement_terminator: ;
-    - keyword: END
-- statement_terminator: ;
-- statement_terminator: /
-- statement:
-    begin_end_block:
-    - declare_segment:
-      - keyword: DECLARE
-      - ref_cursor_type:
-        - keyword: TYPE
-        - naked_identifier: EmpCurTyp
-        - keyword: IS
-        - keyword: REF
-        - keyword: CURSOR
       - statement_terminator: ;
-      - naked_identifier: v_emp_cursor
-      - data_type:
-          data_type_identifier: EmpCurTyp
+      - statement:
+          close_statement:
+            keyword: CLOSE
+            naked_identifier: c1
       - statement_terminator: ;
-      - naked_identifier: emp_record
-      - row_type_reference:
-          table_reference:
-            naked_identifier: employees
-          binary_operator: '%'
-          keyword: ROWTYPE
-      - statement_terminator: ;
-      - naked_identifier: v_stmt_str
-      - data_type:
-          data_type_identifier: VARCHAR2
-          bracketed_arguments:
-            bracketed:
-              start_bracket: (
-              numeric_literal: '200'
-              end_bracket: )
-      - statement_terminator: ;
-      - naked_identifier: v_e_job
-      - column_type_reference:
-          column_reference:
-          - naked_identifier: employees
-          - dot: .
-          - naked_identifier: job_id
-          binary_operator: '%'
-          keyword: TYPE
-      - statement_terminator: ;
-    - keyword: BEGIN
-    - statement:
-        assignment_segment_statement:
-          object_reference:
-            naked_identifier: v_stmt_str
-          assignment_operator: :=
-          expression:
-            quoted_literal: "'SELECT * FROM employees WHERE job_id = :j'"
-    - statement_terminator: ;
-    - statement:
-        open_for_statement:
-        - keyword: OPEN
-        - naked_identifier: v_emp_cursor
-        - keyword: FOR
-        - naked_identifier: v_stmt_str
-        - keyword: USING
-        - quoted_identifier: "'MANAGER'"
-    - statement_terminator: ;
-    - statement:
-        loop_statement:
-        - keyword: LOOP
-        - statement:
-            fetch_statement:
-              keyword: FETCH
-              naked_identifier: v_emp_cursor
-              into_clause:
-                keyword: INTO
-                naked_identifier: emp_record
-        - statement_terminator: ;
-        - statement:
-            exit_statement:
-            - keyword: EXIT
-            - keyword: WHEN
-            - expression:
-                naked_identifier: v_emp_cursor
-                binary_operator: '%'
-                keyword: NOTFOUND
-        - statement_terminator: ;
-        - keyword: END
-        - keyword: LOOP
-    - statement_terminator: ;
-    - statement:
-        close_statement:
-          keyword: CLOSE
-          naked_identifier: v_emp_cursor
-    - statement_terminator: ;
-    - keyword: END
-- statement_terminator: ;
-- statement_terminator: /
-- statement:
-    begin_end_block:
-    - declare_segment:
-      - keyword: DECLARE
-      - collection_type:
-        - keyword: TYPE
-        - naked_identifier: NameList
-        - keyword: IS
-        - keyword: TABLE
-        - keyword: OF
-        - column_type_reference:
-            column_reference:
-            - naked_identifier: employees
-            - dot: .
-            - naked_identifier: last_name
-            binary_operator: '%'
-            keyword: TYPE
-      - statement_terminator: ;
-      - collection_type:
-        - keyword: TYPE
-        - naked_identifier: SalList
-        - keyword: IS
-        - keyword: TABLE
-        - keyword: OF
-        - column_type_reference:
-            column_reference:
-            - naked_identifier: employees
-            - dot: .
-            - naked_identifier: salary
-            binary_operator: '%'
-            keyword: TYPE
-      - statement_terminator: ;
-      - cursor_variable:
-        - keyword: CURSOR
-        - naked_identifier: c1
-        - keyword: IS
-        - select_statement:
-            select_clause:
-            - keyword: SELECT
-            - select_clause_element:
-                column_reference:
-                  naked_identifier: last_name
-            - comma: ','
-            - select_clause_element:
-                column_reference:
-                  naked_identifier: salary
-            from_clause:
-              keyword: FROM
-              from_expression:
-                from_expression_element:
-                  table_expression:
-                    table_reference:
-                      naked_identifier: employees
-            where_clause:
-              keyword: WHERE
-              expression:
-                column_reference:
-                  naked_identifier: salary
-                comparison_operator:
-                  raw_comparison_operator: '>'
-                numeric_literal: '10000'
-            orderby_clause:
-            - keyword: ORDER
-            - keyword: BY
-            - column_reference:
-                naked_identifier: last_name
-        - statement_terminator: ;
-      - naked_identifier: names
-      - data_type:
-          data_type_identifier: NameList
-      - statement_terminator: ;
-      - naked_identifier: sals
-      - data_type:
-          data_type_identifier: SalList
-      - statement_terminator: ;
-      - collection_type:
-        - keyword: TYPE
-        - naked_identifier: RecList
-        - keyword: IS
-        - keyword: TABLE
-        - keyword: OF
-        - row_type_reference:
-            table_reference:
-              naked_identifier: c1
-            binary_operator: '%'
-            keyword: ROWTYPE
-      - statement_terminator: ;
-      - naked_identifier: recs
-      - data_type:
-          data_type_identifier: RecList
-      - statement_terminator: ;
-      - naked_identifier: v_limit
-      - data_type:
-          data_type_identifier: PLS_INTEGER
-      - assignment_operator: :=
-      - expression:
-          numeric_literal: '10'
-      - statement_terminator: ;
-      - create_procedure_statement:
-        - keyword: PROCEDURE
-        - function_name:
-            function_name_identifier: print_results
-        - keyword: IS
-        - begin_end_block:
-          - keyword: BEGIN
-          - statement:
-              if_then_statement:
-              - if_clause:
-                - keyword: IF
-                - expression:
-                  - column_reference:
-                      naked_identifier: names
-                  - keyword: IS
-                  - null_literal: 'NULL'
-                  - binary_operator: OR
-                  - column_reference:
-                    - naked_identifier: names
-                    - dot: .
-                    - naked_identifier: COUNT
-                  - comparison_operator:
-                      raw_comparison_operator: '='
-                  - numeric_literal: '0'
-                - keyword: THEN
-              - statement:
-                  function:
-                    function_name:
-                      naked_identifier: DBMS_OUTPUT
-                      dot: .
-                      function_name_identifier: PUT_LINE
-                    function_contents:
-                      bracketed:
-                        start_bracket: (
-                        expression:
-                          quoted_literal: "'No results!'"
-                        end_bracket: )
-              - statement_terminator: ;
-              - keyword: ELSE
-              - statement:
-                  function:
-                    function_name:
-                      naked_identifier: DBMS_OUTPUT
-                      dot: .
-                      function_name_identifier: PUT_LINE
-                    function_contents:
-                      bracketed:
-                        start_bracket: (
-                        expression:
-                          quoted_literal: "'Result: '"
-                        end_bracket: )
-              - statement_terminator: ;
-              - statement:
-                  for_loop_statement:
-                  - keyword: FOR
-                  - naked_identifier: i
-                  - keyword: IN
-                  - naked_identifier: names
-                  - dot: .
-                  - naked_identifier: FIRST
-                  - dot: .
-                  - dot: .
-                  - naked_identifier: names
-                  - dot: .
-                  - naked_identifier: LAST
-                  - loop_statement:
-                    - keyword: LOOP
-                    - statement:
-                        function:
-                          function_name:
-                            naked_identifier: DBMS_OUTPUT
-                            dot: .
-                            function_name_identifier: PUT_LINE
-                          function_contents:
-                            bracketed:
-                              start_bracket: (
-                              expression:
-                              - quoted_literal: "'  Employee '"
-                              - binary_operator:
-                                - pipe: '|'
-                                - pipe: '|'
-                              - function:
-                                  function_name:
-                                    function_name_identifier: names
-                                  function_contents:
-                                    bracketed:
-                                      start_bracket: (
-                                      expression:
-                                        column_reference:
-                                          naked_identifier: i
-                                      end_bracket: )
-                              - binary_operator:
-                                - pipe: '|'
-                                - pipe: '|'
-                              - quoted_literal: "': $'"
-                              - binary_operator:
-                                - pipe: '|'
-                                - pipe: '|'
-                              - function:
-                                  function_name:
-                                    function_name_identifier: sals
-                                  function_contents:
-                                    bracketed:
-                                      start_bracket: (
-                                      expression:
-                                        column_reference:
-                                          naked_identifier: i
-                                      end_bracket: )
-                              end_bracket: )
-                    - statement_terminator: ;
-                    - keyword: END
-                    - keyword: LOOP
-              - statement_terminator: ;
-              - keyword: END
-              - keyword: IF
-          - statement_terminator: ;
-          - keyword: END
-        - statement_terminator: ;
-    - keyword: BEGIN
-    - statement:
-        function:
-          function_name:
-            naked_identifier: DBMS_OUTPUT
-            dot: .
-            function_name_identifier: PUT_LINE
-          function_contents:
-            bracketed:
-              start_bracket: (
-              expression:
-                quoted_literal: "'--- Processing all results simultaneously ---'"
-              end_bracket: )
-    - statement_terminator: ;
-    - statement:
-        open_statement:
-          keyword: OPEN
-          naked_identifier: c1
-    - statement_terminator: ;
-    - statement:
-        fetch_statement:
-          keyword: FETCH
-          naked_identifier: c1
-          bulk_collect_into_clause:
-          - keyword: BULK
-          - keyword: COLLECT
-          - keyword: INTO
-          - naked_identifier: names
-          - comma: ','
-          - naked_identifier: sals
-    - statement_terminator: ;
-    - statement:
-        close_statement:
-          keyword: CLOSE
-          naked_identifier: c1
-    - statement_terminator: ;
-    - statement:
-        function:
-          function_name:
-            function_name_identifier: print_results
-          function_contents:
-            bracketed:
-              start_bracket: (
-              end_bracket: )
-    - statement_terminator: ;
-    - statement:
-        function:
-          function_name:
-            naked_identifier: DBMS_OUTPUT
-            dot: .
-            function_name_identifier: PUT_LINE
-          function_contents:
-            bracketed:
-              start_bracket: (
-              expression:
-              - quoted_literal: "'--- Processing '"
-              - binary_operator:
-                - pipe: '|'
-                - pipe: '|'
-              - column_reference:
-                  naked_identifier: v_limit
-              - binary_operator:
-                - pipe: '|'
-                - pipe: '|'
-              - quoted_literal: "' rows at a time ---'"
-              end_bracket: )
-    - statement_terminator: ;
-    - statement:
-        open_statement:
-          keyword: OPEN
-          naked_identifier: c1
-    - statement_terminator: ;
-    - statement:
-        loop_statement:
-        - keyword: LOOP
-        - statement:
-            fetch_statement:
-            - keyword: FETCH
-            - naked_identifier: c1
-            - bulk_collect_into_clause:
-              - keyword: BULK
-              - keyword: COLLECT
-              - keyword: INTO
-              - naked_identifier: names
-              - comma: ','
-              - naked_identifier: sals
-            - keyword: LIMIT
-            - naked_identifier: v_limit
-        - statement_terminator: ;
-        - statement:
-            exit_statement:
-            - keyword: EXIT
-            - keyword: WHEN
-            - expression:
-                column_reference:
-                - naked_identifier: names
-                - dot: .
-                - naked_identifier: COUNT
-                comparison_operator:
-                  raw_comparison_operator: '='
-                numeric_literal: '0'
-        - statement_terminator: ;
-        - statement:
-            function:
-              function_name:
-                function_name_identifier: print_results
-              function_contents:
-                bracketed:
-                  start_bracket: (
-                  end_bracket: )
-        - statement_terminator: ;
-        - keyword: END
-        - keyword: LOOP
-    - statement_terminator: ;
-    - statement:
-        close_statement:
-          keyword: CLOSE
-          naked_identifier: c1
-    - statement_terminator: ;
-    - statement:
-        function:
-          function_name:
-            naked_identifier: DBMS_OUTPUT
-            dot: .
-            function_name_identifier: PUT_LINE
-          function_contents:
-            bracketed:
-              start_bracket: (
-              expression:
-                quoted_literal: "'--- Fetching records rather than columns ---'"
-              end_bracket: )
-    - statement_terminator: ;
-    - statement:
-        open_statement:
-          keyword: OPEN
-          naked_identifier: c1
-    - statement_terminator: ;
-    - statement:
-        fetch_statement:
-          keyword: FETCH
-          naked_identifier: c1
-          bulk_collect_into_clause:
-          - keyword: BULK
-          - keyword: COLLECT
-          - keyword: INTO
-          - naked_identifier: recs
-    - statement_terminator: ;
-    - statement:
-        for_loop_statement:
-        - keyword: FOR
-        - naked_identifier: i
-        - keyword: IN
-        - naked_identifier: recs
-        - dot: .
-        - naked_identifier: FIRST
-        - dot: .
-        - dot: .
-        - naked_identifier: recs
-        - dot: .
-        - naked_identifier: LAST
-        - loop_statement:
-          - keyword: LOOP
-          - statement:
-              function:
-                function_name:
-                  naked_identifier: DBMS_OUTPUT
-                  dot: .
-                  function_name_identifier: PUT_LINE
-                function_contents:
-                  bracketed:
-                    start_bracket: (
-                    expression:
-                      numeric_literal: '1'
-                    end_bracket: )
-          - statement_terminator: ;
-          - keyword: END
-          - keyword: LOOP
-    - statement_terminator: ;
-    - keyword: END
-- statement_terminator: ;
-- statement_terminator: /
-- statement:
-    begin_end_block:
-    - declare_segment:
-      - keyword: DECLARE
-      - cursor_variable:
-        - keyword: CURSOR
-        - naked_identifier: c1
-        - keyword: IS
-        - select_statement:
-            select_clause:
-            - keyword: SELECT
-            - select_clause_element:
-                column_reference:
-                  naked_identifier: first_name
-            - comma: ','
-            - select_clause_element:
-                column_reference:
-                  naked_identifier: last_name
-            - comma: ','
-            - select_clause_element:
-                column_reference:
-                  naked_identifier: hire_date
-            from_clause:
-              keyword: FROM
-              from_expression:
-                from_expression_element:
-                  table_expression:
-                    table_reference:
-                      naked_identifier: employees
-        - statement_terminator: ;
-      - collection_type:
-        - keyword: TYPE
-        - naked_identifier: NameSet
-        - keyword: IS
-        - keyword: TABLE
-        - keyword: OF
-        - row_type_reference:
-            table_reference:
-              naked_identifier: c1
-            binary_operator: '%'
-            keyword: ROWTYPE
-      - statement_terminator: ;
-      - naked_identifier: stock_managers
-      - data_type:
-          data_type_identifier: NameSet
-      - statement_terminator: ;
-      - ref_cursor_type:
-        - keyword: TYPE
-        - naked_identifier: cursor_var_type
-        - keyword: is
-        - keyword: REF
-        - keyword: CURSOR
-      - statement_terminator: ;
-      - naked_identifier: cv
-      - data_type:
-          data_type_identifier: cursor_var_type
-      - statement_terminator: ;
-    - keyword: BEGIN
-    - statement:
-        open_for_statement:
-        - keyword: OPEN
-        - naked_identifier: cv
-        - keyword: FOR
-        - select_statement:
-            select_clause:
-            - keyword: SELECT
-            - select_clause_element:
-                column_reference:
-                  naked_identifier: first_name
-            - comma: ','
-            - select_clause_element:
-                column_reference:
-                  naked_identifier: last_name
-            - comma: ','
-            - select_clause_element:
-                column_reference:
-                  naked_identifier: hire_date
-            from_clause:
-              keyword: FROM
-              from_expression:
-                from_expression_element:
-                  table_expression:
-                    table_reference:
-                      naked_identifier: employees
-            where_clause:
-              keyword: WHERE
-              expression:
-                column_reference:
-                  naked_identifier: job_id
-                comparison_operator:
-                  raw_comparison_operator: '='
-                quoted_literal: "'ST_MAN'"
-            orderby_clause:
-            - keyword: ORDER
-            - keyword: BY
-            - column_reference:
-                naked_identifier: hire_date
-    - statement_terminator: ;
-    - statement:
-        fetch_statement:
-          keyword: FETCH
-          naked_identifier: cv
-          bulk_collect_into_clause:
-          - keyword: BULK
-          - keyword: COLLECT
-          - keyword: INTO
-          - naked_identifier: stock_managers
-    - statement_terminator: ;
-    - statement:
-        close_statement:
-          keyword: CLOSE
-          naked_identifier: cv
-    - statement_terminator: ;
-    - statement:
-        for_loop_statement:
-        - keyword: FOR
-        - naked_identifier: i
-        - keyword: IN
-        - naked_identifier: stock_managers
-        - dot: .
-        - naked_identifier: FIRST
-        - dot: .
-        - dot: .
-        - naked_identifier: stock_managers
-        - dot: .
-        - naked_identifier: LAST
-        - loop_statement:
-          - keyword: LOOP
-          - statement:
-              function:
-                function_name:
-                  naked_identifier: DBMS_OUTPUT
-                  dot: .
-                  function_name_identifier: PUT_LINE
-                function_contents:
-                  bracketed:
-                    start_bracket: (
-                    expression:
-                      numeric_literal: '1'
-                    end_bracket: )
-          - statement_terminator: ;
-          - keyword: END
-          - keyword: LOOP
-    - statement_terminator: ;
-    - keyword: END
-- statement_terminator: ;
-- statement_terminator: /
-- statement:
-    begin_end_block:
-    - declare_segment:
-      - keyword: DECLARE
-      - collection_type:
-        - keyword: TYPE
-        - naked_identifier: numtab
-        - keyword: IS
-        - keyword: TABLE
-        - keyword: OF
-        - data_type:
-            data_type_identifier: NUMBER
-        - keyword: INDEX
-        - keyword: BY
-        - data_type:
-            data_type_identifier: PLS_INTEGER
-      - statement_terminator: ;
-      - cursor_variable:
-        - keyword: CURSOR
-        - naked_identifier: c1
-        - keyword: IS
-        - select_statement:
-            select_clause:
-              keyword: SELECT
-              select_clause_element:
-                column_reference:
-                  naked_identifier: employee_id
-            from_clause:
-              keyword: FROM
-              from_expression:
-                from_expression_element:
-                  table_expression:
-                    table_reference:
-                      naked_identifier: employees
-            where_clause:
-              keyword: WHERE
-              expression:
-                column_reference:
-                  naked_identifier: department_id
-                comparison_operator:
-                  raw_comparison_operator: '='
-                numeric_literal: '80'
-            orderby_clause:
-            - keyword: ORDER
-            - keyword: BY
-            - column_reference:
-                naked_identifier: employee_id
-        - statement_terminator: ;
-      - naked_identifier: empids
-      - data_type:
-          data_type_identifier: numtab
-      - statement_terminator: ;
-    - keyword: BEGIN
-    - statement:
-        open_statement:
-          keyword: OPEN
-          naked_identifier: c1
-    - statement_terminator: ;
-    - statement:
-        loop_statement:
-        - keyword: LOOP
-        - statement:
-            fetch_statement:
-            - keyword: FETCH
-            - naked_identifier: c1
-            - bulk_collect_into_clause:
-              - keyword: BULK
-              - keyword: COLLECT
-              - keyword: INTO
-              - naked_identifier: empids
-            - keyword: LIMIT
-            - numeric_literal: '10'
-        - statement_terminator: ;
-        - statement:
-            function:
-              function_name:
-                naked_identifier: DBMS_OUTPUT
-                dot: .
-                function_name_identifier: PUT_LINE
-              function_contents:
-                bracketed:
-                  start_bracket: (
-                  expression:
-                    quoted_literal: "'------- Results from One Bulk Fetch --------'"
-                  end_bracket: )
-        - statement_terminator: ;
-        - statement:
-            for_loop_statement:
-            - keyword: FOR
-            - naked_identifier: i
-            - keyword: IN
-            - numeric_literal: '1'
-            - dot: .
-            - dot: .
-            - naked_identifier: empids
-            - dot: .
-            - naked_identifier: COUNT
-            - loop_statement:
-              - keyword: LOOP
-              - statement:
-                  function:
-                    function_name:
-                      naked_identifier: DBMS_OUTPUT
-                      dot: .
-                      function_name_identifier: PUT_LINE
-                    function_contents:
-                      bracketed:
-                        start_bracket: (
-                        expression:
-                          quoted_literal: "'Employee Id: '"
-                          binary_operator:
-                          - pipe: '|'
-                          - pipe: '|'
-                          function:
-                            function_name:
-                              function_name_identifier: empids
-                            function_contents:
-                              bracketed:
-                                start_bracket: (
-                                expression:
-                                  column_reference:
-                                    naked_identifier: i
-                                end_bracket: )
-                        end_bracket: )
-              - statement_terminator: ;
-              - keyword: END
-              - keyword: LOOP
-        - statement_terminator: ;
-        - statement:
-            exit_statement:
-            - keyword: EXIT
-            - keyword: WHEN
-            - expression:
-                naked_identifier: c1
-                binary_operator: '%'
-                keyword: NOTFOUND
-        - statement_terminator: ;
-        - keyword: END
-        - keyword: LOOP
-    - statement_terminator: ;
-    - statement:
-        close_statement:
-          keyword: CLOSE
-          naked_identifier: c1
-    - statement_terminator: ;
-    - keyword: END
-- statement_terminator: ;
-- statement_terminator: /
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /

--- a/test/fixtures/dialects/oracle/fetch_first_row_only.yml
+++ b/test/fixtures/dialects/oracle/fetch_first_row_only.yml
@@ -3,87 +3,88 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 536341383952d140b9f33fde33d846482376e3b154d8e8fd49cbd82d2ddfa34e
+_hash: 0e4e6df3016fa742fa5d8a57a16ebff5617dae934ad5cdc87181320e78ccc16f
 file:
-- statement:
-    select_statement:
-      select_clause:
-        keyword: select
-        select_clause_element:
-          column_reference:
-            naked_identifier: column_name
-      from_clause:
-        keyword: from
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: table_name
-      fetch_clause:
-      - keyword: fetch
-      - keyword: first
-      - keyword: row
-      - keyword: only
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-        keyword: select
-        select_clause_element:
-          column_reference:
-            naked_identifier: column_name
-      from_clause:
-        keyword: from
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: table_name
-      fetch_clause:
-      - keyword: fetch
-      - keyword: first
-      - keyword: rows
-      - keyword: only
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-        keyword: select
-        select_clause_element:
-          column_reference:
-            naked_identifier: column_name
-      from_clause:
-        keyword: from
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: table_name
-      fetch_clause:
-      - keyword: fetch
-      - keyword: first
-      - numeric_literal: '2'
-      - keyword: row
-      - keyword: only
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-        keyword: select
-        select_clause_element:
-          column_reference:
-            naked_identifier: column_name
-      from_clause:
-        keyword: from
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: table_name
-      fetch_clause:
-      - keyword: fetch
-      - keyword: first
-      - numeric_literal: '2'
-      - keyword: rows
-      - keyword: only
-- statement_terminator: ;
+  batch:
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: select
+          select_clause_element:
+            column_reference:
+              naked_identifier: column_name
+        from_clause:
+          keyword: from
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: table_name
+        fetch_clause:
+        - keyword: fetch
+        - keyword: first
+        - keyword: row
+        - keyword: only
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: select
+          select_clause_element:
+            column_reference:
+              naked_identifier: column_name
+        from_clause:
+          keyword: from
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: table_name
+        fetch_clause:
+        - keyword: fetch
+        - keyword: first
+        - keyword: rows
+        - keyword: only
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: select
+          select_clause_element:
+            column_reference:
+              naked_identifier: column_name
+        from_clause:
+          keyword: from
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: table_name
+        fetch_clause:
+        - keyword: fetch
+        - keyword: first
+        - numeric_literal: '2'
+        - keyword: row
+        - keyword: only
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: select
+          select_clause_element:
+            column_reference:
+              naked_identifier: column_name
+        from_clause:
+          keyword: from
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: table_name
+        fetch_clause:
+        - keyword: fetch
+        - keyword: first
+        - numeric_literal: '2'
+        - keyword: rows
+        - keyword: only
+  - statement_terminator: ;

--- a/test/fixtures/dialects/oracle/for_loop.yml
+++ b/test/fixtures/dialects/oracle/for_loop.yml
@@ -3,249 +3,29 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 4c472d3c67cc77e0aeff8c8c0cf119727f347828cc9990246bb2ee364c66f66c
+_hash: 513e2e564a872a290e6fafab4870235943739306ab7f6ce4477a04f989a3c6ae
 file:
-- statement:
-    begin_end_block:
-    - keyword: BEGIN
-    - statement:
-        for_loop_statement:
-        - keyword: FOR
-        - naked_identifier: i
-        - keyword: IN
-        - numeric_literal: '1'
-        - dot: .
-        - dot: .
-        - numeric_literal: '3'
-        - loop_statement:
-          - keyword: LOOP
-          - statement:
-              function:
-                function_name:
-                  naked_identifier: DBMS_OUTPUT
-                  dot: .
-                  function_name_identifier: PUT_LINE
-                function_contents:
-                  bracketed:
-                    start_bracket: (
-                    expression:
-                      column_reference:
-                        naked_identifier: i
-                    end_bracket: )
-          - statement_terminator: ;
-          - keyword: END
-          - keyword: LOOP
-    - statement_terminator: ;
-    - keyword: END
-- statement_terminator: ;
-- statement_terminator: /
-- statement:
-    begin_end_block:
-    - keyword: BEGIN
-    - statement:
-        for_loop_statement:
-        - keyword: FOR
-        - naked_identifier: i
-        - keyword: IN
-        - keyword: REVERSE
-        - numeric_literal: '1'
-        - dot: .
-        - dot: .
-        - numeric_literal: '3'
-        - loop_statement:
-          - keyword: LOOP
-          - statement:
-              function:
-                function_name:
-                  naked_identifier: DBMS_OUTPUT
-                  dot: .
-                  function_name_identifier: PUT_LINE
-                function_contents:
-                  bracketed:
-                    start_bracket: (
-                    expression:
-                      column_reference:
-                        naked_identifier: i
-                    end_bracket: )
-          - statement_terminator: ;
-          - keyword: END
-          - keyword: LOOP
-    - statement_terminator: ;
-    - keyword: END
-- statement_terminator: ;
-- statement_terminator: /
-- statement:
-    begin_end_block:
-    - keyword: BEGIN
-    - statement:
-        for_loop_statement:
-        - keyword: FOR
-        - naked_identifier: power
-        - keyword: IN
-        - expression:
-            numeric_literal: '1'
-        - comma: ','
-        - keyword: REPEAT
-        - expression:
-            column_reference:
-              naked_identifier: power
-            binary_operator: '*'
-            numeric_literal: '2'
-        - keyword: WHILE
-        - expression:
-            column_reference:
-              naked_identifier: power
-            comparison_operator:
-            - raw_comparison_operator: <
-            - raw_comparison_operator: '='
-            numeric_literal: '64'
-        - loop_statement:
-          - keyword: LOOP
-          - statement:
-              function:
-                function_name:
-                  naked_identifier: DBMS_OUTPUT
-                  dot: .
-                  function_name_identifier: PUT_LINE
-                function_contents:
-                  bracketed:
-                    start_bracket: (
-                    expression:
-                      column_reference:
-                        naked_identifier: power
-                    end_bracket: )
-          - statement_terminator: ;
-          - keyword: END
-          - keyword: LOOP
-    - statement_terminator: ;
-    - keyword: END
-- statement_terminator: ;
-- statement_terminator: /
-- statement:
-    begin_end_block:
-    - keyword: BEGIN
-    - statement:
-        for_loop_statement:
-        - keyword: FOR
-        - naked_identifier: power
-        - keyword: IN
-        - expression:
-            numeric_literal: '2'
-        - comma: ','
-        - keyword: REPEAT
-        - expression:
-            column_reference:
-              naked_identifier: power
-            binary_operator: '*'
-            numeric_literal: '2'
-        - keyword: WHILE
-        - expression:
-            column_reference:
-              naked_identifier: power
-            comparison_operator:
-            - raw_comparison_operator: <
-            - raw_comparison_operator: '='
-            numeric_literal: '64'
-        - keyword: WHEN
-        - expression:
-            function:
-              function_name:
-                function_name_identifier: MOD
-              function_contents:
-                bracketed:
-                - start_bracket: (
-                - expression:
-                    column_reference:
-                      naked_identifier: power
-                - comma: ','
-                - expression:
-                    numeric_literal: '32'
-                - end_bracket: )
-            comparison_operator:
-              raw_comparison_operator: '='
-            numeric_literal: '0'
-        - loop_statement:
-          - keyword: LOOP
-          - statement:
-              function:
-                function_name:
-                  naked_identifier: DBMS_OUTPUT
-                  dot: .
-                  function_name_identifier: PUT_LINE
-                function_contents:
-                  bracketed:
-                    start_bracket: (
-                    expression:
-                      column_reference:
-                        naked_identifier: power
-                    end_bracket: )
-          - statement_terminator: ;
-          - keyword: END
-          - keyword: LOOP
-    - statement_terminator: ;
-    - keyword: END
-- statement_terminator: ;
-- statement_terminator: /
-- statement:
-    begin_end_block:
-    - keyword: BEGIN
-    - statement:
-        for_loop_statement:
-        - keyword: FOR
-        - naked_identifier: i
-        - keyword: IN
-        - numeric_literal: '1'
-        - dot: .
-        - dot: .
-        - numeric_literal: '3'
-        - loop_statement:
-          - keyword: LOOP
-          - statement:
-              function:
-                function_name:
-                  naked_identifier: DBMS_OUTPUT
-                  dot: .
-                  function_name_identifier: PUT_LINE
-                function_contents:
-                  bracketed:
-                    start_bracket: (
-                    expression:
-                      quoted_literal: "'Inside loop, i is '"
-                      binary_operator:
-                      - pipe: '|'
-                      - pipe: '|'
-                      function:
-                        function_name:
-                          function_name_identifier: TO_CHAR
-                        function_contents:
-                          bracketed:
-                            start_bracket: (
-                            expression:
-                              column_reference:
-                                naked_identifier: i
-                            end_bracket: )
-                    end_bracket: )
-          - statement_terminator: ;
-          - keyword: END
-          - keyword: LOOP
-    - statement_terminator: ;
-    - statement:
-        function:
-          function_name:
-            naked_identifier: DBMS_OUTPUT
-            dot: .
-            function_name_identifier: PUT_LINE
-          function_contents:
-            bracketed:
-              start_bracket: (
-              expression:
-                quoted_literal: "'Outside loop, i is '"
-                binary_operator:
-                - pipe: '|'
-                - pipe: '|'
+- batch:
+    statement:
+      begin_end_block:
+      - keyword: BEGIN
+      - statement:
+          for_loop_statement:
+          - keyword: FOR
+          - naked_identifier: i
+          - keyword: IN
+          - numeric_literal: '1'
+          - dot: .
+          - dot: .
+          - numeric_literal: '3'
+          - loop_statement:
+            - keyword: LOOP
+            - statement:
                 function:
                   function_name:
-                    function_name_identifier: TO_CHAR
+                    naked_identifier: DBMS_OUTPUT
+                    dot: .
+                    function_name_identifier: PUT_LINE
                   function_contents:
                     bracketed:
                       start_bracket: (
@@ -253,80 +33,36 @@ file:
                         column_reference:
                           naked_identifier: i
                       end_bracket: )
-              end_bracket: )
-    - statement_terminator: ;
-    - keyword: END
-- statement_terminator: ;
-- statement_terminator: /
-- statement:
-    begin_end_block:
-    - declare_segment:
-        keyword: DECLARE
-        naked_identifier: i
-        data_type:
-          data_type_identifier: NUMBER
-        assignment_operator: :=
-        expression:
-          numeric_literal: '5'
-        statement_terminator: ;
-    - keyword: BEGIN
-    - statement:
-        for_loop_statement:
-        - keyword: FOR
-        - naked_identifier: i
-        - keyword: IN
-        - numeric_literal: '1'
-        - dot: .
-        - dot: .
-        - numeric_literal: '3'
-        - loop_statement:
-          - keyword: LOOP
-          - statement:
-              function:
-                function_name:
-                  naked_identifier: DBMS_OUTPUT
-                  dot: .
-                  function_name_identifier: PUT_LINE
-                function_contents:
-                  bracketed:
-                    start_bracket: (
-                    expression:
-                      quoted_literal: "'Inside loop, i is '"
-                      binary_operator:
-                      - pipe: '|'
-                      - pipe: '|'
-                      function:
-                        function_name:
-                          function_name_identifier: TO_CHAR
-                        function_contents:
-                          bracketed:
-                            start_bracket: (
-                            expression:
-                              column_reference:
-                                naked_identifier: i
-                            end_bracket: )
-                    end_bracket: )
-          - statement_terminator: ;
-          - keyword: END
-          - keyword: LOOP
-    - statement_terminator: ;
-    - statement:
-        function:
-          function_name:
-            naked_identifier: DBMS_OUTPUT
-            dot: .
-            function_name_identifier: PUT_LINE
-          function_contents:
-            bracketed:
-              start_bracket: (
-              expression:
-                quoted_literal: "'Outside loop, i is '"
-                binary_operator:
-                - pipe: '|'
-                - pipe: '|'
+            - statement_terminator: ;
+            - keyword: END
+            - keyword: LOOP
+      - statement_terminator: ;
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      begin_end_block:
+      - keyword: BEGIN
+      - statement:
+          for_loop_statement:
+          - keyword: FOR
+          - naked_identifier: i
+          - keyword: IN
+          - keyword: REVERSE
+          - numeric_literal: '1'
+          - dot: .
+          - dot: .
+          - numeric_literal: '3'
+          - loop_statement:
+            - keyword: LOOP
+            - statement:
                 function:
                   function_name:
-                    function_name_identifier: TO_CHAR
+                    naked_identifier: DBMS_OUTPUT
+                    dot: .
+                    function_name_identifier: PUT_LINE
                   function_contents:
                     bracketed:
                       start_bracket: (
@@ -334,440 +70,726 @@ file:
                         column_reference:
                           naked_identifier: i
                       end_bracket: )
-              end_bracket: )
-    - statement_terminator: ;
-    - keyword: END
-- statement_terminator: ;
-- statement_terminator: /
-- statement:
-    begin_end_block:
-    - declare_segment:
-        keyword: DECLARE
-        naked_identifier: i
-        data_type:
-          data_type_identifier: NUMBER
-        assignment_operator: :=
-        expression:
-          numeric_literal: '5'
-        statement_terminator: ;
-    - keyword: BEGIN
-    - statement:
-        for_loop_statement:
-        - keyword: FOR
-        - naked_identifier: i
-        - keyword: IN
-        - numeric_literal: '1'
-        - dot: .
-        - dot: .
-        - numeric_literal: '3'
-        - loop_statement:
-          - keyword: LOOP
-          - statement:
+            - statement_terminator: ;
+            - keyword: END
+            - keyword: LOOP
+      - statement_terminator: ;
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      begin_end_block:
+      - keyword: BEGIN
+      - statement:
+          for_loop_statement:
+          - keyword: FOR
+          - naked_identifier: power
+          - keyword: IN
+          - expression:
+              numeric_literal: '1'
+          - comma: ','
+          - keyword: REPEAT
+          - expression:
+              column_reference:
+                naked_identifier: power
+              binary_operator: '*'
+              numeric_literal: '2'
+          - keyword: WHILE
+          - expression:
+              column_reference:
+                naked_identifier: power
+              comparison_operator:
+              - raw_comparison_operator: <
+              - raw_comparison_operator: '='
+              numeric_literal: '64'
+          - loop_statement:
+            - keyword: LOOP
+            - statement:
+                function:
+                  function_name:
+                    naked_identifier: DBMS_OUTPUT
+                    dot: .
+                    function_name_identifier: PUT_LINE
+                  function_contents:
+                    bracketed:
+                      start_bracket: (
+                      expression:
+                        column_reference:
+                          naked_identifier: power
+                      end_bracket: )
+            - statement_terminator: ;
+            - keyword: END
+            - keyword: LOOP
+      - statement_terminator: ;
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      begin_end_block:
+      - keyword: BEGIN
+      - statement:
+          for_loop_statement:
+          - keyword: FOR
+          - naked_identifier: power
+          - keyword: IN
+          - expression:
+              numeric_literal: '2'
+          - comma: ','
+          - keyword: REPEAT
+          - expression:
+              column_reference:
+                naked_identifier: power
+              binary_operator: '*'
+              numeric_literal: '2'
+          - keyword: WHILE
+          - expression:
+              column_reference:
+                naked_identifier: power
+              comparison_operator:
+              - raw_comparison_operator: <
+              - raw_comparison_operator: '='
+              numeric_literal: '64'
+          - keyword: WHEN
+          - expression:
               function:
                 function_name:
-                  naked_identifier: DBMS_OUTPUT
-                  dot: .
-                  function_name_identifier: PUT_LINE
+                  function_name_identifier: MOD
                 function_contents:
                   bracketed:
-                    start_bracket: (
-                    expression:
-                    - quoted_literal: "'local: '"
-                    - binary_operator:
-                      - pipe: '|'
-                      - pipe: '|'
-                    - function:
-                        function_name:
-                          function_name_identifier: TO_CHAR
-                        function_contents:
-                          bracketed:
-                            start_bracket: (
-                            expression:
-                              column_reference:
-                                naked_identifier: i
-                            end_bracket: )
-                    - binary_operator:
-                      - pipe: '|'
-                      - pipe: '|'
-                    - quoted_literal: "', global: '"
-                    - binary_operator:
-                      - pipe: '|'
-                      - pipe: '|'
-                    - function:
-                        function_name:
-                          function_name_identifier: TO_CHAR
-                        function_contents:
-                          bracketed:
-                            start_bracket: (
-                            expression:
-                              column_reference:
-                              - naked_identifier: main
-                              - dot: .
-                              - naked_identifier: i
-                            end_bracket: )
-                    end_bracket: )
-          - statement_terminator: ;
-          - keyword: END
-          - keyword: LOOP
-    - statement_terminator: ;
-    - keyword: END
-    - object_reference:
-        naked_identifier: main
-- statement_terminator: ;
-- statement_terminator: /
-- statement:
-    begin_end_block:
-    - keyword: BEGIN
-    - statement:
-        for_loop_statement:
-        - keyword: FOR
-        - naked_identifier: i
-        - keyword: IN
-        - numeric_literal: '1'
-        - dot: .
-        - dot: .
-        - numeric_literal: '3'
-        - loop_statement:
-          - keyword: LOOP
-          - statement:
-              for_loop_statement:
-              - keyword: FOR
-              - naked_identifier: i
-              - keyword: IN
-              - numeric_literal: '1'
-              - dot: .
-              - dot: .
-              - numeric_literal: '3'
-              - loop_statement:
-                - keyword: LOOP
-                - statement:
-                    if_then_statement:
-                    - if_clause:
-                      - keyword: IF
-                      - expression:
-                          column_reference:
-                          - naked_identifier: outer_loop
-                          - dot: .
-                          - naked_identifier: i
-                          comparison_operator:
-                            raw_comparison_operator: '='
-                          numeric_literal: '2'
-                      - keyword: THEN
-                    - statement:
+                  - start_bracket: (
+                  - expression:
+                      column_reference:
+                        naked_identifier: power
+                  - comma: ','
+                  - expression:
+                      numeric_literal: '32'
+                  - end_bracket: )
+              comparison_operator:
+                raw_comparison_operator: '='
+              numeric_literal: '0'
+          - loop_statement:
+            - keyword: LOOP
+            - statement:
+                function:
+                  function_name:
+                    naked_identifier: DBMS_OUTPUT
+                    dot: .
+                    function_name_identifier: PUT_LINE
+                  function_contents:
+                    bracketed:
+                      start_bracket: (
+                      expression:
+                        column_reference:
+                          naked_identifier: power
+                      end_bracket: )
+            - statement_terminator: ;
+            - keyword: END
+            - keyword: LOOP
+      - statement_terminator: ;
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      begin_end_block:
+      - keyword: BEGIN
+      - statement:
+          for_loop_statement:
+          - keyword: FOR
+          - naked_identifier: i
+          - keyword: IN
+          - numeric_literal: '1'
+          - dot: .
+          - dot: .
+          - numeric_literal: '3'
+          - loop_statement:
+            - keyword: LOOP
+            - statement:
+                function:
+                  function_name:
+                    naked_identifier: DBMS_OUTPUT
+                    dot: .
+                    function_name_identifier: PUT_LINE
+                  function_contents:
+                    bracketed:
+                      start_bracket: (
+                      expression:
+                        quoted_literal: "'Inside loop, i is '"
+                        binary_operator:
+                        - pipe: '|'
+                        - pipe: '|'
                         function:
                           function_name:
-                            naked_identifier: DBMS_OUTPUT
-                            dot: .
-                            function_name_identifier: PUT_LINE
+                            function_name_identifier: TO_CHAR
                           function_contents:
                             bracketed:
                               start_bracket: (
                               expression:
-                              - quoted_literal: "'outer: '"
-                              - binary_operator:
-                                - pipe: '|'
-                                - pipe: '|'
-                              - function:
-                                  function_name:
-                                    function_name_identifier: TO_CHAR
-                                  function_contents:
-                                    bracketed:
-                                      start_bracket: (
-                                      expression:
-                                        column_reference:
-                                        - naked_identifier: outer_loop
-                                        - dot: .
-                                        - naked_identifier: i
-                                      end_bracket: )
-                              - binary_operator:
-                                - pipe: '|'
-                                - pipe: '|'
-                              - quoted_literal: "' inner: '"
-                              - binary_operator:
-                                - pipe: '|'
-                                - pipe: '|'
-                              - function:
-                                  function_name:
-                                    function_name_identifier: TO_CHAR
-                                  function_contents:
-                                    bracketed:
-                                      start_bracket: (
-                                      expression:
-                                        column_reference:
-                                        - naked_identifier: inner_loop
-                                        - dot: .
-                                        - naked_identifier: i
-                                      end_bracket: )
+                                column_reference:
+                                  naked_identifier: i
                               end_bracket: )
-                    - statement_terminator: ;
-                    - keyword: END
-                    - keyword: IF
-                - statement_terminator: ;
-                - keyword: END
-                - keyword: LOOP
-                - naked_identifier: inner_loop
+                      end_bracket: )
+            - statement_terminator: ;
+            - keyword: END
+            - keyword: LOOP
+      - statement_terminator: ;
+      - statement:
+          function:
+            function_name:
+              naked_identifier: DBMS_OUTPUT
+              dot: .
+              function_name_identifier: PUT_LINE
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  quoted_literal: "'Outside loop, i is '"
+                  binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                  function:
+                    function_name:
+                      function_name_identifier: TO_CHAR
+                    function_contents:
+                      bracketed:
+                        start_bracket: (
+                        expression:
+                          column_reference:
+                            naked_identifier: i
+                        end_bracket: )
+                end_bracket: )
+      - statement_terminator: ;
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      begin_end_block:
+      - declare_segment:
+          keyword: DECLARE
+          naked_identifier: i
+          data_type:
+            data_type_identifier: NUMBER
+          assignment_operator: :=
+          expression:
+            numeric_literal: '5'
+          statement_terminator: ;
+      - keyword: BEGIN
+      - statement:
+          for_loop_statement:
+          - keyword: FOR
+          - naked_identifier: i
+          - keyword: IN
+          - numeric_literal: '1'
+          - dot: .
+          - dot: .
+          - numeric_literal: '3'
+          - loop_statement:
+            - keyword: LOOP
+            - statement:
+                function:
+                  function_name:
+                    naked_identifier: DBMS_OUTPUT
+                    dot: .
+                    function_name_identifier: PUT_LINE
+                  function_contents:
+                    bracketed:
+                      start_bracket: (
+                      expression:
+                        quoted_literal: "'Inside loop, i is '"
+                        binary_operator:
+                        - pipe: '|'
+                        - pipe: '|'
+                        function:
+                          function_name:
+                            function_name_identifier: TO_CHAR
+                          function_contents:
+                            bracketed:
+                              start_bracket: (
+                              expression:
+                                column_reference:
+                                  naked_identifier: i
+                              end_bracket: )
+                      end_bracket: )
+            - statement_terminator: ;
+            - keyword: END
+            - keyword: LOOP
+      - statement_terminator: ;
+      - statement:
+          function:
+            function_name:
+              naked_identifier: DBMS_OUTPUT
+              dot: .
+              function_name_identifier: PUT_LINE
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  quoted_literal: "'Outside loop, i is '"
+                  binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                  function:
+                    function_name:
+                      function_name_identifier: TO_CHAR
+                    function_contents:
+                      bracketed:
+                        start_bracket: (
+                        expression:
+                          column_reference:
+                            naked_identifier: i
+                        end_bracket: )
+                end_bracket: )
+      - statement_terminator: ;
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      begin_end_block:
+      - declare_segment:
+          keyword: DECLARE
+          naked_identifier: i
+          data_type:
+            data_type_identifier: NUMBER
+          assignment_operator: :=
+          expression:
+            numeric_literal: '5'
+          statement_terminator: ;
+      - keyword: BEGIN
+      - statement:
+          for_loop_statement:
+          - keyword: FOR
+          - naked_identifier: i
+          - keyword: IN
+          - numeric_literal: '1'
+          - dot: .
+          - dot: .
+          - numeric_literal: '3'
+          - loop_statement:
+            - keyword: LOOP
+            - statement:
+                function:
+                  function_name:
+                    naked_identifier: DBMS_OUTPUT
+                    dot: .
+                    function_name_identifier: PUT_LINE
+                  function_contents:
+                    bracketed:
+                      start_bracket: (
+                      expression:
+                      - quoted_literal: "'local: '"
+                      - binary_operator:
+                        - pipe: '|'
+                        - pipe: '|'
+                      - function:
+                          function_name:
+                            function_name_identifier: TO_CHAR
+                          function_contents:
+                            bracketed:
+                              start_bracket: (
+                              expression:
+                                column_reference:
+                                  naked_identifier: i
+                              end_bracket: )
+                      - binary_operator:
+                        - pipe: '|'
+                        - pipe: '|'
+                      - quoted_literal: "', global: '"
+                      - binary_operator:
+                        - pipe: '|'
+                        - pipe: '|'
+                      - function:
+                          function_name:
+                            function_name_identifier: TO_CHAR
+                          function_contents:
+                            bracketed:
+                              start_bracket: (
+                              expression:
+                                column_reference:
+                                - naked_identifier: main
+                                - dot: .
+                                - naked_identifier: i
+                              end_bracket: )
+                      end_bracket: )
+            - statement_terminator: ;
+            - keyword: END
+            - keyword: LOOP
+      - statement_terminator: ;
+      - keyword: END
+      - object_reference:
+          naked_identifier: main
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      begin_end_block:
+      - keyword: BEGIN
+      - statement:
+          for_loop_statement:
+          - keyword: FOR
+          - naked_identifier: i
+          - keyword: IN
+          - numeric_literal: '1'
+          - dot: .
+          - dot: .
+          - numeric_literal: '3'
+          - loop_statement:
+            - keyword: LOOP
+            - statement:
+                for_loop_statement:
+                - keyword: FOR
+                - naked_identifier: i
+                - keyword: IN
+                - numeric_literal: '1'
+                - dot: .
+                - dot: .
+                - numeric_literal: '3'
+                - loop_statement:
+                  - keyword: LOOP
+                  - statement:
+                      if_then_statement:
+                      - if_clause:
+                        - keyword: IF
+                        - expression:
+                            column_reference:
+                            - naked_identifier: outer_loop
+                            - dot: .
+                            - naked_identifier: i
+                            comparison_operator:
+                              raw_comparison_operator: '='
+                            numeric_literal: '2'
+                        - keyword: THEN
+                      - statement:
+                          function:
+                            function_name:
+                              naked_identifier: DBMS_OUTPUT
+                              dot: .
+                              function_name_identifier: PUT_LINE
+                            function_contents:
+                              bracketed:
+                                start_bracket: (
+                                expression:
+                                - quoted_literal: "'outer: '"
+                                - binary_operator:
+                                  - pipe: '|'
+                                  - pipe: '|'
+                                - function:
+                                    function_name:
+                                      function_name_identifier: TO_CHAR
+                                    function_contents:
+                                      bracketed:
+                                        start_bracket: (
+                                        expression:
+                                          column_reference:
+                                          - naked_identifier: outer_loop
+                                          - dot: .
+                                          - naked_identifier: i
+                                        end_bracket: )
+                                - binary_operator:
+                                  - pipe: '|'
+                                  - pipe: '|'
+                                - quoted_literal: "' inner: '"
+                                - binary_operator:
+                                  - pipe: '|'
+                                  - pipe: '|'
+                                - function:
+                                    function_name:
+                                      function_name_identifier: TO_CHAR
+                                    function_contents:
+                                      bracketed:
+                                        start_bracket: (
+                                        expression:
+                                          column_reference:
+                                          - naked_identifier: inner_loop
+                                          - dot: .
+                                          - naked_identifier: i
+                                        end_bracket: )
+                                end_bracket: )
+                      - statement_terminator: ;
+                      - keyword: END
+                      - keyword: IF
+                  - statement_terminator: ;
+                  - keyword: END
+                  - keyword: LOOP
+                  - naked_identifier: inner_loop
+            - statement_terminator: ;
+            - keyword: END
+            - keyword: LOOP
+            - naked_identifier: outer_loop
+      - statement_terminator: ;
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      begin_end_block:
+      - declare_segment:
+          keyword: DECLARE
+          naked_identifier: v_employees
+          row_type_reference:
+            table_reference:
+              naked_identifier: employees
+            binary_operator: '%'
+            keyword: ROWTYPE
+          statement_terminator: ;
+          cursor_variable:
+          - keyword: CURSOR
+          - naked_identifier: c1
+          - keyword: is
+          - select_statement:
+              select_clause:
+                keyword: SELECT
+                select_clause_element:
+                  wildcard_expression:
+                    wildcard_identifier:
+                      star: '*'
+              from_clause:
+                keyword: FROM
+                from_expression:
+                  from_expression_element:
+                    table_expression:
+                      table_reference:
+                        naked_identifier: employees
           - statement_terminator: ;
-          - keyword: END
-          - keyword: LOOP
-          - naked_identifier: outer_loop
-    - statement_terminator: ;
-    - keyword: END
-- statement_terminator: ;
-- statement_terminator: /
-- statement:
-    begin_end_block:
-    - declare_segment:
-        keyword: DECLARE
-        naked_identifier: v_employees
-        row_type_reference:
-          table_reference:
-            naked_identifier: employees
-          binary_operator: '%'
-          keyword: ROWTYPE
-        statement_terminator: ;
-        cursor_variable:
-        - keyword: CURSOR
-        - naked_identifier: c1
-        - keyword: is
-        - select_statement:
-            select_clause:
-              keyword: SELECT
-              select_clause_element:
-                wildcard_expression:
-                  wildcard_identifier:
-                    star: '*'
-            from_clause:
-              keyword: FROM
-              from_expression:
-                from_expression_element:
-                  table_expression:
-                    table_reference:
-                      naked_identifier: employees
-        - statement_terminator: ;
-    - keyword: BEGIN
-    - statement:
-        open_statement:
-          keyword: OPEN
-          naked_identifier: c1
-    - statement_terminator: ;
-    - statement:
-        for_loop_statement:
-        - keyword: FOR
-        - naked_identifier: i
-        - keyword: IN
-        - numeric_literal: '1'
-        - dot: .
-        - dot: .
-        - numeric_literal: '10'
-        - loop_statement:
-          - keyword: LOOP
-          - statement:
-              fetch_statement:
-                keyword: FETCH
-                naked_identifier: c1
-                into_clause:
-                  keyword: INTO
-                  naked_identifier: v_employees
-          - statement_terminator: ;
-          - statement:
-              exit_statement:
-              - keyword: EXIT
-              - keyword: WHEN
-              - expression:
+      - keyword: BEGIN
+      - statement:
+          open_statement:
+            keyword: OPEN
+            naked_identifier: c1
+      - statement_terminator: ;
+      - statement:
+          for_loop_statement:
+          - keyword: FOR
+          - naked_identifier: i
+          - keyword: IN
+          - numeric_literal: '1'
+          - dot: .
+          - dot: .
+          - numeric_literal: '10'
+          - loop_statement:
+            - keyword: LOOP
+            - statement:
+                fetch_statement:
+                  keyword: FETCH
                   naked_identifier: c1
-                  binary_operator: '%'
-                  keyword: NOTFOUND
+                  into_clause:
+                    keyword: INTO
+                    naked_identifier: v_employees
+            - statement_terminator: ;
+            - statement:
+                exit_statement:
+                - keyword: EXIT
+                - keyword: WHEN
+                - expression:
+                    naked_identifier: c1
+                    binary_operator: '%'
+                    keyword: NOTFOUND
+            - statement_terminator: ;
+            - keyword: END
+            - keyword: LOOP
+      - statement_terminator: ;
+      - statement:
+          close_statement:
+            keyword: CLOSE
+            naked_identifier: c1
+      - statement_terminator: ;
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      begin_end_block:
+      - declare_segment:
+          keyword: DECLARE
+          naked_identifier: v_employees
+          row_type_reference:
+            table_reference:
+              naked_identifier: employees
+            binary_operator: '%'
+            keyword: ROWTYPE
+          statement_terminator: ;
+          cursor_variable:
+          - keyword: CURSOR
+          - naked_identifier: c1
+          - keyword: is
+          - select_statement:
+              select_clause:
+                keyword: SELECT
+                select_clause_element:
+                  wildcard_expression:
+                    wildcard_identifier:
+                      star: '*'
+              from_clause:
+                keyword: FROM
+                from_expression:
+                  from_expression_element:
+                    table_expression:
+                      table_reference:
+                        naked_identifier: employees
           - statement_terminator: ;
-          - keyword: END
-          - keyword: LOOP
-    - statement_terminator: ;
-    - statement:
-        close_statement:
-          keyword: CLOSE
-          naked_identifier: c1
-    - statement_terminator: ;
-    - keyword: END
-- statement_terminator: ;
-- statement_terminator: /
-- statement:
-    begin_end_block:
-    - declare_segment:
-        keyword: DECLARE
-        naked_identifier: v_employees
-        row_type_reference:
-          table_reference:
-            naked_identifier: employees
-          binary_operator: '%'
-          keyword: ROWTYPE
-        statement_terminator: ;
-        cursor_variable:
-        - keyword: CURSOR
-        - naked_identifier: c1
-        - keyword: is
-        - select_statement:
-            select_clause:
-              keyword: SELECT
-              select_clause_element:
-                wildcard_expression:
-                  wildcard_identifier:
-                    star: '*'
-            from_clause:
-              keyword: FROM
-              from_expression:
-                from_expression_element:
-                  table_expression:
-                    table_reference:
-                      naked_identifier: employees
-        - statement_terminator: ;
-    - keyword: BEGIN
-    - statement:
-        open_statement:
-          keyword: OPEN
-          naked_identifier: c1
-    - statement_terminator: ;
-    - statement:
-        for_loop_statement:
-        - keyword: FOR
-        - naked_identifier: i
-        - keyword: IN
-        - numeric_literal: '1'
-        - dot: .
-        - dot: .
-        - numeric_literal: '10'
-        - loop_statement:
-          - keyword: LOOP
-          - statement:
-              for_loop_statement:
-              - keyword: FOR
-              - naked_identifier: j
-              - keyword: IN
-              - numeric_literal: '1'
-              - dot: .
-              - dot: .
-              - numeric_literal: '10'
-              - loop_statement:
-                - keyword: LOOP
-                - statement:
-                    fetch_statement:
-                      keyword: FETCH
-                      naked_identifier: c1
-                      into_clause:
-                        keyword: INTO
-                        naked_identifier: v_employees
-                - statement_terminator: ;
-                - statement:
-                    exit_statement:
-                    - keyword: EXIT
-                    - naked_identifier: outer_loop
-                    - keyword: WHEN
-                    - expression:
+      - keyword: BEGIN
+      - statement:
+          open_statement:
+            keyword: OPEN
+            naked_identifier: c1
+      - statement_terminator: ;
+      - statement:
+          for_loop_statement:
+          - keyword: FOR
+          - naked_identifier: i
+          - keyword: IN
+          - numeric_literal: '1'
+          - dot: .
+          - dot: .
+          - numeric_literal: '10'
+          - loop_statement:
+            - keyword: LOOP
+            - statement:
+                for_loop_statement:
+                - keyword: FOR
+                - naked_identifier: j
+                - keyword: IN
+                - numeric_literal: '1'
+                - dot: .
+                - dot: .
+                - numeric_literal: '10'
+                - loop_statement:
+                  - keyword: LOOP
+                  - statement:
+                      fetch_statement:
+                        keyword: FETCH
                         naked_identifier: c1
-                        binary_operator: '%'
-                        keyword: NOTFOUND
-                - statement_terminator: ;
-                - keyword: END
-                - keyword: LOOP
+                        into_clause:
+                          keyword: INTO
+                          naked_identifier: v_employees
+                  - statement_terminator: ;
+                  - statement:
+                      exit_statement:
+                      - keyword: EXIT
+                      - naked_identifier: outer_loop
+                      - keyword: WHEN
+                      - expression:
+                          naked_identifier: c1
+                          binary_operator: '%'
+                          keyword: NOTFOUND
+                  - statement_terminator: ;
+                  - keyword: END
+                  - keyword: LOOP
+            - statement_terminator: ;
+            - keyword: END
+            - keyword: LOOP
+            - naked_identifier: outer_loop
+      - statement_terminator: ;
+      - statement:
+          close_statement:
+            keyword: CLOSE
+            naked_identifier: c1
+      - statement_terminator: ;
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      begin_end_block:
+      - declare_segment:
+          keyword: DECLARE
+          naked_identifier: v_employees
+          row_type_reference:
+            table_reference:
+              naked_identifier: employees
+            binary_operator: '%'
+            keyword: ROWTYPE
+          statement_terminator: ;
+          cursor_variable:
+          - keyword: CURSOR
+          - naked_identifier: c1
+          - keyword: is
+          - select_statement:
+              select_clause:
+                keyword: SELECT
+                select_clause_element:
+                  wildcard_expression:
+                    wildcard_identifier:
+                      star: '*'
+              from_clause:
+                keyword: FROM
+                from_expression:
+                  from_expression_element:
+                    table_expression:
+                      table_reference:
+                        naked_identifier: employees
           - statement_terminator: ;
-          - keyword: END
-          - keyword: LOOP
-          - naked_identifier: outer_loop
-    - statement_terminator: ;
-    - statement:
-        close_statement:
-          keyword: CLOSE
-          naked_identifier: c1
-    - statement_terminator: ;
-    - keyword: END
-- statement_terminator: ;
-- statement_terminator: /
-- statement:
-    begin_end_block:
-    - declare_segment:
-        keyword: DECLARE
-        naked_identifier: v_employees
-        row_type_reference:
-          table_reference:
-            naked_identifier: employees
-          binary_operator: '%'
-          keyword: ROWTYPE
-        statement_terminator: ;
-        cursor_variable:
-        - keyword: CURSOR
-        - naked_identifier: c1
-        - keyword: is
-        - select_statement:
-            select_clause:
-              keyword: SELECT
-              select_clause_element:
-                wildcard_expression:
-                  wildcard_identifier:
-                    star: '*'
-            from_clause:
-              keyword: FROM
-              from_expression:
-                from_expression_element:
-                  table_expression:
-                    table_reference:
-                      naked_identifier: employees
-        - statement_terminator: ;
-    - keyword: BEGIN
-    - statement:
-        open_statement:
-          keyword: OPEN
-          naked_identifier: c1
-    - statement_terminator: ;
-    - statement:
-        for_loop_statement:
-        - keyword: FOR
-        - naked_identifier: i
-        - keyword: IN
-        - numeric_literal: '1'
-        - dot: .
-        - dot: .
-        - numeric_literal: '10'
-        - loop_statement:
-          - keyword: LOOP
-          - statement:
-              for_loop_statement:
-              - keyword: FOR
-              - naked_identifier: j
-              - keyword: IN
-              - numeric_literal: '1'
-              - dot: .
-              - dot: .
-              - numeric_literal: '10'
-              - loop_statement:
-                - keyword: LOOP
-                - statement:
-                    fetch_statement:
-                      keyword: FETCH
-                      naked_identifier: c1
-                      into_clause:
-                        keyword: INTO
-                        naked_identifier: v_employees
-                - statement_terminator: ;
-                - statement:
-                    continue_statement:
-                    - keyword: CONTINUE
-                    - naked_identifier: outer_loop
-                    - keyword: WHEN
-                    - expression:
+      - keyword: BEGIN
+      - statement:
+          open_statement:
+            keyword: OPEN
+            naked_identifier: c1
+      - statement_terminator: ;
+      - statement:
+          for_loop_statement:
+          - keyword: FOR
+          - naked_identifier: i
+          - keyword: IN
+          - numeric_literal: '1'
+          - dot: .
+          - dot: .
+          - numeric_literal: '10'
+          - loop_statement:
+            - keyword: LOOP
+            - statement:
+                for_loop_statement:
+                - keyword: FOR
+                - naked_identifier: j
+                - keyword: IN
+                - numeric_literal: '1'
+                - dot: .
+                - dot: .
+                - numeric_literal: '10'
+                - loop_statement:
+                  - keyword: LOOP
+                  - statement:
+                      fetch_statement:
+                        keyword: FETCH
                         naked_identifier: c1
-                        binary_operator: '%'
-                        keyword: NOTFOUND
-                - statement_terminator: ;
-                - keyword: END
-                - keyword: LOOP
-          - statement_terminator: ;
-          - keyword: END
-          - keyword: LOOP
-          - naked_identifier: outer_loop
-    - statement_terminator: ;
-    - statement:
-        close_statement:
-          keyword: CLOSE
-          naked_identifier: c1
-    - statement_terminator: ;
-    - keyword: END
-- statement_terminator: ;
-- statement_terminator: /
+                        into_clause:
+                          keyword: INTO
+                          naked_identifier: v_employees
+                  - statement_terminator: ;
+                  - statement:
+                      continue_statement:
+                      - keyword: CONTINUE
+                      - naked_identifier: outer_loop
+                      - keyword: WHEN
+                      - expression:
+                          naked_identifier: c1
+                          binary_operator: '%'
+                          keyword: NOTFOUND
+                  - statement_terminator: ;
+                  - keyword: END
+                  - keyword: LOOP
+            - statement_terminator: ;
+            - keyword: END
+            - keyword: LOOP
+            - naked_identifier: outer_loop
+      - statement_terminator: ;
+      - statement:
+          close_statement:
+            keyword: CLOSE
+            naked_identifier: c1
+      - statement_terminator: ;
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /

--- a/test/fixtures/dialects/oracle/forall.yml
+++ b/test/fixtures/dialects/oracle/forall.yml
@@ -3,198 +3,396 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 3013af9df7c5ca0e7785158e8c7013bd79fcbe18a1263f1ad9fd7bcc7a029668
+_hash: 08ce0a98c0dcb1f5ca298d80a52b719a354d99d59c5333452cbb5f8b882fc12c
 file:
-- statement:
-    begin_end_block:
-    - declare_segment:
-      - keyword: DECLARE
-      - collection_type:
-        - keyword: TYPE
-        - naked_identifier: NumList
-        - keyword: IS
-        - data_type:
-            data_type_identifier: VARRAY
-            bracketed_arguments:
-              bracketed:
-                start_bracket: (
-                numeric_literal: '20'
-                end_bracket: )
-        - keyword: OF
-        - data_type:
-            data_type_identifier: NUMBER
-      - statement_terminator: ;
-      - naked_identifier: depts
-      - data_type:
-          data_type_identifier: NumList
-      - assignment_operator: :=
-      - expression:
-          function:
-            function_name:
-              function_name_identifier: NumList
-            function_contents:
-              bracketed:
-              - start_bracket: (
-              - expression:
-                  numeric_literal: '10'
-              - comma: ','
-              - expression:
-                  numeric_literal: '30'
-              - comma: ','
-              - expression:
-                  numeric_literal: '70'
-              - end_bracket: )
-      - statement_terminator: ;
-    - keyword: BEGIN
-    - statement:
-        forall_statement:
-        - keyword: FORALL
-        - naked_identifier: i
-        - keyword: IN
-        - naked_identifier: depts
-        - dot: .
-        - naked_identifier: FIRST
-        - dot: .
-        - dot: .
-        - naked_identifier: depts
-        - dot: .
-        - naked_identifier: LAST
-        - delete_statement:
-            keyword: DELETE
-            from_clause:
-              keyword: FROM
-              from_expression:
-                from_expression_element:
-                  table_expression:
-                    table_reference:
-                      naked_identifier: employees_temp
-            where_clause:
-              keyword: WHERE
-              expression:
-                column_reference:
-                  naked_identifier: department_id
-                comparison_operator:
-                  raw_comparison_operator: '='
-                function:
-                  function_name:
-                    function_name_identifier: depts
-                  function_contents:
-                    bracketed:
-                      start_bracket: (
-                      expression:
-                        column_reference:
-                          naked_identifier: i
-                      end_bracket: )
-    - statement_terminator: ;
-    - keyword: END
-- statement_terminator: ;
-- statement_terminator: /
-- statement:
-    begin_end_block:
-    - declare_segment:
-      - keyword: DECLARE
-      - collection_type:
-        - keyword: TYPE
-        - naked_identifier: NumTab
-        - keyword: IS
-        - keyword: TABLE
-        - keyword: OF
-        - column_type_reference:
-            column_reference:
-            - naked_identifier: parts1
-            - dot: .
-            - naked_identifier: pnum
-            binary_operator: '%'
-            keyword: TYPE
-        - keyword: INDEX
-        - keyword: BY
-        - data_type:
-            data_type_identifier: PLS_INTEGER
-      - statement_terminator: ;
-      - collection_type:
-        - keyword: TYPE
-        - naked_identifier: NameTab
-        - keyword: IS
-        - keyword: TABLE
-        - keyword: OF
-        - column_type_reference:
-            column_reference:
-            - naked_identifier: parts1
-            - dot: .
-            - naked_identifier: pname
-            binary_operator: '%'
-            keyword: TYPE
-        - keyword: INDEX
-        - keyword: BY
-        - data_type:
-            data_type_identifier: PLS_INTEGER
-      - statement_terminator: ;
-      - naked_identifier: pnums
-      - data_type:
-          data_type_identifier: NumTab
-      - statement_terminator: ;
-      - naked_identifier: pnames
-      - data_type:
-          data_type_identifier: NameTab
-      - statement_terminator: ;
-      - naked_identifier: iterations
-      - keyword: CONSTANT
-      - data_type:
-          data_type_identifier: PLS_INTEGER
-      - assignment_operator: :=
-      - expression:
-          numeric_literal: '50000'
-      - statement_terminator: ;
-      - naked_identifier: t1
-      - data_type:
-          data_type_identifier: INTEGER
-      - statement_terminator: ;
-      - naked_identifier: t2
-      - data_type:
-          data_type_identifier: INTEGER
-      - statement_terminator: ;
-      - naked_identifier: t3
-      - data_type:
-          data_type_identifier: INTEGER
-      - statement_terminator: ;
-    - keyword: BEGIN
-    - statement:
-        for_loop_statement:
-        - keyword: FOR
-        - naked_identifier: j
-        - keyword: IN
-        - numeric_literal: '1'
-        - dot: .
-        - dot: .
-        - naked_identifier: iterations
-        - loop_statement:
-          - keyword: LOOP
-          - statement:
-              assignment_segment_statement:
-                object_reference:
-                  naked_identifier: pnums
+- batch:
+    statement:
+      begin_end_block:
+      - declare_segment:
+        - keyword: DECLARE
+        - collection_type:
+          - keyword: TYPE
+          - naked_identifier: NumList
+          - keyword: IS
+          - data_type:
+              data_type_identifier: VARRAY
+              bracketed_arguments:
                 bracketed:
                   start_bracket: (
-                  object_reference:
-                    naked_identifier: j
+                  numeric_literal: '20'
                   end_bracket: )
-                assignment_operator: :=
+          - keyword: OF
+          - data_type:
+              data_type_identifier: NUMBER
+        - statement_terminator: ;
+        - naked_identifier: depts
+        - data_type:
+            data_type_identifier: NumList
+        - assignment_operator: :=
+        - expression:
+            function:
+              function_name:
+                function_name_identifier: NumList
+              function_contents:
+                bracketed:
+                - start_bracket: (
+                - expression:
+                    numeric_literal: '10'
+                - comma: ','
+                - expression:
+                    numeric_literal: '30'
+                - comma: ','
+                - expression:
+                    numeric_literal: '70'
+                - end_bracket: )
+        - statement_terminator: ;
+      - keyword: BEGIN
+      - statement:
+          forall_statement:
+          - keyword: FORALL
+          - naked_identifier: i
+          - keyword: IN
+          - naked_identifier: depts
+          - dot: .
+          - naked_identifier: FIRST
+          - dot: .
+          - dot: .
+          - naked_identifier: depts
+          - dot: .
+          - naked_identifier: LAST
+          - delete_statement:
+              keyword: DELETE
+              from_clause:
+                keyword: FROM
+                from_expression:
+                  from_expression_element:
+                    table_expression:
+                      table_reference:
+                        naked_identifier: employees_temp
+              where_clause:
+                keyword: WHERE
                 expression:
                   column_reference:
-                    naked_identifier: j
-          - statement_terminator: ;
-          - statement:
-              assignment_segment_statement:
-                object_reference:
-                  naked_identifier: pnames
-                bracketed:
-                  start_bracket: (
+                    naked_identifier: department_id
+                  comparison_operator:
+                    raw_comparison_operator: '='
+                  function:
+                    function_name:
+                      function_name_identifier: depts
+                    function_contents:
+                      bracketed:
+                        start_bracket: (
+                        expression:
+                          column_reference:
+                            naked_identifier: i
+                        end_bracket: )
+      - statement_terminator: ;
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      begin_end_block:
+      - declare_segment:
+        - keyword: DECLARE
+        - collection_type:
+          - keyword: TYPE
+          - naked_identifier: NumTab
+          - keyword: IS
+          - keyword: TABLE
+          - keyword: OF
+          - column_type_reference:
+              column_reference:
+              - naked_identifier: parts1
+              - dot: .
+              - naked_identifier: pnum
+              binary_operator: '%'
+              keyword: TYPE
+          - keyword: INDEX
+          - keyword: BY
+          - data_type:
+              data_type_identifier: PLS_INTEGER
+        - statement_terminator: ;
+        - collection_type:
+          - keyword: TYPE
+          - naked_identifier: NameTab
+          - keyword: IS
+          - keyword: TABLE
+          - keyword: OF
+          - column_type_reference:
+              column_reference:
+              - naked_identifier: parts1
+              - dot: .
+              - naked_identifier: pname
+              binary_operator: '%'
+              keyword: TYPE
+          - keyword: INDEX
+          - keyword: BY
+          - data_type:
+              data_type_identifier: PLS_INTEGER
+        - statement_terminator: ;
+        - naked_identifier: pnums
+        - data_type:
+            data_type_identifier: NumTab
+        - statement_terminator: ;
+        - naked_identifier: pnames
+        - data_type:
+            data_type_identifier: NameTab
+        - statement_terminator: ;
+        - naked_identifier: iterations
+        - keyword: CONSTANT
+        - data_type:
+            data_type_identifier: PLS_INTEGER
+        - assignment_operator: :=
+        - expression:
+            numeric_literal: '50000'
+        - statement_terminator: ;
+        - naked_identifier: t1
+        - data_type:
+            data_type_identifier: INTEGER
+        - statement_terminator: ;
+        - naked_identifier: t2
+        - data_type:
+            data_type_identifier: INTEGER
+        - statement_terminator: ;
+        - naked_identifier: t3
+        - data_type:
+            data_type_identifier: INTEGER
+        - statement_terminator: ;
+      - keyword: BEGIN
+      - statement:
+          for_loop_statement:
+          - keyword: FOR
+          - naked_identifier: j
+          - keyword: IN
+          - numeric_literal: '1'
+          - dot: .
+          - dot: .
+          - naked_identifier: iterations
+          - loop_statement:
+            - keyword: LOOP
+            - statement:
+                assignment_segment_statement:
                   object_reference:
-                    naked_identifier: j
-                  end_bracket: )
-                assignment_operator: :=
+                    naked_identifier: pnums
+                  bracketed:
+                    start_bracket: (
+                    object_reference:
+                      naked_identifier: j
+                    end_bracket: )
+                  assignment_operator: :=
+                  expression:
+                    column_reference:
+                      naked_identifier: j
+            - statement_terminator: ;
+            - statement:
+                assignment_segment_statement:
+                  object_reference:
+                    naked_identifier: pnames
+                  bracketed:
+                    start_bracket: (
+                    object_reference:
+                      naked_identifier: j
+                    end_bracket: )
+                  assignment_operator: :=
+                  expression:
+                    quoted_literal: "'Part No. '"
+                    binary_operator:
+                    - pipe: '|'
+                    - pipe: '|'
+                    function:
+                      function_name:
+                        function_name_identifier: TO_CHAR
+                      function_contents:
+                        bracketed:
+                          start_bracket: (
+                          expression:
+                            column_reference:
+                              naked_identifier: j
+                          end_bracket: )
+            - statement_terminator: ;
+            - keyword: END
+            - keyword: LOOP
+      - statement_terminator: ;
+      - statement:
+          assignment_segment_statement:
+            object_reference:
+              naked_identifier: t1
+            assignment_operator: :=
+            expression:
+              column_reference:
+              - naked_identifier: DBMS_UTILITY
+              - dot: .
+              - naked_identifier: get_time
+      - statement_terminator: ;
+      - statement:
+          for_loop_statement:
+          - keyword: FOR
+          - naked_identifier: i
+          - keyword: IN
+          - numeric_literal: '1'
+          - dot: .
+          - dot: .
+          - naked_identifier: iterations
+          - loop_statement:
+            - keyword: LOOP
+            - statement:
+                insert_statement:
+                - keyword: INSERT
+                - keyword: INTO
+                - table_reference:
+                    naked_identifier: parts1
+                - bracketed:
+                  - start_bracket: (
+                  - column_reference:
+                      naked_identifier: pnum
+                  - comma: ','
+                  - column_reference:
+                      naked_identifier: pname
+                  - end_bracket: )
+                - values_clause:
+                    keyword: VALUES
+                    bracketed:
+                    - start_bracket: (
+                    - expression:
+                        function:
+                          function_name:
+                            function_name_identifier: pnums
+                          function_contents:
+                            bracketed:
+                              start_bracket: (
+                              expression:
+                                column_reference:
+                                  naked_identifier: i
+                              end_bracket: )
+                    - comma: ','
+                    - expression:
+                        function:
+                          function_name:
+                            function_name_identifier: pnames
+                          function_contents:
+                            bracketed:
+                              start_bracket: (
+                              expression:
+                                column_reference:
+                                  naked_identifier: i
+                              end_bracket: )
+                    - end_bracket: )
+            - statement_terminator: ;
+            - keyword: END
+            - keyword: LOOP
+      - statement_terminator: ;
+      - statement:
+          assignment_segment_statement:
+            object_reference:
+              naked_identifier: t2
+            assignment_operator: :=
+            expression:
+              column_reference:
+              - naked_identifier: DBMS_UTILITY
+              - dot: .
+              - naked_identifier: get_time
+      - statement_terminator: ;
+      - statement:
+          forall_statement:
+          - keyword: FORALL
+          - naked_identifier: i
+          - keyword: IN
+          - numeric_literal: '1'
+          - dot: .
+          - dot: .
+          - naked_identifier: iterations
+          - insert_statement:
+            - keyword: INSERT
+            - keyword: INTO
+            - table_reference:
+                naked_identifier: parts2
+            - bracketed:
+              - start_bracket: (
+              - column_reference:
+                  naked_identifier: pnum
+              - comma: ','
+              - column_reference:
+                  naked_identifier: pname
+              - end_bracket: )
+            - values_clause:
+                keyword: VALUES
+                bracketed:
+                - start_bracket: (
+                - expression:
+                    function:
+                      function_name:
+                        function_name_identifier: pnums
+                      function_contents:
+                        bracketed:
+                          start_bracket: (
+                          expression:
+                            column_reference:
+                              naked_identifier: i
+                          end_bracket: )
+                - comma: ','
+                - expression:
+                    function:
+                      function_name:
+                        function_name_identifier: pnames
+                      function_contents:
+                        bracketed:
+                          start_bracket: (
+                          expression:
+                            column_reference:
+                              naked_identifier: i
+                          end_bracket: )
+                - end_bracket: )
+      - statement_terminator: ;
+      - statement:
+          assignment_segment_statement:
+            object_reference:
+              naked_identifier: t3
+            assignment_operator: :=
+            expression:
+              column_reference:
+              - naked_identifier: DBMS_UTILITY
+              - dot: .
+              - naked_identifier: get_time
+      - statement_terminator: ;
+      - statement:
+          function:
+            function_name:
+              naked_identifier: DBMS_OUTPUT
+              dot: .
+              function_name_identifier: PUT_LINE
+            function_contents:
+              bracketed:
+                start_bracket: (
                 expression:
-                  quoted_literal: "'Part No. '"
+                  quoted_literal: "'Execution Time (secs)'"
+                end_bracket: )
+      - statement_terminator: ;
+      - statement:
+          function:
+            function_name:
+              naked_identifier: DBMS_OUTPUT
+              dot: .
+              function_name_identifier: PUT_LINE
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  quoted_literal: "'---------------------'"
+                end_bracket: )
+      - statement_terminator: ;
+      - statement:
+          function:
+            function_name:
+              naked_identifier: DBMS_OUTPUT
+              dot: .
+              function_name_identifier: PUT_LINE
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  quoted_literal: "'FOR LOOP: '"
                   binary_operator:
                   - pipe: '|'
                   - pipe: '|'
@@ -205,520 +403,149 @@ file:
                       bracketed:
                         start_bracket: (
                         expression:
-                          column_reference:
-                            naked_identifier: j
+                          bracketed:
+                            start_bracket: (
+                            expression:
+                            - column_reference:
+                                naked_identifier: t2
+                            - binary_operator: '-'
+                            - column_reference:
+                                naked_identifier: t1
+                            end_bracket: )
+                          binary_operator: /
+                          numeric_literal: '100'
                         end_bracket: )
-          - statement_terminator: ;
-          - keyword: END
-          - keyword: LOOP
-    - statement_terminator: ;
-    - statement:
-        assignment_segment_statement:
-          object_reference:
-            naked_identifier: t1
-          assignment_operator: :=
-          expression:
-            column_reference:
-            - naked_identifier: DBMS_UTILITY
-            - dot: .
-            - naked_identifier: get_time
-    - statement_terminator: ;
-    - statement:
-        for_loop_statement:
-        - keyword: FOR
-        - naked_identifier: i
-        - keyword: IN
-        - numeric_literal: '1'
-        - dot: .
-        - dot: .
-        - naked_identifier: iterations
-        - loop_statement:
-          - keyword: LOOP
-          - statement:
-              insert_statement:
-              - keyword: INSERT
-              - keyword: INTO
-              - table_reference:
-                  naked_identifier: parts1
-              - bracketed:
-                - start_bracket: (
-                - column_reference:
-                    naked_identifier: pnum
-                - comma: ','
-                - column_reference:
-                    naked_identifier: pname
-                - end_bracket: )
-              - values_clause:
-                  keyword: VALUES
-                  bracketed:
-                  - start_bracket: (
-                  - expression:
-                      function:
-                        function_name:
-                          function_name_identifier: pnums
-                        function_contents:
-                          bracketed:
-                            start_bracket: (
-                            expression:
-                              column_reference:
-                                naked_identifier: i
-                            end_bracket: )
-                  - comma: ','
-                  - expression:
-                      function:
-                        function_name:
-                          function_name_identifier: pnames
-                        function_contents:
-                          bracketed:
-                            start_bracket: (
-                            expression:
-                              column_reference:
-                                naked_identifier: i
-                            end_bracket: )
-                  - end_bracket: )
-          - statement_terminator: ;
-          - keyword: END
-          - keyword: LOOP
-    - statement_terminator: ;
-    - statement:
-        assignment_segment_statement:
-          object_reference:
-            naked_identifier: t2
-          assignment_operator: :=
-          expression:
-            column_reference:
-            - naked_identifier: DBMS_UTILITY
-            - dot: .
-            - naked_identifier: get_time
-    - statement_terminator: ;
-    - statement:
-        forall_statement:
-        - keyword: FORALL
-        - naked_identifier: i
-        - keyword: IN
-        - numeric_literal: '1'
-        - dot: .
-        - dot: .
-        - naked_identifier: iterations
-        - insert_statement:
-          - keyword: INSERT
-          - keyword: INTO
-          - table_reference:
-              naked_identifier: parts2
-          - bracketed:
-            - start_bracket: (
-            - column_reference:
-                naked_identifier: pnum
-            - comma: ','
-            - column_reference:
-                naked_identifier: pname
-            - end_bracket: )
-          - values_clause:
-              keyword: VALUES
+                end_bracket: )
+      - statement_terminator: ;
+      - statement:
+          function:
+            function_name:
+              naked_identifier: DBMS_OUTPUT
+              dot: .
+              function_name_identifier: PUT_LINE
+            function_contents:
               bracketed:
-              - start_bracket: (
-              - expression:
+                start_bracket: (
+                expression:
+                  quoted_literal: "'FORALL:   '"
+                  binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
                   function:
                     function_name:
-                      function_name_identifier: pnums
+                      function_name_identifier: TO_CHAR
                     function_contents:
                       bracketed:
                         start_bracket: (
                         expression:
-                          column_reference:
-                            naked_identifier: i
+                          bracketed:
+                            start_bracket: (
+                            expression:
+                            - column_reference:
+                                naked_identifier: t3
+                            - binary_operator: '-'
+                            - column_reference:
+                                naked_identifier: t2
+                            end_bracket: )
+                          binary_operator: /
+                          numeric_literal: '100'
                         end_bracket: )
-              - comma: ','
-              - expression:
-                  function:
-                    function_name:
-                      function_name_identifier: pnames
-                    function_contents:
-                      bracketed:
-                        start_bracket: (
-                        expression:
-                          column_reference:
-                            naked_identifier: i
-                        end_bracket: )
-              - end_bracket: )
-    - statement_terminator: ;
-    - statement:
-        assignment_segment_statement:
-          object_reference:
-            naked_identifier: t3
-          assignment_operator: :=
-          expression:
-            column_reference:
-            - naked_identifier: DBMS_UTILITY
-            - dot: .
-            - naked_identifier: get_time
-    - statement_terminator: ;
-    - statement:
-        function:
-          function_name:
-            naked_identifier: DBMS_OUTPUT
-            dot: .
-            function_name_identifier: PUT_LINE
-          function_contents:
-            bracketed:
-              start_bracket: (
-              expression:
-                quoted_literal: "'Execution Time (secs)'"
-              end_bracket: )
-    - statement_terminator: ;
-    - statement:
-        function:
-          function_name:
-            naked_identifier: DBMS_OUTPUT
-            dot: .
-            function_name_identifier: PUT_LINE
-          function_contents:
-            bracketed:
-              start_bracket: (
-              expression:
-                quoted_literal: "'---------------------'"
-              end_bracket: )
-    - statement_terminator: ;
-    - statement:
-        function:
-          function_name:
-            naked_identifier: DBMS_OUTPUT
-            dot: .
-            function_name_identifier: PUT_LINE
-          function_contents:
-            bracketed:
-              start_bracket: (
-              expression:
-                quoted_literal: "'FOR LOOP: '"
-                binary_operator:
-                - pipe: '|'
-                - pipe: '|'
-                function:
-                  function_name:
-                    function_name_identifier: TO_CHAR
-                  function_contents:
-                    bracketed:
-                      start_bracket: (
-                      expression:
-                        bracketed:
-                          start_bracket: (
-                          expression:
-                          - column_reference:
-                              naked_identifier: t2
-                          - binary_operator: '-'
-                          - column_reference:
-                              naked_identifier: t1
-                          end_bracket: )
-                        binary_operator: /
-                        numeric_literal: '100'
-                      end_bracket: )
-              end_bracket: )
-    - statement_terminator: ;
-    - statement:
-        function:
-          function_name:
-            naked_identifier: DBMS_OUTPUT
-            dot: .
-            function_name_identifier: PUT_LINE
-          function_contents:
-            bracketed:
-              start_bracket: (
-              expression:
-                quoted_literal: "'FORALL:   '"
-                binary_operator:
-                - pipe: '|'
-                - pipe: '|'
-                function:
-                  function_name:
-                    function_name_identifier: TO_CHAR
-                  function_contents:
-                    bracketed:
-                      start_bracket: (
-                      expression:
-                        bracketed:
-                          start_bracket: (
-                          expression:
-                          - column_reference:
-                              naked_identifier: t3
-                          - binary_operator: '-'
-                          - column_reference:
-                              naked_identifier: t2
-                          end_bracket: )
-                        binary_operator: /
-                        numeric_literal: '100'
-                      end_bracket: )
-              end_bracket: )
-    - statement_terminator: ;
-    - statement:
-        transaction_statement:
-          keyword: COMMIT
-    - statement_terminator: ;
-    - keyword: END
-- statement_terminator: ;
-- statement_terminator: /
-- statement:
-    begin_end_block:
-    - declare_segment:
-      - keyword: DECLARE
-      - collection_type:
-        - keyword: TYPE
-        - naked_identifier: NumList
-        - keyword: IS
-        - data_type:
-            data_type_identifier: VARRAY
-            bracketed_arguments:
-              bracketed:
-                start_bracket: (
-                numeric_literal: '10'
-                end_bracket: )
-        - keyword: OF
-        - data_type:
-            data_type_identifier: NUMBER
-      - statement_terminator: ;
-      - naked_identifier: depts
-      - data_type:
-          data_type_identifier: NumList
-      - assignment_operator: :=
-      - expression:
-          function:
-            function_name:
-              function_name_identifier: NumList
-            function_contents:
-              bracketed:
-              - start_bracket: (
-              - expression:
-                  numeric_literal: '5'
-              - comma: ','
-              - expression:
-                  numeric_literal: '10'
-              - comma: ','
-              - expression:
-                  numeric_literal: '20'
-              - comma: ','
-              - expression:
-                  numeric_literal: '30'
-              - comma: ','
-              - expression:
-                  numeric_literal: '50'
-              - comma: ','
-              - expression:
-                  numeric_literal: '55'
-              - comma: ','
-              - expression:
-                  numeric_literal: '57'
-              - comma: ','
-              - expression:
-                  numeric_literal: '60'
-              - comma: ','
-              - expression:
-                  numeric_literal: '70'
-              - comma: ','
-              - expression:
-                  numeric_literal: '75'
-              - end_bracket: )
-      - statement_terminator: ;
-    - keyword: BEGIN
-    - statement:
-        forall_statement:
-        - keyword: FORALL
-        - naked_identifier: j
-        - keyword: IN
-        - numeric_literal: '4'
-        - dot: .
-        - dot: .
-        - numeric_literal: '7'
-        - delete_statement:
-            keyword: DELETE
-            from_clause:
-              keyword: FROM
-              from_expression:
-                from_expression_element:
-                  table_expression:
-                    table_reference:
-                      naked_identifier: employees_temp
-            where_clause:
-              keyword: WHERE
-              expression:
-                column_reference:
-                  naked_identifier: department_id
-                comparison_operator:
-                  raw_comparison_operator: '='
-                function:
-                  function_name:
-                    function_name_identifier: depts
-                  function_contents:
-                    bracketed:
-                      start_bracket: (
-                      expression:
-                        column_reference:
-                          naked_identifier: j
-                      end_bracket: )
-    - statement_terminator: ;
-    - keyword: END
-- statement_terminator: ;
-- statement_terminator: /
-- statement:
-    create_procedure_statement:
-    - keyword: CREATE
-    - keyword: OR
-    - keyword: REPLACE
-    - keyword: PROCEDURE
-    - function_name:
-        function_name_identifier: p
-    - keyword: AUTHID
-    - keyword: DEFINER
-    - keyword: AS
-    - declare_segment:
-      - collection_type:
-        - keyword: TYPE
-        - naked_identifier: NumList
-        - keyword: IS
-        - keyword: TABLE
-        - keyword: OF
-        - data_type:
-            data_type_identifier: NUMBER
-      - statement_terminator: ;
-      - naked_identifier: depts
-      - data_type:
-          data_type_identifier: NumList
-      - assignment_operator: :=
-      - expression:
-          function:
-            function_name:
-              function_name_identifier: NumList
-            function_contents:
-              bracketed:
-              - start_bracket: (
-              - expression:
-                  numeric_literal: '10'
-              - comma: ','
-              - expression:
-                  numeric_literal: '20'
-              - comma: ','
-              - expression:
-                  numeric_literal: '30'
-              - end_bracket: )
-      - statement_terminator: ;
-      - naked_identifier: error_message
-      - data_type:
-          data_type_identifier: VARCHAR2
-          bracketed_arguments:
-            bracketed:
-              start_bracket: (
-              numeric_literal: '100'
-              end_bracket: )
-      - statement_terminator: ;
-    - begin_end_block:
-      - keyword: BEGIN
-      - statement:
-          insert_statement:
-          - keyword: INSERT
-          - keyword: INTO
-          - table_reference:
-              naked_identifier: emp_temp
-          - bracketed:
-            - start_bracket: (
-            - column_reference:
-                naked_identifier: deptno
-            - comma: ','
-            - column_reference:
-                naked_identifier: job
-            - end_bracket: )
-          - values_clause:
-              keyword: VALUES
-              bracketed:
-                start_bracket: (
-                numeric_literal: '10'
-                comma: ','
-                quoted_literal: "'Clerk'"
-                end_bracket: )
-      - statement_terminator: ;
-      - statement:
-          insert_statement:
-          - keyword: INSERT
-          - keyword: INTO
-          - table_reference:
-              naked_identifier: emp_temp
-          - bracketed:
-            - start_bracket: (
-            - column_reference:
-                naked_identifier: deptno
-            - comma: ','
-            - column_reference:
-                naked_identifier: job
-            - end_bracket: )
-          - values_clause:
-              keyword: VALUES
-              bracketed:
-                start_bracket: (
-                numeric_literal: '20'
-                comma: ','
-                quoted_literal: "'Bookkeeper'"
-                end_bracket: )
-      - statement_terminator: ;
-      - statement:
-          insert_statement:
-          - keyword: INSERT
-          - keyword: INTO
-          - table_reference:
-              naked_identifier: emp_temp
-          - bracketed:
-            - start_bracket: (
-            - column_reference:
-                naked_identifier: deptno
-            - comma: ','
-            - column_reference:
-                naked_identifier: job
-            - end_bracket: )
-          - values_clause:
-              keyword: VALUES
-              bracketed:
-                start_bracket: (
-                numeric_literal: '30'
-                comma: ','
-                quoted_literal: "'Analyst'"
                 end_bracket: )
       - statement_terminator: ;
       - statement:
           transaction_statement:
             keyword: COMMIT
       - statement_terminator: ;
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      begin_end_block:
+      - declare_segment:
+        - keyword: DECLARE
+        - collection_type:
+          - keyword: TYPE
+          - naked_identifier: NumList
+          - keyword: IS
+          - data_type:
+              data_type_identifier: VARRAY
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  numeric_literal: '10'
+                  end_bracket: )
+          - keyword: OF
+          - data_type:
+              data_type_identifier: NUMBER
+        - statement_terminator: ;
+        - naked_identifier: depts
+        - data_type:
+            data_type_identifier: NumList
+        - assignment_operator: :=
+        - expression:
+            function:
+              function_name:
+                function_name_identifier: NumList
+              function_contents:
+                bracketed:
+                - start_bracket: (
+                - expression:
+                    numeric_literal: '5'
+                - comma: ','
+                - expression:
+                    numeric_literal: '10'
+                - comma: ','
+                - expression:
+                    numeric_literal: '20'
+                - comma: ','
+                - expression:
+                    numeric_literal: '30'
+                - comma: ','
+                - expression:
+                    numeric_literal: '50'
+                - comma: ','
+                - expression:
+                    numeric_literal: '55'
+                - comma: ','
+                - expression:
+                    numeric_literal: '57'
+                - comma: ','
+                - expression:
+                    numeric_literal: '60'
+                - comma: ','
+                - expression:
+                    numeric_literal: '70'
+                - comma: ','
+                - expression:
+                    numeric_literal: '75'
+                - end_bracket: )
+        - statement_terminator: ;
+      - keyword: BEGIN
       - statement:
           forall_statement:
           - keyword: FORALL
           - naked_identifier: j
           - keyword: IN
-          - naked_identifier: depts
-          - dot: .
-          - naked_identifier: FIRST
+          - numeric_literal: '4'
           - dot: .
           - dot: .
-          - naked_identifier: depts
-          - dot: .
-          - naked_identifier: LAST
-          - update_statement:
-              keyword: UPDATE
-              table_reference:
-                naked_identifier: emp_temp
-              set_clause_list:
-                keyword: SET
-                set_clause:
-                  column_reference:
-                    naked_identifier: job
-                  comparison_operator:
-                    raw_comparison_operator: '='
-                  expression:
-                    column_reference:
-                      naked_identifier: job
-                    binary_operator:
-                    - pipe: '|'
-                    - pipe: '|'
-                    quoted_literal: "' (Senior)'"
+          - numeric_literal: '7'
+          - delete_statement:
+              keyword: DELETE
+              from_clause:
+                keyword: FROM
+                from_expression:
+                  from_expression_element:
+                    table_expression:
+                      table_reference:
+                        naked_identifier: employees_temp
               where_clause:
                 keyword: WHERE
                 expression:
                   column_reference:
-                    naked_identifier: deptno
+                    naked_identifier: department_id
                   comparison_operator:
                     raw_comparison_operator: '='
                   function:
@@ -732,41 +559,222 @@ file:
                             naked_identifier: j
                         end_bracket: )
       - statement_terminator: ;
-      - keyword: EXCEPTION
-      - keyword: WHEN
-      - keyword: OTHERS
-      - keyword: THEN
-      - statement:
-          assignment_segment_statement:
-            object_reference:
-              naked_identifier: error_message
-            assignment_operator: :=
-            expression:
-              column_reference:
-                naked_identifier: SQLERRM
-      - statement_terminator: ;
-      - statement:
-          function:
-            function_name:
-              naked_identifier: DBMS_OUTPUT
-              dot: .
-              function_name_identifier: PUT_LINE
-            function_contents:
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      create_procedure_statement:
+      - keyword: CREATE
+      - keyword: OR
+      - keyword: REPLACE
+      - keyword: PROCEDURE
+      - function_name:
+          function_name_identifier: p
+      - keyword: AUTHID
+      - keyword: DEFINER
+      - keyword: AS
+      - declare_segment:
+        - collection_type:
+          - keyword: TYPE
+          - naked_identifier: NumList
+          - keyword: IS
+          - keyword: TABLE
+          - keyword: OF
+          - data_type:
+              data_type_identifier: NUMBER
+        - statement_terminator: ;
+        - naked_identifier: depts
+        - data_type:
+            data_type_identifier: NumList
+        - assignment_operator: :=
+        - expression:
+            function:
+              function_name:
+                function_name_identifier: NumList
+              function_contents:
+                bracketed:
+                - start_bracket: (
+                - expression:
+                    numeric_literal: '10'
+                - comma: ','
+                - expression:
+                    numeric_literal: '20'
+                - comma: ','
+                - expression:
+                    numeric_literal: '30'
+                - end_bracket: )
+        - statement_terminator: ;
+        - naked_identifier: error_message
+        - data_type:
+            data_type_identifier: VARCHAR2
+            bracketed_arguments:
               bracketed:
                 start_bracket: (
-                expression:
-                  column_reference:
-                    naked_identifier: error_message
+                numeric_literal: '100'
                 end_bracket: )
+        - statement_terminator: ;
+      - begin_end_block:
+        - keyword: BEGIN
+        - statement:
+            insert_statement:
+            - keyword: INSERT
+            - keyword: INTO
+            - table_reference:
+                naked_identifier: emp_temp
+            - bracketed:
+              - start_bracket: (
+              - column_reference:
+                  naked_identifier: deptno
+              - comma: ','
+              - column_reference:
+                  naked_identifier: job
+              - end_bracket: )
+            - values_clause:
+                keyword: VALUES
+                bracketed:
+                  start_bracket: (
+                  numeric_literal: '10'
+                  comma: ','
+                  quoted_literal: "'Clerk'"
+                  end_bracket: )
+        - statement_terminator: ;
+        - statement:
+            insert_statement:
+            - keyword: INSERT
+            - keyword: INTO
+            - table_reference:
+                naked_identifier: emp_temp
+            - bracketed:
+              - start_bracket: (
+              - column_reference:
+                  naked_identifier: deptno
+              - comma: ','
+              - column_reference:
+                  naked_identifier: job
+              - end_bracket: )
+            - values_clause:
+                keyword: VALUES
+                bracketed:
+                  start_bracket: (
+                  numeric_literal: '20'
+                  comma: ','
+                  quoted_literal: "'Bookkeeper'"
+                  end_bracket: )
+        - statement_terminator: ;
+        - statement:
+            insert_statement:
+            - keyword: INSERT
+            - keyword: INTO
+            - table_reference:
+                naked_identifier: emp_temp
+            - bracketed:
+              - start_bracket: (
+              - column_reference:
+                  naked_identifier: deptno
+              - comma: ','
+              - column_reference:
+                  naked_identifier: job
+              - end_bracket: )
+            - values_clause:
+                keyword: VALUES
+                bracketed:
+                  start_bracket: (
+                  numeric_literal: '30'
+                  comma: ','
+                  quoted_literal: "'Analyst'"
+                  end_bracket: )
+        - statement_terminator: ;
+        - statement:
+            transaction_statement:
+              keyword: COMMIT
+        - statement_terminator: ;
+        - statement:
+            forall_statement:
+            - keyword: FORALL
+            - naked_identifier: j
+            - keyword: IN
+            - naked_identifier: depts
+            - dot: .
+            - naked_identifier: FIRST
+            - dot: .
+            - dot: .
+            - naked_identifier: depts
+            - dot: .
+            - naked_identifier: LAST
+            - update_statement:
+                keyword: UPDATE
+                table_reference:
+                  naked_identifier: emp_temp
+                set_clause_list:
+                  keyword: SET
+                  set_clause:
+                    column_reference:
+                      naked_identifier: job
+                    comparison_operator:
+                      raw_comparison_operator: '='
+                    expression:
+                      column_reference:
+                        naked_identifier: job
+                      binary_operator:
+                      - pipe: '|'
+                      - pipe: '|'
+                      quoted_literal: "' (Senior)'"
+                where_clause:
+                  keyword: WHERE
+                  expression:
+                    column_reference:
+                      naked_identifier: deptno
+                    comparison_operator:
+                      raw_comparison_operator: '='
+                    function:
+                      function_name:
+                        function_name_identifier: depts
+                      function_contents:
+                        bracketed:
+                          start_bracket: (
+                          expression:
+                            column_reference:
+                              naked_identifier: j
+                          end_bracket: )
+        - statement_terminator: ;
+        - keyword: EXCEPTION
+        - keyword: WHEN
+        - keyword: OTHERS
+        - keyword: THEN
+        - statement:
+            assignment_segment_statement:
+              object_reference:
+                naked_identifier: error_message
+              assignment_operator: :=
+              expression:
+                column_reference:
+                  naked_identifier: SQLERRM
+        - statement_terminator: ;
+        - statement:
+            function:
+              function_name:
+                naked_identifier: DBMS_OUTPUT
+                dot: .
+                function_name_identifier: PUT_LINE
+              function_contents:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    column_reference:
+                      naked_identifier: error_message
+                  end_bracket: )
+        - statement_terminator: ;
+        - statement:
+            transaction_statement:
+              keyword: COMMIT
+        - statement_terminator: ;
+        - statement:
+            raise_statement:
+              keyword: RAISE
+        - statement_terminator: ;
+        - keyword: END
       - statement_terminator: ;
-      - statement:
-          transaction_statement:
-            keyword: COMMIT
-      - statement_terminator: ;
-      - statement:
-          raise_statement:
-            keyword: RAISE
-      - statement_terminator: ;
-      - keyword: END
-    - statement_terminator: ;
-    - statement_terminator: /
+    slash_buffer_executor:
+      slash: /

--- a/test/fixtures/dialects/oracle/grant.yml
+++ b/test/fixtures/dialects/oracle/grant.yml
@@ -3,267 +3,268 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: ac279e9ce8788687bc814b11c9f2e91277f75357f4b861635ea0e3d5ac301ab9
+_hash: 171171db8b369c26530be3aa171d7eff2a5c147251ec79dafa53d37527681e70
 file:
-- statement:
-    access_statement:
-      grant_statement:
-      - keyword: GRANT
-      - access_permissions:
-          access_permission:
-            keyword: CREATE
-          access_object:
-            keyword: SESSION
-      - keyword: TO
-      - access_target:
-          object_reference:
-            naked_identifier: hr
-- statement_terminator: ;
-- statement:
-    access_statement:
-      grant_statement:
-      - keyword: GRANT
-      - access_permissions:
-          access_permission:
-            keyword: CREATE
-          access_object:
-            keyword: SESSION
-      - keyword: TO
-      - access_target:
-        - object_reference:
-            naked_identifier: hr
-        - comma: ','
-        - object_reference:
-            naked_identifier: newuser
-      - keyword: IDENTIFIED
-      - keyword: BY
-      - naked_identifier: password1
-      - comma: ','
-      - naked_identifier: password2
-- statement_terminator: ;
-- statement:
-    access_statement:
-      grant_statement:
-      - keyword: GRANT
-      - access_permissions:
-        - access_permission:
-            keyword: CREATE
-        - keyword: ANY
-        - access_object:
-          - keyword: MATERIALIZED
-          - keyword: VIEW
-        - comma: ','
-        - access_permission:
-            keyword: ALTER
-        - keyword: ANY
-        - access_object:
-          - keyword: MATERIALIZED
-          - keyword: VIEW
-        - comma: ','
-        - access_permission:
-            keyword: DROP
-        - keyword: ANY
-        - access_object:
-          - keyword: MATERIALIZED
-          - keyword: VIEW
-        - comma: ','
-        - access_permission:
-          - keyword: QUERY
-          - keyword: REWRITE
-        - comma: ','
-        - access_permission:
-          - keyword: GLOBAL
-          - keyword: QUERY
-          - keyword: REWRITE
-      - keyword: TO
-      - access_target:
-          object_reference:
-            naked_identifier: dw_manager
-      - keyword: WITH
-      - keyword: ADMIN
-      - keyword: OPTION
-- statement_terminator: ;
-- statement:
-    access_statement:
-      grant_statement:
-      - keyword: GRANT
-      - access_permissions:
-          role_reference:
-            naked_identifier: dw_manager
-      - keyword: TO
-      - access_target:
-          object_reference:
-            naked_identifier: sh
-      - keyword: WITH
-      - keyword: ADMIN
-      - keyword: OPTION
-- statement_terminator: ;
-- statement:
-    access_statement:
-      grant_statement:
-      - keyword: GRANT
-      - access_permissions:
-          role_reference:
-            naked_identifier: dw_manager
-      - keyword: TO
-      - access_target:
-          object_reference:
-            naked_identifier: sh
-      - keyword: WITH
-      - keyword: DELEGATE
-      - keyword: OPTION
-- statement_terminator: ;
-- statement:
-    access_statement:
-      grant_statement:
-      - keyword: GRANT
-      - access_permissions:
-          access_permission:
-            keyword: SELECT
-      - keyword: 'ON'
-      - object_reference:
-        - naked_identifier: sh
-        - dot: .
-        - naked_identifier: sales
-      - keyword: TO
-      - access_target:
-          object_reference:
-            naked_identifier: warehouse_user
-- statement_terminator: ;
-- statement:
-    access_statement:
-      grant_statement:
-      - keyword: GRANT
-      - access_permissions:
-          role_reference:
-            naked_identifier: warehouse_user
-      - keyword: TO
-      - access_target:
-          object_reference:
-            naked_identifier: dw_manager
-- statement_terminator: ;
-- statement:
-    access_statement:
-      grant_statement:
-      - keyword: GRANT
-      - access_permissions:
-          access_permission:
-            keyword: INHERIT
-          access_object:
-            keyword: PRIVILEGES
-      - keyword: 'ON'
-      - keyword: USER
-      - object_reference:
-          naked_identifier: sh
-      - keyword: TO
-      - access_target:
-          object_reference:
-            naked_identifier: hr
-- statement_terminator: ;
-- statement:
-    access_statement:
-      grant_statement:
-      - keyword: GRANT
-      - access_permissions:
-          access_permission:
-            keyword: READ
-      - keyword: 'ON'
-      - keyword: DIRECTORY
-      - object_reference:
-          naked_identifier: bfile_dir
-      - keyword: TO
-      - access_target:
-          object_reference:
-            naked_identifier: hr
-      - keyword: WITH
-      - keyword: GRANT
-      - keyword: OPTION
-- statement_terminator: ;
-- statement:
-    access_statement:
-      grant_statement:
-      - keyword: GRANT
-      - access_permissions:
-          access_permission:
-            keyword: ALL
-      - keyword: 'ON'
-      - object_reference:
-          naked_identifier: bonuses
-      - keyword: TO
-      - access_target:
-          object_reference:
-            naked_identifier: hr
-      - keyword: WITH
-      - keyword: GRANT
-      - keyword: OPTION
-- statement_terminator: ;
-- statement:
-    access_statement:
-      grant_statement:
-      - keyword: GRANT
-      - access_permissions:
-        - access_permission:
-            keyword: SELECT
-        - comma: ','
-        - access_permission:
-            keyword: UPDATE
-      - keyword: 'ON'
-      - object_reference:
-          naked_identifier: emp_view
-      - keyword: TO
-      - access_target:
-          keyword: PUBLIC
-- statement_terminator: ;
-- statement:
-    access_statement:
-      grant_statement:
-      - keyword: GRANT
-      - access_permissions:
-          access_permission:
-            keyword: SELECT
-      - keyword: 'ON'
-      - object_reference:
-        - naked_identifier: oe
-        - dot: .
-        - naked_identifier: customers_seq
-      - keyword: TO
-      - access_target:
-          object_reference:
-            naked_identifier: hr
-- statement_terminator: ;
-- statement:
-    access_statement:
-      grant_statement:
-      - keyword: GRANT
-      - access_permissions:
-        - access_permission:
-            keyword: REFERENCES
-        - bracketed:
-            start_bracket: (
-            column_reference:
-              naked_identifier: employee_id
-            end_bracket: )
-        - comma: ','
-        - access_permission:
-            keyword: UPDATE
-        - bracketed:
-          - start_bracket: (
-          - column_reference:
-              naked_identifier: employee_id
+  batch:
+  - statement:
+      access_statement:
+        grant_statement:
+        - keyword: GRANT
+        - access_permissions:
+            access_permission:
+              keyword: CREATE
+            access_object:
+              keyword: SESSION
+        - keyword: TO
+        - access_target:
+            object_reference:
+              naked_identifier: hr
+  - statement_terminator: ;
+  - statement:
+      access_statement:
+        grant_statement:
+        - keyword: GRANT
+        - access_permissions:
+            access_permission:
+              keyword: CREATE
+            access_object:
+              keyword: SESSION
+        - keyword: TO
+        - access_target:
+          - object_reference:
+              naked_identifier: hr
           - comma: ','
-          - column_reference:
-              naked_identifier: salary
+          - object_reference:
+              naked_identifier: newuser
+        - keyword: IDENTIFIED
+        - keyword: BY
+        - naked_identifier: password1
+        - comma: ','
+        - naked_identifier: password2
+  - statement_terminator: ;
+  - statement:
+      access_statement:
+        grant_statement:
+        - keyword: GRANT
+        - access_permissions:
+          - access_permission:
+              keyword: CREATE
+          - keyword: ANY
+          - access_object:
+            - keyword: MATERIALIZED
+            - keyword: VIEW
           - comma: ','
-          - column_reference:
-              naked_identifier: commission_pct
-          - end_bracket: )
-      - keyword: 'ON'
-      - object_reference:
-        - naked_identifier: hr
-        - dot: .
-        - naked_identifier: employees
-      - keyword: TO
-      - access_target:
-          object_reference:
-            naked_identifier: oe
-- statement_terminator: ;
+          - access_permission:
+              keyword: ALTER
+          - keyword: ANY
+          - access_object:
+            - keyword: MATERIALIZED
+            - keyword: VIEW
+          - comma: ','
+          - access_permission:
+              keyword: DROP
+          - keyword: ANY
+          - access_object:
+            - keyword: MATERIALIZED
+            - keyword: VIEW
+          - comma: ','
+          - access_permission:
+            - keyword: QUERY
+            - keyword: REWRITE
+          - comma: ','
+          - access_permission:
+            - keyword: GLOBAL
+            - keyword: QUERY
+            - keyword: REWRITE
+        - keyword: TO
+        - access_target:
+            object_reference:
+              naked_identifier: dw_manager
+        - keyword: WITH
+        - keyword: ADMIN
+        - keyword: OPTION
+  - statement_terminator: ;
+  - statement:
+      access_statement:
+        grant_statement:
+        - keyword: GRANT
+        - access_permissions:
+            role_reference:
+              naked_identifier: dw_manager
+        - keyword: TO
+        - access_target:
+            object_reference:
+              naked_identifier: sh
+        - keyword: WITH
+        - keyword: ADMIN
+        - keyword: OPTION
+  - statement_terminator: ;
+  - statement:
+      access_statement:
+        grant_statement:
+        - keyword: GRANT
+        - access_permissions:
+            role_reference:
+              naked_identifier: dw_manager
+        - keyword: TO
+        - access_target:
+            object_reference:
+              naked_identifier: sh
+        - keyword: WITH
+        - keyword: DELEGATE
+        - keyword: OPTION
+  - statement_terminator: ;
+  - statement:
+      access_statement:
+        grant_statement:
+        - keyword: GRANT
+        - access_permissions:
+            access_permission:
+              keyword: SELECT
+        - keyword: 'ON'
+        - object_reference:
+          - naked_identifier: sh
+          - dot: .
+          - naked_identifier: sales
+        - keyword: TO
+        - access_target:
+            object_reference:
+              naked_identifier: warehouse_user
+  - statement_terminator: ;
+  - statement:
+      access_statement:
+        grant_statement:
+        - keyword: GRANT
+        - access_permissions:
+            role_reference:
+              naked_identifier: warehouse_user
+        - keyword: TO
+        - access_target:
+            object_reference:
+              naked_identifier: dw_manager
+  - statement_terminator: ;
+  - statement:
+      access_statement:
+        grant_statement:
+        - keyword: GRANT
+        - access_permissions:
+            access_permission:
+              keyword: INHERIT
+            access_object:
+              keyword: PRIVILEGES
+        - keyword: 'ON'
+        - keyword: USER
+        - object_reference:
+            naked_identifier: sh
+        - keyword: TO
+        - access_target:
+            object_reference:
+              naked_identifier: hr
+  - statement_terminator: ;
+  - statement:
+      access_statement:
+        grant_statement:
+        - keyword: GRANT
+        - access_permissions:
+            access_permission:
+              keyword: READ
+        - keyword: 'ON'
+        - keyword: DIRECTORY
+        - object_reference:
+            naked_identifier: bfile_dir
+        - keyword: TO
+        - access_target:
+            object_reference:
+              naked_identifier: hr
+        - keyword: WITH
+        - keyword: GRANT
+        - keyword: OPTION
+  - statement_terminator: ;
+  - statement:
+      access_statement:
+        grant_statement:
+        - keyword: GRANT
+        - access_permissions:
+            access_permission:
+              keyword: ALL
+        - keyword: 'ON'
+        - object_reference:
+            naked_identifier: bonuses
+        - keyword: TO
+        - access_target:
+            object_reference:
+              naked_identifier: hr
+        - keyword: WITH
+        - keyword: GRANT
+        - keyword: OPTION
+  - statement_terminator: ;
+  - statement:
+      access_statement:
+        grant_statement:
+        - keyword: GRANT
+        - access_permissions:
+          - access_permission:
+              keyword: SELECT
+          - comma: ','
+          - access_permission:
+              keyword: UPDATE
+        - keyword: 'ON'
+        - object_reference:
+            naked_identifier: emp_view
+        - keyword: TO
+        - access_target:
+            keyword: PUBLIC
+  - statement_terminator: ;
+  - statement:
+      access_statement:
+        grant_statement:
+        - keyword: GRANT
+        - access_permissions:
+            access_permission:
+              keyword: SELECT
+        - keyword: 'ON'
+        - object_reference:
+          - naked_identifier: oe
+          - dot: .
+          - naked_identifier: customers_seq
+        - keyword: TO
+        - access_target:
+            object_reference:
+              naked_identifier: hr
+  - statement_terminator: ;
+  - statement:
+      access_statement:
+        grant_statement:
+        - keyword: GRANT
+        - access_permissions:
+          - access_permission:
+              keyword: REFERENCES
+          - bracketed:
+              start_bracket: (
+              column_reference:
+                naked_identifier: employee_id
+              end_bracket: )
+          - comma: ','
+          - access_permission:
+              keyword: UPDATE
+          - bracketed:
+            - start_bracket: (
+            - column_reference:
+                naked_identifier: employee_id
+            - comma: ','
+            - column_reference:
+                naked_identifier: salary
+            - comma: ','
+            - column_reference:
+                naked_identifier: commission_pct
+            - end_bracket: )
+        - keyword: 'ON'
+        - object_reference:
+          - naked_identifier: hr
+          - dot: .
+          - naked_identifier: employees
+        - keyword: TO
+        - access_target:
+            object_reference:
+              naked_identifier: oe
+  - statement_terminator: ;

--- a/test/fixtures/dialects/oracle/hierarchical_queries.yml
+++ b/test/fixtures/dialects/oracle/hierarchical_queries.yml
@@ -3,571 +3,572 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 5cd22054b73c6bc9aebbea851f9df614763a44922e251854c368e9ce175ede44
+_hash: d70a0d24f8bf0d1ae04b488a871af46653fb56d1bd2c8e3c3ef0dfe69862648d
 file:
-- statement:
-    select_statement:
-      select_clause:
-      - keyword: SELECT
-      - select_clause_element:
-          column_reference:
-            naked_identifier: employee_id
-      - comma: ','
-      - select_clause_element:
-          column_reference:
-            naked_identifier: last_name
-      - comma: ','
-      - select_clause_element:
-          column_reference:
-            naked_identifier: manager_id
-      from_clause:
-        keyword: FROM
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: employees
-      hierarchical_query_clause:
-        connectby_clause:
-        - keyword: CONNECT
-        - keyword: BY
-        - expression:
-          - keyword: PRIOR
-          - column_reference:
-              naked_identifier: employee_id
-          - comparison_operator:
-              raw_comparison_operator: '='
-          - column_reference:
-              naked_identifier: manager_id
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-      - keyword: SELECT
-      - select_clause_element:
-          column_reference:
-            naked_identifier: employee_id
-      - comma: ','
-      - select_clause_element:
-          column_reference:
-            naked_identifier: last_name
-      - comma: ','
-      - select_clause_element:
-          column_reference:
-            naked_identifier: manager_id
-      - comma: ','
-      - select_clause_element:
-          keyword: LEVEL
-      from_clause:
-        keyword: FROM
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: employees
-      hierarchical_query_clause:
-        connectby_clause:
-        - keyword: CONNECT
-        - keyword: BY
-        - expression:
-          - keyword: PRIOR
-          - column_reference:
-              naked_identifier: employee_id
-          - comparison_operator:
-              raw_comparison_operator: '='
-          - column_reference:
-              naked_identifier: manager_id
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-      - keyword: SELECT
-      - select_clause_element:
-          column_reference:
-            naked_identifier: last_name
-      - comma: ','
-      - select_clause_element:
-          column_reference:
-            naked_identifier: employee_id
-      - comma: ','
-      - select_clause_element:
-          column_reference:
-            naked_identifier: manager_id
-      - comma: ','
-      - select_clause_element:
-          keyword: LEVEL
-      from_clause:
-        keyword: FROM
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: employees
-      hierarchical_query_clause:
-        startwith_clause:
-        - keyword: START
-        - keyword: WITH
-        - expression:
+  batch:
+  - statement:
+      select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
             column_reference:
               naked_identifier: employee_id
-            comparison_operator:
-              raw_comparison_operator: '='
-            numeric_literal: '100'
-        connectby_clause:
-        - keyword: CONNECT
-        - keyword: BY
-        - expression:
-          - keyword: PRIOR
-          - column_reference:
-              naked_identifier: employee_id
-          - comparison_operator:
-              raw_comparison_operator: '='
-          - column_reference:
-              naked_identifier: manager_id
-      orderby_clause:
-      - keyword: ORDER
-      - keyword: SIBLINGS
-      - keyword: BY
-      - column_reference:
-          naked_identifier: last_name
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-      - keyword: SELECT
-      - select_clause_element:
-          column_reference:
-            naked_identifier: last_name
-          alias_expression:
-            quoted_identifier: '"Employee"'
-      - comma: ','
-      - select_clause_element:
-          keyword: LEVEL
-      - comma: ','
-      - select_clause_element:
-          function:
-            function_name:
-              function_name_identifier: SYS_CONNECT_BY_PATH
-            function_contents:
-              bracketed:
-              - start_bracket: (
-              - expression:
-                  column_reference:
-                    naked_identifier: last_name
-              - comma: ','
-              - expression:
-                  quoted_literal: "'/'"
-              - end_bracket: )
-          alias_expression:
-            quoted_identifier: '"Path"'
-      from_clause:
-        keyword: FROM
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: employees
-      where_clause:
-        keyword: WHERE
-        expression:
-        - keyword: level
-        - comparison_operator:
-          - raw_comparison_operator: <
-          - raw_comparison_operator: '='
-        - numeric_literal: '3'
-        - binary_operator: AND
-        - column_reference:
-            naked_identifier: department_id
-        - comparison_operator:
-            raw_comparison_operator: '='
-        - numeric_literal: '80'
-      hierarchical_query_clause:
-        startwith_clause:
-        - keyword: START
-        - keyword: WITH
-        - expression:
+        - comma: ','
+        - select_clause_element:
             column_reference:
               naked_identifier: last_name
-            comparison_operator:
-              raw_comparison_operator: '='
-            quoted_literal: "'King'"
-        connectby_clause:
-        - keyword: CONNECT
-        - keyword: BY
-        - expression:
-          - keyword: PRIOR
-          - column_reference:
-              naked_identifier: employee_id
-          - comparison_operator:
-              raw_comparison_operator: '='
-          - column_reference:
+        - comma: ','
+        - select_clause_element:
+            column_reference:
               naked_identifier: manager_id
-          - binary_operator: AND
-          - keyword: LEVEL
-          - comparison_operator:
-            - raw_comparison_operator: <
-            - raw_comparison_operator: '='
-          - numeric_literal: '4'
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-      - keyword: SELECT
-      - select_clause_element:
-          column_reference:
-            naked_identifier: last_name
-          alias_expression:
-            quoted_identifier: '"Employee"'
-      - comma: ','
-      - select_clause_element:
-          column_reference:
-            naked_identifier: CONNECT_BY_ISCYCLE
-          alias_expression:
-            quoted_identifier: '"Cycle"'
-      - comma: ','
-      - select_clause_element:
-          keyword: LEVEL
-      - comma: ','
-      - select_clause_element:
-          function:
-            function_name:
-              function_name_identifier: SYS_CONNECT_BY_PATH
-            function_contents:
-              bracketed:
-              - start_bracket: (
-              - expression:
-                  column_reference:
-                    naked_identifier: last_name
-              - comma: ','
-              - expression:
-                  quoted_literal: "'/'"
-              - end_bracket: )
-          alias_expression:
-            quoted_identifier: '"Path"'
-      from_clause:
-        keyword: FROM
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: employees
-      where_clause:
-        keyword: WHERE
-        expression:
-        - keyword: level
-        - comparison_operator:
-          - raw_comparison_operator: <
-          - raw_comparison_operator: '='
-        - numeric_literal: '3'
-        - binary_operator: AND
-        - column_reference:
-            naked_identifier: department_id
-        - comparison_operator:
-            raw_comparison_operator: '='
-        - numeric_literal: '80'
-      hierarchical_query_clause:
-        startwith_clause:
-        - keyword: START
-        - keyword: WITH
-        - expression:
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: employees
+        hierarchical_query_clause:
+          connectby_clause:
+          - keyword: CONNECT
+          - keyword: BY
+          - expression:
+            - keyword: PRIOR
+            - column_reference:
+                naked_identifier: employee_id
+            - comparison_operator:
+                raw_comparison_operator: '='
+            - column_reference:
+                naked_identifier: manager_id
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            column_reference:
+              naked_identifier: employee_id
+        - comma: ','
+        - select_clause_element:
             column_reference:
               naked_identifier: last_name
-            comparison_operator:
-              raw_comparison_operator: '='
-            quoted_literal: "'King'"
-        connectby_clause:
-        - keyword: CONNECT
-        - keyword: BY
-        - keyword: NOCYCLE
-        - expression:
-          - keyword: PRIOR
-          - column_reference:
-              naked_identifier: employee_id
-          - comparison_operator:
-              raw_comparison_operator: '='
-          - column_reference:
-              naked_identifier: manager_id
-          - binary_operator: AND
-          - keyword: LEVEL
-          - comparison_operator:
-            - raw_comparison_operator: <
-            - raw_comparison_operator: '='
-          - numeric_literal: '4'
-      orderby_clause:
-      - keyword: ORDER
-      - keyword: BY
-      - column_reference:
-          quoted_identifier: '"Employee"'
-      - comma: ','
-      - column_reference:
-          quoted_identifier: '"Cycle"'
-      - comma: ','
-      - expression:
-          keyword: LEVEL
-      - comma: ','
-      - column_reference:
-          quoted_identifier: '"Path"'
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-        keyword: SELECT
-        select_clause_element:
-          function:
-            function_name:
-              function_name_identifier: LTRIM
-            function_contents:
-              bracketed:
-              - start_bracket: (
-              - expression:
-                  function:
-                    function_name:
-                      function_name_identifier: SYS_CONNECT_BY_PATH
-                    function_contents:
-                      bracketed:
-                      - start_bracket: (
-                      - expression:
-                          column_reference:
-                            naked_identifier: warehouse_id
-                      - comma: ','
-                      - expression:
-                          quoted_literal: "','"
-                      - end_bracket: )
-              - comma: ','
-              - expression:
-                  quoted_literal: "','"
-              - end_bracket: )
-      from_clause:
-        keyword: FROM
-        from_expression:
-          from_expression_element:
-            table_expression:
-              bracketed:
-                start_bracket: (
-                select_statement:
-                  select_clause:
-                  - keyword: SELECT
-                  - select_clause_element:
-                      keyword: ROWNUM
-                      alias_expression:
-                        naked_identifier: r
-                  - comma: ','
-                  - select_clause_element:
-                      column_reference:
-                        naked_identifier: warehouse_id
-                  from_clause:
-                    keyword: FROM
-                    from_expression:
-                      from_expression_element:
-                        table_expression:
-                          table_reference:
-                            naked_identifier: warehouses
-                end_bracket: )
-      where_clause:
-        keyword: WHERE
-        expression:
-          column_reference:
-            naked_identifier: CONNECT_BY_ISLEAF
-          comparison_operator:
-            raw_comparison_operator: '='
-          numeric_literal: '1'
-      hierarchical_query_clause:
-        startwith_clause:
-        - keyword: START
-        - keyword: WITH
-        - expression:
+        - comma: ','
+        - select_clause_element:
             column_reference:
-              naked_identifier: r
-            comparison_operator:
-              raw_comparison_operator: '='
-            numeric_literal: '1'
-        connectby_clause:
-        - keyword: CONNECT
-        - keyword: BY
-        - expression:
-          - column_reference:
-              naked_identifier: r
-          - comparison_operator:
-              raw_comparison_operator: '='
-          - keyword: PRIOR
-          - column_reference:
-              naked_identifier: r
-          - binary_operator: +
-          - numeric_literal: '1'
-      orderby_clause:
-      - keyword: ORDER
-      - keyword: BY
-      - column_reference:
-          naked_identifier: warehouse_id
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-      - keyword: SELECT
-      - select_clause_element:
-          column_reference:
-            naked_identifier: last_name
-          alias_expression:
-            quoted_identifier: '"Employee"'
-      - comma: ','
-      - select_clause_element:
-          keyword: CONNECT_BY_ROOT
-          naked_identifier: last_name
-          alias_expression:
-            quoted_identifier: '"Manager"'
-      - comma: ','
-      - select_clause_element:
-          expression:
+              naked_identifier: manager_id
+        - comma: ','
+        - select_clause_element:
             keyword: LEVEL
-            binary_operator: '-'
-            numeric_literal: '1'
-          alias_expression:
-            quoted_identifier: '"Pathlen"'
-      - comma: ','
-      - select_clause_element:
-          function:
-            function_name:
-              function_name_identifier: SYS_CONNECT_BY_PATH
-            function_contents:
-              bracketed:
-              - start_bracket: (
-              - expression:
-                  column_reference:
-                    naked_identifier: last_name
-              - comma: ','
-              - expression:
-                  quoted_literal: "'/'"
-              - end_bracket: )
-          alias_expression:
-            quoted_identifier: '"Path"'
-      from_clause:
-        keyword: FROM
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: employees
-      where_clause:
-        keyword: WHERE
-        expression:
-        - keyword: LEVEL
-        - comparison_operator:
-            raw_comparison_operator: '>'
-        - numeric_literal: '1'
-        - binary_operator: and
-        - column_reference:
-            naked_identifier: department_id
-        - comparison_operator:
-            raw_comparison_operator: '='
-        - numeric_literal: '110'
-      hierarchical_query_clause:
-        connectby_clause:
-        - keyword: CONNECT
-        - keyword: BY
-        - expression:
-          - keyword: PRIOR
-          - column_reference:
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: employees
+        hierarchical_query_clause:
+          connectby_clause:
+          - keyword: CONNECT
+          - keyword: BY
+          - expression:
+            - keyword: PRIOR
+            - column_reference:
+                naked_identifier: employee_id
+            - comparison_operator:
+                raw_comparison_operator: '='
+            - column_reference:
+                naked_identifier: manager_id
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            column_reference:
+              naked_identifier: last_name
+        - comma: ','
+        - select_clause_element:
+            column_reference:
               naked_identifier: employee_id
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+              naked_identifier: manager_id
+        - comma: ','
+        - select_clause_element:
+            keyword: LEVEL
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: employees
+        hierarchical_query_clause:
+          startwith_clause:
+          - keyword: START
+          - keyword: WITH
+          - expression:
+              column_reference:
+                naked_identifier: employee_id
+              comparison_operator:
+                raw_comparison_operator: '='
+              numeric_literal: '100'
+          connectby_clause:
+          - keyword: CONNECT
+          - keyword: BY
+          - expression:
+            - keyword: PRIOR
+            - column_reference:
+                naked_identifier: employee_id
+            - comparison_operator:
+                raw_comparison_operator: '='
+            - column_reference:
+                naked_identifier: manager_id
+        orderby_clause:
+        - keyword: ORDER
+        - keyword: SIBLINGS
+        - keyword: BY
+        - column_reference:
+            naked_identifier: last_name
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            column_reference:
+              naked_identifier: last_name
+            alias_expression:
+              quoted_identifier: '"Employee"'
+        - comma: ','
+        - select_clause_element:
+            keyword: LEVEL
+        - comma: ','
+        - select_clause_element:
+            function:
+              function_name:
+                function_name_identifier: SYS_CONNECT_BY_PATH
+              function_contents:
+                bracketed:
+                - start_bracket: (
+                - expression:
+                    column_reference:
+                      naked_identifier: last_name
+                - comma: ','
+                - expression:
+                    quoted_literal: "'/'"
+                - end_bracket: )
+            alias_expression:
+              quoted_identifier: '"Path"'
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: employees
+        where_clause:
+          keyword: WHERE
+          expression:
+          - keyword: level
+          - comparison_operator:
+            - raw_comparison_operator: <
+            - raw_comparison_operator: '='
+          - numeric_literal: '3'
+          - binary_operator: AND
+          - column_reference:
+              naked_identifier: department_id
           - comparison_operator:
               raw_comparison_operator: '='
-          - column_reference:
-              naked_identifier: manager_id
-      orderby_clause:
-      - keyword: ORDER
-      - keyword: BY
-      - column_reference:
-          quoted_identifier: '"Employee"'
-      - comma: ','
-      - column_reference:
-          quoted_identifier: '"Manager"'
-      - comma: ','
-      - column_reference:
-          quoted_identifier: '"Pathlen"'
-      - comma: ','
-      - column_reference:
-          quoted_identifier: '"Path"'
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-      - keyword: SELECT
-      - select_clause_element:
-          column_reference:
-            naked_identifier: name
-      - comma: ','
-      - select_clause_element:
-          function:
-            function_name:
-              function_name_identifier: SUM
-            function_contents:
-              bracketed:
-                start_bracket: (
-                expression:
-                  column_reference:
-                    naked_identifier: salary
-                end_bracket: )
-          alias_expression:
-            quoted_identifier: '"Total_Salary"'
-      from_clause:
-        keyword: FROM
-        from_expression:
-          from_expression_element:
-            table_expression:
-              bracketed:
-                start_bracket: (
-                select_statement:
-                  select_clause:
-                  - keyword: SELECT
-                  - select_clause_element:
-                      keyword: CONNECT_BY_ROOT
+          - numeric_literal: '80'
+        hierarchical_query_clause:
+          startwith_clause:
+          - keyword: START
+          - keyword: WITH
+          - expression:
+              column_reference:
+                naked_identifier: last_name
+              comparison_operator:
+                raw_comparison_operator: '='
+              quoted_literal: "'King'"
+          connectby_clause:
+          - keyword: CONNECT
+          - keyword: BY
+          - expression:
+            - keyword: PRIOR
+            - column_reference:
+                naked_identifier: employee_id
+            - comparison_operator:
+                raw_comparison_operator: '='
+            - column_reference:
+                naked_identifier: manager_id
+            - binary_operator: AND
+            - keyword: LEVEL
+            - comparison_operator:
+              - raw_comparison_operator: <
+              - raw_comparison_operator: '='
+            - numeric_literal: '4'
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            column_reference:
+              naked_identifier: last_name
+            alias_expression:
+              quoted_identifier: '"Employee"'
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+              naked_identifier: CONNECT_BY_ISCYCLE
+            alias_expression:
+              quoted_identifier: '"Cycle"'
+        - comma: ','
+        - select_clause_element:
+            keyword: LEVEL
+        - comma: ','
+        - select_clause_element:
+            function:
+              function_name:
+                function_name_identifier: SYS_CONNECT_BY_PATH
+              function_contents:
+                bracketed:
+                - start_bracket: (
+                - expression:
+                    column_reference:
                       naked_identifier: last_name
-                      alias_expression:
-                        alias_operator:
-                          keyword: as
-                        naked_identifier: name
-                  - comma: ','
-                  - select_clause_element:
-                      column_reference:
-                        naked_identifier: Salary
-                  from_clause:
-                    keyword: FROM
-                    from_expression:
-                      from_expression_element:
-                        table_expression:
-                          table_reference:
-                            naked_identifier: employees
-                  where_clause:
-                    keyword: WHERE
-                    expression:
-                      column_reference:
-                        naked_identifier: department_id
-                      comparison_operator:
-                        raw_comparison_operator: '='
-                      numeric_literal: '110'
-                  hierarchical_query_clause:
-                    connectby_clause:
-                    - keyword: CONNECT
-                    - keyword: BY
-                    - expression:
-                      - keyword: PRIOR
-                      - column_reference:
-                          naked_identifier: employee_id
-                      - comparison_operator:
+                - comma: ','
+                - expression:
+                    quoted_literal: "'/'"
+                - end_bracket: )
+            alias_expression:
+              quoted_identifier: '"Path"'
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: employees
+        where_clause:
+          keyword: WHERE
+          expression:
+          - keyword: level
+          - comparison_operator:
+            - raw_comparison_operator: <
+            - raw_comparison_operator: '='
+          - numeric_literal: '3'
+          - binary_operator: AND
+          - column_reference:
+              naked_identifier: department_id
+          - comparison_operator:
+              raw_comparison_operator: '='
+          - numeric_literal: '80'
+        hierarchical_query_clause:
+          startwith_clause:
+          - keyword: START
+          - keyword: WITH
+          - expression:
+              column_reference:
+                naked_identifier: last_name
+              comparison_operator:
+                raw_comparison_operator: '='
+              quoted_literal: "'King'"
+          connectby_clause:
+          - keyword: CONNECT
+          - keyword: BY
+          - keyword: NOCYCLE
+          - expression:
+            - keyword: PRIOR
+            - column_reference:
+                naked_identifier: employee_id
+            - comparison_operator:
+                raw_comparison_operator: '='
+            - column_reference:
+                naked_identifier: manager_id
+            - binary_operator: AND
+            - keyword: LEVEL
+            - comparison_operator:
+              - raw_comparison_operator: <
+              - raw_comparison_operator: '='
+            - numeric_literal: '4'
+        orderby_clause:
+        - keyword: ORDER
+        - keyword: BY
+        - column_reference:
+            quoted_identifier: '"Employee"'
+        - comma: ','
+        - column_reference:
+            quoted_identifier: '"Cycle"'
+        - comma: ','
+        - expression:
+            keyword: LEVEL
+        - comma: ','
+        - column_reference:
+            quoted_identifier: '"Path"'
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            function:
+              function_name:
+                function_name_identifier: LTRIM
+              function_contents:
+                bracketed:
+                - start_bracket: (
+                - expression:
+                    function:
+                      function_name:
+                        function_name_identifier: SYS_CONNECT_BY_PATH
+                      function_contents:
+                        bracketed:
+                        - start_bracket: (
+                        - expression:
+                            column_reference:
+                              naked_identifier: warehouse_id
+                        - comma: ','
+                        - expression:
+                            quoted_literal: "','"
+                        - end_bracket: )
+                - comma: ','
+                - expression:
+                    quoted_literal: "','"
+                - end_bracket: )
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                bracketed:
+                  start_bracket: (
+                  select_statement:
+                    select_clause:
+                    - keyword: SELECT
+                    - select_clause_element:
+                        keyword: ROWNUM
+                        alias_expression:
+                          naked_identifier: r
+                    - comma: ','
+                    - select_clause_element:
+                        column_reference:
+                          naked_identifier: warehouse_id
+                    from_clause:
+                      keyword: FROM
+                      from_expression:
+                        from_expression_element:
+                          table_expression:
+                            table_reference:
+                              naked_identifier: warehouses
+                  end_bracket: )
+        where_clause:
+          keyword: WHERE
+          expression:
+            column_reference:
+              naked_identifier: CONNECT_BY_ISLEAF
+            comparison_operator:
+              raw_comparison_operator: '='
+            numeric_literal: '1'
+        hierarchical_query_clause:
+          startwith_clause:
+          - keyword: START
+          - keyword: WITH
+          - expression:
+              column_reference:
+                naked_identifier: r
+              comparison_operator:
+                raw_comparison_operator: '='
+              numeric_literal: '1'
+          connectby_clause:
+          - keyword: CONNECT
+          - keyword: BY
+          - expression:
+            - column_reference:
+                naked_identifier: r
+            - comparison_operator:
+                raw_comparison_operator: '='
+            - keyword: PRIOR
+            - column_reference:
+                naked_identifier: r
+            - binary_operator: +
+            - numeric_literal: '1'
+        orderby_clause:
+        - keyword: ORDER
+        - keyword: BY
+        - column_reference:
+            naked_identifier: warehouse_id
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            column_reference:
+              naked_identifier: last_name
+            alias_expression:
+              quoted_identifier: '"Employee"'
+        - comma: ','
+        - select_clause_element:
+            keyword: CONNECT_BY_ROOT
+            naked_identifier: last_name
+            alias_expression:
+              quoted_identifier: '"Manager"'
+        - comma: ','
+        - select_clause_element:
+            expression:
+              keyword: LEVEL
+              binary_operator: '-'
+              numeric_literal: '1'
+            alias_expression:
+              quoted_identifier: '"Pathlen"'
+        - comma: ','
+        - select_clause_element:
+            function:
+              function_name:
+                function_name_identifier: SYS_CONNECT_BY_PATH
+              function_contents:
+                bracketed:
+                - start_bracket: (
+                - expression:
+                    column_reference:
+                      naked_identifier: last_name
+                - comma: ','
+                - expression:
+                    quoted_literal: "'/'"
+                - end_bracket: )
+            alias_expression:
+              quoted_identifier: '"Path"'
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: employees
+        where_clause:
+          keyword: WHERE
+          expression:
+          - keyword: LEVEL
+          - comparison_operator:
+              raw_comparison_operator: '>'
+          - numeric_literal: '1'
+          - binary_operator: and
+          - column_reference:
+              naked_identifier: department_id
+          - comparison_operator:
+              raw_comparison_operator: '='
+          - numeric_literal: '110'
+        hierarchical_query_clause:
+          connectby_clause:
+          - keyword: CONNECT
+          - keyword: BY
+          - expression:
+            - keyword: PRIOR
+            - column_reference:
+                naked_identifier: employee_id
+            - comparison_operator:
+                raw_comparison_operator: '='
+            - column_reference:
+                naked_identifier: manager_id
+        orderby_clause:
+        - keyword: ORDER
+        - keyword: BY
+        - column_reference:
+            quoted_identifier: '"Employee"'
+        - comma: ','
+        - column_reference:
+            quoted_identifier: '"Manager"'
+        - comma: ','
+        - column_reference:
+            quoted_identifier: '"Pathlen"'
+        - comma: ','
+        - column_reference:
+            quoted_identifier: '"Path"'
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            column_reference:
+              naked_identifier: name
+        - comma: ','
+        - select_clause_element:
+            function:
+              function_name:
+                function_name_identifier: SUM
+              function_contents:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    column_reference:
+                      naked_identifier: salary
+                  end_bracket: )
+            alias_expression:
+              quoted_identifier: '"Total_Salary"'
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                bracketed:
+                  start_bracket: (
+                  select_statement:
+                    select_clause:
+                    - keyword: SELECT
+                    - select_clause_element:
+                        keyword: CONNECT_BY_ROOT
+                        naked_identifier: last_name
+                        alias_expression:
+                          alias_operator:
+                            keyword: as
+                          naked_identifier: name
+                    - comma: ','
+                    - select_clause_element:
+                        column_reference:
+                          naked_identifier: Salary
+                    from_clause:
+                      keyword: FROM
+                      from_expression:
+                        from_expression_element:
+                          table_expression:
+                            table_reference:
+                              naked_identifier: employees
+                    where_clause:
+                      keyword: WHERE
+                      expression:
+                        column_reference:
+                          naked_identifier: department_id
+                        comparison_operator:
                           raw_comparison_operator: '='
-                      - column_reference:
-                          naked_identifier: manager_id
-                end_bracket: )
-      groupby_clause:
-      - keyword: GROUP
-      - keyword: BY
-      - column_reference:
-          naked_identifier: name
-      orderby_clause:
-      - keyword: ORDER
-      - keyword: BY
-      - column_reference:
-          naked_identifier: name
-      - comma: ','
-      - column_reference:
-          quoted_identifier: '"Total_Salary"'
-- statement_terminator: ;
+                        numeric_literal: '110'
+                    hierarchical_query_clause:
+                      connectby_clause:
+                      - keyword: CONNECT
+                      - keyword: BY
+                      - expression:
+                        - keyword: PRIOR
+                        - column_reference:
+                            naked_identifier: employee_id
+                        - comparison_operator:
+                            raw_comparison_operator: '='
+                        - column_reference:
+                            naked_identifier: manager_id
+                  end_bracket: )
+        groupby_clause:
+        - keyword: GROUP
+        - keyword: BY
+        - column_reference:
+            naked_identifier: name
+        orderby_clause:
+        - keyword: ORDER
+        - keyword: BY
+        - column_reference:
+            naked_identifier: name
+        - comma: ','
+        - column_reference:
+            quoted_identifier: '"Total_Salary"'
+  - statement_terminator: ;

--- a/test/fixtures/dialects/oracle/if.yml
+++ b/test/fixtures/dialects/oracle/if.yml
@@ -3,729 +3,737 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 80731e713fe589d548488105199e012c434011c05398b3965bc017938b8d7255
+_hash: fda034df4173512d8220e1e2e5403874fc26b3bd889b0eba2b99ab53a5d61843
 file:
-- statement:
-    begin_end_block:
-    - declare_segment:
-        keyword: DECLARE
-        create_procedure_statement:
-        - keyword: PROCEDURE
-        - function_name:
-            function_name_identifier: p
-        - function_parameter_list:
-            bracketed:
-            - start_bracket: (
-            - parameter: sales
+- batch:
+    statement:
+      begin_end_block:
+      - declare_segment:
+          keyword: DECLARE
+          create_procedure_statement:
+          - keyword: PROCEDURE
+          - function_name:
+              function_name_identifier: p
+          - function_parameter_list:
+              bracketed:
+              - start_bracket: (
+              - parameter: sales
+              - data_type:
+                  data_type_identifier: NUMBER
+              - comma: ','
+              - parameter: quota
+              - data_type:
+                  data_type_identifier: NUMBER
+              - comma: ','
+              - parameter: emp_id
+              - data_type:
+                  data_type_identifier: NUMBER
+              - end_bracket: )
+          - keyword: IS
+          - declare_segment:
+            - naked_identifier: bonus
             - data_type:
                 data_type_identifier: NUMBER
-            - comma: ','
-            - parameter: quota
+            - assignment_operator: :=
+            - expression:
+                numeric_literal: '0'
+            - statement_terminator: ;
+            - naked_identifier: updated
             - data_type:
-                data_type_identifier: NUMBER
-            - comma: ','
-            - parameter: emp_id
-            - data_type:
-                data_type_identifier: NUMBER
-            - end_bracket: )
-        - keyword: IS
-        - declare_segment:
-          - naked_identifier: bonus
-          - data_type:
-              data_type_identifier: NUMBER
-          - assignment_operator: :=
-          - expression:
-              numeric_literal: '0'
-          - statement_terminator: ;
-          - naked_identifier: updated
-          - data_type:
-              data_type_identifier: VARCHAR2
-              bracketed_arguments:
-                bracketed:
-                  start_bracket: (
-                  numeric_literal: '3'
-                  end_bracket: )
-          - assignment_operator: :=
-          - expression:
-              quoted_literal: "'No'"
-          - statement_terminator: ;
-        - begin_end_block:
-          - keyword: BEGIN
-          - statement:
-              if_then_statement:
-              - if_clause:
-                - keyword: IF
-                - expression:
-                    column_reference:
-                      naked_identifier: sales
-                    comparison_operator:
-                      raw_comparison_operator: '>'
-                    bracketed:
-                      start_bracket: (
-                      expression:
-                        column_reference:
-                          naked_identifier: quota
-                        binary_operator: +
-                        numeric_literal: '200'
-                      end_bracket: )
-                - keyword: THEN
-              - statement:
-                  assignment_segment_statement:
-                    object_reference:
-                      naked_identifier: bonus
-                    assignment_operator: :=
-                    expression:
-                      bracketed:
-                        start_bracket: (
-                        expression:
-                        - column_reference:
-                            naked_identifier: sales
-                        - binary_operator: '-'
-                        - column_reference:
-                            naked_identifier: quota
-                        end_bracket: )
-                      binary_operator: /
-                      numeric_literal: '4'
-              - statement_terminator: ;
-              - statement:
-                  update_statement:
-                    keyword: UPDATE
-                    table_reference:
-                      naked_identifier: employees
-                    set_clause_list:
-                      keyword: SET
-                      set_clause:
-                        column_reference:
-                          naked_identifier: salary
-                        comparison_operator:
-                          raw_comparison_operator: '='
-                        expression:
-                        - column_reference:
-                            naked_identifier: salary
-                        - binary_operator: +
-                        - column_reference:
-                            naked_identifier: bonus
-                    where_clause:
-                      keyword: WHERE
-                      expression:
-                      - column_reference:
-                          naked_identifier: employee_id
-                      - comparison_operator:
-                          raw_comparison_operator: '='
-                      - column_reference:
-                          naked_identifier: emp_id
-              - statement_terminator: ;
-              - statement:
-                  assignment_segment_statement:
-                    object_reference:
-                      naked_identifier: updated
-                    assignment_operator: :=
-                    expression:
-                      quoted_literal: "'Yes'"
-              - statement_terminator: ;
-              - keyword: END
-              - keyword: IF
-          - statement_terminator: ;
-          - statement:
-              function:
-                function_name:
-                  naked_identifier: DBMS_OUTPUT
-                  dot: .
-                  function_name_identifier: PUT_LINE
-                function_contents:
+                data_type_identifier: VARCHAR2
+                bracketed_arguments:
                   bracketed:
                     start_bracket: (
-                    expression:
-                    - quoted_literal: "'Table updated?  '"
-                    - binary_operator:
-                      - pipe: '|'
-                      - pipe: '|'
-                    - column_reference:
-                        naked_identifier: updated
-                    - binary_operator:
-                      - pipe: '|'
-                      - pipe: '|'
-                    - quoted_literal: "', '"
-                    - binary_operator:
-                      - pipe: '|'
-                      - pipe: '|'
-                    - quoted_literal: "'bonus = '"
-                    - binary_operator:
-                      - pipe: '|'
-                      - pipe: '|'
-                    - column_reference:
-                        naked_identifier: bonus
-                    - binary_operator:
-                      - pipe: '|'
-                      - pipe: '|'
-                    - quoted_literal: "'.'"
+                    numeric_literal: '3'
                     end_bracket: )
-          - statement_terminator: ;
-          - keyword: END
-          - object_reference:
-              naked_identifier: p
-        - statement_terminator: ;
-    - keyword: BEGIN
-    - statement:
-        function:
-          function_name:
-            function_name_identifier: p
-          function_contents:
-            bracketed:
-            - start_bracket: (
+            - assignment_operator: :=
             - expression:
-                numeric_literal: '10100'
-            - comma: ','
-            - expression:
-                numeric_literal: '10000'
-            - comma: ','
-            - expression:
-                numeric_literal: '120'
-            - end_bracket: )
-    - statement_terminator: ;
-    - statement:
-        function:
-          function_name:
-            function_name_identifier: p
-          function_contents:
-            bracketed:
-            - start_bracket: (
-            - expression:
-                numeric_literal: '10500'
-            - comma: ','
-            - expression:
-                numeric_literal: '10000'
-            - comma: ','
-            - expression:
-                numeric_literal: '121'
-            - end_bracket: )
-    - statement_terminator: ;
-    - keyword: END
-- statement_terminator: ;
-- statement_terminator: /
-- statement:
-    begin_end_block:
-    - declare_segment:
-        keyword: DECLARE
-        create_procedure_statement:
-        - keyword: PROCEDURE
-        - function_name:
-            function_name_identifier: p
-        - function_parameter_list:
-            bracketed:
-            - start_bracket: (
-            - parameter: sales
-            - data_type:
-                data_type_identifier: NUMBER
-            - comma: ','
-            - parameter: quota
-            - data_type:
-                data_type_identifier: NUMBER
-            - comma: ','
-            - parameter: emp_id
-            - data_type:
-                data_type_identifier: NUMBER
-            - end_bracket: )
-        - keyword: IS
-        - declare_segment:
-            naked_identifier: bonus
-            data_type:
-              data_type_identifier: NUMBER
-            assignment_operator: :=
-            expression:
-              numeric_literal: '0'
-            statement_terminator: ;
-        - begin_end_block:
-          - keyword: BEGIN
-          - statement:
-              if_then_statement:
-              - if_clause:
-                - keyword: IF
-                - expression:
-                    column_reference:
-                      naked_identifier: sales
-                    comparison_operator:
-                      raw_comparison_operator: '>'
-                    bracketed:
-                      start_bracket: (
-                      expression:
-                        column_reference:
-                          naked_identifier: quota
-                        binary_operator: +
-                        numeric_literal: '200'
-                      end_bracket: )
-                - keyword: THEN
-              - statement:
-                  assignment_segment_statement:
-                    object_reference:
-                      naked_identifier: bonus
-                    assignment_operator: :=
-                    expression:
-                      bracketed:
-                        start_bracket: (
-                        expression:
-                        - column_reference:
-                            naked_identifier: sales
-                        - binary_operator: '-'
-                        - column_reference:
-                            naked_identifier: quota
-                        end_bracket: )
-                      binary_operator: /
-                      numeric_literal: '4'
-              - statement_terminator: ;
-              - keyword: ELSE
-              - statement:
-                  assignment_segment_statement:
-                    object_reference:
-                      naked_identifier: bonus
-                    assignment_operator: :=
-                    expression:
-                      numeric_literal: '50'
-              - statement_terminator: ;
-              - keyword: END
-              - keyword: IF
-          - statement_terminator: ;
-          - statement:
-              function:
-                function_name:
-                  naked_identifier: DBMS_OUTPUT
-                  dot: .
-                  function_name_identifier: PUT_LINE
-                function_contents:
-                  bracketed:
-                    start_bracket: (
-                    expression:
-                      quoted_literal: "'bonus = '"
-                      binary_operator:
-                      - pipe: '|'
-                      - pipe: '|'
-                      column_reference:
-                        naked_identifier: bonus
-                    end_bracket: )
-          - statement_terminator: ;
-          - statement:
-              update_statement:
-                keyword: UPDATE
-                table_reference:
-                  naked_identifier: employees
-                set_clause_list:
-                  keyword: SET
-                  set_clause:
-                    column_reference:
-                      naked_identifier: salary
-                    comparison_operator:
-                      raw_comparison_operator: '='
-                    expression:
-                    - column_reference:
-                        naked_identifier: salary
-                    - binary_operator: +
-                    - column_reference:
-                        naked_identifier: bonus
-                where_clause:
-                  keyword: WHERE
-                  expression:
-                  - column_reference:
-                      naked_identifier: employee_id
-                  - comparison_operator:
-                      raw_comparison_operator: '='
-                  - column_reference:
-                      naked_identifier: emp_id
-          - statement_terminator: ;
-          - keyword: END
-          - object_reference:
-              naked_identifier: p
-        - statement_terminator: ;
-    - keyword: BEGIN
-    - statement:
-        function:
-          function_name:
-            function_name_identifier: p
-          function_contents:
-            bracketed:
-            - start_bracket: (
-            - expression:
-                numeric_literal: '10100'
-            - comma: ','
-            - expression:
-                numeric_literal: '10000'
-            - comma: ','
-            - expression:
-                numeric_literal: '120'
-            - end_bracket: )
-    - statement_terminator: ;
-    - statement:
-        function:
-          function_name:
-            function_name_identifier: p
-          function_contents:
-            bracketed:
-            - start_bracket: (
-            - expression:
-                numeric_literal: '10500'
-            - comma: ','
-            - expression:
-                numeric_literal: '10000'
-            - comma: ','
-            - expression:
-                numeric_literal: '121'
-            - end_bracket: )
-    - statement_terminator: ;
-    - keyword: END
-- statement_terminator: ;
-- statement_terminator: /
-- statement:
-    begin_end_block:
-    - declare_segment:
-        keyword: DECLARE
-        create_procedure_statement:
-        - keyword: PROCEDURE
-        - function_name:
-            function_name_identifier: p
-        - function_parameter_list:
-            bracketed:
-            - start_bracket: (
-            - parameter: sales
-            - data_type:
-                data_type_identifier: NUMBER
-            - comma: ','
-            - parameter: quota
-            - data_type:
-                data_type_identifier: NUMBER
-            - comma: ','
-            - parameter: emp_id
-            - data_type:
-                data_type_identifier: NUMBER
-            - end_bracket: )
-        - keyword: IS
-        - declare_segment:
-            naked_identifier: bonus
-            data_type:
-              data_type_identifier: NUMBER
-            assignment_operator: :=
-            expression:
-              numeric_literal: '0'
-            statement_terminator: ;
-        - begin_end_block:
-          - keyword: BEGIN
-          - statement:
-              if_then_statement:
-              - if_clause:
-                - keyword: IF
-                - expression:
-                    column_reference:
-                      naked_identifier: sales
-                    comparison_operator:
-                      raw_comparison_operator: '>'
-                    bracketed:
-                      start_bracket: (
-                      expression:
-                        column_reference:
-                          naked_identifier: quota
-                        binary_operator: +
-                        numeric_literal: '200'
-                      end_bracket: )
-                - keyword: THEN
-              - statement:
-                  assignment_segment_statement:
-                    object_reference:
-                      naked_identifier: bonus
-                    assignment_operator: :=
-                    expression:
-                      bracketed:
-                        start_bracket: (
-                        expression:
-                        - column_reference:
-                            naked_identifier: sales
-                        - binary_operator: '-'
-                        - column_reference:
-                            naked_identifier: quota
-                        end_bracket: )
-                      binary_operator: /
-                      numeric_literal: '4'
-              - statement_terminator: ;
-              - keyword: ELSE
-              - statement:
-                  if_then_statement:
-                  - if_clause:
-                    - keyword: IF
-                    - expression:
-                      - column_reference:
-                          naked_identifier: sales
-                      - comparison_operator:
-                          raw_comparison_operator: '>'
-                      - column_reference:
-                          naked_identifier: quota
-                    - keyword: THEN
-                  - statement:
-                      assignment_segment_statement:
-                        object_reference:
-                          naked_identifier: bonus
-                        assignment_operator: :=
-                        expression:
-                          numeric_literal: '50'
-                  - statement_terminator: ;
-                  - keyword: ELSE
-                  - statement:
-                      assignment_segment_statement:
-                        object_reference:
-                          naked_identifier: bonus
-                        assignment_operator: :=
-                        expression:
-                          numeric_literal: '0'
-                  - statement_terminator: ;
-                  - keyword: END
+                quoted_literal: "'No'"
+            - statement_terminator: ;
+          - begin_end_block:
+            - keyword: BEGIN
+            - statement:
+                if_then_statement:
+                - if_clause:
                   - keyword: IF
-              - statement_terminator: ;
-              - keyword: END
-              - keyword: IF
-          - statement_terminator: ;
-          - statement:
-              function:
-                function_name:
-                  naked_identifier: DBMS_OUTPUT
-                  dot: .
-                  function_name_identifier: PUT_LINE
-                function_contents:
-                  bracketed:
-                    start_bracket: (
-                    expression:
-                      quoted_literal: "'bonus = '"
-                      binary_operator:
-                      - pipe: '|'
-                      - pipe: '|'
+                  - expression:
                       column_reference:
+                        naked_identifier: sales
+                      comparison_operator:
+                        raw_comparison_operator: '>'
+                      bracketed:
+                        start_bracket: (
+                        expression:
+                          column_reference:
+                            naked_identifier: quota
+                          binary_operator: +
+                          numeric_literal: '200'
+                        end_bracket: )
+                  - keyword: THEN
+                - statement:
+                    assignment_segment_statement:
+                      object_reference:
                         naked_identifier: bonus
-                    end_bracket: )
+                      assignment_operator: :=
+                      expression:
+                        bracketed:
+                          start_bracket: (
+                          expression:
+                          - column_reference:
+                              naked_identifier: sales
+                          - binary_operator: '-'
+                          - column_reference:
+                              naked_identifier: quota
+                          end_bracket: )
+                        binary_operator: /
+                        numeric_literal: '4'
+                - statement_terminator: ;
+                - statement:
+                    update_statement:
+                      keyword: UPDATE
+                      table_reference:
+                        naked_identifier: employees
+                      set_clause_list:
+                        keyword: SET
+                        set_clause:
+                          column_reference:
+                            naked_identifier: salary
+                          comparison_operator:
+                            raw_comparison_operator: '='
+                          expression:
+                          - column_reference:
+                              naked_identifier: salary
+                          - binary_operator: +
+                          - column_reference:
+                              naked_identifier: bonus
+                      where_clause:
+                        keyword: WHERE
+                        expression:
+                        - column_reference:
+                            naked_identifier: employee_id
+                        - comparison_operator:
+                            raw_comparison_operator: '='
+                        - column_reference:
+                            naked_identifier: emp_id
+                - statement_terminator: ;
+                - statement:
+                    assignment_segment_statement:
+                      object_reference:
+                        naked_identifier: updated
+                      assignment_operator: :=
+                      expression:
+                        quoted_literal: "'Yes'"
+                - statement_terminator: ;
+                - keyword: END
+                - keyword: IF
+            - statement_terminator: ;
+            - statement:
+                function:
+                  function_name:
+                    naked_identifier: DBMS_OUTPUT
+                    dot: .
+                    function_name_identifier: PUT_LINE
+                  function_contents:
+                    bracketed:
+                      start_bracket: (
+                      expression:
+                      - quoted_literal: "'Table updated?  '"
+                      - binary_operator:
+                        - pipe: '|'
+                        - pipe: '|'
+                      - column_reference:
+                          naked_identifier: updated
+                      - binary_operator:
+                        - pipe: '|'
+                        - pipe: '|'
+                      - quoted_literal: "', '"
+                      - binary_operator:
+                        - pipe: '|'
+                        - pipe: '|'
+                      - quoted_literal: "'bonus = '"
+                      - binary_operator:
+                        - pipe: '|'
+                        - pipe: '|'
+                      - column_reference:
+                          naked_identifier: bonus
+                      - binary_operator:
+                        - pipe: '|'
+                        - pipe: '|'
+                      - quoted_literal: "'.'"
+                      end_bracket: )
+            - statement_terminator: ;
+            - keyword: END
+            - object_reference:
+                naked_identifier: p
           - statement_terminator: ;
-          - statement:
-              update_statement:
-                keyword: UPDATE
-                table_reference:
-                  naked_identifier: employees
-                set_clause_list:
-                  keyword: SET
-                  set_clause:
-                    column_reference:
-                      naked_identifier: salary
-                    comparison_operator:
-                      raw_comparison_operator: '='
-                    expression:
-                    - column_reference:
-                        naked_identifier: salary
-                    - binary_operator: +
-                    - column_reference:
-                        naked_identifier: bonus
-                where_clause:
-                  keyword: WHERE
-                  expression:
-                  - column_reference:
-                      naked_identifier: employee_id
-                  - comparison_operator:
-                      raw_comparison_operator: '='
-                  - column_reference:
-                      naked_identifier: emp_id
-          - statement_terminator: ;
-          - keyword: END
-          - object_reference:
-              naked_identifier: p
-        - statement_terminator: ;
-    - keyword: BEGIN
-    - statement:
-        function:
-          function_name:
-            function_name_identifier: p
-          function_contents:
-            bracketed:
-            - start_bracket: (
-            - expression:
-                numeric_literal: '10100'
-            - comma: ','
-            - expression:
-                numeric_literal: '10000'
-            - comma: ','
-            - expression:
-                numeric_literal: '120'
-            - end_bracket: )
-    - statement_terminator: ;
-    - statement:
-        function:
-          function_name:
-            function_name_identifier: p
-          function_contents:
-            bracketed:
-            - start_bracket: (
-            - expression:
-                numeric_literal: '10500'
-            - comma: ','
-            - expression:
-                numeric_literal: '10000'
-            - comma: ','
-            - expression:
-                numeric_literal: '121'
-            - end_bracket: )
-    - statement_terminator: ;
-    - statement:
-        function:
-          function_name:
-            function_name_identifier: p
-          function_contents:
-            bracketed:
-            - start_bracket: (
-            - expression:
-                numeric_literal: '9500'
-            - comma: ','
-            - expression:
-                numeric_literal: '10000'
-            - comma: ','
-            - expression:
-                numeric_literal: '122'
-            - end_bracket: )
-    - statement_terminator: ;
-    - keyword: END
-- statement_terminator: ;
-- statement_terminator: /
-- statement:
-    begin_end_block:
-    - declare_segment:
-        keyword: DECLARE
-        create_procedure_statement:
-        - keyword: PROCEDURE
-        - function_name:
-            function_name_identifier: p
-        - function_parameter_list:
-            bracketed:
-              start_bracket: (
-              parameter: sales
+      - keyword: BEGIN
+      - statement:
+          function:
+            function_name:
+              function_name_identifier: p
+            function_contents:
+              bracketed:
+              - start_bracket: (
+              - expression:
+                  numeric_literal: '10100'
+              - comma: ','
+              - expression:
+                  numeric_literal: '10000'
+              - comma: ','
+              - expression:
+                  numeric_literal: '120'
+              - end_bracket: )
+      - statement_terminator: ;
+      - statement:
+          function:
+            function_name:
+              function_name_identifier: p
+            function_contents:
+              bracketed:
+              - start_bracket: (
+              - expression:
+                  numeric_literal: '10500'
+              - comma: ','
+              - expression:
+                  numeric_literal: '10000'
+              - comma: ','
+              - expression:
+                  numeric_literal: '121'
+              - end_bracket: )
+      - statement_terminator: ;
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      begin_end_block:
+      - declare_segment:
+          keyword: DECLARE
+          create_procedure_statement:
+          - keyword: PROCEDURE
+          - function_name:
+              function_name_identifier: p
+          - function_parameter_list:
+              bracketed:
+              - start_bracket: (
+              - parameter: sales
+              - data_type:
+                  data_type_identifier: NUMBER
+              - comma: ','
+              - parameter: quota
+              - data_type:
+                  data_type_identifier: NUMBER
+              - comma: ','
+              - parameter: emp_id
+              - data_type:
+                  data_type_identifier: NUMBER
+              - end_bracket: )
+          - keyword: IS
+          - declare_segment:
+              naked_identifier: bonus
               data_type:
                 data_type_identifier: NUMBER
-              end_bracket: )
-        - keyword: IS
-        - declare_segment:
-            naked_identifier: bonus
-            data_type:
-              data_type_identifier: NUMBER
-            assignment_operator: :=
-            expression:
-              numeric_literal: '0'
-            statement_terminator: ;
-        - begin_end_block:
-          - keyword: BEGIN
-          - statement:
-              if_then_statement:
-              - if_clause:
+              assignment_operator: :=
+              expression:
+                numeric_literal: '0'
+              statement_terminator: ;
+          - begin_end_block:
+            - keyword: BEGIN
+            - statement:
+                if_then_statement:
+                - if_clause:
+                  - keyword: IF
+                  - expression:
+                      column_reference:
+                        naked_identifier: sales
+                      comparison_operator:
+                        raw_comparison_operator: '>'
+                      bracketed:
+                        start_bracket: (
+                        expression:
+                          column_reference:
+                            naked_identifier: quota
+                          binary_operator: +
+                          numeric_literal: '200'
+                        end_bracket: )
+                  - keyword: THEN
+                - statement:
+                    assignment_segment_statement:
+                      object_reference:
+                        naked_identifier: bonus
+                      assignment_operator: :=
+                      expression:
+                        bracketed:
+                          start_bracket: (
+                          expression:
+                          - column_reference:
+                              naked_identifier: sales
+                          - binary_operator: '-'
+                          - column_reference:
+                              naked_identifier: quota
+                          end_bracket: )
+                        binary_operator: /
+                        numeric_literal: '4'
+                - statement_terminator: ;
+                - keyword: ELSE
+                - statement:
+                    assignment_segment_statement:
+                      object_reference:
+                        naked_identifier: bonus
+                      assignment_operator: :=
+                      expression:
+                        numeric_literal: '50'
+                - statement_terminator: ;
+                - keyword: END
                 - keyword: IF
+            - statement_terminator: ;
+            - statement:
+                function:
+                  function_name:
+                    naked_identifier: DBMS_OUTPUT
+                    dot: .
+                    function_name_identifier: PUT_LINE
+                  function_contents:
+                    bracketed:
+                      start_bracket: (
+                      expression:
+                        quoted_literal: "'bonus = '"
+                        binary_operator:
+                        - pipe: '|'
+                        - pipe: '|'
+                        column_reference:
+                          naked_identifier: bonus
+                      end_bracket: )
+            - statement_terminator: ;
+            - statement:
+                update_statement:
+                  keyword: UPDATE
+                  table_reference:
+                    naked_identifier: employees
+                  set_clause_list:
+                    keyword: SET
+                    set_clause:
+                      column_reference:
+                        naked_identifier: salary
+                      comparison_operator:
+                        raw_comparison_operator: '='
+                      expression:
+                      - column_reference:
+                          naked_identifier: salary
+                      - binary_operator: +
+                      - column_reference:
+                          naked_identifier: bonus
+                  where_clause:
+                    keyword: WHERE
+                    expression:
+                    - column_reference:
+                        naked_identifier: employee_id
+                    - comparison_operator:
+                        raw_comparison_operator: '='
+                    - column_reference:
+                        naked_identifier: emp_id
+            - statement_terminator: ;
+            - keyword: END
+            - object_reference:
+                naked_identifier: p
+          - statement_terminator: ;
+      - keyword: BEGIN
+      - statement:
+          function:
+            function_name:
+              function_name_identifier: p
+            function_contents:
+              bracketed:
+              - start_bracket: (
+              - expression:
+                  numeric_literal: '10100'
+              - comma: ','
+              - expression:
+                  numeric_literal: '10000'
+              - comma: ','
+              - expression:
+                  numeric_literal: '120'
+              - end_bracket: )
+      - statement_terminator: ;
+      - statement:
+          function:
+            function_name:
+              function_name_identifier: p
+            function_contents:
+              bracketed:
+              - start_bracket: (
+              - expression:
+                  numeric_literal: '10500'
+              - comma: ','
+              - expression:
+                  numeric_literal: '10000'
+              - comma: ','
+              - expression:
+                  numeric_literal: '121'
+              - end_bracket: )
+      - statement_terminator: ;
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      begin_end_block:
+      - declare_segment:
+          keyword: DECLARE
+          create_procedure_statement:
+          - keyword: PROCEDURE
+          - function_name:
+              function_name_identifier: p
+          - function_parameter_list:
+              bracketed:
+              - start_bracket: (
+              - parameter: sales
+              - data_type:
+                  data_type_identifier: NUMBER
+              - comma: ','
+              - parameter: quota
+              - data_type:
+                  data_type_identifier: NUMBER
+              - comma: ','
+              - parameter: emp_id
+              - data_type:
+                  data_type_identifier: NUMBER
+              - end_bracket: )
+          - keyword: IS
+          - declare_segment:
+              naked_identifier: bonus
+              data_type:
+                data_type_identifier: NUMBER
+              assignment_operator: :=
+              expression:
+                numeric_literal: '0'
+              statement_terminator: ;
+          - begin_end_block:
+            - keyword: BEGIN
+            - statement:
+                if_then_statement:
+                - if_clause:
+                  - keyword: IF
+                  - expression:
+                      column_reference:
+                        naked_identifier: sales
+                      comparison_operator:
+                        raw_comparison_operator: '>'
+                      bracketed:
+                        start_bracket: (
+                        expression:
+                          column_reference:
+                            naked_identifier: quota
+                          binary_operator: +
+                          numeric_literal: '200'
+                        end_bracket: )
+                  - keyword: THEN
+                - statement:
+                    assignment_segment_statement:
+                      object_reference:
+                        naked_identifier: bonus
+                      assignment_operator: :=
+                      expression:
+                        bracketed:
+                          start_bracket: (
+                          expression:
+                          - column_reference:
+                              naked_identifier: sales
+                          - binary_operator: '-'
+                          - column_reference:
+                              naked_identifier: quota
+                          end_bracket: )
+                        binary_operator: /
+                        numeric_literal: '4'
+                - statement_terminator: ;
+                - keyword: ELSE
+                - statement:
+                    if_then_statement:
+                    - if_clause:
+                      - keyword: IF
+                      - expression:
+                        - column_reference:
+                            naked_identifier: sales
+                        - comparison_operator:
+                            raw_comparison_operator: '>'
+                        - column_reference:
+                            naked_identifier: quota
+                      - keyword: THEN
+                    - statement:
+                        assignment_segment_statement:
+                          object_reference:
+                            naked_identifier: bonus
+                          assignment_operator: :=
+                          expression:
+                            numeric_literal: '50'
+                    - statement_terminator: ;
+                    - keyword: ELSE
+                    - statement:
+                        assignment_segment_statement:
+                          object_reference:
+                            naked_identifier: bonus
+                          assignment_operator: :=
+                          expression:
+                            numeric_literal: '0'
+                    - statement_terminator: ;
+                    - keyword: END
+                    - keyword: IF
+                - statement_terminator: ;
+                - keyword: END
+                - keyword: IF
+            - statement_terminator: ;
+            - statement:
+                function:
+                  function_name:
+                    naked_identifier: DBMS_OUTPUT
+                    dot: .
+                    function_name_identifier: PUT_LINE
+                  function_contents:
+                    bracketed:
+                      start_bracket: (
+                      expression:
+                        quoted_literal: "'bonus = '"
+                        binary_operator:
+                        - pipe: '|'
+                        - pipe: '|'
+                        column_reference:
+                          naked_identifier: bonus
+                      end_bracket: )
+            - statement_terminator: ;
+            - statement:
+                update_statement:
+                  keyword: UPDATE
+                  table_reference:
+                    naked_identifier: employees
+                  set_clause_list:
+                    keyword: SET
+                    set_clause:
+                      column_reference:
+                        naked_identifier: salary
+                      comparison_operator:
+                        raw_comparison_operator: '='
+                      expression:
+                      - column_reference:
+                          naked_identifier: salary
+                      - binary_operator: +
+                      - column_reference:
+                          naked_identifier: bonus
+                  where_clause:
+                    keyword: WHERE
+                    expression:
+                    - column_reference:
+                        naked_identifier: employee_id
+                    - comparison_operator:
+                        raw_comparison_operator: '='
+                    - column_reference:
+                        naked_identifier: emp_id
+            - statement_terminator: ;
+            - keyword: END
+            - object_reference:
+                naked_identifier: p
+          - statement_terminator: ;
+      - keyword: BEGIN
+      - statement:
+          function:
+            function_name:
+              function_name_identifier: p
+            function_contents:
+              bracketed:
+              - start_bracket: (
+              - expression:
+                  numeric_literal: '10100'
+              - comma: ','
+              - expression:
+                  numeric_literal: '10000'
+              - comma: ','
+              - expression:
+                  numeric_literal: '120'
+              - end_bracket: )
+      - statement_terminator: ;
+      - statement:
+          function:
+            function_name:
+              function_name_identifier: p
+            function_contents:
+              bracketed:
+              - start_bracket: (
+              - expression:
+                  numeric_literal: '10500'
+              - comma: ','
+              - expression:
+                  numeric_literal: '10000'
+              - comma: ','
+              - expression:
+                  numeric_literal: '121'
+              - end_bracket: )
+      - statement_terminator: ;
+      - statement:
+          function:
+            function_name:
+              function_name_identifier: p
+            function_contents:
+              bracketed:
+              - start_bracket: (
+              - expression:
+                  numeric_literal: '9500'
+              - comma: ','
+              - expression:
+                  numeric_literal: '10000'
+              - comma: ','
+              - expression:
+                  numeric_literal: '122'
+              - end_bracket: )
+      - statement_terminator: ;
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      begin_end_block:
+      - declare_segment:
+          keyword: DECLARE
+          create_procedure_statement:
+          - keyword: PROCEDURE
+          - function_name:
+              function_name_identifier: p
+          - function_parameter_list:
+              bracketed:
+                start_bracket: (
+                parameter: sales
+                data_type:
+                  data_type_identifier: NUMBER
+                end_bracket: )
+          - keyword: IS
+          - declare_segment:
+              naked_identifier: bonus
+              data_type:
+                data_type_identifier: NUMBER
+              assignment_operator: :=
+              expression:
+                numeric_literal: '0'
+              statement_terminator: ;
+          - begin_end_block:
+            - keyword: BEGIN
+            - statement:
+                if_then_statement:
+                - if_clause:
+                  - keyword: IF
+                  - expression:
+                      column_reference:
+                        naked_identifier: sales
+                      comparison_operator:
+                        raw_comparison_operator: '>'
+                      numeric_literal: '50000'
+                  - keyword: THEN
+                - statement:
+                    assignment_segment_statement:
+                      object_reference:
+                        naked_identifier: bonus
+                      assignment_operator: :=
+                      expression:
+                        numeric_literal: '1500'
+                - statement_terminator: ;
+                - keyword: ELSIF
                 - expression:
                     column_reference:
                       naked_identifier: sales
                     comparison_operator:
                       raw_comparison_operator: '>'
-                    numeric_literal: '50000'
+                    numeric_literal: '35000'
                 - keyword: THEN
-              - statement:
-                  assignment_segment_statement:
-                    object_reference:
-                      naked_identifier: bonus
-                    assignment_operator: :=
-                    expression:
-                      numeric_literal: '1500'
-              - statement_terminator: ;
-              - keyword: ELSIF
-              - expression:
-                  column_reference:
-                    naked_identifier: sales
-                  comparison_operator:
-                    raw_comparison_operator: '>'
-                  numeric_literal: '35000'
-              - keyword: THEN
-              - statement:
-                  assignment_segment_statement:
-                    object_reference:
-                      naked_identifier: bonus
-                    assignment_operator: :=
-                    expression:
-                      numeric_literal: '500'
-              - statement_terminator: ;
-              - keyword: ELSE
-              - statement:
-                  assignment_segment_statement:
-                    object_reference:
-                      naked_identifier: bonus
-                    assignment_operator: :=
-                    expression:
-                      numeric_literal: '100'
-              - statement_terminator: ;
-              - keyword: END
-              - keyword: IF
-          - statement_terminator: ;
-          - statement:
-              function:
-                function_name:
-                  naked_identifier: DBMS_OUTPUT
-                  dot: .
-                  function_name_identifier: PUT_LINE
-                function_contents:
-                  bracketed:
-                    start_bracket: (
-                    expression:
-                    - quoted_literal: "'Sales = '"
-                    - binary_operator:
-                      - pipe: '|'
-                      - pipe: '|'
-                    - column_reference:
-                        naked_identifier: sales
-                    - binary_operator:
-                      - pipe: '|'
-                      - pipe: '|'
-                    - quoted_literal: "', bonus = '"
-                    - binary_operator:
-                      - pipe: '|'
-                      - pipe: '|'
-                    - column_reference:
+                - statement:
+                    assignment_segment_statement:
+                      object_reference:
                         naked_identifier: bonus
-                    - binary_operator:
-                      - pipe: '|'
-                      - pipe: '|'
-                    - quoted_literal: "'.'"
-                    end_bracket: )
+                      assignment_operator: :=
+                      expression:
+                        numeric_literal: '500'
+                - statement_terminator: ;
+                - keyword: ELSE
+                - statement:
+                    assignment_segment_statement:
+                      object_reference:
+                        naked_identifier: bonus
+                      assignment_operator: :=
+                      expression:
+                        numeric_literal: '100'
+                - statement_terminator: ;
+                - keyword: END
+                - keyword: IF
+            - statement_terminator: ;
+            - statement:
+                function:
+                  function_name:
+                    naked_identifier: DBMS_OUTPUT
+                    dot: .
+                    function_name_identifier: PUT_LINE
+                  function_contents:
+                    bracketed:
+                      start_bracket: (
+                      expression:
+                      - quoted_literal: "'Sales = '"
+                      - binary_operator:
+                        - pipe: '|'
+                        - pipe: '|'
+                      - column_reference:
+                          naked_identifier: sales
+                      - binary_operator:
+                        - pipe: '|'
+                        - pipe: '|'
+                      - quoted_literal: "', bonus = '"
+                      - binary_operator:
+                        - pipe: '|'
+                        - pipe: '|'
+                      - column_reference:
+                          naked_identifier: bonus
+                      - binary_operator:
+                        - pipe: '|'
+                        - pipe: '|'
+                      - quoted_literal: "'.'"
+                      end_bracket: )
+            - statement_terminator: ;
+            - keyword: END
+            - object_reference:
+                naked_identifier: p
           - statement_terminator: ;
-          - keyword: END
-          - object_reference:
-              naked_identifier: p
-        - statement_terminator: ;
-    - keyword: BEGIN
-    - statement:
-        function:
-          function_name:
-            function_name_identifier: p
-          function_contents:
-            bracketed:
-              start_bracket: (
-              expression:
-                numeric_literal: '55000'
-              end_bracket: )
-    - statement_terminator: ;
-    - statement:
-        function:
-          function_name:
-            function_name_identifier: p
-          function_contents:
-            bracketed:
-              start_bracket: (
-              expression:
-                numeric_literal: '40000'
-              end_bracket: )
-    - statement_terminator: ;
-    - statement:
-        function:
-          function_name:
-            function_name_identifier: p
-          function_contents:
-            bracketed:
-              start_bracket: (
-              expression:
-                numeric_literal: '30000'
-              end_bracket: )
-    - statement_terminator: ;
-    - keyword: END
-- statement_terminator: ;
-- statement_terminator: /
+      - keyword: BEGIN
+      - statement:
+          function:
+            function_name:
+              function_name_identifier: p
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  numeric_literal: '55000'
+                end_bracket: )
+      - statement_terminator: ;
+      - statement:
+          function:
+            function_name:
+              function_name_identifier: p
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  numeric_literal: '40000'
+                end_bracket: )
+      - statement_terminator: ;
+      - statement:
+          function:
+            function_name:
+              function_name_identifier: p
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  numeric_literal: '30000'
+                end_bracket: )
+      - statement_terminator: ;
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /

--- a/test/fixtures/dialects/oracle/insert.yml
+++ b/test/fixtures/dialects/oracle/insert.yml
@@ -3,102 +3,167 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: e90a718c0d1e95a444ec74ff34034bc4c9e4e74275574c07156ce1f6eaa00bac
+_hash: fa3a5fa53786662f0cb7ed9d487d71738f9eecb708734849ff82a409bdae78c0
 file:
-- statement:
-    insert_statement:
-    - keyword: INSERT
-    - keyword: INTO
-    - table_reference:
-        naked_identifier: departments
-    - values_clause:
-        keyword: VALUES
-        bracketed:
+  batch:
+  - statement:
+      insert_statement:
+      - keyword: INSERT
+      - keyword: INTO
+      - table_reference:
+          naked_identifier: departments
+      - values_clause:
+          keyword: VALUES
+          bracketed:
+          - start_bracket: (
+          - numeric_literal: '280'
+          - comma: ','
+          - quoted_literal: "'Recreation'"
+          - comma: ','
+          - numeric_literal: '121'
+          - comma: ','
+          - numeric_literal: '1700'
+          - end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      insert_statement:
+      - keyword: INSERT
+      - keyword: INTO
+      - table_reference:
+          naked_identifier: departments
+      - values_clause:
+          keyword: VALUES
+          bracketed:
+          - start_bracket: (
+          - numeric_literal: '280'
+          - comma: ','
+          - quoted_literal: "'Recreation'"
+          - comma: ','
+          - keyword: DEFAULT
+          - comma: ','
+          - numeric_literal: '1700'
+          - end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      insert_statement:
+      - keyword: INSERT
+      - keyword: INTO
+      - table_reference:
+          naked_identifier: employees
+      - bracketed:
         - start_bracket: (
-        - numeric_literal: '280'
+        - column_reference:
+            naked_identifier: employee_id
         - comma: ','
-        - quoted_literal: "'Recreation'"
+        - column_reference:
+            naked_identifier: last_name
         - comma: ','
-        - numeric_literal: '121'
+        - column_reference:
+            naked_identifier: email
         - comma: ','
-        - numeric_literal: '1700'
+        - column_reference:
+            naked_identifier: hire_date
+        - comma: ','
+        - column_reference:
+            naked_identifier: job_id
+        - comma: ','
+        - column_reference:
+            naked_identifier: salary
+        - comma: ','
+        - column_reference:
+            naked_identifier: commission_pct
         - end_bracket: )
-- statement_terminator: ;
-- statement:
-    insert_statement:
-    - keyword: INSERT
-    - keyword: INTO
-    - table_reference:
-        naked_identifier: departments
-    - values_clause:
-        keyword: VALUES
-        bracketed:
-        - start_bracket: (
-        - numeric_literal: '280'
-        - comma: ','
-        - quoted_literal: "'Recreation'"
-        - comma: ','
-        - keyword: DEFAULT
-        - comma: ','
-        - numeric_literal: '1700'
-        - end_bracket: )
-- statement_terminator: ;
-- statement:
-    insert_statement:
-    - keyword: INSERT
-    - keyword: INTO
-    - table_reference:
-        naked_identifier: employees
-    - bracketed:
-      - start_bracket: (
-      - column_reference:
-          naked_identifier: employee_id
-      - comma: ','
-      - column_reference:
-          naked_identifier: last_name
-      - comma: ','
-      - column_reference:
-          naked_identifier: email
-      - comma: ','
-      - column_reference:
-          naked_identifier: hire_date
-      - comma: ','
-      - column_reference:
-          naked_identifier: job_id
-      - comma: ','
-      - column_reference:
-          naked_identifier: salary
-      - comma: ','
-      - column_reference:
-          naked_identifier: commission_pct
-      - end_bracket: )
-    - values_clause:
-        keyword: VALUES
-        bracketed:
-        - start_bracket: (
-        - numeric_literal: '207'
-        - comma: ','
-        - quoted_literal: "'Gregory'"
-        - comma: ','
-        - quoted_literal: "'pgregory@example.com'"
-        - comma: ','
-        - expression:
-            bare_function: sysdate
-        - comma: ','
-        - quoted_literal: "'PU_CLERK'"
-        - comma: ','
-        - numeric_literal: 1.2E3
-        - comma: ','
-        - null_literal: 'NULL'
-        - end_bracket: )
-- statement_terminator: ;
-- statement:
-    insert_statement:
-    - keyword: INSERT
-    - keyword: INTO
-    - bracketed:
-        start_bracket: (
-        select_statement:
+      - values_clause:
+          keyword: VALUES
+          bracketed:
+          - start_bracket: (
+          - numeric_literal: '207'
+          - comma: ','
+          - quoted_literal: "'Gregory'"
+          - comma: ','
+          - quoted_literal: "'pgregory@example.com'"
+          - comma: ','
+          - expression:
+              bare_function: sysdate
+          - comma: ','
+          - quoted_literal: "'PU_CLERK'"
+          - comma: ','
+          - numeric_literal: 1.2E3
+          - comma: ','
+          - null_literal: 'NULL'
+          - end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      insert_statement:
+      - keyword: INSERT
+      - keyword: INTO
+      - bracketed:
+          start_bracket: (
+          select_statement:
+            select_clause:
+            - keyword: SELECT
+            - select_clause_element:
+                column_reference:
+                  naked_identifier: employee_id
+            - comma: ','
+            - select_clause_element:
+                column_reference:
+                  naked_identifier: last_name
+            - comma: ','
+            - select_clause_element:
+                column_reference:
+                  naked_identifier: email
+            - comma: ','
+            - select_clause_element:
+                column_reference:
+                  naked_identifier: hire_date
+            - comma: ','
+            - select_clause_element:
+                column_reference:
+                  naked_identifier: job_id
+            - comma: ','
+            - select_clause_element:
+                column_reference:
+                  naked_identifier: salary
+            - comma: ','
+            - select_clause_element:
+                column_reference:
+                  naked_identifier: commission_pct
+            from_clause:
+              keyword: FROM
+              from_expression:
+                from_expression_element:
+                  table_expression:
+                    table_reference:
+                      naked_identifier: employees
+          end_bracket: )
+      - values_clause:
+          keyword: VALUES
+          bracketed:
+          - start_bracket: (
+          - numeric_literal: '207'
+          - comma: ','
+          - quoted_literal: "'Gregory'"
+          - comma: ','
+          - quoted_literal: "'pgregory@example.com'"
+          - comma: ','
+          - expression:
+              bare_function: sysdate
+          - comma: ','
+          - quoted_literal: "'PU_CLERK'"
+          - comma: ','
+          - numeric_literal: 1.2E3
+          - comma: ','
+          - null_literal: 'NULL'
+          - end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      insert_statement:
+      - keyword: INSERT
+      - keyword: INTO
+      - table_reference:
+          naked_identifier: bonuses
+      - select_statement:
           select_clause:
           - keyword: SELECT
           - select_clause_element:
@@ -106,28 +171,11 @@ file:
                 naked_identifier: employee_id
           - comma: ','
           - select_clause_element:
-              column_reference:
-                naked_identifier: last_name
-          - comma: ','
-          - select_clause_element:
-              column_reference:
-                naked_identifier: email
-          - comma: ','
-          - select_clause_element:
-              column_reference:
-                naked_identifier: hire_date
-          - comma: ','
-          - select_clause_element:
-              column_reference:
-                naked_identifier: job_id
-          - comma: ','
-          - select_clause_element:
-              column_reference:
-                naked_identifier: salary
-          - comma: ','
-          - select_clause_element:
-              column_reference:
-                naked_identifier: commission_pct
+              expression:
+                column_reference:
+                  naked_identifier: salary
+                binary_operator: '*'
+                numeric_literal: '1.1'
           from_clause:
             keyword: FROM
             from_expression:
@@ -135,904 +183,981 @@ file:
                 table_expression:
                   table_reference:
                     naked_identifier: employees
-        end_bracket: )
-    - values_clause:
-        keyword: VALUES
-        bracketed:
-        - start_bracket: (
-        - numeric_literal: '207'
-        - comma: ','
-        - quoted_literal: "'Gregory'"
-        - comma: ','
-        - quoted_literal: "'pgregory@example.com'"
-        - comma: ','
-        - expression:
-            bare_function: sysdate
-        - comma: ','
-        - quoted_literal: "'PU_CLERK'"
-        - comma: ','
-        - numeric_literal: 1.2E3
-        - comma: ','
-        - null_literal: 'NULL'
-        - end_bracket: )
-- statement_terminator: ;
-- statement:
-    insert_statement:
-    - keyword: INSERT
-    - keyword: INTO
-    - table_reference:
-        naked_identifier: bonuses
-    - select_statement:
-        select_clause:
-        - keyword: SELECT
-        - select_clause_element:
-            column_reference:
-              naked_identifier: employee_id
-        - comma: ','
-        - select_clause_element:
+          where_clause:
+            keyword: WHERE
             expression:
               column_reference:
-                naked_identifier: salary
-              binary_operator: '*'
-              numeric_literal: '1.1'
-        from_clause:
-          keyword: FROM
-          from_expression:
-            from_expression_element:
-              table_expression:
-                table_reference:
-                  naked_identifier: employees
-        where_clause:
-          keyword: WHERE
-          expression:
-            column_reference:
-              naked_identifier: commission_pct
-            comparison_operator:
-              raw_comparison_operator: '>'
-            numeric_literal: '0.25'
-- statement_terminator: ;
-- statement:
-    insert_statement:
-    - keyword: INSERT
-    - keyword: INTO
-    - table_reference:
-        naked_identifier: raises
-    - select_statement:
-        select_clause:
-        - keyword: SELECT
-        - select_clause_element:
-            column_reference:
-              naked_identifier: employee_id
-        - comma: ','
-        - select_clause_element:
+                naked_identifier: commission_pct
+              comparison_operator:
+                raw_comparison_operator: '>'
+              numeric_literal: '0.25'
+  - statement_terminator: ;
+  - statement:
+      insert_statement:
+      - keyword: INSERT
+      - keyword: INTO
+      - table_reference:
+          naked_identifier: raises
+      - select_statement:
+          select_clause:
+          - keyword: SELECT
+          - select_clause_element:
+              column_reference:
+                naked_identifier: employee_id
+          - comma: ','
+          - select_clause_element:
+              expression:
+                column_reference:
+                  naked_identifier: salary
+                binary_operator: '*'
+                numeric_literal: '1.1'
+          from_clause:
+            keyword: FROM
+            from_expression:
+              from_expression_element:
+                table_expression:
+                  table_reference:
+                    naked_identifier: employees
+          where_clause:
+            keyword: WHERE
             expression:
               column_reference:
-                naked_identifier: salary
-              binary_operator: '*'
-              numeric_literal: '1.1'
-        from_clause:
-          keyword: FROM
-          from_expression:
-            from_expression_element:
-              table_expression:
-                table_reference:
-                  naked_identifier: employees
-        where_clause:
-          keyword: WHERE
+                naked_identifier: commission_pct
+              comparison_operator:
+                raw_comparison_operator: '>'
+              numeric_literal: '0.2'
+      - keyword: LOG
+      - keyword: ERRORS
+      - keyword: INTO
+      - table_reference:
+          naked_identifier: errlog
+      - bracketed:
+          start_bracket: (
           expression:
-            column_reference:
-              naked_identifier: commission_pct
-            comparison_operator:
-              raw_comparison_operator: '>'
-            numeric_literal: '0.2'
-    - keyword: LOG
-    - keyword: ERRORS
-    - keyword: INTO
-    - table_reference:
-        naked_identifier: errlog
-    - bracketed:
-        start_bracket: (
-        expression:
-          quoted_literal: "'my_bad'"
-        end_bracket: )
-    - keyword: REJECT
-    - keyword: LIMIT
-    - numeric_literal: '10'
-- statement_terminator: ;
-- statement:
-    insert_statement:
-    - keyword: INSERT
-    - keyword: INTO
-    - table_reference:
-      - naked_identifier: employees
-      - at_sign: '@'
-      - naked_identifier: remote
-    - values_clause:
-        keyword: VALUES
-        bracketed:
+            quoted_literal: "'my_bad'"
+          end_bracket: )
+      - keyword: REJECT
+      - keyword: LIMIT
+      - numeric_literal: '10'
+  - statement_terminator: ;
+  - statement:
+      insert_statement:
+      - keyword: INSERT
+      - keyword: INTO
+      - table_reference:
+        - naked_identifier: employees
+        - at_sign: '@'
+        - naked_identifier: remote
+      - values_clause:
+          keyword: VALUES
+          bracketed:
+          - start_bracket: (
+          - numeric_literal: '8002'
+          - comma: ','
+          - quoted_literal: "'Juan'"
+          - comma: ','
+          - quoted_literal: "'Fernandez'"
+          - comma: ','
+          - quoted_literal: "'juanf@example.com'"
+          - comma: ','
+          - null_literal: 'NULL'
+          - comma: ','
+          - expression:
+              function:
+                function_name:
+                  function_name_identifier: TO_DATE
+                function_contents:
+                  bracketed:
+                  - start_bracket: (
+                  - expression:
+                      quoted_literal: "'04-OCT-1992'"
+                  - comma: ','
+                  - expression:
+                      quoted_literal: "'DD-MON-YYYY'"
+                  - end_bracket: )
+          - comma: ','
+          - quoted_literal: "'SH_CLERK'"
+          - comma: ','
+          - numeric_literal: '3000'
+          - comma: ','
+          - null_literal: 'NULL'
+          - comma: ','
+          - numeric_literal: '121'
+          - comma: ','
+          - numeric_literal: '20'
+          - end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      insert_statement:
+      - keyword: INSERT
+      - keyword: INTO
+      - table_reference:
+          naked_identifier: departments
+      - values_clause:
+          keyword: VALUES
+          bracketed:
+          - start_bracket: (
+          - expression:
+              column_reference:
+              - naked_identifier: departments_seq
+              - dot: .
+              - naked_identifier: nextval
+          - comma: ','
+          - quoted_literal: "'Entertainment'"
+          - comma: ','
+          - numeric_literal: '162'
+          - comma: ','
+          - numeric_literal: '1400'
+          - end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      insert_statement:
+      - keyword: INSERT
+      - keyword: INTO
+      - table_reference:
+          naked_identifier: employees
+      - bracketed:
         - start_bracket: (
-        - numeric_literal: '8002'
+        - column_reference:
+            naked_identifier: employee_id
         - comma: ','
-        - quoted_literal: "'Juan'"
+        - column_reference:
+            naked_identifier: last_name
         - comma: ','
-        - quoted_literal: "'Fernandez'"
+        - column_reference:
+            naked_identifier: email
         - comma: ','
-        - quoted_literal: "'juanf@example.com'"
+        - column_reference:
+            naked_identifier: hire_date
         - comma: ','
-        - null_literal: 'NULL'
+        - column_reference:
+            naked_identifier: job_id
         - comma: ','
-        - expression:
-            function:
-              function_name:
-                function_name_identifier: TO_DATE
-              function_contents:
-                bracketed:
-                - start_bracket: (
-                - expression:
-                    quoted_literal: "'04-OCT-1992'"
-                - comma: ','
-                - expression:
-                    quoted_literal: "'DD-MON-YYYY'"
-                - end_bracket: )
-        - comma: ','
-        - quoted_literal: "'SH_CLERK'"
-        - comma: ','
-        - numeric_literal: '3000'
-        - comma: ','
-        - null_literal: 'NULL'
-        - comma: ','
-        - numeric_literal: '121'
-        - comma: ','
-        - numeric_literal: '20'
-        - end_bracket: )
-- statement_terminator: ;
-- statement:
-    insert_statement:
-    - keyword: INSERT
-    - keyword: INTO
-    - table_reference:
-        naked_identifier: departments
-    - values_clause:
-        keyword: VALUES
-        bracketed:
-        - start_bracket: (
-        - expression:
-            column_reference:
-            - naked_identifier: departments_seq
-            - dot: .
-            - naked_identifier: nextval
-        - comma: ','
-        - quoted_literal: "'Entertainment'"
-        - comma: ','
-        - numeric_literal: '162'
-        - comma: ','
-        - numeric_literal: '1400'
-        - end_bracket: )
-- statement_terminator: ;
-- statement:
-    insert_statement:
-    - keyword: INSERT
-    - keyword: INTO
-    - table_reference:
-        naked_identifier: employees
-    - bracketed:
-      - start_bracket: (
-      - column_reference:
-          naked_identifier: employee_id
-      - comma: ','
-      - column_reference:
-          naked_identifier: last_name
-      - comma: ','
-      - column_reference:
-          naked_identifier: email
-      - comma: ','
-      - column_reference:
-          naked_identifier: hire_date
-      - comma: ','
-      - column_reference:
-          naked_identifier: job_id
-      - comma: ','
-      - column_reference:
-          naked_identifier: salary
-      - end_bracket: )
-    - values_clause:
-        keyword: VALUES
-        bracketed:
-        - start_bracket: (
-        - expression:
-            column_reference:
-            - naked_identifier: employees_seq
-            - dot: .
-            - naked_identifier: nextval
-        - comma: ','
-        - quoted_literal: "'Doe'"
-        - comma: ','
-        - quoted_literal: "'john.doe@example.com'"
-        - comma: ','
-        - expression:
-            bare_function: SYSDATE
-        - comma: ','
-        - quoted_literal: "'SH_CLERK'"
-        - comma: ','
-        - numeric_literal: '2400'
-        - end_bracket: )
-    - returning_clause:
-        keyword: RETURNING
-        expression:
-          column_reference:
+        - column_reference:
             naked_identifier: salary
-          binary_operator: '*'
-          numeric_literal: '12'
-        comma: ','
-        naked_identifier: job_id
-        into_clause:
-        - keyword: INTO
-        - sqlplus_variable:
-            colon: ':'
-            parameter: bnd1
-        - comma: ','
-        - sqlplus_variable:
-            colon: ':'
-            parameter: bnd2
-- statement_terminator: ;
-- statement:
-    insert_statement:
-    - keyword: INSERT
-    - keyword: INTO
-    - table_reference:
-        naked_identifier: persons
-    - values_clause:
-        keyword: VALUES
-        bracketed:
-          start_bracket: (
+        - end_bracket: )
+      - values_clause:
+          keyword: VALUES
+          bracketed:
+          - start_bracket: (
+          - expression:
+              column_reference:
+              - naked_identifier: employees_seq
+              - dot: .
+              - naked_identifier: nextval
+          - comma: ','
+          - quoted_literal: "'Doe'"
+          - comma: ','
+          - quoted_literal: "'john.doe@example.com'"
+          - comma: ','
+          - expression:
+              bare_function: SYSDATE
+          - comma: ','
+          - quoted_literal: "'SH_CLERK'"
+          - comma: ','
+          - numeric_literal: '2400'
+          - end_bracket: )
+      - returning_clause:
+          keyword: RETURNING
           expression:
-            function:
-              function_name:
-                function_name_identifier: person_t
-              function_contents:
-                bracketed:
-                - start_bracket: (
-                - expression:
-                    quoted_literal: "'Bob'"
-                - comma: ','
-                - expression:
-                    numeric_literal: '1234'
-                - end_bracket: )
-          end_bracket: )
-- statement_terminator: ;
-- statement:
-    insert_statement:
-    - keyword: INSERT
-    - keyword: INTO
-    - table_reference:
-        naked_identifier: persons
-    - values_clause:
-        keyword: VALUES
-        bracketed:
-          start_bracket: (
-          expression:
-            function:
-              function_name:
-                function_name_identifier: employee_t
-              function_contents:
-                bracketed:
-                - start_bracket: (
-                - expression:
-                    quoted_literal: "'Joe'"
-                - comma: ','
-                - expression:
-                    numeric_literal: '32456'
-                - comma: ','
-                - expression:
-                    numeric_literal: '12'
-                - comma: ','
-                - expression:
-                    numeric_literal: '100000'
-                - end_bracket: )
-          end_bracket: )
-- statement_terminator: ;
-- statement:
-    insert_statement:
-    - keyword: INSERT
-    - keyword: INTO
-    - table_reference:
-        naked_identifier: persons
-    - values_clause:
-        keyword: VALUES
-        bracketed:
-          start_bracket: (
-          expression:
-            function:
-              function_name:
-                function_name_identifier: part_time_emp_t
-              function_contents:
-                bracketed:
-                - start_bracket: (
-                - expression:
-                    quoted_literal: "'Tim'"
-                - comma: ','
-                - expression:
-                    numeric_literal: '5678'
-                - comma: ','
-                - expression:
-                    numeric_literal: '13'
-                - comma: ','
-                - expression:
-                    numeric_literal: '1000'
-                - comma: ','
-                - expression:
-                    numeric_literal: '20'
-                - end_bracket: )
-          end_bracket: )
-- statement_terminator: ;
-- statement:
-    insert_statement:
-    - keyword: INSERT
-    - keyword: INTO
-    - table_reference:
-        naked_identifier: books
-    - values_clause:
-        keyword: VALUES
-        bracketed:
-          start_bracket: (
-          quoted_literal: "'An Autobiography'"
+            column_reference:
+              naked_identifier: salary
+            binary_operator: '*'
+            numeric_literal: '12'
           comma: ','
-          expression:
-            function:
-              function_name:
-                function_name_identifier: person_t
-              function_contents:
-                bracketed:
-                - start_bracket: (
-                - expression:
-                    quoted_literal: "'Bob'"
-                - comma: ','
-                - expression:
-                    numeric_literal: '1234'
-                - end_bracket: )
-          end_bracket: )
-- statement_terminator: ;
-- statement:
-    insert_statement:
-    - keyword: INSERT
-    - keyword: INTO
-    - table_reference:
-        naked_identifier: books
-    - values_clause:
-        keyword: VALUES
-        bracketed:
-          start_bracket: (
-          quoted_literal: "'Business Rules'"
-          comma: ','
-          expression:
-            function:
-              function_name:
-                function_name_identifier: employee_t
-              function_contents:
-                bracketed:
-                - start_bracket: (
-                - expression:
-                    quoted_literal: "'Joe'"
-                - comma: ','
-                - expression:
-                    numeric_literal: '3456'
-                - comma: ','
-                - expression:
-                    numeric_literal: '12'
-                - comma: ','
-                - expression:
-                    numeric_literal: '10000'
-                - end_bracket: )
-          end_bracket: )
-- statement_terminator: ;
-- statement:
-    insert_statement:
-    - keyword: INSERT
-    - keyword: INTO
-    - table_reference:
-        naked_identifier: books
-    - values_clause:
-        keyword: VALUES
-        bracketed:
-          start_bracket: (
-          quoted_literal: "'Mixing School and Work'"
-          comma: ','
-          expression:
-            function:
-              function_name:
-                function_name_identifier: part_time_emp_t
-              function_contents:
-                bracketed:
-                - start_bracket: (
-                - expression:
-                    quoted_literal: "'Tim'"
-                - comma: ','
-                - expression:
-                    numeric_literal: '5678'
-                - comma: ','
-                - expression:
-                    numeric_literal: '13'
-                - comma: ','
-                - expression:
-                    numeric_literal: '1000'
-                - comma: ','
-                - expression:
-                    numeric_literal: '20'
-                - end_bracket: )
-          end_bracket: )
-- statement_terminator: ;
-- statement:
-    insert_statement:
-    - keyword: INSERT
-    - keyword: INTO
-    - table_reference:
-        naked_identifier: lob_tab
-    - select_statement:
-        select_clause:
-        - keyword: SELECT
-        - select_clause_element:
-            column_reference:
-              naked_identifier: pic_id
-        - comma: ','
-        - select_clause_element:
-            function:
-              function_name:
-                function_name_identifier: TO_LOB
-              function_contents:
-                bracketed:
-                  start_bracket: (
-                  expression:
-                    column_reference:
-                      naked_identifier: long_pics
-                  end_bracket: )
-        from_clause:
-          keyword: FROM
-          from_expression:
-            from_expression_element:
-              table_expression:
-                table_reference:
-                  naked_identifier: long_tab
-- statement_terminator: ;
-- statement:
-    insert_statement:
-    - keyword: INSERT
-    - keyword: ALL
-    - keyword: INTO
-    - table_reference:
-        naked_identifier: sales
-    - bracketed:
-      - start_bracket: (
-      - column_reference:
-          naked_identifier: prod_id
-      - comma: ','
-      - column_reference:
-          naked_identifier: cust_id
-      - comma: ','
-      - column_reference:
-          naked_identifier: time_id
-      - comma: ','
-      - column_reference:
-          naked_identifier: amount
-      - end_bracket: )
-    - values_clause:
-        keyword: VALUES
-        bracketed:
+          naked_identifier: job_id
+          into_clause:
+          - keyword: INTO
+          - sqlplus_variable:
+              colon: ':'
+              parameter: bnd1
+          - comma: ','
+          - sqlplus_variable:
+              colon: ':'
+              parameter: bnd2
+  - statement_terminator: ;
+  - statement:
+      insert_statement:
+      - keyword: INSERT
+      - keyword: INTO
+      - table_reference:
+          naked_identifier: persons
+      - values_clause:
+          keyword: VALUES
+          bracketed:
+            start_bracket: (
+            expression:
+              function:
+                function_name:
+                  function_name_identifier: person_t
+                function_contents:
+                  bracketed:
+                  - start_bracket: (
+                  - expression:
+                      quoted_literal: "'Bob'"
+                  - comma: ','
+                  - expression:
+                      numeric_literal: '1234'
+                  - end_bracket: )
+            end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      insert_statement:
+      - keyword: INSERT
+      - keyword: INTO
+      - table_reference:
+          naked_identifier: persons
+      - values_clause:
+          keyword: VALUES
+          bracketed:
+            start_bracket: (
+            expression:
+              function:
+                function_name:
+                  function_name_identifier: employee_t
+                function_contents:
+                  bracketed:
+                  - start_bracket: (
+                  - expression:
+                      quoted_literal: "'Joe'"
+                  - comma: ','
+                  - expression:
+                      numeric_literal: '32456'
+                  - comma: ','
+                  - expression:
+                      numeric_literal: '12'
+                  - comma: ','
+                  - expression:
+                      numeric_literal: '100000'
+                  - end_bracket: )
+            end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      insert_statement:
+      - keyword: INSERT
+      - keyword: INTO
+      - table_reference:
+          naked_identifier: persons
+      - values_clause:
+          keyword: VALUES
+          bracketed:
+            start_bracket: (
+            expression:
+              function:
+                function_name:
+                  function_name_identifier: part_time_emp_t
+                function_contents:
+                  bracketed:
+                  - start_bracket: (
+                  - expression:
+                      quoted_literal: "'Tim'"
+                  - comma: ','
+                  - expression:
+                      numeric_literal: '5678'
+                  - comma: ','
+                  - expression:
+                      numeric_literal: '13'
+                  - comma: ','
+                  - expression:
+                      numeric_literal: '1000'
+                  - comma: ','
+                  - expression:
+                      numeric_literal: '20'
+                  - end_bracket: )
+            end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      insert_statement:
+      - keyword: INSERT
+      - keyword: INTO
+      - table_reference:
+          naked_identifier: books
+      - values_clause:
+          keyword: VALUES
+          bracketed:
+            start_bracket: (
+            quoted_literal: "'An Autobiography'"
+            comma: ','
+            expression:
+              function:
+                function_name:
+                  function_name_identifier: person_t
+                function_contents:
+                  bracketed:
+                  - start_bracket: (
+                  - expression:
+                      quoted_literal: "'Bob'"
+                  - comma: ','
+                  - expression:
+                      numeric_literal: '1234'
+                  - end_bracket: )
+            end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      insert_statement:
+      - keyword: INSERT
+      - keyword: INTO
+      - table_reference:
+          naked_identifier: books
+      - values_clause:
+          keyword: VALUES
+          bracketed:
+            start_bracket: (
+            quoted_literal: "'Business Rules'"
+            comma: ','
+            expression:
+              function:
+                function_name:
+                  function_name_identifier: employee_t
+                function_contents:
+                  bracketed:
+                  - start_bracket: (
+                  - expression:
+                      quoted_literal: "'Joe'"
+                  - comma: ','
+                  - expression:
+                      numeric_literal: '3456'
+                  - comma: ','
+                  - expression:
+                      numeric_literal: '12'
+                  - comma: ','
+                  - expression:
+                      numeric_literal: '10000'
+                  - end_bracket: )
+            end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      insert_statement:
+      - keyword: INSERT
+      - keyword: INTO
+      - table_reference:
+          naked_identifier: books
+      - values_clause:
+          keyword: VALUES
+          bracketed:
+            start_bracket: (
+            quoted_literal: "'Mixing School and Work'"
+            comma: ','
+            expression:
+              function:
+                function_name:
+                  function_name_identifier: part_time_emp_t
+                function_contents:
+                  bracketed:
+                  - start_bracket: (
+                  - expression:
+                      quoted_literal: "'Tim'"
+                  - comma: ','
+                  - expression:
+                      numeric_literal: '5678'
+                  - comma: ','
+                  - expression:
+                      numeric_literal: '13'
+                  - comma: ','
+                  - expression:
+                      numeric_literal: '1000'
+                  - comma: ','
+                  - expression:
+                      numeric_literal: '20'
+                  - end_bracket: )
+            end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      insert_statement:
+      - keyword: INSERT
+      - keyword: INTO
+      - table_reference:
+          naked_identifier: lob_tab
+      - select_statement:
+          select_clause:
+          - keyword: SELECT
+          - select_clause_element:
+              column_reference:
+                naked_identifier: pic_id
+          - comma: ','
+          - select_clause_element:
+              function:
+                function_name:
+                  function_name_identifier: TO_LOB
+                function_contents:
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                      column_reference:
+                        naked_identifier: long_pics
+                    end_bracket: )
+          from_clause:
+            keyword: FROM
+            from_expression:
+              from_expression_element:
+                table_expression:
+                  table_reference:
+                    naked_identifier: long_tab
+  - statement_terminator: ;
+  - statement:
+      insert_statement:
+      - keyword: INSERT
+      - keyword: ALL
+      - keyword: INTO
+      - table_reference:
+          naked_identifier: sales
+      - bracketed:
         - start_bracket: (
-        - expression:
-            column_reference:
-              naked_identifier: product_id
+        - column_reference:
+            naked_identifier: prod_id
         - comma: ','
-        - expression:
-            column_reference:
-              naked_identifier: customer_id
+        - column_reference:
+            naked_identifier: cust_id
         - comma: ','
-        - expression:
-            column_reference:
-              naked_identifier: weekly_start_date
+        - column_reference:
+            naked_identifier: time_id
         - comma: ','
-        - expression:
-            column_reference:
-              naked_identifier: sales_sun
+        - column_reference:
+            naked_identifier: amount
         - end_bracket: )
-    - keyword: INTO
-    - table_reference:
-        naked_identifier: sales
-    - bracketed:
-      - start_bracket: (
-      - column_reference:
-          naked_identifier: prod_id
-      - comma: ','
-      - column_reference:
-          naked_identifier: cust_id
-      - comma: ','
-      - column_reference:
-          naked_identifier: time_id
-      - comma: ','
-      - column_reference:
-          naked_identifier: amount
-      - end_bracket: )
-    - values_clause:
-        keyword: VALUES
-        bracketed:
+      - values_clause:
+          keyword: VALUES
+          bracketed:
+          - start_bracket: (
+          - expression:
+              column_reference:
+                naked_identifier: product_id
+          - comma: ','
+          - expression:
+              column_reference:
+                naked_identifier: customer_id
+          - comma: ','
+          - expression:
+              column_reference:
+                naked_identifier: weekly_start_date
+          - comma: ','
+          - expression:
+              column_reference:
+                naked_identifier: sales_sun
+          - end_bracket: )
+      - keyword: INTO
+      - table_reference:
+          naked_identifier: sales
+      - bracketed:
         - start_bracket: (
-        - expression:
-            column_reference:
-              naked_identifier: product_id
+        - column_reference:
+            naked_identifier: prod_id
         - comma: ','
-        - expression:
-            column_reference:
-              naked_identifier: customer_id
+        - column_reference:
+            naked_identifier: cust_id
         - comma: ','
-        - expression:
-            column_reference:
-              naked_identifier: weekly_start_date
-            binary_operator: +
-            numeric_literal: '1'
+        - column_reference:
+            naked_identifier: time_id
         - comma: ','
-        - expression:
-            column_reference:
-              naked_identifier: sales_mon
+        - column_reference:
+            naked_identifier: amount
         - end_bracket: )
-    - keyword: INTO
-    - table_reference:
-        naked_identifier: sales
-    - bracketed:
-      - start_bracket: (
-      - column_reference:
-          naked_identifier: prod_id
-      - comma: ','
-      - column_reference:
-          naked_identifier: cust_id
-      - comma: ','
-      - column_reference:
-          naked_identifier: time_id
-      - comma: ','
-      - column_reference:
-          naked_identifier: amount
-      - end_bracket: )
-    - values_clause:
-        keyword: VALUES
-        bracketed:
+      - values_clause:
+          keyword: VALUES
+          bracketed:
+          - start_bracket: (
+          - expression:
+              column_reference:
+                naked_identifier: product_id
+          - comma: ','
+          - expression:
+              column_reference:
+                naked_identifier: customer_id
+          - comma: ','
+          - expression:
+              column_reference:
+                naked_identifier: weekly_start_date
+              binary_operator: +
+              numeric_literal: '1'
+          - comma: ','
+          - expression:
+              column_reference:
+                naked_identifier: sales_mon
+          - end_bracket: )
+      - keyword: INTO
+      - table_reference:
+          naked_identifier: sales
+      - bracketed:
         - start_bracket: (
-        - expression:
-            column_reference:
-              naked_identifier: product_id
+        - column_reference:
+            naked_identifier: prod_id
         - comma: ','
-        - expression:
-            column_reference:
-              naked_identifier: customer_id
+        - column_reference:
+            naked_identifier: cust_id
         - comma: ','
-        - expression:
-            column_reference:
-              naked_identifier: weekly_start_date
-            binary_operator: +
-            numeric_literal: '2'
+        - column_reference:
+            naked_identifier: time_id
         - comma: ','
-        - expression:
-            column_reference:
-              naked_identifier: sales_tue
+        - column_reference:
+            naked_identifier: amount
         - end_bracket: )
-    - keyword: INTO
-    - table_reference:
-        naked_identifier: sales
-    - bracketed:
-      - start_bracket: (
-      - column_reference:
-          naked_identifier: prod_id
-      - comma: ','
-      - column_reference:
-          naked_identifier: cust_id
-      - comma: ','
-      - column_reference:
-          naked_identifier: time_id
-      - comma: ','
-      - column_reference:
-          naked_identifier: amount
-      - end_bracket: )
-    - values_clause:
-        keyword: VALUES
-        bracketed:
+      - values_clause:
+          keyword: VALUES
+          bracketed:
+          - start_bracket: (
+          - expression:
+              column_reference:
+                naked_identifier: product_id
+          - comma: ','
+          - expression:
+              column_reference:
+                naked_identifier: customer_id
+          - comma: ','
+          - expression:
+              column_reference:
+                naked_identifier: weekly_start_date
+              binary_operator: +
+              numeric_literal: '2'
+          - comma: ','
+          - expression:
+              column_reference:
+                naked_identifier: sales_tue
+          - end_bracket: )
+      - keyword: INTO
+      - table_reference:
+          naked_identifier: sales
+      - bracketed:
         - start_bracket: (
-        - expression:
-            column_reference:
-              naked_identifier: product_id
+        - column_reference:
+            naked_identifier: prod_id
         - comma: ','
-        - expression:
-            column_reference:
-              naked_identifier: customer_id
+        - column_reference:
+            naked_identifier: cust_id
         - comma: ','
-        - expression:
-            column_reference:
-              naked_identifier: weekly_start_date
-            binary_operator: +
-            numeric_literal: '3'
+        - column_reference:
+            naked_identifier: time_id
         - comma: ','
-        - expression:
-            column_reference:
-              naked_identifier: sales_wed
+        - column_reference:
+            naked_identifier: amount
         - end_bracket: )
-    - keyword: INTO
-    - table_reference:
-        naked_identifier: sales
-    - bracketed:
-      - start_bracket: (
-      - column_reference:
-          naked_identifier: prod_id
-      - comma: ','
-      - column_reference:
-          naked_identifier: cust_id
-      - comma: ','
-      - column_reference:
-          naked_identifier: time_id
-      - comma: ','
-      - column_reference:
-          naked_identifier: amount
-      - end_bracket: )
-    - values_clause:
-        keyword: VALUES
-        bracketed:
+      - values_clause:
+          keyword: VALUES
+          bracketed:
+          - start_bracket: (
+          - expression:
+              column_reference:
+                naked_identifier: product_id
+          - comma: ','
+          - expression:
+              column_reference:
+                naked_identifier: customer_id
+          - comma: ','
+          - expression:
+              column_reference:
+                naked_identifier: weekly_start_date
+              binary_operator: +
+              numeric_literal: '3'
+          - comma: ','
+          - expression:
+              column_reference:
+                naked_identifier: sales_wed
+          - end_bracket: )
+      - keyword: INTO
+      - table_reference:
+          naked_identifier: sales
+      - bracketed:
         - start_bracket: (
-        - expression:
-            column_reference:
-              naked_identifier: product_id
+        - column_reference:
+            naked_identifier: prod_id
         - comma: ','
-        - expression:
-            column_reference:
-              naked_identifier: customer_id
+        - column_reference:
+            naked_identifier: cust_id
         - comma: ','
-        - expression:
-            column_reference:
-              naked_identifier: weekly_start_date
-            binary_operator: +
-            numeric_literal: '4'
+        - column_reference:
+            naked_identifier: time_id
         - comma: ','
-        - expression:
-            column_reference:
-              naked_identifier: sales_thu
+        - column_reference:
+            naked_identifier: amount
         - end_bracket: )
-    - keyword: INTO
-    - table_reference:
-        naked_identifier: sales
-    - bracketed:
-      - start_bracket: (
-      - column_reference:
-          naked_identifier: prod_id
-      - comma: ','
-      - column_reference:
-          naked_identifier: cust_id
-      - comma: ','
-      - column_reference:
-          naked_identifier: time_id
-      - comma: ','
-      - column_reference:
-          naked_identifier: amount
-      - end_bracket: )
-    - values_clause:
-        keyword: VALUES
-        bracketed:
+      - values_clause:
+          keyword: VALUES
+          bracketed:
+          - start_bracket: (
+          - expression:
+              column_reference:
+                naked_identifier: product_id
+          - comma: ','
+          - expression:
+              column_reference:
+                naked_identifier: customer_id
+          - comma: ','
+          - expression:
+              column_reference:
+                naked_identifier: weekly_start_date
+              binary_operator: +
+              numeric_literal: '4'
+          - comma: ','
+          - expression:
+              column_reference:
+                naked_identifier: sales_thu
+          - end_bracket: )
+      - keyword: INTO
+      - table_reference:
+          naked_identifier: sales
+      - bracketed:
         - start_bracket: (
-        - expression:
-            column_reference:
-              naked_identifier: product_id
+        - column_reference:
+            naked_identifier: prod_id
         - comma: ','
-        - expression:
-            column_reference:
-              naked_identifier: customer_id
+        - column_reference:
+            naked_identifier: cust_id
         - comma: ','
-        - expression:
-            column_reference:
-              naked_identifier: weekly_start_date
-            binary_operator: +
-            numeric_literal: '5'
+        - column_reference:
+            naked_identifier: time_id
         - comma: ','
-        - expression:
-            column_reference:
-              naked_identifier: sales_fri
+        - column_reference:
+            naked_identifier: amount
         - end_bracket: )
-    - keyword: INTO
-    - table_reference:
-        naked_identifier: sales
-    - bracketed:
-      - start_bracket: (
-      - column_reference:
-          naked_identifier: prod_id
-      - comma: ','
-      - column_reference:
-          naked_identifier: cust_id
-      - comma: ','
-      - column_reference:
-          naked_identifier: time_id
-      - comma: ','
-      - column_reference:
-          naked_identifier: amount
-      - end_bracket: )
-    - values_clause:
-        keyword: VALUES
-        bracketed:
+      - values_clause:
+          keyword: VALUES
+          bracketed:
+          - start_bracket: (
+          - expression:
+              column_reference:
+                naked_identifier: product_id
+          - comma: ','
+          - expression:
+              column_reference:
+                naked_identifier: customer_id
+          - comma: ','
+          - expression:
+              column_reference:
+                naked_identifier: weekly_start_date
+              binary_operator: +
+              numeric_literal: '5'
+          - comma: ','
+          - expression:
+              column_reference:
+                naked_identifier: sales_fri
+          - end_bracket: )
+      - keyword: INTO
+      - table_reference:
+          naked_identifier: sales
+      - bracketed:
         - start_bracket: (
-        - expression:
-            column_reference:
-              naked_identifier: product_id
+        - column_reference:
+            naked_identifier: prod_id
         - comma: ','
-        - expression:
-            column_reference:
-              naked_identifier: customer_id
+        - column_reference:
+            naked_identifier: cust_id
         - comma: ','
-        - expression:
-            column_reference:
-              naked_identifier: weekly_start_date
-            binary_operator: +
-            numeric_literal: '6'
+        - column_reference:
+            naked_identifier: time_id
         - comma: ','
-        - expression:
-            column_reference:
-              naked_identifier: sales_sat
+        - column_reference:
+            naked_identifier: amount
         - end_bracket: )
-    - select_statement:
-        select_clause:
-        - keyword: SELECT
-        - select_clause_element:
-            column_reference:
-              naked_identifier: product_id
-        - comma: ','
-        - select_clause_element:
-            column_reference:
-              naked_identifier: customer_id
-        - comma: ','
-        - select_clause_element:
-            column_reference:
-              naked_identifier: weekly_start_date
-        - comma: ','
-        - select_clause_element:
-            column_reference:
-              naked_identifier: sales_sun
-        - comma: ','
-        - select_clause_element:
-            column_reference:
-              naked_identifier: sales_mon
-        - comma: ','
-        - select_clause_element:
-            column_reference:
-              naked_identifier: sales_tue
-        - comma: ','
-        - select_clause_element:
-            column_reference:
-              naked_identifier: sales_wed
-        - comma: ','
-        - select_clause_element:
-            column_reference:
-              naked_identifier: sales_thu
-        - comma: ','
-        - select_clause_element:
-            column_reference:
-              naked_identifier: sales_fri
-        - comma: ','
-        - select_clause_element:
-            column_reference:
-              naked_identifier: sales_sat
-        from_clause:
-          keyword: FROM
-          from_expression:
-            from_expression_element:
-              table_expression:
-                table_reference:
-                  naked_identifier: sales_input_table
-- statement_terminator: ;
-- statement:
-    insert_statement:
-    - keyword: INSERT
-    - keyword: INTO
-    - table_reference:
-        naked_identifier: people
-    - values_clause:
-        keyword: VALUES
-        bracketed:
+      - values_clause:
+          keyword: VALUES
+          bracketed:
+          - start_bracket: (
+          - expression:
+              column_reference:
+                naked_identifier: product_id
+          - comma: ','
+          - expression:
+              column_reference:
+                naked_identifier: customer_id
+          - comma: ','
+          - expression:
+              column_reference:
+                naked_identifier: weekly_start_date
+              binary_operator: +
+              numeric_literal: '6'
+          - comma: ','
+          - expression:
+              column_reference:
+                naked_identifier: sales_sat
+          - end_bracket: )
+      - select_statement:
+          select_clause:
+          - keyword: SELECT
+          - select_clause_element:
+              column_reference:
+                naked_identifier: product_id
+          - comma: ','
+          - select_clause_element:
+              column_reference:
+                naked_identifier: customer_id
+          - comma: ','
+          - select_clause_element:
+              column_reference:
+                naked_identifier: weekly_start_date
+          - comma: ','
+          - select_clause_element:
+              column_reference:
+                naked_identifier: sales_sun
+          - comma: ','
+          - select_clause_element:
+              column_reference:
+                naked_identifier: sales_mon
+          - comma: ','
+          - select_clause_element:
+              column_reference:
+                naked_identifier: sales_tue
+          - comma: ','
+          - select_clause_element:
+              column_reference:
+                naked_identifier: sales_wed
+          - comma: ','
+          - select_clause_element:
+              column_reference:
+                naked_identifier: sales_thu
+          - comma: ','
+          - select_clause_element:
+              column_reference:
+                naked_identifier: sales_fri
+          - comma: ','
+          - select_clause_element:
+              column_reference:
+                naked_identifier: sales_sat
+          from_clause:
+            keyword: FROM
+            from_expression:
+              from_expression_element:
+                table_expression:
+                  table_reference:
+                    naked_identifier: sales_input_table
+  - statement_terminator: ;
+  - statement:
+      insert_statement:
+      - keyword: INSERT
+      - keyword: INTO
+      - table_reference:
+          naked_identifier: people
+      - values_clause:
+          keyword: VALUES
+          bracketed:
+          - start_bracket: (
+          - numeric_literal: '1'
+          - comma: ','
+          - quoted_literal: "'Dave'"
+          - comma: ','
+          - quoted_literal: "'Badger'"
+          - comma: ','
+          - quoted_literal: "'Mr'"
+          - comma: ','
+          - expression:
+              data_type:
+                data_type_identifier: date
+              quoted_literal: "'1960-05-01'"
+          - end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      insert_statement:
+      - keyword: INSERT
+      - keyword: INTO
+      - table_reference:
+          naked_identifier: people
+      - values_clause:
+          keyword: VALUES
+          bracketed:
+          - start_bracket: (
+          - numeric_literal: '2'
+          - comma: ','
+          - quoted_literal: "'Simon'"
+          - comma: ','
+          - quoted_literal: "'Fox'"
+          - comma: ','
+          - quoted_literal: "'Mr'"
+          - end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      insert_statement:
+      - keyword: INSERT
+      - keyword: INTO
+      - table_reference:
+          naked_identifier: people
+      - bracketed:
         - start_bracket: (
-        - numeric_literal: '1'
+        - column_reference:
+            naked_identifier: person_id
         - comma: ','
-        - quoted_literal: "'Dave'"
+        - column_reference:
+            naked_identifier: given_name
         - comma: ','
-        - quoted_literal: "'Badger'"
+        - column_reference:
+            naked_identifier: family_name
         - comma: ','
-        - quoted_literal: "'Mr'"
-        - comma: ','
-        - expression:
-            data_type:
-              data_type_identifier: date
-            quoted_literal: "'1960-05-01'"
+        - column_reference:
+            naked_identifier: title
         - end_bracket: )
-- statement_terminator: ;
-- statement:
-    insert_statement:
-    - keyword: INSERT
-    - keyword: INTO
-    - table_reference:
-        naked_identifier: people
-    - values_clause:
-        keyword: VALUES
-        bracketed:
+      - values_clause:
+          keyword: VALUES
+          bracketed:
+          - start_bracket: (
+          - numeric_literal: '2'
+          - comma: ','
+          - quoted_literal: "'Simon'"
+          - comma: ','
+          - quoted_literal: "'Fox'"
+          - comma: ','
+          - quoted_literal: "'Mr'"
+          - end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      insert_statement:
+      - keyword: INSERT
+      - keyword: INTO
+      - table_reference:
+          naked_identifier: people
+      - bracketed:
         - start_bracket: (
-        - numeric_literal: '2'
+        - column_reference:
+            naked_identifier: person_id
         - comma: ','
-        - quoted_literal: "'Simon'"
+        - column_reference:
+            naked_identifier: given_name
         - comma: ','
-        - quoted_literal: "'Fox'"
+        - column_reference:
+            naked_identifier: family_name
         - comma: ','
-        - quoted_literal: "'Mr'"
+        - column_reference:
+            naked_identifier: title
         - end_bracket: )
-- statement_terminator: ;
-- statement:
-    insert_statement:
-    - keyword: INSERT
-    - keyword: INTO
-    - table_reference:
-        naked_identifier: people
-    - bracketed:
-      - start_bracket: (
-      - column_reference:
-          naked_identifier: person_id
-      - comma: ','
-      - column_reference:
-          naked_identifier: given_name
-      - comma: ','
-      - column_reference:
-          naked_identifier: family_name
-      - comma: ','
-      - column_reference:
-          naked_identifier: title
-      - end_bracket: )
-    - values_clause:
-        keyword: VALUES
-        bracketed:
+      - values_clause:
+          keyword: VALUES
+          bracketed:
+          - start_bracket: (
+          - numeric_literal: '3'
+          - comma: ','
+          - quoted_literal: "'Dave'"
+          - comma: ','
+          - quoted_literal: "'Frog'"
+          - comma: ','
+          - expression:
+              bracketed:
+                start_bracket: (
+                expression:
+                  select_statement:
+                    select_clause:
+                      keyword: SELECT
+                      select_clause_element:
+                        quoted_literal: "'Mr'"
+                    from_clause:
+                      keyword: FROM
+                      from_expression:
+                        from_expression_element:
+                          table_expression:
+                            table_reference:
+                              naked_identifier: dual
+                end_bracket: )
+          - end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      insert_statement:
+      - keyword: INSERT
+      - keyword: INTO
+      - table_reference:
+          naked_identifier: people
+      - bracketed:
         - start_bracket: (
-        - numeric_literal: '2'
+        - column_reference:
+            naked_identifier: person_id
         - comma: ','
-        - quoted_literal: "'Simon'"
+        - column_reference:
+            naked_identifier: given_name
         - comma: ','
-        - quoted_literal: "'Fox'"
+        - column_reference:
+            naked_identifier: family_name
         - comma: ','
-        - quoted_literal: "'Mr'"
+        - column_reference:
+            naked_identifier: title
         - end_bracket: )
-- statement_terminator: ;
-- statement:
-    insert_statement:
-    - keyword: INSERT
-    - keyword: INTO
-    - table_reference:
-        naked_identifier: people
-    - bracketed:
-      - start_bracket: (
-      - column_reference:
-          naked_identifier: person_id
-      - comma: ','
-      - column_reference:
-          naked_identifier: given_name
-      - comma: ','
-      - column_reference:
-          naked_identifier: family_name
-      - comma: ','
-      - column_reference:
-          naked_identifier: title
-      - end_bracket: )
-    - values_clause:
-        keyword: VALUES
-        bracketed:
-        - start_bracket: (
-        - numeric_literal: '3'
-        - comma: ','
-        - quoted_literal: "'Dave'"
-        - comma: ','
-        - quoted_literal: "'Frog'"
-        - comma: ','
-        - expression:
+      - with_compound_statement:
+          keyword: WITH
+          common_table_expression:
+            naked_identifier: names
+            keyword: AS
             bracketed:
               start_bracket: (
-              expression:
-                select_statement:
+              set_expression:
+              - select_statement:
                   select_clause:
-                    keyword: SELECT
-                    select_clause_element:
-                      quoted_literal: "'Mr'"
+                  - keyword: SELECT
+                  - select_clause_element:
+                      numeric_literal: '4'
+                  - comma: ','
+                  - select_clause_element:
+                      quoted_literal: "'Ruth'"
+                  - comma: ','
+                  - select_clause_element:
+                      quoted_literal: "'Fox'"
+                  - comma: ','
+                  - select_clause_element:
+                      quoted_literal: "'Mrs'"
+                  from_clause:
+                    keyword: FROM
+                    from_expression:
+                      from_expression_element:
+                        table_expression:
+                          table_reference:
+                            naked_identifier: dual
+              - set_operator:
+                - keyword: UNION
+                - keyword: ALL
+              - select_statement:
+                  select_clause:
+                  - keyword: SELECT
+                  - select_clause_element:
+                      numeric_literal: '5'
+                  - comma: ','
+                  - select_clause_element:
+                      quoted_literal: "'Isabelle'"
+                  - comma: ','
+                  - select_clause_element:
+                      quoted_literal: "'Squirrel'"
+                  - comma: ','
+                  - select_clause_element:
+                      quoted_literal: "'Miss'"
+                  from_clause:
+                    keyword: FROM
+                    from_expression:
+                      from_expression_element:
+                        table_expression:
+                          table_reference:
+                            naked_identifier: dual
+              - set_operator:
+                - keyword: UNION
+                - keyword: ALL
+              - select_statement:
+                  select_clause:
+                  - keyword: SELECT
+                  - select_clause_element:
+                      numeric_literal: '6'
+                  - comma: ','
+                  - select_clause_element:
+                      quoted_literal: "'Justin'"
+                  - comma: ','
+                  - select_clause_element:
+                      quoted_literal: "'Frog'"
+                  - comma: ','
+                  - select_clause_element:
+                      quoted_literal: "'Master'"
+                  from_clause:
+                    keyword: FROM
+                    from_expression:
+                      from_expression_element:
+                        table_expression:
+                          table_reference:
+                            naked_identifier: dual
+              - set_operator:
+                - keyword: UNION
+                - keyword: ALL
+              - select_statement:
+                  select_clause:
+                  - keyword: SELECT
+                  - select_clause_element:
+                      numeric_literal: '7'
+                  - comma: ','
+                  - select_clause_element:
+                      quoted_literal: "'Lisa'"
+                  - comma: ','
+                  - select_clause_element:
+                      quoted_literal: "'Owl'"
+                  - comma: ','
+                  - select_clause_element:
+                      quoted_literal: "'Dr'"
                   from_clause:
                     keyword: FROM
                     from_expression:
@@ -1041,582 +1166,458 @@ file:
                           table_reference:
                             naked_identifier: dual
               end_bracket: )
+          select_statement:
+            select_clause:
+              keyword: SELECT
+              select_clause_element:
+                wildcard_expression:
+                  wildcard_identifier:
+                    star: '*'
+            from_clause:
+              keyword: FROM
+              from_expression:
+                from_expression_element:
+                  table_expression:
+                    table_reference:
+                      naked_identifier: names
+  - statement_terminator: ;
+  - statement:
+      insert_statement:
+      - keyword: INSERT
+      - keyword: INTO
+      - table_reference:
+          naked_identifier: people
+      - bracketed:
+        - start_bracket: (
+        - column_reference:
+            naked_identifier: person_id
+        - comma: ','
+        - column_reference:
+            naked_identifier: given_name
+        - comma: ','
+        - column_reference:
+            naked_identifier: family_name
+        - comma: ','
+        - column_reference:
+            naked_identifier: title
         - end_bracket: )
-- statement_terminator: ;
-- statement:
-    insert_statement:
-    - keyword: INSERT
-    - keyword: INTO
-    - table_reference:
-        naked_identifier: people
-    - bracketed:
-      - start_bracket: (
-      - column_reference:
-          naked_identifier: person_id
-      - comma: ','
-      - column_reference:
-          naked_identifier: given_name
-      - comma: ','
-      - column_reference:
-          naked_identifier: family_name
-      - comma: ','
-      - column_reference:
-          naked_identifier: title
-      - end_bracket: )
-    - with_compound_statement:
-        keyword: WITH
-        common_table_expression:
-          naked_identifier: names
-          keyword: AS
+      - with_compound_statement:
+          keyword: WITH
+          common_table_expression:
+            naked_identifier: names
+            keyword: AS
+            bracketed:
+              start_bracket: (
+              set_expression:
+              - select_statement:
+                  select_clause:
+                  - keyword: SELECT
+                  - select_clause_element:
+                      numeric_literal: '4'
+                  - comma: ','
+                  - select_clause_element:
+                      quoted_literal: "'Ruth'"
+                  - comma: ','
+                  - select_clause_element:
+                      quoted_literal: "'Fox'"
+                      alias_expression:
+                        naked_identifier: family_name
+                  - comma: ','
+                  - select_clause_element:
+                      quoted_literal: "'Mrs'"
+                  from_clause:
+                    keyword: FROM
+                    from_expression:
+                      from_expression_element:
+                        table_expression:
+                          table_reference:
+                            naked_identifier: dual
+              - set_operator:
+                - keyword: UNION
+                - keyword: ALL
+              - select_statement:
+                  select_clause:
+                  - keyword: SELECT
+                  - select_clause_element:
+                      numeric_literal: '5'
+                  - comma: ','
+                  - select_clause_element:
+                      quoted_literal: "'Isabelle'"
+                  - comma: ','
+                  - select_clause_element:
+                      quoted_literal: "'Squirrel'"
+                      alias_expression:
+                        naked_identifier: family_name
+                  - comma: ','
+                  - select_clause_element:
+                      quoted_literal: "'Miss'"
+                  from_clause:
+                    keyword: FROM
+                    from_expression:
+                      from_expression_element:
+                        table_expression:
+                          table_reference:
+                            naked_identifier: dual
+              - set_operator:
+                - keyword: UNION
+                - keyword: ALL
+              - select_statement:
+                  select_clause:
+                  - keyword: SELECT
+                  - select_clause_element:
+                      numeric_literal: '6'
+                  - comma: ','
+                  - select_clause_element:
+                      quoted_literal: "'Justin'"
+                  - comma: ','
+                  - select_clause_element:
+                      quoted_literal: "'Frog'"
+                      alias_expression:
+                        naked_identifier: family_name
+                  - comma: ','
+                  - select_clause_element:
+                      quoted_literal: "'Master'"
+                  from_clause:
+                    keyword: FROM
+                    from_expression:
+                      from_expression_element:
+                        table_expression:
+                          table_reference:
+                            naked_identifier: dual
+              - set_operator:
+                - keyword: UNION
+                - keyword: ALL
+              - select_statement:
+                  select_clause:
+                  - keyword: SELECT
+                  - select_clause_element:
+                      numeric_literal: '7'
+                  - comma: ','
+                  - select_clause_element:
+                      quoted_literal: "'Lisa'"
+                  - comma: ','
+                  - select_clause_element:
+                      quoted_literal: "'Owl'"
+                      alias_expression:
+                        naked_identifier: family_name
+                  - comma: ','
+                  - select_clause_element:
+                      quoted_literal: "'Dr'"
+                  from_clause:
+                    keyword: FROM
+                    from_expression:
+                      from_expression_element:
+                        table_expression:
+                          table_reference:
+                            naked_identifier: dual
+              end_bracket: )
+          select_statement:
+            select_clause:
+              keyword: SELECT
+              select_clause_element:
+                wildcard_expression:
+                  wildcard_identifier:
+                    star: '*'
+            from_clause:
+              keyword: FROM
+              from_expression:
+                from_expression_element:
+                  table_expression:
+                    table_reference:
+                      naked_identifier: names
+            where_clause:
+              keyword: WHERE
+              expression:
+                column_reference:
+                  naked_identifier: family_name
+                keyword: LIKE
+                quoted_literal: "'F%'"
+  - statement_terminator: ;
+  - statement:
+      insert_statement:
+      - keyword: INSERT
+      - keyword: ALL
+      - keyword: INTO
+      - table_reference:
+          naked_identifier: people
+      - bracketed:
+        - start_bracket: (
+        - column_reference:
+            naked_identifier: person_id
+        - comma: ','
+        - column_reference:
+            naked_identifier: given_name
+        - comma: ','
+        - column_reference:
+            naked_identifier: family_name
+        - comma: ','
+        - column_reference:
+            naked_identifier: title
+        - end_bracket: )
+      - values_clause:
+          keyword: VALUES
           bracketed:
-            start_bracket: (
-            set_expression:
-            - select_statement:
-                select_clause:
-                - keyword: SELECT
-                - select_clause_element:
-                    numeric_literal: '4'
-                - comma: ','
-                - select_clause_element:
-                    quoted_literal: "'Ruth'"
-                - comma: ','
-                - select_clause_element:
-                    quoted_literal: "'Fox'"
-                - comma: ','
-                - select_clause_element:
-                    quoted_literal: "'Mrs'"
-                from_clause:
-                  keyword: FROM
-                  from_expression:
-                    from_expression_element:
-                      table_expression:
-                        table_reference:
-                          naked_identifier: dual
-            - set_operator:
-              - keyword: UNION
-              - keyword: ALL
-            - select_statement:
-                select_clause:
-                - keyword: SELECT
-                - select_clause_element:
-                    numeric_literal: '5'
-                - comma: ','
-                - select_clause_element:
-                    quoted_literal: "'Isabelle'"
-                - comma: ','
-                - select_clause_element:
-                    quoted_literal: "'Squirrel'"
-                - comma: ','
-                - select_clause_element:
-                    quoted_literal: "'Miss'"
-                from_clause:
-                  keyword: FROM
-                  from_expression:
-                    from_expression_element:
-                      table_expression:
-                        table_reference:
-                          naked_identifier: dual
-            - set_operator:
-              - keyword: UNION
-              - keyword: ALL
-            - select_statement:
-                select_clause:
-                - keyword: SELECT
-                - select_clause_element:
-                    numeric_literal: '6'
-                - comma: ','
-                - select_clause_element:
-                    quoted_literal: "'Justin'"
-                - comma: ','
-                - select_clause_element:
-                    quoted_literal: "'Frog'"
-                - comma: ','
-                - select_clause_element:
-                    quoted_literal: "'Master'"
-                from_clause:
-                  keyword: FROM
-                  from_expression:
-                    from_expression_element:
-                      table_expression:
-                        table_reference:
-                          naked_identifier: dual
-            - set_operator:
-              - keyword: UNION
-              - keyword: ALL
-            - select_statement:
-                select_clause:
-                - keyword: SELECT
-                - select_clause_element:
-                    numeric_literal: '7'
-                - comma: ','
-                - select_clause_element:
-                    quoted_literal: "'Lisa'"
-                - comma: ','
-                - select_clause_element:
-                    quoted_literal: "'Owl'"
-                - comma: ','
-                - select_clause_element:
-                    quoted_literal: "'Dr'"
-                from_clause:
-                  keyword: FROM
-                  from_expression:
-                    from_expression_element:
-                      table_expression:
-                        table_reference:
-                          naked_identifier: dual
-            end_bracket: )
-        select_statement:
-          select_clause:
-            keyword: SELECT
-            select_clause_element:
-              wildcard_expression:
-                wildcard_identifier:
-                  star: '*'
-          from_clause:
-            keyword: FROM
-            from_expression:
-              from_expression_element:
-                table_expression:
-                  table_reference:
-                    naked_identifier: names
-- statement_terminator: ;
-- statement:
-    insert_statement:
-    - keyword: INSERT
-    - keyword: INTO
-    - table_reference:
-        naked_identifier: people
-    - bracketed:
-      - start_bracket: (
-      - column_reference:
-          naked_identifier: person_id
-      - comma: ','
-      - column_reference:
-          naked_identifier: given_name
-      - comma: ','
-      - column_reference:
-          naked_identifier: family_name
-      - comma: ','
-      - column_reference:
-          naked_identifier: title
-      - end_bracket: )
-    - with_compound_statement:
-        keyword: WITH
-        common_table_expression:
-          naked_identifier: names
-          keyword: AS
-          bracketed:
-            start_bracket: (
-            set_expression:
-            - select_statement:
-                select_clause:
-                - keyword: SELECT
-                - select_clause_element:
-                    numeric_literal: '4'
-                - comma: ','
-                - select_clause_element:
-                    quoted_literal: "'Ruth'"
-                - comma: ','
-                - select_clause_element:
-                    quoted_literal: "'Fox'"
-                    alias_expression:
-                      naked_identifier: family_name
-                - comma: ','
-                - select_clause_element:
-                    quoted_literal: "'Mrs'"
-                from_clause:
-                  keyword: FROM
-                  from_expression:
-                    from_expression_element:
-                      table_expression:
-                        table_reference:
-                          naked_identifier: dual
-            - set_operator:
-              - keyword: UNION
-              - keyword: ALL
-            - select_statement:
-                select_clause:
-                - keyword: SELECT
-                - select_clause_element:
-                    numeric_literal: '5'
-                - comma: ','
-                - select_clause_element:
-                    quoted_literal: "'Isabelle'"
-                - comma: ','
-                - select_clause_element:
-                    quoted_literal: "'Squirrel'"
-                    alias_expression:
-                      naked_identifier: family_name
-                - comma: ','
-                - select_clause_element:
-                    quoted_literal: "'Miss'"
-                from_clause:
-                  keyword: FROM
-                  from_expression:
-                    from_expression_element:
-                      table_expression:
-                        table_reference:
-                          naked_identifier: dual
-            - set_operator:
-              - keyword: UNION
-              - keyword: ALL
-            - select_statement:
-                select_clause:
-                - keyword: SELECT
-                - select_clause_element:
-                    numeric_literal: '6'
-                - comma: ','
-                - select_clause_element:
-                    quoted_literal: "'Justin'"
-                - comma: ','
-                - select_clause_element:
-                    quoted_literal: "'Frog'"
-                    alias_expression:
-                      naked_identifier: family_name
-                - comma: ','
-                - select_clause_element:
-                    quoted_literal: "'Master'"
-                from_clause:
-                  keyword: FROM
-                  from_expression:
-                    from_expression_element:
-                      table_expression:
-                        table_reference:
-                          naked_identifier: dual
-            - set_operator:
-              - keyword: UNION
-              - keyword: ALL
-            - select_statement:
-                select_clause:
-                - keyword: SELECT
-                - select_clause_element:
-                    numeric_literal: '7'
-                - comma: ','
-                - select_clause_element:
-                    quoted_literal: "'Lisa'"
-                - comma: ','
-                - select_clause_element:
-                    quoted_literal: "'Owl'"
-                    alias_expression:
-                      naked_identifier: family_name
-                - comma: ','
-                - select_clause_element:
-                    quoted_literal: "'Dr'"
-                from_clause:
-                  keyword: FROM
-                  from_expression:
-                    from_expression_element:
-                      table_expression:
-                        table_reference:
-                          naked_identifier: dual
-            end_bracket: )
-        select_statement:
-          select_clause:
-            keyword: SELECT
-            select_clause_element:
-              wildcard_expression:
-                wildcard_identifier:
-                  star: '*'
-          from_clause:
-            keyword: FROM
-            from_expression:
-              from_expression_element:
-                table_expression:
-                  table_reference:
-                    naked_identifier: names
-          where_clause:
-            keyword: WHERE
-            expression:
+          - start_bracket: (
+          - expression:
+              column_reference:
+                naked_identifier: id
+          - comma: ','
+          - expression:
+              column_reference:
+                naked_identifier: given_name
+          - comma: ','
+          - expression:
               column_reference:
                 naked_identifier: family_name
-              keyword: LIKE
-              quoted_literal: "'F%'"
-- statement_terminator: ;
-- statement:
-    insert_statement:
-    - keyword: INSERT
-    - keyword: ALL
-    - keyword: INTO
-    - table_reference:
-        naked_identifier: people
-    - bracketed:
-      - start_bracket: (
-      - column_reference:
-          naked_identifier: person_id
-      - comma: ','
-      - column_reference:
-          naked_identifier: given_name
-      - comma: ','
-      - column_reference:
-          naked_identifier: family_name
-      - comma: ','
-      - column_reference:
-          naked_identifier: title
-      - end_bracket: )
-    - values_clause:
-        keyword: VALUES
-        bracketed:
+          - comma: ','
+          - expression:
+              column_reference:
+                naked_identifier: title
+          - end_bracket: )
+      - keyword: INTO
+      - table_reference:
+          naked_identifier: patients
+      - bracketed:
         - start_bracket: (
-        - expression:
-            column_reference:
-              naked_identifier: id
+        - column_reference:
+            naked_identifier: patient_id
         - comma: ','
-        - expression:
-            column_reference:
-              naked_identifier: given_name
-        - comma: ','
-        - expression:
-            column_reference:
-              naked_identifier: family_name
-        - comma: ','
-        - expression:
-            column_reference:
-              naked_identifier: title
+        - column_reference:
+            naked_identifier: last_admission_date
         - end_bracket: )
-    - keyword: INTO
-    - table_reference:
-        naked_identifier: patients
-    - bracketed:
-      - start_bracket: (
-      - column_reference:
-          naked_identifier: patient_id
-      - comma: ','
-      - column_reference:
-          naked_identifier: last_admission_date
-      - end_bracket: )
-    - values_clause:
-        keyword: VALUES
-        bracketed:
-        - start_bracket: (
-        - expression:
-            column_reference:
-              naked_identifier: id
-        - comma: ','
-        - expression:
-            column_reference:
-              naked_identifier: admission_date
-        - end_bracket: )
-    - keyword: INTO
-    - table_reference:
-        naked_identifier: staff
-    - bracketed:
-      - start_bracket: (
-      - column_reference:
-          naked_identifier: staff_id
-      - comma: ','
-      - column_reference:
-          naked_identifier: hired_date
-      - end_bracket: )
-    - values_clause:
-        keyword: VALUES
-        bracketed:
-        - start_bracket: (
-        - expression:
-            column_reference:
-              naked_identifier: id
-        - comma: ','
-        - expression:
-            column_reference:
-              naked_identifier: hired_date
-        - end_bracket: )
-    - with_compound_statement:
-        keyword: WITH
-        common_table_expression:
-          naked_identifier: names
-          keyword: AS
+      - values_clause:
+          keyword: VALUES
           bracketed:
-            start_bracket: (
-            set_expression:
-            - select_statement:
-                select_clause:
-                - keyword: SELECT
-                - select_clause_element:
-                    numeric_literal: '4'
-                    alias_expression:
-                      naked_identifier: id
-                - comma: ','
-                - select_clause_element:
-                    quoted_literal: "'Ruth'"
-                    alias_expression:
-                      naked_identifier: given_name
-                - comma: ','
-                - select_clause_element:
-                    quoted_literal: "'Fox'"
-                    alias_expression:
-                      naked_identifier: family_name
-                - comma: ','
-                - select_clause_element:
-                    quoted_literal: "'Mrs'"
-                    alias_expression:
-                      naked_identifier: title
-                - comma: ','
-                - select_clause_element:
-                    null_literal: 'NULL'
-                    alias_expression:
-                      naked_identifier: hired_date
-                - comma: ','
-                - select_clause_element:
-                    expression:
-                      data_type:
-                        data_type_identifier: DATE
-                      quoted_literal: "'2009-12-31'"
-                    alias_expression:
-                      naked_identifier: admission_date
-                from_clause:
-                  keyword: FROM
-                  from_expression:
-                    from_expression_element:
-                      table_expression:
-                        table_reference:
-                          naked_identifier: dual
-            - set_operator:
-              - keyword: UNION
-              - keyword: ALL
-            - select_statement:
-                select_clause:
-                - keyword: SELECT
-                - select_clause_element:
-                    numeric_literal: '5'
-                    alias_expression:
-                      naked_identifier: id
-                - comma: ','
-                - select_clause_element:
-                    quoted_literal: "'Isabelle'"
-                    alias_expression:
-                      naked_identifier: given_name
-                - comma: ','
-                - select_clause_element:
-                    quoted_literal: "'Squirrel'"
-                    alias_expression:
-                      naked_identifier: family_name
-                - comma: ','
-                - select_clause_element:
-                    quoted_literal: "'Miss'"
-                    alias_expression:
-                      naked_identifier: title
-                - comma: ','
-                - select_clause_element:
-                    null_literal: 'NULL'
-                    alias_expression:
-                      naked_identifier: hired_date
-                - comma: ','
-                - select_clause_element:
-                    expression:
-                      data_type:
-                        data_type_identifier: DATE
-                      quoted_literal: "'2014-01-01'"
-                    alias_expression:
-                      naked_identifier: admission_date
-                from_clause:
-                  keyword: FROM
-                  from_expression:
-                    from_expression_element:
-                      table_expression:
-                        table_reference:
-                          naked_identifier: dual
-            - set_operator:
-              - keyword: UNION
-              - keyword: ALL
-            - select_statement:
-                select_clause:
-                - keyword: SELECT
-                - select_clause_element:
-                    numeric_literal: '6'
-                    alias_expression:
-                      naked_identifier: id
-                - comma: ','
-                - select_clause_element:
-                    quoted_literal: "'Justin'"
-                    alias_expression:
-                      naked_identifier: given_name
-                - comma: ','
-                - select_clause_element:
-                    quoted_literal: "'Frog'"
-                    alias_expression:
-                      naked_identifier: family_name
-                - comma: ','
-                - select_clause_element:
-                    quoted_literal: "'Master'"
-                    alias_expression:
-                      naked_identifier: title
-                - comma: ','
-                - select_clause_element:
-                    null_literal: 'NULL'
-                    alias_expression:
-                      naked_identifier: hired_date
-                - comma: ','
-                - select_clause_element:
-                    expression:
-                      data_type:
-                        data_type_identifier: DATE
-                      quoted_literal: "'2015-04-22'"
-                    alias_expression:
-                      naked_identifier: admission_date
-                from_clause:
-                  keyword: FROM
-                  from_expression:
-                    from_expression_element:
-                      table_expression:
-                        table_reference:
-                          naked_identifier: dual
-            - set_operator:
-              - keyword: UNION
-              - keyword: ALL
-            - select_statement:
-                select_clause:
-                - keyword: SELECT
-                - select_clause_element:
-                    numeric_literal: '7'
-                    alias_expression:
-                      naked_identifier: id
-                - comma: ','
-                - select_clause_element:
-                    quoted_literal: "'Lisa'"
-                    alias_expression:
-                      naked_identifier: given_name
-                - comma: ','
-                - select_clause_element:
-                    quoted_literal: "'Owl'"
-                    alias_expression:
-                      naked_identifier: family_name
-                - comma: ','
-                - select_clause_element:
-                    quoted_literal: "'Dr'"
-                    alias_expression:
-                      naked_identifier: title
-                - comma: ','
-                - select_clause_element:
-                    expression:
-                      data_type:
-                        data_type_identifier: DATE
-                      quoted_literal: "'2015-01-01'"
-                    alias_expression:
-                      naked_identifier: hired_date
-                - comma: ','
-                - select_clause_element:
-                    null_literal: 'NULL'
-                    alias_expression:
-                      naked_identifier: admission_date
-                from_clause:
-                  keyword: FROM
-                  from_expression:
-                    from_expression_element:
-                      table_expression:
-                        table_reference:
-                          naked_identifier: dual
-            end_bracket: )
-        select_statement:
-          select_clause:
-            keyword: SELECT
-            select_clause_element:
-              wildcard_expression:
-                wildcard_identifier:
-                  star: '*'
-          from_clause:
-            keyword: FROM
-            from_expression:
-              from_expression_element:
-                table_expression:
-                  table_reference:
-                    naked_identifier: names
-- statement_terminator: ;
+          - start_bracket: (
+          - expression:
+              column_reference:
+                naked_identifier: id
+          - comma: ','
+          - expression:
+              column_reference:
+                naked_identifier: admission_date
+          - end_bracket: )
+      - keyword: INTO
+      - table_reference:
+          naked_identifier: staff
+      - bracketed:
+        - start_bracket: (
+        - column_reference:
+            naked_identifier: staff_id
+        - comma: ','
+        - column_reference:
+            naked_identifier: hired_date
+        - end_bracket: )
+      - values_clause:
+          keyword: VALUES
+          bracketed:
+          - start_bracket: (
+          - expression:
+              column_reference:
+                naked_identifier: id
+          - comma: ','
+          - expression:
+              column_reference:
+                naked_identifier: hired_date
+          - end_bracket: )
+      - with_compound_statement:
+          keyword: WITH
+          common_table_expression:
+            naked_identifier: names
+            keyword: AS
+            bracketed:
+              start_bracket: (
+              set_expression:
+              - select_statement:
+                  select_clause:
+                  - keyword: SELECT
+                  - select_clause_element:
+                      numeric_literal: '4'
+                      alias_expression:
+                        naked_identifier: id
+                  - comma: ','
+                  - select_clause_element:
+                      quoted_literal: "'Ruth'"
+                      alias_expression:
+                        naked_identifier: given_name
+                  - comma: ','
+                  - select_clause_element:
+                      quoted_literal: "'Fox'"
+                      alias_expression:
+                        naked_identifier: family_name
+                  - comma: ','
+                  - select_clause_element:
+                      quoted_literal: "'Mrs'"
+                      alias_expression:
+                        naked_identifier: title
+                  - comma: ','
+                  - select_clause_element:
+                      null_literal: 'NULL'
+                      alias_expression:
+                        naked_identifier: hired_date
+                  - comma: ','
+                  - select_clause_element:
+                      expression:
+                        data_type:
+                          data_type_identifier: DATE
+                        quoted_literal: "'2009-12-31'"
+                      alias_expression:
+                        naked_identifier: admission_date
+                  from_clause:
+                    keyword: FROM
+                    from_expression:
+                      from_expression_element:
+                        table_expression:
+                          table_reference:
+                            naked_identifier: dual
+              - set_operator:
+                - keyword: UNION
+                - keyword: ALL
+              - select_statement:
+                  select_clause:
+                  - keyword: SELECT
+                  - select_clause_element:
+                      numeric_literal: '5'
+                      alias_expression:
+                        naked_identifier: id
+                  - comma: ','
+                  - select_clause_element:
+                      quoted_literal: "'Isabelle'"
+                      alias_expression:
+                        naked_identifier: given_name
+                  - comma: ','
+                  - select_clause_element:
+                      quoted_literal: "'Squirrel'"
+                      alias_expression:
+                        naked_identifier: family_name
+                  - comma: ','
+                  - select_clause_element:
+                      quoted_literal: "'Miss'"
+                      alias_expression:
+                        naked_identifier: title
+                  - comma: ','
+                  - select_clause_element:
+                      null_literal: 'NULL'
+                      alias_expression:
+                        naked_identifier: hired_date
+                  - comma: ','
+                  - select_clause_element:
+                      expression:
+                        data_type:
+                          data_type_identifier: DATE
+                        quoted_literal: "'2014-01-01'"
+                      alias_expression:
+                        naked_identifier: admission_date
+                  from_clause:
+                    keyword: FROM
+                    from_expression:
+                      from_expression_element:
+                        table_expression:
+                          table_reference:
+                            naked_identifier: dual
+              - set_operator:
+                - keyword: UNION
+                - keyword: ALL
+              - select_statement:
+                  select_clause:
+                  - keyword: SELECT
+                  - select_clause_element:
+                      numeric_literal: '6'
+                      alias_expression:
+                        naked_identifier: id
+                  - comma: ','
+                  - select_clause_element:
+                      quoted_literal: "'Justin'"
+                      alias_expression:
+                        naked_identifier: given_name
+                  - comma: ','
+                  - select_clause_element:
+                      quoted_literal: "'Frog'"
+                      alias_expression:
+                        naked_identifier: family_name
+                  - comma: ','
+                  - select_clause_element:
+                      quoted_literal: "'Master'"
+                      alias_expression:
+                        naked_identifier: title
+                  - comma: ','
+                  - select_clause_element:
+                      null_literal: 'NULL'
+                      alias_expression:
+                        naked_identifier: hired_date
+                  - comma: ','
+                  - select_clause_element:
+                      expression:
+                        data_type:
+                          data_type_identifier: DATE
+                        quoted_literal: "'2015-04-22'"
+                      alias_expression:
+                        naked_identifier: admission_date
+                  from_clause:
+                    keyword: FROM
+                    from_expression:
+                      from_expression_element:
+                        table_expression:
+                          table_reference:
+                            naked_identifier: dual
+              - set_operator:
+                - keyword: UNION
+                - keyword: ALL
+              - select_statement:
+                  select_clause:
+                  - keyword: SELECT
+                  - select_clause_element:
+                      numeric_literal: '7'
+                      alias_expression:
+                        naked_identifier: id
+                  - comma: ','
+                  - select_clause_element:
+                      quoted_literal: "'Lisa'"
+                      alias_expression:
+                        naked_identifier: given_name
+                  - comma: ','
+                  - select_clause_element:
+                      quoted_literal: "'Owl'"
+                      alias_expression:
+                        naked_identifier: family_name
+                  - comma: ','
+                  - select_clause_element:
+                      quoted_literal: "'Dr'"
+                      alias_expression:
+                        naked_identifier: title
+                  - comma: ','
+                  - select_clause_element:
+                      expression:
+                        data_type:
+                          data_type_identifier: DATE
+                        quoted_literal: "'2015-01-01'"
+                      alias_expression:
+                        naked_identifier: hired_date
+                  - comma: ','
+                  - select_clause_element:
+                      null_literal: 'NULL'
+                      alias_expression:
+                        naked_identifier: admission_date
+                  from_clause:
+                    keyword: FROM
+                    from_expression:
+                      from_expression_element:
+                        table_expression:
+                          table_reference:
+                            naked_identifier: dual
+              end_bracket: )
+          select_statement:
+            select_clause:
+              keyword: SELECT
+              select_clause_element:
+                wildcard_expression:
+                  wildcard_identifier:
+                    star: '*'
+            from_clause:
+              keyword: FROM
+              from_expression:
+                from_expression_element:
+                  table_expression:
+                    table_reference:
+                      naked_identifier: names
+  - statement_terminator: ;

--- a/test/fixtures/dialects/oracle/interval_operations.yml
+++ b/test/fixtures/dialects/oracle/interval_operations.yml
@@ -3,122 +3,123 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 9cd1d5fc1f9dde36e2cffb518e1baf9011a19d7b21ca9280d6075009b7d11c54
+_hash: 2e4e11de195f3cecf71ff6d251fd3c4a00da31add6ec4640a82a952cb0fe21cf
 file:
-- statement:
-    select_statement:
-      select_clause:
-        keyword: select
-        select_clause_element:
-          numeric_literal: '1'
-      from_clause:
-        keyword: from
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: dual
-      where_clause:
-        keyword: where
-        expression:
-        - bare_function: sysdate
-        - comparison_operator:
-            raw_comparison_operator: '>'
-        - bare_function: sysdate
-        - binary_operator: '-'
-        - keyword: interval
-        - date_constructor_literal: "'2'"
-        - keyword: hour
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-        keyword: select
-        select_clause_element:
+  batch:
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: select
+          select_clause_element:
+            numeric_literal: '1'
+        from_clause:
+          keyword: from
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: dual
+        where_clause:
+          keyword: where
           expression:
+          - bare_function: sysdate
+          - comparison_operator:
+              raw_comparison_operator: '>'
           - bare_function: sysdate
           - binary_operator: '-'
           - keyword: interval
-          - date_constructor_literal: "'3'"
-          - keyword: year
-      from_clause:
-        keyword: from
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: dual
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-        keyword: select
-        select_clause_element:
-        - keyword: interval
-        - date_constructor_literal: "'2 3:04:11.333'"
-        - keyword: day
-        - keyword: to
-        - keyword: second
-      from_clause:
-        keyword: from
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: dual
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-        keyword: select
-        select_clause_element:
-          numeric_literal: '1'
-      from_clause:
-        keyword: from
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: dual
-      where_clause:
-        keyword: where
-        expression:
-        - bare_function: sysdate
-        - comparison_operator:
-            raw_comparison_operator: '>'
-        - function:
-            function_name:
-              function_name_identifier: to_date
-            function_contents:
-              bracketed:
-              - start_bracket: (
-              - expression:
-                  quoted_literal: "'01/01/1970'"
-              - comma: ','
-              - expression:
-                  quoted_literal: "'dd/mm/yyyy'"
-              - end_bracket: )
-        - binary_operator: +
-        - keyword: interval
-        - date_constructor_literal: "'600'"
-        - keyword: month
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-        keyword: select
-        select_clause_element:
+          - date_constructor_literal: "'2'"
+          - keyword: hour
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: select
+          select_clause_element:
+            expression:
+            - bare_function: sysdate
+            - binary_operator: '-'
+            - keyword: interval
+            - date_constructor_literal: "'3'"
+            - keyword: year
+        from_clause:
+          keyword: from
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: dual
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: select
+          select_clause_element:
+          - keyword: interval
+          - date_constructor_literal: "'2 3:04:11.333'"
+          - keyword: day
+          - keyword: to
+          - keyword: second
+        from_clause:
+          keyword: from
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: dual
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: select
+          select_clause_element:
+            numeric_literal: '1'
+        from_clause:
+          keyword: from
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: dual
+        where_clause:
+          keyword: where
           expression:
           - bare_function: sysdate
+          - comparison_operator:
+              raw_comparison_operator: '>'
+          - function:
+              function_name:
+                function_name_identifier: to_date
+              function_contents:
+                bracketed:
+                - start_bracket: (
+                - expression:
+                    quoted_literal: "'01/01/1970'"
+                - comma: ','
+                - expression:
+                    quoted_literal: "'dd/mm/yyyy'"
+                - end_bracket: )
           - binary_operator: +
           - keyword: interval
-          - date_constructor_literal: "'10'"
-          - keyword: minute
-      from_clause:
-        keyword: from
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: dual
-- statement_terminator: ;
+          - date_constructor_literal: "'600'"
+          - keyword: month
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: select
+          select_clause_element:
+            expression:
+            - bare_function: sysdate
+            - binary_operator: +
+            - keyword: interval
+            - date_constructor_literal: "'10'"
+            - keyword: minute
+        from_clause:
+          keyword: from
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: dual
+  - statement_terminator: ;

--- a/test/fixtures/dialects/oracle/join_types.yml
+++ b/test/fixtures/dialects/oracle/join_types.yml
@@ -3,476 +3,477 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 90e19f9063ac31d3d2dba6ebfbd6c2ddaceb381a3fc409787f58bb4f83ad59a2
+_hash: 3c2930b7e8b022a484e151673d094ffe6340dace33d37bc5f5069a0f5613851f
 file:
-- statement:
-    select_statement:
-      select_clause:
-      - keyword: SELECT
-      - select_clause_element:
-          column_reference:
-          - naked_identifier: employee
-          - dot: .
-          - naked_identifier: id
-      - comma: ','
-      - select_clause_element:
-          column_reference:
-          - naked_identifier: employee
-          - dot: .
-          - naked_identifier: name
-      - comma: ','
-      - select_clause_element:
-          column_reference:
-          - naked_identifier: employee
-          - dot: .
-          - naked_identifier: deptno
-      - comma: ','
-      - select_clause_element:
-          column_reference:
-          - naked_identifier: department
-          - dot: .
-          - naked_identifier: deptname
-      from_clause:
-        keyword: FROM
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: employee
-          join_clause:
-          - keyword: INNER
-          - keyword: JOIN
-          - from_expression_element:
+  batch:
+  - statement:
+      select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            column_reference:
+            - naked_identifier: employee
+            - dot: .
+            - naked_identifier: id
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+            - naked_identifier: employee
+            - dot: .
+            - naked_identifier: name
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+            - naked_identifier: employee
+            - dot: .
+            - naked_identifier: deptno
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+            - naked_identifier: department
+            - dot: .
+            - naked_identifier: deptname
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: employee
+            join_clause:
+            - keyword: INNER
+            - keyword: JOIN
+            - from_expression_element:
+                table_expression:
+                  table_reference:
+                    naked_identifier: department
+            - join_on_condition:
+                keyword: 'ON'
+                expression:
+                - column_reference:
+                  - naked_identifier: employee
+                  - dot: .
+                  - naked_identifier: deptno
+                - comparison_operator:
+                    raw_comparison_operator: '='
+                - column_reference:
+                  - naked_identifier: department
+                  - dot: .
+                  - naked_identifier: deptno
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            column_reference:
+            - naked_identifier: employee
+            - dot: .
+            - naked_identifier: id
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+            - naked_identifier: employee
+            - dot: .
+            - naked_identifier: name
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+            - naked_identifier: employee
+            - dot: .
+            - naked_identifier: deptno
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+            - naked_identifier: department
+            - dot: .
+            - naked_identifier: deptname
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: employee
+            join_clause:
+            - keyword: LEFT
+            - keyword: JOIN
+            - from_expression_element:
+                table_expression:
+                  table_reference:
+                    naked_identifier: department
+            - join_on_condition:
+                keyword: 'ON'
+                expression:
+                - column_reference:
+                  - naked_identifier: employee
+                  - dot: .
+                  - naked_identifier: deptno
+                - comparison_operator:
+                    raw_comparison_operator: '='
+                - column_reference:
+                  - naked_identifier: department
+                  - dot: .
+                  - naked_identifier: deptno
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            column_reference:
+            - naked_identifier: employee
+            - dot: .
+            - naked_identifier: id
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+            - naked_identifier: employee
+            - dot: .
+            - naked_identifier: name
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+            - naked_identifier: employee
+            - dot: .
+            - naked_identifier: deptno
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+            - naked_identifier: department
+            - dot: .
+            - naked_identifier: deptname
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: employee
+            join_clause:
+            - keyword: LEFT
+            - keyword: OUTER
+            - keyword: JOIN
+            - from_expression_element:
+                table_expression:
+                  table_reference:
+                    naked_identifier: department
+            - join_on_condition:
+                keyword: 'ON'
+                expression:
+                - column_reference:
+                  - naked_identifier: employee
+                  - dot: .
+                  - naked_identifier: deptno
+                - comparison_operator:
+                    raw_comparison_operator: '='
+                - column_reference:
+                  - naked_identifier: department
+                  - dot: .
+                  - naked_identifier: deptno
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            column_reference:
+            - naked_identifier: employee
+            - dot: .
+            - naked_identifier: id
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+            - naked_identifier: employee
+            - dot: .
+            - naked_identifier: name
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+            - naked_identifier: employee
+            - dot: .
+            - naked_identifier: deptno
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+            - naked_identifier: department
+            - dot: .
+            - naked_identifier: deptname
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: employee
+            join_clause:
+            - keyword: RIGHT
+            - keyword: JOIN
+            - from_expression_element:
+                table_expression:
+                  table_reference:
+                    naked_identifier: department
+            - join_on_condition:
+                keyword: 'ON'
+                expression:
+                - column_reference:
+                  - naked_identifier: employee
+                  - dot: .
+                  - naked_identifier: deptno
+                - comparison_operator:
+                    raw_comparison_operator: '='
+                - column_reference:
+                  - naked_identifier: department
+                  - dot: .
+                  - naked_identifier: deptno
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            column_reference:
+            - naked_identifier: employee
+            - dot: .
+            - naked_identifier: id
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+            - naked_identifier: employee
+            - dot: .
+            - naked_identifier: name
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+            - naked_identifier: employee
+            - dot: .
+            - naked_identifier: deptno
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+            - naked_identifier: department
+            - dot: .
+            - naked_identifier: deptname
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: employee
+            join_clause:
+            - keyword: RIGHT
+            - keyword: OUTER
+            - keyword: JOIN
+            - from_expression_element:
+                table_expression:
+                  table_reference:
+                    naked_identifier: department
+            - join_on_condition:
+                keyword: 'ON'
+                expression:
+                - column_reference:
+                  - naked_identifier: employee
+                  - dot: .
+                  - naked_identifier: deptno
+                - comparison_operator:
+                    raw_comparison_operator: '='
+                - column_reference:
+                  - naked_identifier: department
+                  - dot: .
+                  - naked_identifier: deptno
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            column_reference:
+            - naked_identifier: employee
+            - dot: .
+            - naked_identifier: id
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+            - naked_identifier: employee
+            - dot: .
+            - naked_identifier: name
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+            - naked_identifier: employee
+            - dot: .
+            - naked_identifier: deptno
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+            - naked_identifier: department
+            - dot: .
+            - naked_identifier: deptname
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: employee
+            join_clause:
+            - keyword: FULL
+            - keyword: JOIN
+            - from_expression_element:
+                table_expression:
+                  table_reference:
+                    naked_identifier: department
+            - join_on_condition:
+                keyword: 'ON'
+                expression:
+                - column_reference:
+                  - naked_identifier: employee
+                  - dot: .
+                  - naked_identifier: deptno
+                - comparison_operator:
+                    raw_comparison_operator: '='
+                - column_reference:
+                  - naked_identifier: department
+                  - dot: .
+                  - naked_identifier: deptno
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            column_reference:
+            - naked_identifier: employee
+            - dot: .
+            - naked_identifier: id
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+            - naked_identifier: employee
+            - dot: .
+            - naked_identifier: name
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+            - naked_identifier: employee
+            - dot: .
+            - naked_identifier: deptno
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+            - naked_identifier: department
+            - dot: .
+            - naked_identifier: deptname
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: employee
+            join_clause:
+            - keyword: FULL
+            - keyword: OUTER
+            - keyword: JOIN
+            - from_expression_element:
+                table_expression:
+                  table_reference:
+                    naked_identifier: department
+            - join_on_condition:
+                keyword: 'ON'
+                expression:
+                - column_reference:
+                  - naked_identifier: employee
+                  - dot: .
+                  - naked_identifier: deptno
+                - comparison_operator:
+                    raw_comparison_operator: '='
+                - column_reference:
+                  - naked_identifier: department
+                  - dot: .
+                  - naked_identifier: deptno
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            column_reference:
+            - naked_identifier: employee
+            - dot: .
+            - naked_identifier: id
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+            - naked_identifier: employee
+            - dot: .
+            - naked_identifier: name
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+            - naked_identifier: employee
+            - dot: .
+            - naked_identifier: deptno
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+            - naked_identifier: department
+            - dot: .
+            - naked_identifier: deptname
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: employee
+            join_clause:
+            - keyword: CROSS
+            - keyword: JOIN
+            - from_expression_element:
+                table_expression:
+                  table_reference:
+                    naked_identifier: department
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            column_reference:
+            - naked_identifier: employee
+            - dot: .
+            - naked_identifier: id
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+            - naked_identifier: employee
+            - dot: .
+            - naked_identifier: name
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+            - naked_identifier: employee
+            - dot: .
+            - naked_identifier: deptno
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+            - naked_identifier: department
+            - dot: .
+            - naked_identifier: deptname
+        from_clause:
+        - keyword: FROM
+        - from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: employee
+        - comma: ','
+        - from_expression:
+            from_expression_element:
               table_expression:
                 table_reference:
                   naked_identifier: department
-          - join_on_condition:
-              keyword: 'ON'
-              expression:
-              - column_reference:
-                - naked_identifier: employee
-                - dot: .
-                - naked_identifier: deptno
-              - comparison_operator:
-                  raw_comparison_operator: '='
-              - column_reference:
-                - naked_identifier: department
-                - dot: .
-                - naked_identifier: deptno
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-      - keyword: SELECT
-      - select_clause_element:
-          column_reference:
-          - naked_identifier: employee
-          - dot: .
-          - naked_identifier: id
-      - comma: ','
-      - select_clause_element:
-          column_reference:
-          - naked_identifier: employee
-          - dot: .
-          - naked_identifier: name
-      - comma: ','
-      - select_clause_element:
-          column_reference:
-          - naked_identifier: employee
-          - dot: .
-          - naked_identifier: deptno
-      - comma: ','
-      - select_clause_element:
-          column_reference:
-          - naked_identifier: department
-          - dot: .
-          - naked_identifier: deptname
-      from_clause:
-        keyword: FROM
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: employee
-          join_clause:
-          - keyword: LEFT
-          - keyword: JOIN
-          - from_expression_element:
-              table_expression:
-                table_reference:
-                  naked_identifier: department
-          - join_on_condition:
-              keyword: 'ON'
-              expression:
-              - column_reference:
-                - naked_identifier: employee
-                - dot: .
-                - naked_identifier: deptno
-              - comparison_operator:
-                  raw_comparison_operator: '='
-              - column_reference:
-                - naked_identifier: department
-                - dot: .
-                - naked_identifier: deptno
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-      - keyword: SELECT
-      - select_clause_element:
-          column_reference:
-          - naked_identifier: employee
-          - dot: .
-          - naked_identifier: id
-      - comma: ','
-      - select_clause_element:
-          column_reference:
-          - naked_identifier: employee
-          - dot: .
-          - naked_identifier: name
-      - comma: ','
-      - select_clause_element:
-          column_reference:
-          - naked_identifier: employee
-          - dot: .
-          - naked_identifier: deptno
-      - comma: ','
-      - select_clause_element:
-          column_reference:
-          - naked_identifier: department
-          - dot: .
-          - naked_identifier: deptname
-      from_clause:
-        keyword: FROM
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: employee
-          join_clause:
-          - keyword: LEFT
-          - keyword: OUTER
-          - keyword: JOIN
-          - from_expression_element:
-              table_expression:
-                table_reference:
-                  naked_identifier: department
-          - join_on_condition:
-              keyword: 'ON'
-              expression:
-              - column_reference:
-                - naked_identifier: employee
-                - dot: .
-                - naked_identifier: deptno
-              - comparison_operator:
-                  raw_comparison_operator: '='
-              - column_reference:
-                - naked_identifier: department
-                - dot: .
-                - naked_identifier: deptno
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-      - keyword: SELECT
-      - select_clause_element:
-          column_reference:
-          - naked_identifier: employee
-          - dot: .
-          - naked_identifier: id
-      - comma: ','
-      - select_clause_element:
-          column_reference:
-          - naked_identifier: employee
-          - dot: .
-          - naked_identifier: name
-      - comma: ','
-      - select_clause_element:
-          column_reference:
-          - naked_identifier: employee
-          - dot: .
-          - naked_identifier: deptno
-      - comma: ','
-      - select_clause_element:
-          column_reference:
-          - naked_identifier: department
-          - dot: .
-          - naked_identifier: deptname
-      from_clause:
-        keyword: FROM
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: employee
-          join_clause:
-          - keyword: RIGHT
-          - keyword: JOIN
-          - from_expression_element:
-              table_expression:
-                table_reference:
-                  naked_identifier: department
-          - join_on_condition:
-              keyword: 'ON'
-              expression:
-              - column_reference:
-                - naked_identifier: employee
-                - dot: .
-                - naked_identifier: deptno
-              - comparison_operator:
-                  raw_comparison_operator: '='
-              - column_reference:
-                - naked_identifier: department
-                - dot: .
-                - naked_identifier: deptno
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-      - keyword: SELECT
-      - select_clause_element:
-          column_reference:
-          - naked_identifier: employee
-          - dot: .
-          - naked_identifier: id
-      - comma: ','
-      - select_clause_element:
-          column_reference:
-          - naked_identifier: employee
-          - dot: .
-          - naked_identifier: name
-      - comma: ','
-      - select_clause_element:
-          column_reference:
-          - naked_identifier: employee
-          - dot: .
-          - naked_identifier: deptno
-      - comma: ','
-      - select_clause_element:
-          column_reference:
-          - naked_identifier: department
-          - dot: .
-          - naked_identifier: deptname
-      from_clause:
-        keyword: FROM
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: employee
-          join_clause:
-          - keyword: RIGHT
-          - keyword: OUTER
-          - keyword: JOIN
-          - from_expression_element:
-              table_expression:
-                table_reference:
-                  naked_identifier: department
-          - join_on_condition:
-              keyword: 'ON'
-              expression:
-              - column_reference:
-                - naked_identifier: employee
-                - dot: .
-                - naked_identifier: deptno
-              - comparison_operator:
-                  raw_comparison_operator: '='
-              - column_reference:
-                - naked_identifier: department
-                - dot: .
-                - naked_identifier: deptno
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-      - keyword: SELECT
-      - select_clause_element:
-          column_reference:
-          - naked_identifier: employee
-          - dot: .
-          - naked_identifier: id
-      - comma: ','
-      - select_clause_element:
-          column_reference:
-          - naked_identifier: employee
-          - dot: .
-          - naked_identifier: name
-      - comma: ','
-      - select_clause_element:
-          column_reference:
-          - naked_identifier: employee
-          - dot: .
-          - naked_identifier: deptno
-      - comma: ','
-      - select_clause_element:
-          column_reference:
-          - naked_identifier: department
-          - dot: .
-          - naked_identifier: deptname
-      from_clause:
-        keyword: FROM
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: employee
-          join_clause:
-          - keyword: FULL
-          - keyword: JOIN
-          - from_expression_element:
-              table_expression:
-                table_reference:
-                  naked_identifier: department
-          - join_on_condition:
-              keyword: 'ON'
-              expression:
-              - column_reference:
-                - naked_identifier: employee
-                - dot: .
-                - naked_identifier: deptno
-              - comparison_operator:
-                  raw_comparison_operator: '='
-              - column_reference:
-                - naked_identifier: department
-                - dot: .
-                - naked_identifier: deptno
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-      - keyword: SELECT
-      - select_clause_element:
-          column_reference:
-          - naked_identifier: employee
-          - dot: .
-          - naked_identifier: id
-      - comma: ','
-      - select_clause_element:
-          column_reference:
-          - naked_identifier: employee
-          - dot: .
-          - naked_identifier: name
-      - comma: ','
-      - select_clause_element:
-          column_reference:
-          - naked_identifier: employee
-          - dot: .
-          - naked_identifier: deptno
-      - comma: ','
-      - select_clause_element:
-          column_reference:
-          - naked_identifier: department
-          - dot: .
-          - naked_identifier: deptname
-      from_clause:
-        keyword: FROM
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: employee
-          join_clause:
-          - keyword: FULL
-          - keyword: OUTER
-          - keyword: JOIN
-          - from_expression_element:
-              table_expression:
-                table_reference:
-                  naked_identifier: department
-          - join_on_condition:
-              keyword: 'ON'
-              expression:
-              - column_reference:
-                - naked_identifier: employee
-                - dot: .
-                - naked_identifier: deptno
-              - comparison_operator:
-                  raw_comparison_operator: '='
-              - column_reference:
-                - naked_identifier: department
-                - dot: .
-                - naked_identifier: deptno
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-      - keyword: SELECT
-      - select_clause_element:
-          column_reference:
-          - naked_identifier: employee
-          - dot: .
-          - naked_identifier: id
-      - comma: ','
-      - select_clause_element:
-          column_reference:
-          - naked_identifier: employee
-          - dot: .
-          - naked_identifier: name
-      - comma: ','
-      - select_clause_element:
-          column_reference:
-          - naked_identifier: employee
-          - dot: .
-          - naked_identifier: deptno
-      - comma: ','
-      - select_clause_element:
-          column_reference:
-          - naked_identifier: department
-          - dot: .
-          - naked_identifier: deptname
-      from_clause:
-        keyword: FROM
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: employee
-          join_clause:
-          - keyword: CROSS
-          - keyword: JOIN
-          - from_expression_element:
-              table_expression:
-                table_reference:
-                  naked_identifier: department
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-      - keyword: SELECT
-      - select_clause_element:
-          column_reference:
-          - naked_identifier: employee
-          - dot: .
-          - naked_identifier: id
-      - comma: ','
-      - select_clause_element:
-          column_reference:
-          - naked_identifier: employee
-          - dot: .
-          - naked_identifier: name
-      - comma: ','
-      - select_clause_element:
-          column_reference:
-          - naked_identifier: employee
-          - dot: .
-          - naked_identifier: deptno
-      - comma: ','
-      - select_clause_element:
-          column_reference:
-          - naked_identifier: department
-          - dot: .
-          - naked_identifier: deptname
-      from_clause:
-      - keyword: FROM
-      - from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: employee
-      - comma: ','
-      - from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: department
-- statement_terminator: ;
+  - statement_terminator: ;

--- a/test/fixtures/dialects/oracle/json_object.yml
+++ b/test/fixtures/dialects/oracle/json_object.yml
@@ -3,355 +3,356 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 9a8e4e050743f228c2747538c6facfef1c90a9fdf99b5a11036c10699d4d7f0f
+_hash: bd185fd84144d3e21c50613232b3c87e890ded08f9bdb4a84aa3a1da27cbeb3b
 file:
-- statement:
-    select_statement:
-      select_clause:
-        keyword: SELECT
-        select_clause_element:
-          function:
-            function_name:
-              function_name_identifier: JSON_OBJECT
-            function_contents:
-              bracketed:
-              - start_bracket: (
-              - expression:
+  batch:
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            function:
+              function_name:
+                function_name_identifier: JSON_OBJECT
+              function_contents:
+                bracketed:
+                - start_bracket: (
+                - expression:
+                    quoted_literal: "'name'"
+                - colon: ':'
+                - expression:
+                  - column_reference:
+                      naked_identifier: first_name
+                  - binary_operator:
+                    - pipe: '|'
+                    - pipe: '|'
+                  - quoted_literal: "' '"
+                  - binary_operator:
+                    - pipe: '|'
+                    - pipe: '|'
+                  - column_reference:
+                      naked_identifier: last_name
+                - comma: ','
+                - expression:
+                    quoted_literal: "'email'"
+                - colon: ':'
+                - expression:
+                    column_reference:
+                      naked_identifier: email
+                - comma: ','
+                - expression:
+                    quoted_literal: "'phone'"
+                - colon: ':'
+                - expression:
+                    column_reference:
+                      naked_identifier: phone_number
+                - comma: ','
+                - expression:
+                    quoted_literal: "'hire_date'"
+                - colon: ':'
+                - expression:
+                    column_reference:
+                      naked_identifier: hire_date
+                - end_bracket: )
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: employees
+        where_clause:
+          keyword: WHERE
+          expression:
+            column_reference:
+              naked_identifier: employee_id
+            comparison_operator:
+              raw_comparison_operator: '='
+            numeric_literal: '140'
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            function:
+              function_name:
+                function_name_identifier: JSON_OBJECT
+              function_contents:
+                bracketed:
+                  start_bracket: (
+                  star: '*'
+                  end_bracket: )
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: employees
+        where_clause:
+          keyword: WHERE
+          expression:
+            column_reference:
+              naked_identifier: employee_id
+            comparison_operator:
+              raw_comparison_operator: '='
+            numeric_literal: '140'
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            function:
+              function_name:
+                function_name_identifier: JSON_OBJECT
+              function_contents:
+                bracketed:
+                  start_bracket: (
+                  quoted_literal: "'NAME'"
+                  keyword: VALUE
+                  expression:
+                    column_reference:
+                      naked_identifier: first_name
+                  end_bracket: )
+        from_clause:
+        - keyword: FROM
+        - from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: employees
+              alias_expression:
+                naked_identifier: e
+        - comma: ','
+        - from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: departments
+              alias_expression:
+                naked_identifier: d
+        where_clause:
+          keyword: WHERE
+          expression:
+          - column_reference:
+            - naked_identifier: e
+            - dot: .
+            - naked_identifier: department_id
+          - comparison_operator:
+              raw_comparison_operator: '='
+          - column_reference:
+            - naked_identifier: d
+            - dot: .
+            - naked_identifier: department_id
+          - binary_operator: AND
+          - column_reference:
+            - naked_identifier: e
+            - dot: .
+            - naked_identifier: employee_id
+          - comparison_operator:
+              raw_comparison_operator: '='
+          - numeric_literal: '140'
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            function:
+              function_name:
+                function_name_identifier: JSON_ARRAYAGG
+              function_contents:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    function:
+                      function_name:
+                        function_name_identifier: JSON_OBJECT
+                      function_contents:
+                        bracketed:
+                          start_bracket: (
+                          star: '*'
+                          end_bracket: )
+                  end_bracket: )
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: departments
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            function:
+              function_name:
+                function_name_identifier: JSON_OBJECT
+              function_contents:
+                bracketed:
+                  start_bracket: (
                   quoted_literal: "'name'"
-              - colon: ':'
-              - expression:
-                - column_reference:
-                    naked_identifier: first_name
-                - binary_operator:
-                  - pipe: '|'
-                  - pipe: '|'
-                - quoted_literal: "' '"
-                - binary_operator:
-                  - pipe: '|'
-                  - pipe: '|'
-                - column_reference:
-                    naked_identifier: last_name
-              - comma: ','
-              - expression:
-                  quoted_literal: "'email'"
-              - colon: ':'
-              - expression:
-                  column_reference:
-                    naked_identifier: email
-              - comma: ','
-              - expression:
-                  quoted_literal: "'phone'"
-              - colon: ':'
-              - expression:
-                  column_reference:
-                    naked_identifier: phone_number
-              - comma: ','
-              - expression:
-                  quoted_literal: "'hire_date'"
-              - colon: ':'
-              - expression:
-                  column_reference:
-                    naked_identifier: hire_date
-              - end_bracket: )
-      from_clause:
-        keyword: FROM
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: employees
-      where_clause:
-        keyword: WHERE
-        expression:
-          column_reference:
-            naked_identifier: employee_id
-          comparison_operator:
-            raw_comparison_operator: '='
-          numeric_literal: '140'
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-        keyword: SELECT
-        select_clause_element:
-          function:
-            function_name:
-              function_name_identifier: JSON_OBJECT
-            function_contents:
-              bracketed:
-                start_bracket: (
-                star: '*'
-                end_bracket: )
-      from_clause:
-        keyword: FROM
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: employees
-      where_clause:
-        keyword: WHERE
-        expression:
-          column_reference:
-            naked_identifier: employee_id
-          comparison_operator:
-            raw_comparison_operator: '='
-          numeric_literal: '140'
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-        keyword: SELECT
-        select_clause_element:
-          function:
-            function_name:
-              function_name_identifier: JSON_OBJECT
-            function_contents:
-              bracketed:
-                start_bracket: (
-                quoted_literal: "'NAME'"
-                keyword: VALUE
-                expression:
-                  column_reference:
-                    naked_identifier: first_name
-                end_bracket: )
-      from_clause:
-      - keyword: FROM
-      - from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: employees
+                  keyword: value
+                  expression:
+                    quoted_literal: "'Foo'"
+                  end_bracket: )
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: DUAL
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            function:
+              function_name:
+                function_name_identifier: JSON_OBJECT
+              function_contents:
+                bracketed:
+                - start_bracket: (
+                - quoted_literal: "'name'"
+                - keyword: value
+                - expression:
+                    quoted_literal: "'Foo'"
+                - keyword: FORMAT
+                - keyword: JSON
+                - end_bracket: )
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: DUAL
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            function:
+              function_name:
+                function_name_identifier: JSON_OBJECT
+              function_contents:
+                bracketed:
+                - start_bracket: (
+                - keyword: KEY
+                - quoted_literal: "'deptno'"
+                - keyword: VALUE
+                - expression:
+                    column_reference:
+                    - naked_identifier: d
+                    - dot: .
+                    - naked_identifier: department_id
+                - comma: ','
+                - keyword: KEY
+                - quoted_literal: "'deptname'"
+                - keyword: VALUE
+                - expression:
+                    column_reference:
+                    - naked_identifier: d
+                    - dot: .
+                    - naked_identifier: department_name
+                - end_bracket: )
             alias_expression:
-              naked_identifier: e
-      - comma: ','
-      - from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: departments
-            alias_expression:
-              naked_identifier: d
-      where_clause:
-        keyword: WHERE
-        expression:
-        - column_reference:
-          - naked_identifier: e
-          - dot: .
-          - naked_identifier: department_id
-        - comparison_operator:
-            raw_comparison_operator: '='
+              quoted_identifier: '"Department Objects"'
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: departments
+              alias_expression:
+                naked_identifier: d
+        orderby_clause:
+        - keyword: ORDER
+        - keyword: BY
         - column_reference:
           - naked_identifier: d
           - dot: .
           - naked_identifier: department_id
-        - binary_operator: AND
-        - column_reference:
-          - naked_identifier: e
-          - dot: .
-          - naked_identifier: employee_id
-        - comparison_operator:
-            raw_comparison_operator: '='
-        - numeric_literal: '140'
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-        keyword: SELECT
-        select_clause_element:
-          function:
-            function_name:
-              function_name_identifier: JSON_ARRAYAGG
-            function_contents:
-              bracketed:
-                start_bracket: (
-                expression:
-                  function:
-                    function_name:
-                      function_name_identifier: JSON_OBJECT
-                    function_contents:
-                      bracketed:
-                        start_bracket: (
-                        star: '*'
-                        end_bracket: )
-                end_bracket: )
-      from_clause:
-        keyword: FROM
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: departments
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-        keyword: SELECT
-        select_clause_element:
-          function:
-            function_name:
-              function_name_identifier: JSON_OBJECT
-            function_contents:
-              bracketed:
-                start_bracket: (
-                quoted_literal: "'name'"
-                keyword: value
-                expression:
-                  quoted_literal: "'Foo'"
-                end_bracket: )
-      from_clause:
-        keyword: FROM
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: DUAL
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-        keyword: SELECT
-        select_clause_element:
-          function:
-            function_name:
-              function_name_identifier: JSON_OBJECT
-            function_contents:
-              bracketed:
-              - start_bracket: (
-              - quoted_literal: "'name'"
-              - keyword: value
-              - expression:
-                  quoted_literal: "'Foo'"
-              - keyword: FORMAT
-              - keyword: JSON
-              - end_bracket: )
-      from_clause:
-        keyword: FROM
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: DUAL
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-        keyword: SELECT
-        select_clause_element:
-          function:
-            function_name:
-              function_name_identifier: JSON_OBJECT
-            function_contents:
-              bracketed:
-              - start_bracket: (
-              - keyword: KEY
-              - quoted_literal: "'deptno'"
-              - keyword: VALUE
-              - expression:
-                  column_reference:
-                  - naked_identifier: d
-                  - dot: .
-                  - naked_identifier: department_id
-              - comma: ','
-              - keyword: KEY
-              - quoted_literal: "'deptname'"
-              - keyword: VALUE
-              - expression:
-                  column_reference:
-                  - naked_identifier: d
-                  - dot: .
-                  - naked_identifier: department_name
-              - end_bracket: )
-          alias_expression:
-            quoted_identifier: '"Department Objects"'
-      from_clause:
-        keyword: FROM
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: departments
-            alias_expression:
-              naked_identifier: d
-      orderby_clause:
-      - keyword: ORDER
-      - keyword: BY
-      - column_reference:
-        - naked_identifier: d
-        - dot: .
-        - naked_identifier: department_id
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-        keyword: SELECT
-        select_clause_element:
-          function:
-            function_name:
-              function_name_identifier: JSON_OBJECT
-            function_contents:
-              bracketed:
-              - start_bracket: (
-              - expression:
-                  column_reference:
-                    naked_identifier: first_name
-              - comma: ','
-              - expression:
-                  column_reference:
-                    naked_identifier: last_name
-              - comma: ','
-              - expression:
-                  column_reference:
-                    naked_identifier: email
-              - comma: ','
-              - expression:
-                  column_reference:
-                    naked_identifier: hire_date
-              - end_bracket: )
-      from_clause:
-        keyword: FROM
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: employees
-      where_clause:
-        keyword: WHERE
-        expression:
-          column_reference:
-            naked_identifier: employee_id
-          comparison_operator:
-            raw_comparison_operator: '='
-          numeric_literal: '140'
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-        keyword: SELECT
-        select_clause_element:
-          function:
-            function_name:
-              function_name_identifier: JSON_OBJECT
-            function_contents:
-              bracketed:
-                start_bracket: (
-                expression:
-                  column_reference:
-                    naked_identifier: eMail
-                end_bracket: )
-      from_clause:
-        keyword: FROM
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: employees
-      where_clause:
-        keyword: WHERE
-        expression:
-          column_reference:
-            naked_identifier: employee_id
-          comparison_operator:
-            raw_comparison_operator: '='
-          numeric_literal: '140'
-- statement_terminator: ;
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            function:
+              function_name:
+                function_name_identifier: JSON_OBJECT
+              function_contents:
+                bracketed:
+                - start_bracket: (
+                - expression:
+                    column_reference:
+                      naked_identifier: first_name
+                - comma: ','
+                - expression:
+                    column_reference:
+                      naked_identifier: last_name
+                - comma: ','
+                - expression:
+                    column_reference:
+                      naked_identifier: email
+                - comma: ','
+                - expression:
+                    column_reference:
+                      naked_identifier: hire_date
+                - end_bracket: )
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: employees
+        where_clause:
+          keyword: WHERE
+          expression:
+            column_reference:
+              naked_identifier: employee_id
+            comparison_operator:
+              raw_comparison_operator: '='
+            numeric_literal: '140'
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            function:
+              function_name:
+                function_name_identifier: JSON_OBJECT
+              function_contents:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    column_reference:
+                      naked_identifier: eMail
+                  end_bracket: )
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: employees
+        where_clause:
+          keyword: WHERE
+          expression:
+            column_reference:
+              naked_identifier: employee_id
+            comparison_operator:
+              raw_comparison_operator: '='
+            numeric_literal: '140'
+  - statement_terminator: ;

--- a/test/fixtures/dialects/oracle/lateral.yml
+++ b/test/fixtures/dialects/oracle/lateral.yml
@@ -3,46 +3,185 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: acd2d7ccea6b8957dd10d36e45d32f26fb39e85e66e1b179bebe4b6fbd3b7eb9
+_hash: ed9b4a77dac5f7f98bf38454946c4f839469b45f22e731821cfdfafce3a0c44b
 file:
-- statement:
-    select_statement:
-      select_clause:
-      - keyword: SELECT
-      - select_clause_element:
-          column_reference:
-          - naked_identifier: t1
-          - dot: .
-          - naked_identifier: id
-      - comma: ','
-      - select_clause_element:
-          column_reference:
-          - naked_identifier: t2
-          - dot: .
-          - naked_identifier: id
-          alias_expression:
-            alias_operator:
-              keyword: AS
-            naked_identifier: t2_id
-      - comma: ','
-      - select_clause_element:
-          column_reference:
-          - naked_identifier: t2
-          - dot: .
-          - naked_identifier: col1
-      from_clause:
-        keyword: FROM
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: tbl1
+  batch:
+  - statement:
+      select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            column_reference:
+            - naked_identifier: t1
+            - dot: .
+            - naked_identifier: id
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+            - naked_identifier: t2
+            - dot: .
+            - naked_identifier: id
             alias_expression:
-              naked_identifier: t1
-          join_clause:
-          - keyword: INNER
-          - keyword: JOIN
-          - from_expression_element:
+              alias_operator:
+                keyword: AS
+              naked_identifier: t2_id
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+            - naked_identifier: t2
+            - dot: .
+            - naked_identifier: col1
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: tbl1
+              alias_expression:
+                naked_identifier: t1
+            join_clause:
+            - keyword: INNER
+            - keyword: JOIN
+            - from_expression_element:
+                keyword: LATERAL
+                table_expression:
+                  bracketed:
+                    start_bracket: (
+                    select_statement:
+                      select_clause:
+                      - keyword: SELECT
+                      - select_clause_element:
+                          column_reference:
+                            naked_identifier: id
+                      - comma: ','
+                      - select_clause_element:
+                          column_reference:
+                            naked_identifier: col1
+                      from_clause:
+                        keyword: FROM
+                        from_expression:
+                          from_expression_element:
+                            table_expression:
+                              table_reference:
+                                naked_identifier: tbl2
+                    end_bracket: )
+                alias_expression:
+                  naked_identifier: t2
+            - join_on_condition:
+                keyword: 'ON'
+                expression:
+                - column_reference:
+                  - naked_identifier: t1
+                  - dot: .
+                  - naked_identifier: id
+                - comparison_operator:
+                    raw_comparison_operator: '='
+                - column_reference:
+                  - naked_identifier: t2
+                  - dot: .
+                  - naked_identifier: id
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            column_reference:
+            - naked_identifier: t1
+            - dot: .
+            - naked_identifier: id
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+            - naked_identifier: t2
+            - dot: .
+            - naked_identifier: id
+            alias_expression:
+              alias_operator:
+                keyword: AS
+              naked_identifier: t2_id
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+            - naked_identifier: t2
+            - dot: .
+            - naked_identifier: col1
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: tbl1
+              alias_expression:
+                naked_identifier: t1
+            join_clause:
+            - keyword: CROSS
+            - keyword: JOIN
+            - from_expression_element:
+                keyword: LATERAL
+                table_expression:
+                  bracketed:
+                    start_bracket: (
+                    select_statement:
+                      select_clause:
+                      - keyword: SELECT
+                      - select_clause_element:
+                          column_reference:
+                            naked_identifier: id
+                      - comma: ','
+                      - select_clause_element:
+                          column_reference:
+                            naked_identifier: col1
+                      from_clause:
+                        keyword: FROM
+                        from_expression:
+                          from_expression_element:
+                            table_expression:
+                              table_reference:
+                                naked_identifier: tbl2
+                    end_bracket: )
+                alias_expression:
+                  naked_identifier: t2
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            column_reference:
+            - naked_identifier: t1
+            - dot: .
+            - naked_identifier: id
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+            - naked_identifier: t2
+            - dot: .
+            - naked_identifier: id
+            alias_expression:
+              alias_operator:
+                keyword: AS
+              naked_identifier: t2_id
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+            - naked_identifier: t2
+            - dot: .
+            - naked_identifier: col1
+        from_clause:
+        - keyword: FROM
+        - from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: tbl1
+              alias_expression:
+                naked_identifier: t1
+        - comma: ','
+        - from_expression:
+            from_expression_element:
               keyword: LATERAL
               table_expression:
                 bracketed:
@@ -67,142 +206,4 @@ file:
                   end_bracket: )
               alias_expression:
                 naked_identifier: t2
-          - join_on_condition:
-              keyword: 'ON'
-              expression:
-              - column_reference:
-                - naked_identifier: t1
-                - dot: .
-                - naked_identifier: id
-              - comparison_operator:
-                  raw_comparison_operator: '='
-              - column_reference:
-                - naked_identifier: t2
-                - dot: .
-                - naked_identifier: id
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-      - keyword: SELECT
-      - select_clause_element:
-          column_reference:
-          - naked_identifier: t1
-          - dot: .
-          - naked_identifier: id
-      - comma: ','
-      - select_clause_element:
-          column_reference:
-          - naked_identifier: t2
-          - dot: .
-          - naked_identifier: id
-          alias_expression:
-            alias_operator:
-              keyword: AS
-            naked_identifier: t2_id
-      - comma: ','
-      - select_clause_element:
-          column_reference:
-          - naked_identifier: t2
-          - dot: .
-          - naked_identifier: col1
-      from_clause:
-        keyword: FROM
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: tbl1
-            alias_expression:
-              naked_identifier: t1
-          join_clause:
-          - keyword: CROSS
-          - keyword: JOIN
-          - from_expression_element:
-              keyword: LATERAL
-              table_expression:
-                bracketed:
-                  start_bracket: (
-                  select_statement:
-                    select_clause:
-                    - keyword: SELECT
-                    - select_clause_element:
-                        column_reference:
-                          naked_identifier: id
-                    - comma: ','
-                    - select_clause_element:
-                        column_reference:
-                          naked_identifier: col1
-                    from_clause:
-                      keyword: FROM
-                      from_expression:
-                        from_expression_element:
-                          table_expression:
-                            table_reference:
-                              naked_identifier: tbl2
-                  end_bracket: )
-              alias_expression:
-                naked_identifier: t2
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-      - keyword: SELECT
-      - select_clause_element:
-          column_reference:
-          - naked_identifier: t1
-          - dot: .
-          - naked_identifier: id
-      - comma: ','
-      - select_clause_element:
-          column_reference:
-          - naked_identifier: t2
-          - dot: .
-          - naked_identifier: id
-          alias_expression:
-            alias_operator:
-              keyword: AS
-            naked_identifier: t2_id
-      - comma: ','
-      - select_clause_element:
-          column_reference:
-          - naked_identifier: t2
-          - dot: .
-          - naked_identifier: col1
-      from_clause:
-      - keyword: FROM
-      - from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: tbl1
-            alias_expression:
-              naked_identifier: t1
-      - comma: ','
-      - from_expression:
-          from_expression_element:
-            keyword: LATERAL
-            table_expression:
-              bracketed:
-                start_bracket: (
-                select_statement:
-                  select_clause:
-                  - keyword: SELECT
-                  - select_clause_element:
-                      column_reference:
-                        naked_identifier: id
-                  - comma: ','
-                  - select_clause_element:
-                      column_reference:
-                        naked_identifier: col1
-                  from_clause:
-                    keyword: FROM
-                    from_expression:
-                      from_expression_element:
-                        table_expression:
-                          table_reference:
-                            naked_identifier: tbl2
-                end_bracket: )
-            alias_expression:
-              naked_identifier: t2
-- statement_terminator: ;
+  - statement_terminator: ;

--- a/test/fixtures/dialects/oracle/named_argument.yml
+++ b/test/fixtures/dialects/oracle/named_argument.yml
@@ -3,92 +3,93 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: a5fdbbf6eaa08251ecd5c0f8ccd12e22cf310f3710e32772b2131433c037dfa5
+_hash: 3837d32ccbd24f9014b2cccaf21d11ccd144ca272b24f676def0d79b5f896a6e
 file:
-- statement:
-    select_statement:
-      select_clause:
-        keyword: select
-        select_clause_element:
-          function:
-            function_name:
-              function_name_identifier: my_function
-            function_contents:
-              bracketed:
-              - start_bracket: (
-              - named_argument:
-                  naked_identifier: arg1
-                  right_arrow: =>
+  batch:
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: select
+          select_clause_element:
+            function:
+              function_name:
+                function_name_identifier: my_function
+              function_contents:
+                bracketed:
+                - start_bracket: (
+                - named_argument:
+                    naked_identifier: arg1
+                    right_arrow: =>
+                    expression:
+                      numeric_literal: '3'
+                - comma: ','
+                - named_argument:
+                    naked_identifier: arg2
+                    right_arrow: =>
+                    expression:
+                      numeric_literal: '4'
+                - end_bracket: )
+        from_clause:
+          keyword: from
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: dual
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: select
+          select_clause_element:
+            function:
+              function_name:
+                function_name_identifier: my_function
+              function_contents:
+                bracketed:
+                  start_bracket: (
                   expression:
                     numeric_literal: '3'
-              - comma: ','
-              - named_argument:
-                  naked_identifier: arg2
-                  right_arrow: =>
+                  comma: ','
+                  named_argument:
+                    naked_identifier: arg2
+                    right_arrow: =>
+                    expression:
+                      numeric_literal: '4'
+                  end_bracket: )
+        from_clause:
+          keyword: from
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: dual
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: select
+          select_clause_element:
+            function:
+              function_name:
+                function_name_identifier: my_function
+              function_contents:
+                bracketed:
+                  start_bracket: (
+                  named_argument:
+                    naked_identifier: arg1
+                    right_arrow: =>
+                    expression:
+                      numeric_literal: '3'
+                  comma: ','
                   expression:
                     numeric_literal: '4'
-              - end_bracket: )
-      from_clause:
-        keyword: from
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: dual
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-        keyword: select
-        select_clause_element:
-          function:
-            function_name:
-              function_name_identifier: my_function
-            function_contents:
-              bracketed:
-                start_bracket: (
-                expression:
-                  numeric_literal: '3'
-                comma: ','
-                named_argument:
-                  naked_identifier: arg2
-                  right_arrow: =>
-                  expression:
-                    numeric_literal: '4'
-                end_bracket: )
-      from_clause:
-        keyword: from
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: dual
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-        keyword: select
-        select_clause_element:
-          function:
-            function_name:
-              function_name_identifier: my_function
-            function_contents:
-              bracketed:
-                start_bracket: (
-                named_argument:
-                  naked_identifier: arg1
-                  right_arrow: =>
-                  expression:
-                    numeric_literal: '3'
-                comma: ','
-                expression:
-                  numeric_literal: '4'
-                end_bracket: )
-      from_clause:
-        keyword: from
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: dual
-- statement_terminator: ;
+                  end_bracket: )
+        from_clause:
+          keyword: from
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: dual
+  - statement_terminator: ;

--- a/test/fixtures/dialects/oracle/non_ansi_joins.yml
+++ b/test/fixtures/dialects/oracle/non_ansi_joins.yml
@@ -3,270 +3,271 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 63c86ad061dc379a372315194dc7458692492d468a50742a822af96f1f6ae027
+_hash: c6fd56cd4666545063e7cb8b6df096813d245e31bd65f33adee4463aa6944961
 file:
-- statement:
-    select_statement:
-      select_clause:
-      - keyword: SELECT
-      - select_clause_element:
-          column_reference:
-          - naked_identifier: suppliers
-          - dot: .
-          - naked_identifier: supplier_id
-      - comma: ','
-      - select_clause_element:
-          column_reference:
-          - naked_identifier: suppliers
-          - dot: .
-          - naked_identifier: supplier_name
-      - comma: ','
-      - select_clause_element:
-          column_reference:
-          - naked_identifier: orders
-          - dot: .
-          - naked_identifier: order_date
-      from_clause:
-      - keyword: FROM
-      - from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: suppliers
-      - comma: ','
-      - from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: orders
-      where_clause:
-        keyword: WHERE
-        expression:
-        - column_reference:
-          - naked_identifier: suppliers
-          - dot: .
-          - naked_identifier: supplier_id
-        - bracketed:
-            start_bracket: (
-            plus_join_symbol: +
-            end_bracket: )
-        - comparison_operator:
-            raw_comparison_operator: '='
-        - column_reference:
-          - naked_identifier: orders
-          - dot: .
-          - naked_identifier: supplier_id
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-      - keyword: SELECT
-      - select_clause_element:
-          column_reference:
-          - naked_identifier: suppliers
-          - dot: .
-          - naked_identifier: supplier_id
-      - comma: ','
-      - select_clause_element:
-          column_reference:
-          - naked_identifier: suppliers
-          - dot: .
-          - naked_identifier: supplier_name
-      - comma: ','
-      - select_clause_element:
-          column_reference:
-          - naked_identifier: orders
-          - dot: .
-          - naked_identifier: order_date
-      from_clause:
-      - keyword: FROM
-      - from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: suppliers
-      - comma: ','
-      - from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: orders
-      where_clause:
-        keyword: WHERE
-        expression:
-        - column_reference:
-          - naked_identifier: suppliers
-          - dot: .
-          - naked_identifier: supplier_id
-        - comparison_operator:
-            raw_comparison_operator: '='
-        - column_reference:
-          - naked_identifier: orders
-          - dot: .
-          - naked_identifier: supplier_id
-        - bracketed:
-            start_bracket: (
-            plus_join_symbol: +
-            end_bracket: )
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-      - keyword: SELECT
-      - select_clause_element:
-          column_reference:
-          - naked_identifier: suppliers
-          - dot: .
-          - naked_identifier: supplier_id
-      - comma: ','
-      - select_clause_element:
-          column_reference:
-          - naked_identifier: suppliers
-          - dot: .
-          - naked_identifier: supplier_name
-      - comma: ','
-      - select_clause_element:
-          column_reference:
-          - naked_identifier: orders
-          - dot: .
-          - naked_identifier: order_date
-      from_clause:
-      - keyword: FROM
-      - from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: suppliers
-      - comma: ','
-      - from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: orders
-      - comma: ','
-      - from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: customers
-      where_clause:
-        keyword: WHERE
-        expression:
-        - column_reference:
-          - naked_identifier: suppliers
-          - dot: .
-          - naked_identifier: supplier_id
-        - comparison_operator:
-            raw_comparison_operator: '='
-        - column_reference:
-          - naked_identifier: orders
-          - dot: .
-          - naked_identifier: supplier_id
-        - binary_operator: AND
-        - column_reference:
-          - naked_identifier: orders
-          - dot: .
-          - naked_identifier: customer_id
-        - comparison_operator:
-            raw_comparison_operator: '='
-        - column_reference:
-          - naked_identifier: customers
-          - dot: .
-          - naked_identifier: customer_id
-        - bracketed:
-            start_bracket: (
-            plus_join_symbol: +
-            end_bracket: )
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-        keyword: SELECT
-        select_clause_element:
-          wildcard_expression:
-            wildcard_identifier:
-              star: '*'
-      from_clause:
-      - keyword: FROM
-      - from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: table_a
-      - comma: ','
-      - from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: table_b
-      where_clause:
-        keyword: WHERE
-        expression:
-          column_reference:
-            naked_identifier: column_a
-          bracketed:
-            start_bracket: (
-            plus_join_symbol: +
-            end_bracket: )
-          comparison_operator:
-            raw_comparison_operator: '='
-          function:
-            function_name:
-              function_name_identifier: nvl
-            function_contents:
-              bracketed:
-              - start_bracket: (
-              - expression:
-                  column_reference:
-                    naked_identifier: column_b
-              - comma: ','
-              - expression:
-                  numeric_literal: '1'
-              - end_bracket: )
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-        keyword: SELECT
-        select_clause_element:
-          wildcard_expression:
-            wildcard_identifier:
-              star: '*'
-      from_clause:
-      - keyword: FROM
-      - from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: table_a
-      - comma: ','
-      - from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: table_b
-      where_clause:
-        keyword: WHERE
-        expression:
-          function:
-            function_name:
-              function_name_identifier: nvl
-            function_contents:
-              bracketed:
-              - start_bracket: (
-              - expression:
-                  column_reference:
-                    naked_identifier: column_b
-              - comma: ','
-              - expression:
-                  numeric_literal: '1'
-              - end_bracket: )
-          comparison_operator:
-            raw_comparison_operator: '='
-          column_reference:
-            naked_identifier: column_a
-          bracketed:
-            start_bracket: (
-            plus_join_symbol: +
-            end_bracket: )
-- statement_terminator: ;
+  batch:
+  - statement:
+      select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            column_reference:
+            - naked_identifier: suppliers
+            - dot: .
+            - naked_identifier: supplier_id
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+            - naked_identifier: suppliers
+            - dot: .
+            - naked_identifier: supplier_name
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+            - naked_identifier: orders
+            - dot: .
+            - naked_identifier: order_date
+        from_clause:
+        - keyword: FROM
+        - from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: suppliers
+        - comma: ','
+        - from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: orders
+        where_clause:
+          keyword: WHERE
+          expression:
+          - column_reference:
+            - naked_identifier: suppliers
+            - dot: .
+            - naked_identifier: supplier_id
+          - bracketed:
+              start_bracket: (
+              plus_join_symbol: +
+              end_bracket: )
+          - comparison_operator:
+              raw_comparison_operator: '='
+          - column_reference:
+            - naked_identifier: orders
+            - dot: .
+            - naked_identifier: supplier_id
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            column_reference:
+            - naked_identifier: suppliers
+            - dot: .
+            - naked_identifier: supplier_id
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+            - naked_identifier: suppliers
+            - dot: .
+            - naked_identifier: supplier_name
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+            - naked_identifier: orders
+            - dot: .
+            - naked_identifier: order_date
+        from_clause:
+        - keyword: FROM
+        - from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: suppliers
+        - comma: ','
+        - from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: orders
+        where_clause:
+          keyword: WHERE
+          expression:
+          - column_reference:
+            - naked_identifier: suppliers
+            - dot: .
+            - naked_identifier: supplier_id
+          - comparison_operator:
+              raw_comparison_operator: '='
+          - column_reference:
+            - naked_identifier: orders
+            - dot: .
+            - naked_identifier: supplier_id
+          - bracketed:
+              start_bracket: (
+              plus_join_symbol: +
+              end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            column_reference:
+            - naked_identifier: suppliers
+            - dot: .
+            - naked_identifier: supplier_id
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+            - naked_identifier: suppliers
+            - dot: .
+            - naked_identifier: supplier_name
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+            - naked_identifier: orders
+            - dot: .
+            - naked_identifier: order_date
+        from_clause:
+        - keyword: FROM
+        - from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: suppliers
+        - comma: ','
+        - from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: orders
+        - comma: ','
+        - from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: customers
+        where_clause:
+          keyword: WHERE
+          expression:
+          - column_reference:
+            - naked_identifier: suppliers
+            - dot: .
+            - naked_identifier: supplier_id
+          - comparison_operator:
+              raw_comparison_operator: '='
+          - column_reference:
+            - naked_identifier: orders
+            - dot: .
+            - naked_identifier: supplier_id
+          - binary_operator: AND
+          - column_reference:
+            - naked_identifier: orders
+            - dot: .
+            - naked_identifier: customer_id
+          - comparison_operator:
+              raw_comparison_operator: '='
+          - column_reference:
+            - naked_identifier: customers
+            - dot: .
+            - naked_identifier: customer_id
+          - bracketed:
+              start_bracket: (
+              plus_join_symbol: +
+              end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+        from_clause:
+        - keyword: FROM
+        - from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: table_a
+        - comma: ','
+        - from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: table_b
+        where_clause:
+          keyword: WHERE
+          expression:
+            column_reference:
+              naked_identifier: column_a
+            bracketed:
+              start_bracket: (
+              plus_join_symbol: +
+              end_bracket: )
+            comparison_operator:
+              raw_comparison_operator: '='
+            function:
+              function_name:
+                function_name_identifier: nvl
+              function_contents:
+                bracketed:
+                - start_bracket: (
+                - expression:
+                    column_reference:
+                      naked_identifier: column_b
+                - comma: ','
+                - expression:
+                    numeric_literal: '1'
+                - end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+        from_clause:
+        - keyword: FROM
+        - from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: table_a
+        - comma: ','
+        - from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: table_b
+        where_clause:
+          keyword: WHERE
+          expression:
+            function:
+              function_name:
+                function_name_identifier: nvl
+              function_contents:
+                bracketed:
+                - start_bracket: (
+                - expression:
+                    column_reference:
+                      naked_identifier: column_b
+                - comma: ','
+                - expression:
+                    numeric_literal: '1'
+                - end_bracket: )
+            comparison_operator:
+              raw_comparison_operator: '='
+            column_reference:
+              naked_identifier: column_a
+            bracketed:
+              start_bracket: (
+              plus_join_symbol: +
+              end_bracket: )
+  - statement_terminator: ;

--- a/test/fixtures/dialects/oracle/open_for.yml
+++ b/test/fixtures/dialects/oracle/open_for.yml
@@ -3,534 +3,542 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: e8e77168b63ce895802141f261cb6eeb204f0a191de82fad37bae2df4bcab93b
+_hash: 1923d4143d82b238d9a9640c783855710552440dc24016aa5c5fd2726044fd81
 file:
-- statement:
-    begin_end_block:
-    - declare_segment:
-      - keyword: DECLARE
-      - naked_identifier: cv
-      - data_type:
-          data_type_identifier: SYS_REFCURSOR
-      - statement_terminator: ;
-      - naked_identifier: v_lastname
-      - column_type_reference:
-          column_reference:
-          - naked_identifier: employees
-          - dot: .
-          - naked_identifier: last_name
-          binary_operator: '%'
-          keyword: TYPE
-      - statement_terminator: ;
-      - naked_identifier: v_jobid
-      - column_type_reference:
-          column_reference:
-          - naked_identifier: employees
-          - dot: .
-          - naked_identifier: job_id
-          binary_operator: '%'
-          keyword: TYPE
-      - statement_terminator: ;
-      - naked_identifier: query_2
-      - data_type:
-          data_type_identifier: VARCHAR2
-          bracketed_arguments:
-            bracketed:
-              start_bracket: (
-              numeric_literal: '200'
-              end_bracket: )
-      - assignment_operator: :=
-      - expression:
-          quoted_literal: "'SELECT * FROM employees\n    WHERE REGEXP_LIKE (job_id,\
-            \ ''[ACADFIMKSA]_M[ANGR]'')\n    ORDER BY job_id'"
-      - statement_terminator: ;
-      - naked_identifier: v_employees
-      - row_type_reference:
-          table_reference:
-            naked_identifier: employees
-          binary_operator: '%'
-          keyword: ROWTYPE
-      - statement_terminator: ;
-    - keyword: BEGIN
-    - statement:
-        open_for_statement:
-        - keyword: OPEN
+- batch:
+    statement:
+      begin_end_block:
+      - declare_segment:
+        - keyword: DECLARE
         - naked_identifier: cv
-        - keyword: FOR
-        - select_statement:
-            select_clause:
-            - keyword: SELECT
-            - select_clause_element:
-                column_reference:
-                  naked_identifier: last_name
-            - comma: ','
-            - select_clause_element:
-                column_reference:
-                  naked_identifier: job_id
-            from_clause:
-              keyword: FROM
-              from_expression:
-                from_expression_element:
-                  table_expression:
-                    table_reference:
-                      naked_identifier: employees
-            where_clause:
-              keyword: WHERE
-              expression:
-                function:
-                  function_name:
-                    function_name_identifier: REGEXP_LIKE
-                  function_contents:
-                    bracketed:
-                    - start_bracket: (
-                    - expression:
-                        column_reference:
-                          naked_identifier: job_id
-                    - comma: ','
-                    - expression:
-                        quoted_literal: "'S[HT]_CLERK'"
-                    - end_bracket: )
-            orderby_clause:
-            - keyword: ORDER
-            - keyword: BY
-            - column_reference:
-                naked_identifier: last_name
-    - statement_terminator: ;
-    - statement:
-        loop_statement:
-        - keyword: LOOP
-        - statement:
-            fetch_statement:
-              keyword: FETCH
-              naked_identifier: cv
-              into_clause:
-              - keyword: INTO
-              - naked_identifier: v_lastname
-              - comma: ','
-              - naked_identifier: v_jobid
+        - data_type:
+            data_type_identifier: SYS_REFCURSOR
         - statement_terminator: ;
-        - statement:
-            exit_statement:
-            - keyword: EXIT
-            - keyword: WHEN
-            - expression:
-                naked_identifier: cv
-                binary_operator: '%'
-                keyword: NOTFOUND
+        - naked_identifier: v_lastname
+        - column_type_reference:
+            column_reference:
+            - naked_identifier: employees
+            - dot: .
+            - naked_identifier: last_name
+            binary_operator: '%'
+            keyword: TYPE
         - statement_terminator: ;
-        - statement:
-            function:
-              function_name:
-                naked_identifier: DBMS_OUTPUT
-                dot: .
-                function_name_identifier: PUT_LINE
-              function_contents:
-                bracketed:
-                  start_bracket: (
-                  expression:
-                    function:
-                      function_name:
-                        function_name_identifier: RPAD
-                      function_contents:
-                        bracketed:
-                        - start_bracket: (
-                        - expression:
-                            column_reference:
-                              naked_identifier: v_lastname
-                        - comma: ','
-                        - expression:
-                            numeric_literal: '25'
-                        - comma: ','
-                        - expression:
-                            quoted_literal: "' '"
-                        - end_bracket: )
-                    binary_operator:
-                    - pipe: '|'
-                    - pipe: '|'
-                    column_reference:
-                      naked_identifier: v_jobid
-                  end_bracket: )
+        - naked_identifier: v_jobid
+        - column_type_reference:
+            column_reference:
+            - naked_identifier: employees
+            - dot: .
+            - naked_identifier: job_id
+            binary_operator: '%'
+            keyword: TYPE
         - statement_terminator: ;
-        - keyword: END
-        - keyword: LOOP
-    - statement_terminator: ;
-    - statement:
-        function:
-          function_name:
-            naked_identifier: DBMS_OUTPUT
-            dot: .
-            function_name_identifier: PUT_LINE
-          function_contents:
-            bracketed:
-              start_bracket: (
-              expression:
-                quoted_literal: "'-------------------------------------'"
-              end_bracket: )
-    - statement_terminator: ;
-    - statement:
-        open_for_statement:
-        - keyword: OPEN
-        - naked_identifier: cv
-        - keyword: FOR
         - naked_identifier: query_2
-    - statement_terminator: ;
-    - statement:
-        loop_statement:
-        - keyword: LOOP
-        - statement:
-            fetch_statement:
-              keyword: FETCH
-              naked_identifier: cv
-              into_clause:
-                keyword: INTO
-                naked_identifier: v_employees
+        - data_type:
+            data_type_identifier: VARCHAR2
+            bracketed_arguments:
+              bracketed:
+                start_bracket: (
+                numeric_literal: '200'
+                end_bracket: )
+        - assignment_operator: :=
+        - expression:
+            quoted_literal: "'SELECT * FROM employees\n    WHERE REGEXP_LIKE (job_id,\
+              \ ''[ACADFIMKSA]_M[ANGR]'')\n    ORDER BY job_id'"
         - statement_terminator: ;
-        - statement:
-            exit_statement:
-            - keyword: EXIT
-            - keyword: WHEN
-            - expression:
+        - naked_identifier: v_employees
+        - row_type_reference:
+            table_reference:
+              naked_identifier: employees
+            binary_operator: '%'
+            keyword: ROWTYPE
+        - statement_terminator: ;
+      - keyword: BEGIN
+      - statement:
+          open_for_statement:
+          - keyword: OPEN
+          - naked_identifier: cv
+          - keyword: FOR
+          - select_statement:
+              select_clause:
+              - keyword: SELECT
+              - select_clause_element:
+                  column_reference:
+                    naked_identifier: last_name
+              - comma: ','
+              - select_clause_element:
+                  column_reference:
+                    naked_identifier: job_id
+              from_clause:
+                keyword: FROM
+                from_expression:
+                  from_expression_element:
+                    table_expression:
+                      table_reference:
+                        naked_identifier: employees
+              where_clause:
+                keyword: WHERE
+                expression:
+                  function:
+                    function_name:
+                      function_name_identifier: REGEXP_LIKE
+                    function_contents:
+                      bracketed:
+                      - start_bracket: (
+                      - expression:
+                          column_reference:
+                            naked_identifier: job_id
+                      - comma: ','
+                      - expression:
+                          quoted_literal: "'S[HT]_CLERK'"
+                      - end_bracket: )
+              orderby_clause:
+              - keyword: ORDER
+              - keyword: BY
+              - column_reference:
+                  naked_identifier: last_name
+      - statement_terminator: ;
+      - statement:
+          loop_statement:
+          - keyword: LOOP
+          - statement:
+              fetch_statement:
+                keyword: FETCH
                 naked_identifier: cv
-                binary_operator: '%'
-                keyword: NOTFOUND
-        - statement_terminator: ;
-        - statement:
-            function:
-              function_name:
-                naked_identifier: DBMS_OUTPUT
-                dot: .
-                function_name_identifier: PUT_LINE
-              function_contents:
-                bracketed:
-                  start_bracket: (
-                  expression:
-                    function:
-                      function_name:
-                        function_name_identifier: RPAD
-                      function_contents:
-                        bracketed:
-                        - start_bracket: (
-                        - expression:
-                            column_reference:
-                            - naked_identifier: v_employees
-                            - dot: .
-                            - naked_identifier: last_name
-                        - comma: ','
-                        - expression:
-                            numeric_literal: '25'
-                        - comma: ','
-                        - expression:
-                            quoted_literal: "' '"
-                        - end_bracket: )
-                    binary_operator:
-                    - pipe: '|'
-                    - pipe: '|'
-                    column_reference:
-                    - naked_identifier: v_employees
-                    - dot: .
-                    - naked_identifier: job_id
-                  end_bracket: )
-        - statement_terminator: ;
-        - keyword: END
-        - keyword: LOOP
-    - statement_terminator: ;
-    - statement:
-        close_statement:
-          keyword: CLOSE
-          naked_identifier: cv
-    - statement_terminator: ;
-    - keyword: END
-- statement_terminator: ;
-- statement_terminator: /
-- statement:
-    begin_end_block:
-    - declare_segment:
-      - keyword: DECLARE
-      - naked_identifier: v1
-      - data_type:
-          naked_identifier: pkg
-          dot: .
-          data_type_identifier: mytab
+                into_clause:
+                - keyword: INTO
+                - naked_identifier: v_lastname
+                - comma: ','
+                - naked_identifier: v_jobid
+          - statement_terminator: ;
+          - statement:
+              exit_statement:
+              - keyword: EXIT
+              - keyword: WHEN
+              - expression:
+                  naked_identifier: cv
+                  binary_operator: '%'
+                  keyword: NOTFOUND
+          - statement_terminator: ;
+          - statement:
+              function:
+                function_name:
+                  naked_identifier: DBMS_OUTPUT
+                  dot: .
+                  function_name_identifier: PUT_LINE
+                function_contents:
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                      function:
+                        function_name:
+                          function_name_identifier: RPAD
+                        function_contents:
+                          bracketed:
+                          - start_bracket: (
+                          - expression:
+                              column_reference:
+                                naked_identifier: v_lastname
+                          - comma: ','
+                          - expression:
+                              numeric_literal: '25'
+                          - comma: ','
+                          - expression:
+                              quoted_literal: "' '"
+                          - end_bracket: )
+                      binary_operator:
+                      - pipe: '|'
+                      - pipe: '|'
+                      column_reference:
+                        naked_identifier: v_jobid
+                    end_bracket: )
+          - statement_terminator: ;
+          - keyword: END
+          - keyword: LOOP
       - statement_terminator: ;
-      - naked_identifier: v2
-      - data_type:
-          naked_identifier: pkg
-          dot: .
-          data_type_identifier: rec
+      - statement:
+          function:
+            function_name:
+              naked_identifier: DBMS_OUTPUT
+              dot: .
+              function_name_identifier: PUT_LINE
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  quoted_literal: "'-------------------------------------'"
+                end_bracket: )
       - statement_terminator: ;
-      - naked_identifier: c1
-      - data_type:
-          data_type_identifier: SYS_REFCURSOR
+      - statement:
+          open_for_statement:
+          - keyword: OPEN
+          - naked_identifier: cv
+          - keyword: FOR
+          - naked_identifier: query_2
       - statement_terminator: ;
-    - keyword: BEGIN
-    - statement:
-        assignment_segment_statement:
-        - object_reference:
-            naked_identifier: v1
-        - bracketed:
-            start_bracket: (
-            numeric_literal: '1'
-            end_bracket: )
-        - dot: .
-        - object_reference:
-            naked_identifier: f1
-        - assignment_operator: :=
-        - expression:
-            numeric_literal: '1'
-    - statement_terminator: ;
-    - statement:
-        assignment_segment_statement:
-        - object_reference:
-            naked_identifier: v1
-        - bracketed:
-            start_bracket: (
-            numeric_literal: '1'
-            end_bracket: )
-        - dot: .
-        - object_reference:
-            naked_identifier: f2
-        - assignment_operator: :=
-        - expression:
-            quoted_literal: "'one'"
-    - statement_terminator: ;
-    - statement:
-        open_for_statement:
-        - keyword: OPEN
-        - naked_identifier: c1
-        - keyword: FOR
-        - select_statement:
-            select_clause:
-              keyword: SELECT
-              select_clause_element:
-                wildcard_expression:
-                  wildcard_identifier:
-                    star: '*'
-            from_clause:
-              keyword: FROM
-              from_expression:
-                from_expression_element:
-                  table_expression:
-                    function:
-                      function_name:
-                        function_name_identifier: TABLE
-                      function_contents:
-                        bracketed:
-                          start_bracket: (
-                          expression:
-                            column_reference:
-                              naked_identifier: v1
-                          end_bracket: )
-    - statement_terminator: ;
-    - statement:
-        fetch_statement:
-          keyword: FETCH
-          naked_identifier: c1
-          into_clause:
-            keyword: INTO
-            naked_identifier: v2
-    - statement_terminator: ;
-    - statement:
-        close_statement:
-          keyword: CLOSE
-          naked_identifier: c1
-    - statement_terminator: ;
-    - statement:
-        function:
-          function_name:
-            naked_identifier: DBMS_OUTPUT
-            dot: .
-            function_name_identifier: PUT_LINE
-          function_contents:
-            bracketed:
-              start_bracket: (
-              expression:
-              - quoted_literal: "'Values in record are '"
-              - binary_operator:
-                - pipe: '|'
-                - pipe: '|'
-              - column_reference:
-                - naked_identifier: v2
-                - dot: .
-                - naked_identifier: f1
-              - binary_operator:
-                - pipe: '|'
-                - pipe: '|'
-              - quoted_literal: "' and '"
-              - binary_operator:
-                - pipe: '|'
-                - pipe: '|'
-              - column_reference:
-                - naked_identifier: v2
-                - dot: .
-                - naked_identifier: f2
-              end_bracket: )
-    - statement_terminator: ;
-    - keyword: END
-- statement_terminator: ;
-- statement_terminator: /
-- statement:
-    begin_end_block:
-    - declare_segment:
-      - keyword: DECLARE
-      - ref_cursor_type:
-        - keyword: TYPE
-        - naked_identifier: EmpCurTyp
-        - keyword: IS
-        - keyword: REF
-        - keyword: CURSOR
+      - statement:
+          loop_statement:
+          - keyword: LOOP
+          - statement:
+              fetch_statement:
+                keyword: FETCH
+                naked_identifier: cv
+                into_clause:
+                  keyword: INTO
+                  naked_identifier: v_employees
+          - statement_terminator: ;
+          - statement:
+              exit_statement:
+              - keyword: EXIT
+              - keyword: WHEN
+              - expression:
+                  naked_identifier: cv
+                  binary_operator: '%'
+                  keyword: NOTFOUND
+          - statement_terminator: ;
+          - statement:
+              function:
+                function_name:
+                  naked_identifier: DBMS_OUTPUT
+                  dot: .
+                  function_name_identifier: PUT_LINE
+                function_contents:
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                      function:
+                        function_name:
+                          function_name_identifier: RPAD
+                        function_contents:
+                          bracketed:
+                          - start_bracket: (
+                          - expression:
+                              column_reference:
+                              - naked_identifier: v_employees
+                              - dot: .
+                              - naked_identifier: last_name
+                          - comma: ','
+                          - expression:
+                              numeric_literal: '25'
+                          - comma: ','
+                          - expression:
+                              quoted_literal: "' '"
+                          - end_bracket: )
+                      binary_operator:
+                      - pipe: '|'
+                      - pipe: '|'
+                      column_reference:
+                      - naked_identifier: v_employees
+                      - dot: .
+                      - naked_identifier: job_id
+                    end_bracket: )
+          - statement_terminator: ;
+          - keyword: END
+          - keyword: LOOP
       - statement_terminator: ;
-      - naked_identifier: v_emp_cursor
-      - data_type:
-          data_type_identifier: EmpCurTyp
+      - statement:
+          close_statement:
+            keyword: CLOSE
+            naked_identifier: cv
       - statement_terminator: ;
-      - naked_identifier: emp_record
-      - row_type_reference:
-          table_reference:
-            naked_identifier: employees
-          binary_operator: '%'
-          keyword: ROWTYPE
-      - statement_terminator: ;
-      - naked_identifier: v_stmt_str
-      - data_type:
-          data_type_identifier: VARCHAR2
-          bracketed_arguments:
-            bracketed:
-              start_bracket: (
-              numeric_literal: '200'
-              end_bracket: )
-      - statement_terminator: ;
-      - naked_identifier: v_e_job
-      - column_type_reference:
-          column_reference:
-          - naked_identifier: employees
-          - dot: .
-          - naked_identifier: job_id
-          binary_operator: '%'
-          keyword: TYPE
-      - statement_terminator: ;
-    - keyword: BEGIN
-    - statement:
-        assignment_segment_statement:
-          object_reference:
-            naked_identifier: v_stmt_str
-          assignment_operator: :=
-          expression:
-            quoted_literal: "'SELECT * FROM employees WHERE job_id = :j'"
-    - statement_terminator: ;
-    - statement:
-        open_for_statement:
-        - keyword: OPEN
-        - naked_identifier: v_emp_cursor
-        - keyword: FOR
-        - naked_identifier: v_stmt_str
-        - keyword: USING
-        - quoted_identifier: "'MANAGER'"
-    - statement_terminator: ;
-    - statement:
-        loop_statement:
-        - keyword: LOOP
-        - statement:
-            fetch_statement:
-              keyword: FETCH
-              naked_identifier: v_emp_cursor
-              into_clause:
-                keyword: INTO
-                naked_identifier: emp_record
-        - statement_terminator: ;
-        - statement:
-            exit_statement:
-            - keyword: EXIT
-            - keyword: WHEN
-            - expression:
-                naked_identifier: v_emp_cursor
-                binary_operator: '%'
-                keyword: NOTFOUND
-        - statement_terminator: ;
-        - keyword: END
-        - keyword: LOOP
-    - statement_terminator: ;
-    - statement:
-        close_statement:
-          keyword: CLOSE
-          naked_identifier: v_emp_cursor
-    - statement_terminator: ;
-    - keyword: END
-- statement_terminator: ;
-- statement_terminator: /
-- statement:
-    begin_end_block:
-    - declare_segment:
-      - keyword: DECLARE
-      - naked_identifier: v1
-      - data_type:
-          naked_identifier: pkg
-          dot: .
-          data_type_identifier: mytab
-      - statement_terminator: ;
-      - naked_identifier: v2
-      - data_type:
-          naked_identifier: pkg
-          dot: .
-          data_type_identifier: rec
-      - statement_terminator: ;
-      - naked_identifier: c1
-      - data_type:
-          data_type_identifier: SYS_REFCURSOR
-      - statement_terminator: ;
-    - keyword: BEGIN
-    - statement:
-        open_for_statement:
-        - keyword: OPEN
-        - naked_identifier: c1
-        - keyword: FOR
-        - quoted_identifier: "'SELECT * FROM TABLE(:1)'"
-        - keyword: USING
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      begin_end_block:
+      - declare_segment:
+        - keyword: DECLARE
         - naked_identifier: v1
-    - statement_terminator: ;
-    - statement:
-        fetch_statement:
-          keyword: FETCH
-          naked_identifier: c1
-          into_clause:
-            keyword: INTO
-            naked_identifier: v2
-    - statement_terminator: ;
-    - statement:
-        close_statement:
-          keyword: CLOSE
-          naked_identifier: c1
-    - statement_terminator: ;
-    - statement:
-        function:
-          function_name:
-            naked_identifier: DBMS_OUTPUT
+        - data_type:
+            naked_identifier: pkg
             dot: .
-            function_name_identifier: PUT_LINE
-          function_contents:
-            bracketed:
+            data_type_identifier: mytab
+        - statement_terminator: ;
+        - naked_identifier: v2
+        - data_type:
+            naked_identifier: pkg
+            dot: .
+            data_type_identifier: rec
+        - statement_terminator: ;
+        - naked_identifier: c1
+        - data_type:
+            data_type_identifier: SYS_REFCURSOR
+        - statement_terminator: ;
+      - keyword: BEGIN
+      - statement:
+          assignment_segment_statement:
+          - object_reference:
+              naked_identifier: v1
+          - bracketed:
               start_bracket: (
-              expression:
-              - quoted_literal: "'Values in record are '"
-              - binary_operator:
-                - pipe: '|'
-                - pipe: '|'
-              - column_reference:
-                - naked_identifier: v2
-                - dot: .
-                - naked_identifier: f1
-              - binary_operator:
-                - pipe: '|'
-                - pipe: '|'
-              - quoted_literal: "' and '"
-              - binary_operator:
-                - pipe: '|'
-                - pipe: '|'
-              - column_reference:
-                - naked_identifier: v2
-                - dot: .
-                - naked_identifier: f2
+              numeric_literal: '1'
               end_bracket: )
-    - statement_terminator: ;
-    - keyword: END
-- statement_terminator: ;
-- statement_terminator: /
+          - dot: .
+          - object_reference:
+              naked_identifier: f1
+          - assignment_operator: :=
+          - expression:
+              numeric_literal: '1'
+      - statement_terminator: ;
+      - statement:
+          assignment_segment_statement:
+          - object_reference:
+              naked_identifier: v1
+          - bracketed:
+              start_bracket: (
+              numeric_literal: '1'
+              end_bracket: )
+          - dot: .
+          - object_reference:
+              naked_identifier: f2
+          - assignment_operator: :=
+          - expression:
+              quoted_literal: "'one'"
+      - statement_terminator: ;
+      - statement:
+          open_for_statement:
+          - keyword: OPEN
+          - naked_identifier: c1
+          - keyword: FOR
+          - select_statement:
+              select_clause:
+                keyword: SELECT
+                select_clause_element:
+                  wildcard_expression:
+                    wildcard_identifier:
+                      star: '*'
+              from_clause:
+                keyword: FROM
+                from_expression:
+                  from_expression_element:
+                    table_expression:
+                      function:
+                        function_name:
+                          function_name_identifier: TABLE
+                        function_contents:
+                          bracketed:
+                            start_bracket: (
+                            expression:
+                              column_reference:
+                                naked_identifier: v1
+                            end_bracket: )
+      - statement_terminator: ;
+      - statement:
+          fetch_statement:
+            keyword: FETCH
+            naked_identifier: c1
+            into_clause:
+              keyword: INTO
+              naked_identifier: v2
+      - statement_terminator: ;
+      - statement:
+          close_statement:
+            keyword: CLOSE
+            naked_identifier: c1
+      - statement_terminator: ;
+      - statement:
+          function:
+            function_name:
+              naked_identifier: DBMS_OUTPUT
+              dot: .
+              function_name_identifier: PUT_LINE
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                - quoted_literal: "'Values in record are '"
+                - binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                - column_reference:
+                  - naked_identifier: v2
+                  - dot: .
+                  - naked_identifier: f1
+                - binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                - quoted_literal: "' and '"
+                - binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                - column_reference:
+                  - naked_identifier: v2
+                  - dot: .
+                  - naked_identifier: f2
+                end_bracket: )
+      - statement_terminator: ;
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      begin_end_block:
+      - declare_segment:
+        - keyword: DECLARE
+        - ref_cursor_type:
+          - keyword: TYPE
+          - naked_identifier: EmpCurTyp
+          - keyword: IS
+          - keyword: REF
+          - keyword: CURSOR
+        - statement_terminator: ;
+        - naked_identifier: v_emp_cursor
+        - data_type:
+            data_type_identifier: EmpCurTyp
+        - statement_terminator: ;
+        - naked_identifier: emp_record
+        - row_type_reference:
+            table_reference:
+              naked_identifier: employees
+            binary_operator: '%'
+            keyword: ROWTYPE
+        - statement_terminator: ;
+        - naked_identifier: v_stmt_str
+        - data_type:
+            data_type_identifier: VARCHAR2
+            bracketed_arguments:
+              bracketed:
+                start_bracket: (
+                numeric_literal: '200'
+                end_bracket: )
+        - statement_terminator: ;
+        - naked_identifier: v_e_job
+        - column_type_reference:
+            column_reference:
+            - naked_identifier: employees
+            - dot: .
+            - naked_identifier: job_id
+            binary_operator: '%'
+            keyword: TYPE
+        - statement_terminator: ;
+      - keyword: BEGIN
+      - statement:
+          assignment_segment_statement:
+            object_reference:
+              naked_identifier: v_stmt_str
+            assignment_operator: :=
+            expression:
+              quoted_literal: "'SELECT * FROM employees WHERE job_id = :j'"
+      - statement_terminator: ;
+      - statement:
+          open_for_statement:
+          - keyword: OPEN
+          - naked_identifier: v_emp_cursor
+          - keyword: FOR
+          - naked_identifier: v_stmt_str
+          - keyword: USING
+          - quoted_identifier: "'MANAGER'"
+      - statement_terminator: ;
+      - statement:
+          loop_statement:
+          - keyword: LOOP
+          - statement:
+              fetch_statement:
+                keyword: FETCH
+                naked_identifier: v_emp_cursor
+                into_clause:
+                  keyword: INTO
+                  naked_identifier: emp_record
+          - statement_terminator: ;
+          - statement:
+              exit_statement:
+              - keyword: EXIT
+              - keyword: WHEN
+              - expression:
+                  naked_identifier: v_emp_cursor
+                  binary_operator: '%'
+                  keyword: NOTFOUND
+          - statement_terminator: ;
+          - keyword: END
+          - keyword: LOOP
+      - statement_terminator: ;
+      - statement:
+          close_statement:
+            keyword: CLOSE
+            naked_identifier: v_emp_cursor
+      - statement_terminator: ;
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      begin_end_block:
+      - declare_segment:
+        - keyword: DECLARE
+        - naked_identifier: v1
+        - data_type:
+            naked_identifier: pkg
+            dot: .
+            data_type_identifier: mytab
+        - statement_terminator: ;
+        - naked_identifier: v2
+        - data_type:
+            naked_identifier: pkg
+            dot: .
+            data_type_identifier: rec
+        - statement_terminator: ;
+        - naked_identifier: c1
+        - data_type:
+            data_type_identifier: SYS_REFCURSOR
+        - statement_terminator: ;
+      - keyword: BEGIN
+      - statement:
+          open_for_statement:
+          - keyword: OPEN
+          - naked_identifier: c1
+          - keyword: FOR
+          - quoted_identifier: "'SELECT * FROM TABLE(:1)'"
+          - keyword: USING
+          - naked_identifier: v1
+      - statement_terminator: ;
+      - statement:
+          fetch_statement:
+            keyword: FETCH
+            naked_identifier: c1
+            into_clause:
+              keyword: INTO
+              naked_identifier: v2
+      - statement_terminator: ;
+      - statement:
+          close_statement:
+            keyword: CLOSE
+            naked_identifier: c1
+      - statement_terminator: ;
+      - statement:
+          function:
+            function_name:
+              naked_identifier: DBMS_OUTPUT
+              dot: .
+              function_name_identifier: PUT_LINE
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                - quoted_literal: "'Values in record are '"
+                - binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                - column_reference:
+                  - naked_identifier: v2
+                  - dot: .
+                  - naked_identifier: f1
+                - binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                - quoted_literal: "' and '"
+                - binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                - column_reference:
+                  - naked_identifier: v2
+                  - dot: .
+                  - naked_identifier: f2
+                end_bracket: )
+      - statement_terminator: ;
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /

--- a/test/fixtures/dialects/oracle/oracle_operators.yml
+++ b/test/fixtures/dialects/oracle/oracle_operators.yml
@@ -3,493 +3,494 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 237b8bdde08c4e05a5f4d88f7ef991f25ada78ab77bdb123126f85d976e5d89b
+_hash: 95ccc21f007f781f7a4883bb35d66f29a936bcb904d236ae2b8d6c170c71b39a
 file:
-  statement:
-    begin_end_block:
-    - keyword: BEGIN
-    - statement:
-        if_then_statement:
-        - if_clause:
+  batch:
+    statement:
+      begin_end_block:
+      - keyword: BEGIN
+      - statement:
+          if_then_statement:
+          - if_clause:
+            - keyword: IF
+            - expression:
+              - column_reference:
+                  naked_identifier: i
+              - binary_operator: '**'
+              - numeric_literal: '2'
+              - comparison_operator:
+                  raw_comparison_operator: '>'
+              - numeric_literal: '50'
+            - keyword: THEN
+          - statement:
+              function:
+                function_name:
+                  naked_identifier: DBMS_OUTPUT
+                  dot: .
+                  function_name_identifier: PUT_LINE
+                function_contents:
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                      quoted_literal: "'i squared is greater than 50'"
+                    end_bracket: )
+          - statement_terminator: ;
+          - keyword: END
           - keyword: IF
-          - expression:
-            - column_reference:
-                naked_identifier: i
-            - binary_operator: '**'
-            - numeric_literal: '2'
-            - comparison_operator:
-                raw_comparison_operator: '>'
-            - numeric_literal: '50'
-          - keyword: THEN
-        - statement:
-            function:
-              function_name:
-                naked_identifier: DBMS_OUTPUT
-                dot: .
-                function_name_identifier: PUT_LINE
-              function_contents:
-                bracketed:
+      - statement_terminator: ;
+      - statement:
+          if_then_statement:
+          - if_clause:
+            - keyword: IF
+            - expression:
+              - column_reference:
+                  naked_identifier: i
+              - binary_operator: MOD
+              - numeric_literal: '2'
+              - comparison_operator:
+                  raw_comparison_operator: '='
+              - numeric_literal: '0'
+            - keyword: THEN
+          - statement:
+              function:
+                function_name:
+                  naked_identifier: DBMS_OUTPUT
+                  dot: .
+                  function_name_identifier: PUT_LINE
+                function_contents:
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                      quoted_literal: "'i is even number'"
+                    end_bracket: )
+          - statement_terminator: ;
+          - keyword: ELSE
+          - statement:
+              function:
+                function_name:
+                  naked_identifier: DBMS_OUTPUT
+                  dot: .
+                  function_name_identifier: PUT_LINE
+                function_contents:
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                      quoted_literal: "'i is odd number'"
+                    end_bracket: )
+          - statement_terminator: ;
+          - keyword: END
+          - keyword: IF
+      - statement_terminator: ;
+      - statement:
+          if_then_statement:
+          - if_clause:
+            - keyword: IF
+            - expression:
+              - bracketed:
                   start_bracket: (
                   expression:
-                    quoted_literal: "'i squared is greater than 50'"
+                  - column_reference:
+                      naked_identifier: x
+                  - binary_operator: +
+                  - column_reference:
+                      naked_identifier: y
                   end_bracket: )
-        - statement_terminator: ;
-        - keyword: END
-        - keyword: IF
-    - statement_terminator: ;
-    - statement:
-        if_then_statement:
-        - if_clause:
+              - binary_operator: '**'
+              - numeric_literal: '3'
+              - binary_operator: MOD
+              - numeric_literal: '10'
+              - comparison_operator:
+                  raw_comparison_operator: '='
+              - numeric_literal: '0'
+            - keyword: THEN
+          - statement:
+              function:
+                function_name:
+                  naked_identifier: DBMS_OUTPUT
+                  dot: .
+                  function_name_identifier: PUT_LINE
+                function_contents:
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                      quoted_literal: "'complex expression test'"
+                    end_bracket: )
+          - statement_terminator: ;
+          - keyword: END
           - keyword: IF
-          - expression:
-            - column_reference:
-                naked_identifier: i
-            - binary_operator: MOD
-            - numeric_literal: '2'
-            - comparison_operator:
-                raw_comparison_operator: '='
-            - numeric_literal: '0'
-          - keyword: THEN
-        - statement:
-            function:
-              function_name:
-                naked_identifier: DBMS_OUTPUT
-                dot: .
-                function_name_identifier: PUT_LINE
-              function_contents:
-                bracketed:
-                  start_bracket: (
-                  expression:
-                    quoted_literal: "'i is even number'"
-                  end_bracket: )
-        - statement_terminator: ;
-        - keyword: ELSE
-        - statement:
-            function:
-              function_name:
-                naked_identifier: DBMS_OUTPUT
-                dot: .
-                function_name_identifier: PUT_LINE
-              function_contents:
-                bracketed:
-                  start_bracket: (
-                  expression:
-                    quoted_literal: "'i is odd number'"
-                  end_bracket: )
-        - statement_terminator: ;
-        - keyword: END
-        - keyword: IF
-    - statement_terminator: ;
-    - statement:
-        if_then_statement:
-        - if_clause:
-          - keyword: IF
-          - expression:
-            - bracketed:
-                start_bracket: (
+      - statement_terminator: ;
+      - statement:
+          select_statement:
+            select_clause:
+            - keyword: SELECT
+            - select_clause_element:
+                column_reference:
+                  naked_identifier: id
+            - comma: ','
+            - select_clause_element:
                 expression:
-                - column_reference:
-                    naked_identifier: x
-                - binary_operator: +
-                - column_reference:
-                    naked_identifier: y
-                end_bracket: )
-            - binary_operator: '**'
-            - numeric_literal: '3'
-            - binary_operator: MOD
-            - numeric_literal: '10'
-            - comparison_operator:
-                raw_comparison_operator: '='
-            - numeric_literal: '0'
-          - keyword: THEN
-        - statement:
-            function:
-              function_name:
-                naked_identifier: DBMS_OUTPUT
-                dot: .
-                function_name_identifier: PUT_LINE
-              function_contents:
-                bracketed:
-                  start_bracket: (
-                  expression:
-                    quoted_literal: "'complex expression test'"
-                  end_bracket: )
-        - statement_terminator: ;
-        - keyword: END
-        - keyword: IF
-    - statement_terminator: ;
-    - statement:
-        select_statement:
-          select_clause:
-          - keyword: SELECT
-          - select_clause_element:
-              column_reference:
-                naked_identifier: id
-          - comma: ','
-          - select_clause_element:
+                  column_reference:
+                    naked_identifier: value
+                  binary_operator: '**'
+                  numeric_literal: '2'
+                alias_expression:
+                  alias_operator:
+                    keyword: AS
+                  naked_identifier: value_squared
+            - comma: ','
+            - select_clause_element:
+                expression:
+                  column_reference:
+                    naked_identifier: amount
+                  binary_operator: '**'
+                  numeric_literal: '0.5'
+                alias_expression:
+                  alias_operator:
+                    keyword: AS
+                  naked_identifier: square_root
+            from_clause:
+              keyword: FROM
+              from_expression:
+                from_expression_element:
+                  table_expression:
+                    table_reference:
+                      naked_identifier: test_table
+      - statement_terminator: ;
+      - statement:
+          select_statement:
+            select_clause:
+            - keyword: SELECT
+            - select_clause_element:
+                column_reference:
+                  naked_identifier: id
+            - comma: ','
+            - select_clause_element:
+                expression:
+                  column_reference:
+                    naked_identifier: amount
+                  binary_operator: MOD
+                  numeric_literal: '100'
+                alias_expression:
+                  alias_operator:
+                    keyword: AS
+                  naked_identifier: last_two_digits
+            - comma: ','
+            - select_clause_element:
+                expression:
+                  case_expression:
+                  - keyword: CASE
+                  - when_clause:
+                    - keyword: WHEN
+                    - expression:
+                      - column_reference:
+                          naked_identifier: id
+                      - binary_operator: MOD
+                      - numeric_literal: '2'
+                      - comparison_operator:
+                          raw_comparison_operator: '='
+                      - numeric_literal: '0'
+                    - keyword: THEN
+                    - expression:
+                        quoted_literal: "'Even'"
+                  - else_clause:
+                      keyword: ELSE
+                      expression:
+                        quoted_literal: "'Odd'"
+                  - keyword: END
+                alias_expression:
+                  alias_operator:
+                    keyword: AS
+                  naked_identifier: parity
+            from_clause:
+              keyword: FROM
+              from_expression:
+                from_expression_element:
+                  table_expression:
+                    table_reference:
+                      naked_identifier: test_table
+      - statement_terminator: ;
+      - statement:
+          select_statement:
+            select_clause:
+              keyword: SELECT
+              select_clause_element:
+                wildcard_expression:
+                  wildcard_identifier:
+                    star: '*'
+            from_clause:
+              keyword: FROM
+              from_expression:
+                from_expression_element:
+                  table_expression:
+                    table_reference:
+                      naked_identifier: test_table
+            where_clause:
+              keyword: WHERE
               expression:
+              - column_reference:
+                  naked_identifier: value
+              - binary_operator: '**'
+              - numeric_literal: '2'
+              - keyword: BETWEEN
+              - numeric_literal: '100'
+              - keyword: AND
+              - numeric_literal: '400'
+      - statement_terminator: ;
+      - statement:
+          select_statement:
+            select_clause:
+              keyword: SELECT
+              select_clause_element:
+                wildcard_expression:
+                  wildcard_identifier:
+                    star: '*'
+            from_clause:
+              keyword: FROM
+              from_expression:
+                from_expression_element:
+                  table_expression:
+                    table_reference:
+                      naked_identifier: test_table
+            where_clause:
+              keyword: WHERE
+              expression:
+              - column_reference:
+                  naked_identifier: id
+              - binary_operator: MOD
+              - numeric_literal: '5'
+              - comparison_operator:
+                  raw_comparison_operator: '='
+              - numeric_literal: '0'
+      - statement_terminator: ;
+      - statement:
+          select_statement:
+            select_clause:
+            - keyword: SELECT
+            - select_clause_element:
+                column_reference:
+                  naked_identifier: id
+            - comma: ','
+            - select_clause_element:
+                column_reference:
+                  naked_identifier: value
+            from_clause:
+              keyword: FROM
+              from_expression:
+                from_expression_element:
+                  table_expression:
+                    table_reference:
+                      naked_identifier: test_table
+            orderby_clause:
+            - keyword: ORDER
+            - keyword: BY
+            - expression:
                 column_reference:
                   naked_identifier: value
                 binary_operator: '**'
                 numeric_literal: '2'
-              alias_expression:
-                alias_operator:
-                  keyword: AS
-                naked_identifier: value_squared
-          - comma: ','
-          - select_clause_element:
-              expression:
+            - keyword: DESC
+            - comma: ','
+            - expression:
                 column_reference:
-                  naked_identifier: amount
-                binary_operator: '**'
-                numeric_literal: '0.5'
-              alias_expression:
-                alias_operator:
-                  keyword: AS
-                naked_identifier: square_root
-          from_clause:
-            keyword: FROM
-            from_expression:
-              from_expression_element:
-                table_expression:
-                  table_reference:
-                    naked_identifier: test_table
-    - statement_terminator: ;
-    - statement:
-        select_statement:
-          select_clause:
-          - keyword: SELECT
-          - select_clause_element:
-              column_reference:
-                naked_identifier: id
-          - comma: ','
-          - select_clause_element:
-              expression:
-                column_reference:
-                  naked_identifier: amount
+                  naked_identifier: id
                 binary_operator: MOD
-                numeric_literal: '100'
-              alias_expression:
-                alias_operator:
-                  keyword: AS
-                naked_identifier: last_two_digits
-          - comma: ','
-          - select_clause_element:
-              expression:
-                case_expression:
-                - keyword: CASE
-                - when_clause:
-                  - keyword: WHEN
-                  - expression:
-                    - column_reference:
-                        naked_identifier: id
-                    - binary_operator: MOD
-                    - numeric_literal: '2'
-                    - comparison_operator:
-                        raw_comparison_operator: '='
-                    - numeric_literal: '0'
-                  - keyword: THEN
-                  - expression:
-                      quoted_literal: "'Even'"
-                - else_clause:
-                    keyword: ELSE
+                numeric_literal: '10'
+      - statement_terminator: ;
+      - statement:
+          function:
+            function_name:
+              naked_identifier: DBMS_OUTPUT
+              dot: .
+              function_name_identifier: PUT_LINE
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  quoted_literal: "'Result: '"
+                  binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                  function:
+                    function_name:
+                      function_name_identifier: TO_CHAR
+                    function_contents:
+                      bracketed:
+                        start_bracket: (
+                        expression:
+                        - column_reference:
+                            naked_identifier: base
+                        - binary_operator: '**'
+                        - column_reference:
+                            naked_identifier: exponent
+                        end_bracket: )
+                end_bracket: )
+      - statement_terminator: ;
+      - statement:
+          function:
+            function_name:
+              naked_identifier: DBMS_OUTPUT
+              dot: .
+              function_name_identifier: PUT_LINE
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  quoted_literal: "'Remainder: '"
+                  binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                  function:
+                    function_name:
+                      function_name_identifier: TO_CHAR
+                    function_contents:
+                      bracketed:
+                        start_bracket: (
+                        expression:
+                        - column_reference:
+                            naked_identifier: dividend
+                        - binary_operator: MOD
+                        - column_reference:
+                            naked_identifier: divisor
+                        end_bracket: )
+                end_bracket: )
+      - statement_terminator: ;
+      - statement:
+          select_statement:
+            select_clause:
+              keyword: SELECT
+              select_clause_element:
+                expression:
+                  bracketed:
+                    start_bracket: (
                     expression:
-                      quoted_literal: "'Odd'"
-                - keyword: END
-              alias_expression:
-                alias_operator:
-                  keyword: AS
-                naked_identifier: parity
-          from_clause:
-            keyword: FROM
-            from_expression:
-              from_expression_element:
-                table_expression:
-                  table_reference:
-                    naked_identifier: test_table
-    - statement_terminator: ;
-    - statement:
-        select_statement:
-          select_clause:
-            keyword: SELECT
-            select_clause_element:
-              wildcard_expression:
-                wildcard_identifier:
-                  star: '*'
-          from_clause:
-            keyword: FROM
-            from_expression:
-              from_expression_element:
-                table_expression:
-                  table_reference:
-                    naked_identifier: test_table
-          where_clause:
-            keyword: WHERE
-            expression:
-            - column_reference:
-                naked_identifier: value
-            - binary_operator: '**'
-            - numeric_literal: '2'
-            - keyword: BETWEEN
-            - numeric_literal: '100'
-            - keyword: AND
-            - numeric_literal: '400'
-    - statement_terminator: ;
-    - statement:
-        select_statement:
-          select_clause:
-            keyword: SELECT
-            select_clause_element:
-              wildcard_expression:
-                wildcard_identifier:
-                  star: '*'
-          from_clause:
-            keyword: FROM
-            from_expression:
-              from_expression_element:
-                table_expression:
-                  table_reference:
-                    naked_identifier: test_table
-          where_clause:
-            keyword: WHERE
-            expression:
-            - column_reference:
-                naked_identifier: id
-            - binary_operator: MOD
-            - numeric_literal: '5'
-            - comparison_operator:
-                raw_comparison_operator: '='
-            - numeric_literal: '0'
-    - statement_terminator: ;
-    - statement:
-        select_statement:
-          select_clause:
-          - keyword: SELECT
-          - select_clause_element:
-              column_reference:
-                naked_identifier: id
-          - comma: ','
-          - select_clause_element:
-              column_reference:
-                naked_identifier: value
-          from_clause:
-            keyword: FROM
-            from_expression:
-              from_expression_element:
-                table_expression:
-                  table_reference:
-                    naked_identifier: test_table
-          orderby_clause:
-          - keyword: ORDER
-          - keyword: BY
-          - expression:
-              column_reference:
-                naked_identifier: value
-              binary_operator: '**'
-              numeric_literal: '2'
-          - keyword: DESC
-          - comma: ','
-          - expression:
-              column_reference:
-                naked_identifier: id
-              binary_operator: MOD
-              numeric_literal: '10'
-    - statement_terminator: ;
-    - statement:
-        function:
-          function_name:
-            naked_identifier: DBMS_OUTPUT
-            dot: .
-            function_name_identifier: PUT_LINE
-          function_contents:
-            bracketed:
-              start_bracket: (
-              expression:
-                quoted_literal: "'Result: '"
-                binary_operator:
-                - pipe: '|'
-                - pipe: '|'
-                function:
-                  function_name:
-                    function_name_identifier: TO_CHAR
-                  function_contents:
-                    bracketed:
-                      start_bracket: (
-                      expression:
-                      - column_reference:
-                          naked_identifier: base
-                      - binary_operator: '**'
-                      - column_reference:
-                          naked_identifier: exponent
-                      end_bracket: )
-              end_bracket: )
-    - statement_terminator: ;
-    - statement:
-        function:
-          function_name:
-            naked_identifier: DBMS_OUTPUT
-            dot: .
-            function_name_identifier: PUT_LINE
-          function_contents:
-            bracketed:
-              start_bracket: (
-              expression:
-                quoted_literal: "'Remainder: '"
-                binary_operator:
-                - pipe: '|'
-                - pipe: '|'
-                function:
-                  function_name:
-                    function_name_identifier: TO_CHAR
-                  function_contents:
-                    bracketed:
-                      start_bracket: (
-                      expression:
-                      - column_reference:
-                          naked_identifier: dividend
-                      - binary_operator: MOD
-                      - column_reference:
-                          naked_identifier: divisor
-                      end_bracket: )
-              end_bracket: )
-    - statement_terminator: ;
-    - statement:
-        select_statement:
-          select_clause:
-            keyword: SELECT
-            select_clause_element:
-              expression:
-                bracketed:
-                  start_bracket: (
-                  expression:
-                    bracketed:
-                      start_bracket: (
-                      expression:
-                      - column_reference:
-                          naked_identifier: a
-                      - binary_operator: +
-                      - column_reference:
-                          naked_identifier: b
-                      end_bracket: )
-                    binary_operator: '**'
-                    numeric_literal: '2'
-                  end_bracket: )
-                binary_operator: MOD
-                numeric_literal: '1000'
-              alias_expression:
-                alias_operator:
-                  keyword: AS
-                naked_identifier: complex_calc
-          from_clause:
-            keyword: FROM
-            from_expression:
-              from_expression_element:
-                table_expression:
-                  table_reference:
-                    naked_identifier: dual
-    - statement_terminator: ;
-    - statement:
-        select_statement:
-          select_clause:
-          - keyword: SELECT
-          - select_clause_element:
-              expression:
-                numeric_literal: '2'
-                binary_operator: '**'
-                bracketed:
-                  start_bracket: (
-                  expression:
-                  - numeric_literal: '3'
-                  - binary_operator: +
-                  - numeric_literal: '1'
-                  end_bracket: )
-              alias_expression:
-                alias_operator:
-                  keyword: AS
-                naked_identifier: power_with_parens
-          - comma: ','
-          - select_clause_element:
-              expression:
-                bracketed:
-                  start_bracket: (
-                  expression:
-                  - numeric_literal: '2'
-                  - binary_operator: '**'
-                  - numeric_literal: '3'
-                  end_bracket: )
-                binary_operator: +
-                numeric_literal: '1'
-              alias_expression:
-                alias_operator:
-                  keyword: AS
-                naked_identifier: parens_around_power
-          from_clause:
-            keyword: FROM
-            from_expression:
-              from_expression_element:
-                table_expression:
-                  table_reference:
-                    naked_identifier: dual
-    - statement_terminator: ;
-    - statement:
-        select_statement:
-          select_clause:
-            keyword: SELECT
-            select_clause_element:
-              expression:
-              - column_reference:
-                  naked_identifier: x
-              - binary_operator: MOD
-              - column_reference:
-                  naked_identifier: y
-              - binary_operator: MOD
-              - column_reference:
-                  naked_identifier: z
-              alias_expression:
-                alias_operator:
-                  keyword: AS
-                naked_identifier: chained_mod
-          from_clause:
-            keyword: FROM
-            from_expression:
-              from_expression_element:
-                table_expression:
-                  table_reference:
-                    naked_identifier: dual
-    - statement_terminator: ;
-    - statement:
-        select_statement:
-          select_clause:
-            keyword: SELECT
-            select_clause_element:
-              expression:
-              - column_reference:
-                  naked_identifier: a
-              - binary_operator: +
-              - column_reference:
-                  naked_identifier: b
-              - binary_operator: '**'
-              - numeric_literal: '2'
-              - binary_operator: '-'
-              - column_reference:
-                  naked_identifier: c
-              - binary_operator: MOD
-              - column_reference:
-                  naked_identifier: d
-              - binary_operator: '*'
-              - column_reference:
-                  naked_identifier: e
-              alias_expression:
-                alias_operator:
-                  keyword: AS
-                naked_identifier: mixed_arithmetic
-          from_clause:
-            keyword: FROM
-            from_expression:
-              from_expression_element:
-                table_expression:
-                  table_reference:
-                    naked_identifier: dual
-    - statement_terminator: ;
-    - keyword: END
-  statement_terminator: ;
+                      bracketed:
+                        start_bracket: (
+                        expression:
+                        - column_reference:
+                            naked_identifier: a
+                        - binary_operator: +
+                        - column_reference:
+                            naked_identifier: b
+                        end_bracket: )
+                      binary_operator: '**'
+                      numeric_literal: '2'
+                    end_bracket: )
+                  binary_operator: MOD
+                  numeric_literal: '1000'
+                alias_expression:
+                  alias_operator:
+                    keyword: AS
+                  naked_identifier: complex_calc
+            from_clause:
+              keyword: FROM
+              from_expression:
+                from_expression_element:
+                  table_expression:
+                    table_reference:
+                      naked_identifier: dual
+      - statement_terminator: ;
+      - statement:
+          select_statement:
+            select_clause:
+            - keyword: SELECT
+            - select_clause_element:
+                expression:
+                  numeric_literal: '2'
+                  binary_operator: '**'
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                    - numeric_literal: '3'
+                    - binary_operator: +
+                    - numeric_literal: '1'
+                    end_bracket: )
+                alias_expression:
+                  alias_operator:
+                    keyword: AS
+                  naked_identifier: power_with_parens
+            - comma: ','
+            - select_clause_element:
+                expression:
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                    - numeric_literal: '2'
+                    - binary_operator: '**'
+                    - numeric_literal: '3'
+                    end_bracket: )
+                  binary_operator: +
+                  numeric_literal: '1'
+                alias_expression:
+                  alias_operator:
+                    keyword: AS
+                  naked_identifier: parens_around_power
+            from_clause:
+              keyword: FROM
+              from_expression:
+                from_expression_element:
+                  table_expression:
+                    table_reference:
+                      naked_identifier: dual
+      - statement_terminator: ;
+      - statement:
+          select_statement:
+            select_clause:
+              keyword: SELECT
+              select_clause_element:
+                expression:
+                - column_reference:
+                    naked_identifier: x
+                - binary_operator: MOD
+                - column_reference:
+                    naked_identifier: y
+                - binary_operator: MOD
+                - column_reference:
+                    naked_identifier: z
+                alias_expression:
+                  alias_operator:
+                    keyword: AS
+                  naked_identifier: chained_mod
+            from_clause:
+              keyword: FROM
+              from_expression:
+                from_expression_element:
+                  table_expression:
+                    table_reference:
+                      naked_identifier: dual
+      - statement_terminator: ;
+      - statement:
+          select_statement:
+            select_clause:
+              keyword: SELECT
+              select_clause_element:
+                expression:
+                - column_reference:
+                    naked_identifier: a
+                - binary_operator: +
+                - column_reference:
+                    naked_identifier: b
+                - binary_operator: '**'
+                - numeric_literal: '2'
+                - binary_operator: '-'
+                - column_reference:
+                    naked_identifier: c
+                - binary_operator: MOD
+                - column_reference:
+                    naked_identifier: d
+                - binary_operator: '*'
+                - column_reference:
+                    naked_identifier: e
+                alias_expression:
+                  alias_operator:
+                    keyword: AS
+                  naked_identifier: mixed_arithmetic
+            from_clause:
+              keyword: FROM
+              from_expression:
+                from_expression_element:
+                  table_expression:
+                    table_reference:
+                      naked_identifier: dual
+      - statement_terminator: ;
+      - keyword: END
+    statement_terminator: ;

--- a/test/fixtures/dialects/oracle/pivot_unpivot.yml
+++ b/test/fixtures/dialects/oracle/pivot_unpivot.yml
@@ -3,434 +3,435 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 689eb8e9c6be114a8b8e8bf0fafdcebe5d65d2d9d874f6e6cd3f7f1d278b722c
+_hash: 1a2550044a87327b4a547d9bacd638b1ec8e0024bd5497d0499b69953f7c508d
 file:
-- statement:
-    select_statement:
-      select_clause:
-        keyword: select
-        select_clause_element:
-          wildcard_expression:
-            wildcard_identifier:
-              star: '*'
-      from_clause:
-        keyword: from
-        from_expression:
-          from_expression_element:
-            table_expression:
-              bracketed:
-                start_bracket: (
-                select_statement:
-                  select_clause:
-                  - keyword: select
-                  - select_clause_element:
-                      column_reference:
-                        naked_identifier: times_purchased
-                  - comma: ','
-                  - select_clause_element:
-                      column_reference:
-                        naked_identifier: state_code
-                  from_clause:
-                    keyword: from
-                    from_expression:
-                      from_expression_element:
-                        table_expression:
-                          table_reference:
-                            naked_identifier: customers
-                        alias_expression:
-                          naked_identifier: t
-                end_bracket: )
-      pivot_clause:
-        keyword: pivot
-        bracketed:
-        - start_bracket: (
-        - function:
-            function_name:
-              function_name_identifier: count
-            function_contents:
-              bracketed:
-                start_bracket: (
-                expression:
-                  column_reference:
-                    naked_identifier: state_code
-                end_bracket: )
-        - keyword: for
-        - column_reference:
-            naked_identifier: state_code
-        - keyword: in
-        - bracketed:
+  batch:
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: select
+          select_clause_element:
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+        from_clause:
+          keyword: from
+          from_expression:
+            from_expression_element:
+              table_expression:
+                bracketed:
+                  start_bracket: (
+                  select_statement:
+                    select_clause:
+                    - keyword: select
+                    - select_clause_element:
+                        column_reference:
+                          naked_identifier: times_purchased
+                    - comma: ','
+                    - select_clause_element:
+                        column_reference:
+                          naked_identifier: state_code
+                    from_clause:
+                      keyword: from
+                      from_expression:
+                        from_expression_element:
+                          table_expression:
+                            table_reference:
+                              naked_identifier: customers
+                          alias_expression:
+                            naked_identifier: t
+                  end_bracket: )
+        pivot_clause:
+          keyword: pivot
+          bracketed:
           - start_bracket: (
-          - quoted_literal: "'NY'"
-          - alias_expression:
-              alias_operator:
-                keyword: as
-              naked_identifier: new_york
-          - comma: ','
-          - quoted_literal: "'CT'"
-          - comma: ','
-          - quoted_literal: "'NJ'"
-          - comma: ','
-          - quoted_literal: "'FL'"
-          - comma: ','
-          - quoted_literal: "'MO'"
+          - function:
+              function_name:
+                function_name_identifier: count
+              function_contents:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    column_reference:
+                      naked_identifier: state_code
+                  end_bracket: )
+          - keyword: for
+          - column_reference:
+              naked_identifier: state_code
+          - keyword: in
+          - bracketed:
+            - start_bracket: (
+            - quoted_literal: "'NY'"
+            - alias_expression:
+                alias_operator:
+                  keyword: as
+                naked_identifier: new_york
+            - comma: ','
+            - quoted_literal: "'CT'"
+            - comma: ','
+            - quoted_literal: "'NJ'"
+            - comma: ','
+            - quoted_literal: "'FL'"
+            - comma: ','
+            - quoted_literal: "'MO'"
+            - end_bracket: )
           - end_bracket: )
-        - end_bracket: )
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-        keyword: select
-        select_clause_element:
-          wildcard_expression:
-            wildcard_identifier:
-              star: '*'
-      from_clause:
-        keyword: from
-        from_expression:
-          from_expression_element:
-            table_expression:
-              bracketed:
-                start_bracket: (
-                select_statement:
-                  select_clause:
-                  - keyword: select
-                  - select_clause_element:
-                      column_reference:
-                        naked_identifier: times_purchased
-                  - comma: ','
-                  - select_clause_element:
-                      column_reference:
-                        naked_identifier: state_code
-                  from_clause:
-                    keyword: from
-                    from_expression:
-                      from_expression_element:
-                        table_expression:
-                          table_reference:
-                            naked_identifier: customers
-                        alias_expression:
-                          naked_identifier: t
-                end_bracket: )
-      pivot_clause:
-        keyword: pivot
-        bracketed:
-        - start_bracket: (
-        - function:
-            function_name:
-              function_name_identifier: count
-            function_contents:
-              bracketed:
-                start_bracket: (
-                expression:
-                  column_reference:
-                    naked_identifier: state_code
-                end_bracket: )
-        - keyword: for
-        - column_reference:
-            naked_identifier: state_code
-        - keyword: in
-        - bracketed:
-            start_bracket: (
-            select_statement:
-              select_clause:
-                keyword: select
-                select_clause_modifier:
-                  keyword: distinct
-                select_clause_element:
-                  column_reference:
-                    naked_identifier: state_code
-              from_clause:
-                keyword: from
-                from_expression:
-                  from_expression_element:
-                    table_expression:
-                      table_reference:
-                        naked_identifier: state
-            end_bracket: )
-        - end_bracket: )
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-        keyword: select
-        select_clause_element:
-          wildcard_expression:
-            wildcard_identifier:
-              star: '*'
-      from_clause:
-        keyword: from
-        from_expression:
-          from_expression_element:
-            table_expression:
-              bracketed:
-                start_bracket: (
-                select_statement:
-                  select_clause:
-                  - keyword: select
-                  - select_clause_element:
-                      column_reference:
-                        naked_identifier: times_purchased
-                  - comma: ','
-                  - select_clause_element:
-                      column_reference:
-                        naked_identifier: state_code
-                  from_clause:
-                    keyword: from
-                    from_expression:
-                      from_expression_element:
-                        table_expression:
-                          table_reference:
-                            naked_identifier: customers
-                        alias_expression:
-                          naked_identifier: t
-                end_bracket: )
-      pivot_clause:
-        keyword: pivot
-        bracketed:
-        - start_bracket: (
-        - function:
-            function_name:
-              function_name_identifier: count
-            function_contents:
-              bracketed:
-                start_bracket: (
-                expression:
-                  column_reference:
-                    naked_identifier: state_code
-                end_bracket: )
-        - keyword: for
-        - column_reference:
-            naked_identifier: state_code
-        - keyword: in
-        - bracketed:
-            start_bracket: (
-            keyword: any
-            end_bracket: )
-        - end_bracket: )
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-        keyword: select
-        select_clause_element:
-          wildcard_expression:
-            wildcard_identifier:
-              star: '*'
-      from_clause:
-        keyword: from
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: sale_stats
-      unpivot_clause:
-        keyword: unpivot
-        bracketed:
-        - start_bracket: (
-        - column_reference:
-            naked_identifier: quantity
-        - keyword: for
-        - column_reference:
-            naked_identifier: product_code
-        - keyword: in
-        - bracketed:
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: select
+          select_clause_element:
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+        from_clause:
+          keyword: from
+          from_expression:
+            from_expression_element:
+              table_expression:
+                bracketed:
+                  start_bracket: (
+                  select_statement:
+                    select_clause:
+                    - keyword: select
+                    - select_clause_element:
+                        column_reference:
+                          naked_identifier: times_purchased
+                    - comma: ','
+                    - select_clause_element:
+                        column_reference:
+                          naked_identifier: state_code
+                    from_clause:
+                      keyword: from
+                      from_expression:
+                        from_expression_element:
+                          table_expression:
+                            table_reference:
+                              naked_identifier: customers
+                          alias_expression:
+                            naked_identifier: t
+                  end_bracket: )
+        pivot_clause:
+          keyword: pivot
+          bracketed:
+          - start_bracket: (
+          - function:
+              function_name:
+                function_name_identifier: count
+              function_contents:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    column_reference:
+                      naked_identifier: state_code
+                  end_bracket: )
+          - keyword: for
+          - column_reference:
+              naked_identifier: state_code
+          - keyword: in
+          - bracketed:
+              start_bracket: (
+              select_statement:
+                select_clause:
+                  keyword: select
+                  select_clause_modifier:
+                    keyword: distinct
+                  select_clause_element:
+                    column_reference:
+                      naked_identifier: state_code
+                from_clause:
+                  keyword: from
+                  from_expression:
+                    from_expression_element:
+                      table_expression:
+                        table_reference:
+                          naked_identifier: state
+              end_bracket: )
+          - end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: select
+          select_clause_element:
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+        from_clause:
+          keyword: from
+          from_expression:
+            from_expression_element:
+              table_expression:
+                bracketed:
+                  start_bracket: (
+                  select_statement:
+                    select_clause:
+                    - keyword: select
+                    - select_clause_element:
+                        column_reference:
+                          naked_identifier: times_purchased
+                    - comma: ','
+                    - select_clause_element:
+                        column_reference:
+                          naked_identifier: state_code
+                    from_clause:
+                      keyword: from
+                      from_expression:
+                        from_expression_element:
+                          table_expression:
+                            table_reference:
+                              naked_identifier: customers
+                          alias_expression:
+                            naked_identifier: t
+                  end_bracket: )
+        pivot_clause:
+          keyword: pivot
+          bracketed:
+          - start_bracket: (
+          - function:
+              function_name:
+                function_name_identifier: count
+              function_contents:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    column_reference:
+                      naked_identifier: state_code
+                  end_bracket: )
+          - keyword: for
+          - column_reference:
+              naked_identifier: state_code
+          - keyword: in
+          - bracketed:
+              start_bracket: (
+              keyword: any
+              end_bracket: )
+          - end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: select
+          select_clause_element:
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+        from_clause:
+          keyword: from
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: sale_stats
+        unpivot_clause:
+          keyword: unpivot
+          bracketed:
           - start_bracket: (
           - column_reference:
-              naked_identifier: product_a
-          - alias_expression:
-              alias_operator:
-                keyword: AS
-              quoted_identifier: "'A'"
-          - comma: ','
+              naked_identifier: quantity
+          - keyword: for
           - column_reference:
-              naked_identifier: product_b
-          - alias_expression:
-              alias_operator:
-                keyword: AS
-              quoted_identifier: "'B'"
-          - comma: ','
-          - column_reference:
-              naked_identifier: product_c
-          - alias_expression:
-              alias_operator:
-                keyword: AS
-              quoted_identifier: "'C'"
+              naked_identifier: product_code
+          - keyword: in
+          - bracketed:
+            - start_bracket: (
+            - column_reference:
+                naked_identifier: product_a
+            - alias_expression:
+                alias_operator:
+                  keyword: AS
+                quoted_identifier: "'A'"
+            - comma: ','
+            - column_reference:
+                naked_identifier: product_b
+            - alias_expression:
+                alias_operator:
+                  keyword: AS
+                quoted_identifier: "'B'"
+            - comma: ','
+            - column_reference:
+                naked_identifier: product_c
+            - alias_expression:
+                alias_operator:
+                  keyword: AS
+                quoted_identifier: "'C'"
+            - end_bracket: )
           - end_bracket: )
-        - end_bracket: )
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-        keyword: select
-        select_clause_element:
-          wildcard_expression:
-            wildcard_identifier:
-              star: '*'
-      from_clause:
-        keyword: from
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: sale_stats
-      unpivot_clause:
-      - keyword: unpivot
-      - keyword: include
-      - keyword: nulls
-      - bracketed:
-        - start_bracket: (
-        - column_reference:
-            naked_identifier: quantity
-        - keyword: for
-        - column_reference:
-            naked_identifier: product_code
-        - keyword: in
-        - bracketed:
-          - start_bracket: (
-          - column_reference:
-              naked_identifier: product_a
-          - alias_expression:
-              alias_operator:
-                keyword: AS
-              quoted_identifier: "'A'"
-          - comma: ','
-          - column_reference:
-              naked_identifier: product_b
-          - alias_expression:
-              alias_operator:
-                keyword: AS
-              quoted_identifier: "'B'"
-          - comma: ','
-          - column_reference:
-              naked_identifier: product_c
-          - alias_expression:
-              alias_operator:
-                keyword: AS
-              quoted_identifier: "'C'"
-          - end_bracket: )
-        - end_bracket: )
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-        keyword: select
-        select_clause_element:
-          wildcard_expression:
-            wildcard_identifier:
-              star: '*'
-      from_clause:
-        keyword: from
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: sale_stats
-      unpivot_clause:
-        keyword: unpivot
-        bracketed:
-        - start_bracket: (
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: select
+          select_clause_element:
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+        from_clause:
+          keyword: from
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: sale_stats
+        unpivot_clause:
+        - keyword: unpivot
+        - keyword: include
+        - keyword: nulls
         - bracketed:
           - start_bracket: (
           - column_reference:
               naked_identifier: quantity
-          - comma: ','
+          - keyword: for
           - column_reference:
-              naked_identifier: amount
+              naked_identifier: product_code
+          - keyword: in
+          - bracketed:
+            - start_bracket: (
+            - column_reference:
+                naked_identifier: product_a
+            - alias_expression:
+                alias_operator:
+                  keyword: AS
+                quoted_identifier: "'A'"
+            - comma: ','
+            - column_reference:
+                naked_identifier: product_b
+            - alias_expression:
+                alias_operator:
+                  keyword: AS
+                quoted_identifier: "'B'"
+            - comma: ','
+            - column_reference:
+                naked_identifier: product_c
+            - alias_expression:
+                alias_operator:
+                  keyword: AS
+                quoted_identifier: "'C'"
+            - end_bracket: )
           - end_bracket: )
-        - keyword: for
-        - column_reference:
-            naked_identifier: product_code
-        - keyword: in
-        - bracketed:
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: select
+          select_clause_element:
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+        from_clause:
+          keyword: from
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: sale_stats
+        unpivot_clause:
+          keyword: unpivot
+          bracketed:
           - start_bracket: (
           - bracketed:
             - start_bracket: (
             - column_reference:
-                naked_identifier: a_qty
+                naked_identifier: quantity
             - comma: ','
             - column_reference:
-                naked_identifier: a_value
+                naked_identifier: amount
             - end_bracket: )
-          - alias_expression:
-              alias_operator:
-                keyword: as
-              quoted_identifier: "'A'"
-          - comma: ','
+          - keyword: for
+          - column_reference:
+              naked_identifier: product_code
+          - keyword: in
           - bracketed:
             - start_bracket: (
-            - column_reference:
-                naked_identifier: b_qty
+            - bracketed:
+              - start_bracket: (
+              - column_reference:
+                  naked_identifier: a_qty
+              - comma: ','
+              - column_reference:
+                  naked_identifier: a_value
+              - end_bracket: )
+            - alias_expression:
+                alias_operator:
+                  keyword: as
+                quoted_identifier: "'A'"
             - comma: ','
-            - column_reference:
-                naked_identifier: b_value
+            - bracketed:
+              - start_bracket: (
+              - column_reference:
+                  naked_identifier: b_qty
+              - comma: ','
+              - column_reference:
+                  naked_identifier: b_value
+              - end_bracket: )
+            - alias_expression:
+                alias_operator:
+                  keyword: as
+                quoted_identifier: "'B'"
             - end_bracket: )
+          - end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: select
+          select_clause_element:
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+        from_clause:
+          keyword: from
+          from_expression:
+            from_expression_element:
+              table_expression:
+                bracketed:
+                  start_bracket: (
+                  select_statement:
+                    select_clause:
+                    - keyword: select
+                    - select_clause_element:
+                        column_reference:
+                          naked_identifier: times_purchased
+                    - comma: ','
+                    - select_clause_element:
+                        column_reference:
+                          naked_identifier: state_code
+                    from_clause:
+                      keyword: from
+                      from_expression:
+                        from_expression_element:
+                          table_expression:
+                            table_reference:
+                              naked_identifier: customers
+                          alias_expression:
+                            naked_identifier: t
+                  end_bracket: )
+        pivot_clause:
+          keyword: pivot
+          bracketed:
+          - start_bracket: (
+          - function:
+              function_name:
+                function_name_identifier: count
+              function_contents:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    column_reference:
+                      naked_identifier: state_code
+                  end_bracket: )
           - alias_expression:
               alias_operator:
                 keyword: as
-              quoted_identifier: "'B'"
+              naked_identifier: state_code
+          - keyword: for
+          - column_reference:
+              naked_identifier: state_code
+          - keyword: in
+          - bracketed:
+              start_bracket: (
+              keyword: any
+              end_bracket: )
           - end_bracket: )
-        - end_bracket: )
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-        keyword: select
-        select_clause_element:
-          wildcard_expression:
-            wildcard_identifier:
-              star: '*'
-      from_clause:
-        keyword: from
-        from_expression:
-          from_expression_element:
-            table_expression:
-              bracketed:
-                start_bracket: (
-                select_statement:
-                  select_clause:
-                  - keyword: select
-                  - select_clause_element:
-                      column_reference:
-                        naked_identifier: times_purchased
-                  - comma: ','
-                  - select_clause_element:
-                      column_reference:
-                        naked_identifier: state_code
-                  from_clause:
-                    keyword: from
-                    from_expression:
-                      from_expression_element:
-                        table_expression:
-                          table_reference:
-                            naked_identifier: customers
-                        alias_expression:
-                          naked_identifier: t
-                end_bracket: )
-      pivot_clause:
-        keyword: pivot
-        bracketed:
-        - start_bracket: (
-        - function:
-            function_name:
-              function_name_identifier: count
-            function_contents:
-              bracketed:
-                start_bracket: (
-                expression:
-                  column_reference:
-                    naked_identifier: state_code
-                end_bracket: )
-        - alias_expression:
-            alias_operator:
-              keyword: as
-            naked_identifier: state_code
-        - keyword: for
-        - column_reference:
-            naked_identifier: state_code
-        - keyword: in
-        - bracketed:
-            start_bracket: (
-            keyword: any
-            end_bracket: )
-        - end_bracket: )
-- statement_terminator: ;
+  - statement_terminator: ;

--- a/test/fixtures/dialects/oracle/prompt.yml
+++ b/test/fixtures/dialects/oracle/prompt.yml
@@ -3,20 +3,21 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 644b16a31198e9167e689a0a8420ae5b78ab8aa0a39e43b68c8328503d12790f
+_hash: dd89c566834dc77a55fb51c415f26136fbba083b183fd79aa51c9a2911e3d6cd
 file:
-  statement:
-    select_statement:
-      select_clause:
-        keyword: SELECT
-        select_clause_element:
-          column_reference:
-            naked_identifier: job_id
-      from_clause:
-        keyword: from
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: employees
-  statement_terminator: ;
+  batch:
+    statement:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            column_reference:
+              naked_identifier: job_id
+        from_clause:
+          keyword: from
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: employees
+    statement_terminator: ;

--- a/test/fixtures/dialects/oracle/pseudorecords.yml
+++ b/test/fixtures/dialects/oracle/pseudorecords.yml
@@ -3,98 +3,99 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: c51b711fd30141bde95ddc56f3cd3112fb6372dfe3f0fa34a0d93d21a980b960
+_hash: 7b174e6a8796e33727cbe26ec486a0e1b80c8aba0327ad38cca616d77f6c14aa
 file:
-  statement:
-    create_trigger_statement:
-    - keyword: CREATE
-    - keyword: OR
-    - keyword: REPLACE
-    - keyword: TRIGGER
-    - trigger_reference:
-        naked_identifier: example_trigger
-    - keyword: BEFORE
-    - dml_event_clause:
-      - keyword: INSERT
+  batch:
+    statement:
+      create_trigger_statement:
+      - keyword: CREATE
       - keyword: OR
-      - keyword: UPDATE
-      - keyword: 'ON'
-      - table_reference:
-          naked_identifier: example_table
-    - keyword: FOR
-    - keyword: EACH
-    - keyword: ROW
-    - statement:
-        begin_end_block:
-        - keyword: BEGIN
-        - statement:
-            assignment_segment_statement:
-              bind_variable:
-                colon_delimiter: ':'
-                trigger_correlation_name:
-                  keyword: NEW
-                dot: .
-                naked_identifier: column_name
-              assignment_operator: :=
-              expression:
+      - keyword: REPLACE
+      - keyword: TRIGGER
+      - trigger_reference:
+          naked_identifier: example_trigger
+      - keyword: BEFORE
+      - dml_event_clause:
+        - keyword: INSERT
+        - keyword: OR
+        - keyword: UPDATE
+        - keyword: 'ON'
+        - table_reference:
+            naked_identifier: example_table
+      - keyword: FOR
+      - keyword: EACH
+      - keyword: ROW
+      - statement:
+          begin_end_block:
+          - keyword: BEGIN
+          - statement:
+              assignment_segment_statement:
                 bind_variable:
                   colon_delimiter: ':'
                   trigger_correlation_name:
-                    keyword: OLD
+                    keyword: NEW
                   dot: .
                   naked_identifier: column_name
-        - statement_terminator: ;
-        - statement:
-            if_then_statement:
-            - if_clause:
-              - keyword: IF
-              - expression:
-                - bind_variable:
-                    colon_delimiter: ':'
-                    trigger_correlation_name:
-                      keyword: NEW
-                    dot: .
-                    naked_identifier: val
-                - comparison_operator:
-                    raw_comparison_operator: '>'
-                - bind_variable:
+                assignment_operator: :=
+                expression:
+                  bind_variable:
                     colon_delimiter: ':'
                     trigger_correlation_name:
                       keyword: OLD
                     dot: .
-                    naked_identifier: val
-              - keyword: THEN
-            - statement:
-                assignment_segment_statement:
-                  bind_variable:
-                    colon_delimiter: ':'
-                    trigger_correlation_name:
-                      keyword: NEW
-                    dot: .
-                    naked_identifier: status
-                  assignment_operator: :=
-                  expression:
-                    quoted_literal: "'changed'"
-            - statement_terminator: ;
-            - keyword: END
-            - keyword: IF
-        - statement_terminator: ;
-        - statement:
-            assignment_segment_statement:
-              bind_variable:
-                colon_delimiter: ':'
-                trigger_correlation_name:
-                  keyword: NEW
-                dot: .
-                naked_identifier: parent_val
-              assignment_operator: :=
-              expression:
+                    naked_identifier: column_name
+          - statement_terminator: ;
+          - statement:
+              if_then_statement:
+              - if_clause:
+                - keyword: IF
+                - expression:
+                  - bind_variable:
+                      colon_delimiter: ':'
+                      trigger_correlation_name:
+                        keyword: NEW
+                      dot: .
+                      naked_identifier: val
+                  - comparison_operator:
+                      raw_comparison_operator: '>'
+                  - bind_variable:
+                      colon_delimiter: ':'
+                      trigger_correlation_name:
+                        keyword: OLD
+                      dot: .
+                      naked_identifier: val
+                - keyword: THEN
+              - statement:
+                  assignment_segment_statement:
+                    bind_variable:
+                      colon_delimiter: ':'
+                      trigger_correlation_name:
+                        keyword: NEW
+                      dot: .
+                      naked_identifier: status
+                    assignment_operator: :=
+                    expression:
+                      quoted_literal: "'changed'"
+              - statement_terminator: ;
+              - keyword: END
+              - keyword: IF
+          - statement_terminator: ;
+          - statement:
+              assignment_segment_statement:
                 bind_variable:
                   colon_delimiter: ':'
                   trigger_correlation_name:
-                    keyword: PARENT
+                    keyword: NEW
                   dot: .
-                  naked_identifier: val
-        - statement_terminator: ;
-        - keyword: END
-    - statement_terminator: ;
+                  naked_identifier: parent_val
+                assignment_operator: :=
+                expression:
+                  bind_variable:
+                    colon_delimiter: ':'
+                    trigger_correlation_name:
+                      keyword: PARENT
+                    dot: .
+                    naked_identifier: val
+          - statement_terminator: ;
+          - keyword: END
+      - statement_terminator: ;

--- a/test/fixtures/dialects/oracle/quoted_slash.yml
+++ b/test/fixtures/dialects/oracle/quoted_slash.yml
@@ -3,13 +3,61 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: fc6be259bf3c4a5351db0bcea71a973b9a94c1ae2f1a70e9194f09b18356debe
+_hash: 040369595e25fd46b054ecf0698e50b30e5983164eba7534a048164dd9a9a9ab
 file:
-- statement:
-    select_statement:
-      select_clause:
-        keyword: select
-        select_clause_element:
+  batch:
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: select
+          select_clause_element:
+            expression:
+            - column_reference:
+              - naked_identifier: a
+              - dot: .
+              - naked_identifier: column_a
+            - binary_operator:
+              - pipe: '|'
+              - pipe: '|'
+            - quoted_literal: "'\\'"
+            - binary_operator:
+              - pipe: '|'
+              - pipe: '|'
+            - column_reference:
+              - naked_identifier: a
+              - dot: .
+              - naked_identifier: column_b
+            alias_expression:
+              naked_identifier: test
+        from_clause:
+          keyword: from
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: test_table
+              alias_expression:
+                naked_identifier: a
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: select
+          select_clause_element:
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+        from_clause:
+          keyword: from
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: test_table
+              alias_expression:
+                naked_identifier: a
+        where_clause:
+          keyword: where
           expression:
           - column_reference:
             - naked_identifier: a
@@ -26,82 +74,35 @@ file:
             - naked_identifier: a
             - dot: .
             - naked_identifier: column_b
-          alias_expression:
-            naked_identifier: test
-      from_clause:
-        keyword: from
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: test_table
-            alias_expression:
-              naked_identifier: a
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-        keyword: select
-        select_clause_element:
-          wildcard_expression:
-            wildcard_identifier:
-              star: '*'
-      from_clause:
-        keyword: from
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: test_table
-            alias_expression:
-              naked_identifier: a
-      where_clause:
-        keyword: where
-        expression:
-        - column_reference:
-          - naked_identifier: a
-          - dot: .
-          - naked_identifier: column_a
-        - binary_operator:
-          - pipe: '|'
-          - pipe: '|'
-        - quoted_literal: "'\\'"
-        - binary_operator:
-          - pipe: '|'
-          - pipe: '|'
-        - column_reference:
-          - naked_identifier: a
-          - dot: .
-          - naked_identifier: column_b
-        - comparison_operator:
-            raw_comparison_operator: '='
-        - quoted_literal: "'10\\10'"
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-        keyword: select
-        select_clause_element:
-          quoted_literal: "'Test\\ '"
-      from_clause:
-        keyword: from
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: dual
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-        keyword: select
-        select_clause_element:
-          quoted_literal: "'\\Test\\'"
-      from_clause:
-        keyword: from
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: dual
-- statement_terminator: ;
+          - comparison_operator:
+              raw_comparison_operator: '='
+          - quoted_literal: "'10\\10'"
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: select
+          select_clause_element:
+            quoted_literal: "'Test\\ '"
+        from_clause:
+          keyword: from
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: dual
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: select
+          select_clause_element:
+            quoted_literal: "'\\Test\\'"
+        from_clause:
+          keyword: from
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: dual
+  - statement_terminator: ;

--- a/test/fixtures/dialects/oracle/raise.yml
+++ b/test/fixtures/dialects/oracle/raise.yml
@@ -3,210 +3,35 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: acaeb3e2b1089b2d6122ba504ef0ad701c7aeaa61faaa1bf2a81a43ef4eeb0d5
+_hash: 755186f0967a1f2d739b4ce9d4b8c92c284276a6021d320bef0dd2336eb45921
 file:
-- statement:
-    create_procedure_statement:
-    - keyword: CREATE
-    - keyword: PROCEDURE
-    - function_name:
-        function_name_identifier: account_status
-    - function_parameter_list:
-        bracketed:
-        - start_bracket: (
-        - parameter: due_date
-        - data_type:
-            data_type_identifier: DATE
-        - comma: ','
-        - parameter: today
-        - data_type:
-            data_type_identifier: DATE
-        - end_bracket: )
-    - keyword: AUTHID
-    - keyword: DEFINER
-    - keyword: IS
-    - declare_segment:
-        naked_identifier: past_due
-        data_type:
-          data_type_identifier: EXCEPTION
-        statement_terminator: ;
-    - begin_end_block:
-      - keyword: BEGIN
-      - statement:
-          if_then_statement:
-          - if_clause:
-            - keyword: IF
-            - expression:
-              - column_reference:
-                  naked_identifier: due_date
-              - comparison_operator:
-                  raw_comparison_operator: <
-              - column_reference:
-                  naked_identifier: today
-            - keyword: THEN
-          - statement:
-              raise_statement:
-                keyword: RAISE
-                naked_identifier: past_due
-          - statement_terminator: ;
-          - keyword: END
-          - keyword: IF
-      - statement_terminator: ;
-      - keyword: EXCEPTION
-      - keyword: WHEN
-      - naked_identifier: past_due
-      - keyword: THEN
-      - statement:
-          function:
-            function_name:
-              naked_identifier: DBMS_OUTPUT
-              dot: .
-              function_name_identifier: PUT_LINE
-            function_contents:
-              bracketed:
-                start_bracket: (
-                expression:
-                  quoted_literal: "'Account past due.'"
-                end_bracket: )
-      - statement_terminator: ;
-      - keyword: END
-    - statement_terminator: ;
-    - statement_terminator: /
-- statement:
-    create_procedure_statement:
-    - keyword: CREATE
-    - keyword: PROCEDURE
-    - function_name:
-        function_name_identifier: p
-    - function_parameter_list:
-        bracketed:
-          start_bracket: (
-          parameter: n
+- batch:
+    statement:
+      create_procedure_statement:
+      - keyword: CREATE
+      - keyword: PROCEDURE
+      - function_name:
+          function_name_identifier: account_status
+      - function_parameter_list:
+          bracketed:
+          - start_bracket: (
+          - parameter: due_date
+          - data_type:
+              data_type_identifier: DATE
+          - comma: ','
+          - parameter: today
+          - data_type:
+              data_type_identifier: DATE
+          - end_bracket: )
+      - keyword: AUTHID
+      - keyword: DEFINER
+      - keyword: IS
+      - declare_segment:
+          naked_identifier: past_due
           data_type:
-            data_type_identifier: NUMBER
-          end_bracket: )
-    - keyword: AUTHID
-    - keyword: DEFINER
-    - keyword: IS
-    - declare_segment:
-        naked_identifier: default_number
-        data_type:
-          data_type_identifier: NUMBER
-        assignment_operator: :=
-        expression:
-          numeric_literal: '0'
-        statement_terminator: ;
-    - begin_end_block:
-      - keyword: BEGIN
-      - statement:
-          if_then_statement:
-          - if_clause:
-            - keyword: IF
-            - expression:
-                column_reference:
-                  naked_identifier: n
-                comparison_operator:
-                  raw_comparison_operator: <
-                numeric_literal: '0'
-            - keyword: THEN
-          - statement:
-              raise_statement:
-                keyword: RAISE
-                naked_identifier: INVALID_NUMBER
-          - statement_terminator: ;
-          - keyword: ELSE
-          - statement:
-              insert_statement:
-              - keyword: INSERT
-              - keyword: INTO
-              - table_reference:
-                  naked_identifier: t
-              - values_clause:
-                  keyword: VALUES
-                  bracketed:
-                    start_bracket: (
-                    expression:
-                      function:
-                        function_name:
-                          function_name_identifier: TO_NUMBER
-                        function_contents:
-                          bracketed:
-                          - start_bracket: (
-                          - expression:
-                              quoted_literal: "'100.00'"
-                          - comma: ','
-                          - expression:
-                              quoted_literal: "'9G999'"
-                          - end_bracket: )
-                    end_bracket: )
-          - statement_terminator: ;
-          - keyword: END
-          - keyword: IF
-      - statement_terminator: ;
-      - keyword: EXCEPTION
-      - keyword: WHEN
-      - naked_identifier: INVALID_NUMBER
-      - keyword: THEN
-      - statement:
-          function:
-            function_name:
-              naked_identifier: DBMS_OUTPUT
-              dot: .
-              function_name_identifier: PUT_LINE
-            function_contents:
-              bracketed:
-                start_bracket: (
-                expression:
-                  quoted_literal: "'Substituting default value for invalid number.'"
-                end_bracket: )
-      - statement_terminator: ;
-      - statement:
-          insert_statement:
-          - keyword: INSERT
-          - keyword: INTO
-          - table_reference:
-              naked_identifier: t
-          - values_clause:
-              keyword: VALUES
-              bracketed:
-                start_bracket: (
-                expression:
-                  column_reference:
-                    naked_identifier: default_number
-                end_bracket: )
-      - statement_terminator: ;
-      - keyword: END
-    - statement_terminator: ;
-    - statement_terminator: /
-- statement:
-    begin_end_block:
-    - declare_segment:
-      - keyword: DECLARE
-      - naked_identifier: salary_too_high
-      - data_type:
-          data_type_identifier: EXCEPTION
-      - statement_terminator: ;
-      - naked_identifier: current_salary
-      - data_type:
-          data_type_identifier: NUMBER
-      - assignment_operator: :=
-      - expression:
-          numeric_literal: '20000'
-      - statement_terminator: ;
-      - naked_identifier: max_salary
-      - data_type:
-          data_type_identifier: NUMBER
-      - assignment_operator: :=
-      - expression:
-          numeric_literal: '10000'
-      - statement_terminator: ;
-      - naked_identifier: erroneous_salary
-      - data_type:
-          data_type_identifier: NUMBER
-      - statement_terminator: ;
-    - keyword: BEGIN
-    - statement:
-        begin_end_block:
+            data_type_identifier: EXCEPTION
+          statement_terminator: ;
+      - begin_end_block:
         - keyword: BEGIN
         - statement:
             if_then_statement:
@@ -214,34 +39,25 @@ file:
               - keyword: IF
               - expression:
                 - column_reference:
-                    naked_identifier: current_salary
+                    naked_identifier: due_date
                 - comparison_operator:
-                    raw_comparison_operator: '>'
+                    raw_comparison_operator: <
                 - column_reference:
-                    naked_identifier: max_salary
+                    naked_identifier: today
               - keyword: THEN
             - statement:
                 raise_statement:
                   keyword: RAISE
-                  naked_identifier: salary_too_high
+                  naked_identifier: past_due
             - statement_terminator: ;
             - keyword: END
             - keyword: IF
         - statement_terminator: ;
         - keyword: EXCEPTION
         - keyword: WHEN
-        - naked_identifier: salary_too_high
+        - naked_identifier: past_due
         - keyword: THEN
         - statement:
-            assignment_segment_statement:
-              object_reference:
-                naked_identifier: erroneous_salary
-              assignment_operator: :=
-              expression:
-                column_reference:
-                  naked_identifier: current_salary
-        - statement_terminator: ;
-        - statement:
             function:
               function_name:
                 naked_identifier: DBMS_OUTPUT
@@ -251,90 +67,280 @@ file:
                 bracketed:
                   start_bracket: (
                   expression:
-                  - quoted_literal: "'Salary '"
-                  - binary_operator:
-                    - pipe: '|'
-                    - pipe: '|'
-                  - column_reference:
-                      naked_identifier: erroneous_salary
-                  - binary_operator:
-                    - pipe: '|'
-                    - pipe: '|'
-                  - quoted_literal: "' is out of range.'"
+                    quoted_literal: "'Account past due.'"
                   end_bracket: )
-        - statement_terminator: ;
-        - statement:
-            function:
-              function_name:
-                naked_identifier: DBMS_OUTPUT
-                dot: .
-                function_name_identifier: PUT_LINE
-              function_contents:
-                bracketed:
-                  start_bracket: (
-                  expression:
-                  - quoted_literal: "'Maximum salary is '"
-                  - binary_operator:
-                    - pipe: '|'
-                    - pipe: '|'
-                  - column_reference:
-                      naked_identifier: max_salary
-                  - binary_operator:
-                    - pipe: '|'
-                    - pipe: '|'
-                  - quoted_literal: "'.'"
-                  end_bracket: )
-        - statement_terminator: ;
-        - statement:
-            raise_statement:
-              keyword: RAISE
         - statement_terminator: ;
         - keyword: END
-    - statement_terminator: ;
-    - keyword: EXCEPTION
-    - keyword: WHEN
-    - naked_identifier: salary_too_high
-    - keyword: THEN
-    - statement:
-        assignment_segment_statement:
-          object_reference:
-            naked_identifier: current_salary
+      - statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      create_procedure_statement:
+      - keyword: CREATE
+      - keyword: PROCEDURE
+      - function_name:
+          function_name_identifier: p
+      - function_parameter_list:
+          bracketed:
+            start_bracket: (
+            parameter: n
+            data_type:
+              data_type_identifier: NUMBER
+            end_bracket: )
+      - keyword: AUTHID
+      - keyword: DEFINER
+      - keyword: IS
+      - declare_segment:
+          naked_identifier: default_number
+          data_type:
+            data_type_identifier: NUMBER
           assignment_operator: :=
           expression:
-            column_reference:
-              naked_identifier: max_salary
-    - statement_terminator: ;
-    - statement:
-        function:
-          function_name:
-            naked_identifier: DBMS_OUTPUT
-            dot: .
-            function_name_identifier: PUT_LINE
-          function_contents:
-            bracketed:
-              start_bracket: (
-              expression:
-              - quoted_literal: "'Revising salary from '"
-              - binary_operator:
-                - pipe: '|'
-                - pipe: '|'
-              - column_reference:
+            numeric_literal: '0'
+          statement_terminator: ;
+      - begin_end_block:
+        - keyword: BEGIN
+        - statement:
+            if_then_statement:
+            - if_clause:
+              - keyword: IF
+              - expression:
+                  column_reference:
+                    naked_identifier: n
+                  comparison_operator:
+                    raw_comparison_operator: <
+                  numeric_literal: '0'
+              - keyword: THEN
+            - statement:
+                raise_statement:
+                  keyword: RAISE
+                  naked_identifier: INVALID_NUMBER
+            - statement_terminator: ;
+            - keyword: ELSE
+            - statement:
+                insert_statement:
+                - keyword: INSERT
+                - keyword: INTO
+                - table_reference:
+                    naked_identifier: t
+                - values_clause:
+                    keyword: VALUES
+                    bracketed:
+                      start_bracket: (
+                      expression:
+                        function:
+                          function_name:
+                            function_name_identifier: TO_NUMBER
+                          function_contents:
+                            bracketed:
+                            - start_bracket: (
+                            - expression:
+                                quoted_literal: "'100.00'"
+                            - comma: ','
+                            - expression:
+                                quoted_literal: "'9G999'"
+                            - end_bracket: )
+                      end_bracket: )
+            - statement_terminator: ;
+            - keyword: END
+            - keyword: IF
+        - statement_terminator: ;
+        - keyword: EXCEPTION
+        - keyword: WHEN
+        - naked_identifier: INVALID_NUMBER
+        - keyword: THEN
+        - statement:
+            function:
+              function_name:
+                naked_identifier: DBMS_OUTPUT
+                dot: .
+                function_name_identifier: PUT_LINE
+              function_contents:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    quoted_literal: "'Substituting default value for invalid number.'"
+                  end_bracket: )
+        - statement_terminator: ;
+        - statement:
+            insert_statement:
+            - keyword: INSERT
+            - keyword: INTO
+            - table_reference:
+                naked_identifier: t
+            - values_clause:
+                keyword: VALUES
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    column_reference:
+                      naked_identifier: default_number
+                  end_bracket: )
+        - statement_terminator: ;
+        - keyword: END
+      - statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      begin_end_block:
+      - declare_segment:
+        - keyword: DECLARE
+        - naked_identifier: salary_too_high
+        - data_type:
+            data_type_identifier: EXCEPTION
+        - statement_terminator: ;
+        - naked_identifier: current_salary
+        - data_type:
+            data_type_identifier: NUMBER
+        - assignment_operator: :=
+        - expression:
+            numeric_literal: '20000'
+        - statement_terminator: ;
+        - naked_identifier: max_salary
+        - data_type:
+            data_type_identifier: NUMBER
+        - assignment_operator: :=
+        - expression:
+            numeric_literal: '10000'
+        - statement_terminator: ;
+        - naked_identifier: erroneous_salary
+        - data_type:
+            data_type_identifier: NUMBER
+        - statement_terminator: ;
+      - keyword: BEGIN
+      - statement:
+          begin_end_block:
+          - keyword: BEGIN
+          - statement:
+              if_then_statement:
+              - if_clause:
+                - keyword: IF
+                - expression:
+                  - column_reference:
+                      naked_identifier: current_salary
+                  - comparison_operator:
+                      raw_comparison_operator: '>'
+                  - column_reference:
+                      naked_identifier: max_salary
+                - keyword: THEN
+              - statement:
+                  raise_statement:
+                    keyword: RAISE
+                    naked_identifier: salary_too_high
+              - statement_terminator: ;
+              - keyword: END
+              - keyword: IF
+          - statement_terminator: ;
+          - keyword: EXCEPTION
+          - keyword: WHEN
+          - naked_identifier: salary_too_high
+          - keyword: THEN
+          - statement:
+              assignment_segment_statement:
+                object_reference:
                   naked_identifier: erroneous_salary
-              - binary_operator:
-                - pipe: '|'
-                - pipe: '|'
-              - quoted_literal: "' to '"
-              - binary_operator:
-                - pipe: '|'
-                - pipe: '|'
-              - column_reference:
-                  naked_identifier: current_salary
-              - binary_operator:
-                - pipe: '|'
-                - pipe: '|'
-              - quoted_literal: "'.'"
-              end_bracket: )
-    - statement_terminator: ;
-    - keyword: END
-- statement_terminator: ;
-- statement_terminator: /
+                assignment_operator: :=
+                expression:
+                  column_reference:
+                    naked_identifier: current_salary
+          - statement_terminator: ;
+          - statement:
+              function:
+                function_name:
+                  naked_identifier: DBMS_OUTPUT
+                  dot: .
+                  function_name_identifier: PUT_LINE
+                function_contents:
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                    - quoted_literal: "'Salary '"
+                    - binary_operator:
+                      - pipe: '|'
+                      - pipe: '|'
+                    - column_reference:
+                        naked_identifier: erroneous_salary
+                    - binary_operator:
+                      - pipe: '|'
+                      - pipe: '|'
+                    - quoted_literal: "' is out of range.'"
+                    end_bracket: )
+          - statement_terminator: ;
+          - statement:
+              function:
+                function_name:
+                  naked_identifier: DBMS_OUTPUT
+                  dot: .
+                  function_name_identifier: PUT_LINE
+                function_contents:
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                    - quoted_literal: "'Maximum salary is '"
+                    - binary_operator:
+                      - pipe: '|'
+                      - pipe: '|'
+                    - column_reference:
+                        naked_identifier: max_salary
+                    - binary_operator:
+                      - pipe: '|'
+                      - pipe: '|'
+                    - quoted_literal: "'.'"
+                    end_bracket: )
+          - statement_terminator: ;
+          - statement:
+              raise_statement:
+                keyword: RAISE
+          - statement_terminator: ;
+          - keyword: END
+      - statement_terminator: ;
+      - keyword: EXCEPTION
+      - keyword: WHEN
+      - naked_identifier: salary_too_high
+      - keyword: THEN
+      - statement:
+          assignment_segment_statement:
+            object_reference:
+              naked_identifier: current_salary
+            assignment_operator: :=
+            expression:
+              column_reference:
+                naked_identifier: max_salary
+      - statement_terminator: ;
+      - statement:
+          function:
+            function_name:
+              naked_identifier: DBMS_OUTPUT
+              dot: .
+              function_name_identifier: PUT_LINE
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                - quoted_literal: "'Revising salary from '"
+                - binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                - column_reference:
+                    naked_identifier: erroneous_salary
+                - binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                - quoted_literal: "' to '"
+                - binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                - column_reference:
+                    naked_identifier: current_salary
+                - binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                - quoted_literal: "'.'"
+                end_bracket: )
+      - statement_terminator: ;
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /

--- a/test/fixtures/dialects/oracle/record_type.yml
+++ b/test/fixtures/dialects/oracle/record_type.yml
@@ -3,421 +3,427 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 43f3f35561ce9b381d36b3d4197525025647c2f8026ca9270b19f5adafbf7fb0
+_hash: d1b8a38170f9796a60169e55d24db976a846bd274bc0b31250a47bf523733b6e
 file:
-- statement:
-    begin_end_block:
-    - declare_segment:
-      - keyword: DECLARE
-      - record_type:
-        - keyword: TYPE
-        - naked_identifier: DeptRecTyp
-        - keyword: IS
-        - keyword: RECORD
-        - bracketed:
-          - start_bracket: (
-          - naked_identifier: dept_id
+- batch:
+    statement:
+      begin_end_block:
+      - declare_segment:
+        - keyword: DECLARE
+        - record_type:
+          - keyword: TYPE
+          - naked_identifier: DeptRecTyp
+          - keyword: IS
+          - keyword: RECORD
+          - bracketed:
+            - start_bracket: (
+            - naked_identifier: dept_id
+            - data_type:
+                data_type_identifier: NUMBER
+                bracketed_arguments:
+                  bracketed:
+                    start_bracket: (
+                    numeric_literal: '4'
+                    end_bracket: )
+            - keyword: NOT
+            - keyword: 'NULL'
+            - assignment_operator: :=
+            - expression:
+                numeric_literal: '10'
+            - comma: ','
+            - naked_identifier: dept_name
+            - data_type:
+                data_type_identifier: VARCHAR2
+                bracketed_arguments:
+                  bracketed:
+                    start_bracket: (
+                    numeric_literal: '30'
+                    end_bracket: )
+            - keyword: NOT
+            - keyword: 'NULL'
+            - assignment_operator: :=
+            - expression:
+                quoted_literal: "'Administration'"
+            - comma: ','
+            - naked_identifier: mgr_id
+            - data_type:
+                data_type_identifier: NUMBER
+                bracketed_arguments:
+                  bracketed:
+                    start_bracket: (
+                    numeric_literal: '6'
+                    end_bracket: )
+            - assignment_operator: :=
+            - expression:
+                numeric_literal: '200'
+            - comma: ','
+            - naked_identifier: loc_id
+            - data_type:
+                data_type_identifier: NUMBER
+                bracketed_arguments:
+                  bracketed:
+                    start_bracket: (
+                    numeric_literal: '4'
+                    end_bracket: )
+            - assignment_operator: :=
+            - expression:
+                numeric_literal: '1700'
+            - end_bracket: )
+        - statement_terminator: ;
+        - naked_identifier: dept_rec
+        - data_type:
+            data_type_identifier: DeptRecTyp
+        - statement_terminator: ;
+      - keyword: BEGIN
+      - statement:
+          function:
+            function_name:
+              naked_identifier: DBMS_OUTPUT
+              dot: .
+              function_name_identifier: PUT_LINE
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  quoted_literal: "'dept_id:   '"
+                  binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                  column_reference:
+                  - naked_identifier: dept_rec
+                  - dot: .
+                  - naked_identifier: dept_id
+                end_bracket: )
+      - statement_terminator: ;
+      - statement:
+          function:
+            function_name:
+              naked_identifier: DBMS_OUTPUT
+              dot: .
+              function_name_identifier: PUT_LINE
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  quoted_literal: "'dept_name: '"
+                  binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                  column_reference:
+                  - naked_identifier: dept_rec
+                  - dot: .
+                  - naked_identifier: dept_name
+                end_bracket: )
+      - statement_terminator: ;
+      - statement:
+          function:
+            function_name:
+              naked_identifier: DBMS_OUTPUT
+              dot: .
+              function_name_identifier: PUT_LINE
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  quoted_literal: "'mgr_id:    '"
+                  binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                  column_reference:
+                  - naked_identifier: dept_rec
+                  - dot: .
+                  - naked_identifier: mgr_id
+                end_bracket: )
+      - statement_terminator: ;
+      - statement:
+          function:
+            function_name:
+              naked_identifier: DBMS_OUTPUT
+              dot: .
+              function_name_identifier: PUT_LINE
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  quoted_literal: "'loc_id:    '"
+                  binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                  column_reference:
+                  - naked_identifier: dept_rec
+                  - dot: .
+                  - naked_identifier: loc_id
+                end_bracket: )
+      - statement_terminator: ;
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      begin_end_block:
+      - declare_segment:
+        - keyword: DECLARE
+        - record_type:
+          - keyword: TYPE
+          - naked_identifier: name_rec
+          - keyword: IS
+          - keyword: RECORD
+          - bracketed:
+            - start_bracket: (
+            - naked_identifier: first
+            - column_type_reference:
+                column_reference:
+                - naked_identifier: employees
+                - dot: .
+                - naked_identifier: first_name
+                binary_operator: '%'
+                keyword: TYPE
+            - comma: ','
+            - naked_identifier: last
+            - column_type_reference:
+                column_reference:
+                - naked_identifier: employees
+                - dot: .
+                - naked_identifier: last_name
+                binary_operator: '%'
+                keyword: TYPE
+            - end_bracket: )
+        - statement_terminator: ;
+        - record_type:
+          - keyword: TYPE
+          - naked_identifier: contact
+          - keyword: IS
+          - keyword: RECORD
+          - bracketed:
+            - start_bracket: (
+            - naked_identifier: name
+            - data_type:
+                data_type_identifier: name_rec
+            - comma: ','
+            - naked_identifier: phone
+            - column_type_reference:
+                column_reference:
+                - naked_identifier: employees
+                - dot: .
+                - naked_identifier: phone_number
+                binary_operator: '%'
+                keyword: TYPE
+            - end_bracket: )
+        - statement_terminator: ;
+        - naked_identifier: friend
+        - data_type:
+            data_type_identifier: contact
+        - statement_terminator: ;
+      - keyword: BEGIN
+      - statement:
+          assignment_segment_statement:
+            object_reference:
+            - naked_identifier: friend
+            - dot: .
+            - naked_identifier: name
+            - dot: .
+            - naked_identifier: first
+            assignment_operator: :=
+            expression:
+              quoted_literal: "'John'"
+      - statement_terminator: ;
+      - statement:
+          assignment_segment_statement:
+            object_reference:
+            - naked_identifier: friend
+            - dot: .
+            - naked_identifier: name
+            - dot: .
+            - naked_identifier: last
+            assignment_operator: :=
+            expression:
+              quoted_literal: "'Smith'"
+      - statement_terminator: ;
+      - statement:
+          assignment_segment_statement:
+            object_reference:
+            - naked_identifier: friend
+            - dot: .
+            - naked_identifier: phone
+            assignment_operator: :=
+            expression:
+              quoted_literal: "'1-650-555-1234'"
+      - statement_terminator: ;
+      - statement:
+          function:
+            function_name:
+              naked_identifier: DBMS_OUTPUT
+              dot: .
+              function_name_identifier: PUT_LINE
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                - column_reference:
+                  - naked_identifier: friend
+                  - dot: .
+                  - naked_identifier: name
+                  - dot: .
+                  - naked_identifier: first
+                - binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                - quoted_literal: "' '"
+                - binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                - column_reference:
+                  - naked_identifier: friend
+                  - dot: .
+                  - naked_identifier: name
+                  - dot: .
+                  - naked_identifier: last
+                - binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                - quoted_literal: "', '"
+                - binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                - column_reference:
+                  - naked_identifier: friend
+                  - dot: .
+                  - naked_identifier: phone
+                end_bracket: )
+      - statement_terminator: ;
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      begin_end_block:
+      - declare_segment:
+        - keyword: DECLARE
+        - collection_type:
+          - keyword: TYPE
+          - naked_identifier: full_name
+          - keyword: IS
           - data_type:
-              data_type_identifier: NUMBER
+              data_type_identifier: VARRAY
               bracketed_arguments:
                 bracketed:
                   start_bracket: (
-                  numeric_literal: '4'
+                  numeric_literal: '2'
                   end_bracket: )
-          - keyword: NOT
-          - keyword: 'NULL'
-          - assignment_operator: :=
-          - expression:
-              numeric_literal: '10'
-          - comma: ','
-          - naked_identifier: dept_name
+          - keyword: OF
           - data_type:
               data_type_identifier: VARCHAR2
               bracketed_arguments:
                 bracketed:
                   start_bracket: (
-                  numeric_literal: '30'
+                  numeric_literal: '20'
                   end_bracket: )
-          - keyword: NOT
-          - keyword: 'NULL'
-          - assignment_operator: :=
-          - expression:
-              quoted_literal: "'Administration'"
-          - comma: ','
-          - naked_identifier: mgr_id
-          - data_type:
-              data_type_identifier: NUMBER
-              bracketed_arguments:
-                bracketed:
-                  start_bracket: (
-                  numeric_literal: '6'
-                  end_bracket: )
-          - assignment_operator: :=
-          - expression:
-              numeric_literal: '200'
-          - comma: ','
-          - naked_identifier: loc_id
-          - data_type:
-              data_type_identifier: NUMBER
-              bracketed_arguments:
-                bracketed:
-                  start_bracket: (
-                  numeric_literal: '4'
-                  end_bracket: )
-          - assignment_operator: :=
-          - expression:
-              numeric_literal: '1700'
-          - end_bracket: )
-      - statement_terminator: ;
-      - naked_identifier: dept_rec
-      - data_type:
-          data_type_identifier: DeptRecTyp
-      - statement_terminator: ;
-    - keyword: BEGIN
-    - statement:
-        function:
-          function_name:
-            naked_identifier: DBMS_OUTPUT
-            dot: .
-            function_name_identifier: PUT_LINE
-          function_contents:
-            bracketed:
-              start_bracket: (
-              expression:
-                quoted_literal: "'dept_id:   '"
-                binary_operator:
-                - pipe: '|'
-                - pipe: '|'
-                column_reference:
-                - naked_identifier: dept_rec
-                - dot: .
-                - naked_identifier: dept_id
-              end_bracket: )
-    - statement_terminator: ;
-    - statement:
-        function:
-          function_name:
-            naked_identifier: DBMS_OUTPUT
-            dot: .
-            function_name_identifier: PUT_LINE
-          function_contents:
-            bracketed:
-              start_bracket: (
-              expression:
-                quoted_literal: "'dept_name: '"
-                binary_operator:
-                - pipe: '|'
-                - pipe: '|'
-                column_reference:
-                - naked_identifier: dept_rec
-                - dot: .
-                - naked_identifier: dept_name
-              end_bracket: )
-    - statement_terminator: ;
-    - statement:
-        function:
-          function_name:
-            naked_identifier: DBMS_OUTPUT
-            dot: .
-            function_name_identifier: PUT_LINE
-          function_contents:
-            bracketed:
-              start_bracket: (
-              expression:
-                quoted_literal: "'mgr_id:    '"
-                binary_operator:
-                - pipe: '|'
-                - pipe: '|'
-                column_reference:
-                - naked_identifier: dept_rec
-                - dot: .
-                - naked_identifier: mgr_id
-              end_bracket: )
-    - statement_terminator: ;
-    - statement:
-        function:
-          function_name:
-            naked_identifier: DBMS_OUTPUT
-            dot: .
-            function_name_identifier: PUT_LINE
-          function_contents:
-            bracketed:
-              start_bracket: (
-              expression:
-                quoted_literal: "'loc_id:    '"
-                binary_operator:
-                - pipe: '|'
-                - pipe: '|'
-                column_reference:
-                - naked_identifier: dept_rec
-                - dot: .
-                - naked_identifier: loc_id
-              end_bracket: )
-    - statement_terminator: ;
-    - keyword: END
-- statement_terminator: ;
-- statement_terminator: /
-- statement:
-    begin_end_block:
-    - declare_segment:
-      - keyword: DECLARE
-      - record_type:
-        - keyword: TYPE
-        - naked_identifier: name_rec
-        - keyword: IS
-        - keyword: RECORD
-        - bracketed:
-          - start_bracket: (
-          - naked_identifier: first
-          - column_type_reference:
-              column_reference:
-              - naked_identifier: employees
-              - dot: .
-              - naked_identifier: first_name
-              binary_operator: '%'
-              keyword: TYPE
-          - comma: ','
-          - naked_identifier: last
-          - column_type_reference:
-              column_reference:
-              - naked_identifier: employees
-              - dot: .
-              - naked_identifier: last_name
-              binary_operator: '%'
-              keyword: TYPE
-          - end_bracket: )
-      - statement_terminator: ;
-      - record_type:
-        - keyword: TYPE
-        - naked_identifier: contact
-        - keyword: IS
-        - keyword: RECORD
-        - bracketed:
-          - start_bracket: (
-          - naked_identifier: name
-          - data_type:
-              data_type_identifier: name_rec
-          - comma: ','
-          - naked_identifier: phone
-          - column_type_reference:
-              column_reference:
-              - naked_identifier: employees
-              - dot: .
-              - naked_identifier: phone_number
-              binary_operator: '%'
-              keyword: TYPE
-          - end_bracket: )
-      - statement_terminator: ;
-      - naked_identifier: friend
-      - data_type:
-          data_type_identifier: contact
-      - statement_terminator: ;
-    - keyword: BEGIN
-    - statement:
-        assignment_segment_statement:
-          object_reference:
-          - naked_identifier: friend
-          - dot: .
-          - naked_identifier: name
-          - dot: .
-          - naked_identifier: first
-          assignment_operator: :=
-          expression:
-            quoted_literal: "'John'"
-    - statement_terminator: ;
-    - statement:
-        assignment_segment_statement:
-          object_reference:
-          - naked_identifier: friend
-          - dot: .
-          - naked_identifier: name
-          - dot: .
-          - naked_identifier: last
-          assignment_operator: :=
-          expression:
-            quoted_literal: "'Smith'"
-    - statement_terminator: ;
-    - statement:
-        assignment_segment_statement:
-          object_reference:
-          - naked_identifier: friend
-          - dot: .
-          - naked_identifier: phone
-          assignment_operator: :=
-          expression:
-            quoted_literal: "'1-650-555-1234'"
-    - statement_terminator: ;
-    - statement:
-        function:
-          function_name:
-            naked_identifier: DBMS_OUTPUT
-            dot: .
-            function_name_identifier: PUT_LINE
-          function_contents:
-            bracketed:
-              start_bracket: (
-              expression:
-              - column_reference:
-                - naked_identifier: friend
-                - dot: .
-                - naked_identifier: name
-                - dot: .
-                - naked_identifier: first
-              - binary_operator:
-                - pipe: '|'
-                - pipe: '|'
-              - quoted_literal: "' '"
-              - binary_operator:
-                - pipe: '|'
-                - pipe: '|'
-              - column_reference:
-                - naked_identifier: friend
-                - dot: .
-                - naked_identifier: name
-                - dot: .
-                - naked_identifier: last
-              - binary_operator:
-                - pipe: '|'
-                - pipe: '|'
-              - quoted_literal: "', '"
-              - binary_operator:
-                - pipe: '|'
-                - pipe: '|'
-              - column_reference:
-                - naked_identifier: friend
-                - dot: .
-                - naked_identifier: phone
-              end_bracket: )
-    - statement_terminator: ;
-    - keyword: END
-- statement_terminator: ;
-- statement_terminator: /
-- statement:
-    begin_end_block:
-    - declare_segment:
-      - keyword: DECLARE
-      - collection_type:
-        - keyword: TYPE
-        - naked_identifier: full_name
-        - keyword: IS
-        - data_type:
-            data_type_identifier: VARRAY
-            bracketed_arguments:
-              bracketed:
-                start_bracket: (
-                numeric_literal: '2'
-                end_bracket: )
-        - keyword: OF
-        - data_type:
-            data_type_identifier: VARCHAR2
-            bracketed_arguments:
-              bracketed:
-                start_bracket: (
-                numeric_literal: '20'
-                end_bracket: )
-      - statement_terminator: ;
-      - record_type:
-        - keyword: TYPE
-        - naked_identifier: contact
-        - keyword: IS
-        - keyword: RECORD
-        - bracketed:
-          - start_bracket: (
-          - naked_identifier: name
-          - data_type:
-              data_type_identifier: full_name
-          - assignment_operator: :=
-          - expression:
-              function:
-                function_name:
-                  function_name_identifier: full_name
-                function_contents:
-                  bracketed:
-                  - start_bracket: (
-                  - expression:
-                      quoted_literal: "'John'"
-                  - comma: ','
-                  - expression:
-                      quoted_literal: "'Smith'"
-                  - end_bracket: )
-          - comma: ','
-          - naked_identifier: phone
-          - column_type_reference:
-              column_reference:
-              - naked_identifier: employees
-              - dot: .
-              - naked_identifier: phone_number
-              binary_operator: '%'
-              keyword: TYPE
-          - end_bracket: )
-      - statement_terminator: ;
-      - naked_identifier: friend
-      - data_type:
-          data_type_identifier: contact
-      - statement_terminator: ;
-    - keyword: BEGIN
-    - statement:
-        assignment_segment_statement:
-          object_reference:
-          - naked_identifier: friend
-          - dot: .
-          - naked_identifier: phone
-          assignment_operator: :=
-          expression:
-            quoted_literal: "'1-650-555-1234'"
-    - statement_terminator: ;
-    - statement:
-        function:
-          function_name:
-            naked_identifier: DBMS_OUTPUT
-            dot: .
-            function_name_identifier: PUT_LINE
-          function_contents:
-            bracketed:
-              start_bracket: (
-              expression:
-              - function:
+        - statement_terminator: ;
+        - record_type:
+          - keyword: TYPE
+          - naked_identifier: contact
+          - keyword: IS
+          - keyword: RECORD
+          - bracketed:
+            - start_bracket: (
+            - naked_identifier: name
+            - data_type:
+                data_type_identifier: full_name
+            - assignment_operator: :=
+            - expression:
+                function:
                   function_name:
-                    naked_identifier: friend
-                    dot: .
-                    function_name_identifier: name
+                    function_name_identifier: full_name
                   function_contents:
                     bracketed:
-                      start_bracket: (
-                      expression:
-                        numeric_literal: '1'
-                      end_bracket: )
-              - binary_operator:
-                - pipe: '|'
-                - pipe: '|'
-              - quoted_literal: "' '"
-              - binary_operator:
-                - pipe: '|'
-                - pipe: '|'
-              - function:
-                  function_name:
-                    naked_identifier: friend
-                    dot: .
-                    function_name_identifier: name
-                  function_contents:
-                    bracketed:
-                      start_bracket: (
-                      expression:
-                        numeric_literal: '2'
-                      end_bracket: )
-              - binary_operator:
-                - pipe: '|'
-                - pipe: '|'
-              - quoted_literal: "', '"
-              - binary_operator:
-                - pipe: '|'
-                - pipe: '|'
-              - column_reference:
-                - naked_identifier: friend
+                    - start_bracket: (
+                    - expression:
+                        quoted_literal: "'John'"
+                    - comma: ','
+                    - expression:
+                        quoted_literal: "'Smith'"
+                    - end_bracket: )
+            - comma: ','
+            - naked_identifier: phone
+            - column_type_reference:
+                column_reference:
+                - naked_identifier: employees
                 - dot: .
-                - naked_identifier: phone
-              end_bracket: )
-    - statement_terminator: ;
-    - keyword: END
-- statement_terminator: ;
-- statement_terminator: /
+                - naked_identifier: phone_number
+                binary_operator: '%'
+                keyword: TYPE
+            - end_bracket: )
+        - statement_terminator: ;
+        - naked_identifier: friend
+        - data_type:
+            data_type_identifier: contact
+        - statement_terminator: ;
+      - keyword: BEGIN
+      - statement:
+          assignment_segment_statement:
+            object_reference:
+            - naked_identifier: friend
+            - dot: .
+            - naked_identifier: phone
+            assignment_operator: :=
+            expression:
+              quoted_literal: "'1-650-555-1234'"
+      - statement_terminator: ;
+      - statement:
+          function:
+            function_name:
+              naked_identifier: DBMS_OUTPUT
+              dot: .
+              function_name_identifier: PUT_LINE
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                - function:
+                    function_name:
+                      naked_identifier: friend
+                      dot: .
+                      function_name_identifier: name
+                    function_contents:
+                      bracketed:
+                        start_bracket: (
+                        expression:
+                          numeric_literal: '1'
+                        end_bracket: )
+                - binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                - quoted_literal: "' '"
+                - binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                - function:
+                    function_name:
+                      naked_identifier: friend
+                      dot: .
+                      function_name_identifier: name
+                    function_contents:
+                      bracketed:
+                        start_bracket: (
+                        expression:
+                          numeric_literal: '2'
+                        end_bracket: )
+                - binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                - quoted_literal: "', '"
+                - binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                - column_reference:
+                  - naked_identifier: friend
+                  - dot: .
+                  - naked_identifier: phone
+                end_bracket: )
+      - statement_terminator: ;
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /

--- a/test/fixtures/dialects/oracle/return.yml
+++ b/test/fixtures/dialects/oracle/return.yml
@@ -3,309 +3,385 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 903d491a2ed0bb65ba615a00efb7587bc7903d0fc04f1584b84d5037e38707e1
+_hash: df6bc97802539fb6e78b51ec37773ac75a1262bae7d1a1dd127a146ddadb918a
 file:
-- statement:
-    begin_end_block:
-    - declare_segment:
-        keyword: DECLARE
-        naked_identifier: x
-        data_type:
-          data_type_identifier: INTEGER
-        statement_terminator: ;
-        create_function_statement:
-        - keyword: FUNCTION
-        - function_name:
-            function_name_identifier: f
-        - function_parameter_list:
-            bracketed:
-              start_bracket: (
-              parameter: n
-              data_type:
-                data_type_identifier: INTEGER
-              end_bracket: )
-        - keyword: RETURN
-        - data_type:
+- batch:
+    statement:
+      begin_end_block:
+      - declare_segment:
+          keyword: DECLARE
+          naked_identifier: x
+          data_type:
             data_type_identifier: INTEGER
-        - keyword: IS
-        - begin_end_block:
-          - keyword: BEGIN
-          - statement:
-              function:
-                function_name:
-                  function_name_identifier: RETURN
-                function_contents:
-                  bracketed:
-                    start_bracket: (
-                    expression:
-                    - column_reference:
-                        naked_identifier: n
-                    - binary_operator: '*'
-                    - column_reference:
-                        naked_identifier: n
-                    end_bracket: )
-          - statement_terminator: ;
-          - keyword: END
-        - statement_terminator: ;
-    - keyword: BEGIN
-    - statement:
-        function:
-          function_name:
-            naked_identifier: DBMS_OUTPUT
-            dot: .
-            function_name_identifier: PUT_LINE
-          function_contents:
-            bracketed:
-              start_bracket: (
-              expression:
-              - quoted_literal: "'f returns '"
-              - binary_operator:
-                - pipe: '|'
-                - pipe: '|'
-              - function:
+          statement_terminator: ;
+          create_function_statement:
+          - keyword: FUNCTION
+          - function_name:
+              function_name_identifier: f
+          - function_parameter_list:
+              bracketed:
+                start_bracket: (
+                parameter: n
+                data_type:
+                  data_type_identifier: INTEGER
+                end_bracket: )
+          - keyword: RETURN
+          - data_type:
+              data_type_identifier: INTEGER
+          - keyword: IS
+          - begin_end_block:
+            - keyword: BEGIN
+            - statement:
+                function:
                   function_name:
-                    function_name_identifier: f
+                    function_name_identifier: RETURN
                   function_contents:
                     bracketed:
                       start_bracket: (
                       expression:
-                        numeric_literal: '2'
+                      - column_reference:
+                          naked_identifier: n
+                      - binary_operator: '*'
+                      - column_reference:
+                          naked_identifier: n
                       end_bracket: )
-              - binary_operator:
-                - pipe: '|'
-                - pipe: '|'
-              - quoted_literal: "'. Execution returns here (1).'"
-              end_bracket: )
-    - statement_terminator: ;
-    - statement:
-        assignment_segment_statement:
-          object_reference:
-            naked_identifier: x
-          assignment_operator: :=
-          expression:
-            function:
-              function_name:
-                function_name_identifier: f
-              function_contents:
-                bracketed:
-                  start_bracket: (
-                  expression:
-                    numeric_literal: '2'
-                  end_bracket: )
-    - statement_terminator: ;
-    - statement:
-        function:
-          function_name:
-            naked_identifier: DBMS_OUTPUT
-            dot: .
-            function_name_identifier: PUT_LINE
-          function_contents:
-            bracketed:
-              start_bracket: (
-              expression:
-                quoted_literal: "'Execution returns here (2).'"
-              end_bracket: )
-    - statement_terminator: ;
-    - keyword: END
-- statement_terminator: ;
-- statement_terminator: /
-- statement:
-    begin_end_block:
-    - declare_segment:
-      - create_function_statement:
-        - keyword: CREATE
-        - keyword: OR
-        - keyword: REPLACE
-        - keyword: FUNCTION
-        - function_name:
-            function_name_identifier: f
-        - function_parameter_list:
-            bracketed:
-              start_bracket: (
-              parameter: n
-              data_type:
-                data_type_identifier: INTEGER
-              end_bracket: )
-        - keyword: RETURN
-        - data_type:
-            data_type_identifier: INTEGER
-        - keyword: AUTHID
-        - keyword: DEFINER
-        - keyword: IS
-        - begin_end_block:
-          - keyword: BEGIN
-          - statement:
-              if_then_statement:
-              - if_clause:
-                - keyword: IF
-                - expression:
-                    column_reference:
-                      naked_identifier: n
-                    comparison_operator:
-                      raw_comparison_operator: '='
-                    numeric_literal: '0'
-                - keyword: THEN
-              - statement:
-                  return_statement:
-                    keyword: RETURN
-                    expression:
-                      numeric_literal: '1'
-              - statement_terminator: ;
-              - keyword: ELSIF
-              - expression:
-                  column_reference:
-                    naked_identifier: n
-                  comparison_operator:
-                    raw_comparison_operator: '='
-                  numeric_literal: '1'
-              - keyword: THEN
-              - statement:
-                  return_statement:
-                    keyword: RETURN
-                    expression:
-                      column_reference:
-                        naked_identifier: n
-              - statement_terminator: ;
-              - keyword: END
-              - keyword: IF
+            - statement_terminator: ;
+            - keyword: END
           - statement_terminator: ;
-          - keyword: END
-        - statement_terminator: ;
-        - statement_terminator: /
-      - create_function_statement:
-        - keyword: CREATE
-        - keyword: OR
-        - keyword: REPLACE
-        - keyword: FUNCTION
-        - function_name:
-            function_name_identifier: f
-        - function_parameter_list:
-            bracketed:
-              start_bracket: (
-              parameter: n
-              data_type:
-                data_type_identifier: INTEGER
-              end_bracket: )
-        - keyword: RETURN
-        - data_type:
-            data_type_identifier: INTEGER
-        - keyword: AUTHID
-        - keyword: DEFINER
-        - keyword: IS
-        - begin_end_block:
-          - keyword: BEGIN
-          - statement:
-              if_then_statement:
-              - if_clause:
-                - keyword: IF
-                - expression:
-                    column_reference:
-                      naked_identifier: n
-                    comparison_operator:
-                      raw_comparison_operator: '='
-                    numeric_literal: '0'
-                - keyword: THEN
-              - statement:
-                  return_statement:
-                    keyword: RETURN
-                    expression:
-                      numeric_literal: '1'
-              - statement_terminator: ;
-              - keyword: ELSIF
-              - expression:
-                  column_reference:
-                    naked_identifier: n
-                  comparison_operator:
-                    raw_comparison_operator: '='
-                  numeric_literal: '1'
-              - keyword: THEN
-              - statement:
-                  return_statement:
-                    keyword: RETURN
-                    expression:
-                      column_reference:
-                        naked_identifier: n
-              - statement_terminator: ;
-              - keyword: ELSE
-              - statement:
-                  return_statement:
-                    keyword: RETURN
-                    expression:
-                    - column_reference:
-                        naked_identifier: n
-                    - binary_operator: '*'
-                    - column_reference:
-                        naked_identifier: n
-              - statement_terminator: ;
-              - keyword: END
-              - keyword: IF
-          - statement_terminator: ;
-          - keyword: END
-        - statement_terminator: ;
-        - statement_terminator: /
-    - keyword: BEGIN
-    - statement:
-        for_loop_statement:
-        - keyword: FOR
-        - naked_identifier: i
-        - keyword: IN
-        - numeric_literal: '0'
-        - dot: .
-        - dot: .
-        - numeric_literal: '3'
-        - loop_statement:
-          - keyword: LOOP
-          - statement:
+      - keyword: BEGIN
+      - statement:
+          function:
+            function_name:
+              naked_identifier: DBMS_OUTPUT
+              dot: .
+              function_name_identifier: PUT_LINE
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                - quoted_literal: "'f returns '"
+                - binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                - function:
+                    function_name:
+                      function_name_identifier: f
+                    function_contents:
+                      bracketed:
+                        start_bracket: (
+                        expression:
+                          numeric_literal: '2'
+                        end_bracket: )
+                - binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                - quoted_literal: "'. Execution returns here (1).'"
+                end_bracket: )
+      - statement_terminator: ;
+      - statement:
+          assignment_segment_statement:
+            object_reference:
+              naked_identifier: x
+            assignment_operator: :=
+            expression:
               function:
                 function_name:
-                  naked_identifier: DBMS_OUTPUT
-                  dot: .
-                  function_name_identifier: PUT_LINE
+                  function_name_identifier: f
                 function_contents:
                   bracketed:
                     start_bracket: (
                     expression:
-                    - quoted_literal: "'f('"
-                    - binary_operator:
-                      - pipe: '|'
-                      - pipe: '|'
-                    - column_reference:
-                        naked_identifier: i
-                    - binary_operator:
-                      - pipe: '|'
-                      - pipe: '|'
-                    - quoted_literal: "') = '"
-                    - binary_operator:
-                      - pipe: '|'
-                      - pipe: '|'
-                    - function:
-                        function_name:
-                          function_name_identifier: f
-                        function_contents:
-                          bracketed:
-                            start_bracket: (
-                            expression:
-                              column_reference:
-                                naked_identifier: i
-                            end_bracket: )
+                      numeric_literal: '2'
                     end_bracket: )
+      - statement_terminator: ;
+      - statement:
+          function:
+            function_name:
+              naked_identifier: DBMS_OUTPUT
+              dot: .
+              function_name_identifier: PUT_LINE
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  quoted_literal: "'Execution returns here (2).'"
+                end_bracket: )
+      - statement_terminator: ;
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      create_function_statement:
+      - keyword: CREATE
+      - keyword: OR
+      - keyword: REPLACE
+      - keyword: FUNCTION
+      - function_name:
+          function_name_identifier: f
+      - function_parameter_list:
+          bracketed:
+            start_bracket: (
+            parameter: n
+            data_type:
+              data_type_identifier: INTEGER
+            end_bracket: )
+      - keyword: RETURN
+      - data_type:
+          data_type_identifier: INTEGER
+      - keyword: AUTHID
+      - keyword: DEFINER
+      - keyword: IS
+      - begin_end_block:
+        - keyword: BEGIN
+        - statement:
+            if_then_statement:
+            - if_clause:
+              - keyword: IF
+              - expression:
+                  column_reference:
+                    naked_identifier: n
+                  comparison_operator:
+                    raw_comparison_operator: '='
+                  numeric_literal: '0'
+              - keyword: THEN
+            - statement:
+                return_statement:
+                  keyword: RETURN
+                  expression:
+                    numeric_literal: '1'
+            - statement_terminator: ;
+            - keyword: ELSIF
+            - expression:
+                column_reference:
+                  naked_identifier: n
+                comparison_operator:
+                  raw_comparison_operator: '='
+                numeric_literal: '1'
+            - keyword: THEN
+            - statement:
+                return_statement:
+                  keyword: RETURN
+                  expression:
+                    column_reference:
+                      naked_identifier: n
+            - statement_terminator: ;
+            - keyword: END
+            - keyword: IF
+        - statement_terminator: ;
+        - keyword: END
+      - statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      create_function_statement:
+      - keyword: CREATE
+      - keyword: OR
+      - keyword: REPLACE
+      - keyword: FUNCTION
+      - function_name:
+          function_name_identifier: f
+      - function_parameter_list:
+          bracketed:
+            start_bracket: (
+            parameter: n
+            data_type:
+              data_type_identifier: INTEGER
+            end_bracket: )
+      - keyword: RETURN
+      - data_type:
+          data_type_identifier: INTEGER
+      - keyword: AUTHID
+      - keyword: DEFINER
+      - keyword: IS
+      - begin_end_block:
+        - keyword: BEGIN
+        - statement:
+            if_then_statement:
+            - if_clause:
+              - keyword: IF
+              - expression:
+                  column_reference:
+                    naked_identifier: n
+                  comparison_operator:
+                    raw_comparison_operator: '='
+                  numeric_literal: '0'
+              - keyword: THEN
+            - statement:
+                return_statement:
+                  keyword: RETURN
+                  expression:
+                    numeric_literal: '1'
+            - statement_terminator: ;
+            - keyword: ELSIF
+            - expression:
+                column_reference:
+                  naked_identifier: n
+                comparison_operator:
+                  raw_comparison_operator: '='
+                numeric_literal: '1'
+            - keyword: THEN
+            - statement:
+                return_statement:
+                  keyword: RETURN
+                  expression:
+                    column_reference:
+                      naked_identifier: n
+            - statement_terminator: ;
+            - keyword: ELSE
+            - statement:
+                return_statement:
+                  keyword: RETURN
+                  expression:
+                  - column_reference:
+                      naked_identifier: n
+                  - binary_operator: '*'
+                  - column_reference:
+                      naked_identifier: n
+            - statement_terminator: ;
+            - keyword: END
+            - keyword: IF
+        - statement_terminator: ;
+        - keyword: END
+      - statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      begin_end_block:
+      - keyword: BEGIN
+      - statement:
+          for_loop_statement:
+          - keyword: FOR
+          - naked_identifier: i
+          - keyword: IN
+          - numeric_literal: '0'
+          - dot: .
+          - dot: .
+          - numeric_literal: '3'
+          - loop_statement:
+            - keyword: LOOP
+            - statement:
+                function:
+                  function_name:
+                    naked_identifier: DBMS_OUTPUT
+                    dot: .
+                    function_name_identifier: PUT_LINE
+                  function_contents:
+                    bracketed:
+                      start_bracket: (
+                      expression:
+                      - quoted_literal: "'f('"
+                      - binary_operator:
+                        - pipe: '|'
+                        - pipe: '|'
+                      - column_reference:
+                          naked_identifier: i
+                      - binary_operator:
+                        - pipe: '|'
+                        - pipe: '|'
+                      - quoted_literal: "') = '"
+                      - binary_operator:
+                        - pipe: '|'
+                        - pipe: '|'
+                      - function:
+                          function_name:
+                            function_name_identifier: f
+                          function_contents:
+                            bracketed:
+                              start_bracket: (
+                              expression:
+                                column_reference:
+                                  naked_identifier: i
+                              end_bracket: )
+                      end_bracket: )
+            - statement_terminator: ;
+            - keyword: END
+            - keyword: LOOP
+      - statement_terminator: ;
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      begin_end_block:
+      - declare_segment:
+          keyword: DECLARE
+          create_procedure_statement:
+          - keyword: PROCEDURE
+          - function_name:
+              function_name_identifier: p
+          - keyword: IS
+          - begin_end_block:
+            - keyword: BEGIN
+            - statement:
+                function:
+                  function_name:
+                    naked_identifier: DBMS_OUTPUT
+                    dot: .
+                    function_name_identifier: PUT_LINE
+                  function_contents:
+                    bracketed:
+                      start_bracket: (
+                      expression:
+                        quoted_literal: "'Inside p'"
+                      end_bracket: )
+            - statement_terminator: ;
+            - statement:
+                return_statement:
+                  keyword: RETURN
+            - statement_terminator: ;
+            - statement:
+                function:
+                  function_name:
+                    naked_identifier: DBMS_OUTPUT
+                    dot: .
+                    function_name_identifier: PUT_LINE
+                  function_contents:
+                    bracketed:
+                      start_bracket: (
+                      expression:
+                        quoted_literal: "'Unreachable statement.'"
+                      end_bracket: )
+            - statement_terminator: ;
+            - keyword: END
           - statement_terminator: ;
-          - keyword: END
-          - keyword: LOOP
-    - statement_terminator: ;
-    - keyword: END
-- statement_terminator: ;
-- statement_terminator: /
-- statement:
-    begin_end_block:
-    - declare_segment:
-        keyword: DECLARE
-        create_procedure_statement:
-        - keyword: PROCEDURE
-        - function_name:
-            function_name_identifier: p
-        - keyword: IS
-        - begin_end_block:
+      - keyword: BEGIN
+      - statement:
+          function:
+            function_name:
+              function_name_identifier: p
+            function_contents:
+              bracketed:
+                start_bracket: (
+                end_bracket: )
+      - statement_terminator: ;
+      - statement:
+          function:
+            function_name:
+              naked_identifier: DBMS_OUTPUT
+              dot: .
+              function_name_identifier: PUT_LINE
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  quoted_literal: "'Control returns here.'"
+                end_bracket: )
+      - statement_terminator: ;
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      begin_end_block:
+      - keyword: BEGIN
+      - statement:
+          begin_end_block:
           - keyword: BEGIN
           - statement:
               function:
@@ -317,7 +393,7 @@ file:
                   bracketed:
                     start_bracket: (
                     expression:
-                      quoted_literal: "'Inside p'"
+                      quoted_literal: "'Inside inner block.'"
                     end_bracket: )
           - statement_terminator: ;
           - statement:
@@ -338,84 +414,21 @@ file:
                     end_bracket: )
           - statement_terminator: ;
           - keyword: END
-        - statement_terminator: ;
-    - keyword: BEGIN
-    - statement:
-        function:
-          function_name:
-            function_name_identifier: p
-          function_contents:
-            bracketed:
-              start_bracket: (
-              end_bracket: )
-    - statement_terminator: ;
-    - statement:
-        function:
-          function_name:
-            naked_identifier: DBMS_OUTPUT
-            dot: .
-            function_name_identifier: PUT_LINE
-          function_contents:
-            bracketed:
-              start_bracket: (
-              expression:
-                quoted_literal: "'Control returns here.'"
-              end_bracket: )
-    - statement_terminator: ;
-    - keyword: END
-- statement_terminator: ;
-- statement_terminator: /
-- statement:
-    begin_end_block:
-    - keyword: BEGIN
-    - statement:
-        begin_end_block:
-        - keyword: BEGIN
-        - statement:
-            function:
-              function_name:
-                naked_identifier: DBMS_OUTPUT
-                dot: .
-                function_name_identifier: PUT_LINE
-              function_contents:
-                bracketed:
-                  start_bracket: (
-                  expression:
-                    quoted_literal: "'Inside inner block.'"
-                  end_bracket: )
-        - statement_terminator: ;
-        - statement:
-            return_statement:
-              keyword: RETURN
-        - statement_terminator: ;
-        - statement:
-            function:
-              function_name:
-                naked_identifier: DBMS_OUTPUT
-                dot: .
-                function_name_identifier: PUT_LINE
-              function_contents:
-                bracketed:
-                  start_bracket: (
-                  expression:
-                    quoted_literal: "'Unreachable statement.'"
-                  end_bracket: )
-        - statement_terminator: ;
-        - keyword: END
-    - statement_terminator: ;
-    - statement:
-        function:
-          function_name:
-            naked_identifier: DBMS_OUTPUT
-            dot: .
-            function_name_identifier: PUT_LINE
-          function_contents:
-            bracketed:
-              start_bracket: (
-              expression:
-                quoted_literal: "'Inside outer block. Unreachable statement.'"
-              end_bracket: )
-    - statement_terminator: ;
-    - keyword: END
-- statement_terminator: ;
-- statement_terminator: /
+      - statement_terminator: ;
+      - statement:
+          function:
+            function_name:
+              naked_identifier: DBMS_OUTPUT
+              dot: .
+              function_name_identifier: PUT_LINE
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  quoted_literal: "'Inside outer block. Unreachable statement.'"
+                end_bracket: )
+      - statement_terminator: ;
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /

--- a/test/fixtures/dialects/oracle/returning_into.yml
+++ b/test/fixtures/dialects/oracle/returning_into.yml
@@ -3,482 +3,44 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 50c679c4cedb00a3789e9f036bcdcb765362656f0b9012693ee3ae332aa01d63
+_hash: ed4960348e96325dd5a4e302dd3016d53d6fc215645738473703a23ef88c18a7
 file:
-- statement:
-    begin_end_block:
-    - declare_segment:
-      - keyword: DECLARE
-      - record_type:
-        - keyword: TYPE
-        - naked_identifier: EmpRec
-        - keyword: IS
-        - keyword: RECORD
-        - bracketed:
-          - start_bracket: (
-          - naked_identifier: last_name
-          - column_type_reference:
-              column_reference:
-              - naked_identifier: employees
-              - dot: .
-              - naked_identifier: last_name
-              binary_operator: '%'
-              keyword: TYPE
-          - comma: ','
-          - naked_identifier: salary
-          - column_type_reference:
-              column_reference:
-              - naked_identifier: employees
-              - dot: .
-              - naked_identifier: salary
-              binary_operator: '%'
-              keyword: TYPE
-          - end_bracket: )
-      - statement_terminator: ;
-      - naked_identifier: emp_info
-      - data_type:
-          data_type_identifier: EmpRec
-      - statement_terminator: ;
-      - naked_identifier: old_salary
-      - column_type_reference:
-          column_reference:
-          - naked_identifier: employees
-          - dot: .
-          - naked_identifier: salary
-          binary_operator: '%'
-          keyword: TYPE
-      - statement_terminator: ;
-    - keyword: BEGIN
-    - statement:
-        select_statement:
-          select_clause:
-            keyword: SELECT
-            select_clause_element:
-              column_reference:
-                naked_identifier: salary
-          into_clause:
-            keyword: INTO
-            naked_identifier: old_salary
-          from_clause:
-            keyword: FROM
-            from_expression:
-              from_expression_element:
-                table_expression:
-                  table_reference:
-                    naked_identifier: employees
-          where_clause:
-            keyword: WHERE
-            expression:
-              column_reference:
-                naked_identifier: employee_id
-              comparison_operator:
-                raw_comparison_operator: '='
-              numeric_literal: '100'
-    - statement_terminator: ;
-    - statement:
-        update_statement:
-          keyword: UPDATE
-          table_reference:
-            naked_identifier: employees
-          set_clause_list:
-            keyword: SET
-            set_clause:
-              column_reference:
-                naked_identifier: salary
-              comparison_operator:
-                raw_comparison_operator: '='
-              expression:
+- batch:
+    statement:
+      begin_end_block:
+      - declare_segment:
+        - keyword: DECLARE
+        - record_type:
+          - keyword: TYPE
+          - naked_identifier: EmpRec
+          - keyword: IS
+          - keyword: RECORD
+          - bracketed:
+            - start_bracket: (
+            - naked_identifier: last_name
+            - column_type_reference:
                 column_reference:
-                  naked_identifier: salary
-                binary_operator: '*'
-                numeric_literal: '1.1'
-          where_clause:
-            keyword: WHERE
-            expression:
-              column_reference:
-                naked_identifier: employee_id
-              comparison_operator:
-                raw_comparison_operator: '='
-              numeric_literal: '100'
-          returning_clause:
-          - keyword: RETURNING
-          - naked_identifier: last_name
-          - comma: ','
-          - naked_identifier: salary
-          - into_clause:
-              keyword: INTO
-              naked_identifier: emp_info
-    - statement_terminator: ;
-    - statement:
-        function:
-          function_name:
-            naked_identifier: DBMS_OUTPUT
-            dot: .
-            function_name_identifier: PUT_LINE
-          function_contents:
-            bracketed:
-              start_bracket: (
-              expression:
-              - quoted_literal: "'Salary of '"
-              - binary_operator:
-                - pipe: '|'
-                - pipe: '|'
-              - column_reference:
-                - naked_identifier: emp_info
+                - naked_identifier: employees
                 - dot: .
                 - naked_identifier: last_name
-              - binary_operator:
-                - pipe: '|'
-                - pipe: '|'
-              - quoted_literal: "' raised from '"
-              - binary_operator:
-                - pipe: '|'
-                - pipe: '|'
-              - column_reference:
-                  naked_identifier: old_salary
-              - binary_operator:
-                - pipe: '|'
-                - pipe: '|'
-              - quoted_literal: "' to '"
-              - binary_operator:
-                - pipe: '|'
-                - pipe: '|'
-              - column_reference:
-                - naked_identifier: emp_info
+                binary_operator: '%'
+                keyword: TYPE
+            - comma: ','
+            - naked_identifier: salary
+            - column_type_reference:
+                column_reference:
+                - naked_identifier: employees
                 - dot: .
                 - naked_identifier: salary
-              end_bracket: )
-    - statement_terminator: ;
-    - keyword: END
-- statement_terminator: ;
-- statement_terminator: /
-- statement:
-    begin_end_block:
-    - declare_segment:
-      - keyword: DECLARE
-      - naked_identifier: emp_id
-      - column_type_reference:
-          column_reference:
-          - naked_identifier: employees_temp
-          - dot: .
-          - naked_identifier: employee_id
-          binary_operator: '%'
-          keyword: TYPE
-      - assignment_operator: :=
-      - expression:
-          numeric_literal: '299'
-      - statement_terminator: ;
-      - naked_identifier: emp_first_name
-      - column_type_reference:
-          column_reference:
-          - naked_identifier: employees_temp
-          - dot: .
-          - naked_identifier: first_name
-          binary_operator: '%'
-          keyword: TYPE
-      - assignment_operator: :=
-      - expression:
-          quoted_literal: "'Bob'"
-      - statement_terminator: ;
-      - naked_identifier: emp_last_name
-      - column_type_reference:
-          column_reference:
-          - naked_identifier: employees_temp
-          - dot: .
-          - naked_identifier: last_name
-          binary_operator: '%'
-          keyword: TYPE
-      - assignment_operator: :=
-      - expression:
-          quoted_literal: "'Henry'"
-      - statement_terminator: ;
-    - keyword: BEGIN
-    - statement:
-        insert_statement:
-        - keyword: INSERT
-        - keyword: INTO
-        - table_reference:
-            naked_identifier: employees_temp
-        - bracketed:
-          - start_bracket: (
-          - column_reference:
-              naked_identifier: employee_id
-          - comma: ','
-          - column_reference:
-              naked_identifier: first_name
-          - comma: ','
-          - column_reference:
-              naked_identifier: last_name
-          - end_bracket: )
-        - values_clause:
-            keyword: VALUES
-            bracketed:
-            - start_bracket: (
-            - expression:
-                column_reference:
-                  naked_identifier: emp_id
-            - comma: ','
-            - expression:
-                column_reference:
-                  naked_identifier: emp_first_name
-            - comma: ','
-            - expression:
-                column_reference:
-                  naked_identifier: emp_last_name
+                binary_operator: '%'
+                keyword: TYPE
             - end_bracket: )
-    - statement_terminator: ;
-    - statement:
-        update_statement:
-          keyword: UPDATE
-          table_reference:
-            naked_identifier: employees_temp
-          set_clause_list:
-            keyword: SET
-            set_clause:
-              column_reference:
-                naked_identifier: first_name
-              comparison_operator:
-                raw_comparison_operator: '='
-              quoted_literal: "'Robert'"
-          where_clause:
-            keyword: WHERE
-            expression:
-            - column_reference:
-                naked_identifier: employee_id
-            - comparison_operator:
-                raw_comparison_operator: '='
-            - column_reference:
-                naked_identifier: emp_id
-    - statement_terminator: ;
-    - statement:
-        delete_statement:
-          keyword: DELETE
-          from_clause:
-            keyword: FROM
-            from_expression:
-              from_expression_element:
-                table_expression:
-                  table_reference:
-                    naked_identifier: employees_temp
-          where_clause:
-            keyword: WHERE
-            expression:
-            - column_reference:
-                naked_identifier: employee_id
-            - comparison_operator:
-                raw_comparison_operator: '='
-            - column_reference:
-                naked_identifier: emp_id
-          returning_clause:
-          - keyword: RETURNING
-          - naked_identifier: first_name
-          - comma: ','
-          - naked_identifier: last_name
-          - into_clause:
-            - keyword: INTO
-            - naked_identifier: emp_first_name
-            - comma: ','
-            - naked_identifier: emp_last_name
-    - statement_terminator: ;
-    - statement:
-        transaction_statement:
-          keyword: COMMIT
-    - statement_terminator: ;
-    - statement:
-        function:
-          function_name:
-            naked_identifier: DBMS_OUTPUT
-            dot: .
-            function_name_identifier: PUT_LINE
-          function_contents:
-            bracketed:
-              start_bracket: (
-              expression:
-              - column_reference:
-                  naked_identifier: emp_first_name
-              - binary_operator:
-                - pipe: '|'
-                - pipe: '|'
-              - quoted_literal: "' '"
-              - binary_operator:
-                - pipe: '|'
-                - pipe: '|'
-              - column_reference:
-                  naked_identifier: emp_last_name
-              end_bracket: )
-    - statement_terminator: ;
-    - keyword: END
-- statement_terminator: ;
-- statement_terminator: /
-- statement:
-    begin_end_block:
-    - declare_segment:
-      - keyword: DECLARE
-      - collection_type:
-        - keyword: TYPE
-        - naked_identifier: NumList
-        - keyword: IS
-        - keyword: TABLE
-        - keyword: OF
-        - column_type_reference:
-            column_reference:
-            - naked_identifier: employees
-            - dot: .
-            - naked_identifier: employee_id
-            binary_operator: '%'
-            keyword: TYPE
-      - statement_terminator: ;
-      - naked_identifier: enums
-      - data_type:
-          data_type_identifier: NumList
-      - statement_terminator: ;
-      - collection_type:
-        - keyword: TYPE
-        - naked_identifier: NameList
-        - keyword: IS
-        - keyword: TABLE
-        - keyword: OF
-        - column_type_reference:
-            column_reference:
-            - naked_identifier: employees
-            - dot: .
-            - naked_identifier: last_name
-            binary_operator: '%'
-            keyword: TYPE
-      - statement_terminator: ;
-      - naked_identifier: names
-      - data_type:
-          data_type_identifier: NameList
-      - statement_terminator: ;
-    - keyword: BEGIN
-    - statement:
-        delete_statement:
-          keyword: DELETE
-          from_clause:
-            keyword: FROM
-            from_expression:
-              from_expression_element:
-                table_expression:
-                  table_reference:
-                    naked_identifier: emp_temp
-          where_clause:
-            keyword: WHERE
-            expression:
-              column_reference:
-                naked_identifier: department_id
-              comparison_operator:
-                raw_comparison_operator: '='
-              numeric_literal: '30'
-          returning_clause:
-          - keyword: RETURNING
-          - naked_identifier: employee_id
-          - comma: ','
-          - naked_identifier: last_name
-          - bulk_collect_into_clause:
-            - keyword: BULK
-            - keyword: COLLECT
-            - keyword: INTO
-            - naked_identifier: enums
-            - comma: ','
-            - naked_identifier: names
-    - statement_terminator: ;
-    - statement:
-        function:
-          function_name:
-            naked_identifier: DBMS_OUTPUT
-            dot: .
-            function_name_identifier: PUT_LINE
-          function_contents:
-            bracketed:
-              start_bracket: (
-              expression:
-              - quoted_literal: "'Deleted '"
-              - binary_operator:
-                - pipe: '|'
-                - pipe: '|'
-              - naked_identifier: SQL
-              - binary_operator: '%'
-              - keyword: ROWCOUNT
-              - binary_operator:
-                - pipe: '|'
-                - pipe: '|'
-              - quoted_literal: "' rows:'"
-              end_bracket: )
-    - statement_terminator: ;
-    - statement:
-        for_loop_statement:
-        - keyword: FOR
-        - naked_identifier: i
-        - keyword: IN
-        - naked_identifier: enums
-        - dot: .
-        - naked_identifier: FIRST
-        - dot: .
-        - dot: .
-        - naked_identifier: enums
-        - dot: .
-        - naked_identifier: LAST
-        - loop_statement:
-          - keyword: LOOP
-          - statement:
-              function:
-                function_name:
-                  naked_identifier: DBMS_OUTPUT
-                  dot: .
-                  function_name_identifier: PUT_LINE
-                function_contents:
-                  bracketed:
-                    start_bracket: (
-                    expression:
-                    - quoted_literal: "'Employee #'"
-                    - binary_operator:
-                      - pipe: '|'
-                      - pipe: '|'
-                    - function:
-                        function_name:
-                          function_name_identifier: enums
-                        function_contents:
-                          bracketed:
-                            start_bracket: (
-                            expression:
-                              column_reference:
-                                naked_identifier: i
-                            end_bracket: )
-                    - binary_operator:
-                      - pipe: '|'
-                      - pipe: '|'
-                    - quoted_literal: "': '"
-                    - binary_operator:
-                      - pipe: '|'
-                      - pipe: '|'
-                    - function:
-                        function_name:
-                          function_name_identifier: names
-                        function_contents:
-                          bracketed:
-                            start_bracket: (
-                            expression:
-                              column_reference:
-                                naked_identifier: i
-                            end_bracket: )
-                    end_bracket: )
-          - statement_terminator: ;
-          - keyword: END
-          - keyword: LOOP
-    - statement_terminator: ;
-    - keyword: END
-- statement_terminator: ;
-- statement_terminator: /
-- statement:
-    begin_end_block:
-    - declare_segment:
-      - keyword: DECLARE
-      - collection_type:
-        - keyword: TYPE
-        - naked_identifier: SalList
-        - keyword: IS
-        - keyword: TABLE
-        - keyword: OF
+        - statement_terminator: ;
+        - naked_identifier: emp_info
+        - data_type:
+            data_type_identifier: EmpRec
+        - statement_terminator: ;
+        - naked_identifier: old_salary
         - column_type_reference:
             column_reference:
             - naked_identifier: employees
@@ -486,263 +48,316 @@ file:
             - naked_identifier: salary
             binary_operator: '%'
             keyword: TYPE
-      - statement_terminator: ;
-      - naked_identifier: old_sals
-      - data_type:
-          data_type_identifier: SalList
-      - statement_terminator: ;
-      - naked_identifier: new_sals
-      - data_type:
-          data_type_identifier: SalList
-      - statement_terminator: ;
-      - collection_type:
-        - keyword: TYPE
-        - naked_identifier: NameList
-        - keyword: IS
-        - keyword: TABLE
-        - keyword: OF
-        - column_type_reference:
-            column_reference:
-            - naked_identifier: employees
-            - dot: .
-            - naked_identifier: last_name
-            binary_operator: '%'
-            keyword: TYPE
-      - statement_terminator: ;
-      - naked_identifier: names
-      - data_type:
-          data_type_identifier: NameList
-      - statement_terminator: ;
-    - keyword: BEGIN
-    - statement:
-        update_statement:
-          keyword: UPDATE
-          table_reference:
-            naked_identifier: emp_temp
-          set_clause_list:
-            keyword: SET
-            set_clause:
-              column_reference:
-                naked_identifier: salary
-              comparison_operator:
-                raw_comparison_operator: '='
-              expression:
+        - statement_terminator: ;
+      - keyword: BEGIN
+      - statement:
+          select_statement:
+            select_clause:
+              keyword: SELECT
+              select_clause_element:
                 column_reference:
                   naked_identifier: salary
-                binary_operator: '*'
-                numeric_literal: '1.15'
-          where_clause:
-            keyword: WHERE
-            expression:
-              column_reference:
-                naked_identifier: salary
-              comparison_operator:
-                raw_comparison_operator: <
-              numeric_literal: '2500'
-          returning_clause:
-          - keyword: RETURNING
-          - keyword: OLD
-          - naked_identifier: salary
-          - comma: ','
-          - keyword: NEW
-          - naked_identifier: salary
-          - comma: ','
-          - naked_identifier: last_name
-          - bulk_collect_into_clause:
-            - keyword: BULK
-            - keyword: COLLECT
-            - keyword: INTO
-            - naked_identifier: old_sals
-            - comma: ','
-            - naked_identifier: new_sals
-            - comma: ','
-            - naked_identifier: names
-    - statement_terminator: ;
-    - statement:
-        function:
-          function_name:
-            naked_identifier: DBMS_OUTPUT
-            dot: .
-            function_name_identifier: PUT_LINE
-          function_contents:
-            bracketed:
-              start_bracket: (
+            into_clause:
+              keyword: INTO
+              naked_identifier: old_salary
+            from_clause:
+              keyword: FROM
+              from_expression:
+                from_expression_element:
+                  table_expression:
+                    table_reference:
+                      naked_identifier: employees
+            where_clause:
+              keyword: WHERE
               expression:
-              - quoted_literal: "'Updated '"
-              - binary_operator:
-                - pipe: '|'
-                - pipe: '|'
-              - naked_identifier: SQL
-              - binary_operator: '%'
-              - keyword: ROWCOUNT
-              - binary_operator:
-                - pipe: '|'
-                - pipe: '|'
-              - quoted_literal: "' rows: '"
-              end_bracket: )
-    - statement_terminator: ;
-    - statement:
-        for_loop_statement:
-        - keyword: FOR
-        - naked_identifier: i
-        - keyword: IN
-        - naked_identifier: old_sals
-        - dot: .
-        - naked_identifier: FIRST
-        - dot: .
-        - dot: .
-        - naked_identifier: old_sals
-        - dot: .
-        - naked_identifier: LAST
-        - loop_statement:
-          - keyword: LOOP
-          - statement:
-              function:
-                function_name:
-                  naked_identifier: DBMS_OUTPUT
-                  dot: .
-                  function_name_identifier: PUT_LINE
-                function_contents:
-                  bracketed:
-                    start_bracket: (
-                    expression:
-                    - function:
-                        function_name:
-                          function_name_identifier: names
-                        function_contents:
-                          bracketed:
-                            start_bracket: (
-                            expression:
-                              column_reference:
-                                naked_identifier: i
-                            end_bracket: )
-                    - binary_operator:
-                      - pipe: '|'
-                      - pipe: '|'
-                    - quoted_literal: "': Old Salary $'"
-                    - binary_operator:
-                      - pipe: '|'
-                      - pipe: '|'
-                    - function:
-                        function_name:
-                          function_name_identifier: old_sals
-                        function_contents:
-                          bracketed:
-                            start_bracket: (
-                            expression:
-                              column_reference:
-                                naked_identifier: i
-                            end_bracket: )
-                    - binary_operator:
-                      - pipe: '|'
-                      - pipe: '|'
-                    - quoted_literal: "', New Salary $'"
-                    - binary_operator:
-                      - pipe: '|'
-                      - pipe: '|'
-                    - function:
-                        function_name:
-                          function_name_identifier: new_sals
-                        function_contents:
-                          bracketed:
-                            start_bracket: (
-                            expression:
-                              column_reference:
-                                naked_identifier: i
-                            end_bracket: )
-                    end_bracket: )
-          - statement_terminator: ;
-          - keyword: END
-          - keyword: LOOP
-    - statement_terminator: ;
-    - keyword: END
-- statement_terminator: ;
-- statement_terminator: /
-- statement:
-    begin_end_block:
-    - declare_segment:
-      - keyword: DECLARE
-      - collection_type:
-        - keyword: TYPE
-        - naked_identifier: NumList
-        - keyword: IS
-        - keyword: TABLE
-        - keyword: OF
-        - data_type:
-            data_type_identifier: NUMBER
+                column_reference:
+                  naked_identifier: employee_id
+                comparison_operator:
+                  raw_comparison_operator: '='
+                numeric_literal: '100'
       - statement_terminator: ;
-      - naked_identifier: depts
-      - data_type:
-          data_type_identifier: NumList
-      - assignment_operator: :=
-      - expression:
+      - statement:
+          update_statement:
+            keyword: UPDATE
+            table_reference:
+              naked_identifier: employees
+            set_clause_list:
+              keyword: SET
+              set_clause:
+                column_reference:
+                  naked_identifier: salary
+                comparison_operator:
+                  raw_comparison_operator: '='
+                expression:
+                  column_reference:
+                    naked_identifier: salary
+                  binary_operator: '*'
+                  numeric_literal: '1.1'
+            where_clause:
+              keyword: WHERE
+              expression:
+                column_reference:
+                  naked_identifier: employee_id
+                comparison_operator:
+                  raw_comparison_operator: '='
+                numeric_literal: '100'
+            returning_clause:
+            - keyword: RETURNING
+            - naked_identifier: last_name
+            - comma: ','
+            - naked_identifier: salary
+            - into_clause:
+                keyword: INTO
+                naked_identifier: emp_info
+      - statement_terminator: ;
+      - statement:
           function:
             function_name:
-              function_name_identifier: NumList
+              naked_identifier: DBMS_OUTPUT
+              dot: .
+              function_name_identifier: PUT_LINE
             function_contents:
               bracketed:
-              - start_bracket: (
-              - expression:
-                  numeric_literal: '10'
-              - comma: ','
-              - expression:
-                  numeric_literal: '20'
-              - comma: ','
-              - expression:
-                  numeric_literal: '30'
-              - end_bracket: )
+                start_bracket: (
+                expression:
+                - quoted_literal: "'Salary of '"
+                - binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                - column_reference:
+                  - naked_identifier: emp_info
+                  - dot: .
+                  - naked_identifier: last_name
+                - binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                - quoted_literal: "' raised from '"
+                - binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                - column_reference:
+                    naked_identifier: old_salary
+                - binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                - quoted_literal: "' to '"
+                - binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                - column_reference:
+                  - naked_identifier: emp_info
+                  - dot: .
+                  - naked_identifier: salary
+                end_bracket: )
       - statement_terminator: ;
-      - collection_type:
-        - keyword: TYPE
-        - naked_identifier: enum_t
-        - keyword: IS
-        - keyword: TABLE
-        - keyword: OF
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      begin_end_block:
+      - declare_segment:
+        - keyword: DECLARE
+        - naked_identifier: emp_id
         - column_type_reference:
             column_reference:
-            - naked_identifier: employees
+            - naked_identifier: employees_temp
             - dot: .
             - naked_identifier: employee_id
             binary_operator: '%'
             keyword: TYPE
-      - statement_terminator: ;
-      - naked_identifier: e_ids
-      - data_type:
-          data_type_identifier: enum_t
-      - statement_terminator: ;
-      - collection_type:
-        - keyword: TYPE
-        - naked_identifier: dept_t
-        - keyword: IS
-        - keyword: TABLE
-        - keyword: OF
+        - assignment_operator: :=
+        - expression:
+            numeric_literal: '299'
+        - statement_terminator: ;
+        - naked_identifier: emp_first_name
         - column_type_reference:
             column_reference:
-            - naked_identifier: employees
+            - naked_identifier: employees_temp
             - dot: .
-            - naked_identifier: department_id
+            - naked_identifier: first_name
             binary_operator: '%'
             keyword: TYPE
+        - assignment_operator: :=
+        - expression:
+            quoted_literal: "'Bob'"
+        - statement_terminator: ;
+        - naked_identifier: emp_last_name
+        - column_type_reference:
+            column_reference:
+            - naked_identifier: employees_temp
+            - dot: .
+            - naked_identifier: last_name
+            binary_operator: '%'
+            keyword: TYPE
+        - assignment_operator: :=
+        - expression:
+            quoted_literal: "'Henry'"
+        - statement_terminator: ;
+      - keyword: BEGIN
+      - statement:
+          insert_statement:
+          - keyword: INSERT
+          - keyword: INTO
+          - table_reference:
+              naked_identifier: employees_temp
+          - bracketed:
+            - start_bracket: (
+            - column_reference:
+                naked_identifier: employee_id
+            - comma: ','
+            - column_reference:
+                naked_identifier: first_name
+            - comma: ','
+            - column_reference:
+                naked_identifier: last_name
+            - end_bracket: )
+          - values_clause:
+              keyword: VALUES
+              bracketed:
+              - start_bracket: (
+              - expression:
+                  column_reference:
+                    naked_identifier: emp_id
+              - comma: ','
+              - expression:
+                  column_reference:
+                    naked_identifier: emp_first_name
+              - comma: ','
+              - expression:
+                  column_reference:
+                    naked_identifier: emp_last_name
+              - end_bracket: )
       - statement_terminator: ;
-      - naked_identifier: d_ids
-      - data_type:
-          data_type_identifier: dept_t
+      - statement:
+          update_statement:
+            keyword: UPDATE
+            table_reference:
+              naked_identifier: employees_temp
+            set_clause_list:
+              keyword: SET
+              set_clause:
+                column_reference:
+                  naked_identifier: first_name
+                comparison_operator:
+                  raw_comparison_operator: '='
+                quoted_literal: "'Robert'"
+            where_clause:
+              keyword: WHERE
+              expression:
+              - column_reference:
+                  naked_identifier: employee_id
+              - comparison_operator:
+                  raw_comparison_operator: '='
+              - column_reference:
+                  naked_identifier: emp_id
       - statement_terminator: ;
-    - keyword: BEGIN
-    - statement:
-        forall_statement:
-        - keyword: FORALL
-        - naked_identifier: j
-        - keyword: IN
-        - naked_identifier: depts
-        - dot: .
-        - naked_identifier: FIRST
-        - dot: .
-        - dot: .
-        - naked_identifier: depts
-        - dot: .
-        - naked_identifier: LAST
-        - delete_statement:
+      - statement:
+          delete_statement:
+            keyword: DELETE
+            from_clause:
+              keyword: FROM
+              from_expression:
+                from_expression_element:
+                  table_expression:
+                    table_reference:
+                      naked_identifier: employees_temp
+            where_clause:
+              keyword: WHERE
+              expression:
+              - column_reference:
+                  naked_identifier: employee_id
+              - comparison_operator:
+                  raw_comparison_operator: '='
+              - column_reference:
+                  naked_identifier: emp_id
+            returning_clause:
+            - keyword: RETURNING
+            - naked_identifier: first_name
+            - comma: ','
+            - naked_identifier: last_name
+            - into_clause:
+              - keyword: INTO
+              - naked_identifier: emp_first_name
+              - comma: ','
+              - naked_identifier: emp_last_name
+      - statement_terminator: ;
+      - statement:
+          transaction_statement:
+            keyword: COMMIT
+      - statement_terminator: ;
+      - statement:
+          function:
+            function_name:
+              naked_identifier: DBMS_OUTPUT
+              dot: .
+              function_name_identifier: PUT_LINE
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                - column_reference:
+                    naked_identifier: emp_first_name
+                - binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                - quoted_literal: "' '"
+                - binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                - column_reference:
+                    naked_identifier: emp_last_name
+                end_bracket: )
+      - statement_terminator: ;
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      begin_end_block:
+      - declare_segment:
+        - keyword: DECLARE
+        - collection_type:
+          - keyword: TYPE
+          - naked_identifier: NumList
+          - keyword: IS
+          - keyword: TABLE
+          - keyword: OF
+          - column_type_reference:
+              column_reference:
+              - naked_identifier: employees
+              - dot: .
+              - naked_identifier: employee_id
+              binary_operator: '%'
+              keyword: TYPE
+        - statement_terminator: ;
+        - naked_identifier: enums
+        - data_type:
+            data_type_identifier: NumList
+        - statement_terminator: ;
+        - collection_type:
+          - keyword: TYPE
+          - naked_identifier: NameList
+          - keyword: IS
+          - keyword: TABLE
+          - keyword: OF
+          - column_type_reference:
+              column_reference:
+              - naked_identifier: employees
+              - dot: .
+              - naked_identifier: last_name
+              binary_operator: '%'
+              keyword: TYPE
+        - statement_terminator: ;
+        - naked_identifier: names
+        - data_type:
+            data_type_identifier: NameList
+        - statement_terminator: ;
+      - keyword: BEGIN
+      - statement:
+          delete_statement:
             keyword: DELETE
             from_clause:
               keyword: FROM
@@ -758,518 +373,917 @@ file:
                   naked_identifier: department_id
                 comparison_operator:
                   raw_comparison_operator: '='
-                function:
-                  function_name:
-                    function_name_identifier: depts
-                  function_contents:
-                    bracketed:
-                      start_bracket: (
-                      expression:
-                        column_reference:
-                          naked_identifier: j
-                      end_bracket: )
+                numeric_literal: '30'
             returning_clause:
             - keyword: RETURNING
             - naked_identifier: employee_id
             - comma: ','
-            - naked_identifier: department_id
+            - naked_identifier: last_name
             - bulk_collect_into_clause:
               - keyword: BULK
               - keyword: COLLECT
               - keyword: INTO
-              - naked_identifier: e_ids
+              - naked_identifier: enums
               - comma: ','
-              - naked_identifier: d_ids
-    - statement_terminator: ;
-    - statement:
-        function:
-          function_name:
-            naked_identifier: DBMS_OUTPUT
-            dot: .
-            function_name_identifier: PUT_LINE
-          function_contents:
-            bracketed:
-              start_bracket: (
-              expression:
-              - quoted_literal: "'Deleted '"
-              - binary_operator:
-                - pipe: '|'
-                - pipe: '|'
-              - naked_identifier: SQL
-              - binary_operator: '%'
-              - keyword: ROWCOUNT
-              - binary_operator:
-                - pipe: '|'
-                - pipe: '|'
-              - quoted_literal: "' rows:'"
-              end_bracket: )
-    - statement_terminator: ;
-    - statement:
-        for_loop_statement:
-        - keyword: FOR
-        - naked_identifier: i
-        - keyword: IN
-        - naked_identifier: e_ids
-        - dot: .
-        - naked_identifier: FIRST
-        - dot: .
-        - dot: .
-        - naked_identifier: e_ids
-        - dot: .
-        - naked_identifier: LAST
-        - loop_statement:
-          - keyword: LOOP
-          - statement:
-              function:
-                function_name:
-                  naked_identifier: DBMS_OUTPUT
-                  dot: .
-                  function_name_identifier: PUT_LINE
-                function_contents:
-                  bracketed:
-                    start_bracket: (
-                    expression:
-                    - quoted_literal: "'Employee #'"
-                    - binary_operator:
-                      - pipe: '|'
-                      - pipe: '|'
-                    - function:
-                        function_name:
-                          function_name_identifier: e_ids
-                        function_contents:
-                          bracketed:
-                            start_bracket: (
-                            expression:
-                              column_reference:
-                                naked_identifier: i
-                            end_bracket: )
-                    - binary_operator:
-                      - pipe: '|'
-                      - pipe: '|'
-                    - quoted_literal: "' from dept #'"
-                    - binary_operator:
-                      - pipe: '|'
-                      - pipe: '|'
-                    - function:
-                        function_name:
-                          function_name_identifier: d_ids
-                        function_contents:
-                          bracketed:
-                            start_bracket: (
-                            expression:
-                              column_reference:
-                                naked_identifier: i
-                            end_bracket: )
-                    end_bracket: )
-          - statement_terminator: ;
-          - keyword: END
-          - keyword: LOOP
-    - statement_terminator: ;
-    - keyword: END
-- statement_terminator: ;
-- statement_terminator: /
-- statement:
-    begin_end_block:
-    - declare_segment:
-      - keyword: DECLARE
-      - collection_type:
-        - keyword: TYPE
-        - naked_identifier: t_desc_tab
-        - keyword: IS
-        - keyword: TABLE
-        - keyword: OF
-        - column_type_reference:
-            column_reference:
-            - naked_identifier: t1
-            - dot: .
-            - naked_identifier: description
-            binary_operator: '%'
-            keyword: TYPE
+              - naked_identifier: names
       - statement_terminator: ;
-      - collection_type:
-        - keyword: TYPE
-        - naked_identifier: t_id_tab
-        - keyword: IS
-        - keyword: TABLE
-        - keyword: OF
-        - column_type_reference:
-            column_reference:
-            - naked_identifier: t1
-            - dot: .
-            - naked_identifier: id
-            binary_operator: '%'
-            keyword: TYPE
-      - statement_terminator: ;
-      - collection_type:
-        - keyword: TYPE
-        - naked_identifier: t_desc_out_tab
-        - keyword: IS
-        - keyword: TABLE
-        - keyword: OF
-        - column_type_reference:
-            column_reference:
-            - naked_identifier: t1
-            - dot: .
-            - naked_identifier: description
-            binary_operator: '%'
-            keyword: TYPE
-      - statement_terminator: ;
-      - naked_identifier: l_desc_tab
-      - data_type:
-          data_type_identifier: t_desc_tab
-      - assignment_operator: :=
-      - expression:
+      - statement:
           function:
             function_name:
-              function_name_identifier: t_desc_tab
+              naked_identifier: DBMS_OUTPUT
+              dot: .
+              function_name_identifier: PUT_LINE
             function_contents:
               bracketed:
-              - start_bracket: (
-              - expression:
-                  quoted_literal: "'FIVE'"
-              - comma: ','
-              - expression:
-                  quoted_literal: "'SIX'"
-              - comma: ','
-              - expression:
-                  quoted_literal: "'SEVEN'"
-              - end_bracket: )
+                start_bracket: (
+                expression:
+                - quoted_literal: "'Deleted '"
+                - binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                - naked_identifier: SQL
+                - binary_operator: '%'
+                - keyword: ROWCOUNT
+                - binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                - quoted_literal: "' rows:'"
+                end_bracket: )
       - statement_terminator: ;
-      - naked_identifier: l_id_tab
-      - data_type:
-          data_type_identifier: t_id_tab
+      - statement:
+          for_loop_statement:
+          - keyword: FOR
+          - naked_identifier: i
+          - keyword: IN
+          - naked_identifier: enums
+          - dot: .
+          - naked_identifier: FIRST
+          - dot: .
+          - dot: .
+          - naked_identifier: enums
+          - dot: .
+          - naked_identifier: LAST
+          - loop_statement:
+            - keyword: LOOP
+            - statement:
+                function:
+                  function_name:
+                    naked_identifier: DBMS_OUTPUT
+                    dot: .
+                    function_name_identifier: PUT_LINE
+                  function_contents:
+                    bracketed:
+                      start_bracket: (
+                      expression:
+                      - quoted_literal: "'Employee #'"
+                      - binary_operator:
+                        - pipe: '|'
+                        - pipe: '|'
+                      - function:
+                          function_name:
+                            function_name_identifier: enums
+                          function_contents:
+                            bracketed:
+                              start_bracket: (
+                              expression:
+                                column_reference:
+                                  naked_identifier: i
+                              end_bracket: )
+                      - binary_operator:
+                        - pipe: '|'
+                        - pipe: '|'
+                      - quoted_literal: "': '"
+                      - binary_operator:
+                        - pipe: '|'
+                        - pipe: '|'
+                      - function:
+                          function_name:
+                            function_name_identifier: names
+                          function_contents:
+                            bracketed:
+                              start_bracket: (
+                              expression:
+                                column_reference:
+                                  naked_identifier: i
+                              end_bracket: )
+                      end_bracket: )
+            - statement_terminator: ;
+            - keyword: END
+            - keyword: LOOP
       - statement_terminator: ;
-      - naked_identifier: l_desc_out_tab
-      - data_type:
-          data_type_identifier: t_desc_out_tab
-      - statement_terminator: ;
-    - keyword: BEGIN
-    - statement:
-        forall_statement:
-        - keyword: FORALL
-        - naked_identifier: i
-        - keyword: IN
-        - naked_identifier: l_desc_tab
-        - dot: .
-        - naked_identifier: FIRST
-        - dot: .
-        - dot: .
-        - naked_identifier: l_desc_tab
-        - dot: .
-        - naked_identifier: LAST
-        - insert_statement:
-          - keyword: INSERT
-          - keyword: INTO
-          - table_reference:
-              naked_identifier: t1
-          - values_clause:
-              keyword: VALUES
-              bracketed:
-              - start_bracket: (
-              - expression:
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      begin_end_block:
+      - declare_segment:
+        - keyword: DECLARE
+        - collection_type:
+          - keyword: TYPE
+          - naked_identifier: SalList
+          - keyword: IS
+          - keyword: TABLE
+          - keyword: OF
+          - column_type_reference:
+              column_reference:
+              - naked_identifier: employees
+              - dot: .
+              - naked_identifier: salary
+              binary_operator: '%'
+              keyword: TYPE
+        - statement_terminator: ;
+        - naked_identifier: old_sals
+        - data_type:
+            data_type_identifier: SalList
+        - statement_terminator: ;
+        - naked_identifier: new_sals
+        - data_type:
+            data_type_identifier: SalList
+        - statement_terminator: ;
+        - collection_type:
+          - keyword: TYPE
+          - naked_identifier: NameList
+          - keyword: IS
+          - keyword: TABLE
+          - keyword: OF
+          - column_type_reference:
+              column_reference:
+              - naked_identifier: employees
+              - dot: .
+              - naked_identifier: last_name
+              binary_operator: '%'
+              keyword: TYPE
+        - statement_terminator: ;
+        - naked_identifier: names
+        - data_type:
+            data_type_identifier: NameList
+        - statement_terminator: ;
+      - keyword: BEGIN
+      - statement:
+          update_statement:
+            keyword: UPDATE
+            table_reference:
+              naked_identifier: emp_temp
+            set_clause_list:
+              keyword: SET
+              set_clause:
+                column_reference:
+                  naked_identifier: salary
+                comparison_operator:
+                  raw_comparison_operator: '='
+                expression:
                   column_reference:
-                  - naked_identifier: t1_seq
-                  - dot: .
-                  - naked_identifier: NEXTVAL
+                    naked_identifier: salary
+                  binary_operator: '*'
+                  numeric_literal: '1.15'
+            where_clause:
+              keyword: WHERE
+              expression:
+                column_reference:
+                  naked_identifier: salary
+                comparison_operator:
+                  raw_comparison_operator: <
+                numeric_literal: '2500'
+            returning_clause:
+            - keyword: RETURNING
+            - keyword: OLD
+            - naked_identifier: salary
+            - comma: ','
+            - keyword: NEW
+            - naked_identifier: salary
+            - comma: ','
+            - naked_identifier: last_name
+            - bulk_collect_into_clause:
+              - keyword: BULK
+              - keyword: COLLECT
+              - keyword: INTO
+              - naked_identifier: old_sals
               - comma: ','
-              - expression:
+              - naked_identifier: new_sals
+              - comma: ','
+              - naked_identifier: names
+      - statement_terminator: ;
+      - statement:
+          function:
+            function_name:
+              naked_identifier: DBMS_OUTPUT
+              dot: .
+              function_name_identifier: PUT_LINE
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                - quoted_literal: "'Updated '"
+                - binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                - naked_identifier: SQL
+                - binary_operator: '%'
+                - keyword: ROWCOUNT
+                - binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                - quoted_literal: "' rows: '"
+                end_bracket: )
+      - statement_terminator: ;
+      - statement:
+          for_loop_statement:
+          - keyword: FOR
+          - naked_identifier: i
+          - keyword: IN
+          - naked_identifier: old_sals
+          - dot: .
+          - naked_identifier: FIRST
+          - dot: .
+          - dot: .
+          - naked_identifier: old_sals
+          - dot: .
+          - naked_identifier: LAST
+          - loop_statement:
+            - keyword: LOOP
+            - statement:
+                function:
+                  function_name:
+                    naked_identifier: DBMS_OUTPUT
+                    dot: .
+                    function_name_identifier: PUT_LINE
+                  function_contents:
+                    bracketed:
+                      start_bracket: (
+                      expression:
+                      - function:
+                          function_name:
+                            function_name_identifier: names
+                          function_contents:
+                            bracketed:
+                              start_bracket: (
+                              expression:
+                                column_reference:
+                                  naked_identifier: i
+                              end_bracket: )
+                      - binary_operator:
+                        - pipe: '|'
+                        - pipe: '|'
+                      - quoted_literal: "': Old Salary $'"
+                      - binary_operator:
+                        - pipe: '|'
+                        - pipe: '|'
+                      - function:
+                          function_name:
+                            function_name_identifier: old_sals
+                          function_contents:
+                            bracketed:
+                              start_bracket: (
+                              expression:
+                                column_reference:
+                                  naked_identifier: i
+                              end_bracket: )
+                      - binary_operator:
+                        - pipe: '|'
+                        - pipe: '|'
+                      - quoted_literal: "', New Salary $'"
+                      - binary_operator:
+                        - pipe: '|'
+                        - pipe: '|'
+                      - function:
+                          function_name:
+                            function_name_identifier: new_sals
+                          function_contents:
+                            bracketed:
+                              start_bracket: (
+                              expression:
+                                column_reference:
+                                  naked_identifier: i
+                              end_bracket: )
+                      end_bracket: )
+            - statement_terminator: ;
+            - keyword: END
+            - keyword: LOOP
+      - statement_terminator: ;
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      begin_end_block:
+      - declare_segment:
+        - keyword: DECLARE
+        - collection_type:
+          - keyword: TYPE
+          - naked_identifier: NumList
+          - keyword: IS
+          - keyword: TABLE
+          - keyword: OF
+          - data_type:
+              data_type_identifier: NUMBER
+        - statement_terminator: ;
+        - naked_identifier: depts
+        - data_type:
+            data_type_identifier: NumList
+        - assignment_operator: :=
+        - expression:
+            function:
+              function_name:
+                function_name_identifier: NumList
+              function_contents:
+                bracketed:
+                - start_bracket: (
+                - expression:
+                    numeric_literal: '10'
+                - comma: ','
+                - expression:
+                    numeric_literal: '20'
+                - comma: ','
+                - expression:
+                    numeric_literal: '30'
+                - end_bracket: )
+        - statement_terminator: ;
+        - collection_type:
+          - keyword: TYPE
+          - naked_identifier: enum_t
+          - keyword: IS
+          - keyword: TABLE
+          - keyword: OF
+          - column_type_reference:
+              column_reference:
+              - naked_identifier: employees
+              - dot: .
+              - naked_identifier: employee_id
+              binary_operator: '%'
+              keyword: TYPE
+        - statement_terminator: ;
+        - naked_identifier: e_ids
+        - data_type:
+            data_type_identifier: enum_t
+        - statement_terminator: ;
+        - collection_type:
+          - keyword: TYPE
+          - naked_identifier: dept_t
+          - keyword: IS
+          - keyword: TABLE
+          - keyword: OF
+          - column_type_reference:
+              column_reference:
+              - naked_identifier: employees
+              - dot: .
+              - naked_identifier: department_id
+              binary_operator: '%'
+              keyword: TYPE
+        - statement_terminator: ;
+        - naked_identifier: d_ids
+        - data_type:
+            data_type_identifier: dept_t
+        - statement_terminator: ;
+      - keyword: BEGIN
+      - statement:
+          forall_statement:
+          - keyword: FORALL
+          - naked_identifier: j
+          - keyword: IN
+          - naked_identifier: depts
+          - dot: .
+          - naked_identifier: FIRST
+          - dot: .
+          - dot: .
+          - naked_identifier: depts
+          - dot: .
+          - naked_identifier: LAST
+          - delete_statement:
+              keyword: DELETE
+              from_clause:
+                keyword: FROM
+                from_expression:
+                  from_expression_element:
+                    table_expression:
+                      table_reference:
+                        naked_identifier: emp_temp
+              where_clause:
+                keyword: WHERE
+                expression:
+                  column_reference:
+                    naked_identifier: department_id
+                  comparison_operator:
+                    raw_comparison_operator: '='
                   function:
                     function_name:
-                      function_name_identifier: l_desc_tab
+                      function_name_identifier: depts
                     function_contents:
                       bracketed:
                         start_bracket: (
                         expression:
                           column_reference:
-                            naked_identifier: i
+                            naked_identifier: j
                         end_bracket: )
-              - end_bracket: )
-          - returning_clause:
-            - keyword: RETURNING
-            - naked_identifier: id
-            - comma: ','
-            - naked_identifier: description
-            - bulk_collect_into_clause:
-              - keyword: BULK
-              - keyword: COLLECT
-              - keyword: INTO
-              - naked_identifier: l_id_tab
+              returning_clause:
+              - keyword: RETURNING
+              - naked_identifier: employee_id
               - comma: ','
-              - naked_identifier: l_desc_out_tab
-    - statement_terminator: ;
-    - statement:
-        for_loop_statement:
-        - keyword: FOR
-        - naked_identifier: i
-        - keyword: IN
+              - naked_identifier: department_id
+              - bulk_collect_into_clause:
+                - keyword: BULK
+                - keyword: COLLECT
+                - keyword: INTO
+                - naked_identifier: e_ids
+                - comma: ','
+                - naked_identifier: d_ids
+      - statement_terminator: ;
+      - statement:
+          function:
+            function_name:
+              naked_identifier: DBMS_OUTPUT
+              dot: .
+              function_name_identifier: PUT_LINE
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                - quoted_literal: "'Deleted '"
+                - binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                - naked_identifier: SQL
+                - binary_operator: '%'
+                - keyword: ROWCOUNT
+                - binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                - quoted_literal: "' rows:'"
+                end_bracket: )
+      - statement_terminator: ;
+      - statement:
+          for_loop_statement:
+          - keyword: FOR
+          - naked_identifier: i
+          - keyword: IN
+          - naked_identifier: e_ids
+          - dot: .
+          - naked_identifier: FIRST
+          - dot: .
+          - dot: .
+          - naked_identifier: e_ids
+          - dot: .
+          - naked_identifier: LAST
+          - loop_statement:
+            - keyword: LOOP
+            - statement:
+                function:
+                  function_name:
+                    naked_identifier: DBMS_OUTPUT
+                    dot: .
+                    function_name_identifier: PUT_LINE
+                  function_contents:
+                    bracketed:
+                      start_bracket: (
+                      expression:
+                      - quoted_literal: "'Employee #'"
+                      - binary_operator:
+                        - pipe: '|'
+                        - pipe: '|'
+                      - function:
+                          function_name:
+                            function_name_identifier: e_ids
+                          function_contents:
+                            bracketed:
+                              start_bracket: (
+                              expression:
+                                column_reference:
+                                  naked_identifier: i
+                              end_bracket: )
+                      - binary_operator:
+                        - pipe: '|'
+                        - pipe: '|'
+                      - quoted_literal: "' from dept #'"
+                      - binary_operator:
+                        - pipe: '|'
+                        - pipe: '|'
+                      - function:
+                          function_name:
+                            function_name_identifier: d_ids
+                          function_contents:
+                            bracketed:
+                              start_bracket: (
+                              expression:
+                                column_reference:
+                                  naked_identifier: i
+                              end_bracket: )
+                      end_bracket: )
+            - statement_terminator: ;
+            - keyword: END
+            - keyword: LOOP
+      - statement_terminator: ;
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      begin_end_block:
+      - declare_segment:
+        - keyword: DECLARE
+        - collection_type:
+          - keyword: TYPE
+          - naked_identifier: t_desc_tab
+          - keyword: IS
+          - keyword: TABLE
+          - keyword: OF
+          - column_type_reference:
+              column_reference:
+              - naked_identifier: t1
+              - dot: .
+              - naked_identifier: description
+              binary_operator: '%'
+              keyword: TYPE
+        - statement_terminator: ;
+        - collection_type:
+          - keyword: TYPE
+          - naked_identifier: t_id_tab
+          - keyword: IS
+          - keyword: TABLE
+          - keyword: OF
+          - column_type_reference:
+              column_reference:
+              - naked_identifier: t1
+              - dot: .
+              - naked_identifier: id
+              binary_operator: '%'
+              keyword: TYPE
+        - statement_terminator: ;
+        - collection_type:
+          - keyword: TYPE
+          - naked_identifier: t_desc_out_tab
+          - keyword: IS
+          - keyword: TABLE
+          - keyword: OF
+          - column_type_reference:
+              column_reference:
+              - naked_identifier: t1
+              - dot: .
+              - naked_identifier: description
+              binary_operator: '%'
+              keyword: TYPE
+        - statement_terminator: ;
+        - naked_identifier: l_desc_tab
+        - data_type:
+            data_type_identifier: t_desc_tab
+        - assignment_operator: :=
+        - expression:
+            function:
+              function_name:
+                function_name_identifier: t_desc_tab
+              function_contents:
+                bracketed:
+                - start_bracket: (
+                - expression:
+                    quoted_literal: "'FIVE'"
+                - comma: ','
+                - expression:
+                    quoted_literal: "'SIX'"
+                - comma: ','
+                - expression:
+                    quoted_literal: "'SEVEN'"
+                - end_bracket: )
+        - statement_terminator: ;
         - naked_identifier: l_id_tab
-        - dot: .
-        - naked_identifier: FIRST
-        - dot: .
-        - dot: .
-        - naked_identifier: l_id_tab
-        - dot: .
-        - naked_identifier: LAST
-        - loop_statement:
-          - keyword: LOOP
-          - statement:
-              function:
-                function_name:
-                  naked_identifier: DBMS_OUTPUT
-                  dot: .
-                  function_name_identifier: put_line
-                function_contents:
-                  bracketed:
-                    start_bracket: (
-                    expression:
-                    - quoted_literal: "'INSERT ID='"
-                    - binary_operator:
-                      - pipe: '|'
-                      - pipe: '|'
-                    - function:
-                        function_name:
-                          function_name_identifier: l_id_tab
-                        function_contents:
-                          bracketed:
-                            start_bracket: (
-                            expression:
-                              column_reference:
-                                naked_identifier: i
-                            end_bracket: )
-                    - binary_operator:
-                      - pipe: '|'
-                      - pipe: '|'
-                    - quoted_literal: "' DESC='"
-                    - binary_operator:
-                      - pipe: '|'
-                      - pipe: '|'
-                    - function:
-                        function_name:
-                          function_name_identifier: l_desc_out_tab
-                        function_contents:
-                          bracketed:
-                            start_bracket: (
-                            expression:
-                              column_reference:
-                                naked_identifier: i
-                            end_bracket: )
-                    end_bracket: )
-          - statement_terminator: ;
-          - keyword: END
-          - keyword: LOOP
-    - statement_terminator: ;
-    - statement:
-        transaction_statement:
-          keyword: COMMIT
-    - statement_terminator: ;
-    - keyword: END
-- statement_terminator: ;
-- statement_terminator: /
-- statement:
-    begin_end_block:
-    - declare_segment:
-      - keyword: DECLARE
-      - collection_type:
-        - keyword: TYPE
-        - naked_identifier: t_sal_tab
-        - keyword: IS
-        - keyword: TABLE
-        - keyword: OF
-        - column_type_reference:
-            column_reference:
-            - naked_identifier: emp
-            - dot: .
-            - naked_identifier: sal
-            binary_operator: '%'
-            keyword: TYPE
-      - statement_terminator: ;
-      - collection_type:
-        - keyword: TYPE
-        - naked_identifier: t_empno_tab
-        - keyword: IS
-        - keyword: TABLE
-        - keyword: OF
-        - column_type_reference:
-            column_reference:
-            - naked_identifier: emp
-            - dot: .
-            - naked_identifier: empno
-            binary_operator: '%'
-            keyword: TYPE
-      - statement_terminator: ;
-      - naked_identifier: l_empno
-      - data_type:
-          data_type_identifier: t_empno_tab
-      - statement_terminator: ;
-      - naked_identifier: l_salo
-      - data_type:
-          data_type_identifier: t_sal_tab
-      - statement_terminator: ;
-      - naked_identifier: l_saln
-      - data_type:
-          data_type_identifier: t_sal_tab
-      - statement_terminator: ;
-    - keyword: BEGIN
-    - statement:
-        merge_statement:
-        - keyword: MERGE
-        - keyword: INTO
-        - table_reference:
-            naked_identifier: emp
-        - alias_expression:
-            naked_identifier: t
-        - keyword: USING
-        - table_reference:
-            naked_identifier: emp_sal_increase
-        - alias_expression:
-            naked_identifier: q
-        - join_on_condition:
-            keyword: 'ON'
-            bracketed:
-              start_bracket: (
-              expression:
-              - column_reference:
-                - naked_identifier: t
-                - dot: .
-                - naked_identifier: deptno
-              - comparison_operator:
-                  raw_comparison_operator: '='
-              - column_reference:
-                - naked_identifier: q
-                - dot: .
-                - naked_identifier: deptno
-              end_bracket: )
-        - merge_match:
-            merge_when_matched_clause:
-            - keyword: WHEN
-            - keyword: MATCHED
-            - keyword: THEN
-            - merge_update_clause:
-                keyword: UPDATE
-                set_clause_list:
-                  keyword: SET
-                  set_clause:
+        - data_type:
+            data_type_identifier: t_id_tab
+        - statement_terminator: ;
+        - naked_identifier: l_desc_out_tab
+        - data_type:
+            data_type_identifier: t_desc_out_tab
+        - statement_terminator: ;
+      - keyword: BEGIN
+      - statement:
+          forall_statement:
+          - keyword: FORALL
+          - naked_identifier: i
+          - keyword: IN
+          - naked_identifier: l_desc_tab
+          - dot: .
+          - naked_identifier: FIRST
+          - dot: .
+          - dot: .
+          - naked_identifier: l_desc_tab
+          - dot: .
+          - naked_identifier: LAST
+          - insert_statement:
+            - keyword: INSERT
+            - keyword: INTO
+            - table_reference:
+                naked_identifier: t1
+            - values_clause:
+                keyword: VALUES
+                bracketed:
+                - start_bracket: (
+                - expression:
                     column_reference:
-                    - naked_identifier: t
+                    - naked_identifier: t1_seq
                     - dot: .
-                    - naked_identifier: sal
-                    comparison_operator:
-                      raw_comparison_operator: '='
-                    expression:
+                    - naked_identifier: NEXTVAL
+                - comma: ','
+                - expression:
+                    function:
+                      function_name:
+                        function_name_identifier: l_desc_tab
+                      function_contents:
+                        bracketed:
+                          start_bracket: (
+                          expression:
+                            column_reference:
+                              naked_identifier: i
+                          end_bracket: )
+                - end_bracket: )
+            - returning_clause:
+              - keyword: RETURNING
+              - naked_identifier: id
+              - comma: ','
+              - naked_identifier: description
+              - bulk_collect_into_clause:
+                - keyword: BULK
+                - keyword: COLLECT
+                - keyword: INTO
+                - naked_identifier: l_id_tab
+                - comma: ','
+                - naked_identifier: l_desc_out_tab
+      - statement_terminator: ;
+      - statement:
+          for_loop_statement:
+          - keyword: FOR
+          - naked_identifier: i
+          - keyword: IN
+          - naked_identifier: l_id_tab
+          - dot: .
+          - naked_identifier: FIRST
+          - dot: .
+          - dot: .
+          - naked_identifier: l_id_tab
+          - dot: .
+          - naked_identifier: LAST
+          - loop_statement:
+            - keyword: LOOP
+            - statement:
+                function:
+                  function_name:
+                    naked_identifier: DBMS_OUTPUT
+                    dot: .
+                    function_name_identifier: put_line
+                  function_contents:
+                    bracketed:
+                      start_bracket: (
+                      expression:
+                      - quoted_literal: "'INSERT ID='"
+                      - binary_operator:
+                        - pipe: '|'
+                        - pipe: '|'
+                      - function:
+                          function_name:
+                            function_name_identifier: l_id_tab
+                          function_contents:
+                            bracketed:
+                              start_bracket: (
+                              expression:
+                                column_reference:
+                                  naked_identifier: i
+                              end_bracket: )
+                      - binary_operator:
+                        - pipe: '|'
+                        - pipe: '|'
+                      - quoted_literal: "' DESC='"
+                      - binary_operator:
+                        - pipe: '|'
+                        - pipe: '|'
+                      - function:
+                          function_name:
+                            function_name_identifier: l_desc_out_tab
+                          function_contents:
+                            bracketed:
+                              start_bracket: (
+                              expression:
+                                column_reference:
+                                  naked_identifier: i
+                              end_bracket: )
+                      end_bracket: )
+            - statement_terminator: ;
+            - keyword: END
+            - keyword: LOOP
+      - statement_terminator: ;
+      - statement:
+          transaction_statement:
+            keyword: COMMIT
+      - statement_terminator: ;
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      begin_end_block:
+      - declare_segment:
+        - keyword: DECLARE
+        - collection_type:
+          - keyword: TYPE
+          - naked_identifier: t_sal_tab
+          - keyword: IS
+          - keyword: TABLE
+          - keyword: OF
+          - column_type_reference:
+              column_reference:
+              - naked_identifier: emp
+              - dot: .
+              - naked_identifier: sal
+              binary_operator: '%'
+              keyword: TYPE
+        - statement_terminator: ;
+        - collection_type:
+          - keyword: TYPE
+          - naked_identifier: t_empno_tab
+          - keyword: IS
+          - keyword: TABLE
+          - keyword: OF
+          - column_type_reference:
+              column_reference:
+              - naked_identifier: emp
+              - dot: .
+              - naked_identifier: empno
+              binary_operator: '%'
+              keyword: TYPE
+        - statement_terminator: ;
+        - naked_identifier: l_empno
+        - data_type:
+            data_type_identifier: t_empno_tab
+        - statement_terminator: ;
+        - naked_identifier: l_salo
+        - data_type:
+            data_type_identifier: t_sal_tab
+        - statement_terminator: ;
+        - naked_identifier: l_saln
+        - data_type:
+            data_type_identifier: t_sal_tab
+        - statement_terminator: ;
+      - keyword: BEGIN
+      - statement:
+          merge_statement:
+          - keyword: MERGE
+          - keyword: INTO
+          - table_reference:
+              naked_identifier: emp
+          - alias_expression:
+              naked_identifier: t
+          - keyword: USING
+          - table_reference:
+              naked_identifier: emp_sal_increase
+          - alias_expression:
+              naked_identifier: q
+          - join_on_condition:
+              keyword: 'ON'
+              bracketed:
+                start_bracket: (
+                expression:
+                - column_reference:
+                  - naked_identifier: t
+                  - dot: .
+                  - naked_identifier: deptno
+                - comparison_operator:
+                    raw_comparison_operator: '='
+                - column_reference:
+                  - naked_identifier: q
+                  - dot: .
+                  - naked_identifier: deptno
+                end_bracket: )
+          - merge_match:
+              merge_when_matched_clause:
+              - keyword: WHEN
+              - keyword: MATCHED
+              - keyword: THEN
+              - merge_update_clause:
+                  keyword: UPDATE
+                  set_clause_list:
+                    keyword: SET
+                    set_clause:
                       column_reference:
                       - naked_identifier: t
                       - dot: .
                       - naked_identifier: sal
-                      binary_operator: '*'
-                      bracketed:
-                        start_bracket: (
-                        expression:
-                        - numeric_literal: '1'
-                        - binary_operator: +
-                        - column_reference:
-                          - naked_identifier: q
-                          - dot: .
-                          - naked_identifier: increase_pct
-                        - binary_operator: /
-                        - numeric_literal: '100'
-                        end_bracket: )
-                returning_clause:
-                - keyword: RETURNING
-                - naked_identifier: empno
-                - comma: ','
-                - keyword: OLD
-                - naked_identifier: sal
-                - comma: ','
-                - keyword: NEW
-                - naked_identifier: sal
-                - bulk_collect_into_clause:
-                  - keyword: BULK
-                  - keyword: COLLECT
-                  - keyword: INTO
-                  - naked_identifier: l_empno
+                      comparison_operator:
+                        raw_comparison_operator: '='
+                      expression:
+                        column_reference:
+                        - naked_identifier: t
+                        - dot: .
+                        - naked_identifier: sal
+                        binary_operator: '*'
+                        bracketed:
+                          start_bracket: (
+                          expression:
+                          - numeric_literal: '1'
+                          - binary_operator: +
+                          - column_reference:
+                            - naked_identifier: q
+                            - dot: .
+                            - naked_identifier: increase_pct
+                          - binary_operator: /
+                          - numeric_literal: '100'
+                          end_bracket: )
+                  returning_clause:
+                  - keyword: RETURNING
+                  - naked_identifier: empno
                   - comma: ','
-                  - naked_identifier: l_salo
+                  - keyword: OLD
+                  - naked_identifier: sal
                   - comma: ','
-                  - naked_identifier: l_saln
-    - statement_terminator: ;
-    - statement:
-        for_loop_statement:
-        - keyword: FOR
-        - naked_identifier: i
-        - keyword: IN
-        - naked_identifier: l_salo
-        - dot: .
-        - naked_identifier: first
-        - dot: .
-        - dot: .
-        - naked_identifier: l_salo
-        - dot: .
-        - naked_identifier: last
-        - loop_statement:
-          - keyword: LOOP
-          - statement:
-              function:
-                function_name:
-                  naked_identifier: DBMS_OUTPUT
-                  dot: .
-                  function_name_identifier: put_line
-                function_contents:
-                  bracketed:
-                    start_bracket: (
-                    expression:
-                    - quoted_literal: "'EMPNO='"
-                    - binary_operator:
-                      - pipe: '|'
-                      - pipe: '|'
-                    - function:
-                        function_name:
-                          function_name_identifier: l_empno
-                        function_contents:
-                          bracketed:
-                            start_bracket: (
-                            expression:
-                              column_reference:
-                                naked_identifier: i
-                            end_bracket: )
-                    - binary_operator:
-                      - pipe: '|'
-                      - pipe: '|'
-                    - quoted_literal: "', SAL changed from '"
-                    - binary_operator:
-                      - pipe: '|'
-                      - pipe: '|'
-                    - function:
-                        function_name:
-                          function_name_identifier: l_salo
-                        function_contents:
-                          bracketed:
-                            start_bracket: (
-                            expression:
-                              column_reference:
-                                naked_identifier: i
-                            end_bracket: )
-                    - binary_operator:
-                      - pipe: '|'
-                      - pipe: '|'
-                    - quoted_literal: "' to '"
-                    - binary_operator:
-                      - pipe: '|'
-                      - pipe: '|'
-                    - function:
-                        function_name:
-                          function_name_identifier: l_saln
-                        function_contents:
-                          bracketed:
-                            start_bracket: (
-                            expression:
-                              column_reference:
-                                naked_identifier: i
-                            end_bracket: )
-                    end_bracket: )
-          - statement_terminator: ;
-          - keyword: END
-          - keyword: LOOP
-    - statement_terminator: ;
-    - keyword: END
-- statement_terminator: ;
-- statement_terminator: /
+                  - keyword: NEW
+                  - naked_identifier: sal
+                  - bulk_collect_into_clause:
+                    - keyword: BULK
+                    - keyword: COLLECT
+                    - keyword: INTO
+                    - naked_identifier: l_empno
+                    - comma: ','
+                    - naked_identifier: l_salo
+                    - comma: ','
+                    - naked_identifier: l_saln
+      - statement_terminator: ;
+      - statement:
+          for_loop_statement:
+          - keyword: FOR
+          - naked_identifier: i
+          - keyword: IN
+          - naked_identifier: l_salo
+          - dot: .
+          - naked_identifier: first
+          - dot: .
+          - dot: .
+          - naked_identifier: l_salo
+          - dot: .
+          - naked_identifier: last
+          - loop_statement:
+            - keyword: LOOP
+            - statement:
+                function:
+                  function_name:
+                    naked_identifier: DBMS_OUTPUT
+                    dot: .
+                    function_name_identifier: put_line
+                  function_contents:
+                    bracketed:
+                      start_bracket: (
+                      expression:
+                      - quoted_literal: "'EMPNO='"
+                      - binary_operator:
+                        - pipe: '|'
+                        - pipe: '|'
+                      - function:
+                          function_name:
+                            function_name_identifier: l_empno
+                          function_contents:
+                            bracketed:
+                              start_bracket: (
+                              expression:
+                                column_reference:
+                                  naked_identifier: i
+                              end_bracket: )
+                      - binary_operator:
+                        - pipe: '|'
+                        - pipe: '|'
+                      - quoted_literal: "', SAL changed from '"
+                      - binary_operator:
+                        - pipe: '|'
+                        - pipe: '|'
+                      - function:
+                          function_name:
+                            function_name_identifier: l_salo
+                          function_contents:
+                            bracketed:
+                              start_bracket: (
+                              expression:
+                                column_reference:
+                                  naked_identifier: i
+                              end_bracket: )
+                      - binary_operator:
+                        - pipe: '|'
+                        - pipe: '|'
+                      - quoted_literal: "' to '"
+                      - binary_operator:
+                        - pipe: '|'
+                        - pipe: '|'
+                      - function:
+                          function_name:
+                            function_name_identifier: l_saln
+                          function_contents:
+                            bracketed:
+                              start_bracket: (
+                              expression:
+                                column_reference:
+                                  naked_identifier: i
+                              end_bracket: )
+                      end_bracket: )
+            - statement_terminator: ;
+            - keyword: END
+            - keyword: LOOP
+      - statement_terminator: ;
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /

--- a/test/fixtures/dialects/oracle/revoke.yml
+++ b/test/fixtures/dialects/oracle/revoke.yml
@@ -3,192 +3,193 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 13ea10d4938f9ebc49685f9857717468e0b3aef33be59ff65640dc7735d41381
+_hash: 2caf2adb7c5bf01cf9747be5b199ca96858da7b83d81e608e279ae4f24388e97
 file:
-- statement:
-    access_statement:
-      revoke_statement:
-      - keyword: REVOKE
-      - access_permissions:
-          access_permission:
-            keyword: DROP
-          keyword: ANY
-          access_object:
-            keyword: TABLE
-      - keyword: FROM
-      - access_target:
+  batch:
+  - statement:
+      access_statement:
+        revoke_statement:
+        - keyword: REVOKE
+        - access_permissions:
+            access_permission:
+              keyword: DROP
+            keyword: ANY
+            access_object:
+              keyword: TABLE
+        - keyword: FROM
+        - access_target:
+          - object_reference:
+              naked_identifier: hr
+          - comma: ','
+          - object_reference:
+              naked_identifier: oe
+  - statement_terminator: ;
+  - statement:
+      access_statement:
+        revoke_statement:
+        - keyword: REVOKE
+        - access_permissions:
+            role_reference:
+              naked_identifier: dw_manager
+        - keyword: FROM
+        - access_target:
+            object_reference:
+              naked_identifier: sh
+  - statement_terminator: ;
+  - statement:
+      access_statement:
+        revoke_statement:
+        - keyword: REVOKE
+        - access_permissions:
+            access_permission:
+              keyword: CREATE
+            access_object:
+              keyword: TABLESPACE
+        - keyword: FROM
+        - access_target:
+            object_reference:
+              naked_identifier: dw_manager
+  - statement_terminator: ;
+  - statement:
+      access_statement:
+        revoke_statement:
+        - keyword: REVOKE
+        - access_permissions:
+            role_reference:
+              naked_identifier: dw_user
+        - keyword: FROM
+        - access_target:
+            object_reference:
+              naked_identifier: dw_manager
+  - statement_terminator: ;
+  - statement:
+      access_statement:
+        revoke_statement:
+        - keyword: REVOKE
+        - access_permissions:
+            access_permission:
+              keyword: DELETE
+        - keyword: 'ON'
         - object_reference:
-            naked_identifier: hr
-        - comma: ','
+            naked_identifier: orders
+        - keyword: FROM
+        - access_target:
+            object_reference:
+              naked_identifier: hr
+  - statement_terminator: ;
+  - statement:
+      access_statement:
+        revoke_statement:
+        - keyword: REVOKE
+        - access_permissions:
+            access_permission:
+              keyword: ALL
+        - keyword: 'ON'
         - object_reference:
-            naked_identifier: oe
-- statement_terminator: ;
-- statement:
-    access_statement:
-      revoke_statement:
-      - keyword: REVOKE
-      - access_permissions:
-          role_reference:
-            naked_identifier: dw_manager
-      - keyword: FROM
-      - access_target:
-          object_reference:
+            naked_identifier: orders
+        - keyword: FROM
+        - access_target:
+            object_reference:
+              naked_identifier: hr
+  - statement_terminator: ;
+  - statement:
+      access_statement:
+        revoke_statement:
+        - keyword: REVOKE
+        - access_permissions:
+            access_permission:
+              keyword: UPDATE
+        - keyword: 'ON'
+        - object_reference:
+            naked_identifier: emp_details_view
+        - keyword: FROM
+        - access_target:
+            keyword: public
+  - statement_terminator: ;
+  - statement:
+      access_statement:
+        revoke_statement:
+        - keyword: REVOKE
+        - access_permissions:
+            access_permission:
+              keyword: INHERIT
+            access_object:
+              keyword: PRIVILEGES
+        - keyword: 'ON'
+        - keyword: USER
+        - object_reference:
             naked_identifier: sh
-- statement_terminator: ;
-- statement:
-    access_statement:
-      revoke_statement:
-      - keyword: REVOKE
-      - access_permissions:
-          access_permission:
-            keyword: CREATE
-          access_object:
-            keyword: TABLESPACE
-      - keyword: FROM
-      - access_target:
-          object_reference:
-            naked_identifier: dw_manager
-- statement_terminator: ;
-- statement:
-    access_statement:
-      revoke_statement:
-      - keyword: REVOKE
-      - access_permissions:
-          role_reference:
-            naked_identifier: dw_user
-      - keyword: FROM
-      - access_target:
-          object_reference:
-            naked_identifier: dw_manager
-- statement_terminator: ;
-- statement:
-    access_statement:
-      revoke_statement:
-      - keyword: REVOKE
-      - access_permissions:
-          access_permission:
-            keyword: DELETE
-      - keyword: 'ON'
-      - object_reference:
-          naked_identifier: orders
-      - keyword: FROM
-      - access_target:
-          object_reference:
-            naked_identifier: hr
-- statement_terminator: ;
-- statement:
-    access_statement:
-      revoke_statement:
-      - keyword: REVOKE
-      - access_permissions:
-          access_permission:
-            keyword: ALL
-      - keyword: 'ON'
-      - object_reference:
-          naked_identifier: orders
-      - keyword: FROM
-      - access_target:
-          object_reference:
-            naked_identifier: hr
-- statement_terminator: ;
-- statement:
-    access_statement:
-      revoke_statement:
-      - keyword: REVOKE
-      - access_permissions:
-          access_permission:
-            keyword: UPDATE
-      - keyword: 'ON'
-      - object_reference:
-          naked_identifier: emp_details_view
-      - keyword: FROM
-      - access_target:
-          keyword: public
-- statement_terminator: ;
-- statement:
-    access_statement:
-      revoke_statement:
-      - keyword: REVOKE
-      - access_permissions:
-          access_permission:
-            keyword: INHERIT
-          access_object:
-            keyword: PRIVILEGES
-      - keyword: 'ON'
-      - keyword: USER
-      - object_reference:
-          naked_identifier: sh
-      - keyword: FROM
-      - access_target:
-          object_reference:
-            naked_identifier: hr
-- statement_terminator: ;
-- statement:
-    access_statement:
-      revoke_statement:
-      - keyword: REVOKE
-      - access_permissions:
-          access_permission:
-            keyword: SELECT
-      - keyword: 'ON'
-      - object_reference:
-        - naked_identifier: hr
-        - dot: .
-        - naked_identifier: departments_seq
-      - keyword: FROM
-      - access_target:
-          object_reference:
-            naked_identifier: oe
-- statement_terminator: ;
-- statement:
-    access_statement:
-      revoke_statement:
-      - keyword: REVOKE
-      - access_permissions:
-          access_permission:
-            keyword: REFERENCES
-      - keyword: 'ON'
-      - object_reference:
-        - naked_identifier: hr
-        - dot: .
-        - naked_identifier: employees
-      - keyword: FROM
-      - access_target:
-          object_reference:
-            naked_identifier: oe
-      - keyword: CASCADE
-      - keyword: CONSTRAINTS
-- statement_terminator: ;
-- statement:
-    access_statement:
-      revoke_statement:
-      - keyword: REVOKE
-      - access_permissions:
-          access_permission:
-            keyword: READ
-      - keyword: 'ON'
-      - keyword: DIRECTORY
-      - object_reference:
-          naked_identifier: bfile_dir
-      - keyword: FROM
-      - access_target:
-          object_reference:
-            naked_identifier: hr
-- statement_terminator: ;
-- statement:
-    access_statement:
-      revoke_statement:
-      - keyword: REVOKE
-      - access_permissions:
-          access_permission:
-            keyword: UPDATE
-      - keyword: 'ON'
-      - object_reference:
-        - naked_identifier: hr
-        - dot: .
-        - naked_identifier: employees
-      - keyword: FROM
-      - access_target:
-          object_reference:
-            naked_identifier: oe
-- statement_terminator: ;
+        - keyword: FROM
+        - access_target:
+            object_reference:
+              naked_identifier: hr
+  - statement_terminator: ;
+  - statement:
+      access_statement:
+        revoke_statement:
+        - keyword: REVOKE
+        - access_permissions:
+            access_permission:
+              keyword: SELECT
+        - keyword: 'ON'
+        - object_reference:
+          - naked_identifier: hr
+          - dot: .
+          - naked_identifier: departments_seq
+        - keyword: FROM
+        - access_target:
+            object_reference:
+              naked_identifier: oe
+  - statement_terminator: ;
+  - statement:
+      access_statement:
+        revoke_statement:
+        - keyword: REVOKE
+        - access_permissions:
+            access_permission:
+              keyword: REFERENCES
+        - keyword: 'ON'
+        - object_reference:
+          - naked_identifier: hr
+          - dot: .
+          - naked_identifier: employees
+        - keyword: FROM
+        - access_target:
+            object_reference:
+              naked_identifier: oe
+        - keyword: CASCADE
+        - keyword: CONSTRAINTS
+  - statement_terminator: ;
+  - statement:
+      access_statement:
+        revoke_statement:
+        - keyword: REVOKE
+        - access_permissions:
+            access_permission:
+              keyword: READ
+        - keyword: 'ON'
+        - keyword: DIRECTORY
+        - object_reference:
+            naked_identifier: bfile_dir
+        - keyword: FROM
+        - access_target:
+            object_reference:
+              naked_identifier: hr
+  - statement_terminator: ;
+  - statement:
+      access_statement:
+        revoke_statement:
+        - keyword: REVOKE
+        - access_permissions:
+            access_permission:
+              keyword: UPDATE
+        - keyword: 'ON'
+        - object_reference:
+          - naked_identifier: hr
+          - dot: .
+          - naked_identifier: employees
+        - keyword: FROM
+        - access_target:
+            object_reference:
+              naked_identifier: oe
+  - statement_terminator: ;

--- a/test/fixtures/dialects/oracle/rowtype.yml
+++ b/test/fixtures/dialects/oracle/rowtype.yml
@@ -3,697 +3,711 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 102bc1e3e90f039ae6687b2f38d505ee2f970f23573f55c171c90b6d1fe92bee
+_hash: f5cf15fd073e80281505313679e4477ab849088e162756fe1ab070697638aa55
 file:
-- statement:
-    begin_end_block:
-    - declare_segment:
-        keyword: DECLARE
-        naked_identifier: dept_rec
-        row_type_reference:
-          table_reference:
-            naked_identifier: departments
-          binary_operator: '%'
-          keyword: ROWTYPE
-        statement_terminator: ;
-    - keyword: BEGIN
-    - statement:
-        assignment_segment_statement:
-          object_reference:
-          - naked_identifier: dept_rec
-          - dot: .
-          - naked_identifier: department_id
-          assignment_operator: :=
-          expression:
-            numeric_literal: '10'
-    - statement_terminator: ;
-    - statement:
-        assignment_segment_statement:
-          object_reference:
-          - naked_identifier: dept_rec
-          - dot: .
-          - naked_identifier: department_name
-          assignment_operator: :=
-          expression:
-            quoted_literal: "'Administration'"
-    - statement_terminator: ;
-    - statement:
-        assignment_segment_statement:
-          object_reference:
-          - naked_identifier: dept_rec
-          - dot: .
-          - naked_identifier: manager_id
-          assignment_operator: :=
-          expression:
-            numeric_literal: '200'
-    - statement_terminator: ;
-    - statement:
-        assignment_segment_statement:
-          object_reference:
-          - naked_identifier: dept_rec
-          - dot: .
-          - naked_identifier: location_id
-          assignment_operator: :=
-          expression:
-            numeric_literal: '1700'
-    - statement_terminator: ;
-    - statement:
-        function:
-          function_name:
-            naked_identifier: DBMS_OUTPUT
-            dot: .
-            function_name_identifier: PUT_LINE
-          function_contents:
-            bracketed:
-              start_bracket: (
-              expression:
-                quoted_literal: "'dept_id:   '"
-                binary_operator:
-                - pipe: '|'
-                - pipe: '|'
-                column_reference:
-                - naked_identifier: dept_rec
-                - dot: .
-                - naked_identifier: department_id
-              end_bracket: )
-    - statement_terminator: ;
-    - statement:
-        function:
-          function_name:
-            naked_identifier: DBMS_OUTPUT
-            dot: .
-            function_name_identifier: PUT_LINE
-          function_contents:
-            bracketed:
-              start_bracket: (
-              expression:
-                quoted_literal: "'dept_name: '"
-                binary_operator:
-                - pipe: '|'
-                - pipe: '|'
-                column_reference:
-                - naked_identifier: dept_rec
-                - dot: .
-                - naked_identifier: department_name
-              end_bracket: )
-    - statement_terminator: ;
-    - statement:
-        function:
-          function_name:
-            naked_identifier: DBMS_OUTPUT
-            dot: .
-            function_name_identifier: PUT_LINE
-          function_contents:
-            bracketed:
-              start_bracket: (
-              expression:
-                quoted_literal: "'mgr_id:    '"
-                binary_operator:
-                - pipe: '|'
-                - pipe: '|'
-                column_reference:
-                - naked_identifier: dept_rec
-                - dot: .
-                - naked_identifier: manager_id
-              end_bracket: )
-    - statement_terminator: ;
-    - statement:
-        function:
-          function_name:
-            naked_identifier: DBMS_OUTPUT
-            dot: .
-            function_name_identifier: PUT_LINE
-          function_contents:
-            bracketed:
-              start_bracket: (
-              expression:
-                quoted_literal: "'loc_id:    '"
-                binary_operator:
-                - pipe: '|'
-                - pipe: '|'
-                column_reference:
-                - naked_identifier: dept_rec
-                - dot: .
-                - naked_identifier: location_id
-              end_bracket: )
-    - statement_terminator: ;
-    - keyword: END
-- statement_terminator: ;
-- statement_terminator: /
-- statement:
-    begin_end_block:
-    - declare_segment:
-        keyword: DECLARE
-        naked_identifier: t1_row
-        row_type_reference:
-          table_reference:
-            naked_identifier: t1
-          binary_operator: '%'
-          keyword: ROWTYPE
-        statement_terminator: ;
-    - keyword: BEGIN
-    - statement:
-        function:
-          function_name:
-            naked_identifier: DBMS_OUTPUT
-            dot: .
-            function_name_identifier: PUT
-          function_contents:
-            bracketed:
-              start_bracket: (
-              expression:
-                quoted_literal: "'t1.c1 = '"
-              end_bracket: )
-    - statement_terminator: ;
-    - statement:
-        function:
-          function_name:
-            naked_identifier: DBMS_OUTPUT
-            dot: .
-            function_name_identifier: PUT_LINE
-          function_contents:
-            bracketed:
-              start_bracket: (
-              expression:
-                function:
-                  function_name:
-                    function_name_identifier: NVL
-                  function_contents:
-                    bracketed:
-                    - start_bracket: (
-                    - expression:
-                        function:
-                          function_name:
-                            function_name_identifier: TO_CHAR
-                          function_contents:
-                            bracketed:
-                              start_bracket: (
-                              expression:
-                                column_reference:
-                                - naked_identifier: t1_row
-                                - dot: .
-                                - naked_identifier: c1
-                              end_bracket: )
-                    - comma: ','
-                    - expression:
-                        quoted_literal: "'NULL'"
-                    - end_bracket: )
-              end_bracket: )
-    - statement_terminator: ;
-    - statement:
-        function:
-          function_name:
-            naked_identifier: DBMS_OUTPUT
-            dot: .
-            function_name_identifier: PUT
-          function_contents:
-            bracketed:
-              start_bracket: (
-              expression:
-                quoted_literal: "'t1.c2 = '"
-              end_bracket: )
-    - statement_terminator: ;
-    - statement:
-        function:
-          function_name:
-            function_name_identifier: print
-          function_contents:
-            bracketed:
-              start_bracket: (
-              expression:
-                column_reference:
-                - naked_identifier: t1_row
-                - dot: .
-                - naked_identifier: c2
-              end_bracket: )
-    - statement_terminator: ;
-    - statement:
-        function:
-          function_name:
-            naked_identifier: DBMS_OUTPUT
-            dot: .
-            function_name_identifier: PUT_LINE
-          function_contents:
-            bracketed:
-              start_bracket: (
-              expression:
-                function:
-                  function_name:
-                    function_name_identifier: NVL
-                  function_contents:
-                    bracketed:
-                    - start_bracket: (
-                    - expression:
-                        function:
-                          function_name:
-                            function_name_identifier: TO_CHAR
-                          function_contents:
-                            bracketed:
-                              start_bracket: (
-                              expression:
-                                column_reference:
-                                - naked_identifier: t1_row
-                                - dot: .
-                                - naked_identifier: c2
-                              end_bracket: )
-                    - comma: ','
-                    - expression:
-                        quoted_literal: "'NULL'"
-                    - end_bracket: )
-              end_bracket: )
-    - statement_terminator: ;
-    - keyword: END
-- statement_terminator: ;
-- statement_terminator: /
-- statement:
-    begin_end_block:
-    - declare_segment:
-        keyword: DECLARE
-        cursor_variable:
-        - keyword: CURSOR
-        - naked_identifier: c
-        - keyword: IS
-        - select_statement:
+- batch:
+    statement:
+      begin_end_block:
+      - declare_segment:
+          keyword: DECLARE
+          naked_identifier: dept_rec
+          row_type_reference:
+            table_reference:
+              naked_identifier: departments
+            binary_operator: '%'
+            keyword: ROWTYPE
+          statement_terminator: ;
+      - keyword: BEGIN
+      - statement:
+          assignment_segment_statement:
+            object_reference:
+            - naked_identifier: dept_rec
+            - dot: .
+            - naked_identifier: department_id
+            assignment_operator: :=
+            expression:
+              numeric_literal: '10'
+      - statement_terminator: ;
+      - statement:
+          assignment_segment_statement:
+            object_reference:
+            - naked_identifier: dept_rec
+            - dot: .
+            - naked_identifier: department_name
+            assignment_operator: :=
+            expression:
+              quoted_literal: "'Administration'"
+      - statement_terminator: ;
+      - statement:
+          assignment_segment_statement:
+            object_reference:
+            - naked_identifier: dept_rec
+            - dot: .
+            - naked_identifier: manager_id
+            assignment_operator: :=
+            expression:
+              numeric_literal: '200'
+      - statement_terminator: ;
+      - statement:
+          assignment_segment_statement:
+            object_reference:
+            - naked_identifier: dept_rec
+            - dot: .
+            - naked_identifier: location_id
+            assignment_operator: :=
+            expression:
+              numeric_literal: '1700'
+      - statement_terminator: ;
+      - statement:
+          function:
+            function_name:
+              naked_identifier: DBMS_OUTPUT
+              dot: .
+              function_name_identifier: PUT_LINE
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  quoted_literal: "'dept_id:   '"
+                  binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                  column_reference:
+                  - naked_identifier: dept_rec
+                  - dot: .
+                  - naked_identifier: department_id
+                end_bracket: )
+      - statement_terminator: ;
+      - statement:
+          function:
+            function_name:
+              naked_identifier: DBMS_OUTPUT
+              dot: .
+              function_name_identifier: PUT_LINE
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  quoted_literal: "'dept_name: '"
+                  binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                  column_reference:
+                  - naked_identifier: dept_rec
+                  - dot: .
+                  - naked_identifier: department_name
+                end_bracket: )
+      - statement_terminator: ;
+      - statement:
+          function:
+            function_name:
+              naked_identifier: DBMS_OUTPUT
+              dot: .
+              function_name_identifier: PUT_LINE
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  quoted_literal: "'mgr_id:    '"
+                  binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                  column_reference:
+                  - naked_identifier: dept_rec
+                  - dot: .
+                  - naked_identifier: manager_id
+                end_bracket: )
+      - statement_terminator: ;
+      - statement:
+          function:
+            function_name:
+              naked_identifier: DBMS_OUTPUT
+              dot: .
+              function_name_identifier: PUT_LINE
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  quoted_literal: "'loc_id:    '"
+                  binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                  column_reference:
+                  - naked_identifier: dept_rec
+                  - dot: .
+                  - naked_identifier: location_id
+                end_bracket: )
+      - statement_terminator: ;
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      begin_end_block:
+      - declare_segment:
+          keyword: DECLARE
+          naked_identifier: t1_row
+          row_type_reference:
+            table_reference:
+              naked_identifier: t1
+            binary_operator: '%'
+            keyword: ROWTYPE
+          statement_terminator: ;
+      - keyword: BEGIN
+      - statement:
+          function:
+            function_name:
+              naked_identifier: DBMS_OUTPUT
+              dot: .
+              function_name_identifier: PUT
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  quoted_literal: "'t1.c1 = '"
+                end_bracket: )
+      - statement_terminator: ;
+      - statement:
+          function:
+            function_name:
+              naked_identifier: DBMS_OUTPUT
+              dot: .
+              function_name_identifier: PUT_LINE
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  function:
+                    function_name:
+                      function_name_identifier: NVL
+                    function_contents:
+                      bracketed:
+                      - start_bracket: (
+                      - expression:
+                          function:
+                            function_name:
+                              function_name_identifier: TO_CHAR
+                            function_contents:
+                              bracketed:
+                                start_bracket: (
+                                expression:
+                                  column_reference:
+                                  - naked_identifier: t1_row
+                                  - dot: .
+                                  - naked_identifier: c1
+                                end_bracket: )
+                      - comma: ','
+                      - expression:
+                          quoted_literal: "'NULL'"
+                      - end_bracket: )
+                end_bracket: )
+      - statement_terminator: ;
+      - statement:
+          function:
+            function_name:
+              naked_identifier: DBMS_OUTPUT
+              dot: .
+              function_name_identifier: PUT
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  quoted_literal: "'t1.c2 = '"
+                end_bracket: )
+      - statement_terminator: ;
+      - statement:
+          function:
+            function_name:
+              function_name_identifier: print
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  column_reference:
+                  - naked_identifier: t1_row
+                  - dot: .
+                  - naked_identifier: c2
+                end_bracket: )
+      - statement_terminator: ;
+      - statement:
+          function:
+            function_name:
+              naked_identifier: DBMS_OUTPUT
+              dot: .
+              function_name_identifier: PUT_LINE
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  function:
+                    function_name:
+                      function_name_identifier: NVL
+                    function_contents:
+                      bracketed:
+                      - start_bracket: (
+                      - expression:
+                          function:
+                            function_name:
+                              function_name_identifier: TO_CHAR
+                            function_contents:
+                              bracketed:
+                                start_bracket: (
+                                expression:
+                                  column_reference:
+                                  - naked_identifier: t1_row
+                                  - dot: .
+                                  - naked_identifier: c2
+                                end_bracket: )
+                      - comma: ','
+                      - expression:
+                          quoted_literal: "'NULL'"
+                      - end_bracket: )
+                end_bracket: )
+      - statement_terminator: ;
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      begin_end_block:
+      - declare_segment:
+          keyword: DECLARE
+          cursor_variable:
+          - keyword: CURSOR
+          - naked_identifier: c
+          - keyword: IS
+          - select_statement:
+              select_clause:
+              - keyword: SELECT
+              - select_clause_element:
+                  column_reference:
+                    naked_identifier: first_name
+              - comma: ','
+              - select_clause_element:
+                  column_reference:
+                    naked_identifier: last_name
+              - comma: ','
+              - select_clause_element:
+                  column_reference:
+                    naked_identifier: phone_number
+              from_clause:
+                keyword: FROM
+                from_expression:
+                  from_expression_element:
+                    table_expression:
+                      table_reference:
+                        naked_identifier: employees
+          - statement_terminator: ;
+          naked_identifier: friend
+          row_type_reference:
+            table_reference:
+              naked_identifier: c
+            binary_operator: '%'
+            keyword: ROWTYPE
+          statement_terminator: ;
+      - keyword: BEGIN
+      - statement:
+          assignment_segment_statement:
+            object_reference:
+            - naked_identifier: friend
+            - dot: .
+            - naked_identifier: first_name
+            assignment_operator: :=
+            expression:
+              quoted_literal: "'John'"
+      - statement_terminator: ;
+      - statement:
+          assignment_segment_statement:
+            object_reference:
+            - naked_identifier: friend
+            - dot: .
+            - naked_identifier: last_name
+            assignment_operator: :=
+            expression:
+              quoted_literal: "'Smith'"
+      - statement_terminator: ;
+      - statement:
+          assignment_segment_statement:
+            object_reference:
+            - naked_identifier: friend
+            - dot: .
+            - naked_identifier: phone_number
+            assignment_operator: :=
+            expression:
+              quoted_literal: "'1-650-555-1234'"
+      - statement_terminator: ;
+      - statement:
+          function:
+            function_name:
+              naked_identifier: DBMS_OUTPUT
+              dot: .
+              function_name_identifier: PUT_LINE
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                - column_reference:
+                  - naked_identifier: friend
+                  - dot: .
+                  - naked_identifier: first_name
+                - binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                - quoted_literal: "' '"
+                - binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                - column_reference:
+                  - naked_identifier: friend
+                  - dot: .
+                  - naked_identifier: last_name
+                - binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                - quoted_literal: "', '"
+                - binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                - column_reference:
+                  - naked_identifier: friend
+                  - dot: .
+                  - naked_identifier: phone_number
+                end_bracket: )
+      - statement_terminator: ;
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      begin_end_block:
+      - declare_segment:
+          keyword: DECLARE
+          cursor_variable:
+          - keyword: CURSOR
+          - naked_identifier: c2
+          - keyword: IS
+          - select_statement:
+              select_clause:
+              - keyword: SELECT
+              - select_clause_element:
+                  column_reference:
+                    naked_identifier: employee_id
+              - comma: ','
+              - select_clause_element:
+                  column_reference:
+                    naked_identifier: email
+              - comma: ','
+              - select_clause_element:
+                  column_reference:
+                  - naked_identifier: employees
+                  - dot: .
+                  - naked_identifier: manager_id
+              - comma: ','
+              - select_clause_element:
+                  column_reference:
+                    naked_identifier: location_id
+              from_clause:
+              - keyword: FROM
+              - from_expression:
+                  from_expression_element:
+                    table_expression:
+                      table_reference:
+                        naked_identifier: employees
+              - comma: ','
+              - from_expression:
+                  from_expression_element:
+                    table_expression:
+                      table_reference:
+                        naked_identifier: departments
+              where_clause:
+                keyword: WHERE
+                expression:
+                - column_reference:
+                  - naked_identifier: employees
+                  - dot: .
+                  - naked_identifier: department_id
+                - comparison_operator:
+                    raw_comparison_operator: '='
+                - column_reference:
+                  - naked_identifier: departments
+                  - dot: .
+                  - naked_identifier: department_id
+          - statement_terminator: ;
+          naked_identifier: join_rec
+          row_type_reference:
+            table_reference:
+              naked_identifier: c2
+            binary_operator: '%'
+            keyword: ROWTYPE
+          statement_terminator: ;
+      - keyword: BEGIN
+      - statement:
+          null_statement:
+            keyword: 'NULL'
+      - statement_terminator: ;
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      begin_end_block:
+      - declare_segment:
+          keyword: DECLARE
+          naked_identifier: t_rec
+          row_type_reference:
+            table_reference:
+              naked_identifier: t
+            binary_operator: '%'
+            keyword: ROWTYPE
+          statement_terminator: ;
+      - keyword: BEGIN
+      - statement:
+          select_statement:
             select_clause:
-            - keyword: SELECT
-            - select_clause_element:
-                column_reference:
-                  naked_identifier: first_name
-            - comma: ','
-            - select_clause_element:
-                column_reference:
-                  naked_identifier: last_name
-            - comma: ','
-            - select_clause_element:
-                column_reference:
-                  naked_identifier: phone_number
+              keyword: SELECT
+              select_clause_element:
+                wildcard_expression:
+                  wildcard_identifier:
+                    star: '*'
+            into_clause:
+              keyword: INTO
+              naked_identifier: t_rec
             from_clause:
               keyword: FROM
               from_expression:
                 from_expression_element:
                   table_expression:
                     table_reference:
-                      naked_identifier: employees
-        - statement_terminator: ;
-        naked_identifier: friend
-        row_type_reference:
-          table_reference:
-            naked_identifier: c
-          binary_operator: '%'
-          keyword: ROWTYPE
-        statement_terminator: ;
-    - keyword: BEGIN
-    - statement:
-        assignment_segment_statement:
-          object_reference:
-          - naked_identifier: friend
-          - dot: .
-          - naked_identifier: first_name
-          assignment_operator: :=
-          expression:
-            quoted_literal: "'John'"
-    - statement_terminator: ;
-    - statement:
-        assignment_segment_statement:
-          object_reference:
-          - naked_identifier: friend
-          - dot: .
-          - naked_identifier: last_name
-          assignment_operator: :=
-          expression:
-            quoted_literal: "'Smith'"
-    - statement_terminator: ;
-    - statement:
-        assignment_segment_statement:
-          object_reference:
-          - naked_identifier: friend
-          - dot: .
-          - naked_identifier: phone_number
-          assignment_operator: :=
-          expression:
-            quoted_literal: "'1-650-555-1234'"
-    - statement_terminator: ;
-    - statement:
-        function:
-          function_name:
-            naked_identifier: DBMS_OUTPUT
-            dot: .
-            function_name_identifier: PUT_LINE
-          function_contents:
-            bracketed:
-              start_bracket: (
-              expression:
-              - column_reference:
-                - naked_identifier: friend
-                - dot: .
-                - naked_identifier: first_name
-              - binary_operator:
-                - pipe: '|'
-                - pipe: '|'
-              - quoted_literal: "' '"
-              - binary_operator:
-                - pipe: '|'
-                - pipe: '|'
-              - column_reference:
-                - naked_identifier: friend
-                - dot: .
-                - naked_identifier: last_name
-              - binary_operator:
-                - pipe: '|'
-                - pipe: '|'
-              - quoted_literal: "', '"
-              - binary_operator:
-                - pipe: '|'
-                - pipe: '|'
-              - column_reference:
-                - naked_identifier: friend
-                - dot: .
-                - naked_identifier: phone_number
-              end_bracket: )
-    - statement_terminator: ;
-    - keyword: END
-- statement_terminator: ;
-- statement_terminator: /
-- statement:
-    begin_end_block:
-    - declare_segment:
-        keyword: DECLARE
-        cursor_variable:
-        - keyword: CURSOR
-        - naked_identifier: c2
-        - keyword: IS
-        - select_statement:
-            select_clause:
-            - keyword: SELECT
-            - select_clause_element:
-                column_reference:
-                  naked_identifier: employee_id
-            - comma: ','
-            - select_clause_element:
-                column_reference:
-                  naked_identifier: email
-            - comma: ','
-            - select_clause_element:
-                column_reference:
-                - naked_identifier: employees
-                - dot: .
-                - naked_identifier: manager_id
-            - comma: ','
-            - select_clause_element:
-                column_reference:
-                  naked_identifier: location_id
-            from_clause:
-            - keyword: FROM
-            - from_expression:
-                from_expression_element:
-                  table_expression:
-                    table_reference:
-                      naked_identifier: employees
-            - comma: ','
-            - from_expression:
-                from_expression_element:
-                  table_expression:
-                    table_reference:
-                      naked_identifier: departments
+                      naked_identifier: t
             where_clause:
               keyword: WHERE
               expression:
-              - column_reference:
+                keyword: ROWNUM
+                comparison_operator:
+                  raw_comparison_operator: <
+                numeric_literal: '2'
+      - statement_terminator: ;
+      - statement:
+          function:
+            function_name:
+              naked_identifier: DBMS_OUTPUT
+              dot: .
+              function_name_identifier: PUT_LINE
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  quoted_literal: "'c = '"
+                  binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                  column_reference:
+                  - naked_identifier: t_rec
+                  - dot: .
+                  - naked_identifier: c
+                end_bracket: )
+      - statement_terminator: ;
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      begin_end_block:
+      - declare_segment:
+        - keyword: DECLARE
+        - record_type:
+          - keyword: TYPE
+          - naked_identifier: name_rec
+          - keyword: IS
+          - keyword: RECORD
+          - bracketed:
+            - start_bracket: (
+            - naked_identifier: first
+            - column_type_reference:
+                column_reference:
                 - naked_identifier: employees
                 - dot: .
-                - naked_identifier: department_id
-              - comparison_operator:
-                  raw_comparison_operator: '='
-              - column_reference:
-                - naked_identifier: departments
-                - dot: .
-                - naked_identifier: department_id
-        - statement_terminator: ;
-        naked_identifier: join_rec
-        row_type_reference:
-          table_reference:
-            naked_identifier: c2
-          binary_operator: '%'
-          keyword: ROWTYPE
-        statement_terminator: ;
-    - keyword: BEGIN
-    - statement:
-        null_statement:
-          keyword: 'NULL'
-    - statement_terminator: ;
-    - keyword: END
-- statement_terminator: ;
-- statement_terminator: /
-- statement:
-    begin_end_block:
-    - declare_segment:
-        keyword: DECLARE
-        naked_identifier: t_rec
-        row_type_reference:
-          table_reference:
-            naked_identifier: t
-          binary_operator: '%'
-          keyword: ROWTYPE
-        statement_terminator: ;
-    - keyword: BEGIN
-    - statement:
-        select_statement:
-          select_clause:
-            keyword: SELECT
-            select_clause_element:
-              wildcard_expression:
-                wildcard_identifier:
-                  star: '*'
-          into_clause:
-            keyword: INTO
-            naked_identifier: t_rec
-          from_clause:
-            keyword: FROM
-            from_expression:
-              from_expression_element:
-                table_expression:
-                  table_reference:
-                    naked_identifier: t
-          where_clause:
-            keyword: WHERE
-            expression:
-              keyword: ROWNUM
-              comparison_operator:
-                raw_comparison_operator: <
-              numeric_literal: '2'
-    - statement_terminator: ;
-    - statement:
-        function:
-          function_name:
-            naked_identifier: DBMS_OUTPUT
-            dot: .
-            function_name_identifier: PUT_LINE
-          function_contents:
-            bracketed:
-              start_bracket: (
-              expression:
-                quoted_literal: "'c = '"
-                binary_operator:
-                - pipe: '|'
-                - pipe: '|'
-                column_reference:
-                - naked_identifier: t_rec
-                - dot: .
-                - naked_identifier: c
-              end_bracket: )
-    - statement_terminator: ;
-    - keyword: END
-- statement_terminator: ;
-- statement_terminator: /
-- statement:
-    begin_end_block:
-    - declare_segment:
-      - keyword: DECLARE
-      - record_type:
-        - keyword: TYPE
-        - naked_identifier: name_rec
-        - keyword: IS
-        - keyword: RECORD
-        - bracketed:
-          - start_bracket: (
-          - naked_identifier: first
-          - column_type_reference:
-              column_reference:
-              - naked_identifier: employees
-              - dot: .
-              - naked_identifier: first_name
-              binary_operator: '%'
-              keyword: TYPE
-          - keyword: DEFAULT
-          - expression:
-              quoted_literal: "'John'"
-          - comma: ','
-          - naked_identifier: last
-          - column_type_reference:
-              column_reference:
-              - naked_identifier: employees
-              - dot: .
-              - naked_identifier: last_name
-              binary_operator: '%'
-              keyword: TYPE
-          - keyword: DEFAULT
-          - expression:
-              quoted_literal: "'Doe'"
-          - end_bracket: )
-      - statement_terminator: ;
-      - cursor_variable:
-        - keyword: CURSOR
-        - naked_identifier: c
-        - keyword: IS
-        - select_statement:
-            select_clause:
-            - keyword: SELECT
-            - select_clause_element:
-                column_reference:
-                  naked_identifier: first_name
-            - comma: ','
-            - select_clause_element:
-                column_reference:
-                  naked_identifier: last_name
-            from_clause:
-              keyword: FROM
-              from_expression:
-                from_expression_element:
-                  table_expression:
-                    table_reference:
-                      naked_identifier: employees
-        - statement_terminator: ;
-      - naked_identifier: target
-      - data_type:
-          data_type_identifier: name_rec
-      - statement_terminator: ;
-      - naked_identifier: source
-      - row_type_reference:
-          table_reference:
-            naked_identifier: c
-          binary_operator: '%'
-          keyword: ROWTYPE
-      - statement_terminator: ;
-    - keyword: BEGIN
-    - statement:
-        assignment_segment_statement:
-          object_reference:
-          - naked_identifier: source
-          - dot: .
-          - naked_identifier: first_name
-          assignment_operator: :=
-          expression:
-            quoted_literal: "'Jane'"
-    - statement_terminator: ;
-    - statement:
-        assignment_segment_statement:
-          object_reference:
-          - naked_identifier: source
-          - dot: .
-          - naked_identifier: last_name
-          assignment_operator: :=
-          expression:
-            quoted_literal: "'Smith'"
-    - statement_terminator: ;
-    - statement:
-        function:
-          function_name:
-            naked_identifier: DBMS_OUTPUT
-            dot: .
-            function_name_identifier: PUT_LINE
-          function_contents:
-            bracketed:
-              start_bracket: (
-              expression:
-              - quoted_literal: "'source: '"
-              - binary_operator:
-                - pipe: '|'
-                - pipe: '|'
-              - column_reference:
-                - naked_identifier: source
-                - dot: .
                 - naked_identifier: first_name
-              - binary_operator:
-                - pipe: '|'
-                - pipe: '|'
-              - quoted_literal: "' '"
-              - binary_operator:
-                - pipe: '|'
-                - pipe: '|'
-              - column_reference:
-                - naked_identifier: source
+                binary_operator: '%'
+                keyword: TYPE
+            - keyword: DEFAULT
+            - expression:
+                quoted_literal: "'John'"
+            - comma: ','
+            - naked_identifier: last
+            - column_type_reference:
+                column_reference:
+                - naked_identifier: employees
                 - dot: .
                 - naked_identifier: last_name
-              end_bracket: )
-    - statement_terminator: ;
-    - statement:
-        assignment_segment_statement:
-          object_reference:
-            naked_identifier: target
-          assignment_operator: :=
-          expression:
-            column_reference:
-              naked_identifier: source
-    - statement_terminator: ;
-    - statement:
-        function:
-          function_name:
-            naked_identifier: DBMS_OUTPUT
-            dot: .
-            function_name_identifier: PUT_LINE
-          function_contents:
-            bracketed:
-              start_bracket: (
-              expression:
-              - quoted_literal: "'target: '"
-              - binary_operator:
-                - pipe: '|'
-                - pipe: '|'
-              - column_reference:
-                - naked_identifier: target
-                - dot: .
-                - naked_identifier: first
-              - binary_operator:
-                - pipe: '|'
-                - pipe: '|'
-              - quoted_literal: "' '"
-              - binary_operator:
-                - pipe: '|'
-                - pipe: '|'
-              - column_reference:
-                - naked_identifier: target
-                - dot: .
-                - naked_identifier: last
-              end_bracket: )
-    - statement_terminator: ;
-    - keyword: END
-- statement_terminator: ;
-- statement_terminator: /
-- statement:
-    create_procedure_statement:
-    - keyword: create
-    - keyword: or
-    - keyword: replace
-    - keyword: procedure
-    - function_name:
-        function_name_identifier: MY_PROCEDURE
-    - function_parameter_list:
-        bracketed:
-          start_bracket: (
-          parameter: var1
-          row_type_reference:
+                binary_operator: '%'
+                keyword: TYPE
+            - keyword: DEFAULT
+            - expression:
+                quoted_literal: "'Doe'"
+            - end_bracket: )
+        - statement_terminator: ;
+        - cursor_variable:
+          - keyword: CURSOR
+          - naked_identifier: c
+          - keyword: IS
+          - select_statement:
+              select_clause:
+              - keyword: SELECT
+              - select_clause_element:
+                  column_reference:
+                    naked_identifier: first_name
+              - comma: ','
+              - select_clause_element:
+                  column_reference:
+                    naked_identifier: last_name
+              from_clause:
+                keyword: FROM
+                from_expression:
+                  from_expression_element:
+                    table_expression:
+                      table_reference:
+                        naked_identifier: employees
+          - statement_terminator: ;
+        - naked_identifier: target
+        - data_type:
+            data_type_identifier: name_rec
+        - statement_terminator: ;
+        - naked_identifier: source
+        - row_type_reference:
             table_reference:
-              naked_identifier: table_name
+              naked_identifier: c
             binary_operator: '%'
-            keyword: rowtype
-          end_bracket: )
-    - keyword: is
-    - begin_end_block:
-      - keyword: begin
+            keyword: ROWTYPE
+        - statement_terminator: ;
+      - keyword: BEGIN
       - statement:
-          null_statement:
-            keyword: 'null'
+          assignment_segment_statement:
+            object_reference:
+            - naked_identifier: source
+            - dot: .
+            - naked_identifier: first_name
+            assignment_operator: :=
+            expression:
+              quoted_literal: "'Jane'"
       - statement_terminator: ;
-      - keyword: end
-    - statement_terminator: ;
-    - statement_terminator: /
+      - statement:
+          assignment_segment_statement:
+            object_reference:
+            - naked_identifier: source
+            - dot: .
+            - naked_identifier: last_name
+            assignment_operator: :=
+            expression:
+              quoted_literal: "'Smith'"
+      - statement_terminator: ;
+      - statement:
+          function:
+            function_name:
+              naked_identifier: DBMS_OUTPUT
+              dot: .
+              function_name_identifier: PUT_LINE
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                - quoted_literal: "'source: '"
+                - binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                - column_reference:
+                  - naked_identifier: source
+                  - dot: .
+                  - naked_identifier: first_name
+                - binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                - quoted_literal: "' '"
+                - binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                - column_reference:
+                  - naked_identifier: source
+                  - dot: .
+                  - naked_identifier: last_name
+                end_bracket: )
+      - statement_terminator: ;
+      - statement:
+          assignment_segment_statement:
+            object_reference:
+              naked_identifier: target
+            assignment_operator: :=
+            expression:
+              column_reference:
+                naked_identifier: source
+      - statement_terminator: ;
+      - statement:
+          function:
+            function_name:
+              naked_identifier: DBMS_OUTPUT
+              dot: .
+              function_name_identifier: PUT_LINE
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                - quoted_literal: "'target: '"
+                - binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                - column_reference:
+                  - naked_identifier: target
+                  - dot: .
+                  - naked_identifier: first
+                - binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                - quoted_literal: "' '"
+                - binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                - column_reference:
+                  - naked_identifier: target
+                  - dot: .
+                  - naked_identifier: last
+                end_bracket: )
+      - statement_terminator: ;
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      create_procedure_statement:
+      - keyword: create
+      - keyword: or
+      - keyword: replace
+      - keyword: procedure
+      - function_name:
+          function_name_identifier: MY_PROCEDURE
+      - function_parameter_list:
+          bracketed:
+            start_bracket: (
+            parameter: var1
+            row_type_reference:
+              table_reference:
+                naked_identifier: table_name
+              binary_operator: '%'
+              keyword: rowtype
+            end_bracket: )
+      - keyword: is
+      - begin_end_block:
+        - keyword: begin
+        - statement:
+            null_statement:
+              keyword: 'null'
+        - statement_terminator: ;
+        - keyword: end
+      - statement_terminator: ;
+    slash_buffer_executor:
+      slash: /

--- a/test/fixtures/dialects/oracle/select.yml
+++ b/test/fixtures/dialects/oracle/select.yml
@@ -3,48 +3,49 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 7af02b3736ee5d5184d7f9a3145506f5ef95a3af84d202ff38f999784ea48d94
+_hash: a927438573b5644858ebc89fb8d48799d912c58e8a04aeb8a0842818cd92a97c
 file:
-- statement:
-    select_statement:
-      select_clause:
-      - keyword: select
-      - select_clause_element:
-          column_reference:
-            naked_identifier: created_at
-      - comma: ','
-      - select_clause_element:
-          column_reference:
-            naked_identifier: status
-      - comma: ','
-      - select_clause_element:
-          column_reference:
-            naked_identifier: code
-      from_clause:
-        keyword: from
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: item_errors
-            alias_expression:
-              naked_identifier: error
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-        keyword: select
-        select_clause_element:
-          expression:
+  batch:
+  - statement:
+      select_statement:
+        select_clause:
+        - keyword: select
+        - select_clause_element:
             column_reference:
-              naked_identifier: quantity
-            binary_operator: /
-            numeric_literal: '100'
-      from_clause:
-        keyword: from
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: inventory
-- statement_terminator: ;
+              naked_identifier: created_at
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+              naked_identifier: status
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+              naked_identifier: code
+        from_clause:
+          keyword: from
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: item_errors
+              alias_expression:
+                naked_identifier: error
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: select
+          select_clause_element:
+            expression:
+              column_reference:
+                naked_identifier: quantity
+              binary_operator: /
+              numeric_literal: '100'
+        from_clause:
+          keyword: from
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: inventory
+  - statement_terminator: ;

--- a/test/fixtures/dialects/oracle/select_for_update.yml
+++ b/test/fixtures/dialects/oracle/select_for_update.yml
@@ -3,223 +3,224 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: cca773e16b14f61a50a4dc183e640ff15a57294c008d06ca26b7982071b3e361
+_hash: 710ea200f3565a33a1e74be1b38b5bb854e4f3b9b21077fdc13652feb46f1561
 file:
-- statement:
-    select_statement:
-    - select_clause:
-      - keyword: SELECT
-      - select_clause_element:
-          column_reference:
-          - naked_identifier: e
-          - dot: .
-          - naked_identifier: employee_id
-      - comma: ','
-      - select_clause_element:
-          column_reference:
-          - naked_identifier: e
-          - dot: .
-          - naked_identifier: salary
-      - comma: ','
-      - select_clause_element:
-          column_reference:
-          - naked_identifier: e
-          - dot: .
-          - naked_identifier: commission_pct
-    - from_clause:
-      - keyword: FROM
-      - from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: employees
-            alias_expression:
-              naked_identifier: e
-      - comma: ','
-      - from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: departments
-            alias_expression:
-              naked_identifier: d
-    - where_clause:
-        keyword: WHERE
-        expression:
-        - column_reference:
-            naked_identifier: job_id
-        - comparison_operator:
-            raw_comparison_operator: '='
-        - quoted_literal: "'SA_REP'"
-        - binary_operator: AND
-        - column_reference:
-          - naked_identifier: e
-          - dot: .
-          - naked_identifier: department_id
-        - comparison_operator:
-            raw_comparison_operator: '='
-        - column_reference:
-          - naked_identifier: d
-          - dot: .
-          - naked_identifier: department_id
-        - binary_operator: AND
-        - column_reference:
-            naked_identifier: location_id
-        - comparison_operator:
-            raw_comparison_operator: '='
-        - numeric_literal: '2500'
-    - orderby_clause:
-      - keyword: ORDER
-      - keyword: BY
-      - column_reference:
-        - naked_identifier: e
-        - dot: .
-        - naked_identifier: employee_id
-    - keyword: FOR
-    - keyword: UPDATE
-- statement_terminator: ;
-- statement:
-    select_statement:
-    - select_clause:
-      - keyword: SELECT
-      - select_clause_element:
-          column_reference:
-          - naked_identifier: e
-          - dot: .
-          - naked_identifier: employee_id
-      - comma: ','
-      - select_clause_element:
-          column_reference:
-          - naked_identifier: e
-          - dot: .
-          - naked_identifier: salary
-      - comma: ','
-      - select_clause_element:
-          column_reference:
-          - naked_identifier: e
-          - dot: .
-          - naked_identifier: commission_pct
-    - from_clause:
-        keyword: FROM
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: employees
-            alias_expression:
-              naked_identifier: e
-          join_clause:
-          - keyword: JOIN
-          - from_expression_element:
+  batch:
+  - statement:
+      select_statement:
+      - select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            column_reference:
+            - naked_identifier: e
+            - dot: .
+            - naked_identifier: employee_id
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+            - naked_identifier: e
+            - dot: .
+            - naked_identifier: salary
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+            - naked_identifier: e
+            - dot: .
+            - naked_identifier: commission_pct
+      - from_clause:
+        - keyword: FROM
+        - from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: employees
+              alias_expression:
+                naked_identifier: e
+        - comma: ','
+        - from_expression:
+            from_expression_element:
               table_expression:
                 table_reference:
                   naked_identifier: departments
               alias_expression:
                 naked_identifier: d
-          - keyword: USING
-          - bracketed:
-              start_bracket: (
-              naked_identifier: department_id
-              end_bracket: )
-    - where_clause:
-        keyword: WHERE
-        expression:
+      - where_clause:
+          keyword: WHERE
+          expression:
+          - column_reference:
+              naked_identifier: job_id
+          - comparison_operator:
+              raw_comparison_operator: '='
+          - quoted_literal: "'SA_REP'"
+          - binary_operator: AND
+          - column_reference:
+            - naked_identifier: e
+            - dot: .
+            - naked_identifier: department_id
+          - comparison_operator:
+              raw_comparison_operator: '='
+          - column_reference:
+            - naked_identifier: d
+            - dot: .
+            - naked_identifier: department_id
+          - binary_operator: AND
+          - column_reference:
+              naked_identifier: location_id
+          - comparison_operator:
+              raw_comparison_operator: '='
+          - numeric_literal: '2500'
+      - orderby_clause:
+        - keyword: ORDER
+        - keyword: BY
         - column_reference:
-            naked_identifier: job_id
-        - comparison_operator:
-            raw_comparison_operator: '='
-        - quoted_literal: "'SA_REP'"
-        - binary_operator: AND
+          - naked_identifier: e
+          - dot: .
+          - naked_identifier: employee_id
+      - keyword: FOR
+      - keyword: UPDATE
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+      - select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            column_reference:
+            - naked_identifier: e
+            - dot: .
+            - naked_identifier: employee_id
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+            - naked_identifier: e
+            - dot: .
+            - naked_identifier: salary
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+            - naked_identifier: e
+            - dot: .
+            - naked_identifier: commission_pct
+      - from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: employees
+              alias_expression:
+                naked_identifier: e
+            join_clause:
+            - keyword: JOIN
+            - from_expression_element:
+                table_expression:
+                  table_reference:
+                    naked_identifier: departments
+                alias_expression:
+                  naked_identifier: d
+            - keyword: USING
+            - bracketed:
+                start_bracket: (
+                naked_identifier: department_id
+                end_bracket: )
+      - where_clause:
+          keyword: WHERE
+          expression:
+          - column_reference:
+              naked_identifier: job_id
+          - comparison_operator:
+              raw_comparison_operator: '='
+          - quoted_literal: "'SA_REP'"
+          - binary_operator: AND
+          - column_reference:
+              naked_identifier: location_id
+          - comparison_operator:
+              raw_comparison_operator: '='
+          - numeric_literal: '2500'
+      - orderby_clause:
+        - keyword: ORDER
+        - keyword: BY
         - column_reference:
-            naked_identifier: location_id
-        - comparison_operator:
-            raw_comparison_operator: '='
-        - numeric_literal: '2500'
-    - orderby_clause:
-      - keyword: ORDER
-      - keyword: BY
-      - column_reference:
+          - naked_identifier: e
+          - dot: .
+          - naked_identifier: employee_id
+      - keyword: FOR
+      - keyword: UPDATE
+      - keyword: OF
+      - table_reference:
         - naked_identifier: e
         - dot: .
-        - naked_identifier: employee_id
-    - keyword: FOR
-    - keyword: UPDATE
-    - keyword: OF
-    - table_reference:
-      - naked_identifier: e
-      - dot: .
-      - naked_identifier: salary
-- statement_terminator: ;
-- statement:
-    select_statement:
-    - select_clause:
-        keyword: SELECT
-        select_clause_element:
-          column_reference:
-            naked_identifier: employee_id
-    - from_clause:
-        keyword: FROM
-        from_expression:
-          from_expression_element:
-            table_expression:
-              bracketed:
-                start_bracket: (
-                select_statement:
-                  select_clause:
-                    keyword: SELECT
-                    select_clause_element:
-                      wildcard_expression:
-                        wildcard_identifier:
-                          star: '*'
-                  from_clause:
-                    keyword: FROM
-                    from_expression:
-                      from_expression_element:
-                        table_expression:
-                          table_reference:
-                            naked_identifier: employees
-                end_bracket: )
-    - keyword: FOR
-    - keyword: UPDATE
-    - keyword: OF
-    - table_reference:
-        naked_identifier: employee_id
-- statement_terminator: ;
-- statement:
-    select_statement:
-    - select_clause:
-        keyword: SELECT
-        select_clause_element:
-          column_reference:
-            naked_identifier: employee_id
-    - from_clause:
-        keyword: FROM
-        from_expression:
-          from_expression_element:
-            table_expression:
-              bracketed:
-                start_bracket: (
-                select_statement:
-                  select_clause:
-                    keyword: SELECT
-                    select_clause_element:
-                      expression:
-                        column_reference:
+        - naked_identifier: salary
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+      - select_clause:
+          keyword: SELECT
+          select_clause_element:
+            column_reference:
+              naked_identifier: employee_id
+      - from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                bracketed:
+                  start_bracket: (
+                  select_statement:
+                    select_clause:
+                      keyword: SELECT
+                      select_clause_element:
+                        wildcard_expression:
+                          wildcard_identifier:
+                            star: '*'
+                    from_clause:
+                      keyword: FROM
+                      from_expression:
+                        from_expression_element:
+                          table_expression:
+                            table_reference:
+                              naked_identifier: employees
+                  end_bracket: )
+      - keyword: FOR
+      - keyword: UPDATE
+      - keyword: OF
+      - table_reference:
+          naked_identifier: employee_id
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+      - select_clause:
+          keyword: SELECT
+          select_clause_element:
+            column_reference:
+              naked_identifier: employee_id
+      - from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                bracketed:
+                  start_bracket: (
+                  select_statement:
+                    select_clause:
+                      keyword: SELECT
+                      select_clause_element:
+                        expression:
+                          column_reference:
+                            naked_identifier: employee_id
+                          binary_operator: +
+                          numeric_literal: '1'
+                        alias_expression:
+                          alias_operator:
+                            keyword: AS
                           naked_identifier: employee_id
-                        binary_operator: +
-                        numeric_literal: '1'
-                      alias_expression:
-                        alias_operator:
-                          keyword: AS
-                        naked_identifier: employee_id
-                  from_clause:
-                    keyword: FROM
-                    from_expression:
-                      from_expression_element:
-                        table_expression:
-                          table_reference:
-                            naked_identifier: employees
-                end_bracket: )
-    - keyword: FOR
-    - keyword: UPDATE
-- statement_terminator: ;
+                    from_clause:
+                      keyword: FROM
+                      from_expression:
+                        from_expression_element:
+                          table_expression:
+                            table_reference:
+                              naked_identifier: employees
+                  end_bracket: )
+      - keyword: FOR
+      - keyword: UPDATE
+  - statement_terminator: ;

--- a/test/fixtures/dialects/oracle/select_natural_join.yml
+++ b/test/fixtures/dialects/oracle/select_natural_join.yml
@@ -3,199 +3,200 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 83e3312a773ee3e3dee22bd7341b922507c1aaee51ef41c02c3ea414ef6b8c82
+_hash: 5782484e8a211745fbcb0e6edb83a3b78f9915ef32f34d0d6e5e26d770e6d1e3
 file:
-- statement:
-    select_statement:
-      select_clause:
-        keyword: SELECT
-        select_clause_element:
-          wildcard_expression:
-            wildcard_identifier:
-              star: '*'
-      from_clause:
-        keyword: FROM
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: table1
-          join_clause:
-          - keyword: NATURAL
-          - keyword: JOIN
-          - from_expression_element:
+  batch:
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
               table_expression:
                 table_reference:
-                  naked_identifier: table2
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-        keyword: SELECT
-        select_clause_element:
-          wildcard_expression:
-            wildcard_identifier:
-              star: '*'
-      from_clause:
-        keyword: FROM
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: table1
-          join_clause:
-          - keyword: NATURAL
-          - keyword: INNER
-          - keyword: JOIN
-          - from_expression_element:
+                  naked_identifier: table1
+            join_clause:
+            - keyword: NATURAL
+            - keyword: JOIN
+            - from_expression_element:
+                table_expression:
+                  table_reference:
+                    naked_identifier: table2
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
               table_expression:
                 table_reference:
-                  naked_identifier: table2
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-        keyword: SELECT
-        select_clause_element:
-          wildcard_expression:
-            wildcard_identifier:
-              star: '*'
-      from_clause:
-        keyword: FROM
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: table1
-          join_clause:
-          - keyword: NATURAL
-          - keyword: LEFT
-          - keyword: JOIN
-          - from_expression_element:
+                  naked_identifier: table1
+            join_clause:
+            - keyword: NATURAL
+            - keyword: INNER
+            - keyword: JOIN
+            - from_expression_element:
+                table_expression:
+                  table_reference:
+                    naked_identifier: table2
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
               table_expression:
                 table_reference:
-                  naked_identifier: table2
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-        keyword: SELECT
-        select_clause_element:
-          wildcard_expression:
-            wildcard_identifier:
-              star: '*'
-      from_clause:
-        keyword: FROM
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: table1
-          join_clause:
-          - keyword: NATURAL
-          - keyword: LEFT
-          - keyword: OUTER
-          - keyword: JOIN
-          - from_expression_element:
+                  naked_identifier: table1
+            join_clause:
+            - keyword: NATURAL
+            - keyword: LEFT
+            - keyword: JOIN
+            - from_expression_element:
+                table_expression:
+                  table_reference:
+                    naked_identifier: table2
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
               table_expression:
                 table_reference:
-                  naked_identifier: table2
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-        keyword: SELECT
-        select_clause_element:
-          wildcard_expression:
-            wildcard_identifier:
-              star: '*'
-      from_clause:
-        keyword: FROM
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: table1
-          join_clause:
-          - keyword: NATURAL
-          - keyword: RIGHT
-          - keyword: JOIN
-          - from_expression_element:
+                  naked_identifier: table1
+            join_clause:
+            - keyword: NATURAL
+            - keyword: LEFT
+            - keyword: OUTER
+            - keyword: JOIN
+            - from_expression_element:
+                table_expression:
+                  table_reference:
+                    naked_identifier: table2
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
               table_expression:
                 table_reference:
-                  naked_identifier: table2
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-        keyword: SELECT
-        select_clause_element:
-          wildcard_expression:
-            wildcard_identifier:
-              star: '*'
-      from_clause:
-        keyword: FROM
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: table1
-          join_clause:
-          - keyword: NATURAL
-          - keyword: RIGHT
-          - keyword: OUTER
-          - keyword: JOIN
-          - from_expression_element:
+                  naked_identifier: table1
+            join_clause:
+            - keyword: NATURAL
+            - keyword: RIGHT
+            - keyword: JOIN
+            - from_expression_element:
+                table_expression:
+                  table_reference:
+                    naked_identifier: table2
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
               table_expression:
                 table_reference:
-                  naked_identifier: table2
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-        keyword: SELECT
-        select_clause_element:
-          wildcard_expression:
-            wildcard_identifier:
-              star: '*'
-      from_clause:
-        keyword: FROM
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: table1
-          join_clause:
-          - keyword: NATURAL
-          - keyword: FULL
-          - keyword: JOIN
-          - from_expression_element:
+                  naked_identifier: table1
+            join_clause:
+            - keyword: NATURAL
+            - keyword: RIGHT
+            - keyword: OUTER
+            - keyword: JOIN
+            - from_expression_element:
+                table_expression:
+                  table_reference:
+                    naked_identifier: table2
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
               table_expression:
                 table_reference:
-                  naked_identifier: table2
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-        keyword: SELECT
-        select_clause_element:
-          wildcard_expression:
-            wildcard_identifier:
-              star: '*'
-      from_clause:
-        keyword: FROM
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: table1
-          join_clause:
-          - keyword: NATURAL
-          - keyword: FULL
-          - keyword: OUTER
-          - keyword: JOIN
-          - from_expression_element:
+                  naked_identifier: table1
+            join_clause:
+            - keyword: NATURAL
+            - keyword: FULL
+            - keyword: JOIN
+            - from_expression_element:
+                table_expression:
+                  table_reference:
+                    naked_identifier: table2
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
               table_expression:
                 table_reference:
-                  naked_identifier: table2
-- statement_terminator: ;
+                  naked_identifier: table1
+            join_clause:
+            - keyword: NATURAL
+            - keyword: FULL
+            - keyword: OUTER
+            - keyword: JOIN
+            - from_expression_element:
+                table_expression:
+                  table_reference:
+                    naked_identifier: table2
+  - statement_terminator: ;

--- a/test/fixtures/dialects/oracle/select_utf8.yml
+++ b/test/fixtures/dialects/oracle/select_utf8.yml
@@ -3,21 +3,22 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: f1c3dffdf5a678de7b661f45cc8ce4680645faca1673ac871c1a4b916380ce07
+_hash: 5cd0d15d5ccb740d21c8ee54406796f63896894dfcc14a681e6cd4a78d74ca57
 file:
-  statement:
-    select_statement:
-      select_clause:
-        keyword: SELECT
-        select_clause_element:
-          quoted_literal: "'Não'"
-          alias_expression:
-            naked_identifier: reativação
-      from_clause:
-        keyword: FROM
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: TABLE1
-  statement_terminator: ;
+  batch:
+    statement:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            quoted_literal: "'Não'"
+            alias_expression:
+              naked_identifier: reativação
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: TABLE1
+    statement_terminator: ;

--- a/test/fixtures/dialects/oracle/slash_buffer_executor_examples.sql
+++ b/test/fixtures/dialects/oracle/slash_buffer_executor_examples.sql
@@ -1,0 +1,76 @@
+-- Example 1: Procedure with slash buffer executor
+CREATE OR REPLACE PROCEDURE proc1 AS
+BEGIN
+  DBMS_OUTPUT.PUT_LINE('Procedure 1');
+END;
+/
+
+-- Example 2: Function with slash buffer executor
+CREATE OR REPLACE FUNCTION func1 RETURN VARCHAR2 AS
+BEGIN
+  RETURN 'Function 1';
+END;
+/
+
+-- Example 3: Anonymous block with slash buffer executor
+BEGIN
+  DBMS_OUTPUT.PUT_LINE('Anonymous block');
+END;
+/
+
+-- Example 4: Another procedure
+CREATE OR REPLACE PROCEDURE proc2 AS
+BEGIN
+  DBMS_OUTPUT.PUT_LINE('Procedure 2');
+END;
+/
+
+-- Example 5: Function with multiline comment before the slash buffer executor
+CREATE OR REPLACE FUNCTION func3 RETURN VARCHAR2 AS
+BEGIN
+  RETURN 'Function with comments';
+END;
+/*
+  This is a multiline comment
+  right after the function body
+*/
+/
+-- A comment after the slash buffer executor
+
+-- Example 6: Multiline comment after the slash buffer executor
+CREATE OR REPLACE PROCEDURE proc4 AS
+BEGIN
+  NULL;
+END;
+/
+/*
+  Multiline comment
+  AFTER the slash buffer executor
+*/
+
+-- Example 7: Normal comment before the slash buffer executor
+CREATE OR REPLACE PROCEDURE proc5 AS
+BEGIN
+  NULL;
+END;
+-- Comment before buffer executor
+/
+
+-- Example 8: Mixed comments
+CREATE OR REPLACE PROCEDURE proc6 AS
+BEGIN
+  NULL;
+END;
+-- Comment before
+/* Multiline before */
+/
+-- Comment after
+/* Multiline after */
+
+-- Example 9: Only comments between END and slash
+CREATE OR REPLACE PROCEDURE proc7 AS
+BEGIN
+  NULL;
+END;
+-- Just a comment
+/

--- a/test/fixtures/dialects/oracle/slash_buffer_executor_examples.yml
+++ b/test/fixtures/dialects/oracle/slash_buffer_executor_examples.yml
@@ -1,0 +1,216 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 6a710195c6caa6b80990e695e7cfbcd1481d6f90643e2a11d29b56d40c18142e
+file:
+- batch:
+    statement:
+      create_procedure_statement:
+      - keyword: CREATE
+      - keyword: OR
+      - keyword: REPLACE
+      - keyword: PROCEDURE
+      - function_name:
+          function_name_identifier: proc1
+      - keyword: AS
+      - begin_end_block:
+        - keyword: BEGIN
+        - statement:
+            function:
+              function_name:
+                naked_identifier: DBMS_OUTPUT
+                dot: .
+                function_name_identifier: PUT_LINE
+              function_contents:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    quoted_literal: "'Procedure 1'"
+                  end_bracket: )
+        - statement_terminator: ;
+        - keyword: END
+      - statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      create_function_statement:
+      - keyword: CREATE
+      - keyword: OR
+      - keyword: REPLACE
+      - keyword: FUNCTION
+      - function_name:
+          function_name_identifier: func1
+      - keyword: RETURN
+      - data_type:
+          data_type_identifier: VARCHAR2
+      - keyword: AS
+      - begin_end_block:
+        - keyword: BEGIN
+        - statement:
+            return_statement:
+              keyword: RETURN
+              expression:
+                quoted_literal: "'Function 1'"
+        - statement_terminator: ;
+        - keyword: END
+      - statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      begin_end_block:
+      - keyword: BEGIN
+      - statement:
+          function:
+            function_name:
+              naked_identifier: DBMS_OUTPUT
+              dot: .
+              function_name_identifier: PUT_LINE
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  quoted_literal: "'Anonymous block'"
+                end_bracket: )
+      - statement_terminator: ;
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      create_procedure_statement:
+      - keyword: CREATE
+      - keyword: OR
+      - keyword: REPLACE
+      - keyword: PROCEDURE
+      - function_name:
+          function_name_identifier: proc2
+      - keyword: AS
+      - begin_end_block:
+        - keyword: BEGIN
+        - statement:
+            function:
+              function_name:
+                naked_identifier: DBMS_OUTPUT
+                dot: .
+                function_name_identifier: PUT_LINE
+              function_contents:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    quoted_literal: "'Procedure 2'"
+                  end_bracket: )
+        - statement_terminator: ;
+        - keyword: END
+      - statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      create_function_statement:
+      - keyword: CREATE
+      - keyword: OR
+      - keyword: REPLACE
+      - keyword: FUNCTION
+      - function_name:
+          function_name_identifier: func3
+      - keyword: RETURN
+      - data_type:
+          data_type_identifier: VARCHAR2
+      - keyword: AS
+      - begin_end_block:
+        - keyword: BEGIN
+        - statement:
+            return_statement:
+              keyword: RETURN
+              expression:
+                quoted_literal: "'Function with comments'"
+        - statement_terminator: ;
+        - keyword: END
+      - statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      create_procedure_statement:
+      - keyword: CREATE
+      - keyword: OR
+      - keyword: REPLACE
+      - keyword: PROCEDURE
+      - function_name:
+          function_name_identifier: proc4
+      - keyword: AS
+      - begin_end_block:
+        - keyword: BEGIN
+        - statement:
+            null_statement:
+              keyword: 'NULL'
+        - statement_terminator: ;
+        - keyword: END
+      - statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      create_procedure_statement:
+      - keyword: CREATE
+      - keyword: OR
+      - keyword: REPLACE
+      - keyword: PROCEDURE
+      - function_name:
+          function_name_identifier: proc5
+      - keyword: AS
+      - begin_end_block:
+        - keyword: BEGIN
+        - statement:
+            null_statement:
+              keyword: 'NULL'
+        - statement_terminator: ;
+        - keyword: END
+      - statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      create_procedure_statement:
+      - keyword: CREATE
+      - keyword: OR
+      - keyword: REPLACE
+      - keyword: PROCEDURE
+      - function_name:
+          function_name_identifier: proc6
+      - keyword: AS
+      - begin_end_block:
+        - keyword: BEGIN
+        - statement:
+            null_statement:
+              keyword: 'NULL'
+        - statement_terminator: ;
+        - keyword: END
+      - statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      create_procedure_statement:
+      - keyword: CREATE
+      - keyword: OR
+      - keyword: REPLACE
+      - keyword: PROCEDURE
+      - function_name:
+          function_name_identifier: proc7
+      - keyword: AS
+      - begin_end_block:
+        - keyword: BEGIN
+        - statement:
+            null_statement:
+              keyword: 'NULL'
+        - statement_terminator: ;
+        - keyword: END
+      - statement_terminator: ;
+    slash_buffer_executor:
+      slash: /

--- a/test/fixtures/dialects/oracle/space_between_alias_and_column.yml
+++ b/test/fixtures/dialects/oracle/space_between_alias_and_column.yml
@@ -3,92 +3,93 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: e06e67cb2a2be631371438386fa46d37d2c019b329733210725cbeb6aa392b85
+_hash: b28987f9d59c5397f4f4212af7913002e93c8e86e342eb91bac0a8691661ad89
 file:
-- statement:
-    select_statement:
-      select_clause:
-        keyword: select
-        select_clause_element:
-          column_reference:
-          - naked_identifier: a
-          - dot: .
-          - naked_identifier: column_a
-      from_clause:
-        keyword: from
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: test_table
-            alias_expression:
-              naked_identifier: a
-      where_clause:
-        keyword: where
-        expression:
-          column_reference:
-          - naked_identifier: a
-          - dot: .
-          - naked_identifier: column_b
-          comparison_operator:
-            raw_comparison_operator: '='
-          numeric_literal: '1'
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-        keyword: select
-        select_clause_element:
-          column_reference:
-          - naked_identifier: a
-          - dot: .
-          - naked_identifier: column_a
-      from_clause:
-        keyword: from
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: test_table
-            alias_expression:
-              naked_identifier: a
-      where_clause:
-        keyword: where
-        expression:
-          numeric_literal: '1'
-          comparison_operator:
-            raw_comparison_operator: '='
-          column_reference:
-          - naked_identifier: a
-          - dot: .
-          - naked_identifier: column_a
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-        keyword: select
-        select_clause_element:
-          column_reference:
-          - naked_identifier: a
-          - dot: .
-          - naked_identifier: column_a
-      from_clause:
-        keyword: from
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: test_table
-            alias_expression:
-              naked_identifier: a
-      where_clause:
-        keyword: where
-        expression:
-          numeric_literal: '1'
-          comparison_operator:
-            raw_comparison_operator: '='
-          column_reference:
-          - naked_identifier: a
-          - dot: .
-          - naked_identifier: column_a
-- statement_terminator: ;
+  batch:
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: select
+          select_clause_element:
+            column_reference:
+            - naked_identifier: a
+            - dot: .
+            - naked_identifier: column_a
+        from_clause:
+          keyword: from
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: test_table
+              alias_expression:
+                naked_identifier: a
+        where_clause:
+          keyword: where
+          expression:
+            column_reference:
+            - naked_identifier: a
+            - dot: .
+            - naked_identifier: column_b
+            comparison_operator:
+              raw_comparison_operator: '='
+            numeric_literal: '1'
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: select
+          select_clause_element:
+            column_reference:
+            - naked_identifier: a
+            - dot: .
+            - naked_identifier: column_a
+        from_clause:
+          keyword: from
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: test_table
+              alias_expression:
+                naked_identifier: a
+        where_clause:
+          keyword: where
+          expression:
+            numeric_literal: '1'
+            comparison_operator:
+              raw_comparison_operator: '='
+            column_reference:
+            - naked_identifier: a
+            - dot: .
+            - naked_identifier: column_a
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: select
+          select_clause_element:
+            column_reference:
+            - naked_identifier: a
+            - dot: .
+            - naked_identifier: column_a
+        from_clause:
+          keyword: from
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: test_table
+              alias_expression:
+                naked_identifier: a
+        where_clause:
+          keyword: where
+          expression:
+            numeric_literal: '1'
+            comparison_operator:
+              raw_comparison_operator: '='
+            column_reference:
+            - naked_identifier: a
+            - dot: .
+            - naked_identifier: column_a
+  - statement_terminator: ;

--- a/test/fixtures/dialects/oracle/substitution_variable.yml
+++ b/test/fixtures/dialects/oracle/substitution_variable.yml
@@ -3,207 +3,208 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 2ef6d9c8f5352b739ea97a27fa84678614b7e789e84b4b04354d31b5674ad3c6
+_hash: d4c49b1035639be97af8f2e4d0681230d7120b2cb1dc7d8f474a19ac125d9cb7
 file:
-- statement:
-    access_statement:
-      grant_statement:
-      - keyword: grant
-      - access_permissions:
-          access_permission:
-            keyword: select
-      - keyword: 'on'
-      - object_reference:
-          naked_identifier: my_table
-      - keyword: to
-      - access_target:
-          role_reference:
-            sqlplus_variable:
-              ampersand: '&'
-              naked_identifier: REGISTRY
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-      - keyword: SELECT
-      - select_clause_element:
-          expression:
-            sqlplus_variable:
-              ampersand: '&'
-              naked_identifier: SORTCOL
-      - comma: ','
-      - select_clause_element:
-          column_reference:
-            naked_identifier: SALARY
-      from_clause:
-        keyword: FROM
-        from_expression:
-          from_expression_element:
-            table_expression:
+  batch:
+  - statement:
+      access_statement:
+        grant_statement:
+        - keyword: grant
+        - access_permissions:
+            access_permission:
+              keyword: select
+        - keyword: 'on'
+        - object_reference:
+            naked_identifier: my_table
+        - keyword: to
+        - access_target:
+            role_reference:
               sqlplus_variable:
                 ampersand: '&'
-                naked_identifier: MYTABLE
-      where_clause:
-        keyword: WHERE
-        expression:
-          column_reference:
-            naked_identifier: SALARY
-          comparison_operator:
-            raw_comparison_operator: '>'
-          numeric_literal: '12000'
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-        keyword: select
-        select_clause_element:
-          column_reference:
-            naked_identifier: employee_id
-      from_clause:
-        keyword: from
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: employees
-      where_clause:
-        keyword: where
-        expression:
-          column_reference:
-            naked_identifier: last_name
-          comparison_operator:
-            raw_comparison_operator: '='
-          quoted_literal: "'&myv'"
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-        keyword: select
-        select_clause_element:
-          wildcard_expression:
-            wildcard_identifier:
-              star: '*'
-      from_clause:
-        keyword: from
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: employees
-      where_clause:
-        keyword: where
-        expression:
-          column_reference:
-            naked_identifier: employee_id
-          comparison_operator:
-            raw_comparison_operator: '='
-          sqlplus_variable:
-            ampersand: '&'
-            naked_identifier: myv
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-        keyword: SELECT
-        select_clause_element:
-          column_reference:
-            naked_identifier: SALARY
-      from_clause:
-        keyword: FROM
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: EMP_DETAILS_VIEW
-      where_clause:
-        keyword: WHERE
-        expression:
-          column_reference:
-            naked_identifier: EMPLOYEE_ID
-          comparison_operator:
-            raw_comparison_operator: '='
-          quoted_literal: "'&X.5'"
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-      - keyword: SELECT
-      - select_clause_element:
-          expression:
-            sqlplus_variable:
-              ampersand: '&'
-              naked_identifier: GROUP_COL
-      - comma: ','
-      - select_clause_element:
-          function:
-            function_name:
-              function_name_identifier: MAX
-            function_contents:
-              bracketed:
-                start_bracket: (
-                expression:
-                  sqlplus_variable:
-                    ampersand: '&'
-                    naked_identifier: NUMBER_COL
-                end_bracket: )
-          alias_expression:
-            naked_identifier: MAXIMUM
-      from_clause:
-        keyword: FROM
-        from_expression:
-          from_expression_element:
-            table_expression:
+                naked_identifier: REGISTRY
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            expression:
               sqlplus_variable:
                 ampersand: '&'
-                naked_identifier: MY_TABLE
-      groupby_clause:
-      - keyword: GROUP
-      - keyword: BY
-      - expression:
-          sqlplus_variable:
-            ampersand: '&'
-            naked_identifier: GROUP_COL
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-        keyword: select
-        select_clause_element:
-          wildcard_expression:
-            wildcard_identifier:
-              star: '*'
-      from_clause:
-        keyword: from
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: employees
-      where_clause:
-        keyword: where
-        expression:
-          column_reference:
-            naked_identifier: employee_id
-          comparison_operator:
-            raw_comparison_operator: '='
-          sqlplus_variable:
-          - ampersand: '&'
-          - ampersand: '&'
-          - naked_identifier: myv
-- statement_terminator: ;
-- statement:
-    insert_statement:
-    - keyword: insert
-    - keyword: into
-    - table_reference:
-        naked_identifier: mytable
-    - values_clause:
-        keyword: values
-        bracketed:
-          start_bracket: (
+                naked_identifier: SORTCOL
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+              naked_identifier: SALARY
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                sqlplus_variable:
+                  ampersand: '&'
+                  naked_identifier: MYTABLE
+        where_clause:
+          keyword: WHERE
           expression:
+            column_reference:
+              naked_identifier: SALARY
+            comparison_operator:
+              raw_comparison_operator: '>'
+            numeric_literal: '12000'
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: select
+          select_clause_element:
+            column_reference:
+              naked_identifier: employee_id
+        from_clause:
+          keyword: from
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: employees
+        where_clause:
+          keyword: where
+          expression:
+            column_reference:
+              naked_identifier: last_name
+            comparison_operator:
+              raw_comparison_operator: '='
+            quoted_literal: "'&myv'"
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: select
+          select_clause_element:
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+        from_clause:
+          keyword: from
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: employees
+        where_clause:
+          keyword: where
+          expression:
+            column_reference:
+              naked_identifier: employee_id
+            comparison_operator:
+              raw_comparison_operator: '='
             sqlplus_variable:
               ampersand: '&'
               naked_identifier: myv
-          end_bracket: )
-- statement_terminator: ;
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            column_reference:
+              naked_identifier: SALARY
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: EMP_DETAILS_VIEW
+        where_clause:
+          keyword: WHERE
+          expression:
+            column_reference:
+              naked_identifier: EMPLOYEE_ID
+            comparison_operator:
+              raw_comparison_operator: '='
+            quoted_literal: "'&X.5'"
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            expression:
+              sqlplus_variable:
+                ampersand: '&'
+                naked_identifier: GROUP_COL
+        - comma: ','
+        - select_clause_element:
+            function:
+              function_name:
+                function_name_identifier: MAX
+              function_contents:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    sqlplus_variable:
+                      ampersand: '&'
+                      naked_identifier: NUMBER_COL
+                  end_bracket: )
+            alias_expression:
+              naked_identifier: MAXIMUM
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                sqlplus_variable:
+                  ampersand: '&'
+                  naked_identifier: MY_TABLE
+        groupby_clause:
+        - keyword: GROUP
+        - keyword: BY
+        - expression:
+            sqlplus_variable:
+              ampersand: '&'
+              naked_identifier: GROUP_COL
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: select
+          select_clause_element:
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+        from_clause:
+          keyword: from
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: employees
+        where_clause:
+          keyword: where
+          expression:
+            column_reference:
+              naked_identifier: employee_id
+            comparison_operator:
+              raw_comparison_operator: '='
+            sqlplus_variable:
+            - ampersand: '&'
+            - ampersand: '&'
+            - naked_identifier: myv
+  - statement_terminator: ;
+  - statement:
+      insert_statement:
+      - keyword: insert
+      - keyword: into
+      - table_reference:
+          naked_identifier: mytable
+      - values_clause:
+          keyword: values
+          bracketed:
+            start_bracket: (
+            expression:
+              sqlplus_variable:
+                ampersand: '&'
+                naked_identifier: myv
+            end_bracket: )
+  - statement_terminator: ;

--- a/test/fixtures/dialects/oracle/temporary_table.yml
+++ b/test/fixtures/dialects/oracle/temporary_table.yml
@@ -3,210 +3,211 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: ca868384d802f535ba528cb300ea943a1e0e47a38c09240a0fda06b65c8123e1
+_hash: 8318d0fce364403a7d4ae0d7194e1ad18c2670346c9cfcee0864a7bf24902706
 file:
-- statement:
-    create_table_statement:
-    - keyword: CREATE
-    - keyword: GLOBAL
-    - keyword: TEMPORARY
-    - keyword: TABLE
-    - table_reference:
-        naked_identifier: today_sales
-    - keyword: 'ON'
-    - keyword: COMMIT
-    - keyword: PRESERVE
-    - keyword: ROWS
-    - keyword: AS
-    - select_statement:
-        select_clause:
-          keyword: SELECT
-          select_clause_element:
-            wildcard_expression:
-              wildcard_identifier:
-                star: '*'
-        from_clause:
-          keyword: FROM
-          from_expression:
-            from_expression_element:
-              table_expression:
-                table_reference:
-                  naked_identifier: orders
-        where_clause:
-          keyword: WHERE
-          expression:
-            column_reference:
-              naked_identifier: order_date
-            comparison_operator:
-              raw_comparison_operator: '='
-            bare_function: SYSDATE
-- statement_terminator: ;
-- statement:
-    create_table_statement:
-    - keyword: CREATE
-    - keyword: GLOBAL
-    - keyword: TEMPORARY
-    - keyword: TABLE
-    - table_reference:
-        naked_identifier: HT_AFFAIRES
-    - bracketed:
-        start_bracket: (
-        column_definition:
-          naked_identifier: ID
-          data_type:
-            data_type_identifier: CHAR
-          bracketed:
-            start_bracket: (
-            numeric_literal: '36'
-            word: CHAR
-            end_bracket: )
-        end_bracket: )
-    - keyword: 'ON'
-    - keyword: COMMIT
-    - keyword: DELETE
-    - keyword: ROWS
-- statement_terminator: ;
-- statement:
-    create_table_statement:
-    - keyword: CREATE
-    - keyword: GLOBAL
-    - keyword: TEMPORARY
-    - keyword: TABLE
-    - table_reference:
-        naked_identifier: my_temp_table
-    - bracketed:
-      - start_bracket: (
-      - column_definition:
-          naked_identifier: id
-          data_type:
-            data_type_identifier: NUMBER
-      - comma: ','
-      - column_definition:
-          naked_identifier: description
-          data_type:
-            data_type_identifier: VARCHAR2
-            bracketed_arguments:
-              bracketed:
-                start_bracket: (
-                numeric_literal: '20'
-                end_bracket: )
-      - end_bracket: )
-    - keyword: 'ON'
-    - keyword: COMMIT
-    - keyword: DELETE
-    - keyword: ROWS
-- statement_terminator: ;
-- statement:
-    create_table_statement:
-    - keyword: CREATE
-    - keyword: GLOBAL
-    - keyword: TEMPORARY
-    - keyword: TABLE
-    - table_reference:
-        naked_identifier: my_temp_table
-    - bracketed:
-      - start_bracket: (
-      - column_definition:
-          naked_identifier: id
-          data_type:
-            data_type_identifier: NUMBER
-      - comma: ','
-      - column_definition:
-          naked_identifier: description
-          data_type:
-            data_type_identifier: VARCHAR2
-            bracketed_arguments:
-              bracketed:
-                start_bracket: (
-                numeric_literal: '20'
-                end_bracket: )
-      - end_bracket: )
-    - keyword: 'ON'
-    - keyword: COMMIT
-    - keyword: PRESERVE
-    - keyword: ROWS
-- statement_terminator: ;
-- statement:
-    create_table_statement:
-    - keyword: CREATE
-    - keyword: PRIVATE
-    - keyword: TEMPORARY
-    - keyword: TABLE
-    - table_reference:
-        naked_identifier: ora$ptt_my_temp_table
-    - bracketed:
-      - start_bracket: (
-      - column_definition:
-          naked_identifier: id
-          data_type:
-            data_type_identifier: NUMBER
-      - comma: ','
-      - column_definition:
-          naked_identifier: description
-          data_type:
-            data_type_identifier: VARCHAR2
-          bracketed:
-            start_bracket: (
-            numeric_literal: '20'
-            word: BYTE
-            end_bracket: )
-      - end_bracket: )
-    - keyword: 'ON'
-    - keyword: COMMIT
-    - keyword: DROP
-    - keyword: DEFINITION
-- statement_terminator: ;
-- statement:
-    create_table_statement:
-    - keyword: CREATE
-    - keyword: PRIVATE
-    - keyword: TEMPORARY
-    - keyword: TABLE
-    - table_reference:
-        naked_identifier: ora$ptt_my_temp_table
-    - bracketed:
-      - start_bracket: (
-      - column_definition:
-          naked_identifier: id
-          data_type:
-            data_type_identifier: NUMBER
-      - comma: ','
-      - column_definition:
-          naked_identifier: description
-          data_type:
-            data_type_identifier: VARCHAR2
-          bracketed:
-            start_bracket: (
-            numeric_literal: '20'
-            word: CHAR
-            end_bracket: )
-      - end_bracket: )
-    - keyword: 'ON'
-    - keyword: COMMIT
-    - keyword: PRESERVE
-    - keyword: DEFINITION
-- statement_terminator: ;
-- statement:
-    create_table_statement:
-    - keyword: CREATE
-    - keyword: PRIVATE
-    - keyword: TEMPORARY
-    - keyword: TABLE
-    - table_reference:
-        naked_identifier: ora$ptt_emp
-    - keyword: AS
-    - select_statement:
-        select_clause:
-          keyword: SELECT
-          select_clause_element:
-            wildcard_expression:
-              wildcard_identifier:
-                star: '*'
-        from_clause:
-          keyword: FROM
-          from_expression:
-            from_expression_element:
-              table_expression:
-                table_reference:
-                  naked_identifier: emp
-- statement_terminator: ;
+  batch:
+  - statement:
+      create_table_statement:
+      - keyword: CREATE
+      - keyword: GLOBAL
+      - keyword: TEMPORARY
+      - keyword: TABLE
+      - table_reference:
+          naked_identifier: today_sales
+      - keyword: 'ON'
+      - keyword: COMMIT
+      - keyword: PRESERVE
+      - keyword: ROWS
+      - keyword: AS
+      - select_statement:
+          select_clause:
+            keyword: SELECT
+            select_clause_element:
+              wildcard_expression:
+                wildcard_identifier:
+                  star: '*'
+          from_clause:
+            keyword: FROM
+            from_expression:
+              from_expression_element:
+                table_expression:
+                  table_reference:
+                    naked_identifier: orders
+          where_clause:
+            keyword: WHERE
+            expression:
+              column_reference:
+                naked_identifier: order_date
+              comparison_operator:
+                raw_comparison_operator: '='
+              bare_function: SYSDATE
+  - statement_terminator: ;
+  - statement:
+      create_table_statement:
+      - keyword: CREATE
+      - keyword: GLOBAL
+      - keyword: TEMPORARY
+      - keyword: TABLE
+      - table_reference:
+          naked_identifier: HT_AFFAIRES
+      - bracketed:
+          start_bracket: (
+          column_definition:
+            naked_identifier: ID
+            data_type:
+              data_type_identifier: CHAR
+            bracketed:
+              start_bracket: (
+              numeric_literal: '36'
+              word: CHAR
+              end_bracket: )
+          end_bracket: )
+      - keyword: 'ON'
+      - keyword: COMMIT
+      - keyword: DELETE
+      - keyword: ROWS
+  - statement_terminator: ;
+  - statement:
+      create_table_statement:
+      - keyword: CREATE
+      - keyword: GLOBAL
+      - keyword: TEMPORARY
+      - keyword: TABLE
+      - table_reference:
+          naked_identifier: my_temp_table
+      - bracketed:
+        - start_bracket: (
+        - column_definition:
+            naked_identifier: id
+            data_type:
+              data_type_identifier: NUMBER
+        - comma: ','
+        - column_definition:
+            naked_identifier: description
+            data_type:
+              data_type_identifier: VARCHAR2
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  numeric_literal: '20'
+                  end_bracket: )
+        - end_bracket: )
+      - keyword: 'ON'
+      - keyword: COMMIT
+      - keyword: DELETE
+      - keyword: ROWS
+  - statement_terminator: ;
+  - statement:
+      create_table_statement:
+      - keyword: CREATE
+      - keyword: GLOBAL
+      - keyword: TEMPORARY
+      - keyword: TABLE
+      - table_reference:
+          naked_identifier: my_temp_table
+      - bracketed:
+        - start_bracket: (
+        - column_definition:
+            naked_identifier: id
+            data_type:
+              data_type_identifier: NUMBER
+        - comma: ','
+        - column_definition:
+            naked_identifier: description
+            data_type:
+              data_type_identifier: VARCHAR2
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  numeric_literal: '20'
+                  end_bracket: )
+        - end_bracket: )
+      - keyword: 'ON'
+      - keyword: COMMIT
+      - keyword: PRESERVE
+      - keyword: ROWS
+  - statement_terminator: ;
+  - statement:
+      create_table_statement:
+      - keyword: CREATE
+      - keyword: PRIVATE
+      - keyword: TEMPORARY
+      - keyword: TABLE
+      - table_reference:
+          naked_identifier: ora$ptt_my_temp_table
+      - bracketed:
+        - start_bracket: (
+        - column_definition:
+            naked_identifier: id
+            data_type:
+              data_type_identifier: NUMBER
+        - comma: ','
+        - column_definition:
+            naked_identifier: description
+            data_type:
+              data_type_identifier: VARCHAR2
+            bracketed:
+              start_bracket: (
+              numeric_literal: '20'
+              word: BYTE
+              end_bracket: )
+        - end_bracket: )
+      - keyword: 'ON'
+      - keyword: COMMIT
+      - keyword: DROP
+      - keyword: DEFINITION
+  - statement_terminator: ;
+  - statement:
+      create_table_statement:
+      - keyword: CREATE
+      - keyword: PRIVATE
+      - keyword: TEMPORARY
+      - keyword: TABLE
+      - table_reference:
+          naked_identifier: ora$ptt_my_temp_table
+      - bracketed:
+        - start_bracket: (
+        - column_definition:
+            naked_identifier: id
+            data_type:
+              data_type_identifier: NUMBER
+        - comma: ','
+        - column_definition:
+            naked_identifier: description
+            data_type:
+              data_type_identifier: VARCHAR2
+            bracketed:
+              start_bracket: (
+              numeric_literal: '20'
+              word: CHAR
+              end_bracket: )
+        - end_bracket: )
+      - keyword: 'ON'
+      - keyword: COMMIT
+      - keyword: PRESERVE
+      - keyword: DEFINITION
+  - statement_terminator: ;
+  - statement:
+      create_table_statement:
+      - keyword: CREATE
+      - keyword: PRIVATE
+      - keyword: TEMPORARY
+      - keyword: TABLE
+      - table_reference:
+          naked_identifier: ora$ptt_emp
+      - keyword: AS
+      - select_statement:
+          select_clause:
+            keyword: SELECT
+            select_clause_element:
+              wildcard_expression:
+                wildcard_identifier:
+                  star: '*'
+          from_clause:
+            keyword: FROM
+            from_expression:
+              from_expression_element:
+                table_expression:
+                  table_reference:
+                    naked_identifier: emp
+  - statement_terminator: ;

--- a/test/fixtures/dialects/oracle/while_loop.yml
+++ b/test/fixtures/dialects/oracle/while_loop.yml
@@ -3,85 +3,87 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: ef0b2797aa047b7a3819bcc49b606e532d14f0c004ca49400f3a8bc610b1d73b
+_hash: 77772ae82a89f4c7fcb387496811507fbd8c3b8e717514fb57f9f07a053c59a1
 file:
-- statement:
-    begin_end_block:
-    - declare_segment:
-        keyword: DECLARE
-        naked_identifier: done
-        data_type:
-          data_type_identifier: BOOLEAN
-        assignment_operator: :=
-        expression:
-          boolean_literal: 'FALSE'
-        statement_terminator: ;
-    - keyword: BEGIN
-    - statement:
-        while_loop_statement:
-          keyword: WHILE
+  batch:
+    statement:
+      begin_end_block:
+      - declare_segment:
+          keyword: DECLARE
+          naked_identifier: done
+          data_type:
+            data_type_identifier: BOOLEAN
+          assignment_operator: :=
           expression:
-            column_reference:
-              naked_identifier: done
-          loop_statement:
-          - keyword: LOOP
-          - statement:
-              function:
-                function_name:
-                  naked_identifier: DBMS_OUTPUT
-                  dot: .
-                  function_name_identifier: PUT_LINE
-                function_contents:
-                  bracketed:
-                    start_bracket: (
-                    expression:
-                      quoted_literal: "'This line does not print.'"
-                    end_bracket: )
-          - statement_terminator: ;
-          - statement:
-              assignment_segment_statement:
-                object_reference:
-                  naked_identifier: done
-                assignment_operator: :=
-                expression:
-                  boolean_literal: 'TRUE'
-          - statement_terminator: ;
-          - keyword: END
-          - keyword: LOOP
-    - statement_terminator: ;
-    - statement:
-        while_loop_statement:
-          keyword: WHILE
-          expression:
-            keyword: NOT
-            column_reference:
-              naked_identifier: done
-          loop_statement:
-          - keyword: LOOP
-          - statement:
-              function:
-                function_name:
-                  naked_identifier: DBMS_OUTPUT
-                  dot: .
-                  function_name_identifier: PUT_LINE
-                function_contents:
-                  bracketed:
-                    start_bracket: (
-                    expression:
-                      quoted_literal: "'Hello, world!'"
-                    end_bracket: )
-          - statement_terminator: ;
-          - statement:
-              assignment_segment_statement:
-                object_reference:
-                  naked_identifier: done
-                assignment_operator: :=
-                expression:
-                  boolean_literal: 'TRUE'
-          - statement_terminator: ;
-          - keyword: END
-          - keyword: LOOP
-    - statement_terminator: ;
-    - keyword: END
-- statement_terminator: ;
-- statement_terminator: /
+            boolean_literal: 'FALSE'
+          statement_terminator: ;
+      - keyword: BEGIN
+      - statement:
+          while_loop_statement:
+            keyword: WHILE
+            expression:
+              column_reference:
+                naked_identifier: done
+            loop_statement:
+            - keyword: LOOP
+            - statement:
+                function:
+                  function_name:
+                    naked_identifier: DBMS_OUTPUT
+                    dot: .
+                    function_name_identifier: PUT_LINE
+                  function_contents:
+                    bracketed:
+                      start_bracket: (
+                      expression:
+                        quoted_literal: "'This line does not print.'"
+                      end_bracket: )
+            - statement_terminator: ;
+            - statement:
+                assignment_segment_statement:
+                  object_reference:
+                    naked_identifier: done
+                  assignment_operator: :=
+                  expression:
+                    boolean_literal: 'TRUE'
+            - statement_terminator: ;
+            - keyword: END
+            - keyword: LOOP
+      - statement_terminator: ;
+      - statement:
+          while_loop_statement:
+            keyword: WHILE
+            expression:
+              keyword: NOT
+              column_reference:
+                naked_identifier: done
+            loop_statement:
+            - keyword: LOOP
+            - statement:
+                function:
+                  function_name:
+                    naked_identifier: DBMS_OUTPUT
+                    dot: .
+                    function_name_identifier: PUT_LINE
+                  function_contents:
+                    bracketed:
+                      start_bracket: (
+                      expression:
+                        quoted_literal: "'Hello, world!'"
+                      end_bracket: )
+            - statement_terminator: ;
+            - statement:
+                assignment_segment_statement:
+                  object_reference:
+                    naked_identifier: done
+                  assignment_operator: :=
+                  expression:
+                    boolean_literal: 'TRUE'
+            - statement_terminator: ;
+            - keyword: END
+            - keyword: LOOP
+      - statement_terminator: ;
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /

--- a/test/fixtures/dialects/oracle/within_group.yml
+++ b/test/fixtures/dialects/oracle/within_group.yml
@@ -3,277 +3,278 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 088c1674b18b21fef3f58ffe274a3fc6854f5d490f599e5f8e4cf5c418723b07
+_hash: 97c80c67f9df14a8dd7e3c6cf59c1d706b4b65a18aaa6a6ee6f66fd62bd74018
 file:
-- statement:
-    select_statement:
-      select_clause:
-      - keyword: SELECT
-      - select_clause_element:
-          function:
-            function_name:
-              function_name_identifier: LISTAGG
-            function_contents:
-              bracketed:
-              - start_bracket: (
-              - expression:
-                  column_reference:
-                    naked_identifier: last_name
-              - comma: ','
-              - expression:
-                  quoted_literal: "'; '"
-              - end_bracket: )
-            withingroup_clause:
-            - keyword: WITHIN
-            - keyword: GROUP
-            - bracketed:
-                start_bracket: (
-                orderby_clause:
-                - keyword: ORDER
-                - keyword: BY
-                - column_reference:
-                    naked_identifier: hire_date
+  batch:
+  - statement:
+      select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            function:
+              function_name:
+                function_name_identifier: LISTAGG
+              function_contents:
+                bracketed:
+                - start_bracket: (
+                - expression:
+                    column_reference:
+                      naked_identifier: last_name
                 - comma: ','
-                - column_reference:
-                    naked_identifier: last_name
-                end_bracket: )
-          alias_expression:
-            quoted_identifier: '"Emp_list"'
-      - comma: ','
-      - select_clause_element:
-          function:
-            function_name:
-              function_name_identifier: MIN
-            function_contents:
-              bracketed:
-                start_bracket: (
-                expression:
-                  column_reference:
-                    naked_identifier: hire_date
-                end_bracket: )
-          alias_expression:
-            quoted_identifier: '"Earliest"'
-      from_clause:
-        keyword: FROM
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: employees
-      where_clause:
-        keyword: WHERE
-        expression:
-          column_reference:
-            naked_identifier: department_id
-          comparison_operator:
-            raw_comparison_operator: '='
-          numeric_literal: '30'
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-      - keyword: SELECT
-      - select_clause_element:
-          column_reference:
-            naked_identifier: department_id
-          alias_expression:
-            quoted_identifier: '"Dept."'
-      - comma: ','
-      - select_clause_element:
-          function:
-            function_name:
-              function_name_identifier: LISTAGG
-            function_contents:
-              bracketed:
-              - start_bracket: (
-              - expression:
-                  column_reference:
-                    naked_identifier: last_name
-              - comma: ','
-              - expression:
-                  quoted_literal: "'; '"
-              - end_bracket: )
-            withingroup_clause:
-            - keyword: WITHIN
-            - keyword: GROUP
-            - bracketed:
-                start_bracket: (
-                orderby_clause:
-                - keyword: ORDER
-                - keyword: BY
-                - column_reference:
-                    naked_identifier: hire_date
-                end_bracket: )
-          alias_expression:
-            quoted_identifier: '"Employees"'
-      from_clause:
-        keyword: FROM
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: employees
-      groupby_clause:
-      - keyword: GROUP
-      - keyword: BY
-      - column_reference:
-          naked_identifier: department_id
-      orderby_clause:
-      - keyword: ORDER
-      - keyword: BY
-      - column_reference:
-          naked_identifier: department_id
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-      - keyword: SELECT
-      - select_clause_element:
-          column_reference:
-            naked_identifier: department_id
-          alias_expression:
-            quoted_identifier: '"Dept."'
-      - comma: ','
-      - select_clause_element:
-          function:
-            function_name:
-              function_name_identifier: LISTAGG
-            function_contents:
-              bracketed:
-              - start_bracket: (
-              - expression:
-                  column_reference:
-                    naked_identifier: last_name
-              - comma: ','
-              - expression:
-                  quoted_literal: "'; '"
-              - listagg_overflow_clause:
-                - keyword: 'ON'
-                - keyword: OVERFLOW
-                - keyword: TRUNCATE
-                - quoted_identifier: "'...'"
-              - end_bracket: )
-            withingroup_clause:
-            - keyword: WITHIN
-            - keyword: GROUP
-            - bracketed:
-                start_bracket: (
-                orderby_clause:
-                - keyword: ORDER
-                - keyword: BY
-                - column_reference:
-                    naked_identifier: hire_date
-                end_bracket: )
-          alias_expression:
-            quoted_identifier: '"Employees"'
-      from_clause:
-        keyword: FROM
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: employees
-      groupby_clause:
-      - keyword: GROUP
-      - keyword: BY
-      - column_reference:
-          naked_identifier: department_id
-      orderby_clause:
-      - keyword: ORDER
-      - keyword: BY
-      - column_reference:
-          naked_identifier: department_id
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-      - keyword: SELECT
-      - select_clause_element:
-          column_reference:
-            naked_identifier: department_id
-          alias_expression:
-            quoted_identifier: '"Dept"'
-      - comma: ','
-      - select_clause_element:
-          column_reference:
-            naked_identifier: hire_date
-          alias_expression:
-            quoted_identifier: '"Date"'
-      - comma: ','
-      - select_clause_element:
-          column_reference:
-            naked_identifier: last_name
-          alias_expression:
-            quoted_identifier: '"Name"'
-      - comma: ','
-      - select_clause_element:
-          function:
-            function_name:
-              function_name_identifier: LISTAGG
-            function_contents:
-              bracketed:
-              - start_bracket: (
-              - expression:
-                  column_reference:
-                    naked_identifier: last_name
-              - comma: ','
-              - expression:
-                  quoted_literal: "'; '"
-              - end_bracket: )
-            withingroup_clause:
-            - keyword: WITHIN
-            - keyword: GROUP
-            - bracketed:
-                start_bracket: (
-                orderby_clause:
-                - keyword: ORDER
-                - keyword: BY
-                - column_reference:
-                    naked_identifier: hire_date
-                - comma: ','
-                - column_reference:
-                    naked_identifier: last_name
-                end_bracket: )
-            over_clause:
-              keyword: OVER
-              bracketed:
-                start_bracket: (
-                window_specification:
-                  partitionby_clause:
-                  - keyword: PARTITION
+                - expression:
+                    quoted_literal: "'; '"
+                - end_bracket: )
+              withingroup_clause:
+              - keyword: WITHIN
+              - keyword: GROUP
+              - bracketed:
+                  start_bracket: (
+                  orderby_clause:
+                  - keyword: ORDER
                   - keyword: BY
-                  - expression:
-                      column_reference:
-                        naked_identifier: department_id
-                end_bracket: )
-          alias_expression:
-            alias_operator:
-              keyword: as
-            quoted_identifier: '"Emp_list"'
-      from_clause:
-        keyword: FROM
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: employees
-      where_clause:
-        keyword: WHERE
-        expression:
-          column_reference:
-            naked_identifier: hire_date
-          comparison_operator:
-            raw_comparison_operator: <
-          quoted_literal: "'01-SEP-2003'"
-      orderby_clause:
-      - keyword: ORDER
-      - keyword: BY
-      - column_reference:
-          quoted_identifier: '"Dept"'
-      - comma: ','
-      - column_reference:
-          quoted_identifier: '"Date"'
-      - comma: ','
-      - column_reference:
-          quoted_identifier: '"Name"'
-- statement_terminator: ;
+                  - column_reference:
+                      naked_identifier: hire_date
+                  - comma: ','
+                  - column_reference:
+                      naked_identifier: last_name
+                  end_bracket: )
+            alias_expression:
+              quoted_identifier: '"Emp_list"'
+        - comma: ','
+        - select_clause_element:
+            function:
+              function_name:
+                function_name_identifier: MIN
+              function_contents:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    column_reference:
+                      naked_identifier: hire_date
+                  end_bracket: )
+            alias_expression:
+              quoted_identifier: '"Earliest"'
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: employees
+        where_clause:
+          keyword: WHERE
+          expression:
+            column_reference:
+              naked_identifier: department_id
+            comparison_operator:
+              raw_comparison_operator: '='
+            numeric_literal: '30'
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            column_reference:
+              naked_identifier: department_id
+            alias_expression:
+              quoted_identifier: '"Dept."'
+        - comma: ','
+        - select_clause_element:
+            function:
+              function_name:
+                function_name_identifier: LISTAGG
+              function_contents:
+                bracketed:
+                - start_bracket: (
+                - expression:
+                    column_reference:
+                      naked_identifier: last_name
+                - comma: ','
+                - expression:
+                    quoted_literal: "'; '"
+                - end_bracket: )
+              withingroup_clause:
+              - keyword: WITHIN
+              - keyword: GROUP
+              - bracketed:
+                  start_bracket: (
+                  orderby_clause:
+                  - keyword: ORDER
+                  - keyword: BY
+                  - column_reference:
+                      naked_identifier: hire_date
+                  end_bracket: )
+            alias_expression:
+              quoted_identifier: '"Employees"'
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: employees
+        groupby_clause:
+        - keyword: GROUP
+        - keyword: BY
+        - column_reference:
+            naked_identifier: department_id
+        orderby_clause:
+        - keyword: ORDER
+        - keyword: BY
+        - column_reference:
+            naked_identifier: department_id
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            column_reference:
+              naked_identifier: department_id
+            alias_expression:
+              quoted_identifier: '"Dept."'
+        - comma: ','
+        - select_clause_element:
+            function:
+              function_name:
+                function_name_identifier: LISTAGG
+              function_contents:
+                bracketed:
+                - start_bracket: (
+                - expression:
+                    column_reference:
+                      naked_identifier: last_name
+                - comma: ','
+                - expression:
+                    quoted_literal: "'; '"
+                - listagg_overflow_clause:
+                  - keyword: 'ON'
+                  - keyword: OVERFLOW
+                  - keyword: TRUNCATE
+                  - quoted_identifier: "'...'"
+                - end_bracket: )
+              withingroup_clause:
+              - keyword: WITHIN
+              - keyword: GROUP
+              - bracketed:
+                  start_bracket: (
+                  orderby_clause:
+                  - keyword: ORDER
+                  - keyword: BY
+                  - column_reference:
+                      naked_identifier: hire_date
+                  end_bracket: )
+            alias_expression:
+              quoted_identifier: '"Employees"'
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: employees
+        groupby_clause:
+        - keyword: GROUP
+        - keyword: BY
+        - column_reference:
+            naked_identifier: department_id
+        orderby_clause:
+        - keyword: ORDER
+        - keyword: BY
+        - column_reference:
+            naked_identifier: department_id
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            column_reference:
+              naked_identifier: department_id
+            alias_expression:
+              quoted_identifier: '"Dept"'
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+              naked_identifier: hire_date
+            alias_expression:
+              quoted_identifier: '"Date"'
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+              naked_identifier: last_name
+            alias_expression:
+              quoted_identifier: '"Name"'
+        - comma: ','
+        - select_clause_element:
+            function:
+              function_name:
+                function_name_identifier: LISTAGG
+              function_contents:
+                bracketed:
+                - start_bracket: (
+                - expression:
+                    column_reference:
+                      naked_identifier: last_name
+                - comma: ','
+                - expression:
+                    quoted_literal: "'; '"
+                - end_bracket: )
+              withingroup_clause:
+              - keyword: WITHIN
+              - keyword: GROUP
+              - bracketed:
+                  start_bracket: (
+                  orderby_clause:
+                  - keyword: ORDER
+                  - keyword: BY
+                  - column_reference:
+                      naked_identifier: hire_date
+                  - comma: ','
+                  - column_reference:
+                      naked_identifier: last_name
+                  end_bracket: )
+              over_clause:
+                keyword: OVER
+                bracketed:
+                  start_bracket: (
+                  window_specification:
+                    partitionby_clause:
+                    - keyword: PARTITION
+                    - keyword: BY
+                    - expression:
+                        column_reference:
+                          naked_identifier: department_id
+                  end_bracket: )
+            alias_expression:
+              alias_operator:
+                keyword: as
+              quoted_identifier: '"Emp_list"'
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: employees
+        where_clause:
+          keyword: WHERE
+          expression:
+            column_reference:
+              naked_identifier: hire_date
+            comparison_operator:
+              raw_comparison_operator: <
+            quoted_literal: "'01-SEP-2003'"
+        orderby_clause:
+        - keyword: ORDER
+        - keyword: BY
+        - column_reference:
+            quoted_identifier: '"Dept"'
+        - comma: ','
+        - column_reference:
+            quoted_identifier: '"Date"'
+        - comma: ','
+        - column_reference:
+            quoted_identifier: '"Name"'
+  - statement_terminator: ;

--- a/test/fixtures/rules/std_rule_cases/CV06.yml
+++ b/test/fixtures/rules/std_rule_cases/CV06.yml
@@ -517,7 +517,7 @@ test_pass_file_with_only_comments_with_require_final_semicolon:
       convention.terminator:
         require_final_semicolon: true
 
-test_pass_oracle_block_with_slash_delimiter:
+test_pass_oracle_block_with_slash_buffer_executor:
   pass_str: |
     CREATE PROCEDURE test_proc AS
     BEGIN
@@ -531,7 +531,7 @@ test_pass_oracle_block_with_slash_delimiter:
       convention.terminator:
         require_final_semicolon: true
 
-test_pass_oracle_block_with_slash_delimiter_multiline:
+test_pass_oracle_block_with_slash_buffer_executor_multiline:
   pass_str: |
     CREATE PROCEDURE test_proc AS
     BEGIN

--- a/test/fixtures/rules/std_rule_cases/OR01.yml
+++ b/test/fixtures/rules/std_rule_cases/OR01.yml
@@ -1,0 +1,128 @@
+---
+rule: OR01
+
+test_fail_empty_batch_1:
+  fail_str: |
+    CREATE TABLE test (val INT);
+    /
+    /
+  fix_str: |
+    CREATE TABLE test (val INT);
+    /
+  configs:
+    core:
+      dialect: oracle
+
+test_fail_empty_batch_2:
+  fail_str: |
+    SELECT 1 FROM DUAL;
+    /
+    /
+  fix_str: |
+    SELECT 1 FROM DUAL;
+    /
+  configs:
+    core:
+      dialect: oracle
+
+test_fail_empty_batch_3:
+  fail_str: |
+    SELECT 1 FROM DUAL;
+    /
+    /
+    SELECT 2 FROM DUAL;
+    /
+  fix_str: |
+    SELECT 1 FROM DUAL;
+    /
+    SELECT 2 FROM DUAL;
+    /
+  configs:
+    core:
+      dialect: oracle
+
+test_fail_multiple_empty_batches:
+  fail_str: |
+    SELECT 1 FROM DUAL;
+    /
+    /
+    /
+    SELECT 2 FROM DUAL;
+    /
+  fix_str: |
+    SELECT 1 FROM DUAL;
+    /
+    SELECT 2 FROM DUAL;
+    /
+  configs:
+    core:
+      dialect: oracle
+
+test_pass_no_empty_batches:
+  pass_str: |
+    SELECT 1 FROM DUAL;
+    SELECT 2 FROM DUAL;
+  configs:
+    core:
+      dialect: oracle
+
+test_pass_batch_with_content:
+  pass_str: |
+    CREATE TABLE test (val INT);
+    /
+    SELECT * FROM test;
+  configs:
+    core:
+      dialect: oracle
+
+test_pass_single_slash:
+  pass_str: |
+    SELECT 1 FROM DUAL;
+    /
+  configs:
+    core:
+      dialect: oracle
+
+test_pass_multiple_statements_with_slash:
+  pass_str: |
+    SELECT 1 FROM DUAL;
+    /
+    SELECT 2 FROM DUAL;
+    /
+  configs:
+    core:
+      dialect: oracle
+
+test_fail_empty_batch_with_comments:
+  fail_str: |
+    SELECT 1 FROM DUAL;
+    /
+    -- comment
+    /
+  fix_str: |
+    SELECT 1 FROM DUAL;
+    /
+    -- comment
+  configs:
+    core:
+      dialect: oracle
+
+test_fail_empty_batch_with_multiline_comments:
+  fail_str: |
+    SELECT 1 FROM DUAL;
+    /
+    /*
+      multiline
+      comment
+    */
+    /
+  fix_str: |
+    SELECT 1 FROM DUAL;
+    /
+    /*
+      multiline
+      comment
+    */
+  configs:
+    core:
+      dialect: oracle


### PR DESCRIPTION
### Brief summary of the change made
Fix issue in the `DelimiterGrammar` that was preventing `;` and `/` from acting as independent, valid alternatives for statement termination.

Fixes #7497.

### Are there any other side effects of this change that we should be aware of?
No.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
