### PR TITLE
Add dbt parallel templating benchmark jig

### DIFF
--- a/test/utils/benchmark_dbt_parallel_test.py
+++ b/test/utils/benchmark_dbt_parallel_test.py
@@ -98,14 +98,14 @@ def test_intermediate_model_is_parseable_sql():
 
 def test_mart_model_source_count_bounded():
     """Mart model creates between 2 and 4 CTEs (or fewer if int_count is small)."""
-    sql = bench._mart_model(0, int_count=10, int_offset=0)
+    sql = bench._mart_model(0, int_count=10)
     source_ctes = re.findall(r"source_\d+ AS", sql)
     assert 2 <= len(source_ctes) <= 4
 
 
 def test_mart_model_refs_within_bounds():
     """Mart model refs only reference intermediate indices that exist."""
-    sql = bench._mart_model(0, int_count=8, int_offset=0)
+    sql = bench._mart_model(0, int_count=8)
     refs = re.findall(r"ref\('int_(\d+)'\)", sql)
     for ref_idx in refs:
         assert int(ref_idx) < 8, f"int_{ref_idx} out of range for int_count=8"
@@ -232,11 +232,14 @@ def test_reproducible_across_runs(tmp_path):
 
 
 def test_minimum_model_count(tmp_path):
-    """model_count=1 still creates at least one model per tier."""
+    """model_count < 4 is clamped to 4 (one model per tier minimum)."""
     project = bench.generate_dbt_project(str(tmp_path), model_count=1)
+    total = 0
     for tier in ("staging", "intermediate", "marts", "ephemeral"):
         models = list((project / "models" / tier).glob("*.sql"))
         assert len(models) >= 1, f"No models in {tier}/"
+        total += len(models)
+    assert total == 4, f"Expected exactly 4 models (minimum), got {total}"
 
 
 # -- Results formatting ------------------------------------------------------

--- a/utils/benchmark_dbt_parallel.py
+++ b/utils/benchmark_dbt_parallel.py
@@ -160,7 +160,7 @@ def _intermediate_model(idx: int, stg_count: int) -> str:
     """)
 
 
-def _mart_model(idx: int, int_count: int, int_offset: int) -> str:
+def _mart_model(idx: int, int_count: int) -> str:
     num_sources = min(random.randint(2, 4), int_count)
     refs = random.sample(range(int_count), num_sources)
     cte_parts = []
@@ -224,12 +224,15 @@ def generate_dbt_project(target_dir: str, model_count: int = 200) -> Path:
 
     Args:
         target_dir: Directory to create the project in.
-        model_count: Total number of models to generate.
+        model_count: Total number of models to generate (minimum 4, one per tier).
 
     Returns:
         Path to the project root.
     """
     project = Path(target_dir)
+
+    # Enforce minimum of 4 models (one per tier)
+    model_count = max(model_count, 4)
 
     # Tier distribution
     n_staging = max(int(model_count * 0.40), 1)
@@ -254,8 +257,8 @@ def generate_dbt_project(target_dir: str, model_count: int = 200) -> Path:
     (project / "macros" / "custom_macros.sql").write_text(_CUSTOM_MACROS_SQL)
 
     # Write .sqlfluff
-    profiles_dir = str(project / "profiles_yml").replace("\\", "/")
-    project_str = str(project).replace("\\", "/")
+    profiles_dir = (project / "profiles_yml").as_posix()
+    project_str = project.as_posix()
     (project / ".sqlfluff").write_text(
         _SQLFLUFF_CFG.format(project_dir=project_str, profiles_dir=profiles_dir)
     )
@@ -284,7 +287,7 @@ def generate_dbt_project(target_dir: str, model_count: int = 200) -> Path:
     # Generate mart models
     for i in range(n_marts):
         (project / "models" / "marts" / f"mart_{i:04d}.sql").write_text(
-            _mart_model(i, n_intermediate, 0)
+            _mart_model(i, n_intermediate)
         )
 
     # Generate ephemeral models
@@ -315,9 +318,8 @@ def _find_dbt_executable() -> str:
     sys.exit(1)
 
 
-def compile_dbt_project(project_dir: Path) -> None:
+def compile_dbt_project(project_dir: Path, profiles_dir: Path) -> None:
     """Run dbt compile to pre-warm the manifest and partial parse cache."""
-    profiles_dir = project_dir / "profiles_yml"
     env = os.environ.copy()
     env["DBT_SEND_ANONYMOUS_USAGE_STATS"] = "false"
     dbt_exe = _find_dbt_executable()
