### PR TITLE
Rust: Fix sequence terminators

### DIFF
--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/core.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/core.rs
@@ -1508,8 +1508,7 @@ impl<'a> Parser<'a> {
         parent_max_idx: Option<usize>,
     ) -> Result<MatchResult, ParseError> {
         // Create a temporary table-driven frame to use the initial handler and then extract MatchResult
-        let frame =
-            TableParseFrame::new_child(0, grammar_id, self.pos, parent_terminators.to_vec(), None);
+        let frame = TableParseFrame::new_child(0, grammar_id, self.pos, parent_terminators, None);
 
         match self.handle_anything_table_initial(
             frame,

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/frame.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/frame.rs
@@ -50,6 +50,12 @@ pub enum FrameContext {
         meta_buffer: Vec<MetaSegment>, // Buffer for meta elements to be flushed after matching content
         insert_segments: Vec<(usize, MetaSegment)>, // (position, segments) to insert
         child_matches: Vec<Arc<MatchResult>>, // Store child matches here until sequence is complete
+        /// Terminators to pass to child element frames (excludes Sequence's own terminators).
+        /// Python parity: Python's Sequence does NOT push its own terminators into
+        /// parse_context.terminators. Children only see parent terminators, not the
+        /// Sequence's local terminators. The Sequence uses the combined set (own + parent)
+        /// only for its own trim_to_terminator / max_idx computation.
+        child_terminators: Vec<GrammarId>,
     },
     RefTableDriven {
         grammar_id: GrammarId,

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/helpers.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/helpers.rs
@@ -4,6 +4,7 @@
 //! including token navigation, whitespace handling, and terminator checking.
 
 use hashbrown::HashSet;
+use smallvec::SmallVec;
 
 use super::core::Parser;
 use sqlfluffrs_types::{GrammarId, ParseMode, Token};
@@ -224,9 +225,9 @@ impl<'a> Parser<'a> {
         local_terminators: &[GrammarId],
         parent_terminators: &[GrammarId],
         reset_terminators: bool,
-    ) -> Vec<GrammarId> {
+    ) -> SmallVec<[GrammarId; 4]> {
         if reset_terminators {
-            local_terminators.to_vec()
+            SmallVec::from_slice(local_terminators)
         } else {
             local_terminators
                 .iter()

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/anynumberof.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/anynumberof.rs
@@ -196,7 +196,7 @@ impl Parser<'_> {
             stack.frame_id_counter,
             first_element,
             start_pos,
-            frame.table_terminators.to_vec(),
+            &frame.table_terminators,
             Some(max_idx),
         );
 
@@ -311,7 +311,7 @@ impl Parser<'_> {
             stack.frame_id_counter,
             next_candidate,
             *ctx.working_idx,
-            frame.table_terminators.to_vec(),
+            &frame.table_terminators,
             Some(*ctx.max_idx),
         );
 
@@ -477,7 +477,7 @@ impl Parser<'_> {
             stack.frame_id_counter,
             next_element,
             *ctx.working_idx,
-            frame.table_terminators.to_vec(),
+            &frame.table_terminators,
             Some(*ctx.max_idx),
         );
 

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/anynumberof.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/anynumberof.rs
@@ -4,7 +4,6 @@ use crate::parser::{
 };
 #[cfg(feature = "verbose-debug")]
 use crate::vdebug;
-use smallvec::SmallVec;
 use sqlfluffrs_types::GrammarId;
 use std::sync::Arc;
 
@@ -188,7 +187,7 @@ impl Parser<'_> {
         };
 
         // Move terminators into frame (no clone)
-        frame.table_terminators = SmallVec::from_vec(all_terminators);
+        frame.table_terminators = all_terminators;
 
         // Create initial child frame for the first element candidate and
         // let the WaitingForChild handler iterate remaining candidates.

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/contexts.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/contexts.rs
@@ -51,6 +51,7 @@ impl FrameContext {
                 meta_buffer,
                 insert_segments,
                 child_matches,
+                child_terminators,
                 ..
             } => Some(SequenceContextMut {
                 seq_grammar_id,
@@ -63,6 +64,7 @@ impl FrameContext {
                 meta_buffer,
                 insert_segments,
                 child_matches,
+                child_terminators,
             }),
             _ => None,
         }
@@ -142,6 +144,7 @@ pub struct SequenceContextMut<'a> {
     pub meta_buffer: &'a mut Vec<MetaSegment>, // Buffer for meta elements to be flushed after matching content
     pub insert_segments: &'a mut Vec<(usize, MetaSegment)>, // (position, segments) to insert
     pub child_matches: &'a mut Vec<Arc<MatchResult>>, // Store child matches here until sequence is complete
+    pub child_terminators: &'a [GrammarId],           // Parent terminators to pass to child frames
 }
 
 impl<'a> SequenceContextMut<'a> {

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/delimited.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/delimited.rs
@@ -137,6 +137,15 @@ impl Parser<'_> {
         // Store calculated max_idx in frame for cache consistency
         frame.calculated_max_idx = Some(max_idx);
 
+        #[cfg(feature = "verbose-debug")]
+        {
+            vdebug!(
+                "Delimited[table]: Trying elements grammar_id={} with {} child_terminators",
+                elements_id.0,
+                child_terminators.len()
+            );
+        }
+
         // Store context - element_children now just contains the single elements_id
         // (which may be a OneOf internally)
         frame.context = FrameContext::DelimitedTableDriven {
@@ -157,26 +166,21 @@ impl Parser<'_> {
         // Push child to match element(s).
         // Pass child_terminators to allow the element matcher to try all candidates
         // without early termination from local terminators (e.g., ObjectReferenceTerminator).
+        let child_terminators_for_frame = {
+            let FrameContext::DelimitedTableDriven {
+                child_terminators, ..
+            } = &frame.context
+            else {
+                unreachable!()
+            };
+            child_terminators.clone()
+        };
         let child_frame = TableParseFrame::new_child(
             stack.frame_id_counter,
             elements_id,
             start_pos,
-            {
-                let FrameContext::DelimitedTableDriven {
-                    child_terminators, ..
-                } = &frame.context
-                else {
-                    unreachable!()
-                };
-                child_terminators.clone()
-            },
+            &child_terminators_for_frame,
             Some(max_idx),
-        );
-
-        vdebug!(
-            "Delimited[table]: Trying elements grammar_id={} with {} child_terminators",
-            elements_id.0,
-            child_terminators.len()
         );
 
         Ok(stack.push_child_and_wait(frame, child_frame, 0))
@@ -388,7 +392,7 @@ impl Parser<'_> {
                     stack.frame_id_counter,
                     delimiter_id,
                     *working_idx,
-                    frame.table_terminators.to_vec(),
+                    &frame.table_terminators,
                     None, // Don't constrain delimiter by max_idx
                 );
 
@@ -422,7 +426,7 @@ impl Parser<'_> {
                             stack.frame_id_counter,
                             elements_id,
                             *working_idx,
-                            child_terminators_clone.clone(),
+                            &child_terminators_clone,
                             Some(current_max_idx),
                         );
 
