### PR TITLE
T-SQL: support CONTAINSTABLE/FREETEXTTABLE in FROM clauses

### DIFF
--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -4668,6 +4668,8 @@ class ReservedKeywordFunctionNameSegment(BaseSegment):
     type = "function_name"
     match_grammar = OneOf(
         "COALESCE",
+        "CONTAINSTABLE",
+        "FREETEXTTABLE",
         "LEFT",
         "NULLIF",
         "RIGHT",

--- a/test/dialects/tsql_test.py
+++ b/test/dialects/tsql_test.py
@@ -1,0 +1,26 @@
+"""Tests specific to the T-SQL dialect."""
+
+import pytest
+
+from sqlfluff.core import Linter
+
+
+@pytest.mark.parametrize(
+    "sql",
+    [
+        pytest.param(
+            "SELECT * FROM CONTAINSTABLE ([Table], [Column], 'Search')",
+            id="containstable_table_function",
+        ),
+        pytest.param(
+            "SELECT * FROM FREETEXTTABLE ([Table], [Column], 'Search')",
+            id="freetexttable_table_function",
+        ),
+    ],
+)
+def test_tsql_full_text_table_functions_parse(sql: str) -> None:
+    """Full-text table-valued functions should parse in FROM clauses."""
+    parsed = Linter(dialect="tsql").parse_string(sql)
+    assert not parsed.violations
+    assert parsed.tree
+    assert "unparsable" not in parsed.tree.type_set()


### PR DESCRIPTION
## Description:

Issue #7723 reported that T-SQL failed to parse full-text table-valued functions in FROM clauses.

This PR updates the T-SQL dialect grammar to include CONTAINSTABLE and FREETEXTTABLE in ReservedKeywordFunctionNameSegment, so these function names are recognized correctly.

It also adds focused regression tests for both functions.

Closes #7723.

## Checklist:

- [x] I have reviewed all changes in this PR myself.
- [x] I have added relevant regression test cases for this fix.
- [x] I have run linting and formatting checks in WSL using pre-commit run --files src/sqlfluff/dialects/dialect_tsql.py test/dialects/tsql_test.py.
- [x] I have run focused tests in WSL using pytest -q test/dialects/tsql_test.py.
- [x] I have run T-SQL parse fixture coverage in WSL using pytest -q test/dialects/dialects_test.py -k 'tsql and base_file_parse'.

#### The validation screenshots of the tests run, locally on WSL:

<img width="1677" height="348" alt="image" src="https://github.com/user-attachments/assets/661b57eb-0682-462f-b945-2f857f5ff2f1" />
