### PR TITLE
Add aliasing.required rule AL10: derived tables must have an alias

### DIFF
--- a/src/sqlfluff/rules/aliasing/AL10.py
+++ b/src/sqlfluff/rules/aliasing/AL10.py
@@ -1,0 +1,80 @@
+"""Implementation of Rule AL10."""
+
+from sqlfluff.core.parser import BaseSegment
+from sqlfluff.core.rules import BaseRule, EvalResultType, LintResult, RuleContext
+from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
+
+
+class Rule_AL10(BaseRule):
+    """Derived tables must have an alias.
+
+    A derived table (subquery in a ``FROM`` clause) without an alias will
+    cause a runtime error in most SQL dialects including MySQL, PostgreSQL,
+    and T-SQL.
+
+    **Anti-pattern**
+
+    A subquery in a ``FROM`` clause without an alias.
+
+    .. code-block:: sql
+
+        SELECT *
+        FROM (
+            SELECT 1 AS a
+        )
+
+    **Best practice**
+
+    Add an alias to the derived table.
+
+    .. code-block:: sql
+
+        SELECT *
+        FROM (
+            SELECT 1 AS a
+        ) AS derived
+
+    """
+
+    name = "aliasing.required"
+    aliases = ()
+    groups = ("all", "core", "aliasing")
+    crawl_behaviour = SegmentSeekerCrawler({"from_expression_element"})
+    is_fix_compatible = False
+
+    def _eval(self, context: RuleContext) -> EvalResultType:
+        """Check that derived tables have an alias."""
+        assert context.segment.is_type("from_expression_element")
+
+        # Check if this FROM expression contains a derived table.
+        if not self._contains_derived_table(context.segment):
+            return None
+
+        # It's a derived table. Check if it has an alias.
+        if context.segment.get_child("alias_expression"):
+            return None
+
+        # Derived table without an alias.
+        return LintResult(
+            anchor=context.segment,
+            description="Derived table must have an alias.",
+        )
+
+    @staticmethod
+    def _contains_derived_table(from_expression_element: BaseSegment) -> bool:
+        """Check whether a FROM expression element contains a derived table.
+
+        A derived table is a subquery (SELECT, set expression, or CTE)
+        nested inside a FROM clause, potentially wrapped in brackets.
+        """
+        for segment in from_expression_element.iter_segments(expanding=("bracketed",)):
+            if segment.is_type("table_expression"):
+                # Check for nested SELECT, UNION/INTERSECT/EXCEPT, or CTE.
+                for seg in segment.iter_segments(expanding=("bracketed",)):
+                    if seg.is_type(
+                        "select_statement",
+                        "set_expression",
+                        "with_compound_statement",
+                    ):
+                        return True
+        return False

--- a/src/sqlfluff/rules/aliasing/AL10.py
+++ b/src/sqlfluff/rules/aliasing/AL10.py
@@ -9,7 +9,7 @@ class Rule_AL10(BaseRule):
     """Derived tables must have an alias.
 
     A derived table (subquery in a ``FROM`` clause) without an alias will
-    cause a runtime error in most SQL dialects including MySQL, PostgreSQL,
+    cause a syntax error in most SQL dialects including MySQL, PostgreSQL,
     and T-SQL.
 
     **Anti-pattern**
@@ -64,12 +64,13 @@ class Rule_AL10(BaseRule):
     def _contains_derived_table(from_expression_element: BaseSegment) -> bool:
         """Check whether a FROM expression element contains a derived table.
 
