### PR TITLE
fix(tsql): keep required OPENROWSET BULK aliases

### DIFF
--- a/src/sqlfluff/rules/aliasing/AL05.py
+++ b/src/sqlfluff/rules/aliasing/AL05.py
@@ -230,6 +230,13 @@ class Rule_AL05(BaseRule):
         # is actually *required* in order for SQL Server to parse it.
         for segment in from_expression_element.iter_segments(expanding=("bracketed",)):
             if segment.is_type("table_expression"):
+                if dialect_name == "tsql":
+                    openrowset = segment.get_child("openrowset_segment")
+                    if openrowset and any(
+                        seg.raw_upper == "BULK"
+                        for seg in openrowset.recursive_crawl("keyword")
+                    ):
+                        return True
                 # Found a table expression. Does it have a VALUES clause?
                 if segment.get_child("values_clause"):
                     # Found a VALUES clause. Is this a dialect that requires

--- a/test/fixtures/rules/std_rule_cases/AL05.yml
+++ b/test/fixtures/rules/std_rule_cases/AL05.yml
@@ -241,6 +241,39 @@ test_pass_snowflake_values:
     core:
       dialect: snowflake
 
+test_pass_tsql_openrowset_bulk_requires_correlation_name_1:
+  pass_str: |
+    SELECT jsoncontent
+    FROM
+        OPENROWSET (
+            BULK (
+                '/lake-raw/activity*.json'
+                ,'/lake-raw/this_file_doesnt_exist.json'
+            ),
+            DATA_SOURCE = 'datasource_lake'
+        )
+        WITH (
+            jsoncontent varchar(MAX)
+        ) AS result
+  configs:
+    core:
+      dialect: tsql
+
+test_pass_tsql_openrowset_bulk_requires_correlation_name_2:
+  pass_str: |
+    SELECT jsoncontent
+    FROM
+        OPENROWSET (
+            BULK (
+                '/lake-raw/activity*.json'
+                ,'/lake-raw/this_file_doesnt_exist.json'
+            )
+            ,DATA_SOURCE = 'datasource_lake'
+        ) AS name
+  configs:
+    core:
+      dialect: tsql
+
 test_pass_tsql_values_clause_in_parentheses:
   # Tests a fix for issue 3522. In tsql, the parentheses surrounding "values" are
   # required (otherwise syntax error). SQLFluff was incorrectly complaining that


### PR DESCRIPTION
## Summary
- treat T-SQL `OPENROWSET(BULK ...)` correlation names as required instead of unused aliases
- keep `sqlfluff fix` from removing valid `AS result` / `AS name` correlation names
- add regression fixtures covering OPENROWSET BULK forms with and without a WITH clause

## Testing
- `.venv/bin/python -m pytest test/rules/yaml_test_cases_test.py -k openrowset_bulk_requires_correlation_name -q`
- `.venv/bin/python -m py_compile src/sqlfluff/rules/aliasing/AL05.py`
- `.venv/bin/sqlfluff fix /tmp/sqlfluff_7779.sql --dialect tsql` (verified the alias is preserved)

Fixes #7779