### PR TITLE
fix(rust): place remaining `vdebug` behind `verbose-debug` feature

### DIFF
--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/core.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/core.rs
@@ -4,6 +4,7 @@
 //! including the main entry point for parsing with grammar.
 
 use crate::parser::match_result::{self, MatchedClass, SegmentKwargs};
+#[cfg(feature = "verbose-debug")]
 use crate::vdebug;
 use std::sync::Arc;
 

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/match_result.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/match_result.rs
@@ -7,6 +7,7 @@
 //! This eliminates the need for global state tracking of collected whitespace positions,
 //! and makes the parser more functional and composable.
 
+#[cfg(feature = "verbose-debug")]
 use crate::vdebug;
 use std::fmt::Display;
 use std::ops::Range;

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/bracketed.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/bracketed.rs
@@ -1,4 +1,6 @@
-use crate::{parser::match_result::MatchedClass, vdebug};
+use crate::parser::match_result::MatchedClass;
+#[cfg(feature = "verbose-debug")]
+use crate::vdebug;
 use smallvec::SmallVec;
 use sqlfluffrs_types::{GrammarId, GrammarVariant, ParseMode};
 use std::sync::Arc;

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/delimited.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/delimited.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "verbose-debug")]
 use crate::vdebug;
 use smallvec::SmallVec;
 use sqlfluffrs_types::{GrammarId, GrammarVariant};

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/iterative.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/iterative.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "verbose-debug")]
 use crate::vdebug;
 use sqlfluffrs_types::{GrammarId, GrammarVariant};
 use std::sync::Arc;

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/match_algorithms.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/match_algorithms.rs
@@ -2,6 +2,7 @@ use sqlfluffrs_types::{GrammarId, GrammarVariant, Token};
 
 use crate::parser::{ParseError, Parser};
 
+#[cfg(feature = "verbose-debug")]
 use crate::vdebug;
 /// Module-level implementations of the table-driven match algorithms.
 ///

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/sequence.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/sequence.rs
@@ -1,7 +1,6 @@
-use crate::{
-    parser::{match_result::MatchedClass, MetaSegment},
-    vdebug,
-};
+use crate::parser::{match_result::MatchedClass, MetaSegment};
+#[cfg(feature = "verbose-debug")]
+use crate::vdebug;
 use smallvec::SmallVec;
 use sqlfluffrs_types::{GrammarId, GrammarVariant, ParseMode};
 use std::sync::Arc;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
We had a number of `unused_imports` warnings with `vdebug`. This correctly places the imports behind the `verbose-debug` feature.

```sh
warning: unused import: `crate::vdebug`
 --> sqlfluffrs_parser/src/parser/core.rs:7:5
  |
7 | use crate::vdebug;
  |     ^^^^^^^^^^^^^
  |
  = note: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default
```

### Are there any other side effects of this change that we should be aware of?
None

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
