### PR TITLE
Oracle: add support for no-argument procedure calls

### DIFF
--- a/src/sqlfluff/dialects/dialect_oracle.py
+++ b/src/sqlfluff/dialects/dialect_oracle.py
@@ -523,7 +523,14 @@ oracle_dialect.add(
     ),
     UnpivotNullsGrammar=Sequence(OneOf("INCLUDE", "EXCLUDE"), "NULLS"),
     StatementAndDelimiterGrammar=Sequence(
-        Ref("StatementSegment"),
+        # PlsqlStatementSegment extends StatementSegment with ProcedureCallStatementSegment.
+        # Using it here (rather than plain StatementSegment) means bare procedure-call
+        # syntax is only tried inside PL/SQL block bodies (BEGIN/END, loops, IF, etc.)
+        # that use OneOrMoreStatementsGrammar -> StatementAndDelimiterGrammar.
+        # The top-level BatchSegment references StatementSegment directly, so it is
+        # shielded from ProcedureCallStatementSegment and cannot silently absorb DDL
+        # unreserved keywords (e.g. NOCACHE, NOROWDEPENDENCIES) as phantom calls.
+        Ref("PlsqlStatementSegment"),
         Ref("DelimiterGrammar", optional=True),
     ),
     OneOrMoreStatementsGrammar=AnyNumberOf(
@@ -1394,6 +1401,39 @@ class StatementSegment(ansi.StatementSegment):
             Ref("CreateSynonymStatementSegment"),
             Ref("DropSynonymStatementSegment"),
             Ref("AlterSynonymStatementSegment"),
+        ],
+    )
+
+
+class PlsqlStatementSegment(StatementSegment):
+    """PL/SQL block statement with bare procedure call support.
+
+    Adds `ProcedureCallStatementSegment` (e.g. `my_proc;`) for use
+    inside PL/SQL blocks only. This avoids a bug where unreserved DDL
+    keywords (e.g. `NOCACHE`, `NOROWDEPENDENCIES`) could be silently
+    consumed as phantom procedure calls at the top level, hiding real
+    syntax errors. The bug was triggered by Python 3.14's changed
+    dictionary iteration order affecting `longest_match` branch
+    selection; earlier Python versions happened to avoid it due to
+    different internal ordering, making the behaviour non-deterministic
+    across runtimes.
+
+    *Known limitation*: bare procedure calls outside a PL/SQL block
+    (i.e. not inside `BEGIN/END`, loops, or `IF`) are not supported
+    and will produce a parse error. Supporting both safely would require
+    a context-aware grammar that can distinguish unreserved DDL keywords
+    from procedure names -- not possible with the flat `BatchSegment`
+    architecture.
+    """
+
+    type = "statement"
+
+    match_grammar = StatementSegment.match_grammar.copy(
+        insert=[
+            # Must be last: bare reference or call without parentheses used as
+            # a statement (procedure call).  More specific segments above take
+            # priority when the lookahead matches their keywords.
+            Ref("ProcedureCallStatementSegment"),
         ],
     )
 
@@ -3297,6 +3337,49 @@ class AssignmentStatementSegment(BaseSegment):
     )
 
 
