### PR TITLE
feat: Support function calls in MERGE USING clause

### DIFF
--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -3114,6 +3114,10 @@ class MergeStatementSegment(BaseSegment):
                 ),
                 Ref("AliasExpressionSegment", optional=True),
             ),
+            Sequence(
+                Ref("FunctionSegment"),
+                Ref("AliasExpressionSegment", optional=True),
+            ),
         ),
         Dedent,
         Conditional(Indent, indented_using_on=True),

--- a/test/fixtures/dialects/bigquery/merge_into.sql
+++ b/test/fixtures/dialects/bigquery/merge_into.sql
@@ -84,4 +84,13 @@ MERGE dataset.NewArrivals
 USING (SELECT * FROM dataset.NewArrivals WHERE warehouse <> 'warehouse #2')
 ON FALSE
 WHEN MATCHED THEN
-  DELETE
+  DELETE;
+
+-- Merge using UNNEST
+MERGE dataset.inventory t
+USING UNNEST(arr) AS s
+ON t.product = s.product
+WHEN MATCHED THEN
+  UPDATE SET quantity = s.quantity
+WHEN NOT MATCHED THEN
+  INSERT (product, quantity) VALUES (s.product, s.quantity)

--- a/test/fixtures/dialects/bigquery/merge_into.yml
+++ b/test/fixtures/dialects/bigquery/merge_into.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: a5d58da0b69423ce75e2e066d6be1d1339f7b2a87233182e627984d9e0895979
+_hash: d398050ce407c4dee61a7a3d315238cb2269905b092a99b4c804be8fb97723f5
 file:
 - statement:
     merge_statement:
@@ -808,3 +808,90 @@ file:
         - keyword: THEN
         - merge_delete_clause:
             keyword: DELETE
+- statement_terminator: ;
+- statement:
+    merge_statement:
+    - keyword: MERGE
+    - table_reference:
+      - naked_identifier: dataset
+      - dot: .
+      - naked_identifier: inventory
+    - alias_expression:
+        naked_identifier: t
+    - keyword: USING
+    - function:
+        function_name:
+          function_name_identifier: UNNEST
+        function_contents:
+          bracketed:
+            start_bracket: (
+            expression:
+              column_reference:
+                naked_identifier: arr
+            end_bracket: )
+    - alias_expression:
+        alias_operator:
+          keyword: AS
+        naked_identifier: s
+    - join_on_condition:
+        keyword: 'ON'
+        expression:
+        - column_reference:
+          - naked_identifier: t
+          - dot: .
+          - naked_identifier: product
+        - comparison_operator:
+            raw_comparison_operator: '='
+        - column_reference:
+          - naked_identifier: s
+          - dot: .
+          - naked_identifier: product
+    - merge_match:
+        merge_when_matched_clause:
+        - keyword: WHEN
+        - keyword: MATCHED
+        - keyword: THEN
+        - merge_update_clause:
+            keyword: UPDATE
+            set_clause_list:
+              keyword: SET
+              set_clause:
+              - column_reference:
+                  naked_identifier: quantity
+              - comparison_operator:
+                  raw_comparison_operator: '='
+              - column_reference:
+                - naked_identifier: s
+                - dot: .
+                - naked_identifier: quantity
+        not_matched_by_target_clause:
+        - keyword: WHEN
+        - keyword: NOT
+        - keyword: MATCHED
+        - keyword: THEN
+        - merge_insert_clause:
+            keyword: INSERT
+            bracketed:
+            - start_bracket: (
+            - column_reference:
+                naked_identifier: product
+            - comma: ','
+            - column_reference:
+                naked_identifier: quantity
+            - end_bracket: )
+            values_clause:
+              keyword: VALUES
+              bracketed:
+              - start_bracket: (
+              - expression:
+                  column_reference:
+                  - naked_identifier: s
+                  - dot: .
+                  - naked_identifier: product
+              - comma: ','
+              - expression:
+                  column_reference:
+                  - naked_identifier: s
+                  - dot: .
+                  - naked_identifier: quantity
+              - end_bracket: )


### PR DESCRIPTION
## Description

The `MERGE ... USING` clause currently only accepts table references and
subqueries. Function calls like `UNNEST()` are not supported, causing parse
failures.

This is valid syntax in BigQuery (and other dialects) for merging against
array data:

```sql
MERGE dataset.target AS t
USING UNNEST(arr) AS s
ON t.id = s.id
WHEN MATCHED THEN
  UPDATE SET val = s.val
```

The workaround is wrapping in a subquery (`USING (SELECT * FROM UNNEST(...)) AS s`),
but the direct form should parse.

## Fix

Add `FunctionSegment` (with optional alias) as an additional option in the
USING clause's `OneOf` in `MergeStatementSegment`. This is consistent with
how `TableExpressionSegment` already accepts `FunctionSegment` for FROM
clauses.

The change is in `dialect_ansi.py` because function calls in table positions
are an ANSI-level concept, already present in `TableExpressionSegment`. If
maintainers prefer a BigQuery-specific override, happy to move it.

## Test cases

Added a `MERGE ... USING UNNEST(arr) AS alias` test case to the existing
BigQuery `merge_into` fixture.

All 27 MERGE tests pass across all dialects. Full BigQuery suite: 426 passed.

---
AI disclosure: Claude Code was used to assist with this contribution.