### PR TITLE
LT03: add :attached modifier for leading/trailing line_position

### DIFF
--- a/docs/source/configuration/layout.rst
+++ b/docs/source/configuration/layout.rst
@@ -812,6 +812,49 @@ available:
       then there must be a line break on *both sides* (i.e. that it should
       be the only thing on that line.
 
+   *  :code:`trailing` and :code:`leading` can also be qualified with the
+      :code:`:attached` modifier - which *additionally* requires that the
+      operator must not appear on a line by itself. In other words, if there
+      is a line break on *both sides*, the operator is considered standalone
+      and must be moved to be directly attached to the adjacent token. This
+      is useful for operators like the Oracle PL/SQL assignment operator
+      :code:`:=`, where you want it either mid-line or strictly
+      trailing/leading (not floating alone). For example:
+
+      .. code-block:: cfg
+
+         [sqlfluff:layout:type:assignment_operator]
+         line_position = trailing:attached
+
+      With :code:`trailing:attached`, the operator must end the previous
+      line when a line break is involved:
+
+      .. code-block:: sql
+
+         -- Allowed: mid-line
+         my_var := some_value;
+         -- Allowed: truly trailing
+         my_var :=
+             some_value;
+         -- NOT allowed: standalone (own line) or leading
+         my_var
+         :=
+         some_value;
+
+      With :code:`leading:attached`, the operator must start the next line
+      and be directly followed by the RHS token (no blank line between):
+
+      .. code-block:: sql
+
+         -- Allowed: mid-line
+         my_var := some_value;
+         -- Allowed: truly leading (attached to RHS)
+         my_var
+             := some_value;
+         -- NOT allowed: standalone (own line) or trailing
+         my_var :=
+             some_value;
+
    *  All of the above options can be qualified with the :code:`:strict`
       modifier - which prevents the *inline* case. For example:
 

--- a/docsv/configuration/layout.md
+++ b/docsv/configuration/layout.md
@@ -758,6 +758,48 @@ available:
     then there must be a line break on *both sides* (i.e. that it should
     be the only thing on that line.
 
+  * `trailing` and `leading` can also be qualified with the `:attached`
+    modifier - which *additionally* requires that the operator must not appear
+    on a line by itself. In other words, if there is a line break on *both
+    sides*, the operator is considered standalone and must be moved to be
+    directly attached to the adjacent token. This is useful for operators like
+    the Oracle PL/SQL assignment operator `:=`, where you want it either
+    mid-line or strictly trailing/leading (not floating alone). For example:
+
+    ```ini
+    [sqlfluff:layout:type:assignment_operator]
+    line_position = trailing:attached
+    ```
+
+    With `trailing:attached`, the operator must end the previous line when a
+    line break is involved:
+
+    ```sql
+    -- Allowed: mid-line
+    my_var := some_value;
+    -- Allowed: truly trailing
+    my_var :=
+        some_value;
+    -- NOT allowed: standalone (own line) or leading
+    my_var
+    :=
+    some_value;
+    ```
+
+    With `leading:attached`, the operator must start the next line and be
+    directly followed by the RHS token (no blank line between):
+
+    ```sql
+    -- Allowed: mid-line
+    my_var := some_value;
+    -- Allowed: truly leading (attached to RHS)
+    my_var
+        := some_value;
+    -- NOT allowed: standalone (own line) or trailing
+    my_var :=
+        some_value;
+    ```
+
   * All of the above options can be qualified with the `:strict`
     modifier - which prevents the *inline* case. For example:
 

--- a/src/sqlfluff/rules/layout/LT03.py
+++ b/src/sqlfluff/rules/layout/LT03.py
@@ -60,7 +60,9 @@ class Rule_LT03(BaseRule):
     name = "layout.operators"
     aliases = ("L007",)
     groups = ("all", "layout")
-    crawl_behaviour = SegmentSeekerCrawler({"binary_operator", "comparison_operator"})
+    crawl_behaviour = SegmentSeekerCrawler(
+        {"binary_operator", "comparison_operator", "assignment_operator"}
+    )
     is_fix_compatible = True
 
     def _seek_newline(
@@ -98,26 +100,31 @@ class Rule_LT03(BaseRule):
             line_position: The `line_position` config for the segment.
         """
         idx = parent.segments.index(segment)
-        # Strip any modifier suffix (e.g. ":align-following") to get the
-        # base position for the shortcut check.
         base_position = line_position.split(":")[0]
+        attached = "attached" in line_position
+        has_newline_before = self._seek_newline(parent.segments, idx, dir=-1)
+        has_newline_after = self._seek_newline(parent.segments, idx, dir=1)
+
         # Shortcut #1: Leading.
         if base_position == "leading":
-            if self._seek_newline(parent.segments, idx, dir=-1):
-                return True
-            # If we didn't find a newline before, if there's _also_ not a newline
-            # after, then we can also shortcut. i.e. it's a comma "mid line".
-            if not self._seek_newline(parent.segments, idx, dir=1):
-                return True
+            if attached:
+                # leading:attached: shortcut when mid-line or truly leading.
+                # Must reflow when trailing or on its own line (no newline after
+                # means it cannot be standalone or trailing).
+                return not has_newline_after
+            # Standard: OK unless trailing (no newline before, but newline after).
+            return has_newline_before or not has_newline_after
 
         # Shortcut #2: Trailing.
         elif base_position == "trailing":
-            if self._seek_newline(parent.segments, idx, dir=1):
-                return True
-            # If we didn't find a newline after, if there's _also_ not a newline
-            # before, then we can also shortcut. i.e. it's a comma "mid line".
-            if not self._seek_newline(parent.segments, idx, dir=-1):
-                return True
+            if attached:
+                # trailing:attached: shortcut when mid-line or truly trailing.
+                # Must reflow when leading or on its own line (no newline before
+                # means it cannot be standalone or leading).
+                return not has_newline_before
+            # Standard: OK unless leading (no newline after, but newline before).
+            return has_newline_after or not has_newline_before
+
         return False
 
     def _eval(self, context: RuleContext) -> list[LintResult]:
@@ -146,6 +153,14 @@ class Rule_LT03(BaseRule):
             )
             if self._check_trail_lead_shortcut(
                 context.segment, context.parent_stack[-1], binary_positioning
+            ):
+                return [LintResult()]
+        elif context.segment.is_type("assignment_operator"):
+            assignment_positioning = context.config.get(
+                "line_position", ["layout", "type", "assignment_operator"]
+            )
+            if self._check_trail_lead_shortcut(
+                context.segment, context.parent_stack[-1], assignment_positioning
             ):
                 return [LintResult()]
 

--- a/src/sqlfluff/utils/reflow/rebreak.py
+++ b/src/sqlfluff/utils/reflow/rebreak.py
@@ -28,6 +28,7 @@ class _RebreakSpan:
     end_idx: int
     line_position: str
     strict: bool
+    attached: bool = False
 
 
 @dataclass(frozen=True)
@@ -75,6 +76,7 @@ class _RebreakLocation:
     next: _RebreakIndices
     line_position: str
     strict: bool
+    attached: bool = False
 
     @classmethod
     def from_span(
@@ -87,6 +89,7 @@ class _RebreakLocation:
             _RebreakIndices.from_elements(elements, span.end_idx, 1),
             span.line_position,
             span.strict,
+            span.attached,
         )
 
     def pretty_target_name(self) -> str:
@@ -133,6 +136,12 @@ class _RebreakLocation:
         n_next_newlines = elements[self.next.newline_pt_idx].num_newlines()
         newlines_on_neither_side = n_prev_newlines + n_next_newlines == 0
         newlines_on_both_sides = n_prev_newlines > 0 and n_next_newlines > 0
+
+        # For trailing:attached, newlines on both sides means the operator
+        # is on its own line and must be moved to be truly trailing.
+        # We must NOT skip this case.
+        if newlines_on_both_sides and self.attached:
+            return False
 
         return (
             # If there isn't a newline on either side then carry
@@ -210,6 +219,7 @@ def identify_rebreak_spans(
                     # complex, this works.
                     elem.line_position.split(":")[0],
                     elem.line_position.endswith("strict"),
+                    "attached" in elem.line_position,
                 )
             )
         # Do any of its parents have config, and are we at the start
@@ -253,6 +263,7 @@ def identify_rebreak_spans(
                             # complex, this works.
                             elem.line_position_configs[key].split(":")[0],
                             elem.line_position_configs[key].endswith("strict"),
+                            "attached" in elem.line_position_configs[key],
                         )
                     )
                     break
@@ -351,6 +362,7 @@ def identify_keyword_rebreak_spans(
                             # complex, this works.
                             elem.keyword_line_position_configs[key].split(":")[0],
                             elem.keyword_line_position_configs[key].endswith("strict"),
+                            "attached" in elem.keyword_line_position_configs[key],
                         )
                     )
                     break
@@ -433,14 +445,28 @@ def rebreak_sequence(
         # So we know we have a preference, is it ok?
         if loc.line_position == "leading":
             if elem_buff[loc.prev.newline_pt_idx].num_newlines():
-                # We're good. It's already leading.
-                continue
+                # For leading:attached, also check there's no newline after.
+                # An operator on its own line (newlines on both sides) must be
+                # moved to be attached to the following token.
+                if (
+                    not loc.attached
+                    or not elem_buff[loc.next.newline_pt_idx].num_newlines()
+                ):
+                    # We're good. It's already leading.
+                    continue
 
             # Generate the text for any issues.
             pretty_name = loc.pretty_target_name()
             if loc.strict:  # pragma: no cover
                 # TODO: The 'strict' option isn't widely tested yet.
                 desc = f"{pretty_name.capitalize()} should always start a new line."
+            elif loc.attached and elem_buff[loc.prev.newline_pt_idx].num_newlines():
+                # Standalone + leading:attached: operator is on its own line but
+                # must be directly attached to the following token.
+                desc = (
+                    f"Found standalone {pretty_name}. Expected leading and "
+                    "attached to the following token."
+                )
             else:
                 desc = (
                     f"Found trailing {pretty_name}. Expected only leading "
@@ -533,8 +559,15 @@ def rebreak_sequence(
 
         elif loc.line_position == "trailing":
             if elem_buff[loc.next.newline_pt_idx].num_newlines():
-                # We're good, it's already trailing.
-                continue
+                # For trailing:attached, also check there's no newline before.
+                # An operator on its own line (newlines on both sides) must be
+                # moved to the end of the previous line.
+                if (
+                    not loc.attached
+                    or not elem_buff[loc.prev.newline_pt_idx].num_newlines()
+                ):
+                    # We're good, it's already trailing.
+                    continue
 
             # Generate the text for any issues.
             pretty_name = loc.pretty_target_name()
@@ -542,6 +575,13 @@ def rebreak_sequence(
                 # TODO: The 'strict' option isn't widely tested yet.
                 desc = (
                     f"{pretty_name.capitalize()} should always be at the end of a line."
+                )
+            elif loc.attached and elem_buff[loc.next.newline_pt_idx].num_newlines():
+                # Standalone + trailing:attached: operator is on its own line but
+                # must be directly attached to the preceding token.
+                desc = (
+                    f"Found standalone {pretty_name}. Expected trailing and "
+                    "attached to the preceding token."
                 )
             else:
                 desc = (
@@ -782,8 +822,13 @@ def rebreak_keywords_sequence(
         # So we know we have a preference, is it ok?
         if loc.line_position == "leading":
             if elem_buff[loc.prev.newline_pt_idx].num_newlines():
-                # We're good. It's already leading.
-                continue
+                # For leading:attached, also check there's no newline after.
+                if (
+                    not loc.attached
+                    or not elem_buff[loc.next.newline_pt_idx].num_newlines()
+                ):
+                    # We're good. It's already leading.
+                    continue
 
             # Generate the text for any issues.
             pretty_name = loc.pretty_target_name()
@@ -815,8 +860,13 @@ def rebreak_keywords_sequence(
 
         elif loc.line_position == "trailing":
             if elem_buff[loc.next.newline_pt_idx].num_newlines():
-                # We're good, it's already trailing.
-                continue
+                # For trailing:attached, also check there's no newline before.
+                if (
+                    not loc.attached
+                    or not elem_buff[loc.prev.newline_pt_idx].num_newlines()
+                ):
+                    # We're good, it's already trailing.
+                    continue
 
             # Generate the text for any issues.
             pretty_name = loc.pretty_target_name()

--- a/test/fixtures/rules/std_rule_cases/LT03.yml
+++ b/test/fixtures/rules/std_rule_cases/LT03.yml
@@ -1,5 +1,20 @@
 rule: LT03
 
+passes_shortcut_fallthrough_alone:
+  # When line_position = "alone", _check_trail_lead_shortcut returns False
+  # (defers to full reflow) since "alone" is not "leading" or "trailing".
+  # An inline := satisfies the alone constraint, so this is a pass.
+  # This covers the return False fallback in _check_trail_lead_shortcut.
+  pass_str: |
+    LET MY_VAR := SOME_VALUE;
+  configs:
+    layout:
+      type:
+        assignment_operator:
+          line_position: alone
+    core:
+      dialect: snowflake
+
 passes_on_before_default:
   pass_str: |
     select
@@ -288,3 +303,252 @@ fixes_tuple_error_issue:
   configs:
     indentation:
       template_blocks_indent: false
+
+# Assignment operator (:=) tests (Oracle PL/SQL)
+
+# --- trailing config (tolerates standalone := on its own line) ---
+
+assignment_operator_trailing_passes_same_line:
+  # := on the same line as the variable is fine
+  pass_str: |
+    MY_VAR := SOME_VALUE;
+  configs: &assignment_trailing
+    layout:
+      type:
+        assignment_operator:
+          line_position: trailing
+    core:
+      dialect: oracle
+
+assignment_operator_trailing_passes_truly_trailing:
+  # := at end of first line (before newline) is correct for trailing
+  pass_str: |
+    MY_VAR :=
+        SOME_VALUE;
+  configs: *assignment_trailing
+
+assignment_operator_trailing_fails_leading:
+  # := at start of second line must be moved to end of first line
+  fail_str: |
+    MY_VAR
+      := SOME_VALUE;
+  fix_str: |
+    MY_VAR :=
+      SOME_VALUE;
+  configs: *assignment_trailing
+
+assignment_operator_trailing_passes_on_own_line:
+  # := on its own line (newlines on both sides) is tolerated by plain trailing
+  pass_str: |
+    MY_VAR
+    :=
+    SOME_VALUE;
+  configs: *assignment_trailing
+
+# --- trailing:attached config (operator MUST be on the end of the prev line) ---
+
+assignment_operator_trailing_attached_passes_same_line:
+  # := on the same line as the variable is fine
+  pass_str: |
+    MY_VAR := SOME_VALUE;
+  configs: &assignment_trailing_attached
+    layout:
+      type:
+        assignment_operator:
+          line_position: "trailing:attached"
+    core:
+      dialect: oracle
+
+assignment_operator_trailing_attached_passes_truly_trailing:
+  # := at end of first line (before newline) is correct
+  pass_str: |
+    MY_VAR :=
+      SOME_VALUE;
+  configs: *assignment_trailing_attached
+
+assignment_operator_trailing_attached_fails_leading:
+  # := at start of second line must be moved to end of first line
+  fail_str: |
+    MY_VAR
+      := SOME_VALUE;
+  fix_str: |
+    MY_VAR :=
+      SOME_VALUE;
+  configs: *assignment_trailing_attached
+
+assignment_operator_trailing_attached_fails_on_own_line:
+  # := on its own line (newlines on both sides) must be moved to end of variable line
+  fail_str: |
+    MY_VAR
+    :=
+    SOME_FUNCTION(
+      PARAM1,
+      PARAM2
+    );
+  fix_str: |
+    MY_VAR :=
+    SOME_FUNCTION(
+      PARAM1,
+      PARAM2
+    );
+  configs: *assignment_trailing_attached
+
+assignment_operator_trailing_attached_fails_multiline_rhs:
+  # := on its own line with a multi-line RHS expression
+  fail_str: |
+    AUDITINFO
+    :=
+    AUDITINFO
+    || 'SUFFIX';
+  fix_str: |
+    AUDITINFO :=
+    AUDITINFO
+    || 'SUFFIX';
+  configs: *assignment_trailing_attached
+
+# --- leading config (assignment operator should start the line) ---
+
+assignment_operator_leading_passes_same_line:
+  # := on same line as the variable is fine for leading too (mid-line)
+  pass_str: |
+    MY_VAR := SOME_VALUE;
+  configs: &assignment_leading
+    layout:
+      type:
+        assignment_operator:
+          line_position: leading
+    core:
+      dialect: oracle
+
+assignment_operator_leading_passes_truly_leading:
+  # := at start of second line is correct for leading
+  pass_str: |
+    MY_VAR
+      := SOME_VALUE;
+  configs: *assignment_leading
+
+assignment_operator_leading_fails_trailing:
+  # := at end of first line must be moved to start of second line
+  fail_str: |
+    MY_VAR :=
+      SOME_VALUE;
+  fix_str: |
+    MY_VAR
+      := SOME_VALUE;
+  configs: *assignment_leading
+
+assignment_operator_leading_passes_on_own_line:
+  # := on its own line (newlines on both sides) is ok for leading
+  # (it's on a new line, which satisfies the leading constraint)
+  pass_str: |
+    MY_VAR
+    :=
+    SOME_VALUE;
+  configs: *assignment_leading
+
+# --- leading:attached config (operator MUST start the next line, attached to the RHS) ---
+
+assignment_operator_leading_attached_passes_same_line:
+  # := on the same line is fine (mid-line)
+  pass_str: |
+    MY_VAR := SOME_VALUE;
+  configs: &assignment_leading_attached
+    layout:
+      type:
+        assignment_operator:
+          line_position: "leading:attached"
+    core:
+      dialect: oracle
+
+assignment_operator_leading_attached_passes_truly_leading:
+  # := at the start of the next line, directly before the RHS - correct
+  pass_str: |
+    MY_VAR
+      := SOME_VALUE;
+  configs: *assignment_leading_attached
+
+assignment_operator_leading_attached_fails_trailing:
+  # := at end of first line must be moved to start of second line
+  fail_str: |
+    MY_VAR :=
+      SOME_VALUE;
+  fix_str: |
+    MY_VAR
+      := SOME_VALUE;
+  configs: *assignment_leading_attached
+
+assignment_operator_leading_attached_fails_on_own_line:
+  # := on its own line must be joined to the RHS (remove newline after :=)
+  fail_str: |
+    MY_VAR
+    :=
+    SOME_VALUE;
+  fix_str: |
+    MY_VAR
+    := SOME_VALUE;
+  configs: *assignment_leading_attached
+
+# --- Cross-dialect: Snowflake scripting (LET statement) ---
+# These tests guard that assignment_operator handling is dialect-agnostic.
+# Snowflake uses := in LET statements (scripting blocks); the same
+# trailing:attached and leading:attached semantics should apply.
+
+assignment_operator_snowflake_trailing_attached_passes:
+  # LET var := value on same line is always fine
+  pass_str: |
+    LET MY_VAR := SOME_VALUE;
+  configs: &snowflake_trailing_attached
+    layout:
+      type:
+        assignment_operator:
+          line_position: "trailing:attached"
+    core:
+      dialect: snowflake
+
+assignment_operator_snowflake_trailing_attached_passes_truly_trailing:
+  # := at end of line (before newline) is correct for trailing:attached
+  pass_str: |
+    LET MY_VAR :=
+      SOME_VALUE;
+  configs: *snowflake_trailing_attached
+
+assignment_operator_snowflake_trailing_attached_fails_standalone:
+  # := on its own line must be moved to the end of the LET line
+  fail_str: |
+    LET MY_VAR
+    :=
+    SOME_VALUE;
+  fix_str: |
+    LET MY_VAR :=
+    SOME_VALUE;
+  configs: *snowflake_trailing_attached
+
+assignment_operator_snowflake_leading_attached_passes:
+  # LET var := value on same line is always fine
+  pass_str: |
+    LET MY_VAR := SOME_VALUE;
+  configs: &snowflake_leading_attached
+    layout:
+      type:
+        assignment_operator:
+          line_position: "leading:attached"
+    core:
+      dialect: snowflake
+
+assignment_operator_snowflake_leading_attached_passes_truly_leading:
+  # := at start of next line, directly before the RHS - correct
+  pass_str: |
+    LET MY_VAR
+      := SOME_VALUE;
+  configs: *snowflake_leading_attached
+
+assignment_operator_snowflake_leading_attached_fails_standalone:
+  # := on its own line must be joined to the RHS (remove newline after :=)
+  fail_str: |
+    LET MY_VAR
+    :=
+    SOME_VALUE;
+  fix_str: |
+    LET MY_VAR
+    := SOME_VALUE;
+  configs: *snowflake_leading_attached


### PR DESCRIPTION
### Brief summary of the change made

Add `trailing:attached` and `leading:attached` as new `line_position` modifiers in the reflow engine. They extend the existing `trailing` and `leading` semantics by additionally requiring that the operator must not float on its own line; it must stay attached to the preceding token (`trailing:attached`) or the following token (`leading:attached`).

Also extend rule LT03 to crawl and evaluate `assignment_operator` segments (Oracle PL/SQL `:=`), enabling the new modifiers to be applied to it via config.

Fixes #7703.

### Are there any other side effects of this change that we should be aware of?
No.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
