### PR TITLE
TSQL: Parse issues DatatypeMethodSeg in TableRef and TableExp for Merge using

### DIFF
--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -3479,12 +3479,15 @@ class TableReferenceSegment(ObjectReferenceSegment):
         Sequence(
             Ref("SingleIdentifierGrammar"),
             AnyNumberOf(
-                Sequence(
-                    Ref("DotSegment"),
-                    Ref("SingleIdentifierGrammar", optional=True),
+                OneOf(
+                    Ref("DatatypeMethodSegment"),
+                    Sequence(
+                        Ref("DotSegment"),
+                        Ref("SingleIdentifierGrammar", optional=True),
+                    ),
                 ),
                 min_times=0,
-                max_times=3,
+                max_times=4,
             ),
         ),
         # This can have a leading number of dots. If the table reference starts with a
@@ -7128,16 +7131,8 @@ class MergeStatementSegment(ansi.MergeStatementSegment):
         Dedent,
         "USING",
         Indent,
-        OneOf(
-            Ref("TableReferenceSegment"),
-            Ref("AliasedTableReferenceGrammar"),
-            Sequence(
-                Bracketed(
-                    Ref("SelectableGrammar"),
-                ),
-                Ref("AliasExpressionSegment", optional=True),
-            ),
-        ),
+        Ref("TableExpressionSegment"),
+        Ref("AliasExpressionSegment", optional=True),
         Dedent,
         Conditional(Indent, indented_using_on=True),
         Ref("JoinOnConditionSegment"),

--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -7131,8 +7131,20 @@ class MergeStatementSegment(ansi.MergeStatementSegment):
         Dedent,
         "USING",
         Indent,
-        Ref("TableExpressionSegment"),
-        Ref("AliasExpressionSegment", optional=True),
+        OneOf(
+            Ref("TableReferenceSegment"),
+            Ref("AliasedTableReferenceGrammar"),
+            Sequence(
+                Bracketed(
+                    Ref("SelectableGrammar"),
+                ),
+                Ref("AliasExpressionSegment", optional=True),
+            ),
+            Sequence(
+                Ref("TableExpressionSegment"),
+                Ref("AliasExpressionSegment", optional=True),
+            ),
+        ),
         Dedent,
         Conditional(Indent, indented_using_on=True),
         Ref("JoinOnConditionSegment"),

--- a/test/fixtures/dialects/tsql/datatype_methods.sql
+++ b/test/fixtures/dialects/tsql/datatype_methods.sql
@@ -19,3 +19,7 @@ SELECT convert(hierarchyid, '/1/1/2').GetAncestor(2).GetAncestor(2) parent;
 
 SELECT @geography.STArea() area;
 SELECT @geography.STDistance(@other_geography) dist;
+
+SELECT na.Loc.query('.') FROM SomeTable CROSS APPLY SomeXMLColumn.nodex('/root/Location') AS na(Loc);
+SELECT T.c.query('.') FROM @x.nodes('/Root/row') T(c);
+GO

--- a/test/fixtures/dialects/tsql/datatype_methods.yml
+++ b/test/fixtures/dialects/tsql/datatype_methods.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 6460a8172bf65721979ac308a716a5996261c90b1bbdc29ca98b9576290be7c5
+_hash: 11c659de66b99a66717b06502719fc73d6298c843a998e3ccd226c7ec38e7330
 file:
   batch:
   - statement:
@@ -338,3 +338,98 @@ file:
             alias_expression:
               naked_identifier: dist
   - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            column_reference:
+            - naked_identifier: na
+            - dot: .
+            - naked_identifier: Loc
+            - datatype_method:
+                dot: .
+                datatype_method_name_identifier: query
+                function_contents:
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                      quoted_literal: "'.'"
+                    end_bracket: )
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: SomeTable
+            join_clause:
+            - keyword: CROSS
+            - keyword: APPLY
+            - from_expression_element:
+                table_expression:
+                  function:
+                    function_name:
+                      naked_identifier: SomeXMLColumn
+                      dot: .
+                      function_name_identifier: nodex
+                    function_contents:
+                      bracketed:
+                        start_bracket: (
+                        expression:
+                          quoted_literal: "'/root/Location'"
+                        end_bracket: )
+                alias_expression:
+                  alias_operator:
+                    keyword: AS
+                  naked_identifier: na
+                  bracketed:
+                    start_bracket: (
+                    identifier_list:
+                      naked_identifier: Loc
+                    end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            column_reference:
+            - naked_identifier: T
+            - dot: .
+            - naked_identifier: c
+            - datatype_method:
+                dot: .
+                datatype_method_name_identifier: query
+                function_contents:
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                      quoted_literal: "'.'"
+                    end_bracket: )
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  parameter: '@x'
+                  datatype_method:
+                    dot: .
+                    datatype_method_name_identifier: nodes
+                    function_contents:
+                      bracketed:
+                        start_bracket: (
+                        expression:
+                          quoted_literal: "'/Root/row'"
+                        end_bracket: )
+              alias_expression:
+                naked_identifier: T
+                bracketed:
+                  start_bracket: (
+                  identifier_list:
+                    naked_identifier: c
+                  end_bracket: )
+  - statement_terminator: ;
+  - go_statement:
+      keyword: GO

--- a/test/fixtures/dialects/tsql/merge.sql
+++ b/test/fixtures/dialects/tsql/merge.sql
@@ -200,3 +200,8 @@ USING  (	SELECT 1 AS i	) AS source
 ON source.i = target.i
 WHEN MATCHED
 THEN  UPDATE SET target.i = source.i;
+
+MERGE INTO SomeTable t
+USING dbo.SomeFunction() s ON s.Id = t.Id
+WHEN MATCHED THEN UPDATE SET t.data = s.data;
+GO

--- a/test/fixtures/dialects/tsql/merge.yml
+++ b/test/fixtures/dialects/tsql/merge.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 7b73b841e1fdc0085877091eeba8d959706be28ca620115b129928eb10f1b961
+_hash: 665c26d63a489b5fc38dd9e277a29adf980887fa02cfd8e61f40634901c9c185
 file:
 - batch:
     statement:
@@ -16,10 +16,11 @@ file:
       - alias_expression:
           naked_identifier: dst
       - keyword: using
-      - table_reference:
-        - naked_identifier: schema1
-        - dot: .
-        - naked_identifier: table1
+      - table_expression:
+          table_reference:
+          - naked_identifier: schema1
+          - dot: .
+          - naked_identifier: table1
       - alias_expression:
           naked_identifier: src
       - join_on_condition:
@@ -155,8 +156,9 @@ file:
         - alias_expression:
             naked_identifier: dst
         - keyword: using
