### PR TITLE
fix: ST10 RHS constant expression redundancy check

### DIFF
--- a/src/sqlfluff/rules/structure/ST10.py
+++ b/src/sqlfluff/rules/structure/ST10.py
@@ -65,30 +65,15 @@ class Rule_ST10(BaseRule):
                 if seg.raw not in ("=", "!=", "<>"):
                     continue
 
-                has_other_operators_on_lhs = any(
-                    subsegments[i]
-                    for i in range(idx - 1, -1, -1)
-                    if subsegments[i].is_type("comparison_operator", "binary_operator")
-                )
-
-                has_other_operators_on_rhs = any(
-                    subsegments[i]
-                    for i in range(idx - 1, -1, -1)
-                    if subsegments[i].is_type("comparison_operator", "binary_operator")
-                )
-
-                if has_other_operators_on_lhs or has_other_operators_on_rhs:
-                    # Figuring our precedence of different operators is outside of scope
-                    continue
-
-                lhs = next(
+                lhs_idx, lhs = next(
                     (
-                        subsegments[i]
+                        (i, subsegments[i])
                         for i in range(idx - 1, -1, -1)
                         if not subsegments[i].is_whitespace
                     ),
-                    None,
+                    (None, None),
                 )
+
                 rhs = next(
                     (
                         subsegments[i]
@@ -97,11 +82,34 @@ class Rule_ST10(BaseRule):
                     ),
                     None,
                 )
-                if not lhs or not rhs:
+                if lhs is None or rhs is None or lhs_idx is None:
                     # Should be unreachable with correctly parsed tree
                     continue  # pragma: no cover
 
                 if lhs.is_templated or rhs.is_templated:
+                    continue
+
+                prev_before_lhs = (
+                    next(
+                        (
+                            subsegments[i]
+                            for i in range(lhs_idx - 1, -1, -1)
+                            if not subsegments[i].is_whitespace
+                        ),
+                        None,
+                    )
+                    if lhs_idx > 0
+                    else None
+                )
+
+                # We treat the pieces immediately left and right of `=` as its operands.
+                # After AND or OR, that is correct (e.g. `... OR 1 = 2`).
+                # After other binary operators, it is not correct (e.g. `num % 2 = 0`).
+                if (
+                    prev_before_lhs is not None
+                    and prev_before_lhs.is_type("binary_operator")
+                    and prev_before_lhs.raw_normalized().upper() not in ("AND", "OR")
+                ):
                     continue
 
                 # literals need explicit handling (due to well-defined allow-list)

--- a/test/fixtures/rules/std_rule_cases/ST10.yml
+++ b/test/fixtures/rules/std_rule_cases/ST10.yml
@@ -61,6 +61,11 @@ test_fail_disallowed_literal_false2:
   fail_str: |
     select col from foo WHERE 1 <> 1 OR col = 'val'
 
+test_fail_disallowed_literal_false3:
+  # 1 = 2 should be false (or match allow-list)
+  fail_str: |
+    select col from foo WHERE col = 'val' OR 1 = 2
+
 test_fail_bracketed:
   # brackets produce nested subexpression which should be tested
   fail_str: |


### PR DESCRIPTION
* Fix ST10 RHS constant expression redundancy check

<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
fixes #7689 

### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
