### PR TITLE
fix(duckdb): Allow trailing commas in map literals

### DIFF
--- a/src/sqlfluff/dialects/dialect_duckdb.py
+++ b/src/sqlfluff/dialects/dialect_duckdb.py
@@ -441,6 +441,7 @@ class MapLiteralSegment(BaseSegment):
             Delimited(
                 Ref("MapLiteralElementSegment"),
                 optional=True,
+                allow_trailing=True,
             ),
             bracket_type="curly",
         ),

--- a/test/fixtures/dialects/duckdb/map_literal.sql
+++ b/test/fixtures/dialects/duckdb/map_literal.sql
@@ -7,3 +7,10 @@ SELECT MAP {1: 'a', 2: 'b'};
 SELECT MAP {};
 -- Map with IN operator
 SELECT 'key1' IN MAP {'key1': 50, 'key2': 75};
+
+-- Map literal with trailing comma
+SELECT MAP {
+    'key1': 10,
+    'key2': 20,
+    'key3': 30,
+};

--- a/test/fixtures/dialects/duckdb/map_literal.yml
+++ b/test/fixtures/dialects/duckdb/map_literal.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: cb02e19acdc4342153f47076890ccbf8adf5663f02ee192264b1dbf78ed4e6cc
+_hash: 129c12cb8ddfb384b3bdceaa03b749b04df0d4c1fe192bca0ca1eac036fe1933
 file:
 - statement:
     select_statement:
@@ -74,4 +74,29 @@ file:
                 colon: ':'
                 numeric_literal: '75'
             - end_curly_bracket: '}'
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          map_literal:
+          - keyword: MAP
+          - start_curly_bracket: '{'
+          - map_literal_element:
+              quoted_literal: "'key1'"
+              colon: ':'
+              numeric_literal: '10'
+          - comma: ','
+          - map_literal_element:
+              quoted_literal: "'key2'"
+              colon: ':'
+              numeric_literal: '20'
+          - comma: ','
+          - map_literal_element:
+              quoted_literal: "'key3'"
+              colon: ':'
+              numeric_literal: '30'
+          - comma: ','
+          - end_curly_bracket: '}'
 - statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
This is a follow up to #7564 to allow trailing commas in a map for duckdb.

### Are there any other side effects of this change that we should be aware of?
None

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