-        - table_reference:
-            naked_identifier: source_data
+        - table_expression:
+            table_reference:
+              naked_identifier: source_data
         - alias_expression:
             naked_identifier: src
         - join_on_condition:
@@ -255,12 +257,13 @@ file:
       - alias_expression:
           naked_identifier: dst
       - keyword: using
-      - table_reference:
-        - naked_identifier: LA
-        - dot: .
-        - naked_identifier: tt
-        - dot: .
-        - naked_identifier: dd
+      - table_expression:
+          table_reference:
+          - naked_identifier: LA
+          - dot: .
+          - naked_identifier: tt
+          - dot: .
+          - naked_identifier: dd
       - alias_expression:
           naked_identifier: src
       - join_on_condition:
@@ -477,17 +480,18 @@ file:
             keyword: AS
           naked_identifier: tgt
       - keyword: USING
-      - bracketed:
-          start_bracket: (
-          select_statement:
-            select_clause:
-            - keyword: SELECT
-            - select_clause_element:
-                parameter: '@UnitMeasureCode'
-            - comma: ','
-            - select_clause_element:
-                parameter: '@Name'
-          end_bracket: )
+      - table_expression:
+          bracketed:
+            start_bracket: (
+            select_statement:
+              select_clause:
+              - keyword: SELECT
+              - select_clause_element:
+                  parameter: '@UnitMeasureCode'
+              - comma: ','
+              - select_clause_element:
+                  parameter: '@Name'
+            end_bracket: )
       - alias_expression:
           alias_operator:
             keyword: as
@@ -596,78 +600,79 @@ file:
             keyword: AS
           naked_identifier: tgt
       - keyword: USING
-      - bracketed:
-          start_bracket: (
-          select_statement:
-            select_clause:
-            - keyword: SELECT
-            - select_clause_element:
-                column_reference:
-                  naked_identifier: ProductID
-            - comma: ','
-            - select_clause_element:
-                function:
-                  function_name:
-                    function_name_identifier: SUM
-                  function_contents:
-                    bracketed:
-                      start_bracket: (
-                      expression:
-                        column_reference:
-                          naked_identifier: OrderQty
-                      end_bracket: )
-            from_clause:
-              keyword: FROM
-              from_expression:
-                from_expression_element:
-                  table_expression:
-                    table_reference:
-                    - naked_identifier: Sales
-                    - dot: .
-                    - naked_identifier: SalesOrderDetail
-                  alias_expression:
-                    alias_operator:
-                      keyword: AS
-                    naked_identifier: sod
-                join_clause:
-                  keyword: JOIN
+      - table_expression:
+          bracketed:
+            start_bracket: (
+            select_statement:
+              select_clause:
+              - keyword: SELECT
+              - select_clause_element:
+                  column_reference:
+                    naked_identifier: ProductID
+              - comma: ','
+              - select_clause_element:
+                  function:
+                    function_name:
+                      function_name_identifier: SUM
+                    function_contents:
+                      bracketed:
+                        start_bracket: (
+                        expression:
+                          column_reference:
+                            naked_identifier: OrderQty
+                        end_bracket: )
+              from_clause:
+                keyword: FROM
+                from_expression:
                   from_expression_element:
                     table_expression:
                       table_reference:
                       - naked_identifier: Sales
                       - dot: .
-                      - naked_identifier: SalesOrderHeader
+                      - naked_identifier: SalesOrderDetail
                     alias_expression:
                       alias_operator:
                         keyword: AS
-                      naked_identifier: soh
-                  join_on_condition:
-                    keyword: 'ON'
-                    expression:
-                    - column_reference:
-                      - naked_identifier: sod
-                      - dot: .
-                      - naked_identifier: SalesOrderID
-                    - comparison_operator:
-                        raw_comparison_operator: '='
-                    - column_reference:
-                      - naked_identifier: soh
-                      - dot: .
-                      - naked_identifier: SalesOrderID
-                    - binary_operator: AND
-                    - column_reference:
-                      - naked_identifier: soh
-                      - dot: .
-                      - naked_identifier: OrderDate
-                    - comparison_operator:
-                        raw_comparison_operator: '='
-                    - parameter: '@OrderDate'
-            groupby_clause:
-            - keyword: GROUP
-            - keyword: BY
-            - column_reference:
-                naked_identifier: ProductID
-          end_bracket: )
+                      naked_identifier: sod
+                  join_clause:
+                    keyword: JOIN
+                    from_expression_element:
+                      table_expression:
+                        table_reference:
+                        - naked_identifier: Sales
+                        - dot: .
+                        - naked_identifier: SalesOrderHeader
+                      alias_expression:
+                        alias_operator:
+                          keyword: AS
+                        naked_identifier: soh
+                    join_on_condition:
+                      keyword: 'ON'
+                      expression:
+                      - column_reference:
+                        - naked_identifier: sod
+                        - dot: .
+                        - naked_identifier: SalesOrderID
+                      - comparison_operator:
+                          raw_comparison_operator: '='
+                      - column_reference:
+                        - naked_identifier: soh
+                        - dot: .
+                        - naked_identifier: SalesOrderID
+                      - binary_operator: AND
+                      - column_reference:
+                        - naked_identifier: soh
+                        - dot: .
+                        - naked_identifier: OrderDate
+                      - comparison_operator:
+                          raw_comparison_operator: '='
+                      - parameter: '@OrderDate'
+              groupby_clause:
+              - keyword: GROUP
+              - keyword: BY
+              - column_reference:
+                  naked_identifier: ProductID
+            end_bracket: )
       - alias_expression:
           alias_operator:
             keyword: as
@@ -801,79 +806,80 @@ file:
             keyword: AS
           naked_identifier: pi
       - keyword: USING
