### PR TITLE
fix: Ensure `pool.join()` is called in ParallelRunner

### DIFF
--- a/src/sqlfluff/core/linter/runner.py
+++ b/src/sqlfluff/core/linter/runner.py
@@ -179,46 +179,53 @@ class ParallelRunner(BaseRunner):
         the main thread can do the IO work while passing the parsing
         and linting work out to the threads.
         """
-        with self._create_pool(
+        # NOTE: We avoid using `with pool:` here because Pool.__exit__
+        # calls pool.terminate() but NOT pool.join(). Without join(), worker
+        # processes may still be alive when Python's resource_tracker runs at
+        # shutdown, causing "leaked semaphore objects" warnings from the named
+        # POSIX semaphores used by the pool's internal SimpleQueue locks.
+        pool = self._create_pool(
             self.processes,
             self._init_global,
-        ) as pool:
-            try:
-                for lint_result in self._map(
-                    pool,
-                    self._apply,
-                    self.iter_partials(fnames, fix=fix),
-                ):
-                    if isinstance(lint_result, DelayedException):
-                        if isinstance(lint_result.ee, SQLFluffSkipFile):
-                            # A file was skipped (e.g. exceeded
-                            # large_file_skip_byte_limit). Log a plain warning,
-                            # not the "please report as bug" message.
-                            linter_logger.warning(str(lint_result.ee))
-                            self.skipped_file_count += 1
-                        else:
-                            try:
-                                lint_result.reraise()
-                            except Exception as e:
-                                self._handle_lint_path_exception(lint_result.fname, e)
+        )
+        try:
+            for lint_result in self._map(
+                pool,
+                self._apply,
+                self.iter_partials(fnames, fix=fix),
+            ):
+                if isinstance(lint_result, DelayedException):
+                    if isinstance(lint_result.ee, SQLFluffSkipFile):
+                        # A file was skipped (e.g. exceeded
+                        # large_file_skip_byte_limit). Log a plain warning,
+                        # not the "please report as bug" message.
+                        linter_logger.warning(str(lint_result.ee))
+                        self.skipped_file_count += 1
                     else:
-                        # It's a LintedDir.
-                        if self.linter.formatter:
-                            self.linter.formatter.dispatch_file_violations(
-                                lint_result.path,
-                                lint_result,
-                                only_fixable=fix,
-                                warn_unused_ignores=self.linter.config.get(
-                                    "warn_unused_ignores"
-                                ),
-                            )
-                        yield lint_result
-            except KeyboardInterrupt:  # pragma: no cover
-                # On keyboard interrupt (Ctrl-C), terminate the workers.
-                # Notify the user we've received the signal and are cleaning up,
-                # in case it takes awhile.
-                print("Received keyboard interrupt. Cleaning up and shutting down...")
-                pool.terminate()
+                        try:
+                            lint_result.reraise()
+                        except Exception as e:
+                            self._handle_lint_path_exception(lint_result.fname, e)
+                else:
+                    # It's a LintedDir.
+                    if self.linter.formatter:
+                        self.linter.formatter.dispatch_file_violations(
+                            lint_result.path,
+                            lint_result,
+                            only_fixable=fix,
+                            warn_unused_ignores=self.linter.config.get(
+                                "warn_unused_ignores"
+                            ),
+                        )
+                    yield lint_result
+        except KeyboardInterrupt:  # pragma: no cover
+            # On keyboard interrupt (Ctrl-C), terminate the workers.
+            # Notify the user we've received the signal and are cleaning up,
+            # in case it takes awhile.
+            print("Received keyboard interrupt. Cleaning up and shutting down...")
+        finally:
+            pool.terminate()
+            pool.join()
 
     @staticmethod
     def _apply(

--- a/src/sqlfluff/core/linter/runner.py
+++ b/src/sqlfluff/core/linter/runner.py
@@ -224,8 +224,10 @@ class ParallelRunner(BaseRunner):
             # in case it takes awhile.
             print("Received keyboard interrupt. Cleaning up and shutting down...")
         finally:
-            pool.terminate()
-            pool.join()
+            try:
+                pool.terminate()
+            finally:
+                pool.join()
 
     @staticmethod
     def _apply(

--- a/test/core/linter/linter_test.py
+++ b/test/core/linter/linter_test.py
@@ -315,6 +315,12 @@ def test__linter__linting_parallel_thread(force_error, monkeypatch):
                 def imap_unordered(self, *args, **kwargs):
                     yield runner.DelayedException(ValueError())
 
+                def terminate(self):
+                    pass
+
+                def join(self):
+                    pass
+
             return ErrorPool()
 
         monkeypatch.setattr(runner.MultiProcessRunner, "_create_pool", _create_pool)
@@ -589,6 +595,96 @@ def test__linter__lint_paths_closes_runner_iterator_on_early_break(monkeypatch):
     lntr.lint_paths((test_path,), processes=2)
 
     assert closable_iterator.closed
+
+
+def test__parallel_runner__pool_join_called_on_cleanup(monkeypatch):
+    """Ensure ParallelRunner.run() calls pool.terminate() and pool.join().
+
+    Without pool.join(), worker processes may still be alive when Python's
+    resource_tracker runs at shutdown, causing "leaked semaphore" warnings
+    from the named POSIX semaphores used by the pool's internal queues.
+    """
+
+    class TrackingPool:
+        """Fake pool that records terminate/join calls."""
+
+        def __init__(self):
+            self.terminated = False
+            self.joined = False
+
+        def imap_unordered(self, func, iterable):
+            yield from ()
+
+        def imap(self, func, iterable):
+            yield from ()
+
+        def terminate(self):
+            self.terminated = True
+
+        def join(self):
+            self.joined = True
+
+    tracking_pool = TrackingPool()
+
+    monkeypatch.setattr(
+        runner.MultiThreadRunner,
+        "_create_pool",
+        classmethod(lambda cls, *a, **kw: tracking_pool),
+    )
+
+    config = FluffConfig(overrides={"dialect": "ansi"})
+    lntr = Linter(config=config)
+    # Consume the generator to trigger the finally block.
+    list(runner.MultiThreadRunner(lntr, config, processes=1).run([], fix=False))
+
+    assert tracking_pool.terminated, "pool.terminate() was not called"
+    assert tracking_pool.joined, "pool.join() was not called"
+
+
+def test__parallel_runner__pool_join_called_on_generator_close(monkeypatch):
+    """pool.join() is called even when the generator is closed early."""
+
+    class TrackingPool:
+        """Fake pool that records terminate/join calls."""
+
+        def __init__(self):
+            self.terminated = False
+            self.joined = False
+
+        def imap_unordered(self, func, iterable):
+            # Yield a sentinel so the generator suspends at yield.
+            for item in iterable:
+                yield func(item)
+
+        def imap(self, func, iterable):
+            for item in iterable:
+                yield func(item)
+
+        def terminate(self):
+            self.terminated = True
+
+        def join(self):
+            self.joined = True
+
+    tracking_pool = TrackingPool()
+
+    monkeypatch.setattr(
+        runner.MultiThreadRunner,
+        "_create_pool",
+        classmethod(lambda cls, *a, **kw: tracking_pool),
+    )
+
+    config = FluffConfig(overrides={"dialect": "ansi"})
+    lntr = Linter(config=config)
+    gen = runner.MultiThreadRunner(lntr, config, processes=1).run(
+        ["test/fixtures/linter/passing.sql"], fix=False
+    )
+    # Advance to the first yield, then close early.
+    next(gen, None)
+    gen.close()
+
+    assert tracking_pool.terminated, "pool.terminate() was not called"
+    assert tracking_pool.joined, "pool.join() was not called"
 
 
 def test__linter__empty_file():


### PR DESCRIPTION
### Brief summary of the change made
It's another attempt to eliminate "leaked semaphore" messages  and to prevent resource leaks.

Makes progress on #4080

`Pool.__exit__()` (used by the `with pool:` context manager) calls `pool.terminate()` but not `pool.join()`. Without `join()`, worker processes may still be running when Python's resource_tracker checks for leaked resources at shutdown. The pool's internal `SimpleQueue` objects use named POSIX semaphores for their locks, and these (might) get reported as "leaked semaphore objects" because the workers haven't fully exited yet.

Changes:
* Replaced `with self._create_pool(...) as pool:` with explicit `pool = self._create_pool(...)` + `try/finally`. 
* The finally block always calls `pool.terminate()` followed by `pool.join()`, ensuring all worker processes have fully exited and their semaphore references are released before the method returns
* This covers all exit paths: normal completion, GeneratorExit (early close from `lint_paths`, and `KeyboardInterrupt`
* Extended mock ErrorPool in tests, and added tests to verify the method calls

### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [ ] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
