### PR TITLE
fix: prevent placeholder templater from suppressing lint violations

### DIFF
--- a/sqlfluffrs/sqlfluffrs_python/src/templater/fileslice.rs
+++ b/sqlfluffrs/sqlfluffrs_python/src/templater/fileslice.rs
@@ -69,6 +69,14 @@ impl PyRawFileSlice {
     pub fn tag(&self) -> Option<String> {
         self.0.tag.clone()
     }
+
+    pub fn end_source_idx(&self) -> usize {
+        self.0.end_source_idx()
+    }
+
+    pub fn source_slice(&self) -> PySlice {
+        PySlice(self.0.source_slice())
+    }
 }
 
 impl From<PyRawFileSlice> for RawFileSlice {

--- a/src/sqlfluff/core/linter/linter.py
+++ b/src/sqlfluff/core/linter/linter.py
@@ -333,6 +333,9 @@ class Linter:
                 if (
                     # Is it in a literal section?
                     e.segment.pos_marker.is_literal()
+                    # Is it in placeholder-tagged template slices that are
+                    # semantically literal SQL (e.g. ${catalog})?
+                    or Linter._is_semantically_literal_templated(e)
                     # Is it a rule that is designed to work on templated sections?
                     or e.rule.targets_templated
                 ):
@@ -342,6 +345,23 @@ class Linter:
                 # malformed "noqa" comment).
                 result.append(e)
         return result
+
+    @staticmethod
+    def _is_semantically_literal_templated(error: SQLLintError) -> bool:
+        """Whether all non-literal raw slices in the anchor are semantically literal."""
+        assert error.segment.pos_marker
+        source_slice = error.segment.pos_marker.source_slice
+        non_literal_slices = []
+        for raw_slice in error.segment.pos_marker.templated_file.raw_sliced:
+            if raw_slice.end_source_idx() <= source_slice.start:
+                continue
+            if raw_slice.source_idx >= source_slice.stop:
+                break
+            if raw_slice.slice_type != "literal":
+                non_literal_slices.append(raw_slice)
+        return bool(non_literal_slices) and all(
+            raw_slice.tag == "literal" for raw_slice in non_literal_slices
+        )
 
     @staticmethod
     def _report_conflicting_fixes_same_anchor(message: str) -> None:  # pragma: no cover

--- a/src/sqlfluff/core/templaters/placeholder.py
+++ b/src/sqlfluff/core/templaters/placeholder.py
@@ -200,6 +200,9 @@ class PlaceholderTemplater(RawTemplater):
                     raw=in_str[span[0] : span[1]],
                     slice_type="templated",
                     source_idx=span[0],
+                    # Tagged as semantically literal, allowing lint filtering
+                    # to keep violations that only overlap placeholder params.
+                    tag="literal",
                 )
             )
             out_str += replacement

--- a/test/fixtures/rules/std_rule_cases/AM04.yml
+++ b/test/fixtures/rules/std_rule_cases/AM04.yml
@@ -630,3 +630,50 @@ test_pass_sparksql_values_clause:
   configs:
     core:
       dialect: sparksql
+
+test_fail_placeholder_templater_qualified_wildcard:
+  # Regression: placeholder templater should not suppress AM04.
+  # When a placeholder substitution exists in the FROM clause (e.g. ${CATALOG}),
+  # the violation on table.* should still be reported.
+  fail_str: |
+    SELECT
+        contact.*
+    FROM
+        ${CATALOG}.dbo.contact
+  configs:
+    core:
+      templater: placeholder
+    templater:
+      placeholder:
+        param_style: dollar
+        CATALOG: my_catalog
+
+test_fail_placeholder_templater_unqualified_wildcard:
+  # Regression: placeholder templater should not suppress AM04 for SELECT *.
+  fail_str: |
+    SELECT *
+    FROM ${CATALOG}.dbo.contact
+  configs:
+    core:
+      templater: placeholder
+    templater:
+      placeholder:
+        param_style: dollar
+        CATALOG: my_catalog
+
+test_pass_placeholder_templater_explicit_columns:
+  # Placeholder templater should still pass when columns are explicit.
+  pass_str: |
+    SELECT
+        a,
+        b,
+        c
+    FROM
+        ${CATALOG}.dbo.contact
+  configs:
+    core:
+      templater: placeholder
+    templater:
+      placeholder:
+        param_style: dollar
+        CATALOG: my_catalog

