### PR TITLE
docs: Explain `line_position` and `keyword_line_position`

### DIFF
--- a/docs/source/configuration/layout.rst
+++ b/docs/source/configuration/layout.rst
@@ -864,6 +864,36 @@ available:
       * the :code:`WHERE` keyword itself should start a line
         (:code:`keyword_line_position = leading`).
 
+         A concrete :code:`where_clause` example:
+
+         .. code-block:: sql
+
+             SELECT
+                  a
+             FROM t
+             WHERE b = 1
+                  AND c = 2
+
+         In this shape:
+
+         * :code:`line_position` controls where the whole :code:`where_clause` sits
+            relative to surrounding clauses (e.g. forcing a break before/around the
+            clause).
+         * :code:`keyword_line_position` controls where the :code:`WHERE` keyword
+            sits relative to its expression (e.g. :code:`WHERE b = 1` vs
+            :code:`WHERE` on its own line).
+
+         For example, setting :code:`keyword_line_position = alone` would produce:
+
+         .. code-block:: sql
+
+             SELECT
+                  a
+             FROM t
+             WHERE
+                  b = 1
+                  AND c = 2
+
       Another example:
 
       .. code-block:: cfg

--- a/docsv/configuration/layout.md
+++ b/docsv/configuration/layout.md
@@ -810,6 +810,34 @@ available:
       * the `WHERE` keyword itself should start a line
          (`keyword_line_position = leading`).
 
+      A concrete `where_clause` example:
+
+      ```sql
+      SELECT
+         a
+      FROM t
+      WHERE b = 1
+         AND c = 2
+      ```
+
+      In this shape:
+
+      * `line_position` controls where the whole `where_clause` sits relative
+        to surrounding clauses (e.g. forcing a break before/around the clause).
+      * `keyword_line_position` controls where the `WHERE` keyword sits relative
+        to its expression (e.g. `WHERE b = 1` vs `WHERE` on its own line).
+
+      For example, setting `keyword_line_position = alone` would produce:
+
+      ```sql
+      SELECT
+         a
+      FROM t
+      WHERE
+         b = 1
+         AND c = 2
+      ```
+
       Another example:
 
       ```ini


### PR DESCRIPTION
### Brief summary of the change made

Document and explain the difference between `line_position` and `keyword_line_position`.

Fixes #6962

### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