@@ -542,13 +546,57 @@ impl Parser<'_> {
 
                 // Delimiter matched and not a terminator: keep it in `delimiter_match`
                 // (it will be appended only if the next element succeeds).
-                // Recalculate max_idx from the new working position because the parent's
-                // limit may have pointed to the delimiter we just consumed.
+                // PYTHON PARITY: Never expand max_idx beyond parent_max_idx after a delimiter.
+                // In Python, Delimited receives sliced segments (parent only passes what's allowed),
+                // so it can never "escape" the parent's boundary. In Rust, always cap at
+                // parent_max_idx. If parent_limit <= working_idx, the element frame will see
+                // 0 tokens and return empty — correctly triggering allow_trailing logic.
+                //
+                // EXCEPTION: If parent_max_idx was AT the delimiter position (parent's trim
+                // found the comma as a terminator), the constraint is "stale" after consuming
+                // the delimiter. In that case, re-trim from the new position to find the
+                // next boundary (e.g. FROM keyword).
                 let new_max_idx = if let Some(parent_limit) = frame.parent_max_idx {
-                    // If parent_limit <= working_idx, it means the parent's constraint was
-                    // likely based on the delimiter we just consumed. Ignore it and use tokens.len()
                     if parent_limit <= *working_idx {
-                        self.tokens.len()
+                        // Avoid reparsing at parent_limit. We already know exactly where
+                        // the last delimiter matched from `pos_before_delimiter` +
+                        // `delimiter_match.matched_slice`, so we can determine if the parent
+                        // boundary was derived from that delimiter in O(1).
+                        let mut delimiter_consumed_parent_limit =
+                            if let (Some(before_delim), Some(dm)) =
+                                (pos_before_delimiter.as_ref(), delimiter_match.as_ref())
+                            {
+                                parent_limit >= *before_delim && parent_limit < dm.end()
+                            } else {
+                                false
+                            };
+
+                        // Fallback for edge cases where match span metadata is not enough
+                        // to infer whether parent_limit was derived from the consumed
+                        // delimiter. This preserves the previous behavior that relied on a
+                        // direct probe at parent_limit.
+                        if !delimiter_consumed_parent_limit {
+                            let saved_pos = self.pos;
+                            self.pos = parent_limit;
+                            delimiter_consumed_parent_limit = self
+                                .parse_table_iterative_match_result(delimiter_id, &[])
+                                .map(|r| !r.is_empty())
+                                .unwrap_or(false);
+                            self.pos = saved_pos;
+                        }
+
+                        if delimiter_consumed_parent_limit {
+                            // Parent's previous boundary was on the delimiter we just consumed.
+                            // Re-trim from the new working position.
+                            self.trim_to_terminator_table_driven(
+                                *working_idx,
+                                &frame.table_terminators,
+                            )?
+                        } else {
+                            // Genuine parent boundary (e.g., trailing comma with
+                            // newline before FROM). Cap to trigger allow_trailing.
+                            parent_limit
+                        }
                     } else {
                         parent_limit
                     }
@@ -577,7 +625,7 @@ impl Parser<'_> {
                     stack.frame_id_counter,
                     elements_id,
                     *working_idx,
-                    child_terminators_clone.clone(),
+                    &child_terminators_clone,
                     Some(*max_idx), // Use recalculated max_idx
                 );
 

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/delimited.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/delimited.rs
@@ -146,6 +146,16 @@ impl Parser<'_> {
             );
         }
 
