### PR TITLE
TSQL: Add CONTAINSTABLE support

### DIFF
--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -6272,6 +6272,7 @@ class TableExpressionSegment(BaseSegment):
         Sequence(Ref("TableReferenceSegment"), Ref("PostTableExpressionGrammar")),
         Ref("BareFunctionSegment"),
         Ref("FunctionSegment"),
+        Ref("ContainstableSegment"),
         Ref("OpenRowSetSegment"),
         Ref("OpenJsonSegment"),
         Ref("OpenXmlSegment"),
@@ -8381,6 +8382,49 @@ class OpenJsonSegment(BaseSegment):
             ),
         ),
         Ref("OpenJsonWithClauseSegment", optional=True),
+    )
+
+
+class ContainstableSegment(BaseSegment):
+    """A `CONTAINSTABLE()` table-valued function.
+
+    https://learn.microsoft.com/en-us/sql/relational-databases/system-functions/containstable-transact-sql
+    """
+
+    type = "containstable_segment"
+
+    _language_term = OneOf(
+        Ref("NumericLiteralSegment"),
+        Ref("HexadecimalLiteralSegment"),
+        Ref("QuotedLiteralSegmentOptWithN"),
+    )
+
+    _column_specification = OneOf(
+        Ref("ColumnReferenceSegment"),
+        Bracketed(Delimited(Ref("ColumnReferenceSegment"))),
+        Ref("StarSegment"),
+    )
+
+    match_grammar = Sequence(
+        "CONTAINSTABLE",
+        Bracketed(
+            Ref("TableReferenceSegment"),
+            Ref("CommaSegment"),
+            _column_specification,
+            Ref("CommaSegment"),
+            Ref("QuotedLiteralSegmentOptWithN"),
+            Sequence(
+                Ref("CommaSegment"),
+                "LANGUAGE",
+                _language_term,
+                optional=True,
+            ),
+            Sequence(
+                Ref("CommaSegment"),
+                Ref("NumericLiteralSegment"),
+                optional=True,
+            ),
+        ),
     )
 
 

--- a/test/fixtures/dialects/tsql/containstable.sql
+++ b/test/fixtures/dialects/tsql/containstable.sql
@@ -1,0 +1,30 @@
+/* T-SQL CONTAINSTABLE examples. */
+
+SELECT *
+FROM CONTAINSTABLE(Flags, FlagColors, 'Green') AS KEY_TBL
+ORDER BY KEY_TBL.RANK DESC;
+
+SELECT FT_TBL.Name,
+       KEY_TBL.RANK
+FROM Production.Product AS FT_TBL
+     INNER JOIN CONTAINSTABLE(
+         Production.Product,
+         (Name, ProductNumber),
+         'ISABOUT (frame WEIGHT (.8), wheel WEIGHT (.4), tire WEIGHT (.2))',
+         LANGUAGE N'English',
+         5
+     ) AS KEY_TBL
+         ON FT_TBL.ProductID = KEY_TBL.[KEY]
+ORDER BY KEY_TBL.RANK DESC;
+
+SELECT FT_TBL.ProductDescriptionID,
+       FT_TBL.Description,
+       KEY_TBL.RANK
+FROM Production.ProductDescription AS FT_TBL
+     INNER JOIN CONTAINSTABLE(
+         Production.ProductDescription,
+         *,
+         '(light NEAR aluminum) OR (lightweight NEAR aluminum)',
+         5
+     ) AS KEY_TBL
+         ON FT_TBL.ProductDescriptionID = KEY_TBL.[KEY];

