### PR TITLE
build: Add Rust toolchain in "Create release pull request" workflow

### DIFF
--- a/.github/workflows/create-release-pull-request.yaml
+++ b/.github/workflows/create-release-pull-request.yaml
@@ -34,6 +34,9 @@ jobs:
         run: |
           pip install requests click pyyaml ghapi
 
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
       - name: Prepare release
         run: |
           python util.py release ${{ github.event.inputs.newVersionNumber }}


### PR DESCRIPTION
### Brief summary of the change made

This PR adds the necessary Rust toolchain step to the workflow "Create release pull request". This worklflow executes a `python util.py release ...` command, and that requires a rust toolchain present, to run `cargo update --workspace` to update Cargo.lock.

As it was missing the cargo.lock was disconnected at the last release silently:
```
Run python util.py release 4.0.4
Preparing for release 4.0.4. (Pre-release: False)
Updating CHANGELOG.md...
...creating new entry for 4.0.4
Updating plugins/sqlfluff-templater-dbt/pyproject.toml
Updating sqlfluffrs/Cargo.toml
  Converting version: 4.0.4 -> 4.0.4 (SemVer)
Error: cargo not installed, unable to update Cargo.lock
Updating pyproject.toml
Updating gettingstarted.rst
DONE
```

### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