+        // Pass child_terminators to allow the element matcher to try all candidates
+        // without early termination from local terminators (e.g., ObjectReferenceTerminator).
+        let child_frame = TableParseFrame::new_child(
+            stack.frame_id_counter,
+            elements_id,
+            start_pos,
+            &child_terminators,
+            Some(max_idx),
+        );
+
         // Store context - element_children now just contains the single elements_id
         // (which may be a OneOf internally)
         frame.context = FrameContext::DelimitedTableDriven {
@@ -164,25 +174,6 @@ impl Parser<'_> {
         };
 
         // Push child to match element(s).
-        // Pass child_terminators to allow the element matcher to try all candidates
-        // without early termination from local terminators (e.g., ObjectReferenceTerminator).
-        let child_terminators_for_frame = {
-            let FrameContext::DelimitedTableDriven {
-                child_terminators, ..
-            } = &frame.context
-            else {
-                unreachable!()
-            };
-            child_terminators.clone()
-        };
-        let child_frame = TableParseFrame::new_child(
-            stack.frame_id_counter,
-            elements_id,
-            start_pos,
-            &child_terminators_for_frame,
-            Some(max_idx),
-        );
-
         Ok(stack.push_child_and_wait(frame, child_frame, 0))
     }
 

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/frame.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/frame.rs
@@ -392,14 +392,14 @@ impl TableParseFrame {
         frame_id: usize,
         grammar_id: GrammarId,
         pos: usize,
-        table_terminators: Vec<GrammarId>,
+        table_terminators: &[GrammarId],
         parent_max_idx: Option<usize>,
     ) -> Self {
         TableParseFrame {
             frame_id,
             grammar_id,
             pos,
-            table_terminators: SmallVec::from_vec(table_terminators),
+            table_terminators: SmallVec::from_slice(table_terminators),
             state: FrameState::Initial,
             context: FrameContext::None,
             parent_max_idx,

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/oneof.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/oneof.rs
@@ -4,7 +4,6 @@ use crate::parser::{
 };
 #[cfg(feature = "verbose-debug")]
 use crate::vdebug;
-use smallvec::SmallVec;
 use sqlfluffrs_types::{GrammarId, GrammarVariant};
 use std::sync::Arc;
 
@@ -163,7 +162,7 @@ impl Parser<'_> {
         };
 
         // Move terminators into frame (no clone)
-        frame.table_terminators = SmallVec::from_vec(all_terminators);
+        frame.table_terminators = all_terminators;
 
         // Create table-driven child frame (copy terminators from frame)
         let child_frame = TableParseFrame::new_child(

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/oneof.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/oneof.rs
@@ -170,7 +170,7 @@ impl Parser<'_> {
             stack.frame_id_counter,
             first_child,
             post_skip_pos,
-            frame.table_terminators.to_vec(),
+            &frame.table_terminators,
             Some(max_idx),
         );
 
@@ -292,9 +292,13 @@ impl Parser<'_> {
                 let current_is_clean = !current_best.contains_unparsable();
 
                 if child_is_clean && !current_is_clean {
-                    true
+                    // Clean beats unclean only if it consumed at least as much.
+                    // A shorter clean match that leaves content unparsed is worse
+                    // than a longer unclean match that covers everything.
+                    consumed >= *current_consumed
                 } else if !child_is_clean && current_is_clean {
-                    false
+                    // Unclean only beats clean if strictly longer (same length: prefer clean).
+                    consumed > *current_consumed
                 } else {
                     consumed > *current_consumed
                 }
@@ -400,7 +404,7 @@ impl Parser<'_> {
                 stack.frame_id_counter,
                 next_child,
                 *post_skip_pos,
-                frame.table_terminators.to_vec(),
+                &frame.table_terminators,
                 Some(*max_idx),
             );
 

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/ref_grammar.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/ref_grammar.rs
@@ -147,7 +147,7 @@ impl Parser<'_> {
             stack.frame_id_counter,
             child_grammar_id,
             child_start_pos,
