### PR TITLE
T-SQL: add support for `CREATE EXTERNAL TABLE AS SELECT` (CETAS)

### DIFF
--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -910,6 +910,7 @@ class StatementSegment(ansi.StatementSegment):
             Ref("SqlcmdCommandSegment"),
             Ref("CreateExternalFileFormat"),
             Ref("CreateExternalTableStatementSegment"),
+            Ref("CreateExternalTableAsSelectStatementSegment"),
             Ref("DropExternalTableStatementSegment"),
             Ref("CopyIntoTableStatementSegment"),
             Ref("CreateFullTextIndexStatementSegment"),
@@ -8235,6 +8236,61 @@ class CreateExternalTableStatementSegment(BaseSegment):
                 ),
             ),
         ),
+    )
+
+
+class CreateExternalTableAsSelectStatementSegment(BaseSegment):
+    """A `CREATE EXTERNAL TABLE AS SELECT` (CETAS) statement.
+
+    https://learn.microsoft.com/en-us/sql/t-sql/statements/create-external-table-as-select-transact-sql
+    """
+
+    type = "create_external_table_as_select_statement"
+
+    match_grammar = Sequence(
+        "CREATE",
+        "EXTERNAL",
+        "TABLE",
+        Ref("ObjectReferenceSegment"),
+        Bracketed(
+            Delimited(
+                Ref("ColumnReferenceSegment"),
+            ),
+            optional=True,
+        ),
+        "WITH",
+        Bracketed(
+            Delimited(
+                Ref("TableLocationClause"),
+                Sequence(
+                    "DATA_SOURCE",
+                    Ref("EqualsSegment"),
+                    Ref("ObjectReferenceSegment"),
+                ),
+                Sequence(
+                    "FILE_FORMAT",
+                    Ref("EqualsSegment"),
+                    Ref("ObjectReferenceSegment"),
+                ),
+                Sequence(
+                    "REJECT_TYPE",
+                    Ref("EqualsSegment"),
+                    OneOf("value", "percentage"),
+                ),
+                Sequence(
+                    "REJECT_VALUE",
+                    Ref("EqualsSegment"),
+                    Ref("NumericLiteralSegment"),
+                ),
+                Sequence(
+                    "REJECT_SAMPLE_VALUE",
+                    Ref("EqualsSegment"),
+                    Ref("NumericLiteralSegment"),
+                ),
+            ),
+        ),
+        "AS",
+        OptionallyBracketed(Ref("SelectableGrammar")),
     )
 
 

--- a/test/fixtures/dialects/tsql/create_external_table_as_select.sql
+++ b/test/fixtures/dialects/tsql/create_external_table_as_select.sql
@@ -1,0 +1,69 @@
+-- Basic CETAS with minimal options
+CREATE EXTERNAL TABLE dbo.MyExternalTable
+WITH (
+    LOCATION = '/path/to/folder/',
+    DATA_SOURCE = my_external_data_source,
+    FILE_FORMAT = my_file_format
+)
+AS SELECT * FROM dbo.SourceTable;
+
+-- CETAS with explicit column list
+CREATE EXTERNAL TABLE dbo.MyExternalTable
+(
+    col1,
+    col2,
+    col3
+)
+WITH (
+    LOCATION = '/path/to/folder/',
+    DATA_SOURCE = my_external_data_source,
+    FILE_FORMAT = my_file_format
+)
+AS SELECT col1, col2, col3 FROM dbo.SourceTable;
+
+-- CETAS with reject options
+CREATE EXTERNAL TABLE schema_name.table_name
+WITH (
+    LOCATION = '/path/to/folder/',
+    DATA_SOURCE = external_data_source,
+    FILE_FORMAT = parquetfileformat,
+    REJECT_TYPE = value,
+    REJECT_VALUE = 0
+)
+AS SELECT * FROM dbo.SourceTable WHERE col1 IS NOT NULL;
+
+-- CETAS with reject sample value
+CREATE EXTERNAL TABLE schema_name.table_name
+WITH (
+    LOCATION = '/path/to/folder/',
+    DATA_SOURCE = external_data_source,
+    FILE_FORMAT = parquetfileformat,
+    REJECT_TYPE = percentage,
+    REJECT_VALUE = 5,
+    REJECT_SAMPLE_VALUE = 100
+)
+AS SELECT * FROM dbo.SourceTable;
+
+-- CETAS with a CTE
+CREATE EXTERNAL TABLE dbo.Summary
+WITH (
+    LOCATION = '/summary/',
+    DATA_SOURCE = my_external_data_source,
+    FILE_FORMAT = my_file_format
+)
+AS
+WITH cte AS (
+    SELECT id, SUM(amount) AS total_amount
+    FROM dbo.Transactions
+    GROUP BY id
+)
+SELECT * FROM cte;
+
+-- CETAS with three-part table name
+CREATE EXTERNAL TABLE database_name.schema_name.table_name
+WITH (
+    LOCATION = '/output/',
+    DATA_SOURCE = my_external_data_source,
+    FILE_FORMAT = my_file_format
+)
+AS SELECT * FROM dbo.SourceTable;

