### PR TITLE
fix: Support compound statements in BigQuery WHILE body

### DIFF
--- a/src/sqlfluff/dialects/dialect_bigquery.py
+++ b/src/sqlfluff/dialects/dialect_bigquery.py
@@ -967,7 +967,10 @@ class WhileStatementsSegment(BaseSegment):
     type = "while_statements"
     match_grammar = AnyNumberOf(
         Sequence(
-            Ref("StatementSegment"),
+            OneOf(
+                Ref("StatementSegment"),
+                Ref("MultiStatementSegment"),
+            ),
             Ref("DelimiterGrammar"),
         ),
         terminators=[Sequence("END", "WHILE")],

--- a/test/fixtures/dialects/bigquery/procedural_statements.sql
+++ b/test/fixtures/dialects/bigquery/procedural_statements.sql
@@ -11,6 +11,24 @@ WHILE true DO
   CONTINUE;
 END WHILE;
 
+-- WHILE with compound statements in body
+WHILE x > 0 DO
+  BEGIN
+    SET x = x - 1;
+    SELECT x;
+  EXCEPTION WHEN ERROR THEN
+    SET x = 0;
+  END;
+END WHILE;
+
+WHILE x > 0 DO
+  IF x > 5 THEN
+    SET x = x - 2;
+  ELSE
+    SET x = x - 1;
+  END IF;
+END WHILE;
+
 IF x >= 10 THEN
 	SELECT x;
 END IF;

--- a/test/fixtures/dialects/bigquery/procedural_statements.yml
+++ b/test/fixtures/dialects/bigquery/procedural_statements.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 9fce8c162bcaeb4150cca7216bf038c3a37e044d65f1d99f5956c06fb175afb3
+_hash: 23e0caf1c8bcfc61a920f4da056b5f4ccbe5563b75528625ce7f4c38f03dfcf1
 file:
 - statement:
     declare_segment:
@@ -67,6 +67,111 @@ file:
           continue_statement:
             keyword: CONTINUE
       - statement_terminator: ;
+    - keyword: END
+    - keyword: WHILE
+- statement_terminator: ;
+- multi_statement_segment:
+    while_statement:
+    - keyword: WHILE
+    - expression:
+        column_reference:
+          naked_identifier: x
+        comparison_operator:
+          raw_comparison_operator: '>'
+        numeric_literal: '0'
+    - keyword: DO
+    - while_statements:
+        multi_statement_segment:
+          begin_statement:
+          - keyword: BEGIN
+          - statement:
+              set_segment:
+                keyword: SET
+                naked_identifier: x
+                comparison_operator:
+                  raw_comparison_operator: '='
+                expression:
+                  column_reference:
+                    naked_identifier: x
+                  binary_operator: '-'
+                  numeric_literal: '1'
+          - statement_terminator: ;
+          - statement:
+              select_statement:
+                select_clause:
+                  keyword: SELECT
+                  select_clause_element:
+                    column_reference:
+                      naked_identifier: x
+          - statement_terminator: ;
+          - keyword: EXCEPTION
+          - keyword: WHEN
+          - keyword: ERROR
+          - keyword: THEN
+          - statement:
+              set_segment:
+                keyword: SET
+                naked_identifier: x
+                comparison_operator:
+                  raw_comparison_operator: '='
+                numeric_literal: '0'
+          - statement_terminator: ;
+          - keyword: END
+        statement_terminator: ;
+    - keyword: END
+    - keyword: WHILE
+- statement_terminator: ;
+- multi_statement_segment:
+    while_statement:
+    - keyword: WHILE
+    - expression:
+        column_reference:
+          naked_identifier: x
+        comparison_operator:
+          raw_comparison_operator: '>'
+        numeric_literal: '0'
+    - keyword: DO
+    - while_statements:
+        multi_statement_segment:
+          if_statement:
+          - keyword: IF
+          - expression:
+              column_reference:
+                naked_identifier: x
+              comparison_operator:
+                raw_comparison_operator: '>'
+              numeric_literal: '5'
+          - keyword: THEN
+          - if_statements:
+              statement:
+                set_segment:
+                  keyword: SET
+                  naked_identifier: x
+                  comparison_operator:
+                    raw_comparison_operator: '='
+                  expression:
+                    column_reference:
+                      naked_identifier: x
+                    binary_operator: '-'
+                    numeric_literal: '2'
+              statement_terminator: ;
+          - keyword: ELSE
+          - if_statements:
+              statement:
+                set_segment:
+                  keyword: SET
+                  naked_identifier: x
+                  comparison_operator:
+                    raw_comparison_operator: '='
+                  expression:
+                    column_reference:
+                      naked_identifier: x
+                    binary_operator: '-'
+                    numeric_literal: '1'
+              statement_terminator: ;
+          - keyword: END
+          - keyword: IF
+        statement_terminator: ;
     - keyword: END
     - keyword: WHILE
 - statement_terminator: ;


### PR DESCRIPTION
## Description

`WHILE` loops in BigQuery fail to parse when the body contains compound
statements like `BEGIN...END` or `IF...END IF`. The parser's `END WHILE`
terminator matches the inner `END` keyword prematurely.

```sql
-- Fails to parse
WHILE x > 0 DO
  BEGIN
    SET x = x - 1;
  EXCEPTION WHEN ERROR THEN
    SET x = 0;
  END;
END WHILE;
```

## Root cause

`WhileStatementsSegment` only accepts `StatementSegment` in its body,
while `ForInStatementsSegment` and `RepeatStatementsSegment` accept
`OneOf(StatementSegment, MultiStatementSegment)`.
`MultiStatementSegment` handles compound statements (`BEGIN...END`,
`IF...END IF`, `FOR...END FOR`, etc.), so omitting it causes any `END`
keyword inside the WHILE body to be misinterpreted as `END WHILE`.

## Fix

Add `MultiStatementSegment` as an alternative in `WhileStatementsSegment`,
matching the pattern already used by `ForInStatementsSegment` and
`RepeatStatementsSegment`.

## Test cases

Two test cases added to the existing `procedural_statements` fixture:
- `WHILE` with `BEGIN...EXCEPTION...END` block
- `WHILE` with `IF...END IF` block

All 426 BigQuery dialect tests pass.

---
AI disclosure: Claude Code was used to assist with this contribution.