--- a/test/fixtures/rules/std_rule_cases/AM07.yml
+++ b/test/fixtures/rules/std_rule_cases/AM07.yml
@@ -528,3 +528,19 @@ test_pass_duckdb_from_first_syntax:
   configs:
     core:
       dialect: duckdb
+
+test_fail_placeholder_templater_set_columns:
+  # Regression: placeholder templater should not suppress AM07 violations.
+  fail_str: |
+    SELECT a
+    FROM ${CATALOG}.foo
+    UNION
+    SELECT a, b
+    FROM ${CATALOG}.bar
+  configs:
+    core:
+      templater: placeholder
+    templater:
+      placeholder:
+        param_style: dollar
+        CATALOG: my_catalog

--- a/test/fixtures/rules/std_rule_cases/ST11.yml
+++ b/test/fixtures/rules/std_rule_cases/ST11.yml
@@ -259,3 +259,19 @@ test_pass_unaliased_schema_table_column:
     FROM my_schema.a
     LEFT JOIN my_schema.b
         ON my_schema.a.id = my_schema.b.id
+
+test_fail_placeholder_templater_unused_join:
+  # Regression: placeholder templater should not suppress ST11 violations.
+  fail_str: |
+    SELECT
+        foo.a
+    FROM ${CATALOG}.foo
+    LEFT JOIN ${CATALOG}.bar
+        ON foo.a = bar.a
+  configs:
+    core:
+      templater: placeholder
+    templater:
+      placeholder:
+        param_style: dollar
+        CATALOG: my_catalog


### PR DESCRIPTION
## Description

Fixes #7817.

The `placeholder` templater silently suppresses lint violations for any rule whose anchor spans a placeholder substitution region. This is because `remove_templated_errors()` discards violations where `is_literal()` returns `False`, and placeholder substitutions create `slice_type='templated'` raw slices that cause this check to fail.

## Fix

Two minimal changes:

1. **`placeholder.py`**: Tag placeholder substitution `RawFileSlice` objects with `tag='literal'` to mark them as semantically literal SQL (the substituted values are simple literals, not control flow).

2. **`linter.py`**: Add `_is_semantically_literal_templated()` static method that checks whether all non-literal raw slices overlapping a violation anchor have `tag='literal'`. If so, the violation is preserved rather than discarded.

This approach is centralised (no per-rule changes needed) and extensible to other templaters that may have similar semantics.

## Affected Rules

13 rules with broad anchors confirmed working after fix: AL04, AL05, AL06, AL07, AL08, AL09, AM04, AM07, AM09, CV03, LT09, LT10, ST11.

## Test Cases

Added YAML regression tests for AM04 (3 cases), AM07 (1 case), and ST11 (1 case) using placeholder templater config.

## Checklist

- [x] Tests pass (2,285 tests, 0 failures)
- [x] `ruff check` clean
- [x] `ruff format` clean
- [x] `mypy` clean
- [x] No user-facing API/config changes (internal fix only)

*This PR was developed with AI assistance (GitHub Copilot).*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a bug where the `placeholder` templater hid lint violations when a rule’s anchor overlapped placeholder substitutions. Also fixes a crash with the Rust parser by exposing required slice methods.

- **Bug Fixes**
  - Tag placeholder substitution slices with `tag='literal'` in the `placeholder` templater to mark them as semantically literal SQL.
  - Update `remove_templated_errors()` to keep violations that only overlap templated slices tagged as literal via `_is_semantically_literal_templated()`.
  - Add regression tests for AM04, AM07, and ST11 using the `placeholder` templater.
  - Expose `end_source_idx()` and `source_slice()` on Rust `PyRawFileSlice` bindings to prevent `AttributeError` when the Rust parser is enabled.

<sup>Written for commit dbf61e937cc1f6a9358df2000dfa03c4ef471d51. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

