### PR TITLE
fix: clarify handling of leading gaps in Bracketed match results

### DIFF
--- a/src/sqlfluff/core/parser/grammar/sequence.py
+++ b/src/sqlfluff/core/parser/grammar/sequence.py
@@ -521,7 +521,12 @@ class Bracketed(Sequence):
                 segments, end_bracket_idx
             )
 
-        # If there's a gap, add it as a child match
+        # NOTE: This is intentionally asymmetric. We don't add a matching
+        # leading gap before the content because `MatchResult.apply()` will
+        # preserve any untouched slice between `start_match` and the first
+        # content child anyway. Recording the post-content gap here is just
+        # explicit bookkeeping for the non-code we already skipped while
+        # locating the closing bracket; it doesn't affect the rendered result.
         child_matches: tuple[MatchResult, ...] = (start_match,)
         if not is_zero_slice(content_match.matched_slice):
             if content_match.matched_class:


### PR DESCRIPTION
### Brief summary of the change made

I reviewed the Bracketed gap handling and the asymmetry is not behaviorally significant. `MatchResult.apply()` already preserves any untouched slice inside the outer match, so a leading interior gap does not need an explicit child match to survive in the rendered parse tree. The explicit trailing gap in `sequence.py:523` is therefore bookkeeping only: removing it or adding a symmetric leading one changes `child_matches`, but not the materialized output in the current parser grammar tests.

I validated three variants: current behavior, a version with the trailing gap child removed, and a version with both start and end gaps recorded explicitly. All three passed grammar tests.

Fixes #6925 

### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
