### PR TITLE
fix(#7648): MariaDB dialect not allowing literal values CREATE TABLE partition by LIST VALUES IN clause

### DIFF
--- a/src/sqlfluff/dialects/dialect_mariadb.py
+++ b/src/sqlfluff/dialects/dialect_mariadb.py
@@ -227,7 +227,10 @@ class CreateTableStatementSegment(mysql.CreateTableStatementSegment):
                                             Sequence(
                                                 "IN",
                                                 Bracketed(
-                                                    Ref("ObjectReferenceSegment")
+                                                        OneOf(
+                                                            ORS,
+                                                            Ref("LiteralGrammar"),
+                                                        ),
                                                 ),
                                             ),
                                         ),


### PR DESCRIPTION

<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->

fixes #7648

Still working on the test cases, but I believe this fixes the problem at hand. I would like some help in order to understand the ORS implications, I kept it to prevent any breaking changes, however I'm not entirely sure it is necessary when partition by LIST.

I believe this error should also exist on other dialects (i.e. mysql) and on other statements (i.e. ALTER TABLE), should I also fix the issue there, or create separate issues with separate PRs ? 

### Are there any other side effects of this change that we should be aware of?

From what I can imagine no.

### Pull Request checklist
- [ ] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