-            child_terminators,
+            &child_terminators,
             frame.parent_max_idx,
         );
 

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/sequence.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/sequence.rs
@@ -61,6 +61,12 @@ impl Parser<'_> {
         }
 
         // combine parent and local terminators (read parent from frame directly)
+        // PYTHON PARITY: Save the parent terminators BEFORE combining with local.
+        // In Python, the Sequence does NOT push its own terminators into
+        // parse_context.terminators — children only see parent-level terminators.
+        // The Sequence uses the combined set (own + parent) only for its own
+        // trim_to_terminator / max_idx computation.
+        let child_terminators = frame.table_terminators.to_vec();
         let all_terminators = self.combine_table_terminators(
             &local_terminators,
             &frame.table_terminators,
@@ -115,6 +121,7 @@ impl Parser<'_> {
             meta_buffer: Vec::new(),     // Buffer for meta elements to flush
             insert_segments: Vec::new(), // (position, segments) to insert
             child_matches: Vec::new(),   // Store child matches here until sequence is complete
+            child_terminators,           // Parent terminators (without Sequence's own) for children
         };
         frame.table_terminators = SmallVec::from_vec(all_terminators);
 
@@ -134,11 +141,13 @@ impl Parser<'_> {
         }
 
         // Create child frame with potentially new element after meta buffering
