### PR TITLE
fix(postgres): handle COPY FROM STDIN data blocks

### DIFF
--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -210,6 +210,13 @@ postgres_dialect.insert_lexer_matchers(
             LiteralSegment,
         ),
         RegexLexer(
+            # Matches PostgreSQL COPY FROM STDIN data blocks (including raw data
+            # rows) through the terminating "\\." line.
+            "postgres_copy_stdin_data_block",
+            r"(?i)COPY\b.*?\bFROM\b\s+STDIN\b.*?;\r?\n(?:.*?\r?\n)*?\\\.[ \t]*(?=\r?\n|$)",
+            CodeSegment,
+        ),
+        RegexLexer(
             # Matches the psql \copy meta-command, including the form with a
             # parenthesized query that can span multiple lines.
             # https://www.postgresql.org/docs/current/app-psql.html#APP-PSQL-META-COMMAND-COPY
@@ -503,6 +510,11 @@ postgres_dialect.add(
     ),
     PsqlCopyMetaCommandSegment=TypedParser(
         "psql_copy_command", CodeSegment, type="psql_copy_command"
+    ),
+    PostgresCopyStdinDataSegment=TypedParser(
+        "postgres_copy_stdin_data_block",
+        CodeSegment,
+        type="postgres_copy_stdin_data_statement",
     ),
     PsqlSetMetaCommandSegment=TypedParser(
         "psql_set_command", CodeSegment, type="psql_set_command"
@@ -6997,6 +7009,19 @@ class PsqlSetMetaCommandStatementSegment(BaseSegment):
     )
 
 
+class PostgresCopyStdinDataStatementSegment(BaseSegment):
+    r"""A PostgreSQL COPY FROM STDIN data block.
+
+    This includes the COPY statement and raw data rows terminated by ``\.``.
+    """
+
+    type = "postgres_copy_stdin_data_statement"
+
+    match_grammar = Sequence(
+        Ref("PostgresCopyStdinDataSegment"),
+    )
+
+
 class DropForeignTableStatement(BaseSegment):
     """A `DROP FOREIGN TABLE` Statement.
 
@@ -7283,6 +7308,7 @@ class FileSegment(BaseFileSegment):
     """
 
     match_grammar = AnyNumberOf(
+        Ref("PostgresCopyStdinDataStatementSegment"),
         Ref("PsqlCopyMetaCommandStatementSegment"),
         Ref("PsqlSetMetaCommandStatementSegment"),
         Delimited(

--- a/test/dialects/postgres_test.py
+++ b/test/dialects/postgres_test.py
@@ -89,6 +89,22 @@ def test_space_is_not_reserved(raw: str) -> None:
     assert result.num_violations() == 0
 
 
+def test_postgres_copy_from_stdin_data_block_parses() -> None:
+    """Ensure COPY FROM STDIN data blocks parse without unparsable sections."""
+    sql = (
+        "COPY public.bookshelves_books (username, work_id, bookshelf_id) FROM stdin;\n"
+        "openlibrary\t15298516\t1\n"
+        "openlibrary\t45310\t3\n"
+        "\\.\n"
+        "SELECT 1;"
+    )
+    parsed = Linter(dialect="postgres").parse_string(sql)
+
+    assert parsed.tree is not None
+    assert "unparsable" not in parsed.tree.type_set()
+    assert "postgres_copy_stdin_data_statement" in parsed.tree.type_set()
+
+
 def test_priority_keyword_merge() -> None:
     """Test merging on keyword lists works as expected."""
     kw_list_1 = [("A", "not-keyword"), ("B", "non-reserved")]


### PR DESCRIPTION
Issue #7697 reported that PostgreSQL COPY ... FROM STDIN blocks could fail parsing because raw data lines after the COPY statement were parsed as SQL, causing PRS errors.

This PR updates the Postgres dialect to treat COPY FROM STDIN data blocks (up to the \\. terminator) as a dedicated file-level statement, so raw data is not parsed as SQL.

It also adds a focused regression test that covers COPY FROM STDIN raw-data block parsing.

Closes #7697.

## Checklist:

- [x] I have reviewed all changes in this PR myself.
- [x] I have added relevant regression test cases for this fix.
- [x] I have run linting and formatting checks in WSL using:
      ruff check src/sqlfluff/dialects/dialect_postgres.py test/dialects/postgres_test.py
      ruff format --check src/sqlfluff/dialects/dialect_postgres.py test/dialects/postgres_test.py
- [x] I have run focused tests in WSL using:
      pytest -q test/dialects/postgres_test.py -k copy_from_stdin_data_block_parses
      pytest -q test/dialects/postgres_test.py

#### The validation screenshots of the tests run, locally on WSL:

<img width="1548" height="541" alt="image" src="https://github.com/user-attachments/assets/2888173b-47fe-49dd-9404-10c893daa367" />
