### PR TITLE
CV06: properly detect statement terminator

### DIFF
--- a/test/fixtures/rules/std_rule_cases/CV06.yml
+++ b/test/fixtures/rules/std_rule_cases/CV06.yml
@@ -47,13 +47,6 @@ test_fail_no_semi_colon_custom_require:
       convention.terminator:
         require_final_semicolon: true
 
-test_pass_final_semicolon_with_trailing_whitespace_custom_require:
-  pass_str: "SELECT a FROM foo;\t"
-  configs:
-    rules:
-      convention.terminator:
-        require_final_semicolon: true
-
 test_fail_no_semi_colon_custom_require_oneline:
   fail_str: |
     SELECT a FROM foo


### PR DESCRIPTION
### Brief summary of the change made

CV06 was using `[recursive_crawl("statement_terminator")]` on the last statement, so a nested semicolon inside a test BigQuery procedure body (SELECT 1;) was incorrectly treated as the final statement terminator.

The regression was introduced #7498., but went unnoticed as there was no test case for this specifically, until #7534 added this test.

### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
