### PR TITLE
Add max_parse_nodes parser limit

### DIFF
--- a/sqlfluffrs/sqlfluffrs.pyi
+++ b/sqlfluffrs/sqlfluffrs.pyi
@@ -194,6 +194,7 @@ class RsParser:
         max_parser_iterations: Optional[int] = None,
         parser_warn_threshold: Optional[int] = None,
         max_parse_depth: int = 0,
+        max_parse_nodes: int = 0,
     ): ...
     def parse_match_result_from_tokens(
         self, tokens: List[RsToken]

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/core.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/core.rs
@@ -103,6 +103,8 @@ pub struct Parser<'a> {
     pub parser_warn_threshold: usize,
     /// Maximum parse depth (frame stack). 0 = no limit. Used for DoS mitigation.
     pub max_parse_depth: usize,
+    /// Maximum parse nodes in the accepted parse tree. 0 = no limit.
+    pub max_parse_nodes: usize,
 }
 
 impl<'a> Parser<'a> {
@@ -162,6 +164,7 @@ impl<'a> Parser<'a> {
             max_parser_iterations: 3_000_000,
             parser_warn_threshold: 2_000_000,
             max_parse_depth,
+            max_parse_nodes: 0,
         }
     }
 
@@ -174,6 +177,59 @@ impl<'a> Parser<'a> {
         self.max_parser_iterations = max_parser_iterations;
         self.parser_warn_threshold = parser_warn_threshold;
         self
+    }
+
+    /// Override the parse tree node limit for this parser (builder pattern).
+    pub fn with_node_limit(mut self, max_parse_nodes: usize) -> Self {
+        self.max_parse_nodes = max_parse_nodes;
+        self
+    }
+
+    fn check_parse_node_limit(
+        &self,
+        match_result: &MatchResult,
+        base_node_count: usize,
+    ) -> Result<(), ParseError> {
+        if self.max_parse_nodes == 0 {
+            return Ok(());
+        }
+
+        let node_count = base_node_count + match_result.node_count();
+        if node_count > self.max_parse_nodes {
+            return Err(ParseError::with_context(
+                format!(
+                    "Maximum parse node count exceeded (limit {}). This may indicate unusually large SQL or a malicious input.",
+                    self.max_parse_nodes
+                ),
+                Some(match_result.start()),
+                None,
+            ));
+        }
+
+        Ok(())
+    }
+
+    pub(crate) fn check_parse_subtree_limit(
+        &self,
+        match_result: &MatchResult,
+    ) -> Result<(), ParseError> {
+        if self.max_parse_nodes == 0 {
+            return Ok(());
+        }
+
+        let node_count = match_result.node_count();
+        if node_count > self.max_parse_nodes {
+            return Err(ParseError::with_context(
+                format!(
+                    "Maximum parse node count exceeded (limit {}). This may indicate unusually large SQL or a malicious input.",
+                    self.max_parse_nodes
+                ),
+                Some(match_result.start()),
+                None,
+            ));
+        }
+
+        Ok(())
     }
 
     /// Enable or disable the parse cache (for debugging)
@@ -214,7 +270,13 @@ impl<'a> Parser<'a> {
         let result = self.parse_table_iterative_match_result(grammar_id, &[]);
         self.tokens = token_slice_orig;
 
-        result
+        match result {
+            Ok(match_result) => {
+                self.check_parse_node_limit(&match_result, token_slice.len())?;
+                Ok(match_result)
+            }
+            Err(err) => Err(err),
+        }
     }
 
     pub fn root_parse(&mut self) -> Result<Node, ParseError> {
@@ -248,6 +310,7 @@ impl<'a> Parser<'a> {
                 insert_segments: vec![],
                 child_matches: vec![],
             };
+            self.check_parse_node_limit(&file_mr, self.tokens.len())?;
             let nodes = file_mr.apply(self.tokens);
             return Ok(nodes.into_iter().next().unwrap_or_default());
         }
@@ -319,6 +382,7 @@ impl<'a> Parser<'a> {
             insert_segments: vec![],
             child_matches: vec![content_child],
         };
+        self.check_parse_node_limit(&file_mr, token_slice_orig.len())?;
         let root_nodes = file_mr.apply(token_slice_orig);
         Ok(root_nodes.into_iter().next().unwrap_or_default())
     }

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/match_result.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/match_result.rs
@@ -311,6 +311,19 @@ impl MatchResult {
         self.child_matches.iter().any(|c| c.contains_unparsable())
     }
 
+    /// Count the number of materialized nodes implied by this match tree.
+    pub fn node_count(&self) -> usize {
+        let class_count = usize::from(self.matched_class.is_some());
+        let insert_count = self.insert_segments.len();
+        class_count
+            + insert_count
+            + self
+                .child_matches
+                .iter()
+                .map(|child| child.node_count())
+                .sum::<usize>()
+    }
+
     /// Combine another sequential match onto this one.
     ///
     /// If either match is empty, returns the other.

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/python.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/python.rs
@@ -551,11 +551,11 @@ impl PyParser {
             self.indent_config.clone(),
             self.max_parse_depth,
         )
-        .with_parser_limits(self.max_parser_iterations, self.parser_warn_threshold);
+        .with_parser_limits(self.max_parser_iterations, self.parser_warn_threshold)
+        .with_node_limit(self.max_parse_nodes);
 
         // Parse and get the MatchResult directly
         let match_result = parser.call_rule_as_root().map_err(parse_error_to_pyerr)?;
-        self.check_parse_node_limit(&match_result, rust_tokens.len())?;
 
         Ok(PyMatchResult(match_result))
     }
@@ -592,13 +592,13 @@ impl PyParser {
             self.indent_config.clone(),
             self.max_parse_depth,
         )
-        .with_parser_limits(self.max_parser_iterations, self.parser_warn_threshold);
+        .with_parser_limits(self.max_parser_iterations, self.parser_warn_threshold)
+        .with_node_limit(self.max_parse_nodes);
 
         // Parse and get the MatchResult directly
         let match_result = parser
             .call_rule_as_root()
             .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.message))?;
-        self.check_parse_node_limit(&match_result, rust_tokens.len())?;
 
         // Collect statistics
         let (cache_hits, cache_misses, _) = parser.table_cache.stats();
@@ -652,14 +652,14 @@ impl PyParser {
             self.indent_config.clone(),
             self.max_parse_depth,
         )
-        .with_parser_limits(self.max_parser_iterations, self.parser_warn_threshold);
+        .with_parser_limits(self.max_parser_iterations, self.parser_warn_threshold)
+        .with_node_limit(self.max_parse_nodes);
 
         // Track grammar calls using cache misses as a proxy
         // Each unique (grammar_id, pos) pair in the cache represents one grammar call
         let match_result = parser
             .call_rule_as_root()
             .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.message))?;
-        self.check_parse_node_limit(&match_result, rust_tokens.len())?;
 
         // Count calls per grammar by iterating cache entries
         let mut grammar_counts = HashMap::new();
@@ -678,32 +678,6 @@ impl PyParser {
         }
 
         Ok((PyMatchResult(match_result), grammar_counts))
-    }
-}
-
-impl PyParser {
-    fn check_parse_node_limit(
-        &self,
-        match_result: &MatchResult,
-        token_count: usize,
-    ) -> PyResult<()> {
-        if self.max_parse_nodes == 0 {
-            return Ok(());
-        }
-
-        let node_count = token_count + match_result.node_count();
-        if node_count > self.max_parse_nodes {
-            return Err(parse_error_to_pyerr(ParseError::with_context(
-                format!(
-                    "Maximum parse node count exceeded (limit {}). This may indicate unusually large SQL or a malicious input.",
-                    self.max_parse_nodes
-                ),
-                Some(match_result.start()),
-                None,
-            )));
-        }
-
-        Ok(())
     }
 }
 

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/python.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/python.rs
@@ -481,18 +481,20 @@ pub struct PyParser {
     max_parser_iterations: usize,
     parser_warn_threshold: usize,
     max_parse_depth: usize,
+    max_parse_nodes: usize,
 }
 
 #[pymethods]
 impl PyParser {
     #[new]
-    #[pyo3(signature = (dialect=None, indent_config=None, max_parser_iterations=None, parser_warn_threshold=None, max_parse_depth=0))]
+    #[pyo3(signature = (dialect=None, indent_config=None, max_parser_iterations=None, parser_warn_threshold=None, max_parse_depth=0, max_parse_nodes=0))]
     pub fn new(
         dialect: Option<&str>,
         indent_config: Option<HashMap<String, bool>>,
         max_parser_iterations: Option<usize>,
         parser_warn_threshold: Option<usize>,
         max_parse_depth: usize,
+        max_parse_nodes: usize,
     ) -> PyResult<Self> {
         let dialect = dialect
             .and_then(|d| Dialect::from_str(d).ok())
@@ -518,6 +520,7 @@ impl PyParser {
             max_parser_iterations: max_parser_iterations.unwrap_or(3_000_000),
             parser_warn_threshold: parser_warn_threshold.unwrap_or(2_000_000),
             max_parse_depth,
+            max_parse_nodes,
         })
     }
 
@@ -552,6 +555,7 @@ impl PyParser {
 
         // Parse and get the MatchResult directly
         let match_result = parser.call_rule_as_root().map_err(parse_error_to_pyerr)?;
+        self.check_parse_node_limit(&match_result, rust_tokens.len())?;
 
         Ok(PyMatchResult(match_result))
     }
@@ -594,6 +598,7 @@ impl PyParser {
         let match_result = parser
             .call_rule_as_root()
             .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.message))?;
+        self.check_parse_node_limit(&match_result, rust_tokens.len())?;
 
         // Collect statistics
         let (cache_hits, cache_misses, _) = parser.table_cache.stats();
@@ -654,6 +659,7 @@ impl PyParser {
         let match_result = parser
             .call_rule_as_root()
             .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.message))?;
+        self.check_parse_node_limit(&match_result, rust_tokens.len())?;
 
         // Count calls per grammar by iterating cache entries
         let mut grammar_counts = HashMap::new();
@@ -672,6 +678,32 @@ impl PyParser {
         }
 
         Ok((PyMatchResult(match_result), grammar_counts))