--- a/test/fixtures/dialects/tsql/containstable.yml
+++ b/test/fixtures/dialects/tsql/containstable.yml
@@ -1,0 +1,204 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: f142f8944ed6dd987eb9ebf6e3813dce9a7ced06c05c349707584592b4f892e5
+file:
+  batch:
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                containstable_segment:
+                  keyword: CONTAINSTABLE
+                  bracketed:
+                  - start_bracket: (
+                  - table_reference:
+                      naked_identifier: Flags
+                  - comma: ','
+                  - column_reference:
+                      naked_identifier: FlagColors
+                  - comma: ','
+                  - quoted_literal: "'Green'"
+                  - end_bracket: )
+              alias_expression:
+                alias_operator:
+                  keyword: AS
+                naked_identifier: KEY_TBL
+        orderby_clause:
+        - keyword: ORDER
+        - keyword: BY
+        - column_reference:
+          - naked_identifier: KEY_TBL
+          - dot: .
+          - naked_identifier: RANK
+        - keyword: DESC
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            column_reference:
+            - naked_identifier: FT_TBL
+            - dot: .
+            - naked_identifier: Name
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+            - naked_identifier: KEY_TBL
+            - dot: .
+            - naked_identifier: RANK
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                - naked_identifier: Production
+                - dot: .
+                - naked_identifier: Product
+              alias_expression:
+                alias_operator:
+                  keyword: AS
+                naked_identifier: FT_TBL
+            join_clause:
+            - keyword: INNER
+            - keyword: JOIN
+            - from_expression_element:
+                table_expression:
+                  containstable_segment:
+                    keyword: CONTAINSTABLE
+                    bracketed:
+                    - start_bracket: (
+                    - table_reference:
+                      - naked_identifier: Production
+                      - dot: .
+                      - naked_identifier: Product
+                    - comma: ','
+                    - bracketed:
+                      - start_bracket: (
+                      - column_reference:
+                          naked_identifier: Name
+                      - comma: ','
+                      - column_reference:
+                          naked_identifier: ProductNumber
+                      - end_bracket: )
+                    - comma: ','
+                    - quoted_literal: "'ISABOUT (frame WEIGHT (.8), wheel WEIGHT (.4),\
+                        \ tire WEIGHT (.2))'"
+                    - comma: ','
+                    - keyword: LANGUAGE
+                    - quoted_literal: "N'English'"
+                    - comma: ','
+                    - numeric_literal: '5'
+                    - end_bracket: )
+                alias_expression:
+                  alias_operator:
+                    keyword: AS
+                  naked_identifier: KEY_TBL
+            - join_on_condition:
+                keyword: 'ON'
+                expression:
+                - column_reference:
+                  - naked_identifier: FT_TBL
+                  - dot: .
+                  - naked_identifier: ProductID
+                - comparison_operator:
+                    raw_comparison_operator: '='
+                - column_reference:
+                    naked_identifier: KEY_TBL
+                    dot: .
+                    quoted_identifier: '[KEY]'
+        orderby_clause:
+        - keyword: ORDER
+        - keyword: BY
+        - column_reference:
+          - naked_identifier: KEY_TBL
+          - dot: .
+          - naked_identifier: RANK
+        - keyword: DESC
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            column_reference:
+            - naked_identifier: FT_TBL
+            - dot: .
+            - naked_identifier: ProductDescriptionID
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+            - naked_identifier: FT_TBL
+            - dot: .
+            - naked_identifier: Description
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+            - naked_identifier: KEY_TBL
+            - dot: .
+            - naked_identifier: RANK
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                - naked_identifier: Production
+                - dot: .
+                - naked_identifier: ProductDescription
+              alias_expression:
+                alias_operator:
+                  keyword: AS
+                naked_identifier: FT_TBL
+            join_clause:
+            - keyword: INNER
+            - keyword: JOIN
+            - from_expression_element:
+                table_expression:
+                  containstable_segment:
+                    keyword: CONTAINSTABLE
+                    bracketed:
+                    - start_bracket: (
+                    - table_reference:
+                      - naked_identifier: Production
+                      - dot: .
+                      - naked_identifier: ProductDescription
+                    - comma: ','
+                    - star: '*'
+                    - comma: ','
+                    - quoted_literal: "'(light NEAR aluminum) OR (lightweight NEAR\
+                        \ aluminum)'"
+                    - comma: ','
+                    - numeric_literal: '5'
+                    - end_bracket: )
+                alias_expression:
+                  alias_operator:
+                    keyword: AS
+                  naked_identifier: KEY_TBL
+            - join_on_condition:
+                keyword: 'ON'
+                expression:
+                - column_reference:
+                  - naked_identifier: FT_TBL
+                  - dot: .
+                  - naked_identifier: ProductDescriptionID
+                - comparison_operator:
+                    raw_comparison_operator: '='
+                - column_reference:
+                    naked_identifier: KEY_TBL
+                    dot: .
+                    quoted_identifier: '[KEY]'
+  - statement_terminator: ;


### PR DESCRIPTION
### Brief summary of the change made

This PR adds parser support for T-SQL CONTAINSTABLE as a table-valued function.

The change:
* adds a dedicated T-SQL grammar segment for CONTAINSTABLE
* allows CONTAINSTABLE anywhere a table expression is valid, including FROM and JOIN clauses
* adds dialect fixtures covering:
  * a single-column search
  * a multi-column search using a column list
  * the wildcard column form
  * optional LANGUAGE
  * optional top_n_by_rank

Fixes #7723 

### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds T‑SQL `CONTAINSTABLE` parsing as a table‑valued function so it can be used anywhere a table expression is valid (e.g., FROM/JOIN). Includes tests for single/multi‑column, wildcard, optional LANGUAGE, and top‑N‑by‑rank forms.

- **New Features**
  - Add `ContainstableSegment` and integrate into `TableExpressionSegment` to enable `CONTAINSTABLE(...)` in FROM and JOIN.
  - Add T‑SQL parse fixtures for the supported forms.

<sup>Written for commit 21b34f77e5da251dec2d1ba83fb2164e47449504. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

