### PR TITLE
fix: LT02 false positive when Jinja block contains same-line parentheses

### DIFF
--- a/src/sqlfluff/utils/reflow/reindent.py
+++ b/src/sqlfluff/utils/reflow/reindent.py
@@ -515,6 +515,33 @@ def _revise_templated_lines(
                             continue
 
                         _this_through = net_balance + ip.indent_trough
+                        # Guard: skip a zero trough caused by closing same-line
+                        # (untaken) indents during a net-loss dedent. This prevents
+                        # false-positive Case 3 triggers when a keyword's implicit
+                        # indent (e.g. IN (1)) was opened on the same line as the
+                        # bracket — the dedent reaches 0 but is not a genuine
+                        # cross-tree boundary.
+                        # We compute the set of untaken indent levels that are actually
+                        # being closed by this IP (those in the range
+                        # [closing_indent_balance, initial_indent_balance)) and check
+                        # whether any of them were same-line (untaken). Only if the
+                        # trough is exactly 0 (not a genuine deep trough) do we skip.
+                        dedented_untaken_balances = (
+                            tuple(
+                                balance
+                                for balance in range(
+                                    ip.initial_indent_balance,
+                                    ip.closing_indent_balance,
+                                    -1,
+                                )
+                                if balance in ip.untaken_indents
+                            )
+                            if ip.indent_impulse < 0
+                            else ()
+                        )
+                        if _this_through == 0 and dedented_untaken_balances:
+                            net_balance += ip.indent_impulse
+                            continue
                         temp_balance_trough = (
                             _this_through
                             if temp_balance_trough is None

--- a/test/fixtures/rules/std_rule_cases/LT02-indent.yml
+++ b/test/fixtures/rules/std_rule_cases/LT02-indent.yml
@@ -2832,3 +2832,36 @@ test_pass_from_values_bracketed_implicit_allow:
       dialect: snowflake
     indentation:
       implicit_indents: allow
+
+test_pass_jinja_if_with_in_clause:
+  # Regression test for GitHub issue #7740.
+  # Parenthesized expressions inside a Jinja if-block must not produce
+  # false-positive LT02 violations.  The indentation is correct; removing
+  # the parentheses should not change the linting outcome.
+  pass_str: |
+    SELECT 1
+    WHERE
+        1 = 1
+        {%- if true %}
+        AND x IN (1)
+        {%- endif %}
+  configs:
+    core:
+      templater: jinja
+    indentation:
+      template_blocks_indent: false
+
+test_pass_jinja_if_with_in_clause_multi_value:
+  # Same scenario with multiple values in the IN list (issue #7740).
+  pass_str: |
+    SELECT 1
+    WHERE
+        1 = 1
+        {%- if true %}
+        AND x IN (1, 2, 3)
+        {%- endif %}
+  configs:
+    core:
+      templater: jinja
+    indentation:
+      template_blocks_indent: false


### PR DESCRIPTION
Fixes #7740

Found the issue in `_revise_templated_lines()` in reindent.py. 
When a Jinja block contains a parenthesized expression like 
`AND x IN (1)`, the IN keyword creates an implicit indent that 
closes after the bracket on the same line. This produces a 
`balance_trough` of exactly 0, which incorrectly triggers the 
Case 3 dedent and decrements `initial_indent_balance` on inner 
lines — causing false LT02 violations.

The fix adds a guard before the `temp_balance_trough` update that 
computes which balances being dedented are actually untaken 
same-line indents. If the trough reaches exactly 0 and all the 
dedented balances are untaken, the point is spurious and gets 
skipped. Structural boundary dips and genuine deep troughs are 
always kept.

Two regression tests added to LT02-indent.yml covering single 
and multiple values in the IN list.