-      - bracketed:
-          start_bracket: (
-          select_statement:
-            select_clause:
-            - keyword: SELECT
-            - select_clause_element:
-                column_reference:
-                  naked_identifier: ProductID
-            - comma: ','
-            - select_clause_element:
-                function:
-                  function_name:
-                    function_name_identifier: SUM
-                  function_contents:
-                    bracketed:
-                      start_bracket: (
-                      expression:
-                        column_reference:
-                          naked_identifier: OrderQty
-                      end_bracket: )
-            from_clause:
-              keyword: FROM
-              from_expression:
-                from_expression_element:
-                  table_expression:
-                    table_reference:
-                    - naked_identifier: Sales
-                    - dot: .
-                    - naked_identifier: SalesOrderDetail
-                  alias_expression:
-                    alias_operator:
-                      keyword: AS
-                    naked_identifier: sod
-                join_clause:
-                  keyword: JOIN
+      - table_expression:
+          bracketed:
+            start_bracket: (
+            select_statement:
+              select_clause:
+              - keyword: SELECT
+              - select_clause_element:
+                  column_reference:
+                    naked_identifier: ProductID
+              - comma: ','
+              - select_clause_element:
+                  function:
+                    function_name:
+                      function_name_identifier: SUM
+                    function_contents:
+                      bracketed:
+                        start_bracket: (
+                        expression:
+                          column_reference:
+                            naked_identifier: OrderQty
+                        end_bracket: )
+              from_clause:
+                keyword: FROM
+                from_expression:
                   from_expression_element:
                     table_expression:
                       table_reference:
                       - naked_identifier: Sales
                       - dot: .
-                      - naked_identifier: SalesOrderHeader
+                      - naked_identifier: SalesOrderDetail
                     alias_expression:
                       alias_operator:
                         keyword: AS
-                      naked_identifier: soh
-                  join_on_condition:
-                    keyword: 'ON'
-                    expression:
-                    - column_reference:
-                      - naked_identifier: sod
-                      - dot: .
-                      - naked_identifier: SalesOrderID
-                    - comparison_operator:
-                        raw_comparison_operator: '='
-                    - column_reference:
-                      - naked_identifier: soh
-                      - dot: .
-                      - naked_identifier: SalesOrderID
-                    - binary_operator: AND
-                    - column_reference:
-                      - naked_identifier: soh
-                      - dot: .
-                      - naked_identifier: OrderDate
-                    - keyword: BETWEEN
-                    - quoted_literal: "'20030701'"
-                    - keyword: AND
-                    - quoted_literal: "'20030731'"
-            groupby_clause:
-            - keyword: GROUP
-            - keyword: BY
-            - column_reference:
-                naked_identifier: ProductID
-          end_bracket: )
+                      naked_identifier: sod
+                  join_clause:
+                    keyword: JOIN
+                    from_expression_element:
+                      table_expression:
+                        table_reference:
+                        - naked_identifier: Sales
+                        - dot: .
+                        - naked_identifier: SalesOrderHeader
+                      alias_expression:
+                        alias_operator:
+                          keyword: AS
+                        naked_identifier: soh
+                    join_on_condition:
+                      keyword: 'ON'
+                      expression:
+                      - column_reference:
+                        - naked_identifier: sod
+                        - dot: .
+                        - naked_identifier: SalesOrderID
+                      - comparison_operator:
+                          raw_comparison_operator: '='
+                      - column_reference:
+                        - naked_identifier: soh
+                        - dot: .
+                        - naked_identifier: SalesOrderID
+                      - binary_operator: AND
+                      - column_reference:
+                        - naked_identifier: soh
+                        - dot: .
+                        - naked_identifier: OrderDate
+                      - keyword: BETWEEN
+                      - quoted_literal: "'20030701'"
+                      - keyword: AND
+                      - quoted_literal: "'20030731'"
+              groupby_clause:
+              - keyword: GROUP
+              - keyword: BY
+              - column_reference:
+                  naked_identifier: ProductID
+            end_bracket: )
       - alias_expression:
           alias_operator:
             keyword: AS
@@ -1028,30 +1034,31 @@ file:
                     - alias_expression:
                         naked_identifier: trg
                     - keyword: using
-                    - bracketed:
-                        start_bracket: (
-                        select_statement:
-                          select_clause:
-                            keyword: select
-                            select_clause_element:
-                              column_reference:
-                              - naked_identifier: gr
-                              - dot: .
-                              - naked_identifier: columnC
-                          from_clause:
-                            keyword: from
-                            from_expression:
-                              from_expression_element:
-                                table_expression:
-                                  table_reference:
-                                  - naked_identifier: sch2
-                                  - dot: .
-                                  - naked_identifier: table2
-                                alias_expression:
-                                  alias_operator:
-                                    keyword: as
-                                  naked_identifier: gr
-                        end_bracket: )
+                    - table_expression:
+                        bracketed:
+                          start_bracket: (
+                          select_statement:
+                            select_clause:
+                              keyword: select
+                              select_clause_element:
+                                column_reference:
+                                - naked_identifier: gr
+                                - dot: .
+                                - naked_identifier: columnC
+                            from_clause:
+                              keyword: from
+                              from_expression:
+                                from_expression_element:
+                                  table_expression:
+                                    table_reference:
+                                    - naked_identifier: sch2
+                                    - dot: .
+                                    - naked_identifier: table2
+                                  alias_expression:
+                                    alias_operator:
+                                      keyword: as
+                                    naked_identifier: gr
+                          end_bracket: )
                     - alias_expression:
                         naked_identifier: src
                     - join_on_condition:
@@ -1118,17 +1125,18 @@ file:
             keyword: AS
           naked_identifier: tgt
       - keyword: USING
-      - bracketed:
-          start_bracket: (
-          select_statement:
-            select_clause:
-            - keyword: SELECT
-            - select_clause_element:
-                parameter: '@UnitMeasureCode'
-            - comma: ','
-            - select_clause_element:
-                parameter: '@Name'
-          end_bracket: )
+      - table_expression:
+          bracketed:
+            start_bracket: (
+            select_statement:
+              select_clause:
+              - keyword: SELECT
+              - select_clause_element:
+                  parameter: '@UnitMeasureCode'
+              - comma: ','
+              - select_clause_element:
+                  parameter: '@Name'
+            end_bracket: )
       - alias_expression:
           alias_operator:
             keyword: as
@@ -1255,79 +1263,80 @@ file:
             keyword: AS
           naked_identifier: pi
       - keyword: USING