+class ProcedureCallStatementSegment(BaseSegment):
+    """A PL/SQL procedure invocation used as a statement, without an argument list.
+
+    Oracle calls this a *subprogram invocation*; both procedures and functions
+    fall under that umbrella. This segment handles only the **procedure** case
+    (a procedure invocation is a PL/SQL *statement*, whereas a function
+    invocation is an *expression*) and only when the argument list is omitted
+    entirely.
+
+    https://docs.oracle.com/en/database/oracle/oracle-database/26/lnpls/subprogram-invocations.html
+
+    *Known limitation:* collection methods with reserved-keyword names
+    (e.g. `my_collection.DELETE;`) cannot be parsed because
+    `NakedIdentifierSegment` rejects reserved keywords.  Methods with
+    unreserved names (`EXTEND`, `TRIM`, `FIRST`, `LAST`) work fine.
+    """
+
+    type = "procedure_call_statement"
+
+    # END, EXCEPTION, and ELSIF are *unreserved*, so NakedIdentifierSegment
+    # would accept them as identifiers and this segment would consume them
+    # before the enclosing block structure can claim them as block-closing
+    # tokens. All other block keywords (ELSE, WHEN, THEN, LOOP, BEGIN, IF,
+    # ...) are *reserved* and are therefore already rejected by NakedIdentifier
+    # Segment's anti_template without explicit exclusion here.
+    _block_closing_kw_exclusion = OneOf(
+        Ref.keyword("END"),
+        Ref.keyword("EXCEPTION"),
+        Ref.keyword("ELSIF"),
+    )
+
+    match_grammar = Sequence(
+        Ref("SingleIdentifierGrammar", exclude=_block_closing_kw_exclusion),
+        AnyNumberOf(
+            Sequence(
+                Ref("DotSegment"),
+                Ref("SingleIdentifierGrammar", exclude=_block_closing_kw_exclusion),
+            ),
+            max_times=2,
+        ),
+    )
+
+
 class IfExpressionStatement(BaseSegment):
     """IF-ELSE statement.
 
@@ -3654,7 +3737,11 @@ class LoopStatementSegment(BaseSegment):
     type = "loop_statement"
 
     match_grammar: Matchable = Sequence(
-        Ref("SingleIdentifierGrammar", optional=True),
+        Ref(
+            "SingleIdentifierGrammar",
+            optional=True,
+            exclude=Ref.keyword("END"),
+        ),
         "LOOP",
         Indent,
         Ref("OneOrMoreStatementsGrammar"),

--- a/test/fixtures/dialects/oracle/procedure_call.sql
+++ b/test/fixtures/dialects/oracle/procedure_call.sql
@@ -1,0 +1,154 @@
+-- Procedure call statements (no argument list)
+
+-- Unqualified procedure call (no dot, no parentheses)
+BEGIN
+  my_procedure;
+END;
+/
+
+-- Package-qualified procedure call
+BEGIN
+  pkg.my_procedure;
+END;
+/
+
+-- Fully schema-qualified procedure call
+BEGIN
+  schema.pkg.my_procedure;
+END;
+/
+
+-- Collection method calls (no arguments)
+BEGIN
+  my_collection.EXTEND;
+  my_collection.TRIM;
+END;
+/
+
+-- Mixed: procedure call and function call with arguments in same block
+BEGIN
+  my_procedure;
+  DBMS_OUTPUT.PUT_LINE('test');
+END;
+/
+
+-- Multiple procedure calls
+BEGIN
+  first_proc;
+  pkg.second_proc;
+  schema.pkg.third_proc;
+END;
+/
+
+-- Procedure call inside IF block
+BEGIN
+  IF 1 = 1 THEN
+    my_procedure;
+  END IF;
+END;
+/
+
+-- Procedure call inside FOR loop
+BEGIN
+  FOR i IN 1..10 LOOP
+    my_procedure;
+  END LOOP;
+END;
+/
+
+-- Procedure call inside WHILE loop
+BEGIN
+  WHILE TRUE LOOP
+    pkg.my_procedure;
+    EXIT;
+  END LOOP;
+END;
+/
+
+-- Procedure call with DECLARE block
+DECLARE
+  v_count NUMBER := 0;
+BEGIN
+  my_procedure;
+  pkg.my_procedure;
+END;
+/
+
+-- Inline single-statement BEGIN/END blocks
+BEGIN my_procedure; END;
+/
+
+BEGIN schema.pkg.my_procedure; END;
+/
+
+-- Schema-qualified call mixed with a function call that has arguments
+BEGIN
+  pkg.my_procedure;
+  DBMS_OUTPUT.PUT_LINE('test');
+END;
+/
+
+-- Schema-qualified call mixed with other statements
+BEGIN
+  schema.pkg.my_procedure;
+  DBMS_OUTPUT.PUT_LINE('done');
+END;
+/
+
+-- Multiple qualified calls in one block
+BEGIN
+  pkg.my_procedure;
+  schema.pkg.my_procedure;
+  DBMS_OUTPUT.PUT_LINE('test');
+END;
+/
+
+-- Procedure call followed by assignment
+DECLARE
+  v NUMBER;
+BEGIN
+  my_procedure;
+  v := 1;
+  pkg.my_procedure;
+END;
+/
+
+-- Procedure call inside ELSIF branch
+BEGIN
+  IF 1 = 1 THEN
+    my_procedure;
+  ELSIF 2 = 2 THEN
+    pkg.my_procedure;
+  ELSE
+    schema.pkg.my_procedure;
+  END IF;
+END;
+/
+
+-- Procedure call inside nested BEGIN/END
+BEGIN
+  BEGIN
+    my_procedure;
+    pkg.my_procedure;
+  END;
+  schema.pkg.my_procedure;
+END;
+/
+
+-- Regression: EXCEPTION must not be consumed as a procedure-call identifier.
+BEGIN
+  my_procedure;
+EXCEPTION
+  WHEN OTHERS THEN
+    pkg.my_procedure;
+END;
+/
+
+-- Same regression with a schema-qualified call before the handler.
+BEGIN
+  schema.pkg.my_procedure;
+EXCEPTION
+  WHEN OTHERS THEN
+    NULL;
+END;
+/

--- a/test/fixtures/dialects/oracle/procedure_call.yml
+++ b/test/fixtures/dialects/oracle/procedure_call.yml
@@ -1,0 +1,501 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 7aefc94aca08a10996daf4fc654498ba9e94a422e49b549f2e06c2ab9f3b175a
+file:
+- batch:
+    statement:
+      begin_end_block:
+      - keyword: BEGIN
+      - statement:
+          procedure_call_statement:
+            naked_identifier: my_procedure
+      - statement_terminator: ;
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      begin_end_block:
+      - keyword: BEGIN
+      - statement:
+          procedure_call_statement:
+          - naked_identifier: pkg
+          - dot: .
+          - naked_identifier: my_procedure
+      - statement_terminator: ;
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      begin_end_block:
+      - keyword: BEGIN
+      - statement:
+          procedure_call_statement:
+          - naked_identifier: schema
+          - dot: .
+          - naked_identifier: pkg
+          - dot: .
+          - naked_identifier: my_procedure
+      - statement_terminator: ;
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      begin_end_block:
+      - keyword: BEGIN
+      - statement:
+          procedure_call_statement:
+          - naked_identifier: my_collection
+          - dot: .
+          - naked_identifier: EXTEND
+      - statement_terminator: ;
+      - statement:
+          procedure_call_statement:
+          - naked_identifier: my_collection
+          - dot: .
+          - naked_identifier: TRIM
+      - statement_terminator: ;
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      begin_end_block:
+      - keyword: BEGIN
+      - statement:
+          procedure_call_statement:
+            naked_identifier: my_procedure
+      - statement_terminator: ;
+      - statement:
+          function:
+            function_name:
+              naked_identifier: DBMS_OUTPUT
+              dot: .
+              function_name_identifier: PUT_LINE
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  quoted_literal: "'test'"
+                end_bracket: )
+      - statement_terminator: ;
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      begin_end_block:
+      - keyword: BEGIN
+      - statement:
+          procedure_call_statement:
+            naked_identifier: first_proc
+      - statement_terminator: ;
+      - statement:
+          procedure_call_statement:
+          - naked_identifier: pkg
+          - dot: .
+          - naked_identifier: second_proc
+      - statement_terminator: ;
+      - statement:
+          procedure_call_statement:
+          - naked_identifier: schema
+          - dot: .
+          - naked_identifier: pkg
+          - dot: .
+          - naked_identifier: third_proc
+      - statement_terminator: ;
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      begin_end_block:
+      - keyword: BEGIN
+      - statement:
+          if_then_statement:
+          - if_clause:
+            - keyword: IF
+            - expression:
+              - numeric_literal: '1'
+              - comparison_operator:
+                  raw_comparison_operator: '='
+              - numeric_literal: '1'
+            - keyword: THEN
+          - statement:
+              procedure_call_statement:
+                naked_identifier: my_procedure
+          - statement_terminator: ;
+          - keyword: END
+          - keyword: IF
+      - statement_terminator: ;
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      begin_end_block:
+      - keyword: BEGIN
+      - statement:
+          for_loop_statement:
+          - keyword: FOR
+          - naked_identifier: i
+          - keyword: IN
+          - numeric_literal: '1'
+          - dot: .
+          - dot: .
+          - numeric_literal: '10'
+          - loop_statement:
+            - keyword: LOOP
+            - statement:
+                procedure_call_statement:
+                  naked_identifier: my_procedure
+            - statement_terminator: ;
+            - keyword: END
+            - keyword: LOOP
+      - statement_terminator: ;
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      begin_end_block:
+      - keyword: BEGIN
+      - statement:
+          while_loop_statement:
+            keyword: WHILE
+            expression:
+              boolean_literal: 'TRUE'
+            loop_statement:
+            - keyword: LOOP
+            - statement:
+                procedure_call_statement:
+                - naked_identifier: pkg
+                - dot: .
+                - naked_identifier: my_procedure
+            - statement_terminator: ;
+            - statement:
+                exit_statement:
+                  keyword: EXIT
+            - statement_terminator: ;
+            - keyword: END
+            - keyword: LOOP
+      - statement_terminator: ;
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      begin_end_block:
+      - declare_segment:
+          keyword: DECLARE
+          naked_identifier: v_count
+          data_type:
+            data_type_identifier: NUMBER
+          assignment_operator: :=
+          expression:
+            numeric_literal: '0'
+          statement_terminator: ;
+      - keyword: BEGIN
+      - statement:
+          procedure_call_statement:
+            naked_identifier: my_procedure
+      - statement_terminator: ;
+      - statement:
+          procedure_call_statement:
+          - naked_identifier: pkg
+          - dot: .
+          - naked_identifier: my_procedure
+      - statement_terminator: ;
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      begin_end_block:
+      - keyword: BEGIN
+      - statement:
+          procedure_call_statement:
+            naked_identifier: my_procedure
+      - statement_terminator: ;
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      begin_end_block:
+      - keyword: BEGIN
+      - statement:
+          procedure_call_statement:
+          - naked_identifier: schema
+          - dot: .
+          - naked_identifier: pkg
+          - dot: .
+          - naked_identifier: my_procedure
+      - statement_terminator: ;
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      begin_end_block:
+      - keyword: BEGIN
+      - statement:
+          procedure_call_statement:
+          - naked_identifier: pkg
+          - dot: .
+          - naked_identifier: my_procedure
+      - statement_terminator: ;
+      - statement:
+          function:
+            function_name:
+              naked_identifier: DBMS_OUTPUT
+              dot: .
+              function_name_identifier: PUT_LINE
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  quoted_literal: "'test'"
+                end_bracket: )
+      - statement_terminator: ;
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      begin_end_block:
+      - keyword: BEGIN
+      - statement:
+          procedure_call_statement:
+          - naked_identifier: schema
+          - dot: .
+          - naked_identifier: pkg
+          - dot: .
+          - naked_identifier: my_procedure
+      - statement_terminator: ;
+      - statement:
+          function:
+            function_name:
+              naked_identifier: DBMS_OUTPUT
+              dot: .
+              function_name_identifier: PUT_LINE
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  quoted_literal: "'done'"
+                end_bracket: )
+      - statement_terminator: ;
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      begin_end_block:
+      - keyword: BEGIN
+      - statement:
+          procedure_call_statement:
+          - naked_identifier: pkg
+          - dot: .
+          - naked_identifier: my_procedure
+      - statement_terminator: ;
+      - statement:
+          procedure_call_statement:
+          - naked_identifier: schema
+          - dot: .
+          - naked_identifier: pkg
+          - dot: .
+          - naked_identifier: my_procedure
+      - statement_terminator: ;
+      - statement:
+          function:
+            function_name:
+              naked_identifier: DBMS_OUTPUT
+              dot: .
+              function_name_identifier: PUT_LINE
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  quoted_literal: "'test'"
+                end_bracket: )
+      - statement_terminator: ;
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      begin_end_block:
+      - declare_segment:
+          keyword: DECLARE
+          naked_identifier: v
+          data_type:
+            data_type_identifier: NUMBER
+          statement_terminator: ;
+      - keyword: BEGIN
+      - statement:
+          procedure_call_statement:
+            naked_identifier: my_procedure
+      - statement_terminator: ;
+      - statement:
+          assignment_segment_statement:
+            object_reference:
+              naked_identifier: v
+            assignment_operator: :=
+            expression:
+              numeric_literal: '1'
+      - statement_terminator: ;
+      - statement:
+          procedure_call_statement:
+          - naked_identifier: pkg
+          - dot: .
+          - naked_identifier: my_procedure
+      - statement_terminator: ;
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      begin_end_block:
+      - keyword: BEGIN
+      - statement:
+          if_then_statement:
+          - if_clause:
+            - keyword: IF
+            - expression:
+              - numeric_literal: '1'
+              - comparison_operator:
+                  raw_comparison_operator: '='
+              - numeric_literal: '1'
+            - keyword: THEN
+          - statement:
+              procedure_call_statement:
+                naked_identifier: my_procedure
+          - statement_terminator: ;
+          - keyword: ELSIF
+          - expression:
+            - numeric_literal: '2'
+            - comparison_operator:
+                raw_comparison_operator: '='
+            - numeric_literal: '2'
+          - keyword: THEN
+          - statement:
+              procedure_call_statement:
+              - naked_identifier: pkg
+              - dot: .
+              - naked_identifier: my_procedure
+          - statement_terminator: ;
+          - keyword: ELSE
+          - statement:
+              procedure_call_statement:
+              - naked_identifier: schema
+              - dot: .
+              - naked_identifier: pkg
+              - dot: .
+              - naked_identifier: my_procedure
+          - statement_terminator: ;
+          - keyword: END
+          - keyword: IF
+      - statement_terminator: ;
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      begin_end_block:
+      - keyword: BEGIN
+      - statement:
+          begin_end_block:
+          - keyword: BEGIN
+          - statement:
+              procedure_call_statement:
+                naked_identifier: my_procedure
+          - statement_terminator: ;
+          - statement:
+              procedure_call_statement:
+              - naked_identifier: pkg
+              - dot: .
+              - naked_identifier: my_procedure
+          - statement_terminator: ;
+          - keyword: END
+      - statement_terminator: ;
+      - statement:
+          procedure_call_statement:
+          - naked_identifier: schema
+          - dot: .
+          - naked_identifier: pkg
+          - dot: .
+          - naked_identifier: my_procedure
+      - statement_terminator: ;
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      begin_end_block:
+      - keyword: BEGIN
+      - statement:
+          procedure_call_statement:
+            naked_identifier: my_procedure
+      - statement_terminator: ;
+      - keyword: EXCEPTION
+      - keyword: WHEN
+      - keyword: OTHERS
+      - keyword: THEN
+      - statement:
+          procedure_call_statement:
+          - naked_identifier: pkg
+          - dot: .
+          - naked_identifier: my_procedure
+      - statement_terminator: ;
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      begin_end_block:
+      - keyword: BEGIN
+      - statement:
+          procedure_call_statement:
+          - naked_identifier: schema
+          - dot: .
+          - naked_identifier: pkg
+          - dot: .
+          - naked_identifier: my_procedure
+      - statement_terminator: ;
+      - keyword: EXCEPTION
+      - keyword: WHEN
+      - keyword: OTHERS
+      - keyword: THEN
+      - statement:
+          null_statement:
+            keyword: 'NULL'
+      - statement_terminator: ;
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /

--- a/test/fixtures/dialects/oracle/while_loop.sql
+++ b/test/fixtures/dialects/oracle/while_loop.sql
@@ -12,3 +12,28 @@ BEGIN
   END LOOP;
 END;
 /
+
+-- Nested WHILE loops with an end-label on the inner loop.
+-- Regression: without exclude=Ref.keyword("END") on the optional leading
+-- label in LoopStatementSegment, the parser could treat END (of the outer
+-- block) as a loop label, consuming it before the enclosing structure could
+-- claim it and breaking the entire parse.
+BEGIN
+  WHILE TRUE LOOP
+    WHILE TRUE LOOP
+      NULL;
+    END LOOP inner_loop;
+    EXIT;
+  END LOOP;
+END;
+/
+
+-- Same regression with a FOR loop outer body.
+BEGIN
+  FOR i IN 1..3 LOOP
+    FOR j IN 1..3 LOOP
+      NULL;
+    END LOOP inner_loop;
+  END LOOP outer_loop;
+END;
+/

--- a/test/fixtures/dialects/oracle/while_loop.yml
+++ b/test/fixtures/dialects/oracle/while_loop.yml
@@ -3,9 +3,9 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 77772ae82a89f4c7fcb387496811507fbd8c3b8e717514fb57f9f07a053c59a1
+_hash: d902632d8a243de280943a658b69eb8e24130967b05a4238c1da6c6260d037c9
 file:
-  batch:
+- batch:
     statement:
       begin_end_block:
       - declare_segment:
@@ -82,6 +82,85 @@ file:
             - statement_terminator: ;
             - keyword: END
             - keyword: LOOP
+      - statement_terminator: ;
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      begin_end_block:
+      - keyword: BEGIN
+      - statement:
+          while_loop_statement:
+            keyword: WHILE
+            expression:
+              boolean_literal: 'TRUE'
+            loop_statement:
+            - keyword: LOOP
+            - statement:
+                while_loop_statement:
+                  keyword: WHILE
+                  expression:
+                    boolean_literal: 'TRUE'
+                  loop_statement:
+                  - keyword: LOOP
+                  - statement:
+                      null_statement:
+                        keyword: 'NULL'
+                  - statement_terminator: ;
+                  - keyword: END
+                  - keyword: LOOP
+                  - naked_identifier: inner_loop
+            - statement_terminator: ;
+            - statement:
+                exit_statement:
+                  keyword: EXIT
+            - statement_terminator: ;
+            - keyword: END
+            - keyword: LOOP
+      - statement_terminator: ;
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      begin_end_block:
+      - keyword: BEGIN
+      - statement:
+          for_loop_statement:
+          - keyword: FOR
+          - naked_identifier: i
+          - keyword: IN
+          - numeric_literal: '1'
+          - dot: .
+          - dot: .
+          - numeric_literal: '3'
+          - loop_statement:
+            - keyword: LOOP
+            - statement:
+                for_loop_statement:
+                - keyword: FOR
+                - naked_identifier: j
+                - keyword: IN
+                - numeric_literal: '1'
+                - dot: .
+                - dot: .
+                - numeric_literal: '3'
+                - loop_statement:
+                  - keyword: LOOP
+                  - statement:
+                      null_statement:
+                        keyword: 'NULL'
+                  - statement_terminator: ;
+                  - keyword: END
+                  - keyword: LOOP
+                  - naked_identifier: inner_loop
+            - statement_terminator: ;
+            - keyword: END
+            - keyword: LOOP
+            - naked_identifier: outer_loop
       - statement_terminator: ;
       - keyword: END
     statement_terminator: ;


### PR DESCRIPTION
- Introduce `ProcedureCallStatementSegment` to support PL/SQL procedure/method calls without parentheses or arguments (e.g., `my_proc;`, `pkg.my_proc;`, `collection.EXTEND;`).
- Register `ProcedureCallStatementSegment` last in `StatementSegment` to avoid conflicts with more specific statement types.
- Exclude block-closing keywords (`END`, `EXCEPTION`, `ELSIF`) from being parsed as procedure calls.

Fixes #7248.

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->


### Are there any other side effects of this change that we should be aware of?
No.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