--- a/test/fixtures/dialects/tsql/create_external_table_as_select.yml
+++ b/test/fixtures/dialects/tsql/create_external_table_as_select.yml
@@ -1,0 +1,391 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 596ec25cda7e6337cbe6643932ce6ff927ddbafb6b2f6af748a6252f480c4737
+file:
+  batch:
+  - statement:
+      create_external_table_as_select_statement:
+      - keyword: CREATE
+      - keyword: EXTERNAL
+      - keyword: TABLE
+      - object_reference:
+        - naked_identifier: dbo
+        - dot: .
+        - naked_identifier: MyExternalTable
+      - keyword: WITH
+      - bracketed:
+        - start_bracket: (
+        - table_location_clause:
+            keyword: LOCATION
+            comparison_operator:
+              raw_comparison_operator: '='
+            quoted_literal: "'/path/to/folder/'"
+        - comma: ','
+        - keyword: DATA_SOURCE
+        - comparison_operator:
+            raw_comparison_operator: '='
+        - object_reference:
+            naked_identifier: my_external_data_source
+        - comma: ','
+        - keyword: FILE_FORMAT
+        - comparison_operator:
+            raw_comparison_operator: '='
+        - object_reference:
+            naked_identifier: my_file_format
+        - end_bracket: )
+      - keyword: AS
+      - select_statement:
+          select_clause:
+            keyword: SELECT
+            select_clause_element:
+              wildcard_expression:
+                wildcard_identifier:
+                  star: '*'
+          from_clause:
+            keyword: FROM
+            from_expression:
+              from_expression_element:
+                table_expression:
+                  table_reference:
+                  - naked_identifier: dbo
+                  - dot: .
+                  - naked_identifier: SourceTable
+  - statement_terminator: ;
+  - statement:
+      create_external_table_as_select_statement:
+      - keyword: CREATE
+      - keyword: EXTERNAL
+      - keyword: TABLE
+      - object_reference:
+        - naked_identifier: dbo
+        - dot: .
+        - naked_identifier: MyExternalTable
+      - bracketed:
+        - start_bracket: (
+        - column_reference:
+            naked_identifier: col1
+        - comma: ','
+        - column_reference:
+            naked_identifier: col2
+        - comma: ','
+        - column_reference:
+            naked_identifier: col3
+        - end_bracket: )
+      - keyword: WITH
+      - bracketed:
+        - start_bracket: (
+        - table_location_clause:
+            keyword: LOCATION
+            comparison_operator:
+              raw_comparison_operator: '='
+            quoted_literal: "'/path/to/folder/'"
+        - comma: ','
+        - keyword: DATA_SOURCE
+        - comparison_operator:
+            raw_comparison_operator: '='
+        - object_reference:
+            naked_identifier: my_external_data_source
+        - comma: ','
+        - keyword: FILE_FORMAT
+        - comparison_operator:
+            raw_comparison_operator: '='
+        - object_reference:
+            naked_identifier: my_file_format
+        - end_bracket: )
+      - keyword: AS
+      - select_statement:
+          select_clause:
+          - keyword: SELECT
+          - select_clause_element:
+              column_reference:
+                naked_identifier: col1
+          - comma: ','
+          - select_clause_element:
+              column_reference:
+                naked_identifier: col2
+          - comma: ','
+          - select_clause_element:
+              column_reference:
+                naked_identifier: col3
+          from_clause:
+            keyword: FROM
+            from_expression:
+              from_expression_element:
+                table_expression:
+                  table_reference:
+                  - naked_identifier: dbo
+                  - dot: .
+                  - naked_identifier: SourceTable
+  - statement_terminator: ;
+  - statement:
+      create_external_table_as_select_statement:
+      - keyword: CREATE
+      - keyword: EXTERNAL
+      - keyword: TABLE
+      - object_reference:
+        - naked_identifier: schema_name
+        - dot: .
+        - naked_identifier: table_name
+      - keyword: WITH
+      - bracketed:
+        - start_bracket: (
+        - table_location_clause:
+            keyword: LOCATION
+            comparison_operator:
+              raw_comparison_operator: '='
+            quoted_literal: "'/path/to/folder/'"
+        - comma: ','
+        - keyword: DATA_SOURCE
+        - comparison_operator:
+            raw_comparison_operator: '='
+        - object_reference:
+            naked_identifier: external_data_source
+        - comma: ','
+        - keyword: FILE_FORMAT
+        - comparison_operator:
+            raw_comparison_operator: '='
+        - object_reference:
+            naked_identifier: parquetfileformat
+        - comma: ','
+        - keyword: REJECT_TYPE
+        - comparison_operator:
+            raw_comparison_operator: '='
+        - keyword: value
+        - comma: ','
+        - keyword: REJECT_VALUE
+        - comparison_operator:
+            raw_comparison_operator: '='
+        - numeric_literal: '0'
+        - end_bracket: )
+      - keyword: AS
+      - select_statement:
+          select_clause:
+            keyword: SELECT
+            select_clause_element:
+              wildcard_expression:
+                wildcard_identifier:
+                  star: '*'
+          from_clause:
+            keyword: FROM
+            from_expression:
+              from_expression_element:
+                table_expression:
+                  table_reference:
+                  - naked_identifier: dbo
+                  - dot: .
+                  - naked_identifier: SourceTable
+          where_clause:
+            keyword: WHERE
+            expression:
+            - column_reference:
+                naked_identifier: col1
+            - keyword: IS
+            - keyword: NOT
+            - null_literal: 'NULL'
+  - statement_terminator: ;
+  - statement:
+      create_external_table_as_select_statement:
+      - keyword: CREATE
+      - keyword: EXTERNAL
+      - keyword: TABLE
+      - object_reference:
+        - naked_identifier: schema_name
+        - dot: .
+        - naked_identifier: table_name
+      - keyword: WITH
+      - bracketed:
+        - start_bracket: (
+        - table_location_clause:
+            keyword: LOCATION
+            comparison_operator:
+              raw_comparison_operator: '='
+            quoted_literal: "'/path/to/folder/'"
+        - comma: ','
+        - keyword: DATA_SOURCE
+        - comparison_operator:
+            raw_comparison_operator: '='
+        - object_reference:
+            naked_identifier: external_data_source
+        - comma: ','
+        - keyword: FILE_FORMAT
+        - comparison_operator:
+            raw_comparison_operator: '='
+        - object_reference:
+            naked_identifier: parquetfileformat
+        - comma: ','
+        - keyword: REJECT_TYPE
+        - comparison_operator:
+            raw_comparison_operator: '='
+        - keyword: percentage
+        - comma: ','
+        - keyword: REJECT_VALUE
+        - comparison_operator:
+            raw_comparison_operator: '='
+        - numeric_literal: '5'
+        - comma: ','
+        - keyword: REJECT_SAMPLE_VALUE
+        - comparison_operator:
+            raw_comparison_operator: '='
+        - numeric_literal: '100'
+        - end_bracket: )
+      - keyword: AS
+      - select_statement:
+          select_clause:
+            keyword: SELECT
+            select_clause_element:
+              wildcard_expression:
+                wildcard_identifier:
+                  star: '*'
+          from_clause:
+            keyword: FROM
+            from_expression:
+              from_expression_element:
+                table_expression:
+                  table_reference:
+                  - naked_identifier: dbo
+                  - dot: .
+                  - naked_identifier: SourceTable
+  - statement_terminator: ;
+  - statement:
+      create_external_table_as_select_statement:
+      - keyword: CREATE
+      - keyword: EXTERNAL
+      - keyword: TABLE
+      - object_reference:
+        - naked_identifier: dbo
+        - dot: .
+        - naked_identifier: Summary
+      - keyword: WITH
+      - bracketed:
+        - start_bracket: (
+        - table_location_clause:
+            keyword: LOCATION
+            comparison_operator:
+              raw_comparison_operator: '='
+            quoted_literal: "'/summary/'"
+        - comma: ','
+        - keyword: DATA_SOURCE
+        - comparison_operator:
+            raw_comparison_operator: '='
+        - object_reference:
+            naked_identifier: my_external_data_source
+        - comma: ','
+        - keyword: FILE_FORMAT
+        - comparison_operator:
+            raw_comparison_operator: '='
+        - object_reference:
+            naked_identifier: my_file_format
+        - end_bracket: )
+      - keyword: AS
+      - with_compound_statement:
+          keyword: WITH
+          common_table_expression:
+            naked_identifier: cte
+            keyword: AS
+            bracketed:
+              start_bracket: (
+              select_statement:
+                select_clause:
+                - keyword: SELECT
+                - select_clause_element:
+                    column_reference:
+                      naked_identifier: id
+                - comma: ','
+                - select_clause_element:
+                    function:
+                      function_name:
+                        function_name_identifier: SUM
+                      function_contents:
+                        bracketed:
+                          start_bracket: (
+                          expression:
+                            column_reference:
+                              naked_identifier: amount
+                          end_bracket: )
+                    alias_expression:
+                      alias_operator:
+                        keyword: AS
+                      naked_identifier: total_amount
+                from_clause:
+                  keyword: FROM
+                  from_expression:
+                    from_expression_element:
+                      table_expression:
+                        table_reference:
+                        - naked_identifier: dbo
+                        - dot: .
+                        - naked_identifier: Transactions
+                groupby_clause:
+                - keyword: GROUP
+                - keyword: BY
+                - column_reference:
+                    naked_identifier: id
+              end_bracket: )
+          select_statement:
+            select_clause:
+              keyword: SELECT
+              select_clause_element:
+                wildcard_expression:
+                  wildcard_identifier:
+                    star: '*'
+            from_clause:
+              keyword: FROM
+              from_expression:
+                from_expression_element:
+                  table_expression:
+                    table_reference:
+                      naked_identifier: cte
+  - statement_terminator: ;
+  - statement:
+      create_external_table_as_select_statement:
+      - keyword: CREATE
+      - keyword: EXTERNAL
+      - keyword: TABLE
+      - object_reference:
+        - naked_identifier: database_name
+        - dot: .
+        - naked_identifier: schema_name
+        - dot: .
+        - naked_identifier: table_name
+      - keyword: WITH
+      - bracketed:
+        - start_bracket: (
+        - table_location_clause:
+            keyword: LOCATION
+            comparison_operator:
+              raw_comparison_operator: '='
+            quoted_literal: "'/output/'"
+        - comma: ','
+        - keyword: DATA_SOURCE
+        - comparison_operator:
+            raw_comparison_operator: '='
+        - object_reference:
+            naked_identifier: my_external_data_source
+        - comma: ','
+        - keyword: FILE_FORMAT
+        - comparison_operator:
+            raw_comparison_operator: '='
+        - object_reference:
+            naked_identifier: my_file_format
+        - end_bracket: )
+      - keyword: AS
+      - select_statement:
+          select_clause:
+            keyword: SELECT
+            select_clause_element:
+              wildcard_expression:
+                wildcard_identifier:
+                  star: '*'
+          from_clause:
+            keyword: FROM
+            from_expression:
+              from_expression_element:
+                table_expression:
+                  table_reference:
+                  - naked_identifier: dbo
+                  - dot: .
+                  - naked_identifier: SourceTable
+  - statement_terminator: ;


### PR DESCRIPTION
fixes #7594

<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->

Adds the CETAS syntax as described in the [Microsoft docs](https://learn.microsoft.com/en-us/sql/t-sql/statements/create-external-table-as-select-transact-sql?view=azure-sqldw-latest&preserve-view=true&tabs=powershell) with test cases.

### Are there any other side effects of this change that we should be aware of?

No

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