-      - bracketed:
-          start_bracket: (
-          select_statement:
-            select_clause:
-            - keyword: SELECT
-            - select_clause_element:
-                column_reference:
-                  naked_identifier: ProductID
-            - comma: ','
-            - select_clause_element:
-                function:
-                  function_name:
-                    function_name_identifier: SUM
-                  function_contents:
-                    bracketed:
-                      start_bracket: (
-                      expression:
-                        column_reference:
-                          naked_identifier: OrderQty
-                      end_bracket: )
-            from_clause:
-              keyword: FROM
-              from_expression:
-                from_expression_element:
-                  table_expression:
-                    table_reference:
-                    - naked_identifier: Sales
-                    - dot: .
-                    - naked_identifier: SalesOrderDetail
-                  alias_expression:
-                    alias_operator:
-                      keyword: AS
-                    naked_identifier: sod
-                join_clause:
-                  keyword: JOIN
+      - table_expression:
+          bracketed:
+            start_bracket: (
+            select_statement:
+              select_clause:
+              - keyword: SELECT
+              - select_clause_element:
+                  column_reference:
+                    naked_identifier: ProductID
+              - comma: ','
+              - select_clause_element:
+                  function:
+                    function_name:
+                      function_name_identifier: SUM
+                    function_contents:
+                      bracketed:
+                        start_bracket: (
+                        expression:
+                          column_reference:
+                            naked_identifier: OrderQty
+                        end_bracket: )
+              from_clause:
+                keyword: FROM
+                from_expression:
                   from_expression_element:
                     table_expression:
                       table_reference:
                       - naked_identifier: Sales
                       - dot: .
-                      - naked_identifier: SalesOrderHeader
+                      - naked_identifier: SalesOrderDetail
                     alias_expression:
                       alias_operator:
                         keyword: AS
-                      naked_identifier: soh
-                  join_on_condition:
-                    keyword: 'ON'
-                    expression:
-                    - column_reference:
-                      - naked_identifier: sod
-                      - dot: .
-                      - naked_identifier: SalesOrderID
-                    - comparison_operator:
-                        raw_comparison_operator: '='
-                    - column_reference:
-                      - naked_identifier: soh
-                      - dot: .
-                      - naked_identifier: SalesOrderID
-                    - binary_operator: AND
-                    - column_reference:
-                      - naked_identifier: soh
-                      - dot: .
-                      - naked_identifier: OrderDate
-                    - keyword: BETWEEN
-                    - quoted_literal: "'20030701'"
-                    - keyword: AND
-                    - quoted_literal: "'20030731'"
-            groupby_clause:
-            - keyword: GROUP
-            - keyword: BY
-            - column_reference:
-                naked_identifier: ProductID
-          end_bracket: )
+                      naked_identifier: sod
+                  join_clause:
+                    keyword: JOIN
+                    from_expression_element:
+                      table_expression:
+                        table_reference:
+                        - naked_identifier: Sales
+                        - dot: .
+                        - naked_identifier: SalesOrderHeader
+                      alias_expression:
+                        alias_operator:
+                          keyword: AS
+                        naked_identifier: soh
+                    join_on_condition:
+                      keyword: 'ON'
+                      expression:
+                      - column_reference:
+                        - naked_identifier: sod
+                        - dot: .
+                        - naked_identifier: SalesOrderID
+                      - comparison_operator:
+                          raw_comparison_operator: '='
+                      - column_reference:
+                        - naked_identifier: soh
+                        - dot: .
+                        - naked_identifier: SalesOrderID
+                      - binary_operator: AND
+                      - column_reference:
+                        - naked_identifier: soh
+                        - dot: .
+                        - naked_identifier: OrderDate
+                      - keyword: BETWEEN
+                      - quoted_literal: "'20030701'"
+                      - keyword: AND
+                      - quoted_literal: "'20030731'"
+              groupby_clause:
+              - keyword: GROUP
+              - keyword: BY
+              - column_reference:
+                  naked_identifier: ProductID
+            end_bracket: )
       - alias_expression:
           alias_operator:
             keyword: AS
@@ -1445,7 +1454,7 @@ file:
     go_statement:
       keyword: GO
 - batch:
-    statement:
+  - statement:
       merge_statement:
       - keyword: MERGE
       - keyword: INTO
@@ -1454,18 +1463,19 @@ file:
         - dot: .
         - naked_identifier: target
       - keyword: USING
-      - bracketed:
-          start_bracket: (
-          select_statement:
-            select_clause:
-              keyword: SELECT
-              select_clause_element:
-                integer_literal: '1'
-                alias_expression:
-                  alias_operator:
-                    keyword: AS
-                  naked_identifier: i
-          end_bracket: )
+      - table_expression:
+          bracketed:
+            start_bracket: (
+            select_statement:
+              select_clause:
+                keyword: SELECT
+                select_clause_element:
+                  integer_literal: '1'
+                  alias_expression:
+                    alias_operator:
+                      keyword: AS
+                    naked_identifier: i
+            end_bracket: )
       - alias_expression:
           alias_operator:
             keyword: AS
@@ -1504,4 +1514,61 @@ file:
                     - naked_identifier: source
                     - dot: .
                     - naked_identifier: i
-    statement_terminator: ;
+  - statement_terminator: ;
+  - statement:
+      merge_statement:
+      - keyword: MERGE
+      - keyword: INTO
+      - table_reference:
+          naked_identifier: SomeTable
+      - alias_expression:
+          naked_identifier: t
+      - keyword: USING
+      - table_expression:
+          table_reference:
+          - naked_identifier: dbo
+          - dot: .
+          - naked_identifier: SomeFunction
+          post_table_expression:
+            bracketed:
+              start_bracket: (
+              end_bracket: )
+      - alias_expression:
+          naked_identifier: s
+      - join_on_condition:
+          keyword: 'ON'
+          expression:
+          - column_reference:
+            - naked_identifier: s
+            - dot: .
+            - naked_identifier: Id
+          - comparison_operator:
+              raw_comparison_operator: '='
+          - column_reference:
+            - naked_identifier: t
+            - dot: .
+            - naked_identifier: Id
+      - merge_match:
+          merge_when_matched_clause:
+          - keyword: WHEN
+          - keyword: MATCHED
+          - keyword: THEN
+          - merge_update_clause:
+              keyword: UPDATE
+              set_clause_list:
+                keyword: SET
+                set_clause:
+                  column_reference:
+                  - naked_identifier: t
+                  - dot: .
+                  - naked_identifier: data
+                  assignment_operator:
+                    raw_comparison_operator: '='
+                  expression:
+                    column_reference:
+                    - naked_identifier: s
+                    - dot: .
+                    - naked_identifier: data
+  - statement_terminator: ;
+  - go_statement:
+      keyword: GO

--- a/test/fixtures/dialects/tsql/merge.yml
+++ b/test/fixtures/dialects/tsql/merge.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 665c26d63a489b5fc38dd9e277a29adf980887fa02cfd8e61f40634901c9c185
+_hash: f91f474bfec6523b98ddd6be79b122aaab65c0456c9f9534712f7e281c42d982
 file:
 - batch:
     statement:
@@ -16,11 +16,10 @@ file:
       - alias_expression:
           naked_identifier: dst
       - keyword: using
-      - table_expression:
-          table_reference:
-          - naked_identifier: schema1
-          - dot: .
-          - naked_identifier: table1
+      - table_reference:
+        - naked_identifier: schema1
+        - dot: .
+        - naked_identifier: table1
       - alias_expression:
           naked_identifier: src
       - join_on_condition:
@@ -156,9 +155,8 @@ file:
         - alias_expression:
             naked_identifier: dst
         - keyword: using
-        - table_expression:
-            table_reference:
-              naked_identifier: source_data
+        - table_reference:
+            naked_identifier: source_data
         - alias_expression:
             naked_identifier: src
         - join_on_condition:
