### PR TITLE
mysql/mariadb: allow FROM DUAL as a dummy table expression

### DIFF
--- a/src/sqlfluff/dialects/dialect_mysql.py
+++ b/src/sqlfluff/dialects/dialect_mysql.py
@@ -2331,6 +2331,30 @@ class SelectClauseSegment(ansi.SelectClauseSegment):
     )
 
 
+class TableExpressionSegment(ansi.TableExpressionSegment):
+    """The main table expression e.g. within a FROM clause.
+
+    MySQL and MariaDB both reserve ``DUAL`` but also accept it as a
+    dummy table in ``FROM DUAL`` for compatibility with other dialects
+    and for conditional inserts such as
+    ``INSERT ... SELECT ... FROM DUAL WHERE NOT EXISTS (...)``.
+    Because ``DUAL`` is in the reserved-keywords set, the default
+    ``TableReferenceSegment`` won't match it, so accept it explicitly
+    here.
+    """
+
+    match_grammar: Matchable = OneOf(
+        Ref("ValuesClauseSegment"),
+        Ref("BareFunctionSegment"),
+        Ref("FunctionSegment"),
+        Ref("TableReferenceSegment"),
+        Sequence("DUAL"),
+        # Nested Selects
+        Bracketed(Ref("SelectableGrammar")),
+        Bracketed(Ref("MergeStatementSegment")),
+    )
+
+
 class SelectStatementSegment(ansi.SelectStatementSegment):
     """A `SELECT` statement.
 


### PR DESCRIPTION
`DUAL` is in the reserved-keywords sets for `mysql` and `mariadb`, so the default `TableReferenceSegment` (which expects an identifier) never matched it.  That made statements like

    INSERT INTO t (c) SELECT 'x' FROM dual WHERE NOT EXISTS (SELECT 1 FROM t)

unparsable, even though `FROM DUAL` is an accepted dummy source in both dialects and is widely used for conditional inserts.

Override `TableExpressionSegment` in the mysql dialect to include a bare `DUAL` keyword alongside the existing table references; the mariadb dialect inherits the change.

Fixes #7762