### PR TITLE
[codex] Fix DuckDB double-quoted struct keys

### DIFF
--- a/src/sqlfluff/dialects/dialect_duckdb.py
+++ b/src/sqlfluff/dialects/dialect_duckdb.py
@@ -919,7 +919,7 @@ class ObjectLiteralElementSegment(ansi.ObjectLiteralElementSegment):
 
     match_grammar: Matchable = Sequence(
         OneOf(
-            Ref("NakedIdentifierSegment"),
+            Ref("SingleIdentifierGrammar"),
             Ref("QuotedLiteralSegment"),
         ),
         Ref("ColonSegment"),

--- a/test/fixtures/dialects/duckdb/structs.sql
+++ b/test/fixtures/dialects/duckdb/structs.sql
@@ -1,3 +1,14 @@
 SELECT a::STRUCT(y INTEGER) AS b
 FROM
     (SELECT {'x': 42} AS a);
+
+SELECT {"id": foo, "name": bar} AS baz
+FROM my_table;
+
+SELECT
+    CASE
+        WHEN foo IS NULL
+            THEN NULL
+        ELSE {"id": foo, "name": bar}
+        END AS baz
+FROM my_table;

--- a/test/fixtures/dialects/duckdb/structs.yml
+++ b/test/fixtures/dialects/duckdb/structs.yml
@@ -3,9 +3,9 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: dd51a5c24f787c35216072bc3fa03be92be30588bb2c23d01e33bdfb2d56934d
+_hash: da885addc886470561b32166d227adadc1ae5793297e68d88168667aae54b256
 file:
-  statement:
+- statement:
     select_statement:
       select_clause:
         keyword: SELECT
@@ -52,4 +52,83 @@ file:
                           keyword: AS
                         naked_identifier: a
                 end_bracket: )
-  statement_terminator: ;
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          object_literal:
+          - start_curly_bracket: '{'
+          - object_literal_element:
+              quoted_identifier: '"id"'
+              colon: ':'
+              column_reference:
+                naked_identifier: foo
+          - comma: ','
+          - object_literal_element:
+              quoted_identifier: '"name"'
+              colon: ':'
+              column_reference:
+                naked_identifier: bar
+          - end_curly_bracket: '}'
+          alias_expression:
+            alias_operator:
+              keyword: AS
+            naked_identifier: baz
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: my_table
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+            case_expression:
+            - keyword: CASE
+            - when_clause:
+              - keyword: WHEN
+              - expression:
+                  column_reference:
+                    naked_identifier: foo
+                  keyword: IS
+                  null_literal: 'NULL'
+              - keyword: THEN
+              - expression:
+                  null_literal: 'NULL'
+            - else_clause:
+                keyword: ELSE
+                expression:
+                  object_literal:
+                  - start_curly_bracket: '{'
+                  - object_literal_element:
+                      quoted_identifier: '"id"'
+                      colon: ':'
+                      column_reference:
+                        naked_identifier: foo
+                  - comma: ','
+                  - object_literal_element:
+                      quoted_identifier: '"name"'
+                      colon: ':'
+                      column_reference:
+                        naked_identifier: bar
+                  - end_curly_bracket: '}'
+            - keyword: END
+          alias_expression:
+            alias_operator:
+              keyword: AS
+            naked_identifier: baz
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: my_table
+- statement_terminator: ;


### PR DESCRIPTION
## Summary
- accept double-quoted identifier keys in DuckDB object literals
- add DuckDB regression fixtures for the issue repro and the surrounding plain `SELECT` form
- keep the parser change isolated to the DuckDB dialect

## Root Cause
DuckDB itself accepts object/struct literals with double-quoted identifier keys such as `{"id": foo, "name": bar}`. SQLFluff's DuckDB grammar only allowed bare identifiers or quoted literals as object keys, so double-quoted keys were rejected even though the DuckDB engine accepts them.

## Reproduction Validation
Exact issue behavior was validated before and after the change using the two SQL snippets from the report.

Baseline checkout, before this patch:
- `SELECT {'key1': 'value1', 'key2': 42} AS s;` parses successfully with exit code `0`
- the reported DuckDB `CASE ... ELSE {"id": foo, "name": bar}` query fails with exit code `1` and a parse violation on the `CASE` section

This branch, after the patch:
- the working query still parses successfully with exit code `0`
- the reported failing query now parses successfully with exit code `0`

## Validation
- validated against the official `duckdb/duckdb` container that DuckDB accepts the plain `SELECT` form and the `CASE` form with double-quoted keys
- `python test/generate_parse_fixture_yml.py -d duckdb`
- `pytest test/dialects/dialects_test.py -k duckdb`
- `pytest test/dialects/dialects_test.py -k 'duckdb and structs'`
- `ruff check src/sqlfluff/dialects/dialect_duckdb.py`
- `pre-commit run --files src/sqlfluff/dialects/dialect_duckdb.py test/fixtures/dialects/duckdb/structs.sql test/fixtures/dialects/duckdb/structs.yml`
  - all hooks passed except the expected `no-commit-to-branch` failure before branching off `main`

Fixes #7693