@@ -257,13 +255,12 @@ file:
       - alias_expression:
           naked_identifier: dst
       - keyword: using
-      - table_expression:
-          table_reference:
-          - naked_identifier: LA
-          - dot: .
-          - naked_identifier: tt
-          - dot: .
-          - naked_identifier: dd
+      - table_reference:
+        - naked_identifier: LA
+        - dot: .
+        - naked_identifier: tt
+        - dot: .
+        - naked_identifier: dd
       - alias_expression:
           naked_identifier: src
       - join_on_condition:
@@ -480,18 +477,17 @@ file:
             keyword: AS
           naked_identifier: tgt
       - keyword: USING
-      - table_expression:
-          bracketed:
-            start_bracket: (
-            select_statement:
-              select_clause:
-              - keyword: SELECT
-              - select_clause_element:
-                  parameter: '@UnitMeasureCode'
-              - comma: ','
-              - select_clause_element:
-                  parameter: '@Name'
-            end_bracket: )
+      - bracketed:
+          start_bracket: (
+          select_statement:
+            select_clause:
+            - keyword: SELECT
+            - select_clause_element:
+                parameter: '@UnitMeasureCode'
+            - comma: ','
+            - select_clause_element:
+                parameter: '@Name'
+          end_bracket: )
       - alias_expression:
           alias_operator:
             keyword: as
@@ -600,79 +596,78 @@ file:
             keyword: AS
           naked_identifier: tgt
       - keyword: USING
-      - table_expression:
-          bracketed:
-            start_bracket: (
-            select_statement:
-              select_clause:
-              - keyword: SELECT
-              - select_clause_element:
-                  column_reference:
-                    naked_identifier: ProductID
-              - comma: ','
-              - select_clause_element:
-                  function:
-                    function_name:
-                      function_name_identifier: SUM
-                    function_contents:
-                      bracketed:
-                        start_bracket: (
-                        expression:
-                          column_reference:
-                            naked_identifier: OrderQty
-                        end_bracket: )
-              from_clause:
-                keyword: FROM
-                from_expression:
+      - bracketed:
+          start_bracket: (
+          select_statement:
+            select_clause:
+            - keyword: SELECT
+            - select_clause_element:
+                column_reference:
+                  naked_identifier: ProductID
+            - comma: ','
+            - select_clause_element:
+                function:
+                  function_name:
+                    function_name_identifier: SUM
+                  function_contents:
+                    bracketed:
+                      start_bracket: (
+                      expression:
+                        column_reference:
+                          naked_identifier: OrderQty
+                      end_bracket: )
+            from_clause:
+              keyword: FROM
+              from_expression:
+                from_expression_element:
+                  table_expression:
+                    table_reference:
+                    - naked_identifier: Sales
+                    - dot: .
+                    - naked_identifier: SalesOrderDetail
+                  alias_expression:
+                    alias_operator:
+                      keyword: AS
+                    naked_identifier: sod
+                join_clause:
+                  keyword: JOIN
                   from_expression_element:
                     table_expression:
                       table_reference:
                       - naked_identifier: Sales
                       - dot: .
-                      - naked_identifier: SalesOrderDetail
+                      - naked_identifier: SalesOrderHeader
                     alias_expression:
                       alias_operator:
                         keyword: AS
-                      naked_identifier: sod
-                  join_clause:
-                    keyword: JOIN
-                    from_expression_element:
-                      table_expression:
-                        table_reference:
-                        - naked_identifier: Sales
-                        - dot: .
-                        - naked_identifier: SalesOrderHeader
-                      alias_expression:
-                        alias_operator:
-                          keyword: AS
-                        naked_identifier: soh
-                    join_on_condition:
-                      keyword: 'ON'
-                      expression:
-                      - column_reference:
-                        - naked_identifier: sod
-                        - dot: .
-                        - naked_identifier: SalesOrderID
-                      - comparison_operator:
-                          raw_comparison_operator: '='
-                      - column_reference:
-                        - naked_identifier: soh
-                        - dot: .
-                        - naked_identifier: SalesOrderID
-                      - binary_operator: AND
-                      - column_reference:
-                        - naked_identifier: soh
-                        - dot: .
-                        - naked_identifier: OrderDate
-                      - comparison_operator:
-                          raw_comparison_operator: '='
-                      - parameter: '@OrderDate'
-              groupby_clause:
-              - keyword: GROUP
-              - keyword: BY
-              - column_reference:
-                  naked_identifier: ProductID
-            end_bracket: )
+                      naked_identifier: soh
+                  join_on_condition:
+                    keyword: 'ON'
+                    expression:
+                    - column_reference:
+                      - naked_identifier: sod
+                      - dot: .
+                      - naked_identifier: SalesOrderID
+                    - comparison_operator:
+                        raw_comparison_operator: '='
+                    - column_reference:
+                      - naked_identifier: soh
+                      - dot: .
+                      - naked_identifier: SalesOrderID
+                    - binary_operator: AND
+                    - column_reference:
+                      - naked_identifier: soh
+                      - dot: .
+                      - naked_identifier: OrderDate
+                    - comparison_operator:
+                        raw_comparison_operator: '='
+                    - parameter: '@OrderDate'
+            groupby_clause:
+            - keyword: GROUP
+            - keyword: BY
+            - column_reference:
+                naked_identifier: ProductID
+          end_bracket: )
       - alias_expression:
           alias_operator:
             keyword: as
@@ -806,80 +801,79 @@ file:
             keyword: AS
           naked_identifier: pi
       - keyword: USING
