### PR TITLE
feat: Add CREATE AGGREGATE FUNCTION support for BigQuery dialect

### DIFF
--- a/src/sqlfluff/dialects/dialect_bigquery.py
+++ b/src/sqlfluff/dialects/dialect_bigquery.py
@@ -301,6 +301,17 @@ bigquery_dialect.replace(
             casefold=str.upper,
         )
     ),
+    # Extend ANSI to support `NOT AGGREGATE` modifier on parameters
+    # for aggregate function definitions.
+    # https://cloud.google.com/bigquery/docs/reference/standard-sql/user-defined-functions#aggregate-udf-parameters
+    FunctionParameterGrammar=OneOf(
+        Sequence(
+            Ref("ParameterNameSegment", optional=True),
+            OneOf(Sequence("ANY", "TYPE"), Ref("DatatypeSegment")),
+            Sequence("NOT", "AGGREGATE", optional=True),
+        ),
+        OneOf(Sequence("ANY", "TYPE"), Ref("DatatypeSegment")),
+    ),
     DatatypeIdentifierSegment=SegmentGenerator(
         lambda dialect: MultiStringParser(
             [
@@ -1412,6 +1423,33 @@ class StringAggFunctionContentsSegment(BaseSegment):
             )
         ),
         allow_gaps=False,
+    )
+
+
+class CreateFunctionStatementSegment(ansi.CreateFunctionStatementSegment):
+    """A `CREATE FUNCTION` statement.
+
+    Extends ANSI to support `CREATE AGGREGATE FUNCTION`.
+    https://cloud.google.com/bigquery/docs/reference/standard-sql/user-defined-functions
+    """
+
+    type = "create_function_statement"
+
+    match_grammar = Sequence(
+        "CREATE",
+        Ref("OrReplaceGrammar", optional=True),
+        Ref("TemporaryGrammar", optional=True),
+        Sequence("AGGREGATE", optional=True),
+        "FUNCTION",
+        Ref("IfNotExistsGrammar", optional=True),
+        Ref("FunctionNameSegment"),
+        Ref("FunctionParameterListGrammar"),
+        Sequence(
+            "RETURNS",
+            Ref("DatatypeSegment"),
+            optional=True,
+        ),
+        Ref("FunctionDefinitionGrammar"),
     )
 
 

--- a/test/fixtures/dialects/bigquery/create_aggregate_function.sql
+++ b/test/fixtures/dialects/bigquery/create_aggregate_function.sql
@@ -1,0 +1,56 @@
+-- Simple aggregate function
+CREATE OR REPLACE AGGREGATE FUNCTION mydataset.MEDIAN(
+  value FLOAT64
+) RETURNS FLOAT64
+OPTIONS (description = "Calculates the median value")
+AS (
+  mydataset.GET_QUANTILE(value, 50)
+);
+
+-- Aggregate function with NOT AGGREGATE parameter
+CREATE OR REPLACE AGGREGATE FUNCTION mydataset.GET_QUANTILE(
+  value FLOAT64,
+  percentile INT64 NOT AGGREGATE
+) RETURNS FLOAT64
+OPTIONS (description = "Calculates approximate quantiles")
+AS (
+  IF(
+    percentile IS NULL OR percentile < 0 OR percentile > 100,
+    NULL,
+    APPROX_QUANTILES(value, 100)[SAFE_OFFSET(percentile)]
+  )
+);
+
+-- Aggregate function returning STRUCT
+CREATE OR REPLACE AGGREGATE FUNCTION mydataset.BUCKET_AGG(
+  value FLOAT64,
+  ts TIMESTAMP
+) RETURNS STRUCT<
+  total FLOAT64,
+  avg_value FLOAT64,
+  min_value FLOAT64,
+  max_value FLOAT64,
+  num_values INT64,
+  min_ts TIMESTAMP,
+  max_ts TIMESTAMP
+>
+OPTIONS (description = "Aggregates raw data for bucket generation")
+AS (
+  STRUCT(
+    SUM(value) AS total,
+    AVG(value) AS avg_value,
+    MIN(value) AS min_value,
+    MAX(value) AS max_value,
+    COUNT(value) AS num_values,
+    MIN(ts) AS min_ts,
+    MAX(ts) AS max_ts
+  )
+);
+
+-- Aggregate function with IF NOT EXISTS
+CREATE AGGREGATE FUNCTION IF NOT EXISTS mydataset.SAFE_SUM(
+  value FLOAT64
+) RETURNS FLOAT64
+AS (
+  SUM(IF(ABS(value) <= 1e300, value, NULL))
+);