@@ -504,6 +506,12 @@ def main():
         help="Directory for the dbt project (default: temp directory)",
     )
     parser.add_argument(
+        "--profiles-dir",
+        type=str,
+        default=None,
+        help="Directory containing profiles.yml (default: generated inside project)",
+    )
+    parser.add_argument(
         "--no-clean",
         action="store_true",
         help="Don't delete the project directory after benchmarking",
@@ -521,22 +529,35 @@ def main():
     args = parser.parse_args()
 
     process_counts = [int(x.strip()) for x in args.processes.split(",")]
-
-    try:
-        import dbt.adapters.duckdb  # noqa: F401
-    except Exception as e:
-        print(
-            f"Error: dbt-duckdb is required but failed to import: {e}\n"
-            "Install with: pip install dbt-duckdb",
-            file=sys.stderr,
-        )
+    if any(c < 1 for c in process_counts):
+        print("Error: --processes values must be positive integers.", file=sys.stderr)
         sys.exit(1)
+
+    # Only require dbt-duckdb when generating a synthetic project
+    if not args.skip_generate:
+        try:
+            import dbt.adapters.duckdb  # noqa: F401
+        except Exception as e:
+            print(
+                f"Error: dbt-duckdb is required but failed to import: {e}\n"
+                "Install with: pip install dbt-duckdb",
+                file=sys.stderr,
+            )
+            sys.exit(1)
 
     # Determine project directory
     tmpdir = None
     if args.project_dir:
         project_dir = Path(args.project_dir)
-        if not args.skip_generate:
+        if args.skip_generate:
+            if not project_dir.exists():
+                print(
+                    f"Error: --project-dir {project_dir} does not exist "
+                    "(required with --skip-generate).",
+                    file=sys.stderr,
+                )
+                sys.exit(1)
+        else:
             project_dir.mkdir(parents=True, exist_ok=True)
     else:
         tmpdir = tempfile.mkdtemp(prefix="sqlfluff_bench_dbt_")
@@ -547,11 +568,20 @@ def main():
         if not args.skip_generate:
             generate_dbt_project(str(project_dir), model_count=args.models)
 
-        profiles_dir = project_dir / "profiles_yml"
+        if args.profiles_dir:
+            profiles_dir = Path(args.profiles_dir)
+            if not profiles_dir.exists():
+                print(
+                    f"Error: --profiles-dir {profiles_dir} does not exist.",
+                    file=sys.stderr,
+                )
+                sys.exit(1)
+        else:
+            profiles_dir = project_dir / "profiles_yml"
 
         # Compile dbt project
         if not args.skip_compile:
-            compile_dbt_project(project_dir)
+            compile_dbt_project(project_dir, profiles_dir)
 
         # Run benchmarks
         results = run_benchmark(


### PR DESCRIPTION
## Summary

Adds a benchmark tool and tests for measuring `--processes N` effectiveness with the dbt templater, as part of the investigation in #7667.

- **`utils/benchmark_dbt_parallel.py`** — Generates synthetic dbt projects (DuckDB adapter, configurable model count with staging/intermediate/mart/ephemeral tiers) and measures wall-clock time across process counts
- **`test/utils/benchmark_dbt_parallel_test.py`** — 22 unit tests verifying generated SQL parses correctly, YAML configs are structurally valid, cross-tier ref consistency holds, and results formatting works

### Usage

```bash
pip install dbt-duckdb
python utils/benchmark_dbt_parallel.py --models 100 --processes 1,2,4,8
```

### Investigation findings (detailed in #7667)

Using this benchmark, we confirmed:
- The existing pipelined architecture already gives **1.86x speedup** with 4 processes (main-process templating + worker parsing/linting via `imap_unordered`)
- Worker-side templating is blocked by **~2-3s per-worker dbt module import overhead** on `spawn`-context processes — the manifest itself is picklable in 2ms
- Batch pre-templating is slightly worse than the existing lazy generator pipelining

## Test plan

- [x] `pytest test/utils/benchmark_dbt_parallel_test.py` — 22 tests pass in <2s, no dbt/duckdb required
- [x] End-to-end: `python utils/benchmark_dbt_parallel.py --models 20 --processes 1,4` with dbt-duckdb installed
- [x] Error handling: clean message when dbt-duckdb not installed
- [x] `ruff check` and `ruff format` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code) and crashed into a rock multiple times by a wombat.