-      - table_expression:
-          bracketed:
-            start_bracket: (
-            select_statement:
-              select_clause:
-              - keyword: SELECT
-              - select_clause_element:
-                  column_reference:
-                    naked_identifier: ProductID
-              - comma: ','
-              - select_clause_element:
-                  function:
-                    function_name:
-                      function_name_identifier: SUM
-                    function_contents:
-                      bracketed:
-                        start_bracket: (
-                        expression:
-                          column_reference:
-                            naked_identifier: OrderQty
-                        end_bracket: )
-              from_clause:
-                keyword: FROM
-                from_expression:
+      - bracketed:
+          start_bracket: (
+          select_statement:
+            select_clause:
+            - keyword: SELECT
+            - select_clause_element:
+                column_reference:
+                  naked_identifier: ProductID
+            - comma: ','
+            - select_clause_element:
+                function:
+                  function_name:
+                    function_name_identifier: SUM
+                  function_contents:
+                    bracketed:
+                      start_bracket: (
+                      expression:
+                        column_reference:
+                          naked_identifier: OrderQty
+                      end_bracket: )
+            from_clause:
+              keyword: FROM
+              from_expression:
+                from_expression_element:
+                  table_expression:
+                    table_reference:
+                    - naked_identifier: Sales
+                    - dot: .
+                    - naked_identifier: SalesOrderDetail
+                  alias_expression:
+                    alias_operator:
+                      keyword: AS
+                    naked_identifier: sod
+                join_clause:
+                  keyword: JOIN
                   from_expression_element:
                     table_expression:
                       table_reference:
                       - naked_identifier: Sales
                       - dot: .
-                      - naked_identifier: SalesOrderDetail
+                      - naked_identifier: SalesOrderHeader
                     alias_expression:
                       alias_operator:
                         keyword: AS
-                      naked_identifier: sod
-                  join_clause:
-                    keyword: JOIN
-                    from_expression_element:
-                      table_expression:
-                        table_reference:
-                        - naked_identifier: Sales
-                        - dot: .
-                        - naked_identifier: SalesOrderHeader
-                      alias_expression:
-                        alias_operator:
-                          keyword: AS
-                        naked_identifier: soh
-                    join_on_condition:
-                      keyword: 'ON'
-                      expression:
-                      - column_reference:
-                        - naked_identifier: sod
-                        - dot: .
-                        - naked_identifier: SalesOrderID
-                      - comparison_operator:
-                          raw_comparison_operator: '='
-                      - column_reference:
-                        - naked_identifier: soh
-                        - dot: .
-                        - naked_identifier: SalesOrderID
-                      - binary_operator: AND
-                      - column_reference:
-                        - naked_identifier: soh
-                        - dot: .
-                        - naked_identifier: OrderDate
-                      - keyword: BETWEEN
-                      - quoted_literal: "'20030701'"
-                      - keyword: AND
-                      - quoted_literal: "'20030731'"
-              groupby_clause:
-              - keyword: GROUP
-              - keyword: BY
-              - column_reference:
-                  naked_identifier: ProductID
-            end_bracket: )
+                      naked_identifier: soh
+                  join_on_condition:
+                    keyword: 'ON'
+                    expression:
+                    - column_reference:
+                      - naked_identifier: sod
+                      - dot: .
+                      - naked_identifier: SalesOrderID
+                    - comparison_operator:
+                        raw_comparison_operator: '='
+                    - column_reference:
+                      - naked_identifier: soh
+                      - dot: .
+                      - naked_identifier: SalesOrderID
+                    - binary_operator: AND
+                    - column_reference:
+                      - naked_identifier: soh
+                      - dot: .
+                      - naked_identifier: OrderDate
+                    - keyword: BETWEEN
+                    - quoted_literal: "'20030701'"
+                    - keyword: AND
+                    - quoted_literal: "'20030731'"
+            groupby_clause:
+            - keyword: GROUP
+            - keyword: BY
+            - column_reference:
+                naked_identifier: ProductID
+          end_bracket: )
       - alias_expression:
           alias_operator:
             keyword: AS
@@ -1034,31 +1028,30 @@ file:
                     - alias_expression:
                         naked_identifier: trg
                     - keyword: using
-                    - table_expression:
-                        bracketed:
-                          start_bracket: (
-                          select_statement:
-                            select_clause:
-                              keyword: select
-                              select_clause_element:
-                                column_reference:
-                                - naked_identifier: gr
-                                - dot: .
-                                - naked_identifier: columnC
-                            from_clause:
-                              keyword: from
-                              from_expression:
-                                from_expression_element:
-                                  table_expression:
-                                    table_reference:
-                                    - naked_identifier: sch2
-                                    - dot: .
-                                    - naked_identifier: table2
-                                  alias_expression:
-                                    alias_operator:
-                                      keyword: as
-                                    naked_identifier: gr
-                          end_bracket: )
+                    - bracketed:
+                        start_bracket: (
+                        select_statement:
+                          select_clause:
+                            keyword: select
+                            select_clause_element:
+                              column_reference:
+                              - naked_identifier: gr
+                              - dot: .
+                              - naked_identifier: columnC
+                          from_clause:
+                            keyword: from
+                            from_expression:
+                              from_expression_element:
+                                table_expression:
+                                  table_reference:
+                                  - naked_identifier: sch2
+                                  - dot: .
+                                  - naked_identifier: table2
+                                alias_expression:
+                                  alias_operator:
+                                    keyword: as
+                                  naked_identifier: gr
+                        end_bracket: )
                     - alias_expression:
                         naked_identifier: src
                     - join_on_condition:
@@ -1125,18 +1118,17 @@ file:
             keyword: AS
           naked_identifier: tgt
       - keyword: USING
-      - table_expression:
-          bracketed:
-            start_bracket: (
-            select_statement:
-              select_clause:
-              - keyword: SELECT
-              - select_clause_element:
-                  parameter: '@UnitMeasureCode'
-              - comma: ','
-              - select_clause_element:
-                  parameter: '@Name'
-            end_bracket: )
+      - bracketed:
+          start_bracket: (
+          select_statement:
+            select_clause:
+            - keyword: SELECT
+            - select_clause_element:
+                parameter: '@UnitMeasureCode'
+            - comma: ','
+            - select_clause_element:
+                parameter: '@Name'
+          end_bracket: )
       - alias_expression:
           alias_operator:
             keyword: as
@@ -1263,80 +1255,79 @@ file:
             keyword: AS
           naked_identifier: pi
       - keyword: USING
