### PR TITLE
fix: add --no-warn-unused-configs flag to mypyc commands in tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -163,15 +163,15 @@ commands =
 skip_install = true
 changedir = src
 commands =
-    mypyc --config-file  ../pyproject.toml -p sqlfluff.api
-    mypyc --config-file  ../pyproject.toml -p sqlfluff.cli
-    mypyc --config-file  ../pyproject.toml -p sqlfluff.core.config
-    mypyc --config-file  ../pyproject.toml -p sqlfluff.core.dialects
-    mypyc --config-file  ../pyproject.toml -p sqlfluff.core.helpers
-    mypyc --config-file  ../pyproject.toml -p sqlfluff.core.linter
-    mypyc --config-file  ../pyproject.toml -p sqlfluff.core.parser.grammar
-    mypyc --config-file  ../pyproject.toml -p sqlfluff.core.plugin
-    mypyc --config-file  ../pyproject.toml -p sqlfluff.utils.reflow
+    mypyc --config-file ../pyproject.toml --no-warn-unused-configs -p sqlfluff.api
+    mypyc --config-file ../pyproject.toml --no-warn-unused-configs -p sqlfluff.cli
+    mypyc --config-file ../pyproject.toml --no-warn-unused-configs -p sqlfluff.core.config
+    mypyc --config-file ../pyproject.toml --no-warn-unused-configs -p sqlfluff.core.dialects
+    mypyc --config-file ../pyproject.toml --no-warn-unused-configs -p sqlfluff.core.helpers
+    mypyc --config-file ../pyproject.toml --no-warn-unused-configs -p sqlfluff.core.linter
+    mypyc --config-file ../pyproject.toml --no-warn-unused-configs -p sqlfluff.core.parser.grammar
+    mypyc --config-file ../pyproject.toml --no-warn-unused-configs -p sqlfluff.core.plugin
+    mypyc --config-file ../pyproject.toml --no-warn-unused-configs -p sqlfluff.utils.reflow
 
 [testenv:build-dist]
 skip_install = true


### PR DESCRIPTION
### Brief summary of the change made
This change fixes a CI-only regression in the `mypyc` job. Recent `mypy/mypyc` behavior now treats an unused override in the shared type-checking config as a failing condition when `mypyc` compiles only a narrow subset of packages, even though that override is valid for the full project.

The fix scopes the workaround to the `mypyc` tox environment by adding `--no-warn-unused-configs` to those compile commands. That keeps normal `mypy` strictness unchanged for the main codebase while preventing `mypyc` from failing on config that is only irrelevant to the specific package being compiled.

### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