-        A derived table is a subquery (SELECT, set expression, or CTE)
-        nested inside a FROM clause, potentially wrapped in brackets.
+        A derived table is a subquery (SELECT, set expression, or WITH-compound
+        statement) nested inside a FROM clause, potentially wrapped in brackets.
         """
         for segment in from_expression_element.iter_segments(expanding=("bracketed",)):
             if segment.is_type("table_expression"):
-                # Check for nested SELECT, UNION/INTERSECT/EXCEPT, or CTE.
+                # Check for nested SELECT, UNION/INTERSECT/EXCEPT, or
+                # WITH-compound statement.
                 for seg in segment.iter_segments(expanding=("bracketed",)):
                     if seg.is_type(
                         "select_statement",

--- a/src/sqlfluff/rules/aliasing/__init__.py
+++ b/src/sqlfluff/rules/aliasing/__init__.py
@@ -62,6 +62,7 @@ def get_rules() -> list[type[BaseRule]]:
     from sqlfluff.rules.aliasing.AL07 import Rule_AL07
     from sqlfluff.rules.aliasing.AL08 import Rule_AL08
     from sqlfluff.rules.aliasing.AL09 import Rule_AL09
+    from sqlfluff.rules.aliasing.AL10 import Rule_AL10
 
     return [
         Rule_AL01,
@@ -73,4 +74,5 @@ def get_rules() -> list[type[BaseRule]]:
         Rule_AL07,
         Rule_AL08,
         Rule_AL09,
+        Rule_AL10,
     ]

--- a/test/fixtures/rules/std_rule_cases/AL10.yml
+++ b/test/fixtures/rules/std_rule_cases/AL10.yml
@@ -1,0 +1,139 @@
+rule: AL10
+
+# Derived table (subquery) without an alias should fail.
+test_fail_derived_table_no_alias:
+  fail_str: |
+    SELECT *
+    FROM (
+        SELECT 1 AS a
+    )
+
+# Derived table with an alias should pass.
+test_pass_derived_table_with_alias:
+  pass_str: |
+    SELECT *
+    FROM (
+        SELECT 1 AS a
+    ) AS derived
+
+# Derived table with implicit alias (no AS keyword) should pass.
+test_pass_derived_table_with_implicit_alias:
+  pass_str: |
+    SELECT *
+    FROM (
+        SELECT 1 AS a
+    ) derived
+
+# Regular table reference (not a derived table) should pass.
+test_pass_plain_table:
+  pass_str: SELECT * FROM my_table
+
+# Derived table with UNION should fail without alias.
+test_fail_union_derived_table_no_alias:
+  fail_str: |
+    SELECT *
+    FROM (
+        SELECT 1 AS a
+        UNION ALL
+        SELECT 2 AS a
+    )
+
+# Derived table with UNION and alias should pass.
+test_pass_union_derived_table_with_alias:
+  pass_str: |
+    SELECT *
+    FROM (
+        SELECT 1 AS a
+        UNION ALL
+        SELECT 2 AS a
+    ) AS combined
+
+# Subquery in JOIN without alias should fail.
+test_fail_derived_table_in_join_no_alias:
+  fail_str: |
+    SELECT *
+    FROM my_table
+    JOIN (
+        SELECT id FROM other_table
+    ) ON my_table.id = id
+
+# Subquery in JOIN with alias should pass.
+test_pass_derived_table_in_join_with_alias:
+  pass_str: |
+    SELECT *
+    FROM my_table
+    JOIN (
+        SELECT id FROM other_table
+    ) AS sub ON my_table.id = sub.id
+
+# Subquery in LEFT JOIN without alias should fail.
+test_fail_derived_table_in_left_join_no_alias:
+  fail_str: |
+    SELECT *
+    FROM my_table
+    LEFT JOIN (
+        SELECT id, value FROM other_table
+    ) ON my_table.id = id
+
+# CTE is fine (not a derived table in FROM).
+test_pass_cte:
+  pass_str: |
+    WITH cte AS (
+        SELECT 1 AS a
+    )
+    SELECT * FROM cte
+
+# Nested derived table: outer has alias, inner missing alias should fail.
+test_fail_nested_derived_table_inner_no_alias:
+  fail_str: |
+    SELECT *
+    FROM (
+        SELECT *
+        FROM (
+            SELECT 1 AS a
+        )
+    ) AS outer_derived
+
+# Multiple derived tables: one with alias, one without should fail.
+test_fail_one_of_two_derived_tables_missing_alias:
+  fail_str: |
+    SELECT *
+    FROM (
+        SELECT 1 AS a
+    ) AS derived1
+    JOIN (
+        SELECT 2 AS b
+    ) ON derived1.a = b
+
+# MySQL dialect: derived table without alias should fail.
+test_fail_mysql_derived_table_no_alias:
+  fail_str: |
+    SELECT *
+    FROM (
+        SELECT 1 AS a
+    )
+  configs:
+    core:
+      dialect: mysql
+
+# PostgreSQL dialect: derived table without alias should fail.
+test_fail_postgres_derived_table_no_alias:
+  fail_str: |
+    SELECT *
+    FROM (
+        SELECT 1 AS a
+    )
+  configs:
+    core:
+      dialect: postgres
+
+# T-SQL dialect: derived table without alias should fail.
+test_fail_tsql_derived_table_no_alias:
+  fail_str: |
+    SELECT *
+    FROM (
+        SELECT 1 AS a
+    )
+  configs:
+    core:
+      dialect: tsql


### PR DESCRIPTION
### Brief summary of the change made

Adds a new rule **AL10** (`aliasing.required`) that flags derived tables (subqueries in `FROM` clauses) missing an alias. This is a runtime error in every major SQL dialect (MySQL, PostgreSQL, T-SQL) but was not previously caught by sqlfluff.

We discovered this gap when an unaliased derived table passed sqlfluff linting but caused a production error in MySQL. ("Every derived table must have its own alias")

Fixes: #3650. Rather than extending AL05 with a config option, this is implemented as a separate rule because the concerns are distinct: AL05 flags *unused* aliases, while AL10 flags *missing required* aliases. The fix strategy differs between the two. An extra alias could be easily removed (or configured to be left in), while a missing required alias causes a production error.

### Are there any other side effects of this change that we should be aware of?

Existing SQL that has unaliased derived tables will now receive a lint violation. This is intentional, the SQL would fail at runtime in MySQL, PostgreSQL, and T-SQL. The rule is not auto-fixable (`is_fix_compatible = False`) since meaningful alias names cannot be generated automatically.

This rule applies to all dialects, which matches the behavior described in AL05's `_is_alias_required()`. Derived tables require aliases in every dialect I checked. I didn't extract a shared utility because this is only one other usage, also that would mean modifying AL05 which increases the scope and risk of the PR.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.

AI disclosure: Claude (Anthropic) helped me out with this one. I'm less familiar with Python and would be happy to make corrections. The result was verified against a real-world production SQL file that triggered this specific error.