-      - table_expression:
-          bracketed:
-            start_bracket: (
-            select_statement:
-              select_clause:
-              - keyword: SELECT
-              - select_clause_element:
-                  column_reference:
-                    naked_identifier: ProductID
-              - comma: ','
-              - select_clause_element:
-                  function:
-                    function_name:
-                      function_name_identifier: SUM
-                    function_contents:
-                      bracketed:
-                        start_bracket: (
-                        expression:
-                          column_reference:
-                            naked_identifier: OrderQty
-                        end_bracket: )
-              from_clause:
-                keyword: FROM
-                from_expression:
+      - bracketed:
+          start_bracket: (
+          select_statement:
+            select_clause:
+            - keyword: SELECT
+            - select_clause_element:
+                column_reference:
+                  naked_identifier: ProductID
+            - comma: ','
+            - select_clause_element:
+                function:
+                  function_name:
+                    function_name_identifier: SUM
+                  function_contents:
+                    bracketed:
+                      start_bracket: (
+                      expression:
+                        column_reference:
+                          naked_identifier: OrderQty
+                      end_bracket: )
+            from_clause:
+              keyword: FROM
+              from_expression:
+                from_expression_element:
+                  table_expression:
+                    table_reference:
+                    - naked_identifier: Sales
+                    - dot: .
+                    - naked_identifier: SalesOrderDetail
+                  alias_expression:
+                    alias_operator:
+                      keyword: AS
+                    naked_identifier: sod
+                join_clause:
+                  keyword: JOIN
                   from_expression_element:
                     table_expression:
                       table_reference:
                       - naked_identifier: Sales
                       - dot: .
-                      - naked_identifier: SalesOrderDetail
+                      - naked_identifier: SalesOrderHeader
                     alias_expression:
                       alias_operator:
                         keyword: AS
-                      naked_identifier: sod
-                  join_clause:
-                    keyword: JOIN
-                    from_expression_element:
-                      table_expression:
-                        table_reference:
-                        - naked_identifier: Sales
-                        - dot: .
-                        - naked_identifier: SalesOrderHeader
-                      alias_expression:
-                        alias_operator:
-                          keyword: AS
-                        naked_identifier: soh
-                    join_on_condition:
-                      keyword: 'ON'
-                      expression:
-                      - column_reference:
-                        - naked_identifier: sod
-                        - dot: .
-                        - naked_identifier: SalesOrderID
-                      - comparison_operator:
-                          raw_comparison_operator: '='
-                      - column_reference:
-                        - naked_identifier: soh
-                        - dot: .
-                        - naked_identifier: SalesOrderID
-                      - binary_operator: AND
-                      - column_reference:
-                        - naked_identifier: soh
-                        - dot: .
-                        - naked_identifier: OrderDate
-                      - keyword: BETWEEN
-                      - quoted_literal: "'20030701'"
-                      - keyword: AND
-                      - quoted_literal: "'20030731'"
-              groupby_clause:
-              - keyword: GROUP
-              - keyword: BY
-              - column_reference:
-                  naked_identifier: ProductID
-            end_bracket: )
+                      naked_identifier: soh
+                  join_on_condition:
+                    keyword: 'ON'
+                    expression:
+                    - column_reference:
+                      - naked_identifier: sod
+                      - dot: .
+                      - naked_identifier: SalesOrderID
+                    - comparison_operator:
+                        raw_comparison_operator: '='
+                    - column_reference:
+                      - naked_identifier: soh
+                      - dot: .
+                      - naked_identifier: SalesOrderID
+                    - binary_operator: AND
+                    - column_reference:
+                      - naked_identifier: soh
+                      - dot: .
+                      - naked_identifier: OrderDate
+                    - keyword: BETWEEN
+                    - quoted_literal: "'20030701'"
+                    - keyword: AND
+                    - quoted_literal: "'20030731'"
+            groupby_clause:
+            - keyword: GROUP
+            - keyword: BY
+            - column_reference:
+                naked_identifier: ProductID
+          end_bracket: )
       - alias_expression:
           alias_operator:
             keyword: AS
@@ -1463,19 +1454,18 @@ file:
         - dot: .
         - naked_identifier: target
       - keyword: USING
-      - table_expression:
-          bracketed:
-            start_bracket: (
-            select_statement:
-              select_clause:
-                keyword: SELECT
-                select_clause_element:
-                  integer_literal: '1'
-                  alias_expression:
-                    alias_operator:
-                      keyword: AS
-                    naked_identifier: i
-            end_bracket: )
+      - bracketed:
+          start_bracket: (
+          select_statement:
+            select_clause:
+              keyword: SELECT
+              select_clause_element:
+                integer_literal: '1'
+                alias_expression:
+                  alias_operator:
+                    keyword: AS
+                  naked_identifier: i
+          end_bracket: )
       - alias_expression:
           alias_operator:
             keyword: AS

--- a/test/fixtures/dialects/tsql/output_clause.yml
+++ b/test/fixtures/dialects/tsql/output_clause.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: f8b2ed0cb4bac89e058a421e58baa8496f76b7c599ee31012b38cb1163fd19e0
+_hash: b8dbbdd31fe1c573ba9e9cafa87c0e23e93505088c2f5551e1a20465a4eb27b6
 file:
 - batch:
     statement:
@@ -546,45 +546,46 @@ file:
             keyword: AS
           naked_identifier: target
       - keyword: USING
-      - bracketed:
-          start_bracket: (
-          select_statement:
-            select_clause:
-            - keyword: SELECT
-            - select_clause_element:
-                column_reference:
+      - table_expression:
+          bracketed:
+            start_bracket: (
+            select_statement:
+              select_clause:
+              - keyword: SELECT
+              - select_clause_element:
+                  column_reference:
+                    naked_identifier: ProductID
+              - comma: ','
+              - select_clause_element:
+                  function:
+                    function_name:
+                      function_name_identifier: SUM
+                    function_contents:
+                      bracketed:
+                        start_bracket: (
+                        expression:
+                          column_reference:
+                            naked_identifier: OrderQty
+                        end_bracket: )
+                  alias_expression:
+                    alias_operator:
+                      keyword: AS
+                    naked_identifier: TotalQty
+              from_clause:
+                keyword: FROM
+                from_expression:
+                  from_expression_element:
+                    table_expression:
+                      table_reference:
+                      - naked_identifier: Sales
+                      - dot: .
+                      - naked_identifier: SalesOrderDetail
+              groupby_clause:
+              - keyword: GROUP
+              - keyword: BY
+              - column_reference:
                   naked_identifier: ProductID
-            - comma: ','
-            - select_clause_element:
-                function:
-                  function_name:
-                    function_name_identifier: SUM
-                  function_contents:
-                    bracketed:
-                      start_bracket: (
-                      expression:
-                        column_reference:
-                          naked_identifier: OrderQty
-                      end_bracket: )
-                alias_expression:
-                  alias_operator:
-                    keyword: AS
-                  naked_identifier: TotalQty
-            from_clause:
-              keyword: FROM
-              from_expression:
-                from_expression_element:
-                  table_expression:
-                    table_reference:
-                    - naked_identifier: Sales
-                    - dot: .
-                    - naked_identifier: SalesOrderDetail
-            groupby_clause:
-            - keyword: GROUP
-            - keyword: BY
-            - column_reference:
-                naked_identifier: ProductID
-          end_bracket: )
+            end_bracket: )
       - alias_expression:
           alias_operator:
             keyword: AS
@@ -674,45 +675,46 @@ file:
             keyword: AS
           naked_identifier: target
       - keyword: USING