+        // PYTHON PARITY: Pass only parent terminators to children (not Sequence's own).
+        let child_terms = Self::sequence_child_terminators(&mut frame);
         let child_frame = TableParseFrame::new_child(
             child_frame_id,
             elements[current_element_idx],
             child_start_pos,
-            frame.table_terminators.to_vec(),
+            child_terms,
             Some(max_idx),
         );
 
@@ -378,14 +387,15 @@ impl Parser<'_> {
             }
 
             let child_frame_id = stack.frame_id_counter;
+            let child_terms = Self::sequence_child_terminators(&mut frame);
             let child_frame = self.match_sequence_next_element(
-                &frame,
                 next_element_idx,
                 matched_idx,
                 max_idx,
                 allow_gaps,
                 elements,
                 child_frame_id,
+                child_terms,
             );
             stack.push(frame);
             // continue to next element
@@ -508,6 +518,22 @@ impl Parser<'_> {
             ctx.mark_first_match_done();
 
             let matched_idx = ctx.matched_idx_value();
+
+            #[cfg(feature = "verbose-debug")]
+            {
+                let term_names: Vec<String> = frame
+                    .table_terminators
+                    .iter()
+                    .map(|t| format!("{}:{}", t.0, self.grammar_ctx.grammar_id_name(*t)))
+                    .collect();
+                vdebug!(
+                    "Sequence[table] GREEDY_ONCE_STARTED trim: frame_id={}, matched_idx={}, terminators={:?}",
+                    frame.frame_id,
+                    matched_idx,
+                    term_names
+                );
+            }
+
             let new_max_idx =
                 self.trim_to_terminator_table_driven(matched_idx, &frame.table_terminators)?;
 
