### PR TITLE
fix(ST05): don't descend into subqueries when checking for value table functions

### DIFF
--- a/src/sqlfluff/utils/analysis/select.py
+++ b/src/sqlfluff/utils/analysis/select.py
@@ -174,7 +174,9 @@ def _has_value_table_function(
         # function.
         return False  # pragma: no cover
 
-    for function_name in table_expr.recursive_crawl("function_name"):
+    for function_name in table_expr.recursive_crawl(
+        "function_name", no_recursive_seg_type="select_statement"
+    ):
         # Other rules can increase whitespace in the function name, so use strip to
         # remove
         # See: https://github.com/sqlfluff/sqlfluff/issues/1304

--- a/test/fixtures/rules/std_rule_cases/ST05.yml
+++ b/test/fixtures/rules/std_rule_cases/ST05.yml
@@ -1249,3 +1249,48 @@ test_fail_clickhouse_expression_cte_preserved:
   configs:
     core:
       dialect: clickhouse
+
+issue_6176_subquery_with_table_function_in_inner_from:
+  # Regression test for https://github.com/sqlfluff/sqlfluff/issues/6176
+  # ST05 was not detecting subqueries in FROM when the inner query used a
+  # value table function (e.g. UNNEST). _has_value_table_function was
+  # incorrectly descending into the inner select_statement and finding
+  # function names there, causing the outer subquery to be misclassified
+  # as a value table function and skipped.
+  fail_str: |
+    select
+        d AS days
+    from (
+        select *
+        from
+            UNNEST(
+                GENERATE_DATE_ARRAY(
+                    '2016-01-01',
+                    CURRENT_DATE(),
+                    INTERVAL 1 DAY
+                )
+            ) as d
+    )
+    order by 1
+  fix_str: |
+    with prep_1 as (
+        select *
+        from
+            UNNEST(
+                GENERATE_DATE_ARRAY(
+                    '2016-01-01',
+                    CURRENT_DATE(),
+                    INTERVAL 1 DAY
+                )
+            ) as d
+    )
+    select
+        d AS days
+    from prep_1
+    order by 1
+  configs:
+    core:
+      dialect: bigquery
+    rules:
+      structure.subquery:
+        forbid_subquery_in: both


### PR DESCRIPTION
### Brief summary of the change made

Fixes #6176

ST05 was not detecting subqueries in `FROM` clauses when the inner query used a value table function (e.g. `UNNEST`). `_has_value_table_function` was using `recursive_crawl("function_name")` without a depth guard, causing it to descend into nested `SELECT` statements and find function names there. This made the outer subquery get misclassified as a value table function and skipped entirely by ST05.

Fix: add `no_recursive_seg_type="select_statement"` to the `recursive_crawl` call in `_has_value_table_function`, preventing it from descending into nested selects when looking for value table function names.

### Are there any other side effects of this change that we should be aware of?

None. The change is a one-line guard in a utility function. All existing ST05 tests continue to pass.

### Pull Request checklist

- [x] Please confirm you have completed any of the necessary steps below.
- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - [x] `.yml` rule test cases in `test/fixtures/rules/std_rule_cases` — added `issue_6176_subquery_with_table_function_in_inner_from`
  - [ ] `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`)
  - [ ] Full autofix test cases in `test/fixtures/linter/autofix`
  - [ ] Other
- [ ] Added appropriate documentation for the change.
- [ ] Created GitHub issues for any relevant followup/future enhancements if appropriate.
