### PR TITLE
fix(postgres): stop RF04 from flagging PROVIDER as keyword

### DIFF
--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -17,6 +17,7 @@ from sqlfluff.core.parser import (
     IdentifierSegment,
     ImplicitIndent,
     Indent,
+    KeywordSegment,
     LiteralKeywordSegment,
     LiteralSegment,
     Matchable,
@@ -406,6 +407,9 @@ postgres_dialect.sets("date_part_function_name").clear()
 postgres_dialect.sets("value_table_functions").update(["UNNEST", "GENERATE_SERIES"])
 
 postgres_dialect.add(
+    # PROVIDER is used in CREATE COLLATION syntax but is not a PostgreSQL keyword
+    # per the docs appendix, so we register it manually to avoid RF04 false positives.
+    ProviderKeywordSegment=StringParser("provider", KeywordSegment),
     JsonOperatorSegment=TypedParser(
         "json_operator", SymbolSegment, type="binary_operator"
     ),

--- a/src/sqlfluff/dialects/dialect_postgres_keywords.py
+++ b/src/sqlfluff/dialects/dialect_postgres_keywords.py
@@ -979,7 +979,7 @@ postgres_nondocs_keywords = [
     ("NOSUPERUSER", "non-reserved"),
     ("PLAIN", "non-reserved"),
     ("PROCESS_TOAST", "non-reserved"),
-    ("PROVIDER", "non-reserved"),
+    ("PROVIDER", "not-keyword"),
     ("PUBLIC", "non-reserved"),
     ("REMAINDER", "non-reserved"),
     ("REPLICATION", "non-reserved"),


### PR DESCRIPTION
### Brief summary of the change made

Fixes #7691

`PROVIDER` is not listed in the PostgreSQL keyword appendix (verified against PG 13 and PG 17 docs). It was incorrectly classified as `non-reserved` in `postgres_nondocs_keywords`, causing RF04 to flag it when used as an identifier. This reclassifies it as `not-keyword` and registers it as a manual `KeywordSegment` so `CREATE COLLATION ... PROVIDER = ICU` grammar continues to parse.

### Are there any other side effects of this change that we should be aware of?

None. Existing `create_collation` parse fixtures continue to pass.

### Pull Request checklist

- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - [ ] `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - [ ] `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - [ ] Full autofix test cases in `test/fixtures/linter/autofix`.
  - [ ] Other.
- [ ] Added appropriate documentation for the change.
- [ ] Created GitHub issues for any relevant followup/future enhancements if appropriate.