### PR TITLE
fix: support psql variable placeholders in COPY statements

### DIFF
--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -5844,7 +5844,12 @@ class CopyStatementSegment(BaseSegment):
     type = "copy_statement"
 
     _target_subset = OneOf(
-        Ref("QuotedLiteralSegment"), Sequence("PROGRAM", Ref("QuotedLiteralSegment"))
+        Ref("QuotedLiteralSegment"),
+        Sequence(
+            "PROGRAM",
+            OneOf(Ref("QuotedLiteralSegment"), Ref("PsqlVariableGrammar")),
+        ),
+        Ref("PsqlVariableGrammar"),
     )
 
     _table_definition = Sequence(
@@ -5987,6 +5992,7 @@ class CopyStatementSegment(BaseSegment):
                 OneOf(
                     Ref("QuotedLiteralSegment"),
                     Sequence("STDIN"),
+                    Ref("PsqlVariableGrammar"),
                 ),
                 _postgres9_compatible_stdin_options,
             ),
@@ -6005,6 +6011,7 @@ class CopyStatementSegment(BaseSegment):
                 OneOf(
                     Ref("QuotedLiteralSegment"),
                     Sequence("STDOUT"),
+                    Ref("PsqlVariableGrammar"),
                 ),
                 _postgres9_compatible_stdout_options,
             ),

--- a/test/fixtures/dialects/postgres/copy.sql
+++ b/test/fixtures/dialects/postgres/copy.sql
@@ -75,3 +75,12 @@ COPY my_table TO STDOUT WITH CSV ESCAPE '\';
 COPY my_table(col1, col2) TO STDOUT WITH CSV ESCAPE AS '\';
 COPY my_table(col1, col2) TO STDOUT WITH CSV FORCE QUOTE *;
 COPY my_table(col1, col2) TO STDOUT WITH CSV FORCE QUOTE (col1, col2);
+
+-- Issue #7696: psql variable placeholders in COPY commands
+COPY tmp_table FROM :source;
+COPY tmp_table FROM :'source';
+COPY tmp_table TO :dest;
+COPY tmp_table FROM :source WITH (FORMAT csv, HEADER);
+COPY tmp_table(col1, col2) FROM :source WITH (FORMAT csv);
+COPY tmp_table TO PROGRAM :cmd;
+COPY tmp_table FROM PROGRAM :cmd;

--- a/test/fixtures/dialects/postgres/copy.yml
+++ b/test/fixtures/dialects/postgres/copy.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 7183a7dc7491c71f71cee5e900729ff0c5f0d5eb9d01884c0b76be0b066ad37c
+_hash: f17c05b9abe1d80116538c6e4a858ee7f704161e1411d2c410e0e1a05f8efbec
 file:
 - statement:
     copy_statement:
@@ -1440,4 +1440,98 @@ file:
       - column_reference:
           naked_identifier: col2
       - end_bracket: )
+- statement_terminator: ;
+- statement:
+    copy_statement:
+    - keyword: COPY
+    - table_reference:
+        naked_identifier: tmp_table
+    - keyword: FROM
+    - psql_variable:
+        colon: ':'
+        parameter: source
+- statement_terminator: ;
+- statement:
+    copy_statement:
+    - keyword: COPY
+    - table_reference:
+        naked_identifier: tmp_table
+    - keyword: FROM
+    - psql_variable:
+        colon: ':'
+        quoted_literal: "'source'"
+- statement_terminator: ;
+- statement:
+    copy_statement:
+    - keyword: COPY
+    - table_reference:
+        naked_identifier: tmp_table
+    - keyword: TO
+    - psql_variable:
+        colon: ':'
+        parameter: dest
+- statement_terminator: ;
+- statement:
+    copy_statement:
+    - keyword: COPY
+    - table_reference:
+        naked_identifier: tmp_table
+    - keyword: FROM
+    - psql_variable:
+        colon: ':'
+        parameter: source
+    - keyword: WITH
+    - bracketed:
+      - start_bracket: (
+      - keyword: FORMAT
+      - naked_identifier: csv
+      - comma: ','
+      - keyword: HEADER
+      - end_bracket: )
+- statement_terminator: ;
+- statement:
+    copy_statement:
+    - keyword: COPY
+    - table_reference:
+        naked_identifier: tmp_table
+    - bracketed:
+      - start_bracket: (
+      - column_reference:
+          naked_identifier: col1
+      - comma: ','
+      - column_reference:
+          naked_identifier: col2
+      - end_bracket: )
+    - keyword: FROM
+    - psql_variable:
+        colon: ':'
+        parameter: source
+    - keyword: WITH
+    - bracketed:
+        start_bracket: (
+        keyword: FORMAT
+        naked_identifier: csv
+        end_bracket: )
+- statement_terminator: ;
+- statement:
+    copy_statement:
+    - keyword: COPY
+    - table_reference:
+        naked_identifier: tmp_table
+    - keyword: TO
+    - keyword: PROGRAM
+    - psql_variable:
+        colon: ':'
+        parameter: cmd
+- statement_terminator: ;
+- statement:
+    copy_statement:
+    - keyword: COPY
+    - table_reference:
+        naked_identifier: tmp_table
+    - keyword: FROM
+    - keyword: PROGRAM
+    - psql_variable:
+        colon: ':'
+        parameter: cmd
 - statement_terminator: ;


### PR DESCRIPTION
## Summary

- Adds `PsqlVariableGrammar` as a valid target in `CopyStatementSegment` for all COPY source/destination positions
- Supports bare (`:source`) and quoted (`:'source'`) psql variable forms
- Covers modern syntax, postgres9-compatible syntax, and `PROGRAM` argument

Fixes #7696

## Context

When a PostgreSQL script uses psql variable placeholders in COPY commands (e.g. `COPY tmp_table FROM :source`), sqlfluff throws a PRS (unparsable section) error. While v4.1.0 added support for `\copy` and `\set` meta-commands, the standard `COPY` statement grammar did not accept `PsqlVariableGrammar` as a valid file path alternative.

The fix adds `Ref("PsqlVariableGrammar")` to all target positions in `CopyStatementSegment`:
- `_target_subset` (modern FROM/TO with bracketed options)
- postgres9-compatible FROM branch (legacy WITH options)
- postgres9-compatible TO branch (legacy WITH options)
- `PROGRAM` argument (alongside quoted literals)

**Before:** `COPY tmp_table FROM :source;` → PRS error
**After:** `COPY tmp_table FROM :source;` → parsed as `copy_statement` with `psql_variable`

## Test plan

- [x] All 492 existing postgres dialect fixture tests pass
- [x] 7 new test cases added covering FROM, TO, quoted variable, PROGRAM, column lists, and WITH options
- [x] YAML fixtures regenerated via `generate_parse_fixture_yml.py`
- [x] Manual verification with the exact reproduction case from the issue