+    }
+}
+
+impl PyParser {
+    fn check_parse_node_limit(
+        &self,
+        match_result: &MatchResult,
+        token_count: usize,
+    ) -> PyResult<()> {
+        if self.max_parse_nodes == 0 {
+            return Ok(());
+        }
+
+        let node_count = token_count + match_result.node_count();
+        if node_count > self.max_parse_nodes {
+            return Err(parse_error_to_pyerr(ParseError::with_context(
+                format!(
+                    "Maximum parse node count exceeded (limit {}). This may indicate unusually large SQL or a malicious input.",
+                    self.max_parse_nodes
+                ),
+                Some(match_result.start()),
+                None,
+            )));
+        }
+
+        Ok(())
     }
 }
 

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/iterative.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/iterative.rs
@@ -206,7 +206,7 @@ impl Parser<'_> {
                     // The main loop then stores the result in stack.results for parent frames to access.
                     // This separation keeps handlers focused on producing results, while the main
                     // loop coordinates result storage.
-                    self.commit_table_frame_result(&mut stack, &frame, match_result);
+                    self.commit_table_frame_result(&mut stack, &frame, match_result)?;
                 }
             }
         }
@@ -372,6 +372,7 @@ impl Parser<'_> {
                 let res = self.handle_string_parser_table_driven(grammar_id);
                 match res {
                     Ok(match_result) => {
+                        self.check_parse_subtree_limit(&match_result)?;
                         // Insert result directly so parent frames can pick it up
                         vdebug!(
                             "[SYNC INSERT] frame_id={} StringParser result at pos {} -> match={:?}",
@@ -390,6 +391,7 @@ impl Parser<'_> {
                 let res = self.handle_multi_string_parser_table_driven(grammar_id);
                 match res {
                     Ok(match_result) => {
+                        self.check_parse_subtree_limit(&match_result)?;
                         vdebug!(
                             "[SYNC INSERT] frame_id={} MultiStringParser result at pos {}",
                             frame.frame_id,
@@ -405,6 +407,7 @@ impl Parser<'_> {
                 let res = self.handle_regex_parser_table_driven(grammar_id);
                 match res {
                     Ok(match_result) => {
+                        self.check_parse_subtree_limit(&match_result)?;
                         vdebug!(
                             "[SYNC INSERT] frame_id={} RegexParser result at pos {} -> match={:?}",
                             frame.frame_id,
@@ -421,6 +424,7 @@ impl Parser<'_> {
                 let res = self.handle_nothing_table_driven();
                 match res {
                     Ok(match_result) => {
+                        self.check_parse_subtree_limit(&match_result)?;
                         vdebug!(
                             "[SYNC INSERT] frame_id={} Nothing result at pos {} -> MatchResult",
                             frame.frame_id,
@@ -436,6 +440,7 @@ impl Parser<'_> {
                 let res = self.handle_empty_table_driven();
                 match res {
                     Ok(match_result) => {
+                        self.check_parse_subtree_limit(&match_result)?;
                         vdebug!(
                             "[SYNC INSERT] frame_id={} Empty result at pos {} -> MatchResult",
                             frame.frame_id,
@@ -451,6 +456,7 @@ impl Parser<'_> {
                 let res = self.handle_missing_table_driven();
                 match res {
                     Ok(match_result) => {
+                        self.check_parse_subtree_limit(&match_result)?;
                         vdebug!(
                             "[SYNC INSERT] frame_id={} Missing result at pos {} -> MatchResult",
                             frame.frame_id,
@@ -466,6 +472,7 @@ impl Parser<'_> {
                 let res = self.handle_token_table_driven(grammar_id);
                 match res {
                     Ok(match_result) => {
+                        self.check_parse_subtree_limit(&match_result)?;
                         vdebug!(
                             "[SYNC INSERT] frame_id={} Token result at pos {} -> MatchResult",
                             frame.frame_id,
@@ -481,6 +488,7 @@ impl Parser<'_> {
                 let res = self.handle_preceded_by_table_driven(grammar_id);
                 match res {
                     Ok(match_result) => {
+                        self.check_parse_subtree_limit(&match_result)?;
                         vdebug!(
                             "[SYNC INSERT] frame_id={} PrecededBy result at pos {} -> MatchResult",
                             frame.frame_id,
@@ -505,6 +513,7 @@ impl Parser<'_> {
                 );
                 match res {
                     Ok(match_result) => {
+                        self.check_parse_subtree_limit(&match_result)?;
                         vdebug!(
                             "[SYNC INSERT] frame_id={} Meta result at pos {} -> MatchResult",
                             frame.frame_id,
@@ -520,6 +529,7 @@ impl Parser<'_> {
                 let res = self.handle_noncode_matcher_table_driven();
                 match res {
                     Ok(match_result) => {
+                        self.check_parse_subtree_limit(&match_result)?;
                         vdebug!(
                             "[SYNC INSERT] frame_id={} NonCodeMatcher result at pos {} -> MatchResult",
                             frame.frame_id,
@@ -539,6 +549,7 @@ impl Parser<'_> {
                 );
                 match res {
                     Ok(match_result) => {
+                        self.check_parse_subtree_limit(&match_result)?;
                         vdebug!(
                             "[SYNC INSERT] frame_id={} Anything result at pos {} -> MatchResult",
                             frame.frame_id,
@@ -813,7 +824,9 @@ impl Parser<'_> {
         stack: &mut TableParseFrameStack,
         frame: &TableParseFrame,
         match_result: &Arc<MatchResult>,
-    ) {
+    ) -> Result<(), ParseError> {
+        self.check_parse_subtree_limit(match_result)?;
+
         // Log grammar path - different indicator for Empty vs matched nodes
         #[cfg(feature = "verbose-debug")]
         let end_pos = frame.end_pos.unwrap_or(self.pos);
@@ -896,7 +909,7 @@ impl Parser<'_> {
                             Ok(idx) => idx,
                             Err(_) => {
                                 // If max_idx calculation fails, skip caching
-                                return;
+                                return Ok(());
                             }
                         }
                     };
@@ -908,6 +921,8 @@ impl Parser<'_> {
                 }
             }
         }
+
+        Ok(())
     }
 
     /// Checks the cache for a frame and handles cache hits. Returns FrameResult indicating what to do next.

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/iterative.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/iterative.rs
@@ -10,6 +10,22 @@ use crate::parser::{
 };
 
 impl Parser<'_> {
+    fn store_sync_match_result(
+        &self,
+        stack: &mut TableParseFrameStack,
+        frame: &TableParseFrame,
+        match_result: MatchResult,
+    ) -> Result<TableFrameResult, ParseError> {
+        self.check_parse_subtree_limit(&match_result)?;
+        vdebug!(
+            "[SYNC INSERT] frame_id={} result at pos {} -> MatchResult",
+            frame.frame_id,
+            self.pos
+        );
+        stack.insert_result(frame.frame_id, match_result, self.pos);
+        Ok(TableFrameResult::Done)
+    }
+
     // ========================================================================
     // Main Iterative Parser
     // ========================================================================
@@ -371,18 +387,7 @@ impl Parser<'_> {
                 // Synchronous match: call the table-driven string parser and store result for parent
                 let res = self.handle_string_parser_table_driven(grammar_id);
                 match res {
-                    Ok(match_result) => {
-                        self.check_parse_subtree_limit(&match_result)?;
-                        // Insert result directly so parent frames can pick it up
-                        vdebug!(
-                            "[SYNC INSERT] frame_id={} StringParser result at pos {} -> match={:?}",
-                            frame.frame_id,
-                            self.pos,
-                            match_result
-                        );
-                        stack.insert_result(frame.frame_id, match_result, self.pos);
-                        Ok(TableFrameResult::Done)
-                    }
+                    Ok(match_result) => self.store_sync_match_result(stack, &frame, match_result),
                     Err(e) => Err(e),
                 }
             }
@@ -390,113 +395,49 @@ impl Parser<'_> {
             GrammarVariant::MultiStringParser => {
                 let res = self.handle_multi_string_parser_table_driven(grammar_id);
                 match res {
-                    Ok(match_result) => {
-                        self.check_parse_subtree_limit(&match_result)?;
-                        vdebug!(
-                            "[SYNC INSERT] frame_id={} MultiStringParser result at pos {}",
-                            frame.frame_id,
-                            self.pos
-                        );
-                        stack.insert_result(frame.frame_id, match_result, self.pos);
-                        Ok(TableFrameResult::Done)
-                    }
+                    Ok(match_result) => self.store_sync_match_result(stack, &frame, match_result),
                     Err(e) => Err(e),
                 }
             }
             GrammarVariant::RegexParser => {
                 let res = self.handle_regex_parser_table_driven(grammar_id);
                 match res {
-                    Ok(match_result) => {
-                        self.check_parse_subtree_limit(&match_result)?;
-                        vdebug!(
-                            "[SYNC INSERT] frame_id={} RegexParser result at pos {} -> match={:?}",
-                            frame.frame_id,
-                            self.pos,
-                            match_result
-                        );
-                        stack.insert_result(frame.frame_id, match_result, self.pos);
-                        Ok(TableFrameResult::Done)
-                    }
+                    Ok(match_result) => self.store_sync_match_result(stack, &frame, match_result),
                     Err(e) => Err(e),
                 }
             }
             GrammarVariant::Nothing => {
                 let res = self.handle_nothing_table_driven();
                 match res {
-                    Ok(match_result) => {
-                        self.check_parse_subtree_limit(&match_result)?;
-                        vdebug!(
-                            "[SYNC INSERT] frame_id={} Nothing result at pos {} -> MatchResult",
-                            frame.frame_id,
-                            self.pos
-                        );
-                        stack.insert_result(frame.frame_id, match_result, self.pos);
-                        Ok(TableFrameResult::Done)
-                    }
+                    Ok(match_result) => self.store_sync_match_result(stack, &frame, match_result),
                     Err(e) => Err(e),
                 }
             }
             GrammarVariant::Empty => {
                 let res = self.handle_empty_table_driven();
                 match res {
-                    Ok(match_result) => {
-                        self.check_parse_subtree_limit(&match_result)?;
-                        vdebug!(
-                            "[SYNC INSERT] frame_id={} Empty result at pos {} -> MatchResult",
-                            frame.frame_id,
-                            self.pos
-                        );
-                        stack.insert_result(frame.frame_id, match_result, self.pos);
-                        Ok(TableFrameResult::Done)
-                    }
+                    Ok(match_result) => self.store_sync_match_result(stack, &frame, match_result),
                     Err(e) => Err(e),
                 }
             }
             GrammarVariant::Missing => {
                 let res = self.handle_missing_table_driven();
                 match res {
-                    Ok(match_result) => {
-                        self.check_parse_subtree_limit(&match_result)?;
-                        vdebug!(
-                            "[SYNC INSERT] frame_id={} Missing result at pos {} -> MatchResult",
-                            frame.frame_id,
-                            self.pos
-                        );
-                        stack.insert_result(frame.frame_id, match_result, self.pos);
-                        Ok(TableFrameResult::Done)
-                    }
+                    Ok(match_result) => self.store_sync_match_result(stack, &frame, match_result),
                     Err(e) => Err(e),
                 }
             }
             GrammarVariant::Token => {
                 let res = self.handle_token_table_driven(grammar_id);
                 match res {
-                    Ok(match_result) => {
-                        self.check_parse_subtree_limit(&match_result)?;
-                        vdebug!(
-                            "[SYNC INSERT] frame_id={} Token result at pos {} -> MatchResult",
-                            frame.frame_id,
-                            self.pos
-                        );
-                        stack.insert_result(frame.frame_id, match_result, self.pos);
-                        Ok(TableFrameResult::Done)
-                    }
+                    Ok(match_result) => self.store_sync_match_result(stack, &frame, match_result),
                     Err(e) => Err(e),
                 }
             }
             GrammarVariant::PrecededBy => {
                 let res = self.handle_preceded_by_table_driven(grammar_id);
                 match res {
-                    Ok(match_result) => {
-                        self.check_parse_subtree_limit(&match_result)?;
-                        vdebug!(
-                            "[SYNC INSERT] frame_id={} PrecededBy result at pos {} -> MatchResult",
-                            frame.frame_id,
-                            self.pos
-                        );
-                        stack.insert_result(frame.frame_id, match_result, self.pos);
-                        Ok(TableFrameResult::Done)
-                    }
+                    Ok(match_result) => self.store_sync_match_result(stack, &frame, match_result),
                     Err(e) => Err(e),
                 }
             }
@@ -512,32 +453,14 @@ impl Parser<'_> {
 
                 );
                 match res {
-                    Ok(match_result) => {
-                        self.check_parse_subtree_limit(&match_result)?;
-                        vdebug!(
-                            "[SYNC INSERT] frame_id={} Meta result at pos {} -> MatchResult",
-                            frame.frame_id,
-                            self.pos
-                        );
-                        stack.insert_result(frame.frame_id, match_result, self.pos);
-                        Ok(TableFrameResult::Done)
-                    }
+                    Ok(match_result) => self.store_sync_match_result(stack, &frame, match_result),
                     Err(e) => Err(e),
                 }
             }
             GrammarVariant::NonCodeMatcher => {
                 let res = self.handle_noncode_matcher_table_driven();
                 match res {
-                    Ok(match_result) => {
-                        self.check_parse_subtree_limit(&match_result)?;
-                        vdebug!(
-                            "[SYNC INSERT] frame_id={} NonCodeMatcher result at pos {} -> MatchResult",
-                            frame.frame_id,
-                            self.pos
-                        );
-                        stack.insert_result(frame.frame_id, match_result, self.pos);
-                        Ok(TableFrameResult::Done)
-                    }
+                    Ok(match_result) => self.store_sync_match_result(stack, &frame, match_result),
                     Err(e) => Err(e),
                 }
             }
@@ -548,16 +471,7 @@ impl Parser<'_> {
                     frame.parent_max_idx,
                 );
                 match res {
-                    Ok(match_result) => {
-                        self.check_parse_subtree_limit(&match_result)?;
-                        vdebug!(
-                            "[SYNC INSERT] frame_id={} Anything result at pos {} -> MatchResult",
-                            frame.frame_id,
-                            self.pos
-                        );
-                        stack.insert_result(frame.frame_id, match_result, self.pos);
-                        Ok(TableFrameResult::Done)
-                    }
+                    Ok(match_result) => self.store_sync_match_result(stack, &frame, match_result),
                     Err(e) => Err(e),
                 }
             }

--- a/src/sqlfluff/core/config/validate.py
+++ b/src/sqlfluff/core/config/validate.py
@@ -151,6 +151,44 @@ def _validate_max_parse_depth_config(
         )
 
 
+def _validate_max_parse_nodes_config(
+    config: ConfigMappingType, logging_reference: str
+) -> None:
+    """Validate and normalize the max_parse_nodes config value.
+
+    The parser convention is that ``0`` disables the limit. We also normalize
+    missing/None values to ``0`` so parser code can rely on an integer.
+    """
+    core_section = config.get("core", {})
+    if not core_section:
+        return None
+
+    assert isinstance(core_section, dict)
+    if "max_parse_nodes" not in core_section:
+        return None
+
+    max_parse_nodes = core_section.get("max_parse_nodes")
+    if max_parse_nodes is None or max_parse_nodes == "":
+        core_section["max_parse_nodes"] = 0
+        return None
+
+    if isinstance(max_parse_nodes, bool) or not isinstance(max_parse_nodes, int):
+        raise SQLFluffUserError(
+            f"Config file {logging_reference!r} set an invalid value for "
+            f"`max_parse_nodes`: {max_parse_nodes!r}. "
+            "This value must be an integer. Use 0 or an empty value to "
+            "disable the limit."
+        )
+
+    if max_parse_nodes < 0:
+        raise SQLFluffUserError(
+            f"Config file {logging_reference!r} set an invalid value for "
+            f"`max_parse_nodes`: {max_parse_nodes!r}. "
+            "This value must be 0 or a positive integer. Use 0 to disable "
+            "the limit."
+        )
+
+
 def validate_config_dict(config: ConfigMappingType, logging_reference: str) -> None:
     """Validate a config dict.
 
@@ -172,3 +210,5 @@ def validate_config_dict(config: ConfigMappingType, logging_reference: str) -> N
     _validate_indentation_config(config, logging_reference)
     # Validate max parse depth config
     _validate_max_parse_depth_config(config, logging_reference)
+    # Validate max parse nodes config
+    _validate_max_parse_nodes_config(config, logging_reference)

--- a/src/sqlfluff/core/default_config.cfg
+++ b/src/sqlfluff/core/default_config.cfg
@@ -3,6 +3,8 @@
 recursion_limit = None
 # Maximum parse depth (grammar + bracket nesting). Prevents DoS from deeply nested SQL. Set to 0 or empty to disable. Default 255 (Oracle WHERE subquery limit).
 max_parse_depth = 255
+# Maximum parse nodes in the final parse tree. Prevents DoS from unusually wide or expansive SQL. Set to 0 or empty to disable. Default is intentionally high to avoid normal queries.
+max_parse_nodes = 100000
 # verbose is an integer (0-2) indicating the level of log output
 verbose = 0
 # Turn off color formatting of output

--- a/src/sqlfluff/core/linter/fix.py
+++ b/src/sqlfluff/core/linter/fix.py
@@ -110,6 +110,7 @@ def apply_fixes(
     rule_code: str,
     fixes: dict[int, AnchorEditInfo],
     max_parse_depth: int,
+    max_parse_nodes: int = 0,
     fix_even_unparsable: bool = False,
 ) -> tuple["BaseSegment", list["BaseSegment"], list["BaseSegment"], bool]:
     """Apply a dictionary of fixes to this segment.
@@ -255,6 +256,7 @@ def apply_fixes(
             rule_code,
             fixes,
             max_parse_depth=max_parse_depth,
+            max_parse_nodes=max_parse_nodes,
         )
         # 'before' and 'after' will usually be empty. Only used when
         # lower-level fixes left 'seg' with non-code (usually
@@ -332,6 +334,7 @@ def apply_fixes(
             validated = new_seg.validate_segment_with_reparse(
                 dialect,
                 max_parse_depth=max_parse_depth,
+                max_parse_nodes=max_parse_nodes,
             )
     else:
         validated = not requires_validate

--- a/src/sqlfluff/core/linter/linter.py
+++ b/src/sqlfluff/core/linter/linter.py
@@ -580,6 +580,7 @@ class Linter:
                                 anchor_info,
                                 fix_even_unparsable=config.get("fix_even_unparsable"),
                                 max_parse_depth=config.get("max_parse_depth"),
+                                max_parse_nodes=config.get("max_parse_nodes"),
                             )
 
                             # Check for infinite loops. We use a combination of the

--- a/src/sqlfluff/core/linter/linter.py
+++ b/src/sqlfluff/core/linter/linter.py
@@ -230,6 +230,20 @@ class Linter:
         fname: Optional[str] = None,
         parse_statistics: bool = False,
     ) -> tuple[Optional[BaseSegment], list[SQLParseError]]:
+        max_parse_nodes = config.get("max_parse_nodes")
+        assert isinstance(max_parse_nodes, int)
+        if max_parse_nodes > 0 and len(tokens) > max_parse_nodes:
+            anchor = next((seg for seg in tokens if seg.is_code), None)
+            err = SQLParseError(
+                description=(
+                    f"Maximum parse node count exceeded (limit {max_parse_nodes}). "
+                    "This may indicate unusually large SQL or a malicious input."
+                ),
+                segment=anchor,
+            )
+            linter_logger.info("PARSING SKIPPED! : %s", err)
+            return None, [err]
+
         # Use Rust parser if configured (experimental)
         use_rust = config.get_section(["core", "use_rust_parser"])
 

--- a/src/sqlfluff/core/parser/context.py
+++ b/src/sqlfluff/core/parser/context.py
@@ -56,6 +56,7 @@ class ParseContext:
         self,
         dialect: "Dialect",
         max_parse_depth: int,
+        max_parse_nodes: int = 0,
         indentation_config: Optional[dict[str, Any]] = None,
     ) -> None:
         """Initialize a new instance of the class.
@@ -63,6 +64,8 @@ class ParseContext:
         Args:
             dialect (Dialect): The dialect used for parsing.
             max_parse_depth (int): Maximum match depth; ``0`` to disable.
+            max_parse_nodes (int): Maximum number of parse tree nodes; ``0`` to
+                disable.
             indentation_config (Optional[dict[str, Any]], optional): The indentation
                 configuration used by Indent and Dedent to control the intended
                 indentation of certain features. Defaults to None.
@@ -73,6 +76,8 @@ class ParseContext:
         # used in the Conditional grammar.
         self.indentation_config = indentation_config or {}
         self.max_parse_depth = max_parse_depth
+        self.max_parse_nodes = max_parse_nodes
+        self.current_parse_nodes = 0
         # This is the logger that child objects will latch onto.
         self.logger = parser_logger
         # A uuid for this parse context to enable cache invalidation
@@ -129,12 +134,36 @@ class ParseContext:
                 "True or False: {!r}".format(indentation_config)
             )
         max_parse_depth = config.get("max_parse_depth")
+        max_parse_nodes = config.get("max_parse_nodes")
         assert isinstance(max_parse_depth, int)
+        assert isinstance(max_parse_nodes, int)
         return cls(
             dialect=config.get("dialect_obj"),
             indentation_config=indentation_config,
             max_parse_depth=max_parse_depth,
+            max_parse_nodes=max_parse_nodes,
         )
+
+    def increment_parse_nodes(self, count: int = 1) -> None:
+        """Increment the number of materialized parse nodes.
+
+        Args:
+            count (int): Number of nodes to add to the current budget.
+        """
+        assert count >= 0
+        self.current_parse_nodes += count
+        if (
+            self.max_parse_nodes > 0
+            and self.current_parse_nodes > self.max_parse_nodes
+        ):
+            raise SQLParseError(
+                f"Maximum parse node count exceeded (limit {self.max_parse_nodes}). "
+                "This may indicate unusually large SQL or a malicious input."
+            )
+
+    def seed_parse_nodes(self, count: int) -> None:
+        """Seed the current node budget from an existing segment count."""
+        self.increment_parse_nodes(count)
 
     def _set_terminators(
         self,

--- a/src/sqlfluff/core/parser/context.py
+++ b/src/sqlfluff/core/parser/context.py
@@ -152,10 +152,7 @@ class ParseContext:
         """
         assert count >= 0
         self.current_parse_nodes += count
-        if (
-            self.max_parse_nodes > 0
-            and self.current_parse_nodes > self.max_parse_nodes
-        ):
+        if self.max_parse_nodes > 0 and self.current_parse_nodes > self.max_parse_nodes:
             raise SQLParseError(
                 f"Maximum parse node count exceeded (limit {self.max_parse_nodes}). "
                 "This may indicate unusually large SQL or a malicious input."

--- a/src/sqlfluff/core/parser/match_result.py
+++ b/src/sqlfluff/core/parser/match_result.py
@@ -12,6 +12,7 @@ from sqlfluff.core.helpers.slice import slice_length
 from sqlfluff.core.parser.markers import PositionMarker
 
 if TYPE_CHECKING:  # pragma: no cover
+    from sqlfluff.core.parser.context import ParseContext
     from sqlfluff.core.parser.segments import BaseSegment, MetaSegment
 
 
@@ -190,7 +191,11 @@ class MatchResult:
             child_matches=child_matches,
         )
 
-    def apply(self, segments: tuple["BaseSegment", ...]) -> tuple["BaseSegment", ...]:
+    def apply(
+        self,
+        segments: tuple["BaseSegment", ...],
+        parse_context: Optional["ParseContext"] = None,
+    ) -> tuple["BaseSegment", ...]:
         """Actually this match to segments to instantiate.
 
         This turns a theoretical match into a nested structure of segments.
@@ -220,6 +225,8 @@ class MatchResult:
                         f"slice {self.matched_slice}"
                     )
                     _pos = _get_point_pos_at_idx(segments, idx)
+                    if parse_context:
+                        parse_context.increment_parse_nodes()
                     result_segments += (seg(pos_marker=_pos),)
             return result_segments
 
@@ -257,7 +264,9 @@ class MatchResult:
             for trigger in trigger_locs[idx]:
                 # If it's a match, apply it.
                 if isinstance(trigger, MatchResult):
-                    result_segments += trigger.apply(segments=segments)
+                    result_segments += trigger.apply(
+                        segments=segments, parse_context=parse_context
+                    )
                     # Update the end slice.
                     max_idx = trigger.matched_slice.stop
                     continue
@@ -279,4 +288,6 @@ class MatchResult:
         new_seg: "BaseSegment" = self.matched_class.from_result_segments(
             result_segments, self.segment_kwargs
         )
+        if parse_context:
+            parse_context.increment_parse_nodes()
         return (new_seg,)

--- a/src/sqlfluff/core/parser/parser.py
+++ b/src/sqlfluff/core/parser/parser.py
@@ -44,6 +44,7 @@ class Parser:
         # context of a context manager. That's because it's the initial
         # instantiation.
         ctx = ParseContext.from_config(config=self.config)
+        ctx.seed_parse_nodes(len(segments))
         # Kick off parsing with the root segment. The BaseFileSegment has
         # a unique entry point to facilitate exactly this. All other segments
         # will use the standard .match() route.

--- a/src/sqlfluff/core/parser/rust_parser.py
+++ b/src/sqlfluff/core/parser/rust_parser.py
@@ -160,7 +160,9 @@ try:
                 # Extract the original RsToken objects from the RawSegments
                 # PYTHON PARITY: Only parse the code portion (segments[_start_idx:_end_idx])
                 # Just like Python's match(segments[:_end_idx], _start_idx, ...)
-                tokens = self._extract_tokens_from_segments(segments[_start_idx:_end_idx])
+                tokens = self._extract_tokens_from_segments(
+                    segments[_start_idx:_end_idx]
+                )
 
                 # Parse using Rust parser to get MatchResult
                 # The Rust parser may raise RsParseError for certain parse errors (e.g.,
@@ -266,7 +268,9 @@ try:
                     result._rs_node = None
 
                 if parse_statistics:  # pragma: no cover
-                    print("Warning: parse_statistics not yet implemented for Rust parser")
+                    print(
+                        "Warning: parse_statistics not yet implemented for Rust parser"
+                    )
 
                 return result
             except SQLParseError as err:

--- a/src/sqlfluff/core/parser/rust_parser.py
+++ b/src/sqlfluff/core/parser/rust_parser.py
@@ -133,140 +133,154 @@ try:
                 we need to extract the original RsToken objects to pass to the Rust
                 parser directly.
             """
-            if not segments:  # pragma: no cover
-                return None
-
-            parse_context = ParseContext.from_config(config=self.config)
-            parse_context.seed_parse_nodes(len(segments))
-
-            # PYTHON PARITY: Trim non-code from start (like root_parse)
-            _start_idx = 0
-            for _start_idx in range(len(segments)):
-                if segments[_start_idx].is_code:
-                    break
-
-            # PYTHON PARITY: Trim non-code from end (like root_parse)
-            _end_idx = len(segments)
-            for _end_idx in range(len(segments), _start_idx - 1, -1):
-                if segments[_end_idx - 1].is_code:
-                    break
-
-            if _start_idx == _end_idx:
-                # No code segments - return FileSegment with just non-code
-                parse_context.increment_parse_nodes()
-                return self.RootSegment(segments=segments, fname=fname)
-
-            # Extract the original RsToken objects from the RawSegments
-            # PYTHON PARITY: Only parse the code portion (segments[_start_idx:_end_idx])
-            # Just like Python's match(segments[:_end_idx], _start_idx, ...)
-            tokens = self._extract_tokens_from_segments(segments[_start_idx:_end_idx])
-
-            # Parse using Rust parser to get MatchResult
-            # The Rust parser may raise RsParseError for certain parse errors (e.g.,
-            # missing closing brackets in terminators). We catch these and convert to
-            # SQLParseError. Regular parse errors are embedded in the MatchResult.
             try:
-                rs_match = self._rs_parser.parse_match_result_from_tokens(tokens)
-            except RsParseError as e:
-                # Convert Rust parse error to SQLParseError with position info
-                raise SQLParseError.from_rs_parse_error(
-                    e, segments[_start_idx:_end_idx]
-                ) from e
+                if not segments:  # pragma: no cover
+                    return None
 
-            # Convert RsMatchResult to Python MatchResult
-            # This also checks for embedded parse errors and raises them
-            match = self._convert_rs_match_result(
-                rs_match, segments[_start_idx:_end_idx]
-            )
-            parser_logger.info("Root Match:\n%s", match.stringify())
+                parse_context = ParseContext.from_config(config=self.config)
+                parse_context.seed_parse_nodes(len(segments))
 
-            # Apply the match result to construct the BaseSegment tree
-            # PYTHON PARITY: Pass only the code portion (segments[_start_idx:_end_idx])
-            # because match result indices are relative to this trimmed array
-            _matched = match.apply(
-                segments[_start_idx:_end_idx], parse_context=parse_context
-            )
-
-            # PYTHON PARITY: Add back any unmatched segments after the match
-            # (relative to the _start_idx:_end_idx range)
-            matched_stop = _start_idx + match.matched_slice.stop
-            _unmatched = segments[matched_stop:_end_idx]
-
-            # PYTHON PARITY: If there are unmatched code segments, wrap them in
-            # UnparsableSegment. This matches the logic in FileSegment.root_parse()
-            content: tuple[BaseSegment, ...]
-            if not match:
-                parse_context.increment_parse_nodes()
-                content = (
-                    UnparsableSegment(
-                        segments[_start_idx:_end_idx],
-                        expected=str(self.RootSegment.match_grammar),
-                    ),
-                )
-            elif _unmatched:
-                _idx = 0
-                for idx, seg in enumerate(_unmatched):
-                    if seg.is_code:
-                        _idx = idx
+                # PYTHON PARITY: Trim non-code from start (like root_parse)
+                _start_idx = 0
+                for _start_idx in range(len(segments)):
+                    if segments[_start_idx].is_code:
                         break
-                else:  # pragma: no cover
-                    _idx = len(_unmatched)
-                parse_context.increment_parse_nodes()
-                content = (
-                    _matched
-                    + _unmatched[:_idx]
-                    + (
+
+                # PYTHON PARITY: Trim non-code from end (like root_parse)
+                _end_idx = len(segments)
+                for _end_idx in range(len(segments), _start_idx - 1, -1):
+                    if segments[_end_idx - 1].is_code:
+                        break
+
+                if _start_idx == _end_idx:
+                    # No code segments - return FileSegment with just non-code
+                    parse_context.increment_parse_nodes()
+                    return self.RootSegment(segments=segments, fname=fname)
+
+                # Extract the original RsToken objects from the RawSegments
+                # PYTHON PARITY: Only parse the code portion (segments[_start_idx:_end_idx])
+                # Just like Python's match(segments[:_end_idx], _start_idx, ...)
+                tokens = self._extract_tokens_from_segments(segments[_start_idx:_end_idx])
+
+                # Parse using Rust parser to get MatchResult
+                # The Rust parser may raise RsParseError for certain parse errors (e.g.,
+                # missing closing brackets in terminators). We catch these and convert to
+                # SQLParseError. Regular parse errors are embedded in the MatchResult.
+                try:
+                    rs_match = self._rs_parser.parse_match_result_from_tokens(tokens)
+                except RsParseError as e:
+                    # Convert Rust parse error to SQLParseError with position info
+                    raise SQLParseError.from_rs_parse_error(
+                        e, segments[_start_idx:_end_idx]
+                    ) from e
+
+                # Convert RsMatchResult to Python MatchResult
+                # This also checks for embedded parse errors and raises them
+                match = self._convert_rs_match_result(
+                    rs_match, segments[_start_idx:_end_idx]
+                )
+                parser_logger.info("Root Match:\n%s", match.stringify())
+
+                # Apply the match result to construct the BaseSegment tree
+                # PYTHON PARITY: Pass only the code portion (segments[_start_idx:_end_idx])
+                # because match result indices are relative to this trimmed array
+                _matched = match.apply(
+                    segments[_start_idx:_end_idx], parse_context=parse_context
+                )
+
+                # PYTHON PARITY: Add back any unmatched segments after the match
+                # (relative to the _start_idx:_end_idx range)
+                matched_stop = _start_idx + match.matched_slice.stop
+                _unmatched = segments[matched_stop:_end_idx]
+
+                # PYTHON PARITY: If there are unmatched code segments, wrap them in
+                # UnparsableSegment. This matches the logic in FileSegment.root_parse()
+                content: tuple[BaseSegment, ...]
+                if not match:
+                    parse_context.increment_parse_nodes()
+                    content = (
                         UnparsableSegment(
-                            _unmatched[_idx:], expected="Nothing else in FileSegment."
+                            segments[_start_idx:_end_idx],
+                            expected=str(self.RootSegment.match_grammar),
                         ),
                     )
-                )
-            else:
-                content = _matched + _unmatched
+                elif _unmatched:
+                    _idx = 0
+                    for idx, seg in enumerate(_unmatched):
+                        if seg.is_code:
+                            _idx = idx
+                            break
+                    else:  # pragma: no cover
+                        _idx = len(_unmatched)
+                    parse_context.increment_parse_nodes()
+                    content = (
+                        _matched
+                        + _unmatched[:_idx]
+                        + (
+                            UnparsableSegment(
+                                _unmatched[_idx:],
+                                expected="Nothing else in FileSegment.",
+                            ),
+                        )
+                    )
+                else:
+                    content = _matched + _unmatched
 
-            parse_context.increment_parse_nodes()
-            result = self.RootSegment(
-                segments[:_start_idx] + content + segments[_end_idx:], fname=fname
-            )
+                parse_context.increment_parse_nodes()
+                result = self.RootSegment(
+                    segments[:_start_idx] + content + segments[_end_idx:], fname=fname
+                )
 
-            # Build the Rust Node tree (RsNode) from the MatchResult.
-            # This is used by Rust-side linting rules (e.g., LT01 respace)
-            # to avoid expensive round-tripping through Python's segment tree.
-            try:
-                # Extract leading non-code tokens (segments before _start_idx:
-                # whitespace/newlines at the start of the file) so the Rust node's
-                # flat raw list matches Python's raw_segments ordering exactly.
-                leading_tokens = (
-                    self._extract_tokens_from_segments(segments[:_start_idx])
-                    if _start_idx
-                    else []
-                )
-                # Extract trailing non-code tokens (segments after _end_idx: newline,
-                # end_of_file, etc.) and include them in the Rust node so that the
-                # reflow/respace rules can correctly detect EOF and trailing newlines.
-                trailing_tokens = (
-                    self._extract_tokens_from_segments(segments[_end_idx:])
-                    if _end_idx < len(segments)
-                    else []
-                )
-                result._rs_node = rs_match.apply_as_node(
-                    tokens,
-                    leading=leading_tokens,
-                    trailing=trailing_tokens,
-                )
-            except Exception:  # pragma: no cover
-                # Non-critical: if node building fails, rules fall back to Python
-                parser_logger.warning(
-                    f"Unable to apply match result in parse tree for {fname}, falling"
-                    " back to Python. Please report this as a bug with the SQL that"
-                    " caused it."
-                )
-                result._rs_node = None
+                # Build the Rust Node tree (RsNode) from the MatchResult.
+                # This is used by Rust-side linting rules (e.g., LT01 respace)
+                # to avoid expensive round-tripping through Python's segment tree.
+                try:
+                    # Extract leading non-code tokens (segments before _start_idx:
+                    # whitespace/newlines at the start of the file) so the Rust node's
+                    # flat raw list matches Python's raw_segments ordering exactly.
+                    leading_tokens = (
+                        self._extract_tokens_from_segments(segments[:_start_idx])
+                        if _start_idx
+                        else []
+                    )
+                    # Extract trailing non-code tokens (segments after _end_idx: newline,
+                    # end_of_file, etc.) and include them in the Rust node so that the
+                    # reflow/respace rules can correctly detect EOF and trailing newlines.
+                    trailing_tokens = (
+                        self._extract_tokens_from_segments(segments[_end_idx:])
+                        if _end_idx < len(segments)
+                        else []
+                    )
+                    result._rs_node = rs_match.apply_as_node(
+                        tokens,
+                        leading=leading_tokens,
+                        trailing=trailing_tokens,
+                    )
+                except Exception:  # pragma: no cover
+                    # Non-critical: if node building fails, rules fall back to Python
+                    parser_logger.warning(
+                        f"Unable to apply match result in parse tree for {fname}, falling"
+                        " back to Python. Please report this as a bug with the SQL that"
+                        " caused it."
+                    )
+                    result._rs_node = None
 
-            if parse_statistics:  # pragma: no cover
-                print("Warning: parse_statistics not yet implemented for Rust parser")
+                if parse_statistics:  # pragma: no cover
+                    print("Warning: parse_statistics not yet implemented for Rust parser")
 
-            return result
+                return result
+            except SQLParseError as err:
+                if err.segment is None:
+                    anchor = next((seg for seg in segments if seg.is_code), None)
+                    if anchor is not None:
+                        err = SQLParseError(
+                            description=err.description,
+                            segment=anchor,
+                            ignore=err.ignore,
+                            fatal=err.fatal,
+                            warning=err.warning,
+                        )
+                raise err
 
         @functools.lru_cache(maxsize=128)
         def _get_segment_class_by_name(

--- a/src/sqlfluff/core/parser/rust_parser.py
+++ b/src/sqlfluff/core/parser/rust_parser.py
@@ -16,6 +16,7 @@ from typing import TYPE_CHECKING, Any, Optional
 
 from sqlfluff.core.config import FluffConfig
 from sqlfluff.core.errors import SQLParseError
+from sqlfluff.core.parser.context import ParseContext
 from sqlfluff.core.parser.match_result import MatchResult
 from sqlfluff.core.parser.segments import (
     BaseFileSegment,
@@ -88,8 +89,11 @@ try:
 
             # Max parse depth (DoS mitigation); 0 disables the limit
             max_parse_depth = self.config.get("max_parse_depth")
+            max_parse_nodes = self.config.get("max_parse_nodes")
             assert isinstance(max_parse_depth, int)
+            assert isinstance(max_parse_nodes, int)
             assert max_parse_depth >= 0
+            assert max_parse_nodes >= 0
 
             # Create the Rust parser
             self._rs_parser = RsParser(
@@ -100,6 +104,7 @@ try:
                 parser_warn_threshold=self.config.get("rust_parser_warn_threshold")
                 or None,
                 max_parse_depth=max_parse_depth,
+                max_parse_nodes=max_parse_nodes,
             )
 
         def parse(
@@ -131,6 +136,9 @@ try:
             if not segments:  # pragma: no cover
                 return None
 
+            parse_context = ParseContext.from_config(config=self.config)
+            parse_context.seed_parse_nodes(len(segments))
+
             # PYTHON PARITY: Trim non-code from start (like root_parse)
             _start_idx = 0
             for _start_idx in range(len(segments)):
@@ -145,6 +153,7 @@ try:
 
             if _start_idx == _end_idx:
                 # No code segments - return FileSegment with just non-code
+                parse_context.increment_parse_nodes()
                 return self.RootSegment(segments=segments, fname=fname)
 
             # Extract the original RsToken objects from the RawSegments
@@ -174,7 +183,9 @@ try:
             # Apply the match result to construct the BaseSegment tree
             # PYTHON PARITY: Pass only the code portion (segments[_start_idx:_end_idx])
             # because match result indices are relative to this trimmed array
-            _matched = match.apply(segments[_start_idx:_end_idx])
+            _matched = match.apply(
+                segments[_start_idx:_end_idx], parse_context=parse_context
+            )
 
             # PYTHON PARITY: Add back any unmatched segments after the match
             # (relative to the _start_idx:_end_idx range)
@@ -185,6 +196,7 @@ try:
             # UnparsableSegment. This matches the logic in FileSegment.root_parse()
             content: tuple[BaseSegment, ...]
             if not match:
+                parse_context.increment_parse_nodes()
                 content = (
                     UnparsableSegment(
                         segments[_start_idx:_end_idx],
@@ -199,6 +211,7 @@ try:
                         break
                 else:  # pragma: no cover
                     _idx = len(_unmatched)
+                parse_context.increment_parse_nodes()
                 content = (
                     _matched
                     + _unmatched[:_idx]
@@ -211,6 +224,7 @@ try:
             else:
                 content = _matched + _unmatched
 
+            parse_context.increment_parse_nodes()
             result = self.RootSegment(
                 segments[:_start_idx] + content + segments[_end_idx:], fname=fname
             )

--- a/src/sqlfluff/core/parser/segments/base.py
+++ b/src/sqlfluff/core/parser/segments/base.py
@@ -1251,9 +1251,14 @@ class BaseSegment(metaclass=SegmentMetaclass):
         self,
         dialect: Dialect,
         max_parse_depth: int,
+        max_parse_nodes: int = 0,
     ) -> bool:
         """Checks correctness of new segment by re-parsing it."""
-        ctx = ParseContext(dialect=dialect, max_parse_depth=max_parse_depth)
+        ctx = ParseContext(
+            dialect=dialect,
+            max_parse_depth=max_parse_depth,
+            max_parse_nodes=max_parse_nodes,
+        )
         # We're going to check the rematch without any metas because the
         # matching routines will assume they haven't already been added.
         # We also strip any non-code from the ends which might have moved.
@@ -1262,17 +1267,18 @@ class BaseSegment(metaclass=SegmentMetaclass):
         if not trimmed_content and self.can_start_end_non_code:
             # Edge case for empty segments which are allowed to be empty.
             return True
+        ctx.seed_parse_nodes(len(trimmed_content))
         rematch = self.match(trimmed_content, 0, ctx)
         if not rematch.matched_slice == slice(0, len(trimmed_content)):
             linter_logger.debug(
                 f"Validation Check Fail for {self}.Incomplete Match. "
-                f"\nMatched: {rematch.apply(trimmed_content)}. "
+                f"\nMatched: {rematch.apply(trimmed_content, parse_context=ctx)}. "
                 f"\nUnmatched: {trimmed_content[rematch.matched_slice.stop :]}."
             )
             return False
         opening_unparsables = set(self.recursive_crawl("unparsable"))
         closing_unparsables: set[BaseSegment] = set()
-        new_segments = rematch.apply(trimmed_content)
+        new_segments = rematch.apply(trimmed_content, parse_context=ctx)
         for seg in new_segments:
             closing_unparsables.update(seg.recursive_crawl("unparsable"))
         # Check we don't introduce any _additional_ unparsables.

--- a/src/sqlfluff/core/parser/segments/file.py
+++ b/src/sqlfluff/core/parser/segments/file.py
@@ -68,6 +68,7 @@ class BaseFileSegment(BaseSegment):
 
         if _start_idx == _end_idx:
             # Return just a file of non-code segments.
+            parse_context.increment_parse_nodes()
             return cls(segments, fname=fname)
 
         # Match the middle
@@ -88,11 +89,12 @@ class BaseFileSegment(BaseSegment):
             )
 
         parse_context.logger.info("Root Match:\n%s", match.stringify())
-        _matched = match.apply(segments)
+        _matched = match.apply(segments, parse_context=parse_context)
         _unmatched = segments[match.matched_slice.stop : _end_idx]
 
         content: tuple[BaseSegment, ...]
         if not match:
+            parse_context.increment_parse_nodes()
             content = (
                 UnparsableSegment(
                     segments[_start_idx:_end_idx], expected=str(cls.match_grammar)
@@ -103,6 +105,7 @@ class BaseFileSegment(BaseSegment):
             for _idx in range(len(_unmatched)):
                 if _unmatched[_idx].is_code:
                     break
+            parse_context.increment_parse_nodes()
             content = (
                 _matched
                 + _unmatched[:_idx]
@@ -115,6 +118,7 @@ class BaseFileSegment(BaseSegment):
         else:
             content = _matched + _unmatched
 
+        parse_context.increment_parse_nodes()
         return cls(
             segments[:_start_idx] + content + segments[_end_idx:],
             fname=fname,

--- a/test/core/config/validate_test.py
+++ b/test/core/config/validate_test.py
@@ -10,6 +10,7 @@ from sqlfluff.core.config.validate import (
     _validate_indentation_config,
     _validate_layout_config,
     _validate_max_parse_depth_config,
+    _validate_max_parse_nodes_config,
 )
 from sqlfluff.core.errors import SQLFluffUserError
 from sqlfluff.core.helpers.dict import (
@@ -183,4 +184,43 @@ def test__validate_max_parse_depth_invalid(config_dict, config_warning):
     """Test invalid max_parse_depth values are rejected."""
     with pytest.raises(SQLFluffUserError) as excinfo:
         _validate_max_parse_depth_config(config_dict, "<test>")
+    assert config_warning in str(excinfo.value)
+
+
+@pytest.mark.parametrize(
+    "config_dict,expected",
+    [
+        ({"core": {"max_parse_nodes": None}}, 0),
+        ({"core": {"max_parse_nodes": ""}}, 0),
+        ({"core": {"max_parse_nodes": 0}}, 0),
+        ({"core": {"max_parse_nodes": 2500}}, 2500),
+    ],
+)
+def test__validate_max_parse_nodes_valid(config_dict, expected):
+    """Test valid and normalized max_parse_nodes values."""
+    _validate_max_parse_nodes_config(config_dict, "<test>")
+    assert config_dict["core"]["max_parse_nodes"] == expected
+
+
+@pytest.mark.parametrize(
+    "config_dict,config_warning",
+    [
+        (
+            {"core": {"max_parse_nodes": "invalid"}},
+            "set an invalid value for `max_parse_nodes`: 'invalid'",
+        ),
+        (
+            {"core": {"max_parse_nodes": True}},
+            "set an invalid value for `max_parse_nodes`: True",
+        ),
+        (
+            {"core": {"max_parse_nodes": -1}},
+            "set an invalid value for `max_parse_nodes`: -1",
+        ),
+    ],
+)
+def test__validate_max_parse_nodes_invalid(config_dict, config_warning):
+    """Test invalid max_parse_nodes values are rejected."""
+    with pytest.raises(SQLFluffUserError) as excinfo:
+        _validate_max_parse_nodes_config(config_dict, "<test>")
     assert config_warning in str(excinfo.value)

--- a/test/core/parser/max_parse_depth_test.py
+++ b/test/core/parser/max_parse_depth_test.py
@@ -13,6 +13,7 @@ MAX_DEPTH_LIMIT = 100
 NESTING_OVER_LIMIT = 120
 
 MESSAGE_PREFIX = "Maximum parse depth exceeded"
+NODE_MESSAGE_PREFIX = "Maximum parse node count exceeded"
 
 
 def _linter_with_depth_limit(limit: int):
@@ -97,3 +98,46 @@ def test_parse_context_max_parse_depth_zero_disables_limit():
     config = FluffConfig(overrides={"dialect": "ansi", "max_parse_depth": 0})
     ctx = ParseContext.from_config(config)
     assert ctx.max_parse_depth == 0
+
+
+def test_parse_context_reads_max_parse_nodes_from_config():
+    """ParseContext.from_config should load the configured node limit."""
+    from sqlfluff.core.parser.context import ParseContext
+
+    config = FluffConfig(overrides={"dialect": "ansi", "max_parse_nodes": 1234})
+    ctx = ParseContext.from_config(config)
+    assert ctx.max_parse_nodes == 1234
+
+
+def test_parse_context_max_parse_nodes_zero_disables_limit():
+    """ParseContext.from_config with max_parse_nodes=0 disables the node limit."""
+    from sqlfluff.core.parser.context import ParseContext
+
+    config = FluffConfig(overrides={"dialect": "ansi", "max_parse_nodes": 0})
+    ctx = ParseContext.from_config(config)
+    ctx.seed_parse_nodes(1000)
+    ctx.increment_parse_nodes(1000)
+    assert ctx.current_parse_nodes == 2000
+
+
+def test_parse_context_seed_parse_nodes_raises_on_limit():
+    """Seeding the node budget should enforce the configured limit."""
+    from sqlfluff.core.parser.context import ParseContext
+
+    ctx = ParseContext(dialect=None, max_parse_depth=0, max_parse_nodes=3)
+    with pytest.raises(SQLParseError) as exc_info:
+        ctx.seed_parse_nodes(4)
+    assert NODE_MESSAGE_PREFIX in exc_info.value.desc()
+    assert "3" in exc_info.value.desc()
+
+
+def test_parse_context_increment_parse_nodes_raises_on_limit():
+    """Incrementing parse nodes should enforce the configured limit."""
+    from sqlfluff.core.parser.context import ParseContext
+
+    ctx = ParseContext(dialect=None, max_parse_depth=0, max_parse_nodes=3)
+    ctx.seed_parse_nodes(2)
+    with pytest.raises(SQLParseError) as exc_info:
+        ctx.increment_parse_nodes(2)
+    assert NODE_MESSAGE_PREFIX in exc_info.value.desc()
+    assert "3" in exc_info.value.desc()

--- a/test/core/parser/max_parse_depth_test.py
+++ b/test/core/parser/max_parse_depth_test.py
@@ -13,7 +13,6 @@ MAX_DEPTH_LIMIT = 100
 NESTING_OVER_LIMIT = 120
 
 MESSAGE_PREFIX = "Maximum parse depth exceeded"
-NODE_MESSAGE_PREFIX = "Maximum parse node count exceeded"
 
 
 def _linter_with_depth_limit(limit: int):
@@ -98,46 +97,3 @@ def test_parse_context_max_parse_depth_zero_disables_limit():
     config = FluffConfig(overrides={"dialect": "ansi", "max_parse_depth": 0})
     ctx = ParseContext.from_config(config)
     assert ctx.max_parse_depth == 0
-
-
-def test_parse_context_reads_max_parse_nodes_from_config():
-    """ParseContext.from_config should load the configured node limit."""
-    from sqlfluff.core.parser.context import ParseContext
-
-    config = FluffConfig(overrides={"dialect": "ansi", "max_parse_nodes": 1234})
-    ctx = ParseContext.from_config(config)
-    assert ctx.max_parse_nodes == 1234
-
-
-def test_parse_context_max_parse_nodes_zero_disables_limit():
-    """ParseContext.from_config with max_parse_nodes=0 disables the node limit."""
-    from sqlfluff.core.parser.context import ParseContext
-
-    config = FluffConfig(overrides={"dialect": "ansi", "max_parse_nodes": 0})
-    ctx = ParseContext.from_config(config)
-    ctx.seed_parse_nodes(1000)
-    ctx.increment_parse_nodes(1000)
-    assert ctx.current_parse_nodes == 2000
-
-
-def test_parse_context_seed_parse_nodes_raises_on_limit():
-    """Seeding the node budget should enforce the configured limit."""
-    from sqlfluff.core.parser.context import ParseContext
-
-    ctx = ParseContext(dialect=None, max_parse_depth=0, max_parse_nodes=3)
-    with pytest.raises(SQLParseError) as exc_info:
-        ctx.seed_parse_nodes(4)
-    assert NODE_MESSAGE_PREFIX in exc_info.value.desc()
-    assert "3" in exc_info.value.desc()
-
-
-def test_parse_context_increment_parse_nodes_raises_on_limit():
-    """Incrementing parse nodes should enforce the configured limit."""
-    from sqlfluff.core.parser.context import ParseContext
-
-    ctx = ParseContext(dialect=None, max_parse_depth=0, max_parse_nodes=3)
-    ctx.seed_parse_nodes(2)
-    with pytest.raises(SQLParseError) as exc_info:
-        ctx.increment_parse_nodes(2)
-    assert NODE_MESSAGE_PREFIX in exc_info.value.desc()
-    assert "3" in exc_info.value.desc()

--- a/test/core/parser/max_parse_nodes_test.py
+++ b/test/core/parser/max_parse_nodes_test.py
@@ -1,7 +1,8 @@
 """Tests for max_parse_nodes limit (DoS mitigation)."""
 
-import pytest
 from unittest.mock import patch
+
+import pytest
 
 from sqlfluff.core import FluffConfig
 from sqlfluff.core.errors import SQLParseError
@@ -24,6 +25,19 @@ def _linter_with_node_limit(limit: int):
     )
 
 
+def _wide_select_sql() -> str:
+    expr = "x" + "=x" * 6
+    return "SELECT " + ",".join(expr for _ in range(80))
+
+
+def _assert_node_limit_error(err: SQLParseError, limit: int) -> None:
+    assert MESSAGE_PREFIX in err.desc()
+    assert str(limit) in err.desc()
+    assert err.segment is not None
+    assert err.line_no > 0
+    assert err.line_pos > 0
+
+
 def test_max_parse_nodes_default_allows_simple_sql():
     """Simple SQL should parse with the shipped default node limit."""
     linter = _linter_with_node_limit(100000)
@@ -40,18 +54,13 @@ def test_default_max_parse_nodes_matches_config_default():
 def test_max_parse_nodes_exceeded_wide_select_python_parser():
     """A wide select should exceed the configured node budget."""
     linter = _linter_with_node_limit(MAX_NODE_LIMIT)
-    expr = "x" + "=x" * 6
-    sql = "SELECT " + ",".join(expr for _ in range(80))
+    sql = _wide_select_sql()
 
     parsed = linter.parse_string(sql)
     assert parsed.violations
     err = parsed.violations[0]
     assert isinstance(err, SQLParseError)
-    assert MESSAGE_PREFIX in err.desc()
-    assert str(MAX_NODE_LIMIT) in err.desc()
-    assert err.segment is not None
-    assert err.line_no > 0
-    assert err.line_pos > 0
+    _assert_node_limit_error(err, MAX_NODE_LIMIT)
 
 
 def test_max_parse_nodes_rust_parser_exceeds_limit():
@@ -69,17 +78,12 @@ def test_max_parse_nodes_rust_parser_exceeds_limit():
     config = FluffConfig(overrides={"dialect": "ansi", "max_parse_nodes": 300})
     parser = RustParser(config=config)
     lexer = Lexer(config=config)
-    expr = "x" + "=x" * 6
-    sql = "SELECT " + ",".join(expr for _ in range(80))
+    sql = _wide_select_sql()
     segments, _ = lexer.lex(sql)
 
     with pytest.raises(SQLParseError) as exc_info:
         parser.parse(segments, fname="test.sql")
-    assert MESSAGE_PREFIX in exc_info.value.desc()
-    assert "300" in exc_info.value.desc()
-    assert exc_info.value.segment is not None
-    assert exc_info.value.line_no > 0
-    assert exc_info.value.line_pos > 0
+    _assert_node_limit_error(exc_info.value, 300)
 
 
 def test_validate_segment_with_reparse_respects_max_parse_nodes():
@@ -97,57 +101,80 @@ def test_validate_segment_with_reparse_respects_max_parse_nodes():
     assert MESSAGE_PREFIX in exc_info.value.desc()
 
 
-def test_max_parse_nodes_token_gate_skips_python_parser():
+def test_parse_context_reads_max_parse_nodes_from_config():
+    """ParseContext.from_config should load the configured node limit."""
+    from sqlfluff.core.parser.context import ParseContext
+
+    config = FluffConfig(overrides={"dialect": "ansi", "max_parse_nodes": 1234})
+    ctx = ParseContext.from_config(config)
+    assert ctx.max_parse_nodes == 1234
+
+
+def test_parse_context_max_parse_nodes_zero_disables_limit():
+    """ParseContext.from_config with max_parse_nodes=0 disables the node limit."""
+    from sqlfluff.core.parser.context import ParseContext
+
+    config = FluffConfig(overrides={"dialect": "ansi", "max_parse_nodes": 0})
+    ctx = ParseContext.from_config(config)
+    ctx.seed_parse_nodes(1000)
+    ctx.increment_parse_nodes(1000)
+    assert ctx.current_parse_nodes == 2000
+
+
+def test_parse_context_seed_parse_nodes_raises_on_limit():
+    """Seeding the node budget should enforce the configured limit."""
+    from sqlfluff.core.parser.context import ParseContext
+
+    ctx = ParseContext(dialect=None, max_parse_depth=0, max_parse_nodes=3)
+    with pytest.raises(SQLParseError) as exc_info:
+        ctx.seed_parse_nodes(4)
+    assert MESSAGE_PREFIX in exc_info.value.desc()
+    assert "3" in exc_info.value.desc()
+
+
+def test_parse_context_increment_parse_nodes_raises_on_limit():
+    """Incrementing parse nodes should enforce the configured limit."""
+    from sqlfluff.core.parser.context import ParseContext
+
+    ctx = ParseContext(dialect=None, max_parse_depth=0, max_parse_nodes=3)
+    ctx.seed_parse_nodes(2)
+    with pytest.raises(SQLParseError) as exc_info:
+        ctx.increment_parse_nodes(2)
+    assert MESSAGE_PREFIX in exc_info.value.desc()
+    assert "3" in exc_info.value.desc()
+
+
+@pytest.mark.parametrize(
+    ("use_rust_parser", "patch_target"),
+    [
+        (False, "sqlfluff.core.parser.parser.Parser.parse"),
+        pytest.param(
+            True,
+            "sqlfluff.core.parser.rust_parser.RustParser.parse",
+            marks=pytest.mark.skipif(
+                not __import__("sqlfluff.core.parser.rust_parser", fromlist=["_HAS_RUST_PARSER"])._HAS_RUST_PARSER,
+                reason="Rust parser not available",
+            ),
+        ),
+    ],
+)
+def test_max_parse_nodes_token_gate_skips_parser(use_rust_parser, patch_target):
     """The shared token gate should reject oversized token streams before parsing."""
     config = FluffConfig(
         overrides={
             "dialect": "ansi",
             "max_parse_nodes": MAX_NODE_LIMIT,
-            "use_rust_parser": False,
+            "use_rust_parser": use_rust_parser,
         }
     )
     linter = Linter(config=config)
-    expr = "x" + "=x" * 6
-    sql = "SELECT " + ",".join(expr for _ in range(80))
+    sql = _wide_select_sql()
 
-    with patch("sqlfluff.core.parser.parser.Parser.parse") as parse_mock:
+    with patch(patch_target) as parse_mock:
         parsed = linter.parse_string(sql)
 
     parse_mock.assert_not_called()
     assert parsed.violations
     err = parsed.violations[0]
     assert isinstance(err, SQLParseError)
-    assert MESSAGE_PREFIX in err.desc()
-    assert str(MAX_NODE_LIMIT) in err.desc()
-
-
-def test_max_parse_nodes_token_gate_skips_rust_parser():
-    """The shared token gate should also reject before the Rust parser starts."""
-    try:
-        from sqlfluff.core.parser.rust_parser import _HAS_RUST_PARSER
-    except ImportError:
-        _HAS_RUST_PARSER = False
-
-    if not _HAS_RUST_PARSER:
-        pytest.skip("Rust parser not available")
-
-    config = FluffConfig(
-        overrides={
-            "dialect": "ansi",
-            "max_parse_nodes": MAX_NODE_LIMIT,
-            "use_rust_parser": True,
-        }
-    )
-    linter = Linter(config=config)
-    expr = "x" + "=x" * 6
-    sql = "SELECT " + ",".join(expr for _ in range(80))
-
-    with patch("sqlfluff.core.parser.rust_parser.RustParser.parse") as parse_mock:
-        parsed = linter.parse_string(sql)
-
-    parse_mock.assert_not_called()
-    assert parsed.violations
-    err = parsed.violations[0]
-    assert isinstance(err, SQLParseError)
-    assert MESSAGE_PREFIX in err.desc()
-    assert str(MAX_NODE_LIMIT) in err.desc()
+    _assert_node_limit_error(err, MAX_NODE_LIMIT)

--- a/test/core/parser/max_parse_nodes_test.py
+++ b/test/core/parser/max_parse_nodes_test.py
@@ -1,6 +1,7 @@
 """Tests for max_parse_nodes limit (DoS mitigation)."""
 
 import pytest
+from unittest.mock import patch
 
 from sqlfluff.core import FluffConfig
 from sqlfluff.core.errors import SQLParseError
@@ -94,3 +95,59 @@ def test_validate_segment_with_reparse_respects_max_parse_nodes():
         )
 
     assert MESSAGE_PREFIX in exc_info.value.desc()
+
+
+def test_max_parse_nodes_token_gate_skips_python_parser():
+    """The shared token gate should reject oversized token streams before parsing."""
+    config = FluffConfig(
+        overrides={
+            "dialect": "ansi",
+            "max_parse_nodes": MAX_NODE_LIMIT,
+            "use_rust_parser": False,
+        }
+    )
+    linter = Linter(config=config)
+    expr = "x" + "=x" * 6
+    sql = "SELECT " + ",".join(expr for _ in range(80))
+
+    with patch("sqlfluff.core.parser.parser.Parser.parse") as parse_mock:
+        parsed = linter.parse_string(sql)
+
+    parse_mock.assert_not_called()
+    assert parsed.violations
+    err = parsed.violations[0]
+    assert isinstance(err, SQLParseError)
+    assert MESSAGE_PREFIX in err.desc()
+    assert str(MAX_NODE_LIMIT) in err.desc()
+
+
+def test_max_parse_nodes_token_gate_skips_rust_parser():
+    """The shared token gate should also reject before the Rust parser starts."""
+    try:
+        from sqlfluff.core.parser.rust_parser import _HAS_RUST_PARSER
+    except ImportError:
+        _HAS_RUST_PARSER = False
+
+    if not _HAS_RUST_PARSER:
+        pytest.skip("Rust parser not available")
+
+    config = FluffConfig(
+        overrides={
+            "dialect": "ansi",
+            "max_parse_nodes": MAX_NODE_LIMIT,
+            "use_rust_parser": True,
+        }
+    )
+    linter = Linter(config=config)
+    expr = "x" + "=x" * 6
+    sql = "SELECT " + ",".join(expr for _ in range(80))
+
+    with patch("sqlfluff.core.parser.rust_parser.RustParser.parse") as parse_mock:
+        parsed = linter.parse_string(sql)
+
+    parse_mock.assert_not_called()
+    assert parsed.violations
+    err = parsed.violations[0]
+    assert isinstance(err, SQLParseError)
+    assert MESSAGE_PREFIX in err.desc()
+    assert str(MAX_NODE_LIMIT) in err.desc()

--- a/test/core/parser/max_parse_nodes_test.py
+++ b/test/core/parser/max_parse_nodes_test.py
@@ -152,7 +152,9 @@ def test_parse_context_increment_parse_nodes_raises_on_limit():
             True,
             "sqlfluff.core.parser.rust_parser.RustParser.parse",
             marks=pytest.mark.skipif(
-                not __import__("sqlfluff.core.parser.rust_parser", fromlist=["_HAS_RUST_PARSER"])._HAS_RUST_PARSER,
+                not __import__(
+                    "sqlfluff.core.parser.rust_parser", fromlist=["_HAS_RUST_PARSER"]
+                )._HAS_RUST_PARSER,
                 reason="Rust parser not available",
             ),
         ),

--- a/test/core/parser/max_parse_nodes_test.py
+++ b/test/core/parser/max_parse_nodes_test.py
@@ -1,0 +1,96 @@
+"""Tests for max_parse_nodes limit (DoS mitigation)."""
+
+import pytest
+
+from sqlfluff.core import FluffConfig
+from sqlfluff.core.errors import SQLParseError
+from sqlfluff.core.linter.linter import Linter
+
+MAX_NODE_LIMIT = 300
+MESSAGE_PREFIX = "Maximum parse node count exceeded"
+
+
+def _linter_with_node_limit(limit: int):
+    """Linter with max_parse_nodes set, forcing the Python parser path."""
+    return Linter(
+        config=FluffConfig(
+            overrides={
+                "dialect": "ansi",
+                "max_parse_nodes": limit,
+                "use_rust_parser": False,
+            }
+        )
+    )
+
+
+def test_max_parse_nodes_default_allows_simple_sql():
+    """Simple SQL should parse with the shipped default node limit."""
+    linter = _linter_with_node_limit(100000)
+    parsed = linter.parse_string("SELECT 1")
+    assert not parsed.violations
+
+
+def test_default_max_parse_nodes_matches_config_default():
+    """FluffConfig exposes the shipped default max_parse_nodes value."""
+    config = FluffConfig(overrides={"dialect": "ansi"})
+    assert config.get("max_parse_nodes") == 100000
+
+
+def test_max_parse_nodes_exceeded_wide_select_python_parser():
+    """A wide select should exceed the configured node budget."""
+    linter = _linter_with_node_limit(MAX_NODE_LIMIT)
+    expr = "x" + "=x" * 6
+    sql = "SELECT " + ",".join(expr for _ in range(80))
+
+    parsed = linter.parse_string(sql)
+    assert parsed.violations
+    err = parsed.violations[0]
+    assert isinstance(err, SQLParseError)
+    assert MESSAGE_PREFIX in err.desc()
+    assert str(MAX_NODE_LIMIT) in err.desc()
+    assert err.segment is not None
+    assert err.line_no > 0
+    assert err.line_pos > 0
+
+
+def test_max_parse_nodes_rust_parser_exceeds_limit():
+    """Rust parser should surface the same node limit error when available."""
+    try:
+        from sqlfluff.core.parser.rust_parser import _HAS_RUST_PARSER, RustParser
+    except ImportError:
+        _HAS_RUST_PARSER = False
+
+    if not _HAS_RUST_PARSER:
+        pytest.skip("Rust parser not available")
+
+    from sqlfluff.core.parser import Lexer
+
+    config = FluffConfig(overrides={"dialect": "ansi", "max_parse_nodes": 300})
+    parser = RustParser(config=config)
+    lexer = Lexer(config=config)
+    expr = "x" + "=x" * 6
+    sql = "SELECT " + ",".join(expr for _ in range(80))
+    segments, _ = lexer.lex(sql)
+
+    with pytest.raises(SQLParseError) as exc_info:
+        parser.parse(segments, fname="test.sql")
+    assert MESSAGE_PREFIX in exc_info.value.desc()
+    assert "300" in exc_info.value.desc()
+    assert exc_info.value.segment is not None
+    assert exc_info.value.line_no > 0
+    assert exc_info.value.line_pos > 0
+
+
+def test_validate_segment_with_reparse_respects_max_parse_nodes():
+    """Segment reparse validation should use the node budget too."""
+    linter = _linter_with_node_limit(100000)
+    parsed = linter.parse_string("SELECT a, b, c FROM t")
+
+    with pytest.raises(SQLParseError) as exc_info:
+        parsed.tree.validate_segment_with_reparse(
+            parsed.config.get("dialect_obj"),
+            max_parse_depth=parsed.config.get("max_parse_depth"),
+            max_parse_nodes=1,
+        )
+
+    assert MESSAGE_PREFIX in exc_info.value.desc()

--- a/test/core/parser/rust_parser_test.py
+++ b/test/core/parser/rust_parser_test.py
@@ -103,9 +103,39 @@ def test__iteration_limit__rs_parser_constructor_accepts_limits():
         indent_config={},
         max_parser_iterations=500_000,
         parser_warn_threshold=250_000,
+        max_parse_nodes=100_000,
     )
     # The dialect getter confirms the object was created successfully.
     assert p.dialect == "ansi"
+
+
+@pytest.mark.skipif(not _HAS_RUST_PARSER, reason="Rust parser not available")
+def test__rust_parser__max_parse_nodes_exceeded_in_rs_binding():
+    """RsParser should reject oversized match trees via max_parse_nodes."""
+    from sqlfluff.core import FluffConfig
+    from sqlfluff.core.parser import Lexer
+
+    config = FluffConfig(overrides={"dialect": "ansi"})
+    lexer = Lexer(config=config)
+    expr = "x" + "=x" * 6
+    sql = "SELECT " + ",".join(expr for _ in range(80))
+    segments, _ = lexer.lex(sql)
+    tokens = [
+        s._rstoken
+        for s in segments
+        if hasattr(s, "_rstoken") and s._rstoken is not None and s.is_code
+    ]
+
+    p = RsParser(
+        dialect="ansi",
+        indent_config={},
+        max_parse_nodes=300,
+    )
+
+    with pytest.raises(Exception) as exc_info:
+        p.parse_match_result_from_tokens(tokens)
+
+    assert "Maximum parse node count exceeded" in str(exc_info.value)
 
 
 @pytest.mark.skipif(not _HAS_RUST_PARSER, reason="Rust parser not available")

--- a/test/dialects/dialects_test.py
+++ b/test/dialects/dialects_test.py
@@ -90,6 +90,7 @@ def test__dialect__base_file_parse(dialect, file):
     assert parsed.tree.validate_segment_with_reparse(
         parsed.config.get("dialect_obj"),
         max_parse_depth=parsed.config.get("max_parse_depth"),
+        max_parse_nodes=parsed.config.get("max_parse_nodes"),
     )
 
 


### PR DESCRIPTION
## Summary
- add a configurable max_parse_nodes limit alongside the existing parse depth limit
- enforce the limit in the Python parser path, Rust parser path, and a shared token-count gate before parsing
- add and consolidate focused tests covering config validation, ParseContext accounting, parser behavior, and Rust bindings

## Validation
- python -m pytest c:/Users/alanc/dev/sqlfluff/test/core/parser/max_parse_nodes_test.py c:/Users/alanc/dev/sqlfluff/test/core/parser/max_parse_depth_test.py c:/Users/alanc/dev/sqlfluff/test/core/parser/rust_parser_test.py -q
- cargo test -p sqlfluffrs_parser --lib --quiet

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a configurable max_parse_nodes limit to cap parse tree size and prevent DoS from unusually large SQL. Enforced across Python and Rust parsers with a shared pre-parse token gate.

- New Features
  - Added `core.max_parse_nodes` (default `100000`; `0` disables) with config validation and default config docs.
  - Early token gate in the linter skips parsing when token count exceeds the limit and returns a clear, anchored `SQLParseError`.
  - Python path: `ParseContext` tracks a node budget (`seed_parse_nodes()`, `increment_parse_nodes()`); `MatchResult.apply(parse_context=...)` counts nodes; `BaseFileSegment.root_parse()` and reparse validation increment appropriately.
  - Rust path: `RsParser` and `PyParser` accept `max_parse_nodes`; node counting via `MatchResult.node_count()`; limits enforced in parser core and table-driven path; errors are anchored where possible.
  - Fix and validation paths pass `max_parse_nodes` through `apply_fixes()` and `validate_segment_with_reparse()`.
  - Added tests for config validation, Python/Rust behavior, the token gate, and Rust bindings.

<sup>Written for commit e83d3e96d0f8c55aa9a8730daf55b093ea678a5a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

