### PR TITLE
fix(tsql): allow Unicode letters in @parameter names

### DIFF
--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -210,11 +210,11 @@ tsql_dialect.sets("currency_symbols").update(
 tsql_dialect.insert_lexer_matchers(
     [
         # According to Microsoft spec, subsequent characters in identifiers can include
-        # @, $, #, _ in addition to letters and numbers
+        # @, $, #, _ in addition to letters (Unicode 3.2) and numbers
         # https://learn.microsoft.com/en-us/sql/relational-databases/databases/database-identifiers
         RegexLexer(
             "atsign",
-            r"[@][a-zA-Z0-9_@$#]+",
+            r"[@][a-zA-Z0-9_@$#\p{L}]+",
             CodeSegment,
         ),
         # Note: $ can only appear in subsequent positions of identifiers, not as prefix
@@ -576,7 +576,7 @@ tsql_dialect.replace(
         ],
     ),
     ParameterNameSegment=RegexParser(
-        r"@(?!@)[A-Za-z0-9_@$#]+", CodeSegment, type="parameter"
+        r"@(?!@)[A-Za-z0-9_@$#\p{L}]+", CodeSegment, type="parameter"
     ),
     FunctionParameterGrammar=Sequence(
         Ref("ParameterNameSegment", optional=True),

--- a/test/fixtures/dialects/tsql/unicode_parameter_names.sql
+++ b/test/fixtures/dialects/tsql/unicode_parameter_names.sql
@@ -1,0 +1,32 @@
+-- Per Microsoft's identifier rules, T-SQL identifier (and parameter) names
+-- may contain any Unicode 3.2 letter, not just ASCII A-Z.
+-- https://learn.microsoft.com/en-us/sql/relational-databases/databases/database-identifiers
+
+-- Cyrillic
+DECLARE @Дата DATETIME2 = GETDATE();
+
+-- CJK
+DECLARE @正常 INT = 0;
+
+-- Accented Latin (German umlaut + sharp s)
+DECLARE @Größe NVARCHAR(50);
+
+-- Greek
+DECLARE @Παράμετρος INT;
+
+-- Mixed Unicode + ASCII
+DECLARE @user_Имя NVARCHAR(100);
+
+-- Used in SELECT and as procedure parameters
+SELECT
+    @Дата AS [report_date],
+    @正常 AS [status],
+    @Größe AS [size];
+
+CREATE PROCEDURE dbo.GetByCriteria
+    @Дата DATETIME2,
+    @user NVARCHAR(50)
+AS
+BEGIN
+    SELECT @Дата, @user;
+END;

--- a/test/fixtures/dialects/tsql/unicode_parameter_names.yml
+++ b/test/fixtures/dialects/tsql/unicode_parameter_names.yml
@@ -1,0 +1,133 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: c803dee1172dcccd14abdcfa6e77ff098a91d11536b621fbecaf0156a69f59b8
+file:
+  batch:
+  - statement:
+      declare_segment:
+        keyword: DECLARE
+        parameter: '@Дата'
+        data_type:
+          keyword: DATETIME2
+        comparison_operator:
+          raw_comparison_operator: '='
+        expression:
+          function:
+            function_name:
+              function_name_identifier: GETDATE
+            function_contents:
+              bracketed:
+                start_bracket: (
+                end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      declare_segment:
+        keyword: DECLARE
+        parameter: '@正常'
+        data_type:
+          keyword: INT
+        comparison_operator:
+          raw_comparison_operator: '='
+        expression:
+          integer_literal: '0'
+  - statement_terminator: ;
+  - statement:
+      declare_segment:
+        keyword: DECLARE
+        parameter: '@Größe'
+        data_type:
+          keyword: NVARCHAR
+          bracketed_arguments:
+            bracketed:
+              start_bracket: (
+              expression:
+                integer_literal: '50'
+              end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      declare_segment:
+        keyword: DECLARE
+        parameter: '@Παράμετρος'
+        data_type:
+          keyword: INT
+  - statement_terminator: ;
+  - statement:
+      declare_segment:
+        keyword: DECLARE
+        parameter: '@user_Имя'
+        data_type:
+          keyword: NVARCHAR
+          bracketed_arguments:
+            bracketed:
+              start_bracket: (
+              expression:
+                integer_literal: '100'
+              end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            parameter: '@Дата'
+            alias_expression:
+              alias_operator:
+                keyword: AS
+              quoted_identifier: '[report_date]'
+        - comma: ','
+        - select_clause_element:
+            parameter: '@正常'
+            alias_expression:
+              alias_operator:
+                keyword: AS
+              quoted_identifier: '[status]'
+        - comma: ','
+        - select_clause_element:
+            parameter: '@Größe'
+            alias_expression:
+              alias_operator:
+                keyword: AS
+              quoted_identifier: '[size]'
+  - statement_terminator: ;
+  - statement:
+      create_procedure_statement:
+      - keyword: CREATE
+      - keyword: PROCEDURE
+      - object_reference:
+        - naked_identifier: dbo
+        - dot: .
+        - naked_identifier: GetByCriteria
+      - procedure_parameter_list:
+        - parameter: '@Дата'
+        - data_type:
+            keyword: DATETIME2
+        - comma: ','
+        - parameter: '@user'
+        - data_type:
+            keyword: NVARCHAR
+            bracketed_arguments:
+              bracketed:
+                start_bracket: (
+                expression:
+                  integer_literal: '50'
+                end_bracket: )
+      - keyword: AS
+      - procedure_statement:
+          statement:
+            begin_end_block:
+            - keyword: BEGIN
+            - statement:
+                select_statement:
+                  select_clause:
+                  - keyword: SELECT
+                  - select_clause_element:
+                      parameter: '@Дата'
+                  - comma: ','
+                  - select_clause_element:
+                      parameter: '@user'
+            - statement_terminator: ;
+            - keyword: END
+          statement_terminator: ;


### PR DESCRIPTION
### Brief summary of the change made

Closes #7806.

T-SQL identifiers (and therefore `@parameter` names) [allow any Unicode 3.2 letter](https://learn.microsoft.com/en-us/sql/relational-databases/databases/database-identifiers), but two regexes in the tsql dialect were still ASCII-only:

| Location | Pattern | Used for |
| --- | --- | --- |
| `dialect_tsql.py:217` (`atsign` lexer) | `r"[@][a-zA-Z0-9_@$#]+"` | tokenizing `@variable` |
| `dialect_tsql.py:579` (`ParameterNameSegment` parser) | `r"@(?!@)[A-Za-z0-9_@$#]+"` | matching the parameter token |

When `@Дата` arrived, the `atsign` lexer failed (no ASCII char after `@`), the patched `word` lexer (which already had `\p{L}` since #7262) caught `@Дата` as a generic `word`, and parsing then failed for the entire enclosing batch:

```sql
DECLARE @Дата DATETIME2;
-- Found unparsable section: 'DECLARE @Дата DATETIME2;...'
```

Fix is two characters: add `\p{L}` to both classes. Same idiom is already used elsewhere in this file (line 333 `word` lexer, line 524 `NakedIdentifierSegment`) and in vertica's `ParameterNameSegment` (line 521 — comment there literally says *"need to cover cases where non-ascii word is parameter"*).

Background: PR #7262 added Unicode support for the `word`/`NakedIdentifierSegment` path so unquoted Unicode column/table names work, but didn't carry the change over to the `@parameter` path. This PR finishes that work.

### Test fixture

Added `test/fixtures/dialects/tsql/unicode_parameter_names.sql` (+ auto-generated `.yml`) covering Cyrillic, CJK, German umlaut, Greek, and mixed Unicode+ASCII parameter names in `DECLARE`, `SELECT`, and `CREATE PROCEDURE` contexts. Pre-fix all of these are unparsable; post-fix they round-trip through `parse`/`broad_fix`/`parse_struct`.

### Verification

- `pytest -k tsql` → 510 passed, 0 failed (Windows / Python 3.11.9)
- `pytest -k "tsql and unicode_parameter"` → 3 passed (parse, broad_fix, parse_struct)
- The reporter's exact repro (`DECLARE @Дата DATETIME2`) now produces `parameter: '@Дата'` inside a `declare_segment` instead of an unparsable `word` token

### Out of scope

- The `hash_prefix` lexer (`#temp_table`, `##global_temp`) at line 241 has the same ASCII-only shape but is a different concern — happy to send a follow-up if you'd like it tracked separately.
- The `system_variable` parser (`@@SERVERNAME` at line 378) is intentionally ASCII-only by SQL Server spec.

### Are there any other side effects of this change that we should be aware of?

No. The change strictly broadens what is accepted: every existing ASCII parameter name still matches, and the regex remains anchored at `@` and is still bounded by the same `[A-Za-z0-9_@$#…]+` shape (just with `\p{L}` added to that class).

### Pull Request checklist

- [x] Confirmed checks have run
- [x] Added/updated documentation if relevant — no doc change needed (regex is internal)
- [x] Added/updated tests if relevant — `unicode_parameter_names.{sql,yml}` fixture
- [x] Added new/updated rules pass linting — N/A (no new rules)
- [x] Added a clear one-line description in the [changelog](CHANGELOG.md) — handled by release-drafter PR template

Credit to @msergein for the report and root-cause pointer.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow Unicode 3.2 letters in T‑SQL `@parameter` names by updating lexer and parser regexes. Fixes parsing failures for non-ASCII parameters like `DECLARE @Дата DATETIME2`.

- **Bug Fixes**
  - Added `\p{L}` to `atsign` lexer and `ParameterNameSegment` to accept Unicode letters.
  - Parameters now tokenize as `parameter` and parse correctly in DECLARE, SELECT, and PROCEDURE contexts.
  - Added `unicode_parameter_names` fixture covering Cyrillic, CJK, umlauts, Greek, and mixed names.

<sup>Written for commit 5600d3770c40afc8246d8c77d8a98bed2d9dc7bf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