-      - bracketed:
-          start_bracket: (
-          select_statement:
-            select_clause:
-            - keyword: SELECT
-            - select_clause_element:
-                column_reference:
+      - table_expression:
+          bracketed:
+            start_bracket: (
+            select_statement:
+              select_clause:
+              - keyword: SELECT
+              - select_clause_element:
+                  column_reference:
+                    naked_identifier: ProductID
+              - comma: ','
+              - select_clause_element:
+                  function:
+                    function_name:
+                      function_name_identifier: SUM
+                    function_contents:
+                      bracketed:
+                        start_bracket: (
+                        expression:
+                          column_reference:
+                            naked_identifier: OrderQty
+                        end_bracket: )
+                  alias_expression:
+                    alias_operator:
+                      keyword: AS
+                    naked_identifier: TotalQty
+              from_clause:
+                keyword: FROM
+                from_expression:
+                  from_expression_element:
+                    table_expression:
+                      table_reference:
+                      - naked_identifier: Sales
+                      - dot: .
+                      - naked_identifier: SalesOrderDetail
+              groupby_clause:
+              - keyword: GROUP
+              - keyword: BY
+              - column_reference:
                   naked_identifier: ProductID
-            - comma: ','
-            - select_clause_element:
-                function:
-                  function_name:
-                    function_name_identifier: SUM
-                  function_contents:
-                    bracketed:
-                      start_bracket: (
-                      expression:
-                        column_reference:
-                          naked_identifier: OrderQty
-                      end_bracket: )
-                alias_expression:
-                  alias_operator:
-                    keyword: AS
-                  naked_identifier: TotalQty
-            from_clause:
-              keyword: FROM
-              from_expression:
-                from_expression_element:
-                  table_expression:
-                    table_reference:
-                    - naked_identifier: Sales
-                    - dot: .
-                    - naked_identifier: SalesOrderDetail
-            groupby_clause:
-            - keyword: GROUP
-            - keyword: BY
-            - column_reference:
-                naked_identifier: ProductID
-          end_bracket: )
+            end_bracket: )
       - alias_expression:
           alias_operator:
             keyword: AS

--- a/test/fixtures/dialects/tsql/output_clause.yml
+++ b/test/fixtures/dialects/tsql/output_clause.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: b8dbbdd31fe1c573ba9e9cafa87c0e23e93505088c2f5551e1a20465a4eb27b6
+_hash: f8b2ed0cb4bac89e058a421e58baa8496f76b7c599ee31012b38cb1163fd19e0
 file:
 - batch:
     statement:
@@ -546,46 +546,45 @@ file:
             keyword: AS
           naked_identifier: target
       - keyword: USING
-      - table_expression:
-          bracketed:
-            start_bracket: (
-            select_statement:
-              select_clause:
-              - keyword: SELECT
-              - select_clause_element:
-                  column_reference:
-                    naked_identifier: ProductID
-              - comma: ','
-              - select_clause_element:
-                  function:
-                    function_name:
-                      function_name_identifier: SUM
-                    function_contents:
-                      bracketed:
-                        start_bracket: (
-                        expression:
-                          column_reference:
-                            naked_identifier: OrderQty
-                        end_bracket: )
-                  alias_expression:
-                    alias_operator:
-                      keyword: AS
-                    naked_identifier: TotalQty
-              from_clause:
-                keyword: FROM
-                from_expression:
-                  from_expression_element:
-                    table_expression:
-                      table_reference:
-                      - naked_identifier: Sales
-                      - dot: .
-                      - naked_identifier: SalesOrderDetail
-              groupby_clause:
-              - keyword: GROUP
-              - keyword: BY
-              - column_reference:
+      - bracketed:
+          start_bracket: (
+          select_statement:
+            select_clause:
+            - keyword: SELECT
+            - select_clause_element:
+                column_reference:
                   naked_identifier: ProductID
-            end_bracket: )
+            - comma: ','
+            - select_clause_element:
+                function:
+                  function_name:
+                    function_name_identifier: SUM
+                  function_contents:
+                    bracketed:
+                      start_bracket: (
+                      expression:
+                        column_reference:
+                          naked_identifier: OrderQty
+                      end_bracket: )
+                alias_expression:
+                  alias_operator:
+                    keyword: AS
+                  naked_identifier: TotalQty
+            from_clause:
+              keyword: FROM
+              from_expression:
+                from_expression_element:
+                  table_expression:
+                    table_reference:
+                    - naked_identifier: Sales
+                    - dot: .
+                    - naked_identifier: SalesOrderDetail
+            groupby_clause:
+            - keyword: GROUP
+            - keyword: BY
+            - column_reference:
+                naked_identifier: ProductID
+          end_bracket: )
       - alias_expression:
           alias_operator:
             keyword: AS
@@ -675,46 +674,45 @@ file:
             keyword: AS
           naked_identifier: target
       - keyword: USING
-      - table_expression:
-          bracketed:
-            start_bracket: (
-            select_statement:
-              select_clause:
-              - keyword: SELECT
-              - select_clause_element:
-                  column_reference:
-                    naked_identifier: ProductID
-              - comma: ','
-              - select_clause_element:
-                  function:
-                    function_name:
-                      function_name_identifier: SUM
-                    function_contents:
-                      bracketed:
-                        start_bracket: (
-                        expression:
-                          column_reference:
-                            naked_identifier: OrderQty
-                        end_bracket: )
-                  alias_expression:
-                    alias_operator:
-                      keyword: AS
-                    naked_identifier: TotalQty
-              from_clause:
-                keyword: FROM
-                from_expression:
-                  from_expression_element:
-                    table_expression:
-                      table_reference:
-                      - naked_identifier: Sales
-                      - dot: .
-                      - naked_identifier: SalesOrderDetail
-              groupby_clause:
-              - keyword: GROUP
-              - keyword: BY
-              - column_reference:
+      - bracketed:
+          start_bracket: (
+          select_statement:
+            select_clause:
+            - keyword: SELECT
+            - select_clause_element:
+                column_reference:
                   naked_identifier: ProductID
-            end_bracket: )
+            - comma: ','
+            - select_clause_element:
+                function:
+                  function_name:
+                    function_name_identifier: SUM
+                  function_contents:
+                    bracketed:
+                      start_bracket: (
+                      expression:
+                        column_reference:
+                          naked_identifier: OrderQty
+                      end_bracket: )
+                alias_expression:
+                  alias_operator:
+                    keyword: AS
+                  naked_identifier: TotalQty
+            from_clause:
+              keyword: FROM
+              from_expression:
+                from_expression_element:
+                  table_expression:
+                    table_reference:
+                    - naked_identifier: Sales
+                    - dot: .
+                    - naked_identifier: SalesOrderDetail
+            groupby_clause:
+            - keyword: GROUP
+            - keyword: BY
+            - column_reference:
+                naked_identifier: ProductID
+          end_bracket: )
       - alias_expression:
           alias_operator:
             keyword: AS


### PR DESCRIPTION
### Brief summary of the change made
fixes #7800 
fixes #7801

Corrects tsql parsing issue with datatype methods in from clause.
Corrects tsql parsing issue with function and other table expressions in using clause of MERGE statement.

### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [X ] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
