### PR TITLE
fix(postgres): preserve begin atomic body indentation

### DIFF
--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -1826,6 +1826,7 @@ class FunctionDefinitionGrammar(ansi.FunctionDefinitionGrammar):
             Sequence(
                 "BEGIN",
                 "ATOMIC",
+                Indent,
                 AnyNumberOf(
                     Sequence(
                         Ref("InsertStatementSegment"),
@@ -1848,6 +1849,7 @@ class FunctionDefinitionGrammar(ansi.FunctionDefinitionGrammar):
                         Ref("SemicolonSegment"),
                     ),
                 ),
+                Dedent,
                 "END",
             ),
         ),

--- a/test/fixtures/rules/std_rule_cases/LT02-indent.yml
+++ b/test/fixtures/rules/std_rule_cases/LT02-indent.yml
@@ -2529,6 +2529,25 @@ test_fail_sqlite_update_returning:
     core:
       dialect: sqlite
 
+test_fail_postgres_begin_atomic_function_body_indent:
+  fail_str: |
+    create or replace function batch_delete_cron_job_runs()
+    returns void
+    language sql
+    begin atomic
+      select 8;
+    end;
+  fix_str: |
+    create or replace function batch_delete_cron_job_runs()
+    returns void
+    language sql
+    begin atomic
+        select 8;
+    end;
+  configs:
+    core:
+      dialect: postgres
+
 test_fail_postgres_update_returning:
   fail_str: |
     UPDATE


### PR DESCRIPTION
## Summary
- indent `BEGIN ATOMIC` function bodies in the Postgres dialect grammar
- keep LT02 from stripping valid indentation inside SQL-language function bodies
- add a regression fixture for `begin atomic` function formatting

## Testing
- `.venv/bin/python -m pytest test/rules/yaml_test_cases_test.py -k postgres_begin_atomic_function_body_indent -q`
- `.venv/bin/python -m pytest test/rules/yaml_test_cases_test.py -k \"postgres_begin_atomic_function_body_indent or postgres_update_returning or postgres_insert_returning\" -q`
- `.venv/bin/sqlfluff fix /tmp/sqlfluff_7771_demo.sql --force --dialect postgres`
- `.venv/bin/python -m py_compile src/sqlfluff/dialects/dialect_postgres.py`

Fixes #7771