### PR TITLE
Oracle: recognize pseudo-functions USER/UID/SESSION_USER/ORA_ROWSCN

### DIFF
--- a/src/sqlfluff/dialects/dialect_oracle.py
+++ b/src/sqlfluff/dialects/dialect_oracle.py
@@ -313,6 +313,7 @@ oracle_dialect.sets("unreserved_keywords").update(
         "OID",
         "OLTP",
         "OPTIMAL",
+        "ORA_ROWSCN",
         "OUTLINE",
         "PACKAGE",
         "PAIRS",
@@ -356,6 +357,7 @@ oracle_dialect.sets("unreserved_keywords").update(
         "SEGMENT",
         "SERIALIZABLE",
         "SERVICE",
+        "SESSION_USER",
         "SHARD",
         "SHARD_ENABLE",
         "SHARED",
@@ -384,9 +386,13 @@ oracle_dialect.sets("bare_functions").update(
         "current_timestamp",
         "dbtimezone",
         "localtimestamp",
+        "ora_rowscn",
+        "session_user",
         "sessiontimestamp",
         "sysdate",
         "systimestamp",
+        "uid",
+        "user",
     ]
 )
 

--- a/test/fixtures/dialects/oracle/bare_functions.sql
+++ b/test/fixtures/dialects/oracle/bare_functions.sql
@@ -22,3 +22,29 @@ INSERT INTO t (id) VALUES (some_seq.CURRVAL);
 SELECT myschema.some_seq.CURRVAL FROM dual;
 SELECT myschema.some_seq.NEXTVAL FROM dual;
 INSERT INTO t (id) VALUES (myschema.some_seq.NEXTVAL);
+
+-- USER: name of the current schema / session user (VARCHAR2).
+SELECT USER FROM dual;
+
+INSERT INTO audit_log (log_id, created_by)
+VALUES (audit_seq.NEXTVAL, USER);
+
+-- UID: numeric user identifier for the current session.
+SELECT UID FROM dual;
+
+INSERT INTO audit_log (log_id, user_id_num)
+VALUES (audit_seq.NEXTVAL, UID);
+
+-- SESSION_USER: ANSI / Oracle function returning the session user name.
+-- Equivalent to USER in most contexts; differs under proxy authentication.
+SELECT SESSION_USER FROM dual;
+
+INSERT INTO audit_log (log_id, session_user_col)
+VALUES (audit_seq.NEXTVAL, SESSION_USER);
+
+-- ORA_ROWSCN: system change number pseudo-column for each row; read-only,
+-- only valid in queries (SELECT / WHERE), not in INSERT VALUES.
+SELECT ORA_ROWSCN, employee_id FROM employees;
+
+SELECT employee_id FROM employees
+WHERE ORA_ROWSCN > 12345678;

--- a/test/fixtures/dialects/oracle/bare_functions.yml
+++ b/test/fixtures/dialects/oracle/bare_functions.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 47bf7137f9d87816e8aac8d30b7af88b36028450fce854f13770940a480c6617
+_hash: 8cbd3d1db8c88fdf57059bfd44054ab15cab9e706da76da1c1081dc96eb50607
 file:
   batch:
   - statement:
@@ -191,4 +191,170 @@ file:
               - dot: .
               - naked_identifier: NEXTVAL
             end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            bare_function: USER
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: dual
+  - statement_terminator: ;
+  - statement:
+      insert_statement:
+      - keyword: INSERT
+      - keyword: INTO
+      - table_reference:
+          naked_identifier: audit_log
+      - bracketed:
+        - start_bracket: (
+        - column_reference:
+            naked_identifier: log_id
+        - comma: ','
+        - column_reference:
+            naked_identifier: created_by
+        - end_bracket: )
+      - values_clause:
+          keyword: VALUES
+          bracketed:
+          - start_bracket: (
+          - expression:
+              column_reference:
+              - naked_identifier: audit_seq
+              - dot: .
+              - naked_identifier: NEXTVAL
+          - comma: ','
+          - expression:
+              bare_function: USER
+          - end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            bare_function: UID
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: dual
+  - statement_terminator: ;
+  - statement:
+      insert_statement:
+      - keyword: INSERT
+      - keyword: INTO
+      - table_reference:
+          naked_identifier: audit_log
+      - bracketed:
+        - start_bracket: (
+        - column_reference:
+            naked_identifier: log_id
+        - comma: ','
+        - column_reference:
+            naked_identifier: user_id_num
+        - end_bracket: )
+      - values_clause:
+          keyword: VALUES
+          bracketed:
+          - start_bracket: (
+          - expression:
+              column_reference:
+              - naked_identifier: audit_seq
+              - dot: .
+              - naked_identifier: NEXTVAL
+          - comma: ','
+          - expression:
+              bare_function: UID
+          - end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            bare_function: SESSION_USER
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: dual
+  - statement_terminator: ;
+  - statement:
+      insert_statement:
+      - keyword: INSERT
+      - keyword: INTO
+      - table_reference:
+          naked_identifier: audit_log
+      - bracketed:
+        - start_bracket: (
+        - column_reference:
+            naked_identifier: log_id
+        - comma: ','
+        - column_reference:
+            naked_identifier: session_user_col
+        - end_bracket: )
+      - values_clause:
+          keyword: VALUES
+          bracketed:
+          - start_bracket: (
+          - expression:
+              column_reference:
+              - naked_identifier: audit_seq
+              - dot: .
+              - naked_identifier: NEXTVAL
+          - comma: ','
+          - expression:
+              bare_function: SESSION_USER
+          - end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            bare_function: ORA_ROWSCN
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+              naked_identifier: employee_id
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: employees
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            column_reference:
+              naked_identifier: employee_id
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: employees
+        where_clause:
+          keyword: WHERE
+          expression:
+            bare_function: ORA_ROWSCN
+            comparison_operator:
+              raw_comparison_operator: '>'
+            numeric_literal: '12345678'
   - statement_terminator: ;


### PR DESCRIPTION
### Brief summary of the change made
Adds `USER`, `UID`, `SESSION_USER`, and `ORA_ROWSCN` to the Oracle `bare_functions` set so they parse as zero-argument pseudo-functions/pseudo-columns.

Fixes #7662.

### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.