### PR TITLE
Added the beginnings of support for Synapse SQL

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ keywords = [
     "sparksql",
     "sqlite",
     "starrocks",
+    "synapse",
     "teradata",
     "trino",
     "tsql",

--- a/src/sqlfluff/core/dialects/__init__.py
+++ b/src/sqlfluff/core/dialects/__init__.py
@@ -47,6 +47,7 @@ _dialect_lookup = {
     "starrocks": ("dialect_starrocks", "starrocks_dialect"),
     "teradata": ("dialect_teradata", "teradata_dialect"),
     "trino": ("dialect_trino", "trino_dialect"),
+    "synapse": ("dialect_synapse", "synapse_dialect"),
     "tsql": ("dialect_tsql", "tsql_dialect"),
     "vertica": ("dialect_vertica", "vertica_dialect"),
 }

--- a/src/sqlfluff/dialects/dialect_synapse.py
+++ b/src/sqlfluff/dialects/dialect_synapse.py
@@ -1,0 +1,174 @@
+"""The Azure Synapse Analytics dialect.
+
+Azure Synapse Analytics is largely T-SQL compatible, but extends it with
+PolyBase-style external table capabilities (CETAS) and Synapse-specific
+options such as TABLE_OPTIONS.
+
+https://learn.microsoft.com/en-us/azure/synapse-analytics/sql/
+"""
+
+from sqlfluff.core.dialects import load_raw_dialect
+from sqlfluff.core.parser import (
+    BaseSegment,
+    Bracketed,
+    Delimited,
+    Matchable,
+    OneOf,
+    OptionallyBracketed,
+    Ref,
+    Sequence,
+)
+from sqlfluff.dialects import dialect_tsql as tsql
+from sqlfluff.dialects.dialect_synapse_keywords import UNRESERVED_KEYWORDS
+
+tsql_dialect = load_raw_dialect("tsql")
+synapse_dialect = tsql_dialect.copy_as(
+    "synapse",
+    formatted_name="Azure Synapse Analytics",
+    docstring="""The dialect for
+`Azure Synapse Analytics`_.
+
+.. _`Azure Synapse Analytics`:
+    https://learn.microsoft.com/en-us/azure/synapse-analytics/sql/
+""",
+)
+
+# Add Synapse-specific unreserved keywords on top of the inherited T-SQL set.
+synapse_dialect.sets("unreserved_keywords").update(UNRESERVED_KEYWORDS)
+
+
+# ---- Segment overrides / additions ----
+
+
+class CreateExternalTableStatementSegment(tsql.CreateExternalTableStatementSegment):
+    """A ``CREATE EXTERNAL TABLE`` statement for Azure Synapse Analytics.
+
+    Extends the T-SQL definition with the Synapse-specific ``TABLE_OPTIONS``
+    option.
+
+    https://learn.microsoft.com/en-us/azure/synapse-analytics/sql/create-use-external-tables
+    """
+
+    match_grammar = Sequence(
+        "CREATE",
+        "EXTERNAL",
+        "TABLE",
+        Ref("ObjectReferenceSegment"),
+        Bracketed(
+            Delimited(
+                Ref("ColumnDefinitionSegment"),
+            ),
+        ),
+        "WITH",
+        Bracketed(
+            Delimited(
+                Ref("TableLocationClause"),
+                Sequence(
+                    "DATA_SOURCE",
+                    Ref("EqualsSegment"),
+                    Ref("ObjectReferenceSegment"),
+                ),
+                Sequence(
+                    "FILE_FORMAT",
+                    Ref("EqualsSegment"),
+                    Ref("ObjectReferenceSegment"),
+                ),
+                Sequence(
+                    "REJECT_TYPE",
+                    Ref("EqualsSegment"),
+                    OneOf("value", "percentage"),
+                ),
+                Sequence(
+                    "REJECT_VALUE",
+                    Ref("EqualsSegment"),
+                    Ref("NumericLiteralSegment"),
+                ),
+                Sequence(
+                    "REJECT_SAMPLE_VALUE",
+                    Ref("EqualsSegment"),
+                    Ref("NumericLiteralSegment"),
+                ),
+                Sequence(
+                    "REJECTED_ROW_LOCATION",
+                    Ref("EqualsSegment"),
+                    Ref("QuotedLiteralSegmentOptWithN"),
+                ),
+                # Synapse-specific: allows tolerating appendable files.
+                Sequence(
+                    "TABLE_OPTIONS",
+                    Ref("EqualsSegment"),
+                    Ref("QuotedLiteralSegmentOptWithN"),
+                ),
+            ),
+        ),
+    )
+
+
+class CreateExternalTableAsSelectStatementSegment(BaseSegment):
+    """A ``CREATE EXTERNAL TABLE … AS SELECT`` (CETAS) statement.
+
+    This is specific to Azure Synapse Analytics (serverless and dedicated
+    SQL pools).
+
+    https://learn.microsoft.com/en-us/azure/synapse-analytics/sql/create-external-table-as-select
+    """
+
+    type = "create_external_table_as_select_statement"
+
+    match_grammar: Matchable = Sequence(
+        "CREATE",
+        "EXTERNAL",
+        "TABLE",
+        Ref("TableReferenceSegment"),
+        "WITH",
+        Bracketed(
+            Delimited(
+                Ref("TableLocationClause"),
+                Sequence(
+                    "DATA_SOURCE",
+                    Ref("EqualsSegment"),
+                    Ref("ObjectReferenceSegment"),
+                ),
+                Sequence(
+                    "FILE_FORMAT",
+                    Ref("EqualsSegment"),
+                    Ref("ObjectReferenceSegment"),
+                ),
+                Sequence(
+                    "REJECT_TYPE",
+                    Ref("EqualsSegment"),
+                    OneOf("value", "percentage"),
+                ),
+                Sequence(
+                    "REJECT_VALUE",
+                    Ref("EqualsSegment"),
+                    Ref("NumericLiteralSegment"),
+                ),
+                Sequence(
+                    "REJECT_SAMPLE_VALUE",
+                    Ref("EqualsSegment"),
+                    Ref("NumericLiteralSegment"),
+                ),
+                Sequence(
+                    "REJECTED_ROW_LOCATION",
+                    Ref("EqualsSegment"),
+                    Ref("QuotedLiteralSegmentOptWithN"),
+                ),
+            ),
+        ),
+        "AS",
+        OptionallyBracketed(Ref("SelectableGrammar")),
+    )
+
+
+class StatementSegment(tsql.StatementSegment):
+    """Extend T-SQL StatementSegment to include CETAS.
+
+    All other statement types are inherited from the T-SQL dialect.
+    """
+
+    match_grammar = tsql.StatementSegment.match_grammar.copy(
+        insert=[
+            Ref("CreateExternalTableAsSelectStatementSegment"),
+        ],
+    )

--- a/src/sqlfluff/dialects/dialect_synapse_keywords.py
+++ b/src/sqlfluff/dialects/dialect_synapse_keywords.py
@@ -1,0 +1,10 @@
+"""A list of Azure Synapse Analytics unreserved keywords.
+
+https://learn.microsoft.com/en-us/azure/synapse-analytics/sql/reference-tsql-language-elements
+"""
+
+# Azure Synapse Analytics adds TABLE_OPTIONS and a handful of
+# Synapse-specific identifiers not present in base T-SQL.
+UNRESERVED_KEYWORDS = [
+    "TABLE_OPTIONS",
+]

--- a/test/fixtures/dialects/synapse/.sqlfluff
+++ b/test/fixtures/dialects/synapse/.sqlfluff
@@ -1,0 +1,2 @@
+[sqlfluff]
+dialect = synapse

--- a/test/fixtures/dialects/synapse/create_external_data_source.sql
+++ b/test/fixtures/dialects/synapse/create_external_data_source.sql
@@ -1,0 +1,18 @@
+-- CREATE EXTERNAL DATA SOURCE pointing to Azure Blob Storage
+CREATE EXTERNAL DATA SOURCE SqlOnDemandDemo
+WITH (LOCATION = 'https://fabrictutorialdata.blob.core.windows.net/sampledata/Synapse');
+
+-- CREATE EXTERNAL DATA SOURCE pointing to Azure Data Lake Storage Gen2
+CREATE EXTERNAL DATA SOURCE nyctlc
+WITH (LOCATION = 'https://azureopendatastorage.blob.core.windows.net/nyctlc/');
+
+-- CREATE EXTERNAL DATA SOURCE for Delta Lake
+CREATE EXTERNAL DATA SOURCE DeltaLakeStorage
+WITH (LOCATION = 'https://fabrictutorialdata.blob.core.windows.net/sampledata/Synapse/delta-lake');
+
+-- CREATE EXTERNAL DATA SOURCE with SAS credential
+CREATE EXTERNAL DATA SOURCE AzureDataLakeStore
+WITH (
+    LOCATION = 'https://myaccount.dfs.core.windows.net/mycontainer',
+    CREDENTIAL = SasCredential
+);

--- a/test/fixtures/dialects/synapse/create_external_data_source.yml
+++ b/test/fixtures/dialects/synapse/create_external_data_source.yml
@@ -1,0 +1,86 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 51ea37efa6f9b5be7681486cbedbb118a3086c906b3d3efec68892478040f006
+file:
+  batch:
+  - statement:
+      create_external_data_source_statement:
+      - keyword: CREATE
+      - keyword: EXTERNAL
+      - keyword: DATA
+      - keyword: SOURCE
+      - object_reference:
+          naked_identifier: SqlOnDemandDemo
+      - keyword: WITH
+      - bracketed:
+          start_bracket: (
+          table_location_clause:
+            keyword: LOCATION
+            comparison_operator:
+              raw_comparison_operator: '='
+            quoted_literal: "'https://fabrictutorialdata.blob.core.windows.net/sampledata/Synapse'"
+          end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      create_external_data_source_statement:
+      - keyword: CREATE
+      - keyword: EXTERNAL
+      - keyword: DATA
+      - keyword: SOURCE
+      - object_reference:
+          naked_identifier: nyctlc
+      - keyword: WITH
+      - bracketed:
+          start_bracket: (
+          table_location_clause:
+            keyword: LOCATION
+            comparison_operator:
+              raw_comparison_operator: '='
+            quoted_literal: "'https://azureopendatastorage.blob.core.windows.net/nyctlc/'"
+          end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      create_external_data_source_statement:
+      - keyword: CREATE
+      - keyword: EXTERNAL
+      - keyword: DATA
+      - keyword: SOURCE
+      - object_reference:
+          naked_identifier: DeltaLakeStorage
+      - keyword: WITH
+      - bracketed:
+          start_bracket: (
+          table_location_clause:
+            keyword: LOCATION
+            comparison_operator:
+              raw_comparison_operator: '='
+            quoted_literal: "'https://fabrictutorialdata.blob.core.windows.net/sampledata/Synapse/delta-lake'"
+          end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      create_external_data_source_statement:
+      - keyword: CREATE
+      - keyword: EXTERNAL
+      - keyword: DATA
+      - keyword: SOURCE
+      - object_reference:
+          naked_identifier: AzureDataLakeStore
+      - keyword: WITH
+      - bracketed:
+          start_bracket: (
+          table_location_clause:
+            keyword: LOCATION
+            comparison_operator:
+              raw_comparison_operator: '='
+            quoted_literal: "'https://myaccount.dfs.core.windows.net/mycontainer'"
+          comma: ','
+          keyword: CREDENTIAL
+          comparison_operator:
+            raw_comparison_operator: '='
+          object_reference:
+            naked_identifier: SasCredential
+          end_bracket: )
+  - statement_terminator: ;

--- a/test/fixtures/dialects/synapse/create_external_file_format.sql
+++ b/test/fixtures/dialects/synapse/create_external_file_format.sql
@@ -1,0 +1,18 @@
+-- CSV external file format
+CREATE EXTERNAL FILE FORMAT QuotedCsvWithHeaderFormat
+WITH (
+    FORMAT_TYPE = DELIMITEDTEXT,
+    FORMAT_OPTIONS (
+        FIELD_TERMINATOR = ',',
+        STRING_DELIMITER = '"',
+        FIRST_ROW = 2
+    )
+);
+
+-- Parquet external file format
+CREATE EXTERNAL FILE FORMAT ParquetFormat
+WITH (FORMAT_TYPE = PARQUET);
+
+-- Delta Lake external file format
+CREATE EXTERNAL FILE FORMAT DeltaLakeFormat
+WITH (FORMAT_TYPE = DELTA);

--- a/test/fixtures/dialects/synapse/create_external_file_format.yml
+++ b/test/fixtures/dialects/synapse/create_external_file_format.yml
@@ -1,0 +1,84 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 2edfa547900fe1f51a2bd11c0416c22c89d42f4068d42b50ca4aca351acbb791
+file:
+  batch:
+  - statement:
+      create_external_file_format:
+      - keyword: CREATE
+      - keyword: EXTERNAL
+      - keyword: FILE
+      - keyword: FORMAT
+      - object_reference:
+          naked_identifier: QuotedCsvWithHeaderFormat
+      - keyword: WITH
+      - bracketed:
+          start_bracket: (
+          external_file_delimited_text_clause:
+          - keyword: FORMAT_TYPE
+          - comparison_operator:
+              raw_comparison_operator: '='
+          - keyword: DELIMITEDTEXT
+          - comma: ','
+          - keyword: FORMAT_OPTIONS
+          - bracketed:
+            - start_bracket: (
+            - external_file_delimited_text_format_options_clause:
+                keyword: FIELD_TERMINATOR
+                comparison_operator:
+                  raw_comparison_operator: '='
+                quoted_literal: "','"
+            - comma: ','
+            - external_file_delimited_text_format_options_clause:
+                keyword: STRING_DELIMITER
+                comparison_operator:
+                  raw_comparison_operator: '='
+                quoted_literal: "'\"'"
+            - comma: ','
+            - external_file_delimited_text_format_options_clause:
+                keyword: FIRST_ROW
+                comparison_operator:
+                  raw_comparison_operator: '='
+                numeric_literal: '2'
+            - end_bracket: )
+          end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      create_external_file_format:
+      - keyword: CREATE
+      - keyword: EXTERNAL
+      - keyword: FILE
+      - keyword: FORMAT
+      - object_reference:
+          naked_identifier: ParquetFormat
+      - keyword: WITH
+      - bracketed:
+          start_bracket: (
+          external_file_parquet_clause:
+          - keyword: FORMAT_TYPE
+          - comparison_operator:
+              raw_comparison_operator: '='
+          - keyword: PARQUET
+          end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      create_external_file_format:
+      - keyword: CREATE
+      - keyword: EXTERNAL
+      - keyword: FILE
+      - keyword: FORMAT
+      - object_reference:
+          naked_identifier: DeltaLakeFormat
+      - keyword: WITH
+      - bracketed:
+          start_bracket: (
+          external_file_delta_clause:
+          - keyword: FORMAT_TYPE
+          - comparison_operator:
+              raw_comparison_operator: '='
+          - keyword: DELTA
+          end_bracket: )
+  - statement_terminator: ;

--- a/test/fixtures/dialects/synapse/create_external_table.sql
+++ b/test/fixtures/dialects/synapse/create_external_table.sql
@@ -1,0 +1,76 @@
+-- Basic CREATE EXTERNAL TABLE using Parquet
+CREATE EXTERNAL TABLE populationExternalTable
+(
+    [country_code] VARCHAR(5) COLLATE Latin1_General_BIN2,
+    [country_name] VARCHAR(100) COLLATE Latin1_General_BIN2,
+    [year] SMALLINT,
+    [population] BIGINT
+)
+WITH (
+    LOCATION = 'csv/population/population.csv',
+    DATA_SOURCE = sqlondemanddemo,
+    FILE_FORMAT = QuotedCSVWithHeaderFormat
+);
+
+-- CREATE EXTERNAL TABLE using Parquet on a set of wildcard files
+CREATE EXTERNAL TABLE Taxi
+(
+    vendor_id VARCHAR(100) COLLATE Latin1_General_BIN2,
+    pickup_datetime DATETIME2,
+    dropoff_datetime DATETIME2,
+    passenger_count INT,
+    trip_distance FLOAT,
+    fare_amount FLOAT,
+    tip_amount FLOAT,
+    tolls_amount FLOAT,
+    total_amount FLOAT
+)
+WITH (
+    LOCATION = 'yellow/puYear=*/puMonth=*/*.parquet',
+    DATA_SOURCE = nyctlc,
+    FILE_FORMAT = ParquetFormat
+);
+
+-- CREATE EXTERNAL TABLE with TABLE_OPTIONS for appendable files
+CREATE EXTERNAL TABLE populationAppendable
+(
+    [country_code] VARCHAR(5) COLLATE Latin1_General_BIN2,
+    [country_name] VARCHAR(100) COLLATE Latin1_General_BIN2,
+    [year] SMALLINT,
+    [population] BIGINT
+)
+WITH (
+    LOCATION = 'csv/population/population.csv',
+    DATA_SOURCE = sqlondemanddemo,
+    FILE_FORMAT = QuotedCSVWithHeaderFormat,
+    TABLE_OPTIONS = N'{"READ_OPTIONS":["ALLOW_INCONSISTENT_READS"]}'
+);
+
+-- CREATE EXTERNAL TABLE on a Delta Lake folder
+CREATE EXTERNAL TABLE Covid
+(
+    date_rep DATE,
+    cases INT,
+    geo_id VARCHAR(6)
+)
+WITH (
+    LOCATION = 'covid',
+    DATA_SOURCE = DeltaLakeStorage,
+    FILE_FORMAT = DeltaLakeFormat
+);
+
+-- CREATE EXTERNAL TABLE with reject options
+CREATE EXTERNAL TABLE schema_name.table_name
+(
+    column_name_1 VARCHAR(50),
+    column_name_2 VARCHAR(50) NULL,
+    column_name_3 VARCHAR(50) NOT NULL
+)
+WITH (
+    LOCATION = N'/path/to/folder/',
+    DATA_SOURCE = external_data_source,
+    FILE_FORMAT = parquetfileformat,
+    REJECT_TYPE = VALUE,
+    REJECT_VALUE = 0,
+    REJECTED_ROW_LOCATION = '/REJECT_Directory'
+);

--- a/test/fixtures/dialects/synapse/create_external_table.yml
+++ b/test/fixtures/dialects/synapse/create_external_table.yml
@@ -1,0 +1,379 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 54b909948ac155b59ecfa813c4d684fa091cd3b00f963bc1f36174f546d26a22
+file:
+  batch:
+  - statement:
+      create_external_table_statement:
+      - keyword: CREATE
+      - keyword: EXTERNAL
+      - keyword: TABLE
+      - object_reference:
+          naked_identifier: populationExternalTable
+      - bracketed:
+        - start_bracket: (
+        - column_definition:
+            quoted_identifier: '[country_code]'
+            data_type:
+              keyword: VARCHAR
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    integer_literal: '5'
+                  end_bracket: )
+            column_constraint_segment:
+              keyword: COLLATE
+              collation_reference:
+                naked_identifier: Latin1_General_BIN2
+        - comma: ','
+        - column_definition:
+            quoted_identifier: '[country_name]'
+            data_type:
+              keyword: VARCHAR
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    integer_literal: '100'
+                  end_bracket: )
+            column_constraint_segment:
+              keyword: COLLATE
+              collation_reference:
+                naked_identifier: Latin1_General_BIN2
+        - comma: ','
+        - column_definition:
+            quoted_identifier: '[year]'
+            data_type:
+              keyword: SMALLINT
+        - comma: ','
+        - column_definition:
+            quoted_identifier: '[population]'
+            data_type:
+              keyword: BIGINT
+        - end_bracket: )
+      - keyword: WITH
+      - bracketed:
+        - start_bracket: (
+        - table_location_clause:
+            keyword: LOCATION
+            comparison_operator:
+              raw_comparison_operator: '='
+            quoted_literal: "'csv/population/population.csv'"
+        - comma: ','
+        - keyword: DATA_SOURCE
+        - comparison_operator:
+            raw_comparison_operator: '='
+        - object_reference:
+            naked_identifier: sqlondemanddemo
+        - comma: ','
+        - keyword: FILE_FORMAT
+        - comparison_operator:
+            raw_comparison_operator: '='
+        - object_reference:
+            naked_identifier: QuotedCSVWithHeaderFormat
+        - end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      create_external_table_statement:
+      - keyword: CREATE
+      - keyword: EXTERNAL
+      - keyword: TABLE
+      - object_reference:
+          naked_identifier: Taxi
+      - bracketed:
+        - start_bracket: (
+        - column_definition:
+            naked_identifier: vendor_id
+            data_type:
+              keyword: VARCHAR
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    integer_literal: '100'
+                  end_bracket: )
+            column_constraint_segment:
+              keyword: COLLATE
+              collation_reference:
+                naked_identifier: Latin1_General_BIN2
+        - comma: ','
+        - column_definition:
+            naked_identifier: pickup_datetime
+            data_type:
+              keyword: DATETIME2
+        - comma: ','
+        - column_definition:
+            naked_identifier: dropoff_datetime
+            data_type:
+              keyword: DATETIME2
+        - comma: ','
+        - column_definition:
+            naked_identifier: passenger_count
+            data_type:
+              keyword: INT
+        - comma: ','
+        - column_definition:
+            naked_identifier: trip_distance
+            data_type:
+              keyword: FLOAT
+        - comma: ','
+        - column_definition:
+            naked_identifier: fare_amount
+            data_type:
+              keyword: FLOAT
+        - comma: ','
+        - column_definition:
+            naked_identifier: tip_amount
+            data_type:
+              keyword: FLOAT
+        - comma: ','
+        - column_definition:
+            naked_identifier: tolls_amount
+            data_type:
+              keyword: FLOAT
+        - comma: ','
+        - column_definition:
+            naked_identifier: total_amount
+            data_type:
+              keyword: FLOAT
+        - end_bracket: )
+      - keyword: WITH
+      - bracketed:
+        - start_bracket: (
+        - table_location_clause:
+            keyword: LOCATION
+            comparison_operator:
+              raw_comparison_operator: '='
+            quoted_literal: "'yellow/puYear=*/puMonth=*/*.parquet'"
+        - comma: ','
+        - keyword: DATA_SOURCE
+        - comparison_operator:
+            raw_comparison_operator: '='
+        - object_reference:
+            naked_identifier: nyctlc
+        - comma: ','
+        - keyword: FILE_FORMAT
+        - comparison_operator:
+            raw_comparison_operator: '='
+        - object_reference:
+            naked_identifier: ParquetFormat
+        - end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      create_external_table_statement:
+      - keyword: CREATE
+      - keyword: EXTERNAL
+      - keyword: TABLE
+      - object_reference:
+          naked_identifier: populationAppendable
+      - bracketed:
+        - start_bracket: (
+        - column_definition:
+            quoted_identifier: '[country_code]'
+            data_type:
+              keyword: VARCHAR
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    integer_literal: '5'
+                  end_bracket: )
+            column_constraint_segment:
+              keyword: COLLATE
+              collation_reference:
+                naked_identifier: Latin1_General_BIN2
+        - comma: ','
+        - column_definition:
+            quoted_identifier: '[country_name]'
+            data_type:
+              keyword: VARCHAR
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    integer_literal: '100'
+                  end_bracket: )
+            column_constraint_segment:
+              keyword: COLLATE
+              collation_reference:
+                naked_identifier: Latin1_General_BIN2
+        - comma: ','
+        - column_definition:
+            quoted_identifier: '[year]'
+            data_type:
+              keyword: SMALLINT
+        - comma: ','
+        - column_definition:
+            quoted_identifier: '[population]'
+            data_type:
+              keyword: BIGINT
+        - end_bracket: )
+      - keyword: WITH
+      - bracketed:
+        - start_bracket: (
+        - table_location_clause:
+            keyword: LOCATION
+            comparison_operator:
+              raw_comparison_operator: '='
+            quoted_literal: "'csv/population/population.csv'"
+        - comma: ','
+        - keyword: DATA_SOURCE
+        - comparison_operator:
+            raw_comparison_operator: '='
+        - object_reference:
+            naked_identifier: sqlondemanddemo
+        - comma: ','
+        - keyword: FILE_FORMAT
+        - comparison_operator:
+            raw_comparison_operator: '='
+        - object_reference:
+            naked_identifier: QuotedCSVWithHeaderFormat
+        - comma: ','
+        - keyword: TABLE_OPTIONS
+        - comparison_operator:
+            raw_comparison_operator: '='
+        - quoted_literal: "N'{\"READ_OPTIONS\":[\"ALLOW_INCONSISTENT_READS\"]}'"
+        - end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      create_external_table_statement:
+      - keyword: CREATE
+      - keyword: EXTERNAL
+      - keyword: TABLE
+      - object_reference:
+          naked_identifier: Covid
+      - bracketed:
+        - start_bracket: (
+        - column_definition:
+            naked_identifier: date_rep
+            data_type:
+              keyword: DATE
+        - comma: ','
+        - column_definition:
+            naked_identifier: cases
+            data_type:
+              keyword: INT
+        - comma: ','
+        - column_definition:
+            naked_identifier: geo_id
+            data_type:
+              keyword: VARCHAR
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    integer_literal: '6'
+                  end_bracket: )
+        - end_bracket: )
+      - keyword: WITH
+      - bracketed:
+        - start_bracket: (
+        - table_location_clause:
+            keyword: LOCATION
+            comparison_operator:
+              raw_comparison_operator: '='
+            quoted_literal: "'covid'"
+        - comma: ','
+        - keyword: DATA_SOURCE
+        - comparison_operator:
+            raw_comparison_operator: '='
+        - object_reference:
+            naked_identifier: DeltaLakeStorage
+        - comma: ','
+        - keyword: FILE_FORMAT
+        - comparison_operator:
+            raw_comparison_operator: '='
+        - object_reference:
+            naked_identifier: DeltaLakeFormat
+        - end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      create_external_table_statement:
+      - keyword: CREATE
+      - keyword: EXTERNAL
+      - keyword: TABLE
+      - object_reference:
+        - naked_identifier: schema_name
+        - dot: .
+        - naked_identifier: table_name
+      - bracketed:
+        - start_bracket: (
+        - column_definition:
+            naked_identifier: column_name_1
+            data_type:
+              keyword: VARCHAR
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    integer_literal: '50'
+                  end_bracket: )
+        - comma: ','
+        - column_definition:
+            naked_identifier: column_name_2
+            data_type:
+              keyword: VARCHAR
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    integer_literal: '50'
+                  end_bracket: )
+            column_constraint_segment:
+              keyword: 'NULL'
+        - comma: ','
+        - column_definition:
+            naked_identifier: column_name_3
+            data_type:
+              keyword: VARCHAR
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    integer_literal: '50'
+                  end_bracket: )
+            column_constraint_segment:
+            - keyword: NOT
+            - keyword: 'NULL'
+        - end_bracket: )
+      - keyword: WITH
+      - bracketed:
+        - start_bracket: (
+        - table_location_clause:
+            keyword: LOCATION
+            comparison_operator:
+              raw_comparison_operator: '='
+            quoted_literal: "N'/path/to/folder/'"
+        - comma: ','
+        - keyword: DATA_SOURCE
+        - comparison_operator:
+            raw_comparison_operator: '='
+        - object_reference:
+            naked_identifier: external_data_source
+        - comma: ','
+        - keyword: FILE_FORMAT
+        - comparison_operator:
+            raw_comparison_operator: '='
+        - object_reference:
+            naked_identifier: parquetfileformat
+        - comma: ','
+        - keyword: REJECT_TYPE
+        - comparison_operator:
+            raw_comparison_operator: '='
+        - keyword: VALUE
+        - comma: ','
+        - keyword: REJECT_VALUE
+        - comparison_operator:
+            raw_comparison_operator: '='
+        - numeric_literal: '0'
+        - comma: ','
+        - keyword: REJECTED_ROW_LOCATION
+        - comparison_operator:
+            raw_comparison_operator: '='
+        - quoted_literal: "'/REJECT_Directory'"
+        - end_bracket: )
+  - statement_terminator: ;

--- a/test/fixtures/dialects/synapse/create_external_table_as_select.sql
+++ b/test/fixtures/dialects/synapse/create_external_table_as_select.sql
@@ -1,0 +1,44 @@
+-- CREATE EXTERNAL TABLE AS SELECT (CETAS) - basic form
+CREATE EXTERNAL TABLE [dbo].[Product]
+WITH (
+    LOCATION = 'production/product/',
+    DATA_SOURCE = AzureDataLakeStore,
+    FILE_FORMAT = TextFileFormat
+)
+AS
+SELECT * FROM dbo.Product;
+
+-- CETAS writing aggregated results to external storage
+CREATE EXTERNAL TABLE [export].[SalesSummary]
+WITH (
+    LOCATION = 'exports/sales/summary/',
+    DATA_SOURCE = AzureDataLakeStore,
+    FILE_FORMAT = ParquetFormat
+)
+AS
+SELECT
+    region,
+    product_id,
+    SUM(amount) AS total_amount,
+    COUNT(*) AS order_count
+FROM dbo.Orders
+GROUP BY region, product_id;
+
+-- CETAS with a CTE
+CREATE EXTERNAL TABLE [export].[TopCustomers]
+WITH (
+    LOCATION = 'exports/customers/top/',
+    DATA_SOURCE = AzureDataLakeStore,
+    FILE_FORMAT = ParquetFormat
+)
+AS
+WITH ranked AS (
+    SELECT
+        customer_id,
+        total_spend,
+        ROW_NUMBER() OVER (ORDER BY total_spend DESC) AS rn
+    FROM dbo.Customers
+)
+SELECT customer_id, total_spend
+FROM ranked
+WHERE rn <= 100;

--- a/test/fixtures/dialects/synapse/create_external_table_as_select.yml
+++ b/test/fixtures/dialects/synapse/create_external_table_as_select.yml
@@ -1,0 +1,255 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 623b6bcd64c14fcc758d9ca2ca7cccb890303dd281f3d7e836137712b4540a1a
+file:
+  batch:
+  - statement:
+      create_external_table_as_select_statement:
+      - keyword: CREATE
+      - keyword: EXTERNAL
+      - keyword: TABLE
+      - table_reference:
+        - quoted_identifier: '[dbo]'
+        - dot: .
+        - quoted_identifier: '[Product]'
+      - keyword: WITH
+      - bracketed:
+        - start_bracket: (
+        - table_location_clause:
+            keyword: LOCATION
+            comparison_operator:
+              raw_comparison_operator: '='
+            quoted_literal: "'production/product/'"
+        - comma: ','
+        - keyword: DATA_SOURCE
+        - comparison_operator:
+            raw_comparison_operator: '='
+        - object_reference:
+            naked_identifier: AzureDataLakeStore
+        - comma: ','
+        - keyword: FILE_FORMAT
+        - comparison_operator:
+            raw_comparison_operator: '='
+        - object_reference:
+            naked_identifier: TextFileFormat
+        - end_bracket: )
+      - keyword: AS
+      - select_statement:
+          select_clause:
+            keyword: SELECT
+            select_clause_element:
+              wildcard_expression:
+                wildcard_identifier:
+                  star: '*'
+          from_clause:
+            keyword: FROM
+            from_expression:
+              from_expression_element:
+                table_expression:
+                  table_reference:
+                  - naked_identifier: dbo
+                  - dot: .
+                  - naked_identifier: Product
+  - statement_terminator: ;
+  - statement:
+      create_external_table_as_select_statement:
+      - keyword: CREATE
+      - keyword: EXTERNAL
+      - keyword: TABLE
+      - table_reference:
+        - quoted_identifier: '[export]'
+        - dot: .
+        - quoted_identifier: '[SalesSummary]'
+      - keyword: WITH
+      - bracketed:
+        - start_bracket: (
+        - table_location_clause:
+            keyword: LOCATION
+            comparison_operator:
+              raw_comparison_operator: '='
+            quoted_literal: "'exports/sales/summary/'"
+        - comma: ','
+        - keyword: DATA_SOURCE
+        - comparison_operator:
+            raw_comparison_operator: '='
+        - object_reference:
+            naked_identifier: AzureDataLakeStore
+        - comma: ','
+        - keyword: FILE_FORMAT
+        - comparison_operator:
+            raw_comparison_operator: '='
+        - object_reference:
+            naked_identifier: ParquetFormat
+        - end_bracket: )
+      - keyword: AS
+      - select_statement:
+          select_clause:
+          - keyword: SELECT
+          - select_clause_element:
+              column_reference:
+                naked_identifier: region
+          - comma: ','
+          - select_clause_element:
+              column_reference:
+                naked_identifier: product_id
+          - comma: ','
+          - select_clause_element:
+              function:
+                function_name:
+                  function_name_identifier: SUM
+                function_contents:
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                      column_reference:
+                        naked_identifier: amount
+                    end_bracket: )
+              alias_expression:
+                alias_operator:
+                  keyword: AS
+                naked_identifier: total_amount
+          - comma: ','
+          - select_clause_element:
+              function:
+                function_name:
+                  function_name_identifier: COUNT
+                function_contents:
+                  bracketed:
+                    start_bracket: (
+                    star: '*'
+                    end_bracket: )
+              alias_expression:
+                alias_operator:
+                  keyword: AS
+                naked_identifier: order_count
+          from_clause:
+            keyword: FROM
+            from_expression:
+              from_expression_element:
+                table_expression:
+                  table_reference:
+                  - naked_identifier: dbo
+                  - dot: .
+                  - naked_identifier: Orders
+          groupby_clause:
+          - keyword: GROUP
+          - keyword: BY
+          - column_reference:
+              naked_identifier: region
+          - comma: ','
+          - column_reference:
+              naked_identifier: product_id
+  - statement_terminator: ;
+  - statement:
+      create_external_table_as_select_statement:
+      - keyword: CREATE
+      - keyword: EXTERNAL
+      - keyword: TABLE
+      - table_reference:
+        - quoted_identifier: '[export]'
+        - dot: .
+        - quoted_identifier: '[TopCustomers]'
+      - keyword: WITH
+      - bracketed:
+        - start_bracket: (
+        - table_location_clause:
+            keyword: LOCATION
+            comparison_operator:
+              raw_comparison_operator: '='
+            quoted_literal: "'exports/customers/top/'"
+        - comma: ','
+        - keyword: DATA_SOURCE
+        - comparison_operator:
+            raw_comparison_operator: '='
+        - object_reference:
+            naked_identifier: AzureDataLakeStore
+        - comma: ','
+        - keyword: FILE_FORMAT
+        - comparison_operator:
+            raw_comparison_operator: '='
+        - object_reference:
+            naked_identifier: ParquetFormat
+        - end_bracket: )
+      - keyword: AS
+      - with_compound_statement:
+          keyword: WITH
+          common_table_expression:
+            naked_identifier: ranked
+            keyword: AS
+            bracketed:
+              start_bracket: (
+              select_statement:
+                select_clause:
+                - keyword: SELECT
+                - select_clause_element:
+                    column_reference:
+                      naked_identifier: customer_id
+                - comma: ','
+                - select_clause_element:
+                    column_reference:
+                      naked_identifier: total_spend
+                - comma: ','
+                - select_clause_element:
+                    function:
+                      function_name:
+                        keyword: ROW_NUMBER
+                      function_contents:
+                        bracketed:
+                          start_bracket: (
+                          end_bracket: )
+                      over_clause:
+                        keyword: OVER
+                        bracketed:
+                          start_bracket: (
+                          window_specification:
+                            orderby_clause:
+                            - keyword: ORDER
+                            - keyword: BY
+                            - column_reference:
+                                naked_identifier: total_spend
+                            - keyword: DESC
+                          end_bracket: )
+                    alias_expression:
+                      alias_operator:
+                        keyword: AS
+                      naked_identifier: rn
+                from_clause:
+                  keyword: FROM
+                  from_expression:
+                    from_expression_element:
+                      table_expression:
+                        table_reference:
+                        - naked_identifier: dbo
+                        - dot: .
+                        - naked_identifier: Customers
+              end_bracket: )
+          select_statement:
+            select_clause:
+            - keyword: SELECT
+            - select_clause_element:
+                column_reference:
+                  naked_identifier: customer_id
+            - comma: ','
+            - select_clause_element:
+                column_reference:
+                  naked_identifier: total_spend
+            from_clause:
+              keyword: FROM
+              from_expression:
+                from_expression_element:
+                  table_expression:
+                    table_reference:
+                      naked_identifier: ranked
+            where_clause:
+              keyword: WHERE
+              expression:
+                column_reference:
+                  naked_identifier: rn
+                comparison_operator:
+                - raw_comparison_operator: <
+                - raw_comparison_operator: '='
+                integer_literal: '100'
+  - statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->

makes progress on #7589

Azure Synapse Analytics is largely T-SQL compatible, so this PR creates a new dialect called 'synapse' that extends TSQL with PolyBase-style external table capabilities (CETAS) and Synapse-specific options such as TABLE_OPTIONS.

### Are there any other side effects of this change that we should be aware of?

No

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
