### PR TITLE
build: set base_python for dbt and python tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,19 @@ uv_seed = true
 # tox-uv infers base_python from env names. Without an explicit interpreter,
 # dbt180/dbt190 are parsed as dbt1.80/dbt1.90 and env creation fails.
 base_python =
+    py39: python3.9
+    py310: python3.10
+    py311: python3.11
+    py312: python3.12
+    py313: python3.13
+    py314: python3.14
     dbt{170,180,190,1100}: python3.12
+    winpy39: python3.9
+    winpy310: python3.10
+    winpy311: python3.11
+    winpy312: python3.12
+    winpy313: python3.13
+    winpy314: python3.14
     dbt{180,190}-winpy: python3.12
 deps =
     -r requirements_dev.txt


### PR DESCRIPTION
### Brief summary of the change made

The latest release of `tox-uv` changed Python spec resolution from env names, breaking the CI pipelines. This PR fixes it by explicitly setting `base_python` for the dbt and python envs, so tox-uv no longer guesses from names like `dbt180` or `py311`.

### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