@@ -575,12 +601,14 @@ impl Parser<'_> {
         if child_start_pos >= max_idx {
             // Check if next element is optional - if so, create child frame for it
             if self.grammar_ctx.is_optional(next_element) {
+                // PYTHON PARITY: Use parent terminators (without Sequence's own) for children
+                let child_terms = Self::sequence_child_terminators(&mut frame);
                 let child_frame_id = stack.frame_id_counter;
                 let child_frame = TableParseFrame::new_child(
                     child_frame_id,
                     next_element,
                     matched_idx,
-                    frame.table_terminators.to_vec(),
+                    child_terms,
                     Some(max_idx),
                 );
                 stack.push(frame);
@@ -636,12 +664,14 @@ impl Parser<'_> {
         }
 
         // Create child frame for next element
+        // PYTHON PARITY: Use parent terminators (without Sequence's own) for children
+        let child_terms = Self::sequence_child_terminators(&mut frame);
         let child_frame_id = stack.frame_id_counter;
         let child_frame = TableParseFrame::new_child(
             child_frame_id,
             next_element,
             child_start_pos,
-            frame.table_terminators.to_vec(),
+            child_terms,
             Some(max_idx),
         );
 
@@ -653,13 +683,13 @@ impl Parser<'_> {
     #[inline]
     fn match_sequence_next_element(
         &self,
-        frame: &TableParseFrame,
         next_element_idx: usize,
         matched_idx: usize,
         max_idx: usize,
         allow_gaps: bool,
         elements: &[GrammarId],
         child_frame_id: usize,
+        child_terminators: &[GrammarId],
     ) -> TableParseFrame {
         let child_start_pos = self.calculate_sequence_child_start_position(
             matched_idx,
@@ -667,13 +697,25 @@ impl Parser<'_> {
             elements[next_element_idx],
             max_idx,
         );
+        // PYTHON PARITY: Use parent terminators (without Sequence's own) for children.
+        // In Python, Sequence._match() does NOT call deeper_match(push_terminators=self.terminators),
+        // so child elements never see the Sequence's own terminators.
         TableParseFrame::new_child(
             child_frame_id,
             elements[next_element_idx],
             child_start_pos,
-            frame.table_terminators.to_vec(),
+            child_terminators,
             Some(max_idx),
         )
+    }
+
+    #[inline]
+    fn sequence_child_terminators(frame: &mut TableParseFrame) -> &[GrammarId] {
+        frame
+            .context
+            .as_sequence_mut()
+            .expect("sequence_child_terminators called on non-Sequence frame")
+            .child_terminators
     }
 
     /// Handle Sequence Combining state using table-driven approach

--- a/sqlfluffrs/tests/fixture_tests.rs
+++ b/sqlfluffrs/tests/fixture_tests.rs
@@ -1,3 +1,5 @@
+const FIXTURE_TEST_MAX_PARSE_DEPTH: usize = 1024;
+
 /// Normalize YAML by round-tripping through serde_yaml_ng
 fn normalize_yaml_through_serde(yaml_str: &str) -> Result<String, String> {
     // Parse YAML 1.1 and re-serialize with serde_yaml_ng
@@ -42,7 +44,7 @@ fn check_yaml_output_matches_python_for_dialect(dialect: &str) {
             &tokens,
             dialect_obj,
             hashbrown::HashMap::new(),
-            1024,
+            FIXTURE_TEST_MAX_PARSE_DEPTH,
         );
         let ast = parser
             .call_rule_as_root()
@@ -509,8 +511,12 @@ impl FixtureTest {
 
         // Use a generous depth limit so stress-test fixtures like
         // expression_recursion don't hit the DoS guard (default 255).
-        let mut parser =
-            Parser::new_with_max_parse_depth(&tokens, dialect, hashbrown::HashMap::new(), 1024);
+        let mut parser = Parser::new_with_max_parse_depth(
+            &tokens,
+            dialect,
+            hashbrown::HashMap::new(),
+            FIXTURE_TEST_MAX_PARSE_DEPTH,
+        );
 
         // Try to parse as a file (top-level rule)
         let ast = parser

--- a/sqlfluffrs/tests/fixture_tests.rs
+++ b/sqlfluffrs/tests/fixture_tests.rs
@@ -38,8 +38,12 @@ fn check_yaml_output_matches_python_for_dialect(dialect: &str) {
         let lexer = sqlfluffrs_lexer::Lexer::new(None, dialect_obj.get_lexers().to_vec());
         let (tokens, lex_errors) = lexer.lex(input, false);
         assert!(lex_errors.is_empty(), "Lexer errors: {:?}", lex_errors);
-        let mut parser =
-            sqlfluffrs_parser::parser::Parser::new(&tokens, dialect_obj, hashbrown::HashMap::new());
+        let mut parser = sqlfluffrs_parser::parser::Parser::new_with_max_parse_depth(
+            &tokens,
+            dialect_obj,
+            hashbrown::HashMap::new(),
+            1024,
+        );
         let ast = parser
             .call_rule_as_root()
             .expect("Parse error")
@@ -503,12 +507,15 @@ impl FixtureTest {
             return Err(format!("Lexer errors: {:?}", lex_errors));
         }
 
-        let mut parser = Parser::new(&tokens, dialect, hashbrown::HashMap::new());
+        // Use a generous depth limit so stress-test fixtures like
+        // expression_recursion don't hit the DoS guard (default 255).
+        let mut parser =
+            Parser::new_with_max_parse_depth(&tokens, dialect, hashbrown::HashMap::new(), 1024);
 
         // Try to parse as a file (top-level rule)
         let ast = parser
             .call_rule_as_root()
-            .expect("Parse error")
+            .map_err(|e| format!("Parse error: {:?}", e))?
             .apply_as_root(&tokens, &[], &[]);
         Ok(ast)
     }


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
This brings parity to Python on how sequence terminators are handled in Rust.

This also introduces a slight optimization of passing borrowed slices rather than allocating a Vec which in turn is usually converted to a SmallVec immediately after.

- fixes issues found in #7711
- makes progress on #7778

### Are there any other side effects of this change that we should be aware of?
This also fixes cargo tests that would fail due to the recursion limit set in #7473

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.