### PR TITLE
Oracle: support trigger predicate chains in IF/ELSIF/CASE

### DIFF
--- a/src/sqlfluff/dialects/dialect_oracle.py
+++ b/src/sqlfluff/dialects/dialect_oracle.py
@@ -760,6 +760,29 @@ oracle_dialect.add(
         Sequence("UPDATING", Bracketed(Ref("QuotedLiteralSegment"), optional=True)),
         "DELETING",
     ),
+    # AND binds more tightly than OR (same as SQL precedence rules).
+    # Conjunction level handles AND; disjunction level handles OR.
+    TriggerPredicatesConjunctionGrammar=Sequence(
+        Ref.keyword("NOT", optional=True),
+        Ref("TriggerPredicatesGrammar"),
+        AnyNumberOf(
+            Sequence(
+                "AND",
+                Ref.keyword("NOT", optional=True),
+                Ref("TriggerPredicatesGrammar"),
+            )
+        ),
+    ),
+    # OR-level wraps the conjunction level so A OR B AND C parses as A OR (B AND C).
+    TriggerPredicatesExpressionGrammar=Sequence(
+        Ref("TriggerPredicatesConjunctionGrammar"),
+        AnyNumberOf(
+            Sequence(
+                "OR",
+                Ref("TriggerPredicatesConjunctionGrammar"),
+            )
+        ),
+    ),
     JSONObjectContentSegment=Sequence(
         OneOf(Ref("StarSegment"), Delimited(Ref("JSONEntrySegment")), optional=True),
         Ref("JSONOnNullClause", optional=True),
@@ -838,6 +861,21 @@ oracle_dialect.replace(
         ),
         Ref.keyword("PURGE", optional=True),
         optional=True,
+    ),
+    IsClauseGrammar=OneOf(
+        ansi_dialect.get_grammar("IsClauseGrammar"),
+        Sequence(
+            "OF",
+            Ref.keyword("TYPE", optional=True),
+            Bracketed(
+                Delimited(
+                    Sequence(
+                        Ref.keyword("ONLY", optional=True),
+                        Ref("ObjectReferenceSegment"),
+                    )
+                )
+            ),
+        ),
     ),
     NakedIdentifierSegment=SegmentGenerator(
         lambda dialect: RegexParser(
@@ -3226,9 +3264,13 @@ class IfExpressionStatement(BaseSegment):
         AnyNumberOf(
             Sequence(
                 "ELSIF",
+                # TriggerPredicatesExpressionGrammar is preferred over
+                # ExpressionSegment so that bare keywords (INSERTING, DELETING)
+                # and mixed predicate chains always parse via the dedicated
+                # grammar rather than falling through to generic expression nodes.
                 OneOf(
+                    Ref("TriggerPredicatesExpressionGrammar"),
                     Ref("ExpressionSegment"),
-                    Ref("TriggerPredicatesGrammar"),
                 ),
                 "THEN",
                 Indent,
@@ -3258,9 +3300,13 @@ class IfClauseSegment(BaseSegment):
 
     match_grammar = Sequence(
         "IF",
+        # TriggerPredicatesExpressionGrammar is preferred over ExpressionSegment
+        # so bare trigger keywords and mixed OR/AND/NOT chains are always parsed
+        # via the dedicated grammar rather than falling through to generic
+        # expression nodes.
         OneOf(
+            Ref("TriggerPredicatesExpressionGrammar"),
             Ref("ExpressionSegment"),
-            Ref("TriggerPredicatesGrammar"),
         ),
         "THEN",
     )
@@ -3312,9 +3358,18 @@ class CaseExpressionSegment(BaseSegment):
         ),
         Sequence(
             "CASE",
+            # TriggerPredicatesExpressionGrammar is placed first so trigger
+            # selector arms (IF/WHEN-style trigger predicates) are parsed
+            # by the dedicated trigger grammar. For the simple `CASE <expr>`
+            # selector this causes a speculative match attempt: the
+            # TriggerPredicatesExpressionGrammar will try to match and then
+            # fail for ordinary column references, falling back to
+            # `ExpressionSegment`. This speculative check is intentionally
+            # acceptable (negligible overhead) and consistent with how IF
+            # and WHEN arms are handled.
             OneOf(
+                Ref("TriggerPredicatesExpressionGrammar"),
                 Ref("ExpressionSegment"),
-                Ref("TriggerPredicatesGrammar"),
             ),
             ImplicitIndent,
             AnyNumberOf(
@@ -3356,9 +3411,11 @@ class WhenClauseSegment(BaseSegment):
         # https://github.com/sqlfluff/sqlfluff/issues/3988
         Sequence(
             ImplicitIndent,
+            # TriggerPredicatesExpressionGrammar preferred; see IfClauseSegment
+            # for an explanation of the ordering trade-off.
             OneOf(
+                Ref("TriggerPredicatesExpressionGrammar"),
                 Ref("ExpressionSegment"),
-                Ref("TriggerPredicatesGrammar"),
             ),
             Dedent,
         ),

--- a/test/fixtures/dialects/oracle/create_trigger.yml
+++ b/test/fixtures/dialects/oracle/create_trigger.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 09932703362d42bf81706716637af4523ce68574d4d6539724089b61842ffed3
+_hash: 0372d59b52907211a2eb331b08161487f6b45714594c1ac677432811150db0b8
 file:
 - batch:
     statement:
@@ -55,16 +55,11 @@ file:
                 - statement_terminator: ;
               - when_clause:
                 - keyword: WHEN
-                - expression:
-                    function:
-                      function_name:
-                        function_name_identifier: UPDATING
-                      function_contents:
-                        bracketed:
-                          start_bracket: (
-                          expression:
-                            quoted_literal: "'salary'"
-                          end_bracket: )
+                - keyword: UPDATING
+                - bracketed:
+                    start_bracket: (
+                    quoted_literal: "'salary'"
+                    end_bracket: )
                 - keyword: THEN
                 - statement:
                     function:
@@ -81,16 +76,11 @@ file:
                 - statement_terminator: ;
               - when_clause:
                 - keyword: WHEN
-                - expression:
-                    function:
-                      function_name:
-                        function_name_identifier: UPDATING
-                      function_contents:
-                        bracketed:
-                          start_bracket: (
-                          expression:
-                            quoted_literal: "'department_id'"
-                          end_bracket: )
+                - keyword: UPDATING
+                - bracketed:
+                    start_bracket: (
+                    quoted_literal: "'department_id'"
+                    end_bracket: )
                 - keyword: THEN
                 - statement:
                     function:

--- a/test/fixtures/dialects/oracle/if.sql
+++ b/test/fixtures/dialects/oracle/if.sql
@@ -111,3 +111,44 @@ BEGIN
   p(30000);
 END;
 /
+
+-- IS [NOT] OF type predicate (Oracle OO PL/SQL)
+DECLARE
+  obj_ref SYS.ANYDATA;
+BEGIN
+  IF obj_ref IS OF (emp_t) THEN
+    NULL;
+  ELSIF obj_ref IS NOT OF (mgr_t, emp_t) THEN
+    NULL;
+  ELSIF obj_ref IS OF TYPE (worker_t) THEN
+    NULL;
+  ELSIF obj_ref IS NOT OF TYPE (mgr_t) THEN
+    NULL;
+  ELSIF obj_ref IS OF (ONLY emp_t) THEN
+    NULL;
+  ELSIF obj_ref IS NOT OF (ONLY mgr_t, ONLY emp_t) THEN
+    NULL;
+  END IF;
+END;
+/
+
+-- Anonymous block with IF/ELSIF/ELSE
+DECLARE
+  AUDITINFO VARCHAR2(2000);
+  EVENT VARCHAR2(10);
+BEGIN
+  IF 1 = 1 THEN
+    AUDITINFO := 'Insert row into ';
+    EVENT := 'INSERT';
+  ELSIF 1 = 2 THEN
+    AUDITINFO := 'Delete row from ';
+    EVENT := 'DELETE';
+  ELSIF 1 = 3 THEN
+    AUDITINFO := 'Update row from ';
+    EVENT := 'UPDATE';
+  ELSE
+    AUDITINFO := 'Unknow operation ';
+    EVENT := 'UNKNOW';
+  END IF;
+END;
+/

--- a/test/fixtures/dialects/oracle/if.yml
+++ b/test/fixtures/dialects/oracle/if.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: fda034df4173512d8220e1e2e5403874fc26b3bd889b0eba2b99ab53a5d61843
+_hash: c79d3bcd1c1eafcf85cf79490da14e562fde942cff0fa10fb3bdb131c1c5f515
 file:
 - batch:
     statement:
@@ -732,6 +732,258 @@ file:
                 expression:
                   numeric_literal: '30000'
                 end_bracket: )
+      - statement_terminator: ;
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      begin_end_block:
+      - declare_segment:
+          keyword: DECLARE
+          naked_identifier: obj_ref
+          data_type:
+            naked_identifier: SYS
+            dot: .
+            data_type_identifier: ANYDATA
+          statement_terminator: ;
+      - keyword: BEGIN
+      - statement:
+          if_then_statement:
+          - if_clause:
+            - keyword: IF
+            - expression:
+              - column_reference:
+                  naked_identifier: obj_ref
+              - keyword: IS
+              - keyword: OF
+              - bracketed:
+                  start_bracket: (
+                  object_reference:
+                    naked_identifier: emp_t
+                  end_bracket: )
+            - keyword: THEN
+          - statement:
+              null_statement:
+                keyword: 'NULL'
+          - statement_terminator: ;
+          - keyword: ELSIF
+          - expression:
+            - column_reference:
+                naked_identifier: obj_ref
+            - keyword: IS
+            - keyword: NOT
+            - keyword: OF
+            - bracketed:
+              - start_bracket: (
+              - object_reference:
+                  naked_identifier: mgr_t
+              - comma: ','
+              - object_reference:
+                  naked_identifier: emp_t
+              - end_bracket: )
+          - keyword: THEN
+          - statement:
+              null_statement:
+                keyword: 'NULL'
+          - statement_terminator: ;
+          - keyword: ELSIF
+          - expression:
+            - column_reference:
+                naked_identifier: obj_ref
+            - keyword: IS
+            - keyword: OF
+            - keyword: TYPE
+            - bracketed:
+                start_bracket: (
+                object_reference:
+                  naked_identifier: worker_t
+                end_bracket: )
+          - keyword: THEN
+          - statement:
+              null_statement:
+                keyword: 'NULL'
+          - statement_terminator: ;
+          - keyword: ELSIF
+          - expression:
+            - column_reference:
+                naked_identifier: obj_ref
+            - keyword: IS
+            - keyword: NOT
+            - keyword: OF
+            - keyword: TYPE
+            - bracketed:
+                start_bracket: (
+                object_reference:
+                  naked_identifier: mgr_t
+                end_bracket: )
+          - keyword: THEN
+          - statement:
+              null_statement:
+                keyword: 'NULL'
+          - statement_terminator: ;
+          - keyword: ELSIF
+          - expression:
+            - column_reference:
+                naked_identifier: obj_ref
+            - keyword: IS
+            - keyword: OF
+            - bracketed:
+                start_bracket: (
+                keyword: ONLY
+                object_reference:
+                  naked_identifier: emp_t
+                end_bracket: )
+          - keyword: THEN
+          - statement:
+              null_statement:
+                keyword: 'NULL'
+          - statement_terminator: ;
+          - keyword: ELSIF
+          - expression:
+            - column_reference:
+                naked_identifier: obj_ref
+            - keyword: IS
+            - keyword: NOT
+            - keyword: OF
+            - bracketed:
+              - start_bracket: (
+              - keyword: ONLY
+              - object_reference:
+                  naked_identifier: mgr_t
+              - comma: ','
+              - keyword: ONLY
+              - object_reference:
+                  naked_identifier: emp_t
+              - end_bracket: )
+          - keyword: THEN
+          - statement:
+              null_statement:
+                keyword: 'NULL'
+          - statement_terminator: ;
+          - keyword: END
+          - keyword: IF
+      - statement_terminator: ;
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      begin_end_block:
+      - declare_segment:
+        - keyword: DECLARE
+        - naked_identifier: AUDITINFO
+        - data_type:
+            data_type_identifier: VARCHAR2
+            bracketed_arguments:
+              bracketed:
+                start_bracket: (
+                numeric_literal: '2000'
+                end_bracket: )
+        - statement_terminator: ;
+        - naked_identifier: EVENT
+        - data_type:
+            data_type_identifier: VARCHAR2
+            bracketed_arguments:
+              bracketed:
+                start_bracket: (
+                numeric_literal: '10'
+                end_bracket: )
+        - statement_terminator: ;
+      - keyword: BEGIN
+      - statement:
+          if_then_statement:
+          - if_clause:
+            - keyword: IF
+            - expression:
+              - numeric_literal: '1'
+              - comparison_operator:
+                  raw_comparison_operator: '='
+              - numeric_literal: '1'
+            - keyword: THEN
+          - statement:
+              assignment_segment_statement:
+                object_reference:
+                  naked_identifier: AUDITINFO
+                assignment_operator: :=
+                expression:
+                  quoted_literal: "'Insert row into '"
+          - statement_terminator: ;
+          - statement:
+              assignment_segment_statement:
+                object_reference:
+                  naked_identifier: EVENT
+                assignment_operator: :=
+                expression:
+                  quoted_literal: "'INSERT'"
+          - statement_terminator: ;
+          - keyword: ELSIF
+          - expression:
+            - numeric_literal: '1'
+            - comparison_operator:
+                raw_comparison_operator: '='
+            - numeric_literal: '2'
+          - keyword: THEN
+          - statement:
+              assignment_segment_statement:
+                object_reference:
+                  naked_identifier: AUDITINFO
+                assignment_operator: :=
+                expression:
+                  quoted_literal: "'Delete row from '"
+          - statement_terminator: ;
+          - statement:
+              assignment_segment_statement:
+                object_reference:
+                  naked_identifier: EVENT
+                assignment_operator: :=
+                expression:
+                  quoted_literal: "'DELETE'"
+          - statement_terminator: ;
+          - keyword: ELSIF
+          - expression:
+            - numeric_literal: '1'
+            - comparison_operator:
+                raw_comparison_operator: '='
+            - numeric_literal: '3'
+          - keyword: THEN
+          - statement:
+              assignment_segment_statement:
+                object_reference:
+                  naked_identifier: AUDITINFO
+                assignment_operator: :=
+                expression:
+                  quoted_literal: "'Update row from '"
+          - statement_terminator: ;
+          - statement:
+              assignment_segment_statement:
+                object_reference:
+                  naked_identifier: EVENT
+                assignment_operator: :=
+                expression:
+                  quoted_literal: "'UPDATE'"
+          - statement_terminator: ;
+          - keyword: ELSE
+          - statement:
+              assignment_segment_statement:
+                object_reference:
+                  naked_identifier: AUDITINFO
+                assignment_operator: :=
+                expression:
+                  quoted_literal: "'Unknow operation '"
+          - statement_terminator: ;
+          - statement:
+              assignment_segment_statement:
+                object_reference:
+                  naked_identifier: EVENT
+                assignment_operator: :=
+                expression:
+                  quoted_literal: "'UNKNOW'"
+          - statement_terminator: ;
+          - keyword: END
+          - keyword: IF
       - statement_terminator: ;
       - keyword: END
     statement_terminator: ;

--- a/test/fixtures/dialects/oracle/trigger_if.sql
+++ b/test/fixtures/dialects/oracle/trigger_if.sql
@@ -1,0 +1,104 @@
+CREATE OR REPLACE TRIGGER test.trigger_if
+AFTER INSERT OR UPDATE OR DELETE ON test.table_ref
+REFERENCING NEW AS New OLD AS Old
+FOR EACH ROW
+DECLARE
+  AUDITINFO VARCHAR2(2000);
+  EVENT VARCHAR2(10);
+BEGIN
+  IF INSERTING THEN
+    AUDITINFO := 'Insert row into ';
+    EVENT := 'INSERT';
+  ELSIF DELETING THEN
+    AUDITINFO := 'Delete row from ';
+    EVENT := 'DELETE';
+  ELSIF UPDATING THEN
+    AUDITINFO := 'Update row from ';
+    EVENT := 'UPDATE';
+  ELSE
+    AUDITINFO := 'Unknow operation ';
+    EVENT := 'UNKNOW';
+  END IF;
+END;
+/
+
+-- OR-combined trigger predicates in IF / ELSIF
+CREATE OR REPLACE TRIGGER test.trigger_if_or_combined
+AFTER INSERT OR UPDATE OR DELETE ON test.table_ref
+FOR EACH ROW
+DECLARE
+  EVENT VARCHAR2(10);
+BEGIN
+  IF UPDATING('Institution_id') OR INSERTING OR DELETING THEN
+    EVENT := 'MULTI';
+  ELSIF UPDATING('col1') OR UPDATING('col2') THEN
+    EVENT := 'COL_UPDATE';
+  END IF;
+END;
+/
+
+-- UPDATING with a specific column name (single predicate)
+CREATE OR REPLACE TRIGGER test.trigger_if_updating_col
+AFTER UPDATE ON test.table_ref
+FOR EACH ROW
+BEGIN
+  IF UPDATING('salary') THEN
+    NULL;
+  END IF;
+END;
+/
+
+-- NOT before single trigger predicates
+CREATE OR REPLACE TRIGGER test.trigger_if_not_predicate
+AFTER INSERT OR UPDATE OR DELETE ON test.table_ref
+FOR EACH ROW
+BEGIN
+  IF NOT INSERTING THEN
+    NULL;
+  ELSIF NOT DELETING THEN
+    NULL;
+  ELSIF NOT UPDATING THEN
+    NULL;
+  END IF;
+END;
+/
+
+-- AND-combined trigger predicates
+CREATE OR REPLACE TRIGGER test.trigger_if_and_combined
+AFTER INSERT OR UPDATE OR DELETE ON test.table_ref
+FOR EACH ROW
+BEGIN
+  IF UPDATING('col1') AND NOT UPDATING('col2') THEN
+    NULL;
+  ELSIF INSERTING AND NOT DELETING THEN
+    NULL;
+  END IF;
+END;
+/
+
+-- Mixed OR and AND with NOT
+CREATE OR REPLACE TRIGGER test.trigger_if_or_and_not
+AFTER INSERT OR UPDATE OR DELETE ON test.table_ref
+FOR EACH ROW
+BEGIN
+  IF NOT UPDATING('salary') OR INSERTING AND NOT DELETING THEN
+    NULL;
+  END IF;
+END;
+/
+
+-- CASE WHEN with multiple predicates (OR/AND/NOT)
+CREATE OR REPLACE TRIGGER test.trigger_case_predicates
+AFTER INSERT OR UPDATE OR DELETE ON test.table_ref
+FOR EACH ROW
+BEGIN
+  CASE
+    WHEN UPDATING('col') OR INSERTING THEN
+      NULL;
+    WHEN NOT DELETING AND UPDATING('other_col') THEN
+      NULL;
+    ELSE
+      NULL;
+  END CASE;
+END;
+/

--- a/test/fixtures/dialects/oracle/trigger_if.yml
+++ b/test/fixtures/dialects/oracle/trigger_if.yml
@@ -1,0 +1,546 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: a0c03d40496175d333588e3885e1ab5049edb8cabed6162ebce122da4071846f
+file:
+- batch:
+    statement:
+      create_trigger_statement:
+      - keyword: CREATE
+      - keyword: OR
+      - keyword: REPLACE
+      - keyword: TRIGGER
+      - trigger_reference:
+        - naked_identifier: test
+        - dot: .
+        - naked_identifier: trigger_if
+      - keyword: AFTER
+      - dml_event_clause:
+        - keyword: INSERT
+        - keyword: OR
+        - keyword: UPDATE
+        - keyword: OR
+        - keyword: DELETE
+        - keyword: 'ON'
+        - table_reference:
+          - naked_identifier: test
+          - dot: .
+          - naked_identifier: table_ref
+      - referencing_clause:
+        - keyword: REFERENCING
+        - trigger_correlation_name:
+            keyword: NEW
+        - keyword: AS
+        - naked_identifier: New
+        - trigger_correlation_name:
+            keyword: OLD
+        - keyword: AS
+        - naked_identifier: Old
+      - keyword: FOR
+      - keyword: EACH
+      - keyword: ROW
+      - statement:
+          begin_end_block:
+          - declare_segment:
+            - keyword: DECLARE
+            - naked_identifier: AUDITINFO
+            - data_type:
+                data_type_identifier: VARCHAR2
+                bracketed_arguments:
+                  bracketed:
+                    start_bracket: (
+                    numeric_literal: '2000'
+                    end_bracket: )
+            - statement_terminator: ;
+            - naked_identifier: EVENT
+            - data_type:
+                data_type_identifier: VARCHAR2
+                bracketed_arguments:
+                  bracketed:
+                    start_bracket: (
+                    numeric_literal: '10'
+                    end_bracket: )
+            - statement_terminator: ;
+          - keyword: BEGIN
+          - statement:
+              if_then_statement:
+              - if_clause:
+                - keyword: IF
+                - keyword: INSERTING
+                - keyword: THEN
+              - statement:
+                  assignment_segment_statement:
+                    object_reference:
+                      naked_identifier: AUDITINFO
+                    assignment_operator: :=
+                    expression:
+                      quoted_literal: "'Insert row into '"
+              - statement_terminator: ;
+              - statement:
+                  assignment_segment_statement:
+                    object_reference:
+                      naked_identifier: EVENT
+                    assignment_operator: :=
+                    expression:
+                      quoted_literal: "'INSERT'"
+              - statement_terminator: ;
+              - keyword: ELSIF
+              - keyword: DELETING
+              - keyword: THEN
+              - statement:
+                  assignment_segment_statement:
+                    object_reference:
+                      naked_identifier: AUDITINFO
+                    assignment_operator: :=
+                    expression:
+                      quoted_literal: "'Delete row from '"
+              - statement_terminator: ;
+              - statement:
+                  assignment_segment_statement:
+                    object_reference:
+                      naked_identifier: EVENT
+                    assignment_operator: :=
+                    expression:
+                      quoted_literal: "'DELETE'"
+              - statement_terminator: ;
+              - keyword: ELSIF
+              - keyword: UPDATING
+              - keyword: THEN
+              - statement:
+                  assignment_segment_statement:
+                    object_reference:
+                      naked_identifier: AUDITINFO
+                    assignment_operator: :=
+                    expression:
+                      quoted_literal: "'Update row from '"
+              - statement_terminator: ;
+              - statement:
+                  assignment_segment_statement:
+                    object_reference:
+                      naked_identifier: EVENT
+                    assignment_operator: :=
+                    expression:
+                      quoted_literal: "'UPDATE'"
+              - statement_terminator: ;
+              - keyword: ELSE
+              - statement:
+                  assignment_segment_statement:
+                    object_reference:
+                      naked_identifier: AUDITINFO
+                    assignment_operator: :=
+                    expression:
+                      quoted_literal: "'Unknow operation '"
+              - statement_terminator: ;
+              - statement:
+                  assignment_segment_statement:
+                    object_reference:
+                      naked_identifier: EVENT
+                    assignment_operator: :=
+                    expression:
+                      quoted_literal: "'UNKNOW'"
+              - statement_terminator: ;
+              - keyword: END
+              - keyword: IF
+          - statement_terminator: ;
+          - keyword: END
+      - statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      create_trigger_statement:
+      - keyword: CREATE
+      - keyword: OR
+      - keyword: REPLACE
+      - keyword: TRIGGER
+      - trigger_reference:
+        - naked_identifier: test
+        - dot: .
+        - naked_identifier: trigger_if_or_combined
+      - keyword: AFTER
+      - dml_event_clause:
+        - keyword: INSERT
+        - keyword: OR
+        - keyword: UPDATE
+        - keyword: OR
+        - keyword: DELETE
+        - keyword: 'ON'
+        - table_reference:
+          - naked_identifier: test
+          - dot: .
+          - naked_identifier: table_ref
+      - keyword: FOR
+      - keyword: EACH
+      - keyword: ROW
+      - statement:
+          begin_end_block:
+          - declare_segment:
+              keyword: DECLARE
+              naked_identifier: EVENT
+              data_type:
+                data_type_identifier: VARCHAR2
+                bracketed_arguments:
+                  bracketed:
+                    start_bracket: (
+                    numeric_literal: '10'
+                    end_bracket: )
+              statement_terminator: ;
+          - keyword: BEGIN
+          - statement:
+              if_then_statement:
+              - if_clause:
+                - keyword: IF
+                - keyword: UPDATING
+                - bracketed:
+                    start_bracket: (
+                    quoted_literal: "'Institution_id'"
+                    end_bracket: )
+                - keyword: OR
+                - keyword: INSERTING
+                - keyword: OR
+                - keyword: DELETING
+                - keyword: THEN
+              - statement:
+                  assignment_segment_statement:
+                    object_reference:
+                      naked_identifier: EVENT
+                    assignment_operator: :=
+                    expression:
+                      quoted_literal: "'MULTI'"
+              - statement_terminator: ;
+              - keyword: ELSIF
+              - keyword: UPDATING
+              - bracketed:
+                  start_bracket: (
+                  quoted_literal: "'col1'"
+                  end_bracket: )
+              - keyword: OR
+              - keyword: UPDATING
+              - bracketed:
+                  start_bracket: (
+                  quoted_literal: "'col2'"
+                  end_bracket: )
+              - keyword: THEN
+              - statement:
+                  assignment_segment_statement:
+                    object_reference:
+                      naked_identifier: EVENT
+                    assignment_operator: :=
+                    expression:
+                      quoted_literal: "'COL_UPDATE'"
+              - statement_terminator: ;
+              - keyword: END
+              - keyword: IF
+          - statement_terminator: ;
+          - keyword: END
+      - statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      create_trigger_statement:
+      - keyword: CREATE
+      - keyword: OR
+      - keyword: REPLACE
+      - keyword: TRIGGER
+      - trigger_reference:
+        - naked_identifier: test
+        - dot: .
+        - naked_identifier: trigger_if_updating_col
+      - keyword: AFTER
+      - dml_event_clause:
+        - keyword: UPDATE
+        - keyword: 'ON'
+        - table_reference:
+          - naked_identifier: test
+          - dot: .
+          - naked_identifier: table_ref
+      - keyword: FOR
+      - keyword: EACH
+      - keyword: ROW
+      - statement:
+          begin_end_block:
+          - keyword: BEGIN
+          - statement:
+              if_then_statement:
+              - if_clause:
+                - keyword: IF
+                - keyword: UPDATING
+                - bracketed:
+                    start_bracket: (
+                    quoted_literal: "'salary'"
+                    end_bracket: )
+                - keyword: THEN
+              - statement:
+                  null_statement:
+                    keyword: 'NULL'
+              - statement_terminator: ;
+              - keyword: END
+              - keyword: IF
+          - statement_terminator: ;
+          - keyword: END
+      - statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      create_trigger_statement:
+      - keyword: CREATE
+      - keyword: OR
+      - keyword: REPLACE
+      - keyword: TRIGGER
+      - trigger_reference:
+        - naked_identifier: test
+        - dot: .
+        - naked_identifier: trigger_if_not_predicate
+      - keyword: AFTER
+      - dml_event_clause:
+        - keyword: INSERT
+        - keyword: OR
+        - keyword: UPDATE
+        - keyword: OR
+        - keyword: DELETE
+        - keyword: 'ON'
+        - table_reference:
+          - naked_identifier: test
+          - dot: .
+          - naked_identifier: table_ref
+      - keyword: FOR
+      - keyword: EACH
+      - keyword: ROW
+      - statement:
+          begin_end_block:
+          - keyword: BEGIN
+          - statement:
+              if_then_statement:
+              - if_clause:
+                - keyword: IF
+                - keyword: NOT
+                - keyword: INSERTING
+                - keyword: THEN
+              - statement:
+                  null_statement:
+                    keyword: 'NULL'
+              - statement_terminator: ;
+              - keyword: ELSIF
+              - keyword: NOT
+              - keyword: DELETING
+              - keyword: THEN
+              - statement:
+                  null_statement:
+                    keyword: 'NULL'
+              - statement_terminator: ;
+              - keyword: ELSIF
+              - keyword: NOT
+              - keyword: UPDATING
+              - keyword: THEN
+              - statement:
+                  null_statement:
+                    keyword: 'NULL'
+              - statement_terminator: ;
+              - keyword: END
+              - keyword: IF
+          - statement_terminator: ;
+          - keyword: END
+      - statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      create_trigger_statement:
+      - keyword: CREATE
+      - keyword: OR
+      - keyword: REPLACE
+      - keyword: TRIGGER
+      - trigger_reference:
+        - naked_identifier: test
+        - dot: .
+        - naked_identifier: trigger_if_and_combined
+      - keyword: AFTER
+      - dml_event_clause:
+        - keyword: INSERT
+        - keyword: OR
+        - keyword: UPDATE
+        - keyword: OR
+        - keyword: DELETE
+        - keyword: 'ON'
+        - table_reference:
+          - naked_identifier: test
+          - dot: .
+          - naked_identifier: table_ref
+      - keyword: FOR
+      - keyword: EACH
+      - keyword: ROW
+      - statement:
+          begin_end_block:
+          - keyword: BEGIN
+          - statement:
+              if_then_statement:
+              - if_clause:
+                - keyword: IF
+                - keyword: UPDATING
+                - bracketed:
+                    start_bracket: (
+                    quoted_literal: "'col1'"
+                    end_bracket: )
+                - keyword: AND
+                - keyword: NOT
+                - keyword: UPDATING
+                - bracketed:
+                    start_bracket: (
+                    quoted_literal: "'col2'"
+                    end_bracket: )
+                - keyword: THEN
+              - statement:
+                  null_statement:
+                    keyword: 'NULL'
+              - statement_terminator: ;
+              - keyword: ELSIF
+              - keyword: INSERTING
+              - keyword: AND
+              - keyword: NOT
+              - keyword: DELETING
+              - keyword: THEN
+              - statement:
+                  null_statement:
+                    keyword: 'NULL'
+              - statement_terminator: ;
+              - keyword: END
+              - keyword: IF
+          - statement_terminator: ;
+          - keyword: END
+      - statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      create_trigger_statement:
+      - keyword: CREATE
+      - keyword: OR
+      - keyword: REPLACE
+      - keyword: TRIGGER
+      - trigger_reference:
+        - naked_identifier: test
+        - dot: .
+        - naked_identifier: trigger_if_or_and_not
+      - keyword: AFTER
+      - dml_event_clause:
+        - keyword: INSERT
+        - keyword: OR
+        - keyword: UPDATE
+        - keyword: OR
+        - keyword: DELETE
+        - keyword: 'ON'
+        - table_reference:
+          - naked_identifier: test
+          - dot: .
+          - naked_identifier: table_ref
+      - keyword: FOR
+      - keyword: EACH
+      - keyword: ROW
+      - statement:
+          begin_end_block:
+          - keyword: BEGIN
+          - statement:
+              if_then_statement:
+              - if_clause:
+                - keyword: IF
+                - keyword: NOT
+                - keyword: UPDATING
+                - bracketed:
+                    start_bracket: (
+                    quoted_literal: "'salary'"
+                    end_bracket: )
+                - keyword: OR
+                - keyword: INSERTING
+                - keyword: AND
+                - keyword: NOT
+                - keyword: DELETING
+                - keyword: THEN
+              - statement:
+                  null_statement:
+                    keyword: 'NULL'
+              - statement_terminator: ;
+              - keyword: END
+              - keyword: IF
+          - statement_terminator: ;
+          - keyword: END
+      - statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      create_trigger_statement:
+      - keyword: CREATE
+      - keyword: OR
+      - keyword: REPLACE
+      - keyword: TRIGGER
+      - trigger_reference:
+        - naked_identifier: test
+        - dot: .
+        - naked_identifier: trigger_case_predicates
+      - keyword: AFTER
+      - dml_event_clause:
+        - keyword: INSERT
+        - keyword: OR
+        - keyword: UPDATE
+        - keyword: OR
+        - keyword: DELETE
+        - keyword: 'ON'
+        - table_reference:
+          - naked_identifier: test
+          - dot: .
+          - naked_identifier: table_ref
+      - keyword: FOR
+      - keyword: EACH
+      - keyword: ROW
+      - statement:
+          begin_end_block:
+          - keyword: BEGIN
+          - statement:
+              case_expression:
+              - keyword: CASE
+              - when_clause:
+                - keyword: WHEN
+                - keyword: UPDATING
+                - bracketed:
+                    start_bracket: (
+                    quoted_literal: "'col'"
+                    end_bracket: )
+                - keyword: OR
+                - keyword: INSERTING
+                - keyword: THEN
+                - statement:
+                    null_statement:
+                      keyword: 'NULL'
+                - statement_terminator: ;
+              - when_clause:
+                - keyword: WHEN
+                - keyword: NOT
+                - keyword: DELETING
+                - keyword: AND
+                - keyword: UPDATING
+                - bracketed:
+                    start_bracket: (
+                    quoted_literal: "'other_col'"
+                    end_bracket: )
+                - keyword: THEN
+                - statement:
+                    null_statement:
+                      keyword: 'NULL'
+                - statement_terminator: ;
+              - else_clause:
+                  keyword: ELSE
+                  statement:
+                    null_statement:
+                      keyword: 'NULL'
+                  statement_terminator: ;
+              - keyword: END
+              - keyword: CASE
+          - statement_terminator: ;
+          - keyword: END
+      - statement_terminator: ;
+    slash_buffer_executor:
+      slash: /


### PR DESCRIPTION
### Brief summary of the change made
Update `IF/ELSIF/CASE` grammars to accept connector-separated predicate chains (supports `OR/AND` and `NOT`); extended Oracle `IS` clause to support `IS [NOT] OF [TYPE]`.

Fixes #7659.

### Are there any other side effects of this change that we should be aware of?
No.

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
