### PR TITLE
test: add LT02 autofix fixtures for MERGE INSERT VALUES indentation (ansi, bigquery, sparksql)

### DIFF
--- a/test/fixtures/linter/autofix/ansi/031_merge_insert_values_indent/after.sql
+++ b/test/fixtures/linter/autofix/ansi/031_merge_insert_values_indent/after.sql
@@ -1,0 +1,10 @@
+-- VALUES should align with INSERT, not be indented under the column list.
+MERGE INTO dataset.detailedinventory AS t
+USING dataset.inventory AS s
+    ON t.product = s.product
+WHEN NOT MATCHED AND quantity < 20 THEN
+    INSERT (product, quantity, supply_constrained)
+    VALUES (product, quantity, TRUE)
+WHEN NOT MATCHED THEN
+    INSERT (product, quantity, supply_constrained)
+    VALUES (product, quantity, FALSE);

--- a/test/fixtures/linter/autofix/ansi/031_merge_insert_values_indent/before.sql
+++ b/test/fixtures/linter/autofix/ansi/031_merge_insert_values_indent/before.sql
@@ -1,0 +1,10 @@
+-- VALUES should align with INSERT, not be indented under the column list.
+MERGE INTO dataset.detailedinventory AS t
+USING dataset.inventory AS s
+    ON t.product = s.product
+WHEN NOT MATCHED AND quantity < 20 THEN
+    INSERT (product, quantity, supply_constrained)
+        VALUES (product, quantity, TRUE)
+WHEN NOT MATCHED THEN
+    INSERT (product, quantity, supply_constrained)
+        VALUES (product, quantity, FALSE);

--- a/test/fixtures/linter/autofix/ansi/031_merge_insert_values_indent/test-config.yml
+++ b/test/fixtures/linter/autofix/ansi/031_merge_insert_values_indent/test-config.yml
@@ -1,0 +1,3 @@
+test-config:
+  rules:
+    - LT02

--- a/test/fixtures/linter/autofix/bigquery/007_merge_insert_values_indent/after.sql
+++ b/test/fixtures/linter/autofix/bigquery/007_merge_insert_values_indent/after.sql
@@ -1,0 +1,10 @@
+-- VALUES should align with INSERT, not be indented under the column list.
+MERGE dataset.detailedinventory AS t
+USING dataset.inventory AS s
+    ON t.product = s.product
+WHEN NOT MATCHED AND quantity < 20 THEN
+    INSERT (product, quantity, supply_constrained, comments)
+    VALUES (product, quantity, TRUE, 'comment1')
+WHEN NOT MATCHED THEN
+    INSERT (product, quantity, supply_constrained)
+    VALUES (product, quantity, FALSE);

--- a/test/fixtures/linter/autofix/bigquery/007_merge_insert_values_indent/before.sql
+++ b/test/fixtures/linter/autofix/bigquery/007_merge_insert_values_indent/before.sql
@@ -1,0 +1,10 @@
+-- VALUES should align with INSERT, not be indented under the column list.
+MERGE dataset.detailedinventory AS t
+USING dataset.inventory AS s
+    ON t.product = s.product
+WHEN NOT MATCHED AND quantity < 20 THEN
+    INSERT (product, quantity, supply_constrained, comments)
+        VALUES (product, quantity, TRUE, 'comment1')
+WHEN NOT MATCHED THEN
+    INSERT (product, quantity, supply_constrained)
+        VALUES (product, quantity, FALSE);

--- a/test/fixtures/linter/autofix/bigquery/007_merge_insert_values_indent/test-config.yml
+++ b/test/fixtures/linter/autofix/bigquery/007_merge_insert_values_indent/test-config.yml
@@ -1,0 +1,3 @@
+test-config:
+  rules:
+    - LT02

--- a/test/fixtures/linter/autofix/sparksql/001_merge_insert_values_indent/after.sql
+++ b/test/fixtures/linter/autofix/sparksql/001_merge_insert_values_indent/after.sql
@@ -1,0 +1,10 @@
+-- VALUES should align with INSERT, not be indented under the column list.
+MERGE INTO dataset.detailedinventory AS t
+USING dataset.inventory AS s
+    ON t.product = s.product
+WHEN NOT MATCHED AND quantity < 20 THEN
+    INSERT (product, quantity, supply_constrained)
+    VALUES (product, quantity, TRUE)
+WHEN NOT MATCHED THEN
+    INSERT (product, quantity, supply_constrained)
+    VALUES (product, quantity, FALSE);

--- a/test/fixtures/linter/autofix/sparksql/001_merge_insert_values_indent/before.sql
+++ b/test/fixtures/linter/autofix/sparksql/001_merge_insert_values_indent/before.sql
@@ -1,0 +1,10 @@
+-- VALUES should align with INSERT, not be indented under the column list.
+MERGE INTO dataset.detailedinventory AS t
+USING dataset.inventory AS s
+    ON t.product = s.product
+WHEN NOT MATCHED AND quantity < 20 THEN
+    INSERT (product, quantity, supply_constrained)
+        VALUES (product, quantity, TRUE)
+WHEN NOT MATCHED THEN
+    INSERT (product, quantity, supply_constrained)
+        VALUES (product, quantity, FALSE);

--- a/test/fixtures/linter/autofix/sparksql/001_merge_insert_values_indent/test-config.yml
+++ b/test/fixtures/linter/autofix/sparksql/001_merge_insert_values_indent/test-config.yml
@@ -1,0 +1,3 @@
+test-config:
+  rules:
+    - LT02


### PR DESCRIPTION
Closes #4232.

**Why:** Issue #4232 reported that `VALUES` in a `MERGE … INSERT` clause was being indented one level deeper than `INSERT`. The grammar already places `ValuesClauseSegment` _after_ the `Dedent` that closes the column-reference list, so `LT02` correctly identifies and fixes the over-indentation — but there were no autofix test fixtures to prove or protect that behaviour.

**What changed:** Added `before.sql` / `after.sql` / `test-config.yml` fixture sets for the three affected dialects:

| Fixture | Dialect |
|---|---|
| `test/fixtures/linter/autofix/ansi/031_merge_insert_values_indent` | ansi |
| `test/fixtures/linter/autofix/bigquery/007_merge_insert_values_indent` | bigquery |
| `test/fixtures/linter/autofix/sparksql/001_merge_insert_values_indent` | sparksql |

Each fixture demonstrates that `sqlfluff fix --rules LT02` moves an over-indented `VALUES` back to the same indent level as `INSERT`.

**Tests:** `pytest test/rules/std_fix_auto_test.py -k "merge_insert_values_indent"` → 3 passed.