### PR TITLE
Add SET COMPRESSION syntax in Postgres for ALTER TABLE statement.

### DIFF
--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -2770,6 +2770,7 @@ class AlterTableActionSegment(BaseSegment):
                 Sequence(
                     "SET", "STORAGE", OneOf("PLAIN", "EXTERNAL", "EXTENDED", "MAIN")
                 ),
+                Sequence("SET", "COMPRESSION", Ref("ParameterNameSegment")),
             ),
         ),
         Sequence("ADD", Ref("TableConstraintSegment")),

--- a/test/fixtures/dialects/postgres/alter_table.sql
+++ b/test/fixtures/dialects/postgres/alter_table.sql
@@ -199,3 +199,7 @@ ALTER TABLE many_options ADD EXCLUDE
         USING INDEX TABLESPACE tblspc
         WHERE (field != 'def')
         DEFERRABLE NOT VALID INITIALLY DEFERRED;
+
+-- Compression settings
+ALTER TABLE mytable ALTER COLUMN mycolumn SET COMPRESSION LZ4;
+ALTER TABLE mytable ALTER mycolumn SET COMPRESSION LZ4;

--- a/test/fixtures/dialects/postgres/alter_table.yml
+++ b/test/fixtures/dialects/postgres/alter_table.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 098a51ee4994b04f7bf36fb971f45cc33acd908bbf261ef50faca80d0199026d
+_hash: badc43c6ce89dd56f744d4940cbae8e8d9ee4f782398c677cbc57ac8cb1f202e
 file:
 - statement:
     alter_table_statement:
@@ -2203,4 +2203,33 @@ file:
         - keyword: VALID
         - keyword: INITIALLY
         - keyword: DEFERRED
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: mytable
+    - alter_table_action_segment:
+      - keyword: ALTER
+      - keyword: COLUMN
+      - column_reference:
+          naked_identifier: mycolumn
+      - keyword: SET
+      - keyword: COMPRESSION
+      - parameter: LZ4
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: mytable
+    - alter_table_action_segment:
+      - keyword: ALTER
+      - column_reference:
+          naked_identifier: mycolumn
+      - keyword: SET
+      - keyword: COMPRESSION
+      - parameter: LZ4
 - statement_terminator: ;


### PR DESCRIPTION
### Brief summary of the change made

Since version 14 Postgres has supported setting the compression strategy on columns via the `ALTER TABLE ... ALTER COLUMN` statement. For example:

```sql
ALTER TABLE myTable ALTER COLUMN myColumn SET COMPRESSION lz4;
```

This PR updates the `AlterTableActionSegment` to include this (it was already part of materialized views).

### Are there any other side effects of this change that we should be aware of?

This is also configurable in the `CREATE TABLE` syntax, but this PR only addresses the `ALTER TABLE` statement.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
