### PR TITLE
Fix skip_indentation_in not stripping whitespace from comma-separated values

### DIFF
--- a/src/sqlfluff/utils/reflow/config.py
+++ b/src/sqlfluff/utils/reflow/config.py
@@ -117,7 +117,9 @@ class ReflowConfig:
             hanging_indents=config.get("hanging_indents", ["indentation"]),
             max_line_length=config.get("max_line_length"),
             skip_indentation_in=frozenset(
-                config.get("skip_indentation_in", ["indentation"]).split(",")
+                split_comma_separated_string(
+                    config.get("skip_indentation_in", ["indentation"])
+                )
             ),
             implicit_indents=config.get("implicit_indents", ["indentation"]),
             trailing_comments=config.get("trailing_comments", ["indentation"]),


### PR DESCRIPTION
### Summary

`skip_indentation_in` in `ReflowConfig.from_fluff_config` splits the config value on comma using raw `.split(",")`, without stripping whitespace. This means a config like:

```ini
[sqlfluff:indentation]
skip_indentation_in = script_content, select_clause
```

produces `frozenset({'script_content', ' select_clause'})` and the leading space on ` select_clause` silently prevents it from matching any parse tree type.

The fix replaces the raw `.split(",")` with `split_comma_separated_string()`, which is already imported in the file and already used for `keyword_line_position_exclusions` on the same class, as well as in `core/helpers/string.py`, `core/linter/linter.py`, `core/templaters/jinja.py`, and `core/rules/noqa.py`.

No tests added, since `split_comma_separated_string` already has its own unit tests in `test/core/helpers/string_test.py`, including whitespace stripping. This is a one-line wiring fix, not new logic.