--- a/test/fixtures/dialects/bigquery/create_aggregate_function.yml
+++ b/test/fixtures/dialects/bigquery/create_aggregate_function.yml
@@ -1,0 +1,407 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 28a0c14b8dcd378dc7763ed14cb4808320ed7226fdf63f24f8541dc7fdbc35b1
+file:
+- statement:
+    create_function_statement:
+    - keyword: CREATE
+    - keyword: OR
+    - keyword: REPLACE
+    - keyword: AGGREGATE
+    - keyword: FUNCTION
+    - function_name:
+        naked_identifier: mydataset
+        dot: .
+        function_name_identifier: MEDIAN
+    - function_parameter_list:
+        bracketed:
+          start_bracket: (
+          parameter: value
+          data_type:
+            data_type_identifier: FLOAT64
+          end_bracket: )
+    - keyword: RETURNS
+    - data_type:
+        data_type_identifier: FLOAT64
+    - function_definition:
+        options_segment:
+          keyword: OPTIONS
+          bracketed:
+            start_bracket: (
+            parameter: description
+            comparison_operator:
+              raw_comparison_operator: '='
+            quoted_literal: '"Calculates the median value"'
+            end_bracket: )
+        keyword: AS
+        bracketed:
+          start_bracket: (
+          expression:
+            function:
+              function_name:
+                naked_identifier: mydataset
+                dot: .
+                function_name_identifier: GET_QUANTILE
+              function_contents:
+                bracketed:
+                - start_bracket: (
+                - expression:
+                    column_reference:
+                      naked_identifier: value
+                - comma: ','
+                - expression:
+                    numeric_literal: '50'
+                - end_bracket: )
+          end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_function_statement:
+    - keyword: CREATE
+    - keyword: OR
+    - keyword: REPLACE
+    - keyword: AGGREGATE
+    - keyword: FUNCTION
+    - function_name:
+        naked_identifier: mydataset
+        dot: .
+        function_name_identifier: GET_QUANTILE
+    - function_parameter_list:
+        bracketed:
+        - start_bracket: (
+        - parameter: value
+        - data_type:
+            data_type_identifier: FLOAT64
+        - comma: ','
+        - parameter: percentile
+        - data_type:
+            data_type_identifier: INT64
+        - keyword: NOT
+        - keyword: AGGREGATE
+        - end_bracket: )
+    - keyword: RETURNS
+    - data_type:
+        data_type_identifier: FLOAT64
+    - function_definition:
+        options_segment:
+          keyword: OPTIONS
+          bracketed:
+            start_bracket: (
+            parameter: description
+            comparison_operator:
+              raw_comparison_operator: '='
+            quoted_literal: '"Calculates approximate quantiles"'
+            end_bracket: )
+        keyword: AS
+        bracketed:
+          start_bracket: (
+          expression:
+            function:
+              function_name:
+                function_name_identifier: IF
+              function_contents:
+                bracketed:
+                - start_bracket: (
+                - expression:
+                  - column_reference:
+                      naked_identifier: percentile
+                  - keyword: IS
+                  - null_literal: 'NULL'
+                  - binary_operator: OR
+                  - column_reference:
+                      naked_identifier: percentile
+                  - comparison_operator:
+                      raw_comparison_operator: <
+                  - numeric_literal: '0'
+                  - binary_operator: OR
+                  - column_reference:
+                      naked_identifier: percentile
+                  - comparison_operator:
+                      raw_comparison_operator: '>'
+                  - numeric_literal: '100'
+                - comma: ','
+                - expression:
+                    null_literal: 'NULL'
+                - comma: ','
+                - expression:
+                    function:
+                      function_name:
+                        function_name_identifier: APPROX_QUANTILES
+                      function_contents:
+                        bracketed:
+                        - start_bracket: (
+                        - expression:
+                            column_reference:
+                              naked_identifier: value
+                        - comma: ','
+                        - expression:
+                            numeric_literal: '100'
+                        - end_bracket: )
+                      array_accessor:
+                        start_square_bracket: '['
+                        expression:
+                          function:
+                            function_name:
+                              function_name_identifier: SAFE_OFFSET
+                            function_contents:
+                              bracketed:
+                                start_bracket: (
+                                expression:
+                                  column_reference:
+                                    naked_identifier: percentile
+                                end_bracket: )
+                        end_square_bracket: ']'
+                - end_bracket: )
+          end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_function_statement:
+    - keyword: CREATE
+    - keyword: OR
+    - keyword: REPLACE
+    - keyword: AGGREGATE
+    - keyword: FUNCTION
+    - function_name:
+        naked_identifier: mydataset
+        dot: .
+        function_name_identifier: BUCKET_AGG
+    - function_parameter_list:
+        bracketed:
+        - start_bracket: (
+        - parameter: value
+        - data_type:
+            data_type_identifier: FLOAT64
+        - comma: ','
+        - parameter: ts
+        - data_type:
+            data_type_identifier: TIMESTAMP
+        - end_bracket: )
+    - keyword: RETURNS
+    - data_type:
+        data_type:
+          keyword: STRUCT
+          struct_type_schema:
+          - start_angle_bracket: <
+          - parameter: total
+          - data_type:
+              data_type_identifier: FLOAT64
+          - comma: ','
+          - parameter: avg_value
+          - data_type:
+              data_type_identifier: FLOAT64
+          - comma: ','
+          - parameter: min_value
+          - data_type:
+              data_type_identifier: FLOAT64
+          - comma: ','
+          - parameter: max_value
+          - data_type:
+              data_type_identifier: FLOAT64
+          - comma: ','
+          - parameter: num_values
+          - data_type:
+              data_type_identifier: INT64
+          - comma: ','
+          - parameter: min_ts
+          - data_type:
+              data_type_identifier: TIMESTAMP
+          - comma: ','
+          - parameter: max_ts
+          - data_type:
+              data_type_identifier: TIMESTAMP
+          - end_angle_bracket: '>'
+    - function_definition:
+        options_segment:
+          keyword: OPTIONS
+          bracketed:
+            start_bracket: (
+            parameter: description
+            comparison_operator:
+              raw_comparison_operator: '='
+            quoted_literal: '"Aggregates raw data for bucket generation"'
+            end_bracket: )
+        keyword: AS
+        bracketed:
+          start_bracket: (
+          expression:
+            typed_struct_literal:
+              data_type:
+                keyword: STRUCT
+              struct_literal:
+                bracketed:
+                - start_bracket: (
+                - function:
+                    function_name:
+                      function_name_identifier: SUM
+                    function_contents:
+                      bracketed:
+                        start_bracket: (
+                        expression:
+                          column_reference:
+                            naked_identifier: value
+                        end_bracket: )
+                - alias_expression:
+                    alias_operator:
+                      keyword: AS
+                    naked_identifier: total
+                - comma: ','
+                - function:
+                    function_name:
+                      function_name_identifier: AVG
+                    function_contents:
+                      bracketed:
+                        start_bracket: (
+                        expression:
+                          column_reference:
+                            naked_identifier: value
+                        end_bracket: )
+                - alias_expression:
+                    alias_operator:
+                      keyword: AS
+                    naked_identifier: avg_value
+                - comma: ','
+                - function:
+                    function_name:
+                      function_name_identifier: MIN
+                    function_contents:
+                      bracketed:
+                        start_bracket: (
+                        expression:
+                          column_reference:
+                            naked_identifier: value
+                        end_bracket: )
+                - alias_expression:
+                    alias_operator:
+                      keyword: AS
+                    naked_identifier: min_value
+                - comma: ','
+                - function:
+                    function_name:
+                      function_name_identifier: MAX
+                    function_contents:
+                      bracketed:
+                        start_bracket: (
+                        expression:
+                          column_reference:
+                            naked_identifier: value
+                        end_bracket: )
+                - alias_expression:
+                    alias_operator:
+                      keyword: AS
+                    naked_identifier: max_value
+                - comma: ','
+                - function:
+                    function_name:
+                      function_name_identifier: COUNT
+                    function_contents:
+                      bracketed:
+                        start_bracket: (
+                        expression:
+                          column_reference:
+                            naked_identifier: value
+                        end_bracket: )
+                - alias_expression:
+                    alias_operator:
+                      keyword: AS
+                    naked_identifier: num_values
+                - comma: ','
+                - function:
+                    function_name:
+                      function_name_identifier: MIN
+                    function_contents:
+                      bracketed:
+                        start_bracket: (
+                        expression:
+                          column_reference:
+                            naked_identifier: ts
+                        end_bracket: )
+                - alias_expression:
+                    alias_operator:
+                      keyword: AS
+                    naked_identifier: min_ts
+                - comma: ','
+                - function:
+                    function_name:
+                      function_name_identifier: MAX
+                    function_contents:
+                      bracketed:
+                        start_bracket: (
+                        expression:
+                          column_reference:
+                            naked_identifier: ts
+                        end_bracket: )
+                - alias_expression:
+                    alias_operator:
+                      keyword: AS
+                    naked_identifier: max_ts
+                - end_bracket: )
+          end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_function_statement:
+    - keyword: CREATE
+    - keyword: AGGREGATE
+    - keyword: FUNCTION
+    - keyword: IF
+    - keyword: NOT
+    - keyword: EXISTS
+    - function_name:
+        naked_identifier: mydataset
+        dot: .
+        function_name_identifier: SAFE_SUM
+    - function_parameter_list:
+        bracketed:
+          start_bracket: (
+          parameter: value
+          data_type:
+            data_type_identifier: FLOAT64
+          end_bracket: )
+    - keyword: RETURNS
+    - data_type:
+        data_type_identifier: FLOAT64
+    - function_definition:
+        keyword: AS
+        bracketed:
+          start_bracket: (
+          expression:
+            function:
+              function_name:
+                function_name_identifier: SUM
+              function_contents:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    function:
+                      function_name:
+                        function_name_identifier: IF
+                      function_contents:
+                        bracketed:
+                        - start_bracket: (
+                        - expression:
+                            function:
+                              function_name:
+                                function_name_identifier: ABS
+                              function_contents:
+                                bracketed:
+                                  start_bracket: (
+                                  expression:
+                                    column_reference:
+                                      naked_identifier: value
+                                  end_bracket: )
+                            comparison_operator:
+                            - raw_comparison_operator: <
+                            - raw_comparison_operator: '='
+                            numeric_literal: 1e300
+                        - comma: ','
+                        - expression:
+                            column_reference:
+                              naked_identifier: value
+                        - comma: ','
+                        - expression:
+                            null_literal: 'NULL'
+                        - end_bracket: )
+                  end_bracket: )
+          end_bracket: )
+- statement_terminator: ;


### PR DESCRIPTION
## Description

BigQuery supports `CREATE [OR REPLACE] AGGREGATE FUNCTION` for user-defined
aggregate functions, but SQLFluff cannot parse these statements. This forces
users to disable parse checking entirely with `-- noqa: disable=PRS` on
affected files.

Reference: https://cloud.google.com/bigquery/docs/reference/standard-sql/user-defined-functions#create-an-aggregate-udf

## Fix

Two grammar additions to the BigQuery dialect:

1. Override `CreateFunctionStatementSegment` to add an optional `AGGREGATE`
   keyword between `[TEMPORARY]` and `FUNCTION`, enabling
   `CREATE [OR REPLACE] [AGGREGATE] FUNCTION` to parse.

2. Override `FunctionParameterGrammar` to support the `NOT AGGREGATE` modifier
   on parameters. BigQuery allows marking parameters as non-aggregating
   (i.e. constant across the group), e.g. `percentile INT64 NOT AGGREGATE`.

Both overrides follow the existing pattern used throughout the BigQuery dialect
for extending ANSI grammar. All existing function-related parse fixtures were
regenerated and produce identical parse trees, confirming backward compatibility.

## Test cases

New `create_aggregate_function` fixture with four test cases:
- Simple aggregate function with OPTIONS
- Aggregate function with `NOT AGGREGATE` parameter modifier
- Aggregate function returning `STRUCT<...>`
- Aggregate function with `IF NOT EXISTS`

All 426 BigQuery dialect tests pass.

Fixes #7770

---
AI disclosure: Claude Code was used to assist with this contribution.