### PR TITLE
docs: hyphenate user-provided macro wording

### DIFF
--- a/src/sqlfluff/core/templaters/jinja.py
+++ b/src/sqlfluff/core/templaters/jinja.py
@@ -231,7 +231,7 @@ class JinjaTemplater(PythonTemplater):
                 )
             except TemplateSyntaxError as err:
                 raise SQLFluffUserError(
-                    f"Error loading user provided macro:\n`{value}`\n> {err}."
+                    f"Error loading user-provided macro:\n`{value}`\n> {err}."
                 )
         return macro_ctx
 


### PR DESCRIPTION
## Summary
- Hyphenate `user-provided` in the macro-loading error message.

## Related issue
- N/A

## Guideline alignment
- Read the contribution guide where present and kept this to one focused text-only file change.
- No behavior, test, fixture, changelog, or generated-file changes.

## Validation
- `git diff --check`
- Not run: broader tests are unnecessary for this text-only change.

## AI assistance
- Prepared with Codex and reviewed before submission.
