### PR TITLE
Databricks: Fixes for Create MV Statement

### DIFF
--- a/src/sqlfluff/dialects/dialect_databricks.py
+++ b/src/sqlfluff/dialects/dialect_databricks.py
@@ -880,18 +880,7 @@ class CreateMaterializedViewStatementSegment(BaseSegment):
         _schedule,
         Sequence(
             "WITH",
-            "ROW",
-            "FILTER",
-            Ref("FunctionNameSegment"),
-            Sequence(
-                "ON",
-                Bracketed(
-                    Delimited(
-                        Ref("ColumnReferenceSegment"),
-                    ),
-                ),
-                optional=True,
-            ),
+            Ref("RowFilterClauseGrammar"),
         ),
     )
 
@@ -906,7 +895,10 @@ class CreateMaterializedViewStatementSegment(BaseSegment):
         Ref("TableReferenceSegment"),
         Bracketed(
             Delimited(
-                Ref("ColumnFieldDefinitionSegment"),
+                OneOf(
+                    Ref("ColumnFieldDefinitionSegment"),
+                    Ref("TableConstraintSegment"),
+                ),
             ),
             optional=True,
         ),

--- a/test/fixtures/dialects/databricks/create_materialized_view.sql
+++ b/test/fixtures/dialects/databricks/create_materialized_view.sql
@@ -70,6 +70,16 @@ CREATE MATERIALIZED VIEW filtered_mv
 WITH ROW FILTER row_filter_func ON (department, salary)
 AS SELECT * FROM employees;
 
+-- ROW FILTER with a schema-qualified function and a literal argument
+CREATE MATERIALIZED VIEW filtered_literal_mv
+WITH ROW FILTER my_schema.my_filter ON (department, 'ACTIVE')
+AS SELECT * FROM employees;
+
+-- ROW FILTER with empty column list (zero-parameter UDF)
+CREATE MATERIALIZED VIEW filtered_empty_mv
+WITH ROW FILTER my_schema.my_filter ON ()
+AS SELECT * FROM employees;
+
 CREATE OR REPLACE MATERIALIZED VIEW comprehensive_mv (
     id INT NOT NULL,
     region STRING,
@@ -106,3 +116,18 @@ CREATE OR REFRESH PRIVATE MATERIALIZED VIEW dlt_refresh_private_mat_view (
 )
 COMMENT 'DLT refreshed private materialized view'
 AS SELECT a, b FROM live.dlt_bronze;
+
+CREATE OR REPLACE MATERIALIZED VIEW view1
+(
+    col1 BIGINT,
+    col2 STRING,
+    col3 BOOLEAN,
+    CONSTRAINT pk_view1 PRIMARY KEY (col1),
+    CONSTRAINT fk_view1_table1 FOREIGN KEY (col2) REFERENCES table1 (col2)
+)
+AS
+SELECT
+    col1,
+    col2,
+    col3
+FROM source_table;

--- a/test/fixtures/dialects/databricks/create_materialized_view.yml
+++ b/test/fixtures/dialects/databricks/create_materialized_view.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 81e016a9a7a3cf97a83fb36eff4e6debb60c74711505115cf67d987d439462ad
+_hash: cb4449e3f689b62380dcd9908fb116858f0f3ac98cd9491e6a4752d08018c65f
 file:
 - statement:
     create_materialized_view_statement:
@@ -593,8 +593,8 @@ file:
     - keyword: WITH
     - keyword: ROW
     - keyword: FILTER
-    - function_name:
-        function_name_identifier: row_filter_func
+    - object_reference:
+        naked_identifier: row_filter_func
     - keyword: 'ON'
     - bracketed:
       - start_bracket: (
@@ -604,6 +604,79 @@ file:
       - column_reference:
           naked_identifier: salary
       - end_bracket: )
+    - keyword: AS
+    - select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: employees
+- statement_terminator: ;
+- statement:
+    create_materialized_view_statement:
+    - keyword: CREATE
+    - keyword: MATERIALIZED
+    - keyword: VIEW
+    - table_reference:
+        naked_identifier: filtered_literal_mv
+    - keyword: WITH
+    - keyword: ROW
+    - keyword: FILTER
+    - object_reference:
+      - naked_identifier: my_schema
+      - dot: .
+      - naked_identifier: my_filter
+    - keyword: 'ON'
+    - bracketed:
+      - start_bracket: (
+      - column_reference:
+          naked_identifier: department
+      - comma: ','
+      - column_reference:
+          quoted_identifier: "'ACTIVE'"
+      - end_bracket: )
+    - keyword: AS
+    - select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: employees
+- statement_terminator: ;
+- statement:
+    create_materialized_view_statement:
+    - keyword: CREATE
+    - keyword: MATERIALIZED
+    - keyword: VIEW
+    - table_reference:
+        naked_identifier: filtered_empty_mv
+    - keyword: WITH
+    - keyword: ROW
+    - keyword: FILTER
+    - object_reference:
+      - naked_identifier: my_schema
+      - dot: .
+      - naked_identifier: my_filter
+    - keyword: 'ON'
+    - bracketed:
+        start_bracket: (
+        end_bracket: )
     - keyword: AS
     - select_statement:
         select_clause:
@@ -907,4 +980,91 @@ file:
                 - naked_identifier: live
                 - dot: .
                 - naked_identifier: dlt_bronze
+- statement_terminator: ;
+- statement:
+    create_materialized_view_statement:
+    - keyword: CREATE
+    - keyword: OR
+    - keyword: REPLACE
+    - keyword: MATERIALIZED
+    - keyword: VIEW
+    - table_reference:
+        naked_identifier: view1
+    - bracketed:
+      - start_bracket: (
+      - column_definition:
+          column_reference:
+            naked_identifier: col1
+          data_type:
+            primitive_type:
+              keyword: BIGINT
+      - comma: ','
+      - column_definition:
+          column_reference:
+            naked_identifier: col2
+          data_type:
+            primitive_type:
+              keyword: STRING
+      - comma: ','
+      - column_definition:
+          column_reference:
+            naked_identifier: col3
+          data_type:
+            primitive_type:
+              keyword: BOOLEAN
+      - comma: ','
+      - table_constraint:
+        - keyword: CONSTRAINT
+        - object_reference:
+            naked_identifier: pk_view1
+        - keyword: PRIMARY
+        - keyword: KEY
+        - bracketed:
+            start_bracket: (
+            column_reference:
+              naked_identifier: col1
+            end_bracket: )
+      - comma: ','
+      - table_constraint:
+        - keyword: CONSTRAINT
+        - object_reference:
+            naked_identifier: fk_view1_table1
+        - keyword: FOREIGN
+        - keyword: KEY
+        - bracketed:
+            start_bracket: (
+            column_reference:
+              naked_identifier: col2
+            end_bracket: )
+        - keyword: REFERENCES
+        - table_reference:
+            naked_identifier: table1
+        - bracketed:
+            start_bracket: (
+            column_reference:
+              naked_identifier: col2
+            end_bracket: )
+      - end_bracket: )
+    - keyword: AS
+    - select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            column_reference:
+              naked_identifier: col1
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+              naked_identifier: col2
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+              naked_identifier: col3
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: source_table
 - statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
Fixes #7521 bug where table constraint segments were missing in the table definition.
Also fixes a small Row Filter bug that I introduced when creating this new CreateMaterializedViewStatementSegment by mistakenly not using a reference to the already existing RowFilterClauseGrammar.  Added tests to show these nuances to the syntax.

### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
