### PR TITLE
Relax ignore spec typing in discovery module

### DIFF
--- a/src/sqlfluff/core/linter/discovery.py
+++ b/src/sqlfluff/core/linter/discovery.py
@@ -29,7 +29,7 @@ class IgnoreSpec(Protocol):
 
     def match_file(self, file: str) -> object:
         """Return a truthy match result if the file is ignored."""
-        ...
+        ...  # pragma: no cover
 
 
 IgnoreSpecRecord = tuple[str, str, IgnoreSpec]

--- a/src/sqlfluff/core/linter/discovery.py
+++ b/src/sqlfluff/core/linter/discovery.py
@@ -10,7 +10,7 @@ import logging
 import os
 from collections.abc import Iterable, Iterator, Sequence
 from pathlib import Path
-from typing import Callable, Optional
+from typing import Callable, Optional, Protocol
 
 import pathspec
 
@@ -22,7 +22,17 @@ from sqlfluff.core.helpers.file import iter_intermediate_paths
 linter_logger: logging.Logger = logging.getLogger("sqlfluff.linter")
 
 WalkableType = Iterable[tuple[str, Optional[list[str]], list[str]]]
-IgnoreSpecRecord = tuple[str, str, pathspec.PathSpec]
+
+
+class IgnoreSpec(Protocol):
+    """Protocol for ignore spec implementations used by this module."""
+
+    def match_file(self, file: str) -> object:
+        """Return a truthy match result if the file is ignored."""
+        ...
+
+
+IgnoreSpecRecord = tuple[str, str, IgnoreSpec]
 IgnoreSpecRecords = list[IgnoreSpecRecord]
 
 
@@ -40,9 +50,7 @@ def _check_ignore_specs(
     return None
 
 
-def _load_specs_from_lines(
-    lines: Iterable[str], logging_reference: str
-) -> pathspec.PathSpec:
+def _load_specs_from_lines(lines: Iterable[str], logging_reference: str) -> IgnoreSpec:
     """Load the ignore spec from an iterable of lines.
 
     Raises SQLFluffUserError if unparsable for any reason.


### PR DESCRIPTION
### Brief summary of the change made

This updates the discovery typing to avoid depending on the concrete `pathspec.PathSpec` type, which started failing strict mypy checks in CI after upstream typing changes.

The fix introduces a small protocol for the ignore spec interface used by the module and adds the required docstring/coverage exclusion for the protocol stub. Runtime behavior is unchanged; this is a typing-only compatibility fix.

### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
