### PR TITLE
Oracle: parse TABLESPACE/STORAGE and other table/index options

### DIFF
--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/anynumberof.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/anynumberof.rs
@@ -369,11 +369,6 @@ impl Parser<'_> {
             return Ok(stack.transition_to_combining(frame, None));
         }
 
-        // We no longer "collect tokens", it's all lazy evaluation now.
-        if allow_gaps && *ctx.matched_idx < *ctx.working_idx {
-            *ctx.matched_idx = *ctx.working_idx;
-        }
-
         // Check max_times constraint
         if let Some(max) = max_times {
             if *ctx.count >= max {

--- a/src/sqlfluff/dialects/dialect_oracle.py
+++ b/src/sqlfluff/dialects/dialect_oracle.py
@@ -6,6 +6,7 @@ This inherits from the ansi dialect.
 from sqlfluff.core.dialects import load_raw_dialect
 from sqlfluff.core.parser import (
     AnyNumberOf,
+    AnySetOf,
     Anything,
     BaseFileSegment,
     BaseSegment,
@@ -87,8 +88,8 @@ oracle_dialect.sets("reserved_keywords").update(
         "ELSE",
         "ENABLE",
         "EXCLUSIVE",
-        "EXISTS",
         "EXECUTE",
+        "EXISTS",
         "FILE",
         "FLOAT",
         "FOR",
@@ -152,8 +153,8 @@ oracle_dialect.sets("reserved_keywords").update(
         "REBUILD",
         "RENAME",
         "RESOURCE",
-        "REVOKE",
         "REVERSE",
+        "REVOKE",
         "ROW",
         "ROWID",
         "ROWNUM",
@@ -200,27 +201,36 @@ oracle_dialect.sets("unreserved_keywords").update(
         "ACCESSIBLE",
         "ACTIVE",
         "ADMINISTER",
+        "ADVANCED",
         "ADVISE",
         "ADVISOR",
         "ANALYTIC",
-        "ARCHIVE",
         "ARCHIVAL",
+        "ARCHIVE",
         "AUTHENTICATED",
         "AUTHID",
+        "AUTO",
+        "BASIC",
         "BECOME",
+        "BITMAP",
         "BODY",
+        "BUFFER_POOL",
         "BULK",
-        "COMMITTED",
-        "CONSTRAINTS",
         "BULK_EXCEPTIONS",
         "BULK_ROWCOUNT",
         "BYTE",
+        "CAPACITY",
+        "CELL_FLASH_CACHE",
         "COLLECT",
+        "COMMITTED",
         "COMPILE",
         "COMPOUND",
         "CONSTANT",
+        "CONSTRAINTS",
         "CONTAINER",
         "CONTEXT",
+        "CREATION",
+        "CRITICAL",
         "CROSSEDITION",
         "CURSOR",
         "DBA_RECYCLEBIN",
@@ -234,7 +244,9 @@ oracle_dialect.sets("unreserved_keywords").update(
         "DIRECTIVE",
         "DIRECTORIES",
         "DIRECTORY",
+        "DISTRIBUTE",
         "DML",
+        "DUPLICATE",
         "EDITION",
         "EDITIONABLE",
         "EDITIONING",
@@ -248,14 +260,21 @@ oracle_dialect.sets("unreserved_keywords").update(
         "EXTERNALLY",
         "FINE",
         "FLASHBACK",
+        "FLASH_CACHE",
         "FOLLOWS",
         "FORALL",
+        "FREELIST",
+        "FREELISTS",
         "GLOBALLY",
+        "GROUPS",
         "GUARD",
         "HIERARCHY",
+        "HIGH",
         "HTTP",
         "INDICES",
         "INHERITANY",
+        "INITRANS",
+        "INMEMORY",
         "ISOLATION_LEVEL",
         "ISOPEN",
         "JAVA",
@@ -264,33 +283,50 @@ oracle_dialect.sets("unreserved_keywords").update(
         "LIBRARY",
         "LINK",
         "LOCKDOWN",
+        "LOCKING",
         "LOG",
         "LOGMINING",
         "LOOP",
+        "LOW",
+        "MAXSIZE",
+        "MAXTRANS",
         "MEASURE",
+        "MEDIUM",
+        "MEMCOMPRESS",
+        "MINEXTENTS",
         "MINING",
+        "MOVEMENT",
         "MUTABLE",
         "NESTED",
         "NEXTVAL",
         "NOCOPY",
         "NOMAXVALUE",
         "NOMINVALUE",
+        "NONE",
         "NONEDITIONABLE",
-        "NOTHING",
+        "NOPARALLEL",
+        "NOROWDEPENDENCIES",
+        "NOSORT",
         "NOTFOUND",
+        "NOTHING",
         "OID",
+        "OLTP",
+        "OPTIMAL",
         "OUTLINE",
         "PACKAGE",
         "PAIRS",
         "PARALLEL",
         "PARALLEL_ENABLE",
         "PARENT",
+        "PCTINCREASE",
+        "PCTUSED",
         "PERSISTABLE",
         "PIPELINED",
         "PLUGGABLE",
         "POLYMORPHIC",
         "PRAGMA",
         "PRECEDES",
+        "PRIORITY",
         "PRIVILEGE",
         "PROFILE",
         "PROGRAM",
@@ -299,6 +335,7 @@ oracle_dialect.sets("unreserved_keywords").update(
         "QUOTA",
         "RAISE",
         "RECORD",
+        "RECYCLE",
         "REDACTION",
         "REDEFINE",
         "REFRESH",
@@ -312,21 +349,26 @@ oracle_dialect.sets("unreserved_keywords").update(
         "REUSE",
         "REVERSE",
         "REWRITE",
+        "ROWDEPENDENCIES",
         "ROWTYPE",
         "SCHEDULER",
+        "SEGMENT",
         "SERIALIZABLE",
         "SERVICE",
         "SHARD",
         "SHARD_ENABLE",
-        "SYNC",
         "SHARED",
         "SHARING",
         "SIGN",
         "SPECIFICATION",
         "SQL_MACRO",
+        "STORAGE",
+        "STORE",
+        "SUBPARTITION",
+        "SYNC",
         "SYSGUID",
-        "TIME_ZONE",
         "TIMEOUT",
+        "TIME_ZONE",
         "UNLIMITED",
         "VARRAY",
         "VISIBILITY",
@@ -1604,10 +1646,12 @@ class CreateTableStatementSegment(BaseSegment):
                 ),
                 Ref("CommentClauseSegment", optional=True),
                 Ref("OnCommitGrammar", optional=True),
+                Ref("OraclePhysicalAttributesSegment", optional=True),
             ),
             # Create AS syntax:
             Sequence(
                 Ref("OnCommitGrammar", optional=True),
+                Ref("OraclePhysicalAttributesSegment", optional=True),
                 "AS",
                 OptionallyBracketed(Ref("SelectableGrammar")),
             ),
@@ -1615,6 +1659,30 @@ class CreateTableStatementSegment(BaseSegment):
             Sequence("LIKE", Ref("TableReferenceSegment")),
         ),
         Ref("TableEndClauseSegment", optional=True),
+    )
+
+
+class CreateIndexStatementSegment(ansi.CreateIndexStatementSegment):
+    """A CREATE INDEX statement, Oracle-specific extension.
+
+    https://docs.oracle.com/en/database/oracle/oracle-database/23/sqlrf/CREATE-INDEX.html
+    """
+
+    type = "create_index_statement"
+
+    match_grammar: Matchable = Sequence(
+        "CREATE",
+        OneOf(Ref.keyword("UNIQUE"), Ref.keyword("BITMAP"), optional=True),
+        "INDEX",
+        Ref("IndexReferenceSegment"),
+        "ON",
+        Ref("TableReferenceSegment"),
+        Bracketed(
+            Delimited(
+                Ref("IndexColumnDefinitionSegment"),
+            ),
+        ),
+        Ref("OracleIndexPhysicalAttributesSegment", optional=True),
     )
 
 
@@ -2072,6 +2140,299 @@ class TableExpressionSegment(ansi.TableExpressionSegment):
     )
 
 
+class StorageClauseSegment(BaseSegment):
+    """Oracle STORAGE clause for tables and indexes.
+
+    https://docs.oracle.com/en/database/oracle/oracle-database/23/sqlrf/storage_clause.html
+    """
+
+    type = "storage_clause"
+
+    match_grammar: Matchable = Sequence(
+        "STORAGE",
+        Bracketed(
+            AnySetOf(
+                Sequence(
+                    "INITIAL",
+                    OneOf(Ref("SizeClauseGrammar"), Ref("NumericLiteralSegment")),
+                ),
+                Sequence(
+                    "NEXT",
+                    OneOf(Ref("SizeClauseGrammar"), Ref("NumericLiteralSegment")),
+                ),
+                Sequence("MINEXTENTS", Ref("NumericLiteralSegment")),
+                Sequence(
+                    "MAXEXTENTS",
+                    OneOf(Ref("NumericLiteralSegment"), "UNLIMITED"),
+                ),
+                Sequence("PCTINCREASE", Ref("NumericLiteralSegment")),
+                Sequence("FREELISTS", Ref("NumericLiteralSegment")),
+                Sequence("FREELIST", "GROUPS", Ref("NumericLiteralSegment")),
+                Sequence("BUFFER_POOL", OneOf("DEFAULT", "KEEP", "RECYCLE")),
+                Sequence("FLASH_CACHE", OneOf("DEFAULT", "KEEP", "NONE")),
+                Sequence("CELL_FLASH_CACHE", OneOf("DEFAULT", "KEEP", "NONE")),
+                # Max size (used for LOB segments)
+                Sequence(
+                    "MAXSIZE",
+                    OneOf(
+                        "UNLIMITED",
+                        Ref("SizeClauseGrammar"),
+                        Ref("NumericLiteralSegment"),
+                    ),
+                ),
+                # Optimal size (rollback segments only)
+                Sequence(
+                    "OPTIMAL",
+                    OneOf(
+                        "NULL", Ref("SizeClauseGrammar"), Ref("NumericLiteralSegment")
+                    ),
+                ),
+                min_times=1,
+            ),
+            # Use GREEDY parse mode so that once we match the opening
+            # `STORAGE (` we commit to consuming everything up to the
+            # closing `)`. This prevents the parser from backtracking and
+            # interpreting `STORAGE(...)` as a function call when the
+            # inner content is invalid (for example duplicate sub-params).
+            # Instead, invalid inner tokens become unparsable children
+            # of the `storage_clause`, which correctly surfaces the
+            # syntax error at the clause level.
+            parse_mode=ParseMode.GREEDY,
+        ),
+    )
+
+
+class OraclePhysicalAttributesSegment(BaseSegment):
+    """Oracle physical properties for tables.
+
+    https://docs.oracle.com/en/database/oracle/oracle-database/23/sqlrf/CREATE-TABLE.html
+    """
+
+    type = "oracle_physical_attributes"
+
+    match_grammar: Matchable = AnySetOf(
+        # Segment creation policy (Oracle 11g+)
+        Sequence("SEGMENT", "CREATION", OneOf("IMMEDIATE", "DEFERRED")),
+        # Tablespace placement
+        Sequence("TABLESPACE", Ref("ObjectReferenceSegment")),
+        # Block-level space management
+        Sequence("PCTFREE", Ref("NumericLiteralSegment")),
+        Sequence("PCTUSED", Ref("NumericLiteralSegment")),
+        Sequence("INITRANS", Ref("NumericLiteralSegment")),
+        Sequence("MAXTRANS", Ref("NumericLiteralSegment")),
+        # Extent/storage parameters
+        Ref("StorageClauseSegment"),
+        # Redo logging
+        OneOf("LOGGING", "NOLOGGING"),
+        # Parallelism
+        OneOf(
+            "NOPARALLEL",
+            Sequence("PARALLEL", Ref("NumericLiteralSegment", optional=True)),
+        ),
+        # Buffer cache
+        OneOf("NOCACHE", "CACHE"),
+        # Table/partition compression
+        OneOf(
+            "NOCOMPRESS",
+            Sequence(
+                "COMPRESS",
+                Sequence(
+                    "FOR",
+                    OneOf(
+                        "OLTP",
+                        Sequence(
+                            "QUERY",
+                            OneOf("LOW", "HIGH", optional=True),
+                        ),
+                        Sequence(
+                            "ARCHIVE",
+                            OneOf("LOW", "HIGH", optional=True),
+                        ),
+                    ),
+                    optional=True,
+                ),
+            ),
+            # ROW STORE COMPRESS [ BASIC | ADVANCED ] (Oracle 11g+)
+            Sequence(
+                "ROW",
+                "STORE",
+                "COMPRESS",
+                OneOf("BASIC", "ADVANCED", optional=True),
+            ),
+            # COLUMN STORE COMPRESS (HCC / Exadata)
+            Sequence(
+                "COLUMN",
+                "STORE",
+                "COMPRESS",
+                Sequence(
+                    "FOR",
+                    OneOf(
+                        Sequence("QUERY", OneOf("LOW", "HIGH", optional=True)),
+                        Sequence("ARCHIVE", OneOf("LOW", "HIGH", optional=True)),
+                    ),
+                    optional=True,
+                ),
+                Sequence("NO", "ROW", "LEVEL", "LOCKING", optional=True),
+            ),
+        ),
+        # Monitoring (deprecated but still valid)
+        OneOf("MONITORING", "NOMONITORING"),
+        # Row movement
+        Sequence(OneOf("ENABLE", "DISABLE"), "ROW", "MOVEMENT"),
+        # Result cache
+        Sequence(
+            "RESULT_CACHE",
+            Bracketed(
+                Sequence("MODE", OneOf("DEFAULT", "FORCE")),
+            ),
+        ),
+        # In-Memory column store (12c+)
+        OneOf(
+            Sequence(
+                "INMEMORY",
+                AnySetOf(
+                    OneOf(
+                        Sequence("NO", "MEMCOMPRESS"),
+                        Sequence(
+                            "MEMCOMPRESS",
+                            "FOR",
+                            OneOf(
+                                "DML",
+                                Sequence("QUERY", OneOf("LOW", "HIGH", optional=True)),
+                                Sequence(
+                                    "CAPACITY", OneOf("LOW", "HIGH", optional=True)
+                                ),
+                                Sequence(
+                                    "ARCHIVE", OneOf("LOW", "HIGH", optional=True)
+                                ),
+                            ),
+                        ),
+                    ),
+                    Sequence(
+                        "PRIORITY",
+                        OneOf("NONE", "LOW", "MEDIUM", "HIGH", "CRITICAL"),
+                    ),
+                    # NOTE: Both the AUTO/BY and FOR SERVICE sub-options are
+                    # individually optional. This means bare `DISTRIBUTE`
+                    # (with neither sub-option) is accepted by the grammar.
+                    # This is intentional: Oracle allows `DISTRIBUTE` alone
+                    # to reset to the default distribution method.
+                    Sequence(
+                        "DISTRIBUTE",
+                        OneOf(
+                            "AUTO",
+                            Sequence(
+                                "BY",
+                                OneOf(
+                                    Sequence("ROWID", "RANGE"),
+                                    "PARTITION",
+                                    "SUBPARTITION",
+                                ),
+                            ),
+                            optional=True,
+                        ),
+                        Sequence(
+                            "FOR",
+                            "SERVICE",
+                            OneOf(
+                                "DEFAULT",
+                                "ALL",
+                                "NONE",
+                                Ref("ObjectReferenceSegment"),
+                            ),
+                            optional=True,
+                        ),
+                    ),
+                    OneOf(
+                        Sequence("DUPLICATE", Ref.keyword("ALL", optional=True)),
+                        Sequence("NO", "DUPLICATE"),
+                    ),
+                ),
+            ),
+            Sequence("NO", "INMEMORY"),
+        ),
+        # Flashback archive
+        OneOf(
+            Sequence(
+                "FLASHBACK",
+                "ARCHIVE",
+                Ref("ObjectReferenceSegment", optional=True),
+            ),
+            Sequence("NO", "FLASHBACK", "ARCHIVE"),
+        ),
+        # Row dependency tracking
+        OneOf("ROWDEPENDENCIES", "NOROWDEPENDENCIES"),
+        min_times=1,
+    )
+
+
+class OracleIndexPhysicalAttributesSegment(BaseSegment):
+    """Oracle physical attributes valid specifically inside CREATE INDEX.
+
+    https://docs.oracle.com/en/database/oracle/oracle-database/23/sqlrf/CREATE-INDEX.html
+    """
+
+    type = "oracle_index_physical_attributes"
+
+    match_grammar: Matchable = AnySetOf(
+        # Tablespace placement
+        Sequence("TABLESPACE", Ref("ObjectReferenceSegment")),
+        # Block-level space management (PCTUSED excluded – index-only allows PCTFREE)
+        Sequence("PCTFREE", Ref("NumericLiteralSegment")),
+        Sequence("INITRANS", Ref("NumericLiteralSegment")),
+        # MAXTRANS is deprecated for indexes since Oracle 10g and not present
+        # in the Oracle 23c CREATE INDEX grammar. It is retained here for
+        # backward-compatibility with older Oracle versions (<=10g).
+        # TODO: consider removing this entry when support for legacy Oracle
+        # versions is dropped (track by minimum supported Oracle version).
+        Sequence("MAXTRANS", Ref("NumericLiteralSegment")),
+        # Extent/storage parameters
+        Ref("StorageClauseSegment"),
+        # Redo logging
+        OneOf("LOGGING", "NOLOGGING"),
+        # Parallelism
+        OneOf(
+            "NOPARALLEL",
+            Sequence("PARALLEL", Ref("NumericLiteralSegment", optional=True)),
+        ),
+        # Key-prefix compression: COMPRESS [integer] | NOCOMPRESS
+        OneOf(
+            "NOCOMPRESS",
+            Sequence(
+                "COMPRESS",
+                Ref("NumericLiteralSegment", optional=True),
+            ),
+        ),
+        # NOSORT and REVERSE
+        OneOf("NOSORT", "REVERSE"),
+        # Visibility
+        OneOf("VISIBLE", "INVISIBLE"),
+        # Online build
+        "ONLINE",
+        min_times=1,
+    )
+
+
+class UsingIndexClauseSegment(BaseSegment):
+    """Oracle USING INDEX clause within a constraint definition.
+
+    https://docs.oracle.com/en/database/oracle/oracle-database/23/sqlrf/constraint.html
+    """
+
+    type = "using_index_clause"
+
+    match_grammar: Matchable = Sequence(
+        "USING",
+        "INDEX",
+        OneOf(
+            Ref("IndexReferenceSegment"),
+            Bracketed(Ref("CreateIndexStatementSegment")),
+            Ref("OracleIndexPhysicalAttributesSegment"),
+            optional=True,
+        ),
+    )
+
+
 class TableConstraintSegment(ansi.TableConstraintSegment):
     """A table constraint, e.g. for CREATE TABLE.
 
@@ -2095,13 +2456,13 @@ class TableConstraintSegment(ansi.TableConstraintSegment):
             Sequence(  # UNIQUE ( column_name [, ... ] )
                 "UNIQUE",
                 Ref("BracketedColumnReferenceListGrammar"),
-                # Later add support for index_parameters?
+                Ref("UsingIndexClauseSegment", optional=True),
             ),
             Sequence(  # PRIMARY KEY ( column_name [, ... ] ) index_parameters
                 Ref("PrimaryKeyGrammar"),
                 # Columns making up PRIMARY KEY constraint
                 Ref("BracketedColumnReferenceListGrammar"),
-                # Later add support for index_parameters?
+                Ref("UsingIndexClauseSegment", optional=True),
             ),
             Sequence(  # FOREIGN KEY ( column_name [, ... ] )
                 # REFERENCES reftable [ ( refcolumn [, ... ] ) ]

--- a/test/dialects/oracle_test.py
+++ b/test/dialects/oracle_test.py
@@ -1,0 +1,147 @@
+"""Oracle dialect specific parser rejection tests.
+
+Verifies that duplicate attributes and mutually-exclusive pairs in Oracle
+physical-attribute segments are rejected at parse time (AnySetOf semantics).
+
+Positive/valid-SQL cases belong in the SQL/YAML parse fixtures under
+test/fixtures/dialects/oracle/ per project convention.
+"""
+
+import pytest
+
+from sqlfluff.core import Linter
+
+
+def _violations(sql: str) -> list:
+    """Return all parse errors, including unparsable nodes anywhere in the tree.
+
+    Top-level parse failures surface in parsed.violations, but content that
+    cannot be matched inside a Bracketed clause is silently wrapped in an
+    unparsable tree node without raising a SQLParseError. We collect both so
+    that rejection tests for STORAGE(...) sub-parameters work correctly.
+    """
+    parsed = Linter(dialect="oracle").parse_string(sql)
+    violations: list = list(parsed.violations)
+    if parsed.tree:
+        violations += list(parsed.tree.recursive_crawl("unparsable"))
+    return violations
+
+
+# OraclePhysicalAttributesSegment - table-level attributes
+@pytest.mark.parametrize(
+    "sql",
+    [
+        # Duplicate scalar attributes
+        pytest.param(
+            "CREATE TABLE t (c NUMBER) PCTFREE 10 PCTFREE 20;",
+            id="dup_pctfree",
+        ),
+        pytest.param(
+            "CREATE TABLE t (c NUMBER) PCTUSED 40 PCTUSED 60;",
+            id="dup_pctused",
+        ),
+        pytest.param(
+            "CREATE TABLE t (c NUMBER) INITRANS 2 INITRANS 4;",
+            id="dup_initrans",
+        ),
+        pytest.param(
+            "CREATE TABLE t (c NUMBER) MAXTRANS 255 MAXTRANS 100;",
+            id="dup_maxtrans",
+        ),
+        # Mutually exclusive pairs
+        pytest.param(
+            "CREATE TABLE t (c NUMBER) LOGGING NOLOGGING;",
+            id="logging_nologging",
+        ),
+        pytest.param(
+            "CREATE TABLE t (c NUMBER) MONITORING NOMONITORING;",
+            id="monitoring_nomonitoring",
+        ),
+        pytest.param(
+            "CREATE TABLE t (c NUMBER) ROWDEPENDENCIES NOROWDEPENDENCIES;",
+            id="rowdep_norowdep",
+        ),
+        pytest.param(
+            "CREATE TABLE t (c NUMBER) CACHE NOCACHE;",
+            id="cache_nocache",
+        ),
+    ],
+)
+def test_table_physical_attrs_rejected(sql: str) -> None:
+    """Duplicate or mutually-exclusive table physical attributes must produce a parse violation."""
+    assert _violations(sql) != [], f"Expected violations but got none for:\n{sql}"
+
+
+# StorageClauseSegment - STORAGE(...) sub-parameters
+@pytest.mark.parametrize(
+    "sql",
+    [
+        pytest.param(
+            "CREATE TABLE t (c NUMBER) STORAGE (INITIAL 256K INITIAL 512K);",
+            id="storage_dup_initial",
+        ),
+        pytest.param(
+            "CREATE TABLE t (c NUMBER) STORAGE (NEXT 64K NEXT 128K);",
+            id="storage_dup_next",
+        ),
+        pytest.param(
+            "CREATE TABLE t (c NUMBER) STORAGE (MAXEXTENTS 100 MAXEXTENTS 200);",
+            id="storage_dup_maxextents",
+        ),
+        pytest.param(
+            "CREATE TABLE t (c NUMBER) STORAGE (PCTINCREASE 0 PCTINCREASE 10);",
+            id="storage_dup_pctincrease",
+        ),
+        pytest.param(
+            "CREATE TABLE t (c NUMBER) STORAGE (BUFFER_POOL DEFAULT BUFFER_POOL KEEP);",
+            id="storage_dup_buffer_pool",
+        ),
+    ],
+)
+def test_storage_clause_rejected(sql: str) -> None:
+    """Duplicate STORAGE sub-parameters must produce a parse violation."""
+    assert _violations(sql) != [], f"Expected violations but got none for:\n{sql}"
+
+
+# INMEMORY subclause AnySetOf enforcement
+@pytest.mark.parametrize(
+    "sql",
+    [
+        pytest.param(
+            "CREATE TABLE t (c NUMBER) INMEMORY PRIORITY LOW PRIORITY HIGH;",
+            id="inmemory_dup_priority",
+        ),
+    ],
+)
+def test_inmemory_subclauses_rejected(sql: str) -> None:
+    """Duplicate INMEMORY subclauses must produce a parse violation."""
+    assert _violations(sql) != [], f"Expected violations but got none for:\n{sql}"
+
+
+# OracleIndexPhysicalAttributesSegment - index-level attributes
+@pytest.mark.parametrize(
+    "sql",
+    [
+        # Duplicate scalar attributes
+        pytest.param(
+            "CREATE INDEX i ON t (c) PCTFREE 10 PCTFREE 20;",
+            id="index_dup_pctfree",
+        ),
+        # Mutually exclusive pairs
+        pytest.param(
+            "CREATE INDEX i ON t (c) LOGGING NOLOGGING;",
+            id="index_logging_nologging",
+        ),
+        pytest.param(
+            "CREATE INDEX i ON t (c) NOSORT REVERSE;",
+            id="index_nosort_reverse",
+        ),
+        pytest.param(
+            "CREATE INDEX i ON t (c) VISIBLE INVISIBLE;",
+            id="index_visible_invisible",
+        ),
+    ],
+)
+def test_index_physical_attrs_rejected(sql: str) -> None:
+    """Duplicate or mutually-exclusive index physical attributes must produce a parse violation."""
+    assert _violations(sql) != [], f"Expected violations but got none for:\n{sql}"

--- a/test/fixtures/dialects/oracle/create_index.sql
+++ b/test/fixtures/dialects/oracle/create_index.sql
@@ -1,0 +1,193 @@
+CREATE INDEX s1.t_basic_idx ON s1.t (col1);
+
+CREATE INDEX s1.t_multi_idx ON s1.t (col1, col2, col3);
+
+CREATE UNIQUE INDEX s1.t_unique_idx ON s1.t (col1, col2);
+
+CREATE BITMAP INDEX s1.t_bitmap_idx ON s1.t (status_col);
+
+CREATE INDEX s1.t_schema_idx ON s1.t (col1);
+
+CREATE INDEX s1.t_ts_idx ON s1.t (col1)
+
+TABLESPACE idx_ts;
+
+-- Physical attributes
+CREATE INDEX s1.t_pct_idx ON s1.t (col1)
+PCTFREE 10
+INITRANS 2
+MAXTRANS 255
+TABLESPACE idx_ts;
+
+CREATE INDEX s1.t_storage_idx ON s1.t (col1)
+TABLESPACE idx_ts
+STORAGE (
+    INITIAL 256K
+    NEXT 256K
+    MINEXTENTS 1
+    MAXEXTENTS UNLIMITED
+    PCTINCREASE 0
+    FREELISTS 1
+    FREELIST GROUPS 1
+    BUFFER_POOL DEFAULT
+);
+
+CREATE INDEX s1.t_storage_keep_idx ON s1.t (col1)
+TABLESPACE idx_ts
+STORAGE (
+    INITIAL 512K
+    NEXT 512K
+    MAXEXTENTS UNLIMITED
+    BUFFER_POOL KEEP
+);
+
+CREATE INDEX s1.t_storage_recycle_idx ON s1.t (col1)
+TABLESPACE idx_ts
+STORAGE (
+    INITIAL 128K
+    NEXT 128K
+    MAXEXTENTS 500
+    BUFFER_POOL RECYCLE
+);
+
+-- Logging / redo
+CREATE INDEX s1.t_logging_idx ON s1.t (col1)
+TABLESPACE idx_ts
+LOGGING;
+
+CREATE INDEX s1.t_nologging_idx ON s1.t (col1)
+TABLESPACE idx_ts
+NOLOGGING;
+
+-- Parallelism: PARALLEL degree and NOPARALLEL
+CREATE INDEX s1.t_parallel_idx ON s1.t (col1)
+TABLESPACE idx_ts
+PARALLEL 4;
+
+CREATE INDEX s1.t_parallel_default_idx ON s1.t (col1)
+TABLESPACE idx_ts
+PARALLEL;
+
+CREATE INDEX s1.t_noparallel_idx ON s1.t (col1)
+TABLESPACE idx_ts
+NOPARALLEL;
+
+-- ONLINE index build
+CREATE INDEX s1.t_online_idx ON s1.t (col1)
+TABLESPACE idx_ts
+ONLINE;
+
+-- Bare COMPRESS (uses default prefix length)
+CREATE INDEX s1.t_compress_idx ON s1.t (col1, col2)
+TABLESPACE idx_ts
+COMPRESS;
+
+-- COMPRESS with integer: compress first n leading key columns
+CREATE INDEX s1.t_compress_1_idx ON s1.t (col1, col2, col3)
+TABLESPACE idx_ts
+COMPRESS 1;
+
+-- COMPRESS 2 on composite unique index
+CREATE UNIQUE INDEX s1.t_compress_2_unique_idx ON s1.t (col1, col2, col3)
+TABLESPACE idx_ts
+COMPRESS 2;
+
+CREATE INDEX s1.t_nocompress_idx ON s1.t (col1)
+TABLESPACE idx_ts
+NOCOMPRESS;
+
+-- REVERSE key index
+CREATE INDEX s1.t_reverse_idx ON s1.t (col1)
+TABLESPACE idx_ts
+REVERSE;
+
+-- VISIBLE / INVISIBLE
+CREATE INDEX s1.t_visible_idx ON s1.t (col1)
+TABLESPACE idx_ts
+VISIBLE;
+
+CREATE INDEX s1.t_invisible_idx ON s1.t (col1)
+TABLESPACE idx_ts
+INVISIBLE;
+
+-- Ascending / descending column order
+CREATE INDEX s1.t_asc_desc_idx ON s1.t (col1 ASC, col2 DESC, col3 ASC);
+
+-- NOLOGGING + full STORAGE + PARALLEL combined
+CREATE INDEX s1.t_full_phys_idx
+    ON s1.t (col1, col2)
+TABLESPACE idx_ts
+NOLOGGING
+PCTFREE 10
+INITRANS 2
+MAXTRANS 255
+STORAGE (
+    INITIAL 655K
+    NEXT 655K
+    MINEXTENTS 1
+    MAXEXTENTS UNLIMITED
+    PCTINCREASE 50
+    FREELISTS 1
+    FREELIST GROUPS 1
+    BUFFER_POOL DEFAULT
+)
+PARALLEL 8
+NOCOMPRESS
+VISIBLE;
+
+-- Other
+CREATE INDEX s1.t_nosort_idx ON s1.t (col1)
+TABLESPACE idx_ts
+NOSORT;
+
+CREATE INDEX s1.t_nosort_attrs_idx ON s1.t (col1, col2)
+TABLESPACE idx_ts
+PCTFREE 10
+INITRANS 2
+NOLOGGING
+NOSORT;
+
+CREATE INDEX s1.t_reverse_attrs_idx ON s1.t (col1)
+TABLESPACE idx_ts
+PCTFREE 10
+NOLOGGING
+REVERSE;
+
+-- Comprehensive examples
+CREATE INDEX s1.log_instdati_idx
+    ON s1.log (institution_id, datetime)
+PCTFREE 10
+INITRANS 2
+MAXTRANS 255
+TABLESPACE idx_ts
+STORAGE (
+    INITIAL 655K
+    NEXT 655K
+    MINEXTENTS 1
+    MAXEXTENTS UNLIMITED
+    PCTINCREASE 50
+    FREELISTS 1
+    FREELIST GROUPS 1
+    BUFFER_POOL DEFAULT
+)
+NOLOGGING
+NOPARALLEL;
+
+CREATE UNIQUE INDEX s1.filter_instkeytype_idx
+    ON s1.filter (institution_id, filterkey, filtertype_id)
+PCTFREE 10
+INITRANS 2
+MAXTRANS 255
+TABLESPACE idx_ts
+STORAGE (
+    INITIAL 140K
+    NEXT 360K
+    MINEXTENTS 1
+    MAXEXTENTS UNLIMITED
+    PCTINCREASE 50
+    FREELISTS 1
+    FREELIST GROUPS 1
+    BUFFER_POOL DEFAULT
+)
+NOLOGGING
+PARALLEL 4;

--- a/test/fixtures/dialects/oracle/create_index.yml
+++ b/test/fixtures/dialects/oracle/create_index.yml
@@ -1,0 +1,913 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 532b899bf0a1b5871868dec909b1d218c69e3fabfaf3f6a7a25ef4af2500ad63
+file:
+  batch:
+  - statement:
+      create_index_statement:
+      - keyword: CREATE
+      - keyword: INDEX
+      - index_reference:
+        - naked_identifier: s1
+        - dot: .
+        - naked_identifier: t_basic_idx
+      - keyword: 'ON'
+      - table_reference:
+        - naked_identifier: s1
+        - dot: .
+        - naked_identifier: t
+      - bracketed:
+          start_bracket: (
+          index_column_definition:
+            naked_identifier: col1
+          end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      create_index_statement:
+      - keyword: CREATE
+      - keyword: INDEX
+      - index_reference:
+        - naked_identifier: s1
+        - dot: .
+        - naked_identifier: t_multi_idx
+      - keyword: 'ON'
+      - table_reference:
+        - naked_identifier: s1
+        - dot: .
+        - naked_identifier: t
+      - bracketed:
+        - start_bracket: (
+        - index_column_definition:
+            naked_identifier: col1
+        - comma: ','
+        - index_column_definition:
+            naked_identifier: col2
+        - comma: ','
+        - index_column_definition:
+            naked_identifier: col3
+        - end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      create_index_statement:
+      - keyword: CREATE
+      - keyword: UNIQUE
+      - keyword: INDEX
+      - index_reference:
+        - naked_identifier: s1
+        - dot: .
+        - naked_identifier: t_unique_idx
+      - keyword: 'ON'
+      - table_reference:
+        - naked_identifier: s1
+        - dot: .
+        - naked_identifier: t
+      - bracketed:
+        - start_bracket: (
+        - index_column_definition:
+            naked_identifier: col1
+        - comma: ','
+        - index_column_definition:
+            naked_identifier: col2
+        - end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      create_index_statement:
+      - keyword: CREATE
+      - keyword: BITMAP
+      - keyword: INDEX
+      - index_reference:
+        - naked_identifier: s1
+        - dot: .
+        - naked_identifier: t_bitmap_idx
+      - keyword: 'ON'
+      - table_reference:
+        - naked_identifier: s1
+        - dot: .
+        - naked_identifier: t
+      - bracketed:
+          start_bracket: (
+          index_column_definition:
+            naked_identifier: status_col
+          end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      create_index_statement:
+      - keyword: CREATE
+      - keyword: INDEX
+      - index_reference:
+        - naked_identifier: s1
+        - dot: .
+        - naked_identifier: t_schema_idx
+      - keyword: 'ON'
+      - table_reference:
+        - naked_identifier: s1
+        - dot: .
+        - naked_identifier: t
+      - bracketed:
+          start_bracket: (
+          index_column_definition:
+            naked_identifier: col1
+          end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      create_index_statement:
+      - keyword: CREATE
+      - keyword: INDEX
+      - index_reference:
+        - naked_identifier: s1
+        - dot: .
+        - naked_identifier: t_ts_idx
+      - keyword: 'ON'
+      - table_reference:
+        - naked_identifier: s1
+        - dot: .
+        - naked_identifier: t
+      - bracketed:
+          start_bracket: (
+          index_column_definition:
+            naked_identifier: col1
+          end_bracket: )
+      - oracle_index_physical_attributes:
+          keyword: TABLESPACE
+          object_reference:
+            naked_identifier: idx_ts
+  - statement_terminator: ;
+  - statement:
+      create_index_statement:
+      - keyword: CREATE
+      - keyword: INDEX
+      - index_reference:
+        - naked_identifier: s1
+        - dot: .
+        - naked_identifier: t_pct_idx
+      - keyword: 'ON'
+      - table_reference:
+        - naked_identifier: s1
+        - dot: .
+        - naked_identifier: t
+      - bracketed:
+          start_bracket: (
+          index_column_definition:
+            naked_identifier: col1
+          end_bracket: )
+      - oracle_index_physical_attributes:
+        - keyword: PCTFREE
+        - numeric_literal: '10'
+        - keyword: INITRANS
+        - numeric_literal: '2'
+        - keyword: MAXTRANS
+        - numeric_literal: '255'
+        - keyword: TABLESPACE
+        - object_reference:
+            naked_identifier: idx_ts
+  - statement_terminator: ;
+  - statement:
+      create_index_statement:
+      - keyword: CREATE
+      - keyword: INDEX
+      - index_reference:
+        - naked_identifier: s1
+        - dot: .
+        - naked_identifier: t_storage_idx
+      - keyword: 'ON'
+      - table_reference:
+        - naked_identifier: s1
+        - dot: .
+        - naked_identifier: t
+      - bracketed:
+          start_bracket: (
+          index_column_definition:
+            naked_identifier: col1
+          end_bracket: )
+      - oracle_index_physical_attributes:
+          keyword: TABLESPACE
+          object_reference:
+            naked_identifier: idx_ts
+          storage_clause:
+            keyword: STORAGE
+            bracketed:
+            - start_bracket: (
+            - keyword: INITIAL
+            - numeric_literal: '256'
+            - size_prefix: K
+            - keyword: NEXT
+            - numeric_literal: '256'
+            - size_prefix: K
+            - keyword: MINEXTENTS
+            - numeric_literal: '1'
+            - keyword: MAXEXTENTS
+            - keyword: UNLIMITED
+            - keyword: PCTINCREASE
+            - numeric_literal: '0'
+            - keyword: FREELISTS
+            - numeric_literal: '1'
+            - keyword: FREELIST
+            - keyword: GROUPS
+            - numeric_literal: '1'
+            - keyword: BUFFER_POOL
+            - keyword: DEFAULT
+            - end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      create_index_statement:
+      - keyword: CREATE
+      - keyword: INDEX
+      - index_reference:
+        - naked_identifier: s1
+        - dot: .
+        - naked_identifier: t_storage_keep_idx
+      - keyword: 'ON'
+      - table_reference:
+        - naked_identifier: s1
+        - dot: .
+        - naked_identifier: t
+      - bracketed:
+          start_bracket: (
+          index_column_definition:
+            naked_identifier: col1
+          end_bracket: )
+      - oracle_index_physical_attributes:
+          keyword: TABLESPACE
+          object_reference:
+            naked_identifier: idx_ts
+          storage_clause:
+            keyword: STORAGE
+            bracketed:
+            - start_bracket: (
+            - keyword: INITIAL
+            - numeric_literal: '512'
+            - size_prefix: K
+            - keyword: NEXT
+            - numeric_literal: '512'
+            - size_prefix: K
+            - keyword: MAXEXTENTS
+            - keyword: UNLIMITED
+            - keyword: BUFFER_POOL
+            - keyword: KEEP
+            - end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      create_index_statement:
+      - keyword: CREATE
+      - keyword: INDEX
+      - index_reference:
+        - naked_identifier: s1
+        - dot: .
+        - naked_identifier: t_storage_recycle_idx
+      - keyword: 'ON'
+      - table_reference:
+        - naked_identifier: s1
+        - dot: .
+        - naked_identifier: t
+      - bracketed:
+          start_bracket: (
+          index_column_definition:
+            naked_identifier: col1
+          end_bracket: )
+      - oracle_index_physical_attributes:
+          keyword: TABLESPACE
+          object_reference:
+            naked_identifier: idx_ts
+          storage_clause:
+            keyword: STORAGE
+            bracketed:
+            - start_bracket: (
+            - keyword: INITIAL
+            - numeric_literal: '128'
+            - size_prefix: K
+            - keyword: NEXT
+            - numeric_literal: '128'
+            - size_prefix: K
+            - keyword: MAXEXTENTS
+            - numeric_literal: '500'
+            - keyword: BUFFER_POOL
+            - keyword: RECYCLE
+            - end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      create_index_statement:
+      - keyword: CREATE
+      - keyword: INDEX
+      - index_reference:
+        - naked_identifier: s1
+        - dot: .
+        - naked_identifier: t_logging_idx
+      - keyword: 'ON'
+      - table_reference:
+        - naked_identifier: s1
+        - dot: .
+        - naked_identifier: t
+      - bracketed:
+          start_bracket: (
+          index_column_definition:
+            naked_identifier: col1
+          end_bracket: )
+      - oracle_index_physical_attributes:
+        - keyword: TABLESPACE
+        - object_reference:
+            naked_identifier: idx_ts
+        - keyword: LOGGING
+  - statement_terminator: ;
+  - statement:
+      create_index_statement:
+      - keyword: CREATE
+      - keyword: INDEX
+      - index_reference:
+        - naked_identifier: s1
+        - dot: .
+        - naked_identifier: t_nologging_idx
+      - keyword: 'ON'
+      - table_reference:
+        - naked_identifier: s1
+        - dot: .
+        - naked_identifier: t
+      - bracketed:
+          start_bracket: (
+          index_column_definition:
+            naked_identifier: col1
+          end_bracket: )
+      - oracle_index_physical_attributes:
+        - keyword: TABLESPACE
+        - object_reference:
+            naked_identifier: idx_ts
+        - keyword: NOLOGGING
+  - statement_terminator: ;
+  - statement:
+      create_index_statement:
+      - keyword: CREATE
+      - keyword: INDEX
+      - index_reference:
+        - naked_identifier: s1
+        - dot: .
+        - naked_identifier: t_parallel_idx
+      - keyword: 'ON'
+      - table_reference:
+        - naked_identifier: s1
+        - dot: .
+        - naked_identifier: t
+      - bracketed:
+          start_bracket: (
+          index_column_definition:
+            naked_identifier: col1
+          end_bracket: )
+      - oracle_index_physical_attributes:
+        - keyword: TABLESPACE
+        - object_reference:
+            naked_identifier: idx_ts
+        - keyword: PARALLEL
+        - numeric_literal: '4'
+  - statement_terminator: ;
+  - statement:
+      create_index_statement:
+      - keyword: CREATE
+      - keyword: INDEX
+      - index_reference:
+        - naked_identifier: s1
+        - dot: .
+        - naked_identifier: t_parallel_default_idx
+      - keyword: 'ON'
+      - table_reference:
+        - naked_identifier: s1
+        - dot: .
+        - naked_identifier: t
+      - bracketed:
+          start_bracket: (
+          index_column_definition:
+            naked_identifier: col1
+          end_bracket: )
+      - oracle_index_physical_attributes:
+        - keyword: TABLESPACE
+        - object_reference:
+            naked_identifier: idx_ts
+        - keyword: PARALLEL
+  - statement_terminator: ;
+  - statement:
+      create_index_statement:
+      - keyword: CREATE
+      - keyword: INDEX
+      - index_reference:
+        - naked_identifier: s1
+        - dot: .
+        - naked_identifier: t_noparallel_idx
+      - keyword: 'ON'
+      - table_reference:
+        - naked_identifier: s1
+        - dot: .
+        - naked_identifier: t
+      - bracketed:
+          start_bracket: (
+          index_column_definition:
+            naked_identifier: col1
+          end_bracket: )
+      - oracle_index_physical_attributes:
+        - keyword: TABLESPACE
+        - object_reference:
+            naked_identifier: idx_ts
+        - keyword: NOPARALLEL
+  - statement_terminator: ;
+  - statement:
+      create_index_statement:
+      - keyword: CREATE
+      - keyword: INDEX
+      - index_reference:
+        - naked_identifier: s1
+        - dot: .
+        - naked_identifier: t_online_idx
+      - keyword: 'ON'
+      - table_reference:
+        - naked_identifier: s1
+        - dot: .
+        - naked_identifier: t
+      - bracketed:
+          start_bracket: (
+          index_column_definition:
+            naked_identifier: col1
+          end_bracket: )
+      - oracle_index_physical_attributes:
+        - keyword: TABLESPACE
+        - object_reference:
+            naked_identifier: idx_ts
+        - keyword: ONLINE
+  - statement_terminator: ;
+  - statement:
+      create_index_statement:
+      - keyword: CREATE
+      - keyword: INDEX
+      - index_reference:
+        - naked_identifier: s1
+        - dot: .
+        - naked_identifier: t_compress_idx
+      - keyword: 'ON'
+      - table_reference:
+        - naked_identifier: s1
+        - dot: .
+        - naked_identifier: t
+      - bracketed:
+        - start_bracket: (
+        - index_column_definition:
+            naked_identifier: col1
+        - comma: ','
+        - index_column_definition:
+            naked_identifier: col2
+        - end_bracket: )
+      - oracle_index_physical_attributes:
+        - keyword: TABLESPACE
+        - object_reference:
+            naked_identifier: idx_ts
+        - keyword: COMPRESS
+  - statement_terminator: ;
+  - statement:
+      create_index_statement:
+      - keyword: CREATE
+      - keyword: INDEX
+      - index_reference:
+        - naked_identifier: s1
+        - dot: .
+        - naked_identifier: t_compress_1_idx
+      - keyword: 'ON'
+      - table_reference:
+        - naked_identifier: s1
+        - dot: .
+        - naked_identifier: t
+      - bracketed:
+        - start_bracket: (
+        - index_column_definition:
+            naked_identifier: col1
+        - comma: ','
+        - index_column_definition:
+            naked_identifier: col2
+        - comma: ','
+        - index_column_definition:
+            naked_identifier: col3
+        - end_bracket: )
+      - oracle_index_physical_attributes:
+        - keyword: TABLESPACE
+        - object_reference:
+            naked_identifier: idx_ts
+        - keyword: COMPRESS
+        - numeric_literal: '1'
+  - statement_terminator: ;
+  - statement:
+      create_index_statement:
+      - keyword: CREATE
+      - keyword: UNIQUE
+      - keyword: INDEX
+      - index_reference:
+        - naked_identifier: s1
+        - dot: .
+        - naked_identifier: t_compress_2_unique_idx
+      - keyword: 'ON'
+      - table_reference:
+        - naked_identifier: s1
+        - dot: .
+        - naked_identifier: t
+      - bracketed:
+        - start_bracket: (
+        - index_column_definition:
+            naked_identifier: col1
+        - comma: ','
+        - index_column_definition:
+            naked_identifier: col2
+        - comma: ','
+        - index_column_definition:
+            naked_identifier: col3
+        - end_bracket: )
+      - oracle_index_physical_attributes:
+        - keyword: TABLESPACE
+        - object_reference:
+            naked_identifier: idx_ts
+        - keyword: COMPRESS
+        - numeric_literal: '2'
+  - statement_terminator: ;
+  - statement:
+      create_index_statement:
+      - keyword: CREATE
+      - keyword: INDEX
+      - index_reference:
+        - naked_identifier: s1
+        - dot: .
+        - naked_identifier: t_nocompress_idx
+      - keyword: 'ON'
+      - table_reference:
+        - naked_identifier: s1
+        - dot: .
+        - naked_identifier: t
+      - bracketed:
+          start_bracket: (
+          index_column_definition:
+            naked_identifier: col1
+          end_bracket: )
+      - oracle_index_physical_attributes:
+        - keyword: TABLESPACE
+        - object_reference:
+            naked_identifier: idx_ts
+        - keyword: NOCOMPRESS
+  - statement_terminator: ;
+  - statement:
+      create_index_statement:
+      - keyword: CREATE
+      - keyword: INDEX
+      - index_reference:
+        - naked_identifier: s1
+        - dot: .
+        - naked_identifier: t_reverse_idx
+      - keyword: 'ON'
+      - table_reference:
+        - naked_identifier: s1
+        - dot: .
+        - naked_identifier: t
+      - bracketed:
+          start_bracket: (
+          index_column_definition:
+            naked_identifier: col1
+          end_bracket: )
+      - oracle_index_physical_attributes:
+        - keyword: TABLESPACE
+        - object_reference:
+            naked_identifier: idx_ts
+        - keyword: REVERSE
+  - statement_terminator: ;
+  - statement:
+      create_index_statement:
+      - keyword: CREATE
+      - keyword: INDEX
+      - index_reference:
+        - naked_identifier: s1
+        - dot: .
+        - naked_identifier: t_visible_idx
+      - keyword: 'ON'
+      - table_reference:
+        - naked_identifier: s1
+        - dot: .
+        - naked_identifier: t
+      - bracketed:
+          start_bracket: (
+          index_column_definition:
+            naked_identifier: col1
+          end_bracket: )
+      - oracle_index_physical_attributes:
+        - keyword: TABLESPACE
+        - object_reference:
+            naked_identifier: idx_ts
+        - keyword: VISIBLE
+  - statement_terminator: ;
+  - statement:
+      create_index_statement:
+      - keyword: CREATE
+      - keyword: INDEX
+      - index_reference:
+        - naked_identifier: s1
+        - dot: .
+        - naked_identifier: t_invisible_idx
+      - keyword: 'ON'
+      - table_reference:
+        - naked_identifier: s1
+        - dot: .
+        - naked_identifier: t
+      - bracketed:
+          start_bracket: (
+          index_column_definition:
+            naked_identifier: col1
+          end_bracket: )
+      - oracle_index_physical_attributes:
+        - keyword: TABLESPACE
+        - object_reference:
+            naked_identifier: idx_ts
+        - keyword: INVISIBLE
+  - statement_terminator: ;
+  - statement:
+      create_index_statement:
+      - keyword: CREATE
+      - keyword: INDEX
+      - index_reference:
+        - naked_identifier: s1
+        - dot: .
+        - naked_identifier: t_asc_desc_idx
+      - keyword: 'ON'
+      - table_reference:
+        - naked_identifier: s1
+        - dot: .
+        - naked_identifier: t
+      - bracketed:
+        - start_bracket: (
+        - index_column_definition:
+            naked_identifier: col1
+            keyword: ASC
+        - comma: ','
+        - index_column_definition:
+            naked_identifier: col2
+            keyword: DESC
+        - comma: ','
+        - index_column_definition:
+            naked_identifier: col3
+            keyword: ASC
+        - end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      create_index_statement:
+      - keyword: CREATE
+      - keyword: INDEX
+      - index_reference:
+        - naked_identifier: s1
+        - dot: .
+        - naked_identifier: t_full_phys_idx
+      - keyword: 'ON'
+      - table_reference:
+        - naked_identifier: s1
+        - dot: .
+        - naked_identifier: t
+      - bracketed:
+        - start_bracket: (
+        - index_column_definition:
+            naked_identifier: col1
+        - comma: ','
+        - index_column_definition:
+            naked_identifier: col2
+        - end_bracket: )
+      - oracle_index_physical_attributes:
+        - keyword: TABLESPACE
+        - object_reference:
+            naked_identifier: idx_ts
+        - keyword: NOLOGGING
+        - keyword: PCTFREE
+        - numeric_literal: '10'
+        - keyword: INITRANS
+        - numeric_literal: '2'
+        - keyword: MAXTRANS
+        - numeric_literal: '255'
+        - storage_clause:
+            keyword: STORAGE
+            bracketed:
+            - start_bracket: (
+            - keyword: INITIAL
+            - numeric_literal: '655'
+            - size_prefix: K
+            - keyword: NEXT
+            - numeric_literal: '655'
+            - size_prefix: K
+            - keyword: MINEXTENTS
+            - numeric_literal: '1'
+            - keyword: MAXEXTENTS
+            - keyword: UNLIMITED
+            - keyword: PCTINCREASE
+            - numeric_literal: '50'
+            - keyword: FREELISTS
+            - numeric_literal: '1'
+            - keyword: FREELIST
+            - keyword: GROUPS
+            - numeric_literal: '1'
+            - keyword: BUFFER_POOL
+            - keyword: DEFAULT
+            - end_bracket: )
+        - keyword: PARALLEL
+        - numeric_literal: '8'
+        - keyword: NOCOMPRESS
+        - keyword: VISIBLE
+  - statement_terminator: ;
+  - statement:
+      create_index_statement:
+      - keyword: CREATE
+      - keyword: INDEX
+      - index_reference:
+        - naked_identifier: s1
+        - dot: .
+        - naked_identifier: t_nosort_idx
+      - keyword: 'ON'
+      - table_reference:
+        - naked_identifier: s1
+        - dot: .
+        - naked_identifier: t
+      - bracketed:
+          start_bracket: (
+          index_column_definition:
+            naked_identifier: col1
+          end_bracket: )
+      - oracle_index_physical_attributes:
+        - keyword: TABLESPACE
+        - object_reference:
+            naked_identifier: idx_ts
+        - keyword: NOSORT
+  - statement_terminator: ;
+  - statement:
+      create_index_statement:
+      - keyword: CREATE
+      - keyword: INDEX
+      - index_reference:
+        - naked_identifier: s1
+        - dot: .
+        - naked_identifier: t_nosort_attrs_idx
+      - keyword: 'ON'
+      - table_reference:
+        - naked_identifier: s1
+        - dot: .
+        - naked_identifier: t
+      - bracketed:
+        - start_bracket: (
+        - index_column_definition:
+            naked_identifier: col1
+        - comma: ','
+        - index_column_definition:
+            naked_identifier: col2
+        - end_bracket: )
+      - oracle_index_physical_attributes:
+        - keyword: TABLESPACE
+        - object_reference:
+            naked_identifier: idx_ts
+        - keyword: PCTFREE
+        - numeric_literal: '10'
+        - keyword: INITRANS
+        - numeric_literal: '2'
+        - keyword: NOLOGGING
+        - keyword: NOSORT
+  - statement_terminator: ;
+  - statement:
+      create_index_statement:
+      - keyword: CREATE
+      - keyword: INDEX
+      - index_reference:
+        - naked_identifier: s1
+        - dot: .
+        - naked_identifier: t_reverse_attrs_idx
+      - keyword: 'ON'
+      - table_reference:
+        - naked_identifier: s1
+        - dot: .
+        - naked_identifier: t
+      - bracketed:
+          start_bracket: (
+          index_column_definition:
+            naked_identifier: col1
+          end_bracket: )
+      - oracle_index_physical_attributes:
+        - keyword: TABLESPACE
+        - object_reference:
+            naked_identifier: idx_ts
+        - keyword: PCTFREE
+        - numeric_literal: '10'
+        - keyword: NOLOGGING
+        - keyword: REVERSE
+  - statement_terminator: ;
+  - statement:
+      create_index_statement:
+      - keyword: CREATE
+      - keyword: INDEX
+      - index_reference:
+        - naked_identifier: s1
+        - dot: .
+        - naked_identifier: log_instdati_idx
+      - keyword: 'ON'
+      - table_reference:
+        - naked_identifier: s1
+        - dot: .
+        - naked_identifier: log
+      - bracketed:
+        - start_bracket: (
+        - index_column_definition:
+            naked_identifier: institution_id
+        - comma: ','
+        - index_column_definition:
+            naked_identifier: datetime
+        - end_bracket: )
+      - oracle_index_physical_attributes:
+        - keyword: PCTFREE
+        - numeric_literal: '10'
+        - keyword: INITRANS
+        - numeric_literal: '2'
+        - keyword: MAXTRANS
+        - numeric_literal: '255'
+        - keyword: TABLESPACE
+        - object_reference:
+            naked_identifier: idx_ts
+        - storage_clause:
+            keyword: STORAGE
+            bracketed:
+            - start_bracket: (
+            - keyword: INITIAL
+            - numeric_literal: '655'
+            - size_prefix: K
+            - keyword: NEXT
+            - numeric_literal: '655'
+            - size_prefix: K
+            - keyword: MINEXTENTS
+            - numeric_literal: '1'
+            - keyword: MAXEXTENTS
+            - keyword: UNLIMITED
+            - keyword: PCTINCREASE
+            - numeric_literal: '50'
+            - keyword: FREELISTS
+            - numeric_literal: '1'
+            - keyword: FREELIST
+            - keyword: GROUPS
+            - numeric_literal: '1'
+            - keyword: BUFFER_POOL
+            - keyword: DEFAULT
+            - end_bracket: )
+        - keyword: NOLOGGING
+        - keyword: NOPARALLEL
+  - statement_terminator: ;
+  - statement:
+      create_index_statement:
+      - keyword: CREATE
+      - keyword: UNIQUE
+      - keyword: INDEX
+      - index_reference:
+        - naked_identifier: s1
+        - dot: .
+        - naked_identifier: filter_instkeytype_idx
+      - keyword: 'ON'
+      - table_reference:
+        - naked_identifier: s1
+        - dot: .
+        - naked_identifier: filter
+      - bracketed:
+        - start_bracket: (
+        - index_column_definition:
+            naked_identifier: institution_id
+        - comma: ','
+        - index_column_definition:
+            naked_identifier: filterkey
+        - comma: ','
+        - index_column_definition:
+            naked_identifier: filtertype_id
+        - end_bracket: )
+      - oracle_index_physical_attributes:
+        - keyword: PCTFREE
+        - numeric_literal: '10'
+        - keyword: INITRANS
+        - numeric_literal: '2'
+        - keyword: MAXTRANS
+        - numeric_literal: '255'
+        - keyword: TABLESPACE
+        - object_reference:
+            naked_identifier: idx_ts
+        - storage_clause:
+            keyword: STORAGE
+            bracketed:
+            - start_bracket: (
+            - keyword: INITIAL
+            - numeric_literal: '140'
+            - size_prefix: K
+            - keyword: NEXT
+            - numeric_literal: '360'
+            - size_prefix: K
+            - keyword: MINEXTENTS
+            - numeric_literal: '1'
+            - keyword: MAXEXTENTS
+            - keyword: UNLIMITED
+            - keyword: PCTINCREASE
+            - numeric_literal: '50'
+            - keyword: FREELISTS
+            - numeric_literal: '1'
+            - keyword: FREELIST
+            - keyword: GROUPS
+            - numeric_literal: '1'
+            - keyword: BUFFER_POOL
+            - keyword: DEFAULT
+            - end_bracket: )
+        - keyword: NOLOGGING
+        - keyword: PARALLEL
+        - numeric_literal: '4'
+  - statement_terminator: ;

--- a/test/fixtures/dialects/oracle/create_table.sql
+++ b/test/fixtures/dialects/oracle/create_table.sql
@@ -24,3 +24,534 @@ CREATE TABLE departments_demo
     , location_id      NUMBER(4)
     , dn               VARCHAR2(300)
     ) ;
+
+-- Physical attributes: TABLESPACE + full STORAGE clause + LOGGING/NOLOGGING
+CREATE TABLE s1.t_storage (
+    id NUMBER(10) NOT NULL,
+    CONSTRAINT t_storage_pk PRIMARY KEY (id)
+        USING INDEX
+            PCTFREE 10
+            INITRANS 2
+            MAXTRANS 255
+            TABLESPACE idx_ts
+            STORAGE (
+                INITIAL 256K
+                NEXT 256K
+                MINEXTENTS 1
+                MAXEXTENTS 121
+                PCTINCREASE 0
+                FREELISTS 1
+                FREELIST GROUPS 1
+                BUFFER_POOL DEFAULT
+            )
+            LOGGING
+)
+TABLESPACE data_ts
+LOGGING
+PCTFREE 10
+PCTUSED 70
+INITRANS 1
+MAXTRANS 255
+STORAGE (
+    INITIAL 655K
+    NEXT 655K
+    MINEXTENTS 1
+    MAXEXTENTS UNLIMITED
+    PCTINCREASE 1
+    FREELISTS 1
+    FREELIST GROUPS 1
+    BUFFER_POOL DEFAULT
+)
+NOPARALLEL
+NOCACHE;
+
+-- USING INDEX with existing named index reference
+CREATE TABLE s1.t_using_named_idx (
+    id NUMBER(10) NOT NULL,
+    CONSTRAINT t_named_idx_pk PRIMARY KEY (id)
+        USING INDEX idx_ts.t_named_idx_pk
+);
+
+-- Physical attributes: NOLOGGING + PARALLEL degree + BUFFER_POOL KEEP
+CREATE TABLE s1.t_parallel (
+    id NUMBER(10) NOT NULL,
+    payload VARCHAR2(4000)
+)
+TABLESPACE data_ts
+NOLOGGING
+PCTFREE 5
+INITRANS 4
+STORAGE (
+    INITIAL 1M
+    NEXT 1M
+    MAXEXTENTS UNLIMITED
+    BUFFER_POOL KEEP
+)
+PARALLEL 8
+NOCACHE;
+
+-- Compression: COMPRESS (default), COMPRESS FOR OLTP, NOCOMPRESS
+CREATE TABLE s1.t_compress_default (
+    id NUMBER(10) NOT NULL
+)
+TABLESPACE data_ts
+COMPRESS;
+
+CREATE TABLE s1.t_compress_oltp (
+    id NUMBER(10) NOT NULL
+)
+TABLESPACE data_ts
+COMPRESS FOR OLTP;
+
+CREATE TABLE s1.t_compress_query_low (
+    id NUMBER(10) NOT NULL
+)
+TABLESPACE data_ts
+COMPRESS FOR QUERY LOW;
+
+CREATE TABLE s1.t_compress_query_high (
+    id NUMBER(10) NOT NULL
+)
+TABLESPACE data_ts
+COMPRESS FOR QUERY HIGH;
+
+CREATE TABLE s1.t_compress_archive_low (
+    id NUMBER(10) NOT NULL
+)
+TABLESPACE data_ts
+COMPRESS FOR ARCHIVE LOW;
+
+CREATE TABLE s1.t_compress_archive_high (
+    id NUMBER(10) NOT NULL
+)
+TABLESPACE data_ts
+COMPRESS FOR ARCHIVE HIGH;
+
+CREATE TABLE s1.t_nocompress (
+    id NUMBER(10) NOT NULL
+)
+TABLESPACE data_ts
+NOCOMPRESS;
+
+-- Row movement
+CREATE TABLE s1.t_row_movement (
+    id NUMBER(10) NOT NULL,
+    partition_key DATE
+)
+TABLESPACE data_ts
+ENABLE ROW MOVEMENT;
+
+CREATE TABLE s1.t_no_row_movement (
+    id NUMBER(10) NOT NULL
+)
+TABLESPACE data_ts
+DISABLE ROW MOVEMENT;
+
+-- Result cache
+CREATE TABLE s1.t_result_cache_default (
+    id NUMBER(10) NOT NULL
+)
+TABLESPACE data_ts
+RESULT_CACHE (MODE DEFAULT);
+
+CREATE TABLE s1.t_result_cache_force (
+    id NUMBER(10) NOT NULL
+)
+TABLESPACE data_ts
+RESULT_CACHE (MODE FORCE);
+
+-- In-Memory column store (12c+)
+CREATE TABLE s1.t_inmemory_default (
+    id NUMBER(10) NOT NULL
+)
+TABLESPACE data_ts
+INMEMORY;
+
+CREATE TABLE s1.t_inmemory_memcompress_query_high (
+    id NUMBER(10) NOT NULL,
+    data VARCHAR2(200)
+)
+TABLESPACE data_ts
+INMEMORY MEMCOMPRESS FOR QUERY HIGH;
+
+CREATE TABLE s1.t_inmemory_memcompress_archive_low (
+    id NUMBER(10) NOT NULL
+)
+TABLESPACE data_ts
+INMEMORY MEMCOMPRESS FOR ARCHIVE LOW;
+
+CREATE TABLE s1.t_inmemory_priority_critical (
+    id NUMBER(10) NOT NULL
+)
+TABLESPACE data_ts
+INMEMORY PRIORITY CRITICAL;
+
+CREATE TABLE s1.t_inmemory_full (
+    id NUMBER(10) NOT NULL
+)
+TABLESPACE data_ts
+INMEMORY MEMCOMPRESS FOR QUERY HIGH PRIORITY HIGH;
+
+CREATE TABLE s1.t_inmemory_no_memcompress (
+    id NUMBER(10) NOT NULL
+)
+TABLESPACE data_ts
+INMEMORY NO MEMCOMPRESS;
+
+CREATE TABLE s1.t_inmemory_no_memcompress_priority (
+    id NUMBER(10) NOT NULL
+)
+TABLESPACE data_ts
+INMEMORY NO MEMCOMPRESS PRIORITY HIGH;
+
+CREATE TABLE s1.t_no_inmemory (
+    id NUMBER(10) NOT NULL
+)
+TABLESPACE data_ts
+NO INMEMORY;
+
+-- INMEMORY DISTRIBUTE sub-clause
+CREATE TABLE s1.t_inmemory_distribute_auto (
+    id NUMBER(10) NOT NULL
+)
+TABLESPACE data_ts
+INMEMORY DISTRIBUTE AUTO;
+
+CREATE TABLE s1.t_inmemory_distribute_by_rowid_range (
+    id NUMBER(10) NOT NULL
+)
+TABLESPACE data_ts
+INMEMORY DISTRIBUTE BY ROWID RANGE;
+
+CREATE TABLE s1.t_inmemory_distribute_by_partition (
+    id NUMBER(10) NOT NULL
+)
+TABLESPACE data_ts
+INMEMORY DISTRIBUTE BY PARTITION;
+
+CREATE TABLE s1.t_inmemory_distribute_by_subpartition (
+    id NUMBER(10) NOT NULL
+)
+TABLESPACE data_ts
+INMEMORY DISTRIBUTE BY SUBPARTITION;
+
+CREATE TABLE s1.t_inmemory_distribute_for_service (
+    id NUMBER(10) NOT NULL
+)
+TABLESPACE data_ts
+INMEMORY DISTRIBUTE AUTO FOR SERVICE my_service;
+
+CREATE TABLE s1.t_inmemory_distribute_for_service_default (
+    id NUMBER(10) NOT NULL
+)
+TABLESPACE data_ts
+INMEMORY DISTRIBUTE FOR SERVICE DEFAULT;
+
+-- INMEMORY DUPLICATE sub-clause
+CREATE TABLE s1.t_inmemory_duplicate (
+    id NUMBER(10) NOT NULL
+)
+TABLESPACE data_ts
+INMEMORY DUPLICATE;
+
+CREATE TABLE s1.t_inmemory_duplicate_all (
+    id NUMBER(10) NOT NULL
+)
+TABLESPACE data_ts
+INMEMORY DUPLICATE ALL;
+
+CREATE TABLE s1.t_inmemory_no_duplicate (
+    id NUMBER(10) NOT NULL
+)
+TABLESPACE data_ts
+INMEMORY NO DUPLICATE;
+
+-- INMEMORY combined: MEMCOMPRESS + PRIORITY + DISTRIBUTE + DUPLICATE
+CREATE TABLE s1.t_inmemory_all_subclauses (
+    id NUMBER(10) NOT NULL,
+    data VARCHAR2(200)
+)
+TABLESPACE data_ts
+INMEMORY MEMCOMPRESS FOR QUERY HIGH PRIORITY HIGH DISTRIBUTE AUTO DUPLICATE ALL;
+
+-- Flashback archive
+CREATE TABLE s1.t_flashback (
+    id NUMBER(10) NOT NULL,
+    info VARCHAR2(100)
+)
+TABLESPACE data_ts
+FLASHBACK ARCHIVE my_fba;
+
+CREATE TABLE s1.t_flashback_default (
+    id NUMBER(10) NOT NULL
+)
+TABLESPACE data_ts
+FLASHBACK ARCHIVE;
+
+CREATE TABLE s1.t_no_flashback (
+    id NUMBER(10) NOT NULL
+)
+TABLESPACE data_ts
+NO FLASHBACK ARCHIVE;
+
+-- Row dependencies
+CREATE TABLE s1.t_rowdeps (
+    id NUMBER(10) NOT NULL
+)
+TABLESPACE data_ts
+ROWDEPENDENCIES;
+
+CREATE TABLE s1.t_norowdeps (
+    id NUMBER(10) NOT NULL
+)
+TABLESPACE data_ts
+NOROWDEPENDENCIES;
+
+-- Segment Creation
+CREATE TABLE s1.t_segment_immediate (
+    id NUMBER(10) NOT NULL
+)
+SEGMENT CREATION IMMEDIATE
+TABLESPACE data_ts;
+
+CREATE TABLE s1.t_segment_deferred (
+    id NUMBER(10) NOT NULL
+)
+SEGMENT CREATION DEFERRED
+TABLESPACE data_ts;
+
+CREATE TABLE s1.t_segment_immediate_storage
+(
+    id NUMBER(19,0),
+    CONSTRAINT id_pk PRIMARY KEY (id)
+)
+SEGMENT CREATION IMMEDIATE
+PCTFREE 10
+PCTUSED 40
+INITRANS 1
+MAXTRANS 255
+NOCOMPRESS
+LOGGING
+STORAGE (
+    INITIAL 65536
+    NEXT 1048576
+    MINEXTENTS 1
+    MAXEXTENTS 2147483645
+    PCTINCREASE 0
+    FREELISTS 1
+    FREELIST GROUPS 1
+    BUFFER_POOL DEFAULT
+    FLASH_CACHE DEFAULT
+    CELL_FLASH_CACHE DEFAULT
+)
+TABLESPACE data_ts;
+
+-- Storage
+CREATE TABLE s1.t_flash_cache_keep (
+    id NUMBER(10) NOT NULL
+)
+STORAGE (
+    INITIAL 64K
+    BUFFER_POOL DEFAULT
+    FLASH_CACHE KEEP
+    CELL_FLASH_CACHE KEEP
+)
+TABLESPACE data_ts;
+
+CREATE TABLE s1.t_flash_cache_none (
+    id NUMBER(10) NOT NULL
+)
+STORAGE (
+    INITIAL 64K
+    FLASH_CACHE NONE
+    CELL_FLASH_CACHE NONE
+)
+TABLESPACE data_ts;
+
+CREATE TABLE s1.t_storage_maxsize (
+    id NUMBER(10) NOT NULL
+)
+STORAGE (
+    INITIAL 8M
+    MAXSIZE 1G
+)
+TABLESPACE data_ts;
+
+CREATE TABLE s1.t_storage_maxsize_unlimited (
+    id NUMBER(10) NOT NULL
+)
+STORAGE (
+    INITIAL 8M
+    MAXSIZE UNLIMITED
+)
+TABLESPACE data_ts;
+
+-- Row/Column store compress
+CREATE TABLE s1.t_row_store_compress_basic (
+    id NUMBER(10) NOT NULL,
+    data VARCHAR2(200)
+)
+ROW STORE COMPRESS BASIC
+TABLESPACE data_ts;
+
+CREATE TABLE s1.t_row_store_compress_advanced (
+    id NUMBER(10) NOT NULL,
+    data VARCHAR2(200)
+)
+ROW STORE COMPRESS ADVANCED
+TABLESPACE data_ts;
+
+CREATE TABLE s1.t_row_store_compress_no_level (
+    id NUMBER(10) NOT NULL
+)
+ROW STORE COMPRESS
+TABLESPACE data_ts;
+
+CREATE TABLE s1.t_column_store_compress (
+    id NUMBER(10) NOT NULL,
+    data VARCHAR2(200)
+)
+COLUMN STORE COMPRESS
+TABLESPACE data_ts;
+
+CREATE TABLE s1.t_column_store_compress_query_low (
+    id NUMBER(10) NOT NULL,
+    data VARCHAR2(200)
+)
+COLUMN STORE COMPRESS FOR QUERY LOW
+TABLESPACE data_ts;
+
+CREATE TABLE s1.t_column_store_compress_query_high (
+    id NUMBER(10) NOT NULL,
+    data VARCHAR2(200)
+)
+COLUMN STORE COMPRESS FOR QUERY HIGH
+TABLESPACE data_ts;
+
+CREATE TABLE s1.t_column_store_compress_archive_high (
+    id NUMBER(10) NOT NULL,
+    data VARCHAR2(200)
+)
+COLUMN STORE COMPRESS FOR ARCHIVE HIGH
+TABLESPACE data_ts;
+
+CREATE TABLE s1.t_column_store_compress_no_row_locking (
+    id NUMBER(10) NOT NULL,
+    data VARCHAR2(200)
+)
+COLUMN STORE COMPRESS FOR QUERY HIGH NO ROW LEVEL LOCKING
+TABLESPACE data_ts;
+
+-- Monitoring
+CREATE TABLE s1.t_monitoring (
+    id NUMBER(10) NOT NULL
+)
+MONITORING
+TABLESPACE data_ts;
+
+CREATE TABLE s1.t_nomonitoring (
+    id NUMBER(10) NOT NULL
+)
+NOMONITORING
+TABLESPACE data_ts;
+
+-- Combined: all major physical attribute groups together
+CREATE TABLE s1.t_all_physical (
+    id          NUMBER(18)      NOT NULL,
+    institution VARCHAR2(11)    NOT NULL,
+    payload     VARCHAR2(1000)  NOT NULL,
+    created_at  DATE            DEFAULT SYSDATE NOT NULL,
+    CONSTRAINT t_all_phys_pk PRIMARY KEY (id)
+        USING INDEX
+            PCTFREE 10
+            INITRANS 2
+            MAXTRANS 255
+            TABLESPACE idx_ts
+            STORAGE (
+                INITIAL 256K
+                NEXT 256K
+                MINEXTENTS 1
+                MAXEXTENTS 121
+                PCTINCREASE 0
+                FREELISTS 1
+                FREELIST GROUPS 1
+                BUFFER_POOL DEFAULT
+            )
+            LOGGING,
+    CONSTRAINT t_all_phys_uk UNIQUE (institution, payload)
+        USING INDEX
+            PCTFREE 10
+            TABLESPACE idx_ts
+            STORAGE (INITIAL 140K NEXT 360K BUFFER_POOL KEEP)
+            NOLOGGING
+)
+TABLESPACE data_ts
+LOGGING
+PCTFREE 10
+PCTUSED 70
+INITRANS 1
+MAXTRANS 255
+STORAGE (
+    INITIAL 655K
+    NEXT 655K
+    MINEXTENTS 1
+    MAXEXTENTS UNLIMITED
+    PCTINCREASE 1
+    FREELISTS 1
+    FREELIST GROUPS 1
+    BUFFER_POOL DEFAULT
+)
+COMPRESS FOR OLTP
+PARALLEL 4
+NOCACHE
+RESULT_CACHE (MODE DEFAULT)
+INMEMORY MEMCOMPRESS FOR QUERY HIGH PRIORITY HIGH
+ENABLE ROW MOVEMENT
+FLASHBACK ARCHIVE corp_fba
+ROWDEPENDENCIES;
+
+-- USING INDEX with inline CREATE INDEX (basic form)
+CREATE TABLE t_using_idx_inline (
+    id NUMBER,
+    CONSTRAINT pk_t_using_idx_inline PRIMARY KEY (id)
+        USING INDEX (CREATE INDEX pk_t_using_idx_inline_idx ON t_using_idx_inline (id))
+);
+
+-- USING INDEX with inline UNIQUE CREATE INDEX
+CREATE TABLE t_using_idx_inline_unique (
+    id NUMBER,
+    CONSTRAINT uq_t_using_idx_inline_unique UNIQUE (id)
+        USING INDEX (CREATE UNIQUE INDEX uq_t_using_idx_inline_unique_idx ON t_using_idx_inline_unique (id))
+);
+
+-- USING INDEX with inline CREATE INDEX and physical attributes
+CREATE TABLE t_using_idx_inline_attrs (
+    id NUMBER,
+    CONSTRAINT pk_t_using_idx_inline_attrs PRIMARY KEY (id)
+        USING INDEX (
+            CREATE INDEX pk_t_using_idx_inline_attrs_idx ON t_using_idx_inline_attrs (id)
+            TABLESPACE idx_ts
+            PCTFREE 10
+            NOLOGGING
+        )
+);
+
+-- CREATE TABLE ... AS with physical attributes before AS
+CREATE TABLE t_ctas_nologging
+NOLOGGING
+TABLESPACE users
+AS SELECT * FROM emp;
+
+CREATE TABLE t_ctas_storage
+TABLESPACE users
+PCTFREE 5
+INITRANS 4
+STORAGE (INITIAL 1M NEXT 1M)
+NOLOGGING
+AS SELECT * FROM emp;
+
+CREATE GLOBAL TEMPORARY TABLE t_ctas_temp
+ON COMMIT PRESERVE ROWS
+NOLOGGING
+TABLESPACE temp_ts
+AS SELECT * FROM emp;

--- a/test/fixtures/dialects/oracle/create_table.yml
+++ b/test/fixtures/dialects/oracle/create_table.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 0e630f7597a0815d878c040812245c192fb49175b56179a0eb01a4635cf299e5
+_hash: 091a9c8266f4630c6a7e68c6ab4bc4b55537b24affcdc2ab77bab46d35e5cf10
 file:
   batch:
   - statement:
@@ -215,4 +215,2485 @@ file:
                   numeric_literal: '300'
                   end_bracket: )
         - end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      create_table_statement:
+      - keyword: CREATE
+      - keyword: TABLE
+      - table_reference:
+        - naked_identifier: s1
+        - dot: .
+        - naked_identifier: t_storage
+      - bracketed:
+          start_bracket: (
+          column_definition:
+            naked_identifier: id
+            data_type:
+              data_type_identifier: NUMBER
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  numeric_literal: '10'
+                  end_bracket: )
+            column_constraint_segment:
+            - keyword: NOT
+            - keyword: 'NULL'
+          comma: ','
+          table_constraint:
+          - keyword: CONSTRAINT
+          - object_reference:
+              naked_identifier: t_storage_pk
+          - keyword: PRIMARY
+          - keyword: KEY
+          - bracketed:
+              start_bracket: (
+              column_reference:
+                naked_identifier: id
+              end_bracket: )
+          - using_index_clause:
+            - keyword: USING
+            - keyword: INDEX
+            - oracle_index_physical_attributes:
+              - keyword: PCTFREE
+              - numeric_literal: '10'
+              - keyword: INITRANS
+              - numeric_literal: '2'
+              - keyword: MAXTRANS
+              - numeric_literal: '255'
+              - keyword: TABLESPACE
+              - object_reference:
+                  naked_identifier: idx_ts
+              - storage_clause:
+                  keyword: STORAGE
+                  bracketed:
+                  - start_bracket: (
+                  - keyword: INITIAL
+                  - numeric_literal: '256'
+                  - size_prefix: K
+                  - keyword: NEXT
+                  - numeric_literal: '256'
+                  - size_prefix: K
+                  - keyword: MINEXTENTS
+                  - numeric_literal: '1'
+                  - keyword: MAXEXTENTS
+                  - numeric_literal: '121'
+                  - keyword: PCTINCREASE
+                  - numeric_literal: '0'
+                  - keyword: FREELISTS
+                  - numeric_literal: '1'
+                  - keyword: FREELIST
+                  - keyword: GROUPS
+                  - numeric_literal: '1'
+                  - keyword: BUFFER_POOL
+                  - keyword: DEFAULT
+                  - end_bracket: )
+              - keyword: LOGGING
+          end_bracket: )
+      - oracle_physical_attributes:
+        - keyword: TABLESPACE
+        - object_reference:
+            naked_identifier: data_ts
+        - keyword: LOGGING
+        - keyword: PCTFREE
+        - numeric_literal: '10'
+        - keyword: PCTUSED
+        - numeric_literal: '70'
+        - keyword: INITRANS
+        - numeric_literal: '1'
+        - keyword: MAXTRANS
+        - numeric_literal: '255'
+        - storage_clause:
+            keyword: STORAGE
+            bracketed:
+            - start_bracket: (
+            - keyword: INITIAL
+            - numeric_literal: '655'
+            - size_prefix: K
+            - keyword: NEXT
+            - numeric_literal: '655'
+            - size_prefix: K
+            - keyword: MINEXTENTS
+            - numeric_literal: '1'
+            - keyword: MAXEXTENTS
+            - keyword: UNLIMITED
+            - keyword: PCTINCREASE
+            - numeric_literal: '1'
+            - keyword: FREELISTS
+            - numeric_literal: '1'
+            - keyword: FREELIST
+            - keyword: GROUPS
+            - numeric_literal: '1'
+            - keyword: BUFFER_POOL
+            - keyword: DEFAULT
+            - end_bracket: )
+        - keyword: NOPARALLEL
+        - keyword: NOCACHE
+  - statement_terminator: ;
+  - statement:
+      create_table_statement:
+      - keyword: CREATE
+      - keyword: TABLE
+      - table_reference:
+        - naked_identifier: s1
+        - dot: .
+        - naked_identifier: t_using_named_idx
+      - bracketed:
+          start_bracket: (
+          column_definition:
+            naked_identifier: id
+            data_type:
+              data_type_identifier: NUMBER
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  numeric_literal: '10'
+                  end_bracket: )
+            column_constraint_segment:
+            - keyword: NOT
+            - keyword: 'NULL'
+          comma: ','
+          table_constraint:
+          - keyword: CONSTRAINT
+          - object_reference:
+              naked_identifier: t_named_idx_pk
+          - keyword: PRIMARY
+          - keyword: KEY
+          - bracketed:
+              start_bracket: (
+              column_reference:
+                naked_identifier: id
+              end_bracket: )
+          - using_index_clause:
+            - keyword: USING
+            - keyword: INDEX
+            - index_reference:
+              - naked_identifier: idx_ts
+              - dot: .
+              - naked_identifier: t_named_idx_pk
+          end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      create_table_statement:
+      - keyword: CREATE
+      - keyword: TABLE
+      - table_reference:
+        - naked_identifier: s1
+        - dot: .
+        - naked_identifier: t_parallel
+      - bracketed:
+        - start_bracket: (
+        - column_definition:
+            naked_identifier: id
+            data_type:
+              data_type_identifier: NUMBER
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  numeric_literal: '10'
+                  end_bracket: )
+            column_constraint_segment:
+            - keyword: NOT
+            - keyword: 'NULL'
+        - comma: ','
+        - column_definition:
+            naked_identifier: payload
+            data_type:
+              data_type_identifier: VARCHAR2
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  numeric_literal: '4000'
+                  end_bracket: )
+        - end_bracket: )
+      - oracle_physical_attributes:
+        - keyword: TABLESPACE
+        - object_reference:
+            naked_identifier: data_ts
+        - keyword: NOLOGGING
+        - keyword: PCTFREE
+        - numeric_literal: '5'
+        - keyword: INITRANS
+        - numeric_literal: '4'
+        - storage_clause:
+            keyword: STORAGE
+            bracketed:
+            - start_bracket: (
+            - keyword: INITIAL
+            - numeric_literal: '1'
+            - size_prefix: M
+            - keyword: NEXT
+            - numeric_literal: '1'
+            - size_prefix: M
+            - keyword: MAXEXTENTS
+            - keyword: UNLIMITED
+            - keyword: BUFFER_POOL
+            - keyword: KEEP
+            - end_bracket: )
+        - keyword: PARALLEL
+        - numeric_literal: '8'
+        - keyword: NOCACHE
+  - statement_terminator: ;
+  - statement:
+      create_table_statement:
+      - keyword: CREATE
+      - keyword: TABLE
+      - table_reference:
+        - naked_identifier: s1
+        - dot: .
+        - naked_identifier: t_compress_default
+      - bracketed:
+          start_bracket: (
+          column_definition:
+            naked_identifier: id
+            data_type:
+              data_type_identifier: NUMBER
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  numeric_literal: '10'
+                  end_bracket: )
+            column_constraint_segment:
+            - keyword: NOT
+            - keyword: 'NULL'
+          end_bracket: )
+      - oracle_physical_attributes:
+        - keyword: TABLESPACE
+        - object_reference:
+            naked_identifier: data_ts
+        - keyword: COMPRESS
+  - statement_terminator: ;
+  - statement:
+      create_table_statement:
+      - keyword: CREATE
+      - keyword: TABLE
+      - table_reference:
+        - naked_identifier: s1
+        - dot: .
+        - naked_identifier: t_compress_oltp
+      - bracketed:
+          start_bracket: (
+          column_definition:
+            naked_identifier: id
+            data_type:
+              data_type_identifier: NUMBER
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  numeric_literal: '10'
+                  end_bracket: )
+            column_constraint_segment:
+            - keyword: NOT
+            - keyword: 'NULL'
+          end_bracket: )
+      - oracle_physical_attributes:
+        - keyword: TABLESPACE
+        - object_reference:
+            naked_identifier: data_ts
+        - keyword: COMPRESS
+        - keyword: FOR
+        - keyword: OLTP
+  - statement_terminator: ;
+  - statement:
+      create_table_statement:
+      - keyword: CREATE
+      - keyword: TABLE
+      - table_reference:
+        - naked_identifier: s1
+        - dot: .
+        - naked_identifier: t_compress_query_low
+      - bracketed:
+          start_bracket: (
+          column_definition:
+            naked_identifier: id
+            data_type:
+              data_type_identifier: NUMBER
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  numeric_literal: '10'
+                  end_bracket: )
+            column_constraint_segment:
+            - keyword: NOT
+            - keyword: 'NULL'
+          end_bracket: )
+      - oracle_physical_attributes:
+        - keyword: TABLESPACE
+        - object_reference:
+            naked_identifier: data_ts
+        - keyword: COMPRESS
+        - keyword: FOR
+        - keyword: QUERY
+        - keyword: LOW
+  - statement_terminator: ;
+  - statement:
+      create_table_statement:
+      - keyword: CREATE
+      - keyword: TABLE
+      - table_reference:
+        - naked_identifier: s1
+        - dot: .
+        - naked_identifier: t_compress_query_high
+      - bracketed:
+          start_bracket: (
+          column_definition:
+            naked_identifier: id
+            data_type:
+              data_type_identifier: NUMBER
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  numeric_literal: '10'
+                  end_bracket: )
+            column_constraint_segment:
+            - keyword: NOT
+            - keyword: 'NULL'
+          end_bracket: )
+      - oracle_physical_attributes:
+        - keyword: TABLESPACE
+        - object_reference:
+            naked_identifier: data_ts
+        - keyword: COMPRESS
+        - keyword: FOR
+        - keyword: QUERY
+        - keyword: HIGH
+  - statement_terminator: ;
+  - statement:
+      create_table_statement:
+      - keyword: CREATE
+      - keyword: TABLE
+      - table_reference:
+        - naked_identifier: s1
+        - dot: .
+        - naked_identifier: t_compress_archive_low
+      - bracketed:
+          start_bracket: (
+          column_definition:
+            naked_identifier: id
+            data_type:
+              data_type_identifier: NUMBER
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  numeric_literal: '10'
+                  end_bracket: )
+            column_constraint_segment:
+            - keyword: NOT
+            - keyword: 'NULL'
+          end_bracket: )
+      - oracle_physical_attributes:
+        - keyword: TABLESPACE
+        - object_reference:
+            naked_identifier: data_ts
+        - keyword: COMPRESS
+        - keyword: FOR
+        - keyword: ARCHIVE
+        - keyword: LOW
+  - statement_terminator: ;
+  - statement:
+      create_table_statement:
+      - keyword: CREATE
+      - keyword: TABLE
+      - table_reference:
+        - naked_identifier: s1
+        - dot: .
+        - naked_identifier: t_compress_archive_high
+      - bracketed:
+          start_bracket: (
+          column_definition:
+            naked_identifier: id
+            data_type:
+              data_type_identifier: NUMBER
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  numeric_literal: '10'
+                  end_bracket: )
+            column_constraint_segment:
+            - keyword: NOT
+            - keyword: 'NULL'
+          end_bracket: )
+      - oracle_physical_attributes:
+        - keyword: TABLESPACE
+        - object_reference:
+            naked_identifier: data_ts
+        - keyword: COMPRESS
+        - keyword: FOR
+        - keyword: ARCHIVE
+        - keyword: HIGH
+  - statement_terminator: ;
+  - statement:
+      create_table_statement:
+      - keyword: CREATE
+      - keyword: TABLE
+      - table_reference:
+        - naked_identifier: s1
+        - dot: .
+        - naked_identifier: t_nocompress
+      - bracketed:
+          start_bracket: (
+          column_definition:
+            naked_identifier: id
+            data_type:
+              data_type_identifier: NUMBER
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  numeric_literal: '10'
+                  end_bracket: )
+            column_constraint_segment:
+            - keyword: NOT
+            - keyword: 'NULL'
+          end_bracket: )
+      - oracle_physical_attributes:
+        - keyword: TABLESPACE
+        - object_reference:
+            naked_identifier: data_ts
+        - keyword: NOCOMPRESS
+  - statement_terminator: ;
+  - statement:
+      create_table_statement:
+      - keyword: CREATE
+      - keyword: TABLE
+      - table_reference:
+        - naked_identifier: s1
+        - dot: .
+        - naked_identifier: t_row_movement
+      - bracketed:
+        - start_bracket: (
+        - column_definition:
+            naked_identifier: id
+            data_type:
+              data_type_identifier: NUMBER
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  numeric_literal: '10'
+                  end_bracket: )
+            column_constraint_segment:
+            - keyword: NOT
+            - keyword: 'NULL'
+        - comma: ','
+        - column_definition:
+            naked_identifier: partition_key
+            data_type:
+              data_type_identifier: DATE
+        - end_bracket: )
+      - oracle_physical_attributes:
+        - keyword: TABLESPACE
+        - object_reference:
+            naked_identifier: data_ts
+        - keyword: ENABLE
+        - keyword: ROW
+        - keyword: MOVEMENT
+  - statement_terminator: ;
+  - statement:
+      create_table_statement:
+      - keyword: CREATE
+      - keyword: TABLE
+      - table_reference:
+        - naked_identifier: s1
+        - dot: .
+        - naked_identifier: t_no_row_movement
+      - bracketed:
+          start_bracket: (
+          column_definition:
+            naked_identifier: id
+            data_type:
+              data_type_identifier: NUMBER
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  numeric_literal: '10'
+                  end_bracket: )
+            column_constraint_segment:
+            - keyword: NOT
+            - keyword: 'NULL'
+          end_bracket: )
+      - oracle_physical_attributes:
+        - keyword: TABLESPACE
+        - object_reference:
+            naked_identifier: data_ts
+        - keyword: DISABLE
+        - keyword: ROW
+        - keyword: MOVEMENT
+  - statement_terminator: ;
+  - statement:
+      create_table_statement:
+      - keyword: CREATE
+      - keyword: TABLE
+      - table_reference:
+        - naked_identifier: s1
+        - dot: .
+        - naked_identifier: t_result_cache_default
+      - bracketed:
+          start_bracket: (
+          column_definition:
+            naked_identifier: id
+            data_type:
+              data_type_identifier: NUMBER
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  numeric_literal: '10'
+                  end_bracket: )
+            column_constraint_segment:
+            - keyword: NOT
+            - keyword: 'NULL'
+          end_bracket: )
+      - oracle_physical_attributes:
+        - keyword: TABLESPACE
+        - object_reference:
+            naked_identifier: data_ts
+        - keyword: RESULT_CACHE
+        - bracketed:
+          - start_bracket: (
+          - keyword: MODE
+          - keyword: DEFAULT
+          - end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      create_table_statement:
+      - keyword: CREATE
+      - keyword: TABLE
+      - table_reference:
+        - naked_identifier: s1
+        - dot: .
+        - naked_identifier: t_result_cache_force
+      - bracketed:
+          start_bracket: (
+          column_definition:
+            naked_identifier: id
+            data_type:
+              data_type_identifier: NUMBER
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  numeric_literal: '10'
+                  end_bracket: )
+            column_constraint_segment:
+            - keyword: NOT
+            - keyword: 'NULL'
+          end_bracket: )
+      - oracle_physical_attributes:
+        - keyword: TABLESPACE
+        - object_reference:
+            naked_identifier: data_ts
+        - keyword: RESULT_CACHE
+        - bracketed:
+          - start_bracket: (
+          - keyword: MODE
+          - keyword: FORCE
+          - end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      create_table_statement:
+      - keyword: CREATE
+      - keyword: TABLE
+      - table_reference:
+        - naked_identifier: s1
+        - dot: .
+        - naked_identifier: t_inmemory_default
+      - bracketed:
+          start_bracket: (
+          column_definition:
+            naked_identifier: id
+            data_type:
+              data_type_identifier: NUMBER
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  numeric_literal: '10'
+                  end_bracket: )
+            column_constraint_segment:
+            - keyword: NOT
+            - keyword: 'NULL'
+          end_bracket: )
+      - oracle_physical_attributes:
+        - keyword: TABLESPACE
+        - object_reference:
+            naked_identifier: data_ts
+        - keyword: INMEMORY
+  - statement_terminator: ;
+  - statement:
+      create_table_statement:
+      - keyword: CREATE
+      - keyword: TABLE
+      - table_reference:
+        - naked_identifier: s1
+        - dot: .
+        - naked_identifier: t_inmemory_memcompress_query_high
+      - bracketed:
+        - start_bracket: (
+        - column_definition:
+            naked_identifier: id
+            data_type:
+              data_type_identifier: NUMBER
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  numeric_literal: '10'
+                  end_bracket: )
+            column_constraint_segment:
+            - keyword: NOT
+            - keyword: 'NULL'
+        - comma: ','
+        - column_definition:
+            naked_identifier: data
+            data_type:
+              data_type_identifier: VARCHAR2
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  numeric_literal: '200'
+                  end_bracket: )
+        - end_bracket: )
+      - oracle_physical_attributes:
+        - keyword: TABLESPACE
+        - object_reference:
+            naked_identifier: data_ts
+        - keyword: INMEMORY
+        - keyword: MEMCOMPRESS
+        - keyword: FOR
+        - keyword: QUERY
+        - keyword: HIGH
+  - statement_terminator: ;
+  - statement:
+      create_table_statement:
+      - keyword: CREATE
+      - keyword: TABLE
+      - table_reference:
+        - naked_identifier: s1
+        - dot: .
+        - naked_identifier: t_inmemory_memcompress_archive_low
+      - bracketed:
+          start_bracket: (
+          column_definition:
+            naked_identifier: id
+            data_type:
+              data_type_identifier: NUMBER
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  numeric_literal: '10'
+                  end_bracket: )
+            column_constraint_segment:
+            - keyword: NOT
+            - keyword: 'NULL'
+          end_bracket: )
+      - oracle_physical_attributes:
+        - keyword: TABLESPACE
+        - object_reference:
+            naked_identifier: data_ts
+        - keyword: INMEMORY
+        - keyword: MEMCOMPRESS
+        - keyword: FOR
+        - keyword: ARCHIVE
+        - keyword: LOW
+  - statement_terminator: ;
+  - statement:
+      create_table_statement:
+      - keyword: CREATE
+      - keyword: TABLE
+      - table_reference:
+        - naked_identifier: s1
+        - dot: .
+        - naked_identifier: t_inmemory_priority_critical
+      - bracketed:
+          start_bracket: (
+          column_definition:
+            naked_identifier: id
+            data_type:
+              data_type_identifier: NUMBER
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  numeric_literal: '10'
+                  end_bracket: )
+            column_constraint_segment:
+            - keyword: NOT
+            - keyword: 'NULL'
+          end_bracket: )
+      - oracle_physical_attributes:
+        - keyword: TABLESPACE
+        - object_reference:
+            naked_identifier: data_ts
+        - keyword: INMEMORY
+        - keyword: PRIORITY
+        - keyword: CRITICAL
+  - statement_terminator: ;
+  - statement:
+      create_table_statement:
+      - keyword: CREATE
+      - keyword: TABLE
+      - table_reference:
+        - naked_identifier: s1
+        - dot: .
+        - naked_identifier: t_inmemory_full
+      - bracketed:
+          start_bracket: (
+          column_definition:
+            naked_identifier: id
+            data_type:
+              data_type_identifier: NUMBER
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  numeric_literal: '10'
+                  end_bracket: )
+            column_constraint_segment:
+            - keyword: NOT
+            - keyword: 'NULL'
+          end_bracket: )
+      - oracle_physical_attributes:
+        - keyword: TABLESPACE
+        - object_reference:
+            naked_identifier: data_ts
+        - keyword: INMEMORY
+        - keyword: MEMCOMPRESS
+        - keyword: FOR
+        - keyword: QUERY
+        - keyword: HIGH
+        - keyword: PRIORITY
+        - keyword: HIGH
+  - statement_terminator: ;
+  - statement:
+      create_table_statement:
+      - keyword: CREATE
+      - keyword: TABLE
+      - table_reference:
+        - naked_identifier: s1
+        - dot: .
+        - naked_identifier: t_inmemory_no_memcompress
+      - bracketed:
+          start_bracket: (
+          column_definition:
+            naked_identifier: id
+            data_type:
+              data_type_identifier: NUMBER
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  numeric_literal: '10'
+                  end_bracket: )
+            column_constraint_segment:
+            - keyword: NOT
+            - keyword: 'NULL'
+          end_bracket: )
+      - oracle_physical_attributes:
+        - keyword: TABLESPACE
+        - object_reference:
+            naked_identifier: data_ts
+        - keyword: INMEMORY
+        - keyword: 'NO'
+        - keyword: MEMCOMPRESS
+  - statement_terminator: ;
+  - statement:
+      create_table_statement:
+      - keyword: CREATE
+      - keyword: TABLE
+      - table_reference:
+        - naked_identifier: s1
+        - dot: .
+        - naked_identifier: t_inmemory_no_memcompress_priority
+      - bracketed:
+          start_bracket: (
+          column_definition:
+            naked_identifier: id
+            data_type:
+              data_type_identifier: NUMBER
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  numeric_literal: '10'
+                  end_bracket: )
+            column_constraint_segment:
+            - keyword: NOT
+            - keyword: 'NULL'
+          end_bracket: )
+      - oracle_physical_attributes:
+        - keyword: TABLESPACE
+        - object_reference:
+            naked_identifier: data_ts
+        - keyword: INMEMORY
+        - keyword: 'NO'
+        - keyword: MEMCOMPRESS
+        - keyword: PRIORITY
+        - keyword: HIGH
+  - statement_terminator: ;
+  - statement:
+      create_table_statement:
+      - keyword: CREATE
+      - keyword: TABLE
+      - table_reference:
+        - naked_identifier: s1
+        - dot: .
+        - naked_identifier: t_no_inmemory
+      - bracketed:
+          start_bracket: (
+          column_definition:
+            naked_identifier: id
+            data_type:
+              data_type_identifier: NUMBER
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  numeric_literal: '10'
+                  end_bracket: )
+            column_constraint_segment:
+            - keyword: NOT
+            - keyword: 'NULL'
+          end_bracket: )
+      - oracle_physical_attributes:
+        - keyword: TABLESPACE
+        - object_reference:
+            naked_identifier: data_ts
+        - keyword: 'NO'
+        - keyword: INMEMORY
+  - statement_terminator: ;
+  - statement:
+      create_table_statement:
+      - keyword: CREATE
+      - keyword: TABLE
+      - table_reference:
+        - naked_identifier: s1
+        - dot: .
+        - naked_identifier: t_inmemory_distribute_auto
+      - bracketed:
+          start_bracket: (
+          column_definition:
+            naked_identifier: id
+            data_type:
+              data_type_identifier: NUMBER
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  numeric_literal: '10'
+                  end_bracket: )
+            column_constraint_segment:
+            - keyword: NOT
+            - keyword: 'NULL'
+          end_bracket: )
+      - oracle_physical_attributes:
+        - keyword: TABLESPACE
+        - object_reference:
+            naked_identifier: data_ts
+        - keyword: INMEMORY
+        - keyword: DISTRIBUTE
+        - keyword: AUTO
+  - statement_terminator: ;
+  - statement:
+      create_table_statement:
+      - keyword: CREATE
+      - keyword: TABLE
+      - table_reference:
+        - naked_identifier: s1
+        - dot: .
+        - naked_identifier: t_inmemory_distribute_by_rowid_range
+      - bracketed:
+          start_bracket: (
+          column_definition:
+            naked_identifier: id
+            data_type:
+              data_type_identifier: NUMBER
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  numeric_literal: '10'
+                  end_bracket: )
+            column_constraint_segment:
+            - keyword: NOT
+            - keyword: 'NULL'
+          end_bracket: )
+      - oracle_physical_attributes:
+        - keyword: TABLESPACE
+        - object_reference:
+            naked_identifier: data_ts
+        - keyword: INMEMORY
+        - keyword: DISTRIBUTE
+        - keyword: BY
+        - keyword: ROWID
+        - keyword: RANGE
+  - statement_terminator: ;
+  - statement:
+      create_table_statement:
+      - keyword: CREATE
+      - keyword: TABLE
+      - table_reference:
+        - naked_identifier: s1
+        - dot: .
+        - naked_identifier: t_inmemory_distribute_by_partition
+      - bracketed:
+          start_bracket: (
+          column_definition:
+            naked_identifier: id
+            data_type:
+              data_type_identifier: NUMBER
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  numeric_literal: '10'
+                  end_bracket: )
+            column_constraint_segment:
+            - keyword: NOT
+            - keyword: 'NULL'
+          end_bracket: )
+      - oracle_physical_attributes:
+        - keyword: TABLESPACE
+        - object_reference:
+            naked_identifier: data_ts
+        - keyword: INMEMORY
+        - keyword: DISTRIBUTE
+        - keyword: BY
+        - keyword: PARTITION
+  - statement_terminator: ;
+  - statement:
+      create_table_statement:
+      - keyword: CREATE
+      - keyword: TABLE
+      - table_reference:
+        - naked_identifier: s1
+        - dot: .
+        - naked_identifier: t_inmemory_distribute_by_subpartition
+      - bracketed:
+          start_bracket: (
+          column_definition:
+            naked_identifier: id
+            data_type:
+              data_type_identifier: NUMBER
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  numeric_literal: '10'
+                  end_bracket: )
+            column_constraint_segment:
+            - keyword: NOT
+            - keyword: 'NULL'
+          end_bracket: )
+      - oracle_physical_attributes:
+        - keyword: TABLESPACE
+        - object_reference:
+            naked_identifier: data_ts
+        - keyword: INMEMORY
+        - keyword: DISTRIBUTE
+        - keyword: BY
+        - keyword: SUBPARTITION
+  - statement_terminator: ;
+  - statement:
+      create_table_statement:
+      - keyword: CREATE
+      - keyword: TABLE
+      - table_reference:
+        - naked_identifier: s1
+        - dot: .
+        - naked_identifier: t_inmemory_distribute_for_service
+      - bracketed:
+          start_bracket: (
+          column_definition:
+            naked_identifier: id
+            data_type:
+              data_type_identifier: NUMBER
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  numeric_literal: '10'
+                  end_bracket: )
+            column_constraint_segment:
+            - keyword: NOT
+            - keyword: 'NULL'
+          end_bracket: )
+      - oracle_physical_attributes:
+        - keyword: TABLESPACE
+        - object_reference:
+            naked_identifier: data_ts
+        - keyword: INMEMORY
+        - keyword: DISTRIBUTE
+        - keyword: AUTO
+        - keyword: FOR
+        - keyword: SERVICE
+        - object_reference:
+            naked_identifier: my_service
+  - statement_terminator: ;
+  - statement:
+      create_table_statement:
+      - keyword: CREATE
+      - keyword: TABLE
+      - table_reference:
+        - naked_identifier: s1
+        - dot: .
+        - naked_identifier: t_inmemory_distribute_for_service_default
+      - bracketed:
+          start_bracket: (
+          column_definition:
+            naked_identifier: id
+            data_type:
+              data_type_identifier: NUMBER
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  numeric_literal: '10'
+                  end_bracket: )
+            column_constraint_segment:
+            - keyword: NOT
+            - keyword: 'NULL'
+          end_bracket: )
+      - oracle_physical_attributes:
+        - keyword: TABLESPACE
+        - object_reference:
+            naked_identifier: data_ts
+        - keyword: INMEMORY
+        - keyword: DISTRIBUTE
+        - keyword: FOR
+        - keyword: SERVICE
+        - keyword: DEFAULT
+  - statement_terminator: ;
+  - statement:
+      create_table_statement:
+      - keyword: CREATE
+      - keyword: TABLE
+      - table_reference:
+        - naked_identifier: s1
+        - dot: .
+        - naked_identifier: t_inmemory_duplicate
+      - bracketed:
+          start_bracket: (
+          column_definition:
+            naked_identifier: id
+            data_type:
+              data_type_identifier: NUMBER
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  numeric_literal: '10'
+                  end_bracket: )
+            column_constraint_segment:
+            - keyword: NOT
+            - keyword: 'NULL'
+          end_bracket: )
+      - oracle_physical_attributes:
+        - keyword: TABLESPACE
+        - object_reference:
+            naked_identifier: data_ts
+        - keyword: INMEMORY
+        - keyword: DUPLICATE
+  - statement_terminator: ;
+  - statement:
+      create_table_statement:
+      - keyword: CREATE
+      - keyword: TABLE
+      - table_reference:
+        - naked_identifier: s1
+        - dot: .
+        - naked_identifier: t_inmemory_duplicate_all
+      - bracketed:
+          start_bracket: (
+          column_definition:
+            naked_identifier: id
+            data_type:
+              data_type_identifier: NUMBER
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  numeric_literal: '10'
+                  end_bracket: )
+            column_constraint_segment:
+            - keyword: NOT
+            - keyword: 'NULL'
+          end_bracket: )
+      - oracle_physical_attributes:
+        - keyword: TABLESPACE
+        - object_reference:
+            naked_identifier: data_ts
+        - keyword: INMEMORY
+        - keyword: DUPLICATE
+        - keyword: ALL
+  - statement_terminator: ;
+  - statement:
+      create_table_statement:
+      - keyword: CREATE
+      - keyword: TABLE
+      - table_reference:
+        - naked_identifier: s1
+        - dot: .
+        - naked_identifier: t_inmemory_no_duplicate
+      - bracketed:
+          start_bracket: (
+          column_definition:
+            naked_identifier: id
+            data_type:
+              data_type_identifier: NUMBER
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  numeric_literal: '10'
+                  end_bracket: )
+            column_constraint_segment:
+            - keyword: NOT
+            - keyword: 'NULL'
+          end_bracket: )
+      - oracle_physical_attributes:
+        - keyword: TABLESPACE
+        - object_reference:
+            naked_identifier: data_ts
+        - keyword: INMEMORY
+        - keyword: 'NO'
+        - keyword: DUPLICATE
+  - statement_terminator: ;
+  - statement:
+      create_table_statement:
+      - keyword: CREATE
+      - keyword: TABLE
+      - table_reference:
+        - naked_identifier: s1
+        - dot: .
+        - naked_identifier: t_inmemory_all_subclauses
+      - bracketed:
+        - start_bracket: (
+        - column_definition:
+            naked_identifier: id
+            data_type:
+              data_type_identifier: NUMBER
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  numeric_literal: '10'
+                  end_bracket: )
+            column_constraint_segment:
+            - keyword: NOT
+            - keyword: 'NULL'
+        - comma: ','
+        - column_definition:
+            naked_identifier: data
+            data_type:
+              data_type_identifier: VARCHAR2
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  numeric_literal: '200'
+                  end_bracket: )
+        - end_bracket: )
+      - oracle_physical_attributes:
+        - keyword: TABLESPACE
+        - object_reference:
+            naked_identifier: data_ts
+        - keyword: INMEMORY
+        - keyword: MEMCOMPRESS
+        - keyword: FOR
+        - keyword: QUERY
+        - keyword: HIGH
+        - keyword: PRIORITY
+        - keyword: HIGH
+        - keyword: DISTRIBUTE
+        - keyword: AUTO
+        - keyword: DUPLICATE
+        - keyword: ALL
+  - statement_terminator: ;
+  - statement:
+      create_table_statement:
+      - keyword: CREATE
+      - keyword: TABLE
+      - table_reference:
+        - naked_identifier: s1
+        - dot: .
+        - naked_identifier: t_flashback
+      - bracketed:
+        - start_bracket: (
+        - column_definition:
+            naked_identifier: id
+            data_type:
+              data_type_identifier: NUMBER
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  numeric_literal: '10'
+                  end_bracket: )
+            column_constraint_segment:
+            - keyword: NOT
+            - keyword: 'NULL'
+        - comma: ','
+        - column_definition:
+            naked_identifier: info
+            data_type:
+              data_type_identifier: VARCHAR2
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  numeric_literal: '100'
+                  end_bracket: )
+        - end_bracket: )
+      - oracle_physical_attributes:
+        - keyword: TABLESPACE
+        - object_reference:
+            naked_identifier: data_ts
+        - keyword: FLASHBACK
+        - keyword: ARCHIVE
+        - object_reference:
+            naked_identifier: my_fba
+  - statement_terminator: ;
+  - statement:
+      create_table_statement:
+      - keyword: CREATE
+      - keyword: TABLE
+      - table_reference:
+        - naked_identifier: s1
+        - dot: .
+        - naked_identifier: t_flashback_default
+      - bracketed:
+          start_bracket: (
+          column_definition:
+            naked_identifier: id
+            data_type:
+              data_type_identifier: NUMBER
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  numeric_literal: '10'
+                  end_bracket: )
+            column_constraint_segment:
+            - keyword: NOT
+            - keyword: 'NULL'
+          end_bracket: )
+      - oracle_physical_attributes:
+        - keyword: TABLESPACE
+        - object_reference:
+            naked_identifier: data_ts
+        - keyword: FLASHBACK
+        - keyword: ARCHIVE
+  - statement_terminator: ;
+  - statement:
+      create_table_statement:
+      - keyword: CREATE
+      - keyword: TABLE
+      - table_reference:
+        - naked_identifier: s1
+        - dot: .
+        - naked_identifier: t_no_flashback
+      - bracketed:
+          start_bracket: (
+          column_definition:
+            naked_identifier: id
+            data_type:
+              data_type_identifier: NUMBER
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  numeric_literal: '10'
+                  end_bracket: )
+            column_constraint_segment:
+            - keyword: NOT
+            - keyword: 'NULL'
+          end_bracket: )
+      - oracle_physical_attributes:
+        - keyword: TABLESPACE
+        - object_reference:
+            naked_identifier: data_ts
+        - keyword: 'NO'
+        - keyword: FLASHBACK
+        - keyword: ARCHIVE
+  - statement_terminator: ;
+  - statement:
+      create_table_statement:
+      - keyword: CREATE
+      - keyword: TABLE
+      - table_reference:
+        - naked_identifier: s1
+        - dot: .
+        - naked_identifier: t_rowdeps
+      - bracketed:
+          start_bracket: (
+          column_definition:
+            naked_identifier: id
+            data_type:
+              data_type_identifier: NUMBER
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  numeric_literal: '10'
+                  end_bracket: )
+            column_constraint_segment:
+            - keyword: NOT
+            - keyword: 'NULL'
+          end_bracket: )
+      - oracle_physical_attributes:
+        - keyword: TABLESPACE
+        - object_reference:
+            naked_identifier: data_ts
+        - keyword: ROWDEPENDENCIES
+  - statement_terminator: ;
+  - statement:
+      create_table_statement:
+      - keyword: CREATE
+      - keyword: TABLE
+      - table_reference:
+        - naked_identifier: s1
+        - dot: .
+        - naked_identifier: t_norowdeps
+      - bracketed:
+          start_bracket: (
+          column_definition:
+            naked_identifier: id
+            data_type:
+              data_type_identifier: NUMBER
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  numeric_literal: '10'
+                  end_bracket: )
+            column_constraint_segment:
+            - keyword: NOT
+            - keyword: 'NULL'
+          end_bracket: )
+      - oracle_physical_attributes:
+        - keyword: TABLESPACE
+        - object_reference:
+            naked_identifier: data_ts
+        - keyword: NOROWDEPENDENCIES
+  - statement_terminator: ;
+  - statement:
+      create_table_statement:
+      - keyword: CREATE
+      - keyword: TABLE
+      - table_reference:
+        - naked_identifier: s1
+        - dot: .
+        - naked_identifier: t_segment_immediate
+      - bracketed:
+          start_bracket: (
+          column_definition:
+            naked_identifier: id
+            data_type:
+              data_type_identifier: NUMBER
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  numeric_literal: '10'
+                  end_bracket: )
+            column_constraint_segment:
+            - keyword: NOT
+            - keyword: 'NULL'
+          end_bracket: )
+      - oracle_physical_attributes:
+        - keyword: SEGMENT
+        - keyword: CREATION
+        - keyword: IMMEDIATE
+        - keyword: TABLESPACE
+        - object_reference:
+            naked_identifier: data_ts
+  - statement_terminator: ;
+  - statement:
+      create_table_statement:
+      - keyword: CREATE
+      - keyword: TABLE
+      - table_reference:
+        - naked_identifier: s1
+        - dot: .
+        - naked_identifier: t_segment_deferred
+      - bracketed:
+          start_bracket: (
+          column_definition:
+            naked_identifier: id
+            data_type:
+              data_type_identifier: NUMBER
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  numeric_literal: '10'
+                  end_bracket: )
+            column_constraint_segment:
+            - keyword: NOT
+            - keyword: 'NULL'
+          end_bracket: )
+      - oracle_physical_attributes:
+        - keyword: SEGMENT
+        - keyword: CREATION
+        - keyword: DEFERRED
+        - keyword: TABLESPACE
+        - object_reference:
+            naked_identifier: data_ts
+  - statement_terminator: ;
+  - statement:
+      create_table_statement:
+      - keyword: CREATE
+      - keyword: TABLE
+      - table_reference:
+        - naked_identifier: s1
+        - dot: .
+        - naked_identifier: t_segment_immediate_storage
+      - bracketed:
+          start_bracket: (
+          column_definition:
+            naked_identifier: id
+            data_type:
+              data_type_identifier: NUMBER
+              bracketed_arguments:
+                bracketed:
+                - start_bracket: (
+                - numeric_literal: '19'
+                - comma: ','
+                - numeric_literal: '0'
+                - end_bracket: )
+          comma: ','
+          table_constraint:
+          - keyword: CONSTRAINT
+          - object_reference:
+              naked_identifier: id_pk
+          - keyword: PRIMARY
+          - keyword: KEY
+          - bracketed:
+              start_bracket: (
+              column_reference:
+                naked_identifier: id
+              end_bracket: )
+          end_bracket: )
+      - oracle_physical_attributes:
+        - keyword: SEGMENT
+        - keyword: CREATION
+        - keyword: IMMEDIATE
+        - keyword: PCTFREE
+        - numeric_literal: '10'
+        - keyword: PCTUSED
+        - numeric_literal: '40'
+        - keyword: INITRANS
+        - numeric_literal: '1'
+        - keyword: MAXTRANS
+        - numeric_literal: '255'
+        - keyword: NOCOMPRESS
+        - keyword: LOGGING
+        - storage_clause:
+            keyword: STORAGE
+            bracketed:
+            - start_bracket: (
+            - keyword: INITIAL
+            - numeric_literal: '65536'
+            - keyword: NEXT
+            - numeric_literal: '1048576'
+            - keyword: MINEXTENTS
+            - numeric_literal: '1'
+            - keyword: MAXEXTENTS
+            - numeric_literal: '2147483645'
+            - keyword: PCTINCREASE
+            - numeric_literal: '0'
+            - keyword: FREELISTS
+            - numeric_literal: '1'
+            - keyword: FREELIST
+            - keyword: GROUPS
+            - numeric_literal: '1'
+            - keyword: BUFFER_POOL
+            - keyword: DEFAULT
+            - keyword: FLASH_CACHE
+            - keyword: DEFAULT
+            - keyword: CELL_FLASH_CACHE
+            - keyword: DEFAULT
+            - end_bracket: )
+        - keyword: TABLESPACE
+        - object_reference:
+            naked_identifier: data_ts
+  - statement_terminator: ;
+  - statement:
+      create_table_statement:
+      - keyword: CREATE
+      - keyword: TABLE
+      - table_reference:
+        - naked_identifier: s1
+        - dot: .
+        - naked_identifier: t_flash_cache_keep
+      - bracketed:
+          start_bracket: (
+          column_definition:
+            naked_identifier: id
+            data_type:
+              data_type_identifier: NUMBER
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  numeric_literal: '10'
+                  end_bracket: )
+            column_constraint_segment:
+            - keyword: NOT
+            - keyword: 'NULL'
+          end_bracket: )
+      - oracle_physical_attributes:
+          storage_clause:
+            keyword: STORAGE
+            bracketed:
+            - start_bracket: (
+            - keyword: INITIAL
+            - numeric_literal: '64'
+            - size_prefix: K
+            - keyword: BUFFER_POOL
+            - keyword: DEFAULT
+            - keyword: FLASH_CACHE
+            - keyword: KEEP
+            - keyword: CELL_FLASH_CACHE
+            - keyword: KEEP
+            - end_bracket: )
+          keyword: TABLESPACE
+          object_reference:
+            naked_identifier: data_ts
+  - statement_terminator: ;
+  - statement:
+      create_table_statement:
+      - keyword: CREATE
+      - keyword: TABLE
+      - table_reference:
+        - naked_identifier: s1
+        - dot: .
+        - naked_identifier: t_flash_cache_none
+      - bracketed:
+          start_bracket: (
+          column_definition:
+            naked_identifier: id
+            data_type:
+              data_type_identifier: NUMBER
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  numeric_literal: '10'
+                  end_bracket: )
+            column_constraint_segment:
+            - keyword: NOT
+            - keyword: 'NULL'
+          end_bracket: )
+      - oracle_physical_attributes:
+          storage_clause:
+            keyword: STORAGE
+            bracketed:
+            - start_bracket: (
+            - keyword: INITIAL
+            - numeric_literal: '64'
+            - size_prefix: K
+            - keyword: FLASH_CACHE
+            - keyword: NONE
+            - keyword: CELL_FLASH_CACHE
+            - keyword: NONE
+            - end_bracket: )
+          keyword: TABLESPACE
+          object_reference:
+            naked_identifier: data_ts
+  - statement_terminator: ;
+  - statement:
+      create_table_statement:
+      - keyword: CREATE
+      - keyword: TABLE
+      - table_reference:
+        - naked_identifier: s1
+        - dot: .
+        - naked_identifier: t_storage_maxsize
+      - bracketed:
+          start_bracket: (
+          column_definition:
+            naked_identifier: id
+            data_type:
+              data_type_identifier: NUMBER
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  numeric_literal: '10'
+                  end_bracket: )
+            column_constraint_segment:
+            - keyword: NOT
+            - keyword: 'NULL'
+          end_bracket: )
+      - oracle_physical_attributes:
+          storage_clause:
+            keyword: STORAGE
+            bracketed:
+            - start_bracket: (
+            - keyword: INITIAL
+            - numeric_literal: '8'
+            - size_prefix: M
+            - keyword: MAXSIZE
+            - numeric_literal: '1'
+            - size_prefix: G
+            - end_bracket: )
+          keyword: TABLESPACE
+          object_reference:
+            naked_identifier: data_ts
+  - statement_terminator: ;
+  - statement:
+      create_table_statement:
+      - keyword: CREATE
+      - keyword: TABLE
+      - table_reference:
+        - naked_identifier: s1
+        - dot: .
+        - naked_identifier: t_storage_maxsize_unlimited
+      - bracketed:
+          start_bracket: (
+          column_definition:
+            naked_identifier: id
+            data_type:
+              data_type_identifier: NUMBER
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  numeric_literal: '10'
+                  end_bracket: )
+            column_constraint_segment:
+            - keyword: NOT
+            - keyword: 'NULL'
+          end_bracket: )
+      - oracle_physical_attributes:
+          storage_clause:
+            keyword: STORAGE
+            bracketed:
+            - start_bracket: (
+            - keyword: INITIAL
+            - numeric_literal: '8'
+            - size_prefix: M
+            - keyword: MAXSIZE
+            - keyword: UNLIMITED
+            - end_bracket: )
+          keyword: TABLESPACE
+          object_reference:
+            naked_identifier: data_ts
+  - statement_terminator: ;
+  - statement:
+      create_table_statement:
+      - keyword: CREATE
+      - keyword: TABLE
+      - table_reference:
+        - naked_identifier: s1
+        - dot: .
+        - naked_identifier: t_row_store_compress_basic
+      - bracketed:
+        - start_bracket: (
+        - column_definition:
+            naked_identifier: id
+            data_type:
+              data_type_identifier: NUMBER
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  numeric_literal: '10'
+                  end_bracket: )
+            column_constraint_segment:
+            - keyword: NOT
+            - keyword: 'NULL'
+        - comma: ','
+        - column_definition:
+            naked_identifier: data
+            data_type:
+              data_type_identifier: VARCHAR2
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  numeric_literal: '200'
+                  end_bracket: )
+        - end_bracket: )
+      - oracle_physical_attributes:
+        - keyword: ROW
+        - keyword: STORE
+        - keyword: COMPRESS
+        - keyword: BASIC
+        - keyword: TABLESPACE
+        - object_reference:
+            naked_identifier: data_ts
+  - statement_terminator: ;
+  - statement:
+      create_table_statement:
+      - keyword: CREATE
+      - keyword: TABLE
+      - table_reference:
+        - naked_identifier: s1
+        - dot: .
+        - naked_identifier: t_row_store_compress_advanced
+      - bracketed:
+        - start_bracket: (
+        - column_definition:
+            naked_identifier: id
+            data_type:
+              data_type_identifier: NUMBER
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  numeric_literal: '10'
+                  end_bracket: )
+            column_constraint_segment:
+            - keyword: NOT
+            - keyword: 'NULL'
+        - comma: ','
+        - column_definition:
+            naked_identifier: data
+            data_type:
+              data_type_identifier: VARCHAR2
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  numeric_literal: '200'
+                  end_bracket: )
+        - end_bracket: )
+      - oracle_physical_attributes:
+        - keyword: ROW
+        - keyword: STORE
+        - keyword: COMPRESS
+        - keyword: ADVANCED
+        - keyword: TABLESPACE
+        - object_reference:
+            naked_identifier: data_ts
+  - statement_terminator: ;
+  - statement:
+      create_table_statement:
+      - keyword: CREATE
+      - keyword: TABLE
+      - table_reference:
+        - naked_identifier: s1
+        - dot: .
+        - naked_identifier: t_row_store_compress_no_level
+      - bracketed:
+          start_bracket: (
+          column_definition:
+            naked_identifier: id
+            data_type:
+              data_type_identifier: NUMBER
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  numeric_literal: '10'
+                  end_bracket: )
+            column_constraint_segment:
+            - keyword: NOT
+            - keyword: 'NULL'
+          end_bracket: )
+      - oracle_physical_attributes:
+        - keyword: ROW
+        - keyword: STORE
+        - keyword: COMPRESS
+        - keyword: TABLESPACE
+        - object_reference:
+            naked_identifier: data_ts
+  - statement_terminator: ;
+  - statement:
+      create_table_statement:
+      - keyword: CREATE
+      - keyword: TABLE
+      - table_reference:
+        - naked_identifier: s1
+        - dot: .
+        - naked_identifier: t_column_store_compress
+      - bracketed:
+        - start_bracket: (
+        - column_definition:
+            naked_identifier: id
+            data_type:
+              data_type_identifier: NUMBER
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  numeric_literal: '10'
+                  end_bracket: )
+            column_constraint_segment:
+            - keyword: NOT
+            - keyword: 'NULL'
+        - comma: ','
+        - column_definition:
+            naked_identifier: data
+            data_type:
+              data_type_identifier: VARCHAR2
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  numeric_literal: '200'
+                  end_bracket: )
+        - end_bracket: )
+      - oracle_physical_attributes:
+        - keyword: COLUMN
+        - keyword: STORE
+        - keyword: COMPRESS
+        - keyword: TABLESPACE
+        - object_reference:
+            naked_identifier: data_ts
+  - statement_terminator: ;
+  - statement:
+      create_table_statement:
+      - keyword: CREATE
+      - keyword: TABLE
+      - table_reference:
+        - naked_identifier: s1
+        - dot: .
+        - naked_identifier: t_column_store_compress_query_low
+      - bracketed:
+        - start_bracket: (
+        - column_definition:
+            naked_identifier: id
+            data_type:
+              data_type_identifier: NUMBER
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  numeric_literal: '10'
+                  end_bracket: )
+            column_constraint_segment:
+            - keyword: NOT
+            - keyword: 'NULL'
+        - comma: ','
+        - column_definition:
+            naked_identifier: data
+            data_type:
+              data_type_identifier: VARCHAR2
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  numeric_literal: '200'
+                  end_bracket: )
+        - end_bracket: )
+      - oracle_physical_attributes:
+        - keyword: COLUMN
+        - keyword: STORE
+        - keyword: COMPRESS
+        - keyword: FOR
+        - keyword: QUERY
+        - keyword: LOW
+        - keyword: TABLESPACE
+        - object_reference:
+            naked_identifier: data_ts
+  - statement_terminator: ;
+  - statement:
+      create_table_statement:
+      - keyword: CREATE
+      - keyword: TABLE
+      - table_reference:
+        - naked_identifier: s1
+        - dot: .
+        - naked_identifier: t_column_store_compress_query_high
+      - bracketed:
+        - start_bracket: (
+        - column_definition:
+            naked_identifier: id
+            data_type:
+              data_type_identifier: NUMBER
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  numeric_literal: '10'
+                  end_bracket: )
+            column_constraint_segment:
+            - keyword: NOT
+            - keyword: 'NULL'
+        - comma: ','
+        - column_definition:
+            naked_identifier: data
+            data_type:
+              data_type_identifier: VARCHAR2
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  numeric_literal: '200'
+                  end_bracket: )
+        - end_bracket: )
+      - oracle_physical_attributes:
+        - keyword: COLUMN
+        - keyword: STORE
+        - keyword: COMPRESS
+        - keyword: FOR
+        - keyword: QUERY
+        - keyword: HIGH
+        - keyword: TABLESPACE
+        - object_reference:
+            naked_identifier: data_ts
+  - statement_terminator: ;
+  - statement:
+      create_table_statement:
+      - keyword: CREATE
+      - keyword: TABLE
+      - table_reference:
+        - naked_identifier: s1
+        - dot: .
+        - naked_identifier: t_column_store_compress_archive_high
+      - bracketed:
+        - start_bracket: (
+        - column_definition:
+            naked_identifier: id
+            data_type:
+              data_type_identifier: NUMBER
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  numeric_literal: '10'
+                  end_bracket: )
+            column_constraint_segment:
+            - keyword: NOT
+            - keyword: 'NULL'
+        - comma: ','
+        - column_definition:
+            naked_identifier: data
+            data_type:
+              data_type_identifier: VARCHAR2
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  numeric_literal: '200'
+                  end_bracket: )
+        - end_bracket: )
+      - oracle_physical_attributes:
+        - keyword: COLUMN
+        - keyword: STORE
+        - keyword: COMPRESS
+        - keyword: FOR
+        - keyword: ARCHIVE
+        - keyword: HIGH
+        - keyword: TABLESPACE
+        - object_reference:
+            naked_identifier: data_ts
+  - statement_terminator: ;
+  - statement:
+      create_table_statement:
+      - keyword: CREATE
+      - keyword: TABLE
+      - table_reference:
+        - naked_identifier: s1
+        - dot: .
+        - naked_identifier: t_column_store_compress_no_row_locking
+      - bracketed:
+        - start_bracket: (
+        - column_definition:
+            naked_identifier: id
+            data_type:
+              data_type_identifier: NUMBER
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  numeric_literal: '10'
+                  end_bracket: )
+            column_constraint_segment:
+            - keyword: NOT
+            - keyword: 'NULL'
+        - comma: ','
+        - column_definition:
+            naked_identifier: data
+            data_type:
+              data_type_identifier: VARCHAR2
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  numeric_literal: '200'
+                  end_bracket: )
+        - end_bracket: )
+      - oracle_physical_attributes:
+        - keyword: COLUMN
+        - keyword: STORE
+        - keyword: COMPRESS
+        - keyword: FOR
+        - keyword: QUERY
+        - keyword: HIGH
+        - keyword: 'NO'
+        - keyword: ROW
+        - keyword: LEVEL
+        - keyword: LOCKING
+        - keyword: TABLESPACE
+        - object_reference:
+            naked_identifier: data_ts
+  - statement_terminator: ;
+  - statement:
+      create_table_statement:
+      - keyword: CREATE
+      - keyword: TABLE
+      - table_reference:
+        - naked_identifier: s1
+        - dot: .
+        - naked_identifier: t_monitoring
+      - bracketed:
+          start_bracket: (
+          column_definition:
+            naked_identifier: id
+            data_type:
+              data_type_identifier: NUMBER
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  numeric_literal: '10'
+                  end_bracket: )
+            column_constraint_segment:
+            - keyword: NOT
+            - keyword: 'NULL'
+          end_bracket: )
+      - oracle_physical_attributes:
+        - keyword: MONITORING
+        - keyword: TABLESPACE
+        - object_reference:
+            naked_identifier: data_ts
+  - statement_terminator: ;
+  - statement:
+      create_table_statement:
+      - keyword: CREATE
+      - keyword: TABLE
+      - table_reference:
+        - naked_identifier: s1
+        - dot: .
+        - naked_identifier: t_nomonitoring
+      - bracketed:
+          start_bracket: (
+          column_definition:
+            naked_identifier: id
+            data_type:
+              data_type_identifier: NUMBER
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  numeric_literal: '10'
+                  end_bracket: )
+            column_constraint_segment:
+            - keyword: NOT
+            - keyword: 'NULL'
+          end_bracket: )
+      - oracle_physical_attributes:
+        - keyword: NOMONITORING
+        - keyword: TABLESPACE
+        - object_reference:
+            naked_identifier: data_ts
+  - statement_terminator: ;
+  - statement:
+      create_table_statement:
+      - keyword: CREATE
+      - keyword: TABLE
+      - table_reference:
+        - naked_identifier: s1
+        - dot: .
+        - naked_identifier: t_all_physical
+      - bracketed:
+        - start_bracket: (
+        - column_definition:
+            naked_identifier: id
+            data_type:
+              data_type_identifier: NUMBER
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  numeric_literal: '18'
+                  end_bracket: )
+            column_constraint_segment:
+            - keyword: NOT
+            - keyword: 'NULL'
+        - comma: ','
+        - column_definition:
+            naked_identifier: institution
+            data_type:
+              data_type_identifier: VARCHAR2
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  numeric_literal: '11'
+                  end_bracket: )
+            column_constraint_segment:
+            - keyword: NOT
+            - keyword: 'NULL'
+        - comma: ','
+        - column_definition:
+            naked_identifier: payload
+            data_type:
+              data_type_identifier: VARCHAR2
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  numeric_literal: '1000'
+                  end_bracket: )
+            column_constraint_segment:
+            - keyword: NOT
+            - keyword: 'NULL'
+        - comma: ','
+        - column_definition:
+          - naked_identifier: created_at
+          - data_type:
+              data_type_identifier: DATE
+          - column_constraint_segment:
+              keyword: DEFAULT
+              bare_function: SYSDATE
+          - column_constraint_segment:
+            - keyword: NOT
+            - keyword: 'NULL'
+        - comma: ','
+        - table_constraint:
+          - keyword: CONSTRAINT
+          - object_reference:
+              naked_identifier: t_all_phys_pk
+          - keyword: PRIMARY
+          - keyword: KEY
+          - bracketed:
+              start_bracket: (
+              column_reference:
+                naked_identifier: id
+              end_bracket: )
+          - using_index_clause:
+            - keyword: USING
+            - keyword: INDEX
+            - oracle_index_physical_attributes:
+              - keyword: PCTFREE
+              - numeric_literal: '10'
+              - keyword: INITRANS
+              - numeric_literal: '2'
+              - keyword: MAXTRANS
+              - numeric_literal: '255'
+              - keyword: TABLESPACE
+              - object_reference:
+                  naked_identifier: idx_ts
+              - storage_clause:
+                  keyword: STORAGE
+                  bracketed:
+                  - start_bracket: (
+                  - keyword: INITIAL
+                  - numeric_literal: '256'
+                  - size_prefix: K
+                  - keyword: NEXT
+                  - numeric_literal: '256'
+                  - size_prefix: K
+                  - keyword: MINEXTENTS
+                  - numeric_literal: '1'
+                  - keyword: MAXEXTENTS
+                  - numeric_literal: '121'
+                  - keyword: PCTINCREASE
+                  - numeric_literal: '0'
+                  - keyword: FREELISTS
+                  - numeric_literal: '1'
+                  - keyword: FREELIST
+                  - keyword: GROUPS
+                  - numeric_literal: '1'
+                  - keyword: BUFFER_POOL
+                  - keyword: DEFAULT
+                  - end_bracket: )
+              - keyword: LOGGING
+        - comma: ','
+        - table_constraint:
+          - keyword: CONSTRAINT
+          - object_reference:
+              naked_identifier: t_all_phys_uk
+          - keyword: UNIQUE
+          - bracketed:
+            - start_bracket: (
+            - column_reference:
+                naked_identifier: institution
+            - comma: ','
+            - column_reference:
+                naked_identifier: payload
+            - end_bracket: )
+          - using_index_clause:
+            - keyword: USING
+            - keyword: INDEX
+            - oracle_index_physical_attributes:
+              - keyword: PCTFREE
+              - numeric_literal: '10'
+              - keyword: TABLESPACE
+              - object_reference:
+                  naked_identifier: idx_ts
+              - storage_clause:
+                  keyword: STORAGE
+                  bracketed:
+                  - start_bracket: (
+                  - keyword: INITIAL
+                  - numeric_literal: '140'
+                  - size_prefix: K
+                  - keyword: NEXT
+                  - numeric_literal: '360'
+                  - size_prefix: K
+                  - keyword: BUFFER_POOL
+                  - keyword: KEEP
+                  - end_bracket: )
+              - keyword: NOLOGGING
+        - end_bracket: )
+      - oracle_physical_attributes:
+        - keyword: TABLESPACE
+        - object_reference:
+            naked_identifier: data_ts
+        - keyword: LOGGING
+        - keyword: PCTFREE
+        - numeric_literal: '10'
+        - keyword: PCTUSED
+        - numeric_literal: '70'
+        - keyword: INITRANS
+        - numeric_literal: '1'
+        - keyword: MAXTRANS
+        - numeric_literal: '255'
+        - storage_clause:
+            keyword: STORAGE
+            bracketed:
+            - start_bracket: (
+            - keyword: INITIAL
+            - numeric_literal: '655'
+            - size_prefix: K
+            - keyword: NEXT
+            - numeric_literal: '655'
+            - size_prefix: K
+            - keyword: MINEXTENTS
+            - numeric_literal: '1'
+            - keyword: MAXEXTENTS
+            - keyword: UNLIMITED
+            - keyword: PCTINCREASE
+            - numeric_literal: '1'
+            - keyword: FREELISTS
+            - numeric_literal: '1'
+            - keyword: FREELIST
+            - keyword: GROUPS
+            - numeric_literal: '1'
+            - keyword: BUFFER_POOL
+            - keyword: DEFAULT
+            - end_bracket: )
+        - keyword: COMPRESS
+        - keyword: FOR
+        - keyword: OLTP
+        - keyword: PARALLEL
+        - numeric_literal: '4'
+        - keyword: NOCACHE
+        - keyword: RESULT_CACHE
+        - bracketed:
+          - start_bracket: (
+          - keyword: MODE
+          - keyword: DEFAULT
+          - end_bracket: )
+        - keyword: INMEMORY
+        - keyword: MEMCOMPRESS
+        - keyword: FOR
+        - keyword: QUERY
+        - keyword: HIGH
+        - keyword: PRIORITY
+        - keyword: HIGH
+        - keyword: ENABLE
+        - keyword: ROW
+        - keyword: MOVEMENT
+        - keyword: FLASHBACK
+        - keyword: ARCHIVE
+        - object_reference:
+            naked_identifier: corp_fba
+        - keyword: ROWDEPENDENCIES
+  - statement_terminator: ;
+  - statement:
+      create_table_statement:
+      - keyword: CREATE
+      - keyword: TABLE
+      - table_reference:
+          naked_identifier: t_using_idx_inline
+      - bracketed:
+          start_bracket: (
+          column_definition:
+            naked_identifier: id
+            data_type:
+              data_type_identifier: NUMBER
+          comma: ','
+          table_constraint:
+          - keyword: CONSTRAINT
+          - object_reference:
+              naked_identifier: pk_t_using_idx_inline
+          - keyword: PRIMARY
+          - keyword: KEY
+          - bracketed:
+              start_bracket: (
+              column_reference:
+                naked_identifier: id
+              end_bracket: )
+          - using_index_clause:
+            - keyword: USING
+            - keyword: INDEX
+            - bracketed:
+                start_bracket: (
+                create_index_statement:
+                - keyword: CREATE
+                - keyword: INDEX
+                - index_reference:
+                    naked_identifier: pk_t_using_idx_inline_idx
+                - keyword: 'ON'
+                - table_reference:
+                    naked_identifier: t_using_idx_inline
+                - bracketed:
+                    start_bracket: (
+                    index_column_definition:
+                      naked_identifier: id
+                    end_bracket: )
+                end_bracket: )
+          end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      create_table_statement:
+      - keyword: CREATE
+      - keyword: TABLE
+      - table_reference:
+          naked_identifier: t_using_idx_inline_unique
+      - bracketed:
+          start_bracket: (
+          column_definition:
+            naked_identifier: id
+            data_type:
+              data_type_identifier: NUMBER
+          comma: ','
+          table_constraint:
+          - keyword: CONSTRAINT
+          - object_reference:
+              naked_identifier: uq_t_using_idx_inline_unique
+          - keyword: UNIQUE
+          - bracketed:
+              start_bracket: (
+              column_reference:
+                naked_identifier: id
+              end_bracket: )
+          - using_index_clause:
+            - keyword: USING
+            - keyword: INDEX
+            - bracketed:
+                start_bracket: (
+                create_index_statement:
+                - keyword: CREATE
+                - keyword: UNIQUE
+                - keyword: INDEX
+                - index_reference:
+                    naked_identifier: uq_t_using_idx_inline_unique_idx
+                - keyword: 'ON'
+                - table_reference:
+                    naked_identifier: t_using_idx_inline_unique
+                - bracketed:
+                    start_bracket: (
+                    index_column_definition:
+                      naked_identifier: id
+                    end_bracket: )
+                end_bracket: )
+          end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      create_table_statement:
+      - keyword: CREATE
+      - keyword: TABLE
+      - table_reference:
+          naked_identifier: t_using_idx_inline_attrs
+      - bracketed:
+          start_bracket: (
+          column_definition:
+            naked_identifier: id
+            data_type:
+              data_type_identifier: NUMBER
+          comma: ','
+          table_constraint:
+          - keyword: CONSTRAINT
+          - object_reference:
+              naked_identifier: pk_t_using_idx_inline_attrs
+          - keyword: PRIMARY
+          - keyword: KEY
+          - bracketed:
+              start_bracket: (
+              column_reference:
+                naked_identifier: id
+              end_bracket: )
+          - using_index_clause:
+            - keyword: USING
+            - keyword: INDEX
+            - bracketed:
+                start_bracket: (
+                create_index_statement:
+                - keyword: CREATE
+                - keyword: INDEX
+                - index_reference:
+                    naked_identifier: pk_t_using_idx_inline_attrs_idx
+                - keyword: 'ON'
+                - table_reference:
+                    naked_identifier: t_using_idx_inline_attrs
+                - bracketed:
+                    start_bracket: (
+                    index_column_definition:
+                      naked_identifier: id
+                    end_bracket: )
+                - oracle_index_physical_attributes:
+                  - keyword: TABLESPACE
+                  - object_reference:
+                      naked_identifier: idx_ts
+                  - keyword: PCTFREE
+                  - numeric_literal: '10'
+                  - keyword: NOLOGGING
+                end_bracket: )
+          end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      create_table_statement:
+      - keyword: CREATE
+      - keyword: TABLE
+      - table_reference:
+          naked_identifier: t_ctas_nologging
+      - oracle_physical_attributes:
+        - keyword: NOLOGGING
+        - keyword: TABLESPACE
+        - object_reference:
+            naked_identifier: users
+      - keyword: AS
+      - select_statement:
+          select_clause:
+            keyword: SELECT
+            select_clause_element:
+              wildcard_expression:
+                wildcard_identifier:
+                  star: '*'
+          from_clause:
+            keyword: FROM
+            from_expression:
+              from_expression_element:
+                table_expression:
+                  table_reference:
+                    naked_identifier: emp
+  - statement_terminator: ;
+  - statement:
+      create_table_statement:
+      - keyword: CREATE
+      - keyword: TABLE
+      - table_reference:
+          naked_identifier: t_ctas_storage
+      - oracle_physical_attributes:
+        - keyword: TABLESPACE
+        - object_reference:
+            naked_identifier: users
+        - keyword: PCTFREE
+        - numeric_literal: '5'
+        - keyword: INITRANS
+        - numeric_literal: '4'
+        - storage_clause:
+            keyword: STORAGE
+            bracketed:
+            - start_bracket: (
+            - keyword: INITIAL
+            - numeric_literal: '1'
+            - size_prefix: M
+            - keyword: NEXT
+            - numeric_literal: '1'
+            - size_prefix: M
+            - end_bracket: )
+        - keyword: NOLOGGING
+      - keyword: AS
+      - select_statement:
+          select_clause:
+            keyword: SELECT
+            select_clause_element:
+              wildcard_expression:
+                wildcard_identifier:
+                  star: '*'
+          from_clause:
+            keyword: FROM
+            from_expression:
+              from_expression_element:
+                table_expression:
+                  table_reference:
+                    naked_identifier: emp
+  - statement_terminator: ;
+  - statement:
+      create_table_statement:
+      - keyword: CREATE
+      - keyword: GLOBAL
+      - keyword: TEMPORARY
+      - keyword: TABLE
+      - table_reference:
+          naked_identifier: t_ctas_temp
+      - keyword: 'ON'
+      - keyword: COMMIT
+      - keyword: PRESERVE
+      - keyword: ROWS
+      - oracle_physical_attributes:
+        - keyword: NOLOGGING
+        - keyword: TABLESPACE
+        - object_reference:
+            naked_identifier: temp_ts
+      - keyword: AS
+      - select_statement:
+          select_clause:
+            keyword: SELECT
+            select_clause_element:
+              wildcard_expression:
+                wildcard_identifier:
+                  star: '*'
+          from_clause:
+            keyword: FROM
+            from_expression:
+              from_expression_element:
+                table_expression:
+                  table_reference:
+                    naked_identifier: emp
   - statement_terminator: ;

--- a/test/fixtures/dialects/oracle/temporary_table.sql
+++ b/test/fixtures/dialects/oracle/temporary_table.sql
@@ -28,5 +28,23 @@ CREATE PRIVATE TEMPORARY TABLE ora$ptt_my_temp_table (
 )
 ON COMMIT PRESERVE DEFINITION;
 
+-- ON COMMIT must come before physical attributes
+CREATE GLOBAL TEMPORARY TABLE my_temp_phys (
+  id           NUMBER,
+  description  VARCHAR2(20)
+)
+ON COMMIT DELETE ROWS
+TABLESPACE temp_ts;
+
+CREATE GLOBAL TEMPORARY TABLE my_temp_phys2 (
+  id           NUMBER,
+  description  VARCHAR2(20)
+)
+ON COMMIT PRESERVE ROWS
+TABLESPACE temp_ts
+PCTFREE 10
+INITRANS 2
+STORAGE (INITIAL 64K NEXT 64K);
+
 CREATE PRIVATE TEMPORARY TABLE ora$ptt_emp AS
 SELECT * FROM emp;

--- a/test/fixtures/dialects/oracle/temporary_table.yml
+++ b/test/fixtures/dialects/oracle/temporary_table.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 8318d0fce364403a7d4ae0d7194e1ad18c2670346c9cfcee0864a7bf24902706
+_hash: cdb149d1acfa027f1430853d99105d87edb5d6688c80e7018d96f299ba04eed2
 file:
   batch:
   - statement:
@@ -186,6 +186,89 @@ file:
       - keyword: COMMIT
       - keyword: PRESERVE
       - keyword: DEFINITION
+  - statement_terminator: ;
+  - statement:
+      create_table_statement:
+      - keyword: CREATE
+      - keyword: GLOBAL
+      - keyword: TEMPORARY
+      - keyword: TABLE
+      - table_reference:
+          naked_identifier: my_temp_phys
+      - bracketed:
+        - start_bracket: (
+        - column_definition:
+            naked_identifier: id
+            data_type:
+              data_type_identifier: NUMBER
+        - comma: ','
+        - column_definition:
+            naked_identifier: description
+            data_type:
+              data_type_identifier: VARCHAR2
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  numeric_literal: '20'
+                  end_bracket: )
+        - end_bracket: )
+      - keyword: 'ON'
+      - keyword: COMMIT
+      - keyword: DELETE
+      - keyword: ROWS
+      - oracle_physical_attributes:
+          keyword: TABLESPACE
+          object_reference:
+            naked_identifier: temp_ts
+  - statement_terminator: ;
+  - statement:
+      create_table_statement:
+      - keyword: CREATE
+      - keyword: GLOBAL
+      - keyword: TEMPORARY
+      - keyword: TABLE
+      - table_reference:
+          naked_identifier: my_temp_phys2
+      - bracketed:
+        - start_bracket: (
+        - column_definition:
+            naked_identifier: id
+            data_type:
+              data_type_identifier: NUMBER
+        - comma: ','
+        - column_definition:
+            naked_identifier: description
+            data_type:
+              data_type_identifier: VARCHAR2
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  numeric_literal: '20'
+                  end_bracket: )
+        - end_bracket: )
+      - keyword: 'ON'
+      - keyword: COMMIT
+      - keyword: PRESERVE
+      - keyword: ROWS
+      - oracle_physical_attributes:
+        - keyword: TABLESPACE
+        - object_reference:
+            naked_identifier: temp_ts
+        - keyword: PCTFREE
+        - numeric_literal: '10'
+        - keyword: INITRANS
+        - numeric_literal: '2'
+        - storage_clause:
+            keyword: STORAGE
+            bracketed:
+            - start_bracket: (
+            - keyword: INITIAL
+            - numeric_literal: '64'
+            - size_prefix: K
+            - keyword: NEXT
+            - numeric_literal: '64'
+            - size_prefix: K
+            - end_bracket: )
   - statement_terminator: ;
   - statement:
       create_table_statement:

--- a/test/fixtures/dialects/oracle/using_index.sql
+++ b/test/fixtures/dialects/oracle/using_index.sql
@@ -1,0 +1,198 @@
+-- Form 1: Named index reference
+
+CREATE TABLE t_pk_named_idx (
+    id NUMBER,
+    CONSTRAINT pk_t_pk_named_idx PRIMARY KEY (id)
+        USING INDEX pk_t_pk_named_idx_idx
+);
+
+CREATE TABLE t_uq_named_idx (
+    code VARCHAR2(10),
+    CONSTRAINT uq_t_uq_named_idx UNIQUE (code)
+        USING INDEX myschema.uq_t_uq_named_idx_idx
+);
+
+-- Form 2: Physical attributes (no inline DDL, no index name)
+
+CREATE TABLE t_pk_pctfree (
+    id NUMBER,
+    CONSTRAINT pk_t_pk_pctfree PRIMARY KEY (id)
+        USING INDEX PCTFREE 10
+);
+
+CREATE TABLE t_pk_tablespace (
+    id NUMBER,
+    CONSTRAINT pk_t_pk_tablespace PRIMARY KEY (id)
+        USING INDEX TABLESPACE idx_ts
+);
+
+CREATE TABLE t_uq_nologging (
+    code VARCHAR2(10),
+    CONSTRAINT uq_t_uq_nologging UNIQUE (code)
+        USING INDEX NOLOGGING
+);
+
+CREATE TABLE t_pk_multi_attrs (
+    id NUMBER,
+    CONSTRAINT pk_t_pk_multi_attrs PRIMARY KEY (id)
+        USING INDEX
+            PCTFREE 10
+            INITRANS 2
+            TABLESPACE idx_ts
+            NOLOGGING
+);
+
+CREATE TABLE t_pk_storage (
+    id NUMBER,
+    CONSTRAINT pk_t_pk_storage PRIMARY KEY (id)
+        USING INDEX
+            PCTFREE 10
+            TABLESPACE idx_ts
+            STORAGE (INITIAL 140K NEXT 360K BUFFER_POOL KEEP)
+            NOLOGGING
+);
+
+CREATE TABLE t_uq_parallel (
+    code VARCHAR2(10),
+    CONSTRAINT uq_t_uq_parallel UNIQUE (code)
+        USING INDEX PARALLEL 4
+);
+
+CREATE TABLE t_pk_compress (
+    id NUMBER,
+    col2 VARCHAR2(20),
+    CONSTRAINT pk_t_pk_compress PRIMARY KEY (id, col2)
+        USING INDEX COMPRESS 1
+);
+
+CREATE TABLE t_pk_invisible (
+    id NUMBER,
+    CONSTRAINT pk_t_pk_invisible PRIMARY KEY (id)
+        USING INDEX INVISIBLE
+);
+
+CREATE TABLE t_pk_reverse (
+    id NUMBER,
+    CONSTRAINT pk_t_pk_reverse PRIMARY KEY (id)
+        USING INDEX REVERSE
+);
+
+-- Form 3: Inline CREATE INDEX
+
+CREATE TABLE t_pk_inline_idx (
+    id NUMBER,
+    CONSTRAINT pk_t_pk_inline_idx PRIMARY KEY (id)
+        USING INDEX (CREATE INDEX pk_t_pk_inline_idx_i ON t_pk_inline_idx (id))
+);
+
+CREATE TABLE t_pk_inline_unique_idx (
+    id NUMBER,
+    CONSTRAINT pk_t_pk_inline_unique_idx PRIMARY KEY (id)
+        USING INDEX (
+            CREATE UNIQUE INDEX pk_t_pk_inline_unique_idx_i
+                ON t_pk_inline_unique_idx (id)
+        )
+);
+
+CREATE TABLE t_uq_inline_idx (
+    code VARCHAR2(10),
+    CONSTRAINT uq_t_uq_inline_idx UNIQUE (code)
+        USING INDEX (CREATE INDEX uq_t_uq_inline_idx_i ON t_uq_inline_idx (code))
+);
+
+CREATE TABLE t_uq_inline_bitmap_idx (
+    status NUMBER,
+    CONSTRAINT uq_t_uq_inline_bitmap_idx UNIQUE (status)
+        USING INDEX (
+            CREATE BITMAP INDEX uq_t_uq_inline_bitmap_idx_i
+                ON t_uq_inline_bitmap_idx (status)
+        )
+);
+
+CREATE TABLE t_pk_inline_ts (
+    id NUMBER,
+    CONSTRAINT pk_t_pk_inline_ts PRIMARY KEY (id)
+        USING INDEX (
+            CREATE INDEX pk_t_pk_inline_ts_i ON t_pk_inline_ts (id)
+            TABLESPACE idx_ts
+        )
+);
+
+CREATE TABLE t_pk_inline_attrs (
+    id NUMBER,
+    CONSTRAINT pk_t_pk_inline_attrs PRIMARY KEY (id)
+        USING INDEX (
+            CREATE INDEX pk_t_pk_inline_attrs_i ON t_pk_inline_attrs (id)
+            TABLESPACE idx_ts
+            PCTFREE 10
+            INITRANS 2
+            NOLOGGING
+        )
+);
+
+CREATE TABLE t_pk_inline_storage (
+    id NUMBER,
+    CONSTRAINT pk_t_pk_inline_storage PRIMARY KEY (id)
+        USING INDEX (
+            CREATE INDEX pk_t_pk_inline_storage_i ON t_pk_inline_storage (id)
+            TABLESPACE idx_ts
+            STORAGE (
+                INITIAL 256K
+                NEXT 256K
+                MINEXTENTS 1
+                MAXEXTENTS UNLIMITED
+                BUFFER_POOL DEFAULT
+            )
+            NOLOGGING
+        )
+);
+
+CREATE TABLE t_uq_inline_full (
+    code VARCHAR2(20),
+    name VARCHAR2(100),
+    CONSTRAINT uq_t_uq_inline_full UNIQUE (code, name)
+        USING INDEX (
+            CREATE UNIQUE INDEX uq_t_uq_inline_full_i ON t_uq_inline_full (code, name)
+            TABLESPACE idx_ts
+            PCTFREE 5
+            INITRANS 4
+            NOLOGGING
+            PARALLEL 2
+            COMPRESS 1
+            VISIBLE
+        )
+);
+
+-- Multiple constraints in the same table, each with a different USING INDEX form
+
+CREATE TABLE t_multi_constraints (
+    id      NUMBER,
+    code    VARCHAR2(10),
+    status  NUMBER,
+    -- Named index reference
+    CONSTRAINT pk_t_multi_constraints PRIMARY KEY (id)
+        USING INDEX pk_t_multi_constraints_idx,
+    -- Physical attributes
+    CONSTRAINT uq_t_multi_constraints_code UNIQUE (code)
+        USING INDEX TABLESPACE idx_ts NOLOGGING,
+    -- Inline CREATE INDEX
+    CONSTRAINT uq_t_multi_constraints_status UNIQUE (status)
+        USING INDEX (
+            CREATE INDEX uq_t_multi_constraints_status_i
+                ON t_multi_constraints (status)
+            TABLESPACE idx_ts
+        )
+);
+
+-- Without explicit CONSTRAINT name (anonymous constraint)
+
+CREATE TABLE t_anon_pk_inline (
+    id NUMBER,
+    PRIMARY KEY (id)
+        USING INDEX (CREATE INDEX anon_pk_inline_i ON t_anon_pk_inline (id))
+);
+
+CREATE TABLE t_anon_uq_attrs (
+    code VARCHAR2(10),
+    UNIQUE (code) USING INDEX PCTFREE 10 TABLESPACE idx_ts
+);

--- a/test/fixtures/dialects/oracle/using_index.yml
+++ b/test/fixtures/dialects/oracle/using_index.yml
@@ -1,0 +1,1018 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 2af9e2424b621edc982d42fe216554a75c6b8700ed4fa4dab468a2c9433a1788
+file:
+  batch:
+  - statement:
+      create_table_statement:
+      - keyword: CREATE
+      - keyword: TABLE
+      - table_reference:
+          naked_identifier: t_pk_named_idx
+      - bracketed:
+          start_bracket: (
+          column_definition:
+            naked_identifier: id
+            data_type:
+              data_type_identifier: NUMBER
+          comma: ','
+          table_constraint:
+          - keyword: CONSTRAINT
+          - object_reference:
+              naked_identifier: pk_t_pk_named_idx
+          - keyword: PRIMARY
+          - keyword: KEY
+          - bracketed:
+              start_bracket: (
+              column_reference:
+                naked_identifier: id
+              end_bracket: )
+          - using_index_clause:
+            - keyword: USING
+            - keyword: INDEX
+            - index_reference:
+                naked_identifier: pk_t_pk_named_idx_idx
+          end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      create_table_statement:
+      - keyword: CREATE
+      - keyword: TABLE
+      - table_reference:
+          naked_identifier: t_uq_named_idx
+      - bracketed:
+          start_bracket: (
+          column_definition:
+            naked_identifier: code
+            data_type:
+              data_type_identifier: VARCHAR2
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  numeric_literal: '10'
+                  end_bracket: )
+          comma: ','
+          table_constraint:
+          - keyword: CONSTRAINT
+          - object_reference:
+              naked_identifier: uq_t_uq_named_idx
+          - keyword: UNIQUE
+          - bracketed:
+              start_bracket: (
+              column_reference:
+                naked_identifier: code
+              end_bracket: )
+          - using_index_clause:
+            - keyword: USING
+            - keyword: INDEX
+            - index_reference:
+              - naked_identifier: myschema
+              - dot: .
+              - naked_identifier: uq_t_uq_named_idx_idx
+          end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      create_table_statement:
+      - keyword: CREATE
+      - keyword: TABLE
+      - table_reference:
+          naked_identifier: t_pk_pctfree
+      - bracketed:
+          start_bracket: (
+          column_definition:
+            naked_identifier: id
+            data_type:
+              data_type_identifier: NUMBER
+          comma: ','
+          table_constraint:
+          - keyword: CONSTRAINT
+          - object_reference:
+              naked_identifier: pk_t_pk_pctfree
+          - keyword: PRIMARY
+          - keyword: KEY
+          - bracketed:
+              start_bracket: (
+              column_reference:
+                naked_identifier: id
+              end_bracket: )
+          - using_index_clause:
+            - keyword: USING
+            - keyword: INDEX
+            - oracle_index_physical_attributes:
+                keyword: PCTFREE
+                numeric_literal: '10'
+          end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      create_table_statement:
+      - keyword: CREATE
+      - keyword: TABLE
+      - table_reference:
+          naked_identifier: t_pk_tablespace
+      - bracketed:
+          start_bracket: (
+          column_definition:
+            naked_identifier: id
+            data_type:
+              data_type_identifier: NUMBER
+          comma: ','
+          table_constraint:
+          - keyword: CONSTRAINT
+          - object_reference:
+              naked_identifier: pk_t_pk_tablespace
+          - keyword: PRIMARY
+          - keyword: KEY
+          - bracketed:
+              start_bracket: (
+              column_reference:
+                naked_identifier: id
+              end_bracket: )
+          - using_index_clause:
+            - keyword: USING
+            - keyword: INDEX
+            - oracle_index_physical_attributes:
+                keyword: TABLESPACE
+                object_reference:
+                  naked_identifier: idx_ts
+          end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      create_table_statement:
+      - keyword: CREATE
+      - keyword: TABLE
+      - table_reference:
+          naked_identifier: t_uq_nologging
+      - bracketed:
+          start_bracket: (
+          column_definition:
+            naked_identifier: code
+            data_type:
+              data_type_identifier: VARCHAR2
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  numeric_literal: '10'
+                  end_bracket: )
+          comma: ','
+          table_constraint:
+          - keyword: CONSTRAINT
+          - object_reference:
+              naked_identifier: uq_t_uq_nologging
+          - keyword: UNIQUE
+          - bracketed:
+              start_bracket: (
+              column_reference:
+                naked_identifier: code
+              end_bracket: )
+          - using_index_clause:
+            - keyword: USING
+            - keyword: INDEX
+            - oracle_index_physical_attributes:
+                keyword: NOLOGGING
+          end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      create_table_statement:
+      - keyword: CREATE
+      - keyword: TABLE
+      - table_reference:
+          naked_identifier: t_pk_multi_attrs
+      - bracketed:
+          start_bracket: (
+          column_definition:
+            naked_identifier: id
+            data_type:
+              data_type_identifier: NUMBER
+          comma: ','
+          table_constraint:
+          - keyword: CONSTRAINT
+          - object_reference:
+              naked_identifier: pk_t_pk_multi_attrs
+          - keyword: PRIMARY
+          - keyword: KEY
+          - bracketed:
+              start_bracket: (
+              column_reference:
+                naked_identifier: id
+              end_bracket: )
+          - using_index_clause:
+            - keyword: USING
+            - keyword: INDEX
+            - oracle_index_physical_attributes:
+              - keyword: PCTFREE
+              - numeric_literal: '10'
+              - keyword: INITRANS
+              - numeric_literal: '2'
+              - keyword: TABLESPACE
+              - object_reference:
+                  naked_identifier: idx_ts
+              - keyword: NOLOGGING
+          end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      create_table_statement:
+      - keyword: CREATE
+      - keyword: TABLE
+      - table_reference:
+          naked_identifier: t_pk_storage
+      - bracketed:
+          start_bracket: (
+          column_definition:
+            naked_identifier: id
+            data_type:
+              data_type_identifier: NUMBER
+          comma: ','
+          table_constraint:
+          - keyword: CONSTRAINT
+          - object_reference:
+              naked_identifier: pk_t_pk_storage
+          - keyword: PRIMARY
+          - keyword: KEY
+          - bracketed:
+              start_bracket: (
+              column_reference:
+                naked_identifier: id
+              end_bracket: )
+          - using_index_clause:
+            - keyword: USING
+            - keyword: INDEX
+            - oracle_index_physical_attributes:
+              - keyword: PCTFREE
+              - numeric_literal: '10'
+              - keyword: TABLESPACE
+              - object_reference:
+                  naked_identifier: idx_ts
+              - storage_clause:
+                  keyword: STORAGE
+                  bracketed:
+                  - start_bracket: (
+                  - keyword: INITIAL
+                  - numeric_literal: '140'
+                  - size_prefix: K
+                  - keyword: NEXT
+                  - numeric_literal: '360'
+                  - size_prefix: K
+                  - keyword: BUFFER_POOL
+                  - keyword: KEEP
+                  - end_bracket: )
+              - keyword: NOLOGGING
+          end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      create_table_statement:
+      - keyword: CREATE
+      - keyword: TABLE
+      - table_reference:
+          naked_identifier: t_uq_parallel
+      - bracketed:
+          start_bracket: (
+          column_definition:
+            naked_identifier: code
+            data_type:
+              data_type_identifier: VARCHAR2
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  numeric_literal: '10'
+                  end_bracket: )
+          comma: ','
+          table_constraint:
+          - keyword: CONSTRAINT
+          - object_reference:
+              naked_identifier: uq_t_uq_parallel
+          - keyword: UNIQUE
+          - bracketed:
+              start_bracket: (
+              column_reference:
+                naked_identifier: code
+              end_bracket: )
+          - using_index_clause:
+            - keyword: USING
+            - keyword: INDEX
+            - oracle_index_physical_attributes:
+                keyword: PARALLEL
+                numeric_literal: '4'
+          end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      create_table_statement:
+      - keyword: CREATE
+      - keyword: TABLE
+      - table_reference:
+          naked_identifier: t_pk_compress
+      - bracketed:
+        - start_bracket: (
+        - column_definition:
+            naked_identifier: id
+            data_type:
+              data_type_identifier: NUMBER
+        - comma: ','
+        - column_definition:
+            naked_identifier: col2
+            data_type:
+              data_type_identifier: VARCHAR2
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  numeric_literal: '20'
+                  end_bracket: )
+        - comma: ','
+        - table_constraint:
+          - keyword: CONSTRAINT
+          - object_reference:
+              naked_identifier: pk_t_pk_compress
+          - keyword: PRIMARY
+          - keyword: KEY
+          - bracketed:
+            - start_bracket: (
+            - column_reference:
+                naked_identifier: id
+            - comma: ','
+            - column_reference:
+                naked_identifier: col2
+            - end_bracket: )
+          - using_index_clause:
+            - keyword: USING
+            - keyword: INDEX
+            - oracle_index_physical_attributes:
+                keyword: COMPRESS
+                numeric_literal: '1'
+        - end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      create_table_statement:
+      - keyword: CREATE
+      - keyword: TABLE
+      - table_reference:
+          naked_identifier: t_pk_invisible
+      - bracketed:
+          start_bracket: (
+          column_definition:
+            naked_identifier: id
+            data_type:
+              data_type_identifier: NUMBER
+          comma: ','
+          table_constraint:
+          - keyword: CONSTRAINT
+          - object_reference:
+              naked_identifier: pk_t_pk_invisible
+          - keyword: PRIMARY
+          - keyword: KEY
+          - bracketed:
+              start_bracket: (
+              column_reference:
+                naked_identifier: id
+              end_bracket: )
+          - using_index_clause:
+            - keyword: USING
+            - keyword: INDEX
+            - oracle_index_physical_attributes:
+                keyword: INVISIBLE
+          end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      create_table_statement:
+      - keyword: CREATE
+      - keyword: TABLE
+      - table_reference:
+          naked_identifier: t_pk_reverse
+      - bracketed:
+          start_bracket: (
+          column_definition:
+            naked_identifier: id
+            data_type:
+              data_type_identifier: NUMBER
+          comma: ','
+          table_constraint:
+          - keyword: CONSTRAINT
+          - object_reference:
+              naked_identifier: pk_t_pk_reverse
+          - keyword: PRIMARY
+          - keyword: KEY
+          - bracketed:
+              start_bracket: (
+              column_reference:
+                naked_identifier: id
+              end_bracket: )
+          - using_index_clause:
+            - keyword: USING
+            - keyword: INDEX
+            - oracle_index_physical_attributes:
+                keyword: REVERSE
+          end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      create_table_statement:
+      - keyword: CREATE
+      - keyword: TABLE
+      - table_reference:
+          naked_identifier: t_pk_inline_idx
+      - bracketed:
+          start_bracket: (
+          column_definition:
+            naked_identifier: id
+            data_type:
+              data_type_identifier: NUMBER
+          comma: ','
+          table_constraint:
+          - keyword: CONSTRAINT
+          - object_reference:
+              naked_identifier: pk_t_pk_inline_idx
+          - keyword: PRIMARY
+          - keyword: KEY
+          - bracketed:
+              start_bracket: (
+              column_reference:
+                naked_identifier: id
+              end_bracket: )
+          - using_index_clause:
+            - keyword: USING
+            - keyword: INDEX
+            - bracketed:
+                start_bracket: (
+                create_index_statement:
+                - keyword: CREATE
+                - keyword: INDEX
+                - index_reference:
+                    naked_identifier: pk_t_pk_inline_idx_i
+                - keyword: 'ON'
+                - table_reference:
+                    naked_identifier: t_pk_inline_idx
+                - bracketed:
+                    start_bracket: (
+                    index_column_definition:
+                      naked_identifier: id
+                    end_bracket: )
+                end_bracket: )
+          end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      create_table_statement:
+      - keyword: CREATE
+      - keyword: TABLE
+      - table_reference:
+          naked_identifier: t_pk_inline_unique_idx
+      - bracketed:
+          start_bracket: (
+          column_definition:
+            naked_identifier: id
+            data_type:
+              data_type_identifier: NUMBER
+          comma: ','
+          table_constraint:
+          - keyword: CONSTRAINT
+          - object_reference:
+              naked_identifier: pk_t_pk_inline_unique_idx
+          - keyword: PRIMARY
+          - keyword: KEY
+          - bracketed:
+              start_bracket: (
+              column_reference:
+                naked_identifier: id
+              end_bracket: )
+          - using_index_clause:
+            - keyword: USING
+            - keyword: INDEX
+            - bracketed:
+                start_bracket: (
+                create_index_statement:
+                - keyword: CREATE
+                - keyword: UNIQUE
+                - keyword: INDEX
+                - index_reference:
+                    naked_identifier: pk_t_pk_inline_unique_idx_i
+                - keyword: 'ON'
+                - table_reference:
+                    naked_identifier: t_pk_inline_unique_idx
+                - bracketed:
+                    start_bracket: (
+                    index_column_definition:
+                      naked_identifier: id
+                    end_bracket: )
+                end_bracket: )
+          end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      create_table_statement:
+      - keyword: CREATE
+      - keyword: TABLE
+      - table_reference:
+          naked_identifier: t_uq_inline_idx
+      - bracketed:
+          start_bracket: (
+          column_definition:
+            naked_identifier: code
+            data_type:
+              data_type_identifier: VARCHAR2
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  numeric_literal: '10'
+                  end_bracket: )
+          comma: ','
+          table_constraint:
+          - keyword: CONSTRAINT
+          - object_reference:
+              naked_identifier: uq_t_uq_inline_idx
+          - keyword: UNIQUE
+          - bracketed:
+              start_bracket: (
+              column_reference:
+                naked_identifier: code
+              end_bracket: )
+          - using_index_clause:
+            - keyword: USING
+            - keyword: INDEX
+            - bracketed:
+                start_bracket: (
+                create_index_statement:
+                - keyword: CREATE
+                - keyword: INDEX
+                - index_reference:
+                    naked_identifier: uq_t_uq_inline_idx_i
+                - keyword: 'ON'
+                - table_reference:
+                    naked_identifier: t_uq_inline_idx
+                - bracketed:
+                    start_bracket: (
+                    index_column_definition:
+                      naked_identifier: code
+                    end_bracket: )
+                end_bracket: )
+          end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      create_table_statement:
+      - keyword: CREATE
+      - keyword: TABLE
+      - table_reference:
+          naked_identifier: t_uq_inline_bitmap_idx
+      - bracketed:
+          start_bracket: (
+          column_definition:
+            naked_identifier: status
+            data_type:
+              data_type_identifier: NUMBER
+          comma: ','
+          table_constraint:
+          - keyword: CONSTRAINT
+          - object_reference:
+              naked_identifier: uq_t_uq_inline_bitmap_idx
+          - keyword: UNIQUE
+          - bracketed:
+              start_bracket: (
+              column_reference:
+                naked_identifier: status
+              end_bracket: )
+          - using_index_clause:
+            - keyword: USING
+            - keyword: INDEX
+            - bracketed:
+                start_bracket: (
+                create_index_statement:
+                - keyword: CREATE
+                - keyword: BITMAP
+                - keyword: INDEX
+                - index_reference:
+                    naked_identifier: uq_t_uq_inline_bitmap_idx_i
+                - keyword: 'ON'
+                - table_reference:
+                    naked_identifier: t_uq_inline_bitmap_idx
+                - bracketed:
+                    start_bracket: (
+                    index_column_definition:
+                      naked_identifier: status
+                    end_bracket: )
+                end_bracket: )
+          end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      create_table_statement:
+      - keyword: CREATE
+      - keyword: TABLE
+      - table_reference:
+          naked_identifier: t_pk_inline_ts
+      - bracketed:
+          start_bracket: (
+          column_definition:
+            naked_identifier: id
+            data_type:
+              data_type_identifier: NUMBER
+          comma: ','
+          table_constraint:
+          - keyword: CONSTRAINT
+          - object_reference:
+              naked_identifier: pk_t_pk_inline_ts
+          - keyword: PRIMARY
+          - keyword: KEY
+          - bracketed:
+              start_bracket: (
+              column_reference:
+                naked_identifier: id
+              end_bracket: )
+          - using_index_clause:
+            - keyword: USING
+            - keyword: INDEX
+            - bracketed:
+                start_bracket: (
+                create_index_statement:
+                - keyword: CREATE
+                - keyword: INDEX
+                - index_reference:
+                    naked_identifier: pk_t_pk_inline_ts_i
+                - keyword: 'ON'
+                - table_reference:
+                    naked_identifier: t_pk_inline_ts
+                - bracketed:
+                    start_bracket: (
+                    index_column_definition:
+                      naked_identifier: id
+                    end_bracket: )
+                - oracle_index_physical_attributes:
+                    keyword: TABLESPACE
+                    object_reference:
+                      naked_identifier: idx_ts
+                end_bracket: )
+          end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      create_table_statement:
+      - keyword: CREATE
+      - keyword: TABLE
+      - table_reference:
+          naked_identifier: t_pk_inline_attrs
+      - bracketed:
+          start_bracket: (
+          column_definition:
+            naked_identifier: id
+            data_type:
+              data_type_identifier: NUMBER
+          comma: ','
+          table_constraint:
+          - keyword: CONSTRAINT
+          - object_reference:
+              naked_identifier: pk_t_pk_inline_attrs
+          - keyword: PRIMARY
+          - keyword: KEY
+          - bracketed:
+              start_bracket: (
+              column_reference:
+                naked_identifier: id
+              end_bracket: )
+          - using_index_clause:
+            - keyword: USING
+            - keyword: INDEX
+            - bracketed:
+                start_bracket: (
+                create_index_statement:
+                - keyword: CREATE
+                - keyword: INDEX
+                - index_reference:
+                    naked_identifier: pk_t_pk_inline_attrs_i
+                - keyword: 'ON'
+                - table_reference:
+                    naked_identifier: t_pk_inline_attrs
+                - bracketed:
+                    start_bracket: (
+                    index_column_definition:
+                      naked_identifier: id
+                    end_bracket: )
+                - oracle_index_physical_attributes:
+                  - keyword: TABLESPACE
+                  - object_reference:
+                      naked_identifier: idx_ts
+                  - keyword: PCTFREE
+                  - numeric_literal: '10'
+                  - keyword: INITRANS
+                  - numeric_literal: '2'
+                  - keyword: NOLOGGING
+                end_bracket: )
+          end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      create_table_statement:
+      - keyword: CREATE
+      - keyword: TABLE
+      - table_reference:
+          naked_identifier: t_pk_inline_storage
+      - bracketed:
+          start_bracket: (
+          column_definition:
+            naked_identifier: id
+            data_type:
+              data_type_identifier: NUMBER
+          comma: ','
+          table_constraint:
+          - keyword: CONSTRAINT
+          - object_reference:
+              naked_identifier: pk_t_pk_inline_storage
+          - keyword: PRIMARY
+          - keyword: KEY
+          - bracketed:
+              start_bracket: (
+              column_reference:
+                naked_identifier: id
+              end_bracket: )
+          - using_index_clause:
+            - keyword: USING
+            - keyword: INDEX
+            - bracketed:
+                start_bracket: (
+                create_index_statement:
+                - keyword: CREATE
+                - keyword: INDEX
+                - index_reference:
+                    naked_identifier: pk_t_pk_inline_storage_i
+                - keyword: 'ON'
+                - table_reference:
+                    naked_identifier: t_pk_inline_storage
+                - bracketed:
+                    start_bracket: (
+                    index_column_definition:
+                      naked_identifier: id
+                    end_bracket: )
+                - oracle_index_physical_attributes:
+                  - keyword: TABLESPACE
+                  - object_reference:
+                      naked_identifier: idx_ts
+                  - storage_clause:
+                      keyword: STORAGE
+                      bracketed:
+                      - start_bracket: (
+                      - keyword: INITIAL
+                      - numeric_literal: '256'
+                      - size_prefix: K
+                      - keyword: NEXT
+                      - numeric_literal: '256'
+                      - size_prefix: K
+                      - keyword: MINEXTENTS
+                      - numeric_literal: '1'
+                      - keyword: MAXEXTENTS
+                      - keyword: UNLIMITED
+                      - keyword: BUFFER_POOL
+                      - keyword: DEFAULT
+                      - end_bracket: )
+                  - keyword: NOLOGGING
+                end_bracket: )
+          end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      create_table_statement:
+      - keyword: CREATE
+      - keyword: TABLE
+      - table_reference:
+          naked_identifier: t_uq_inline_full
+      - bracketed:
+        - start_bracket: (
+        - column_definition:
+            naked_identifier: code
+            data_type:
+              data_type_identifier: VARCHAR2
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  numeric_literal: '20'
+                  end_bracket: )
+        - comma: ','
+        - column_definition:
+            naked_identifier: name
+            data_type:
+              data_type_identifier: VARCHAR2
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  numeric_literal: '100'
+                  end_bracket: )
+        - comma: ','
+        - table_constraint:
+          - keyword: CONSTRAINT
+          - object_reference:
+              naked_identifier: uq_t_uq_inline_full
+          - keyword: UNIQUE
+          - bracketed:
+            - start_bracket: (
+            - column_reference:
+                naked_identifier: code
+            - comma: ','
+            - column_reference:
+                naked_identifier: name
+            - end_bracket: )
+          - using_index_clause:
+            - keyword: USING
+            - keyword: INDEX
+            - bracketed:
+                start_bracket: (
+                create_index_statement:
+                - keyword: CREATE
+                - keyword: UNIQUE
+                - keyword: INDEX
+                - index_reference:
+                    naked_identifier: uq_t_uq_inline_full_i
+                - keyword: 'ON'
+                - table_reference:
+                    naked_identifier: t_uq_inline_full
+                - bracketed:
+                  - start_bracket: (
+                  - index_column_definition:
+                      naked_identifier: code
+                  - comma: ','
+                  - index_column_definition:
+                      naked_identifier: name
+                  - end_bracket: )
+                - oracle_index_physical_attributes:
+                  - keyword: TABLESPACE
+                  - object_reference:
+                      naked_identifier: idx_ts
+                  - keyword: PCTFREE
+                  - numeric_literal: '5'
+                  - keyword: INITRANS
+                  - numeric_literal: '4'
+                  - keyword: NOLOGGING
+                  - keyword: PARALLEL
+                  - numeric_literal: '2'
+                  - keyword: COMPRESS
+                  - numeric_literal: '1'
+                  - keyword: VISIBLE
+                end_bracket: )
+        - end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      create_table_statement:
+      - keyword: CREATE
+      - keyword: TABLE
+      - table_reference:
+          naked_identifier: t_multi_constraints
+      - bracketed:
+        - start_bracket: (
+        - column_definition:
+            naked_identifier: id
+            data_type:
+              data_type_identifier: NUMBER
+        - comma: ','
+        - column_definition:
+            naked_identifier: code
+            data_type:
+              data_type_identifier: VARCHAR2
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  numeric_literal: '10'
+                  end_bracket: )
+        - comma: ','
+        - column_definition:
+            naked_identifier: status
+            data_type:
+              data_type_identifier: NUMBER
+        - comma: ','
+        - table_constraint:
+          - keyword: CONSTRAINT
+          - object_reference:
+              naked_identifier: pk_t_multi_constraints
+          - keyword: PRIMARY
+          - keyword: KEY
+          - bracketed:
+              start_bracket: (
+              column_reference:
+                naked_identifier: id
+              end_bracket: )
+          - using_index_clause:
+            - keyword: USING
+            - keyword: INDEX
+            - index_reference:
+                naked_identifier: pk_t_multi_constraints_idx
+        - comma: ','
+        - table_constraint:
+          - keyword: CONSTRAINT
+          - object_reference:
+              naked_identifier: uq_t_multi_constraints_code
+          - keyword: UNIQUE
+          - bracketed:
+              start_bracket: (
+              column_reference:
+                naked_identifier: code
+              end_bracket: )
+          - using_index_clause:
+            - keyword: USING
+            - keyword: INDEX
+            - oracle_index_physical_attributes:
+              - keyword: TABLESPACE
+              - object_reference:
+                  naked_identifier: idx_ts
+              - keyword: NOLOGGING
+        - comma: ','
+        - table_constraint:
+          - keyword: CONSTRAINT
+          - object_reference:
+              naked_identifier: uq_t_multi_constraints_status
+          - keyword: UNIQUE
+          - bracketed:
+              start_bracket: (
+              column_reference:
+                naked_identifier: status
+              end_bracket: )
+          - using_index_clause:
+            - keyword: USING
+            - keyword: INDEX
+            - bracketed:
+                start_bracket: (
+                create_index_statement:
+                - keyword: CREATE
+                - keyword: INDEX
+                - index_reference:
+                    naked_identifier: uq_t_multi_constraints_status_i
+                - keyword: 'ON'
+                - table_reference:
+                    naked_identifier: t_multi_constraints
+                - bracketed:
+                    start_bracket: (
+                    index_column_definition:
+                      naked_identifier: status
+                    end_bracket: )
+                - oracle_index_physical_attributes:
+                    keyword: TABLESPACE
+                    object_reference:
+                      naked_identifier: idx_ts
+                end_bracket: )
+        - end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      create_table_statement:
+      - keyword: CREATE
+      - keyword: TABLE
+      - table_reference:
+          naked_identifier: t_anon_pk_inline
+      - bracketed:
+          start_bracket: (
+          column_definition:
+            naked_identifier: id
+            data_type:
+              data_type_identifier: NUMBER
+          comma: ','
+          table_constraint:
+          - keyword: PRIMARY
+          - keyword: KEY
+          - bracketed:
+              start_bracket: (
+              column_reference:
+                naked_identifier: id
+              end_bracket: )
+          - using_index_clause:
+            - keyword: USING
+            - keyword: INDEX
+            - bracketed:
+                start_bracket: (
+                create_index_statement:
+                - keyword: CREATE
+                - keyword: INDEX
+                - index_reference:
+                    naked_identifier: anon_pk_inline_i
+                - keyword: 'ON'
+                - table_reference:
+                    naked_identifier: t_anon_pk_inline
+                - bracketed:
+                    start_bracket: (
+                    index_column_definition:
+                      naked_identifier: id
+                    end_bracket: )
+                end_bracket: )
+          end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      create_table_statement:
+      - keyword: CREATE
+      - keyword: TABLE
+      - table_reference:
+          naked_identifier: t_anon_uq_attrs
+      - bracketed:
+          start_bracket: (
+          column_definition:
+            naked_identifier: code
+            data_type:
+              data_type_identifier: VARCHAR2
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  numeric_literal: '10'
+                  end_bracket: )
+          comma: ','
+          table_constraint:
+            keyword: UNIQUE
+            bracketed:
+              start_bracket: (
+              column_reference:
+                naked_identifier: code
+              end_bracket: )
+            using_index_clause:
+            - keyword: USING
+            - keyword: INDEX
+            - oracle_index_physical_attributes:
+              - keyword: PCTFREE
+              - numeric_literal: '10'
+              - keyword: TABLESPACE
+              - object_reference:
+                  naked_identifier: idx_ts
+          end_bracket: )
+  - statement_terminator: ;

--- a/test/fixtures/rules/std_rule_cases/LT02-indent-oracle.yml
+++ b/test/fixtures/rules/std_rule_cases/LT02-indent-oracle.yml
@@ -478,3 +478,322 @@ test_pass_oracle_exception_block_proper_indentation:
   configs:
     core:
       dialect: oracle
+
+# Test cases for TABLESPACE / STORAGE clause indentation
+test_fail_oracle_storage_clause_missing_indentation:
+  # STORAGE clause contents must be indented inside the parentheses
+  fail_str: |
+    CREATE TABLE s1.t_storage (
+        id NUMBER(10) NOT NULL
+    )
+    TABLESPACE data_ts
+    STORAGE (
+    INITIAL 655K
+    NEXT 655K
+    MINEXTENTS 1
+    MAXEXTENTS UNLIMITED
+    BUFFER_POOL DEFAULT
+    )
+    LOGGING;
+  fix_str: |
+    CREATE TABLE s1.t_storage (
+        id NUMBER(10) NOT NULL
+    )
+    TABLESPACE data_ts
+    STORAGE (
+        INITIAL 655K
+        NEXT 655K
+        MINEXTENTS 1
+        MAXEXTENTS UNLIMITED
+        BUFFER_POOL DEFAULT
+    )
+    LOGGING;
+  configs:
+    core:
+      dialect: oracle
+
+test_pass_oracle_storage_clause_indentation:
+  # Correctly indented STORAGE clause passes LT02
+  pass_str: |
+    CREATE TABLE s1.t_storage (
+        id NUMBER(10) NOT NULL
+    )
+    TABLESPACE data_ts
+    STORAGE (
+        INITIAL 655K
+        NEXT 655K
+        MINEXTENTS 1
+        MAXEXTENTS UNLIMITED
+        PCTINCREASE 0
+        FREELISTS 1
+        FREELIST GROUPS 1
+        BUFFER_POOL DEFAULT
+    )
+    LOGGING
+    NOPARALLEL;
+  configs:
+    core:
+      dialect: oracle
+
+test_fail_oracle_create_index_storage_clause_indentation:
+  # STORAGE clause contents inside CREATE INDEX must be indented
+  fail_str: |
+    CREATE INDEX s1.t_full_idx ON s1.t (col1, col2)
+    TABLESPACE idx_ts
+    NOLOGGING
+    PCTFREE 10
+    INITRANS 2
+    MAXTRANS 255
+    STORAGE (
+    INITIAL 655K
+    NEXT 655K
+    MINEXTENTS 1
+    MAXEXTENTS UNLIMITED
+    BUFFER_POOL DEFAULT
+    )
+    PARALLEL 8
+    NOCOMPRESS
+    VISIBLE;
+  fix_str: |
+    CREATE INDEX s1.t_full_idx ON s1.t (col1, col2)
+    TABLESPACE idx_ts
+    NOLOGGING
+    PCTFREE 10
+    INITRANS 2
+    MAXTRANS 255
+    STORAGE (
+        INITIAL 655K
+        NEXT 655K
+        MINEXTENTS 1
+        MAXEXTENTS UNLIMITED
+        BUFFER_POOL DEFAULT
+    )
+    PARALLEL 8
+    NOCOMPRESS
+    VISIBLE;
+  configs:
+    core:
+      dialect: oracle
+
+test_pass_oracle_create_index_storage_clause_indentation:
+  # Correctly indented STORAGE clause in CREATE INDEX passes LT02
+  pass_str: |
+    CREATE UNIQUE INDEX s1.filter_instkeytype_idx
+    ON s1.filter (institution_id, filterkey, filtertype_id)
+    PCTFREE 10
+    INITRANS 2
+    MAXTRANS 255
+    TABLESPACE idx_ts
+    STORAGE (
+        INITIAL 140K
+        NEXT 360K
+        MINEXTENTS 1
+        MAXEXTENTS UNLIMITED
+        PCTINCREASE 50
+        FREELISTS 1
+        FREELIST GROUPS 1
+        BUFFER_POOL DEFAULT
+    )
+    NOLOGGING
+    PARALLEL 4;
+  configs:
+    core:
+      dialect: oracle
+
+# Test cases for USING INDEX inline CREATE INDEX indentation
+test_fail_oracle_using_index_inline_wrong_indent:
+  # USING INDEX clause and its bracketed inline CREATE INDEX must be
+  # indented at the same level as the enclosing CONSTRAINT keyword.
+  fail_str: |
+    CREATE TABLE t_pk_inline (
+        id NUMBER,
+        CONSTRAINT pk_t_pk_inline PRIMARY KEY (id)
+    USING INDEX (CREATE INDEX pk_t_pk_inline_i ON t_pk_inline (id))
+    );
+  fix_str: |
+    CREATE TABLE t_pk_inline (
+        id NUMBER,
+        CONSTRAINT pk_t_pk_inline PRIMARY KEY (id)
+        USING INDEX (CREATE INDEX pk_t_pk_inline_i ON t_pk_inline (id))
+    );
+  configs:
+    core:
+      dialect: oracle
+
+test_pass_oracle_using_index_inline_basic:
+  # Single-line inline CREATE INDEX correctly indented inside PRIMARY KEY.
+  pass_str: |
+    CREATE TABLE t_pk_inline (
+        id NUMBER,
+        CONSTRAINT pk_t_pk_inline PRIMARY KEY (id)
+        USING INDEX (CREATE INDEX pk_t_pk_inline_i ON t_pk_inline (id))
+    );
+  configs:
+    core:
+      dialect: oracle
+
+test_pass_oracle_using_index_inline_unique:
+  # Single-line inline CREATE UNIQUE INDEX for a UNIQUE constraint.
+  pass_str: |
+    CREATE TABLE t_uq_inline (
+        code VARCHAR2(10),
+        CONSTRAINT uq UNIQUE (code)
+        USING INDEX (CREATE UNIQUE INDEX uq_i ON t_uq_inline (code))
+    );
+  configs:
+    core:
+      dialect: oracle
+
+test_fail_oracle_using_index_inline_multiline_wrong_indent:
+  # Inline CREATE INDEX spanning multiple lines: the body inside the
+  # outer parentheses must be indented deeper.
+  fail_str: |
+    CREATE TABLE t_pk_inline_multi (
+        id NUMBER,
+        CONSTRAINT pk PRIMARY KEY (id)
+        USING INDEX (
+    CREATE INDEX pk_i ON t_pk_inline_multi (id)
+    TABLESPACE idx_ts
+    NOLOGGING
+        )
+    );
+  fix_str: |
+    CREATE TABLE t_pk_inline_multi (
+        id NUMBER,
+        CONSTRAINT pk PRIMARY KEY (id)
+        USING INDEX (
+            CREATE INDEX pk_i ON t_pk_inline_multi (id)
+            TABLESPACE idx_ts
+            NOLOGGING
+        )
+    );
+  configs:
+    core:
+      dialect: oracle
+
+test_pass_oracle_using_index_inline_multiline:
+  # Correctly-indented multi-line inline CREATE INDEX passes LT02.
+  pass_str: |
+    CREATE TABLE t_pk_inline_multi (
+        id NUMBER,
+        CONSTRAINT pk PRIMARY KEY (id)
+        USING INDEX (
+            CREATE INDEX pk_i ON t_pk_inline_multi (id)
+            TABLESPACE idx_ts
+            PCTFREE 10
+            NOLOGGING
+        )
+    );
+  configs:
+    core:
+      dialect: oracle
+
+test_fail_oracle_using_index_inline_storage_wrong_indent:
+  # STORAGE inside the inline CREATE INDEX must be indented inside its
+  # own parentheses.
+  fail_str: |
+    CREATE TABLE t_pk_inline_storage (
+        id NUMBER,
+        CONSTRAINT pk PRIMARY KEY (id)
+        USING INDEX (
+            CREATE INDEX pk_i ON t_pk_inline_storage (id)
+            TABLESPACE idx_ts
+            STORAGE (
+    INITIAL 256K
+    NEXT 256K
+    MAXEXTENTS UNLIMITED
+    BUFFER_POOL DEFAULT
+            )
+            NOLOGGING
+        )
+    );
+  fix_str: |
+    CREATE TABLE t_pk_inline_storage (
+        id NUMBER,
+        CONSTRAINT pk PRIMARY KEY (id)
+        USING INDEX (
+            CREATE INDEX pk_i ON t_pk_inline_storage (id)
+            TABLESPACE idx_ts
+            STORAGE (
+                INITIAL 256K
+                NEXT 256K
+                MAXEXTENTS UNLIMITED
+                BUFFER_POOL DEFAULT
+            )
+            NOLOGGING
+        )
+    );
+  configs:
+    core:
+      dialect: oracle
+
+test_pass_oracle_using_index_inline_storage:
+  # Correctly-indented STORAGE clause inside inline CREATE INDEX passes LT02.
+  pass_str: |
+    CREATE TABLE t_pk_inline_storage (
+        id NUMBER,
+        CONSTRAINT pk PRIMARY KEY (id)
+        USING INDEX (
+            CREATE INDEX pk_i ON t_pk_inline_storage (id)
+            TABLESPACE idx_ts
+            STORAGE (
+                INITIAL 256K
+                NEXT 256K
+                MAXEXTENTS UNLIMITED
+                BUFFER_POOL DEFAULT
+            )
+            NOLOGGING
+        )
+    );
+  configs:
+    core:
+      dialect: oracle
+
+test_fail_oracle_using_index_inline_multi_constraint_wrong_indent:
+  # Table with multiple constraints: each USING INDEX clause (whether a
+  # named index or inline CREATE INDEX) must sit at the constraint indent level.
+  fail_str: |
+    CREATE TABLE t_multi_constraints (
+        id NUMBER,
+        code VARCHAR2(10),
+    CONSTRAINT pk PRIMARY KEY (id)
+        USING INDEX (
+    CREATE INDEX pk_i ON t_multi_constraints (id)
+    TABLESPACE idx_ts
+        ),
+        CONSTRAINT uq UNIQUE (code)
+    USING INDEX uq_idx
+    );
+  fix_str: |
+    CREATE TABLE t_multi_constraints (
+        id NUMBER,
+        code VARCHAR2(10),
+        CONSTRAINT pk PRIMARY KEY (id)
+        USING INDEX (
+            CREATE INDEX pk_i ON t_multi_constraints (id)
+            TABLESPACE idx_ts
+        ),
+        CONSTRAINT uq UNIQUE (code)
+        USING INDEX uq_idx
+    );
+  configs:
+    core:
+      dialect: oracle
+
+test_pass_oracle_using_index_inline_multi_constraint:
+  # Multiple constraints with mixed USING INDEX forms, all correctly indented.
+  pass_str: |
+    CREATE TABLE t_multi_constraints (
+        id NUMBER,
+        code VARCHAR2(10),
+        CONSTRAINT pk PRIMARY KEY (id)
+        USING INDEX (
+            CREATE INDEX pk_i ON t_multi_constraints (id)
+            TABLESPACE idx_ts
+        ),
+        CONSTRAINT uq UNIQUE (code)
+        USING INDEX uq_idx
+    );
+  configs:
+    core:
+      dialect: oracle


### PR DESCRIPTION
### Brief summary of the change made

- Add missing Oracle keywords
- Implement `StorageClauseSegment`, `OraclePhysicalAttributesSegment` and `CreateIndexStatementSegment`
- Add comprehensive `CREATE TABLE` and `CREATE INDEX` fixtures exercising the new clauses
- Update indentation tests at `LT02-indent-oracle` to cover some of the new introduced structures.
- Align sqlfluffrs (Rust parser) with Python by removing premature advancement of `matched_idx` into whitespace in `AnyNumberOf/AnySetOf`, so early-return paths use the pre-gap boundary and trailing whitespace is excluded from matches.

Fixes #7641.

### Are there any other side effects of this change that we should be aware of?
No.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
