### PR TITLE
fix(tsql): parse ALTER TABLE ... ENABLE/DISABLE TRIGGER

### DIFF
--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -5427,6 +5427,16 @@ class AlterTableStatementSegment(BaseSegment):
                     ),
                 ),
             ),
+            # { ENABLE | DISABLE } TRIGGER { ALL | trigger_name [ ,...n ] }
+            # https://learn.microsoft.com/en-us/sql/t-sql/statements/alter-table-transact-sql
+            Sequence(
+                OneOf("ENABLE", "DISABLE"),
+                "TRIGGER",
+                OneOf(
+                    "ALL",
+                    Delimited(Ref("TriggerReferenceSegment")),
+                ),
+            ),
         ),
     )
 

--- a/test/fixtures/dialects/tsql/alter_table_enable_disable_trigger.sql
+++ b/test/fixtures/dialects/tsql/alter_table_enable_disable_trigger.sql
@@ -1,0 +1,14 @@
+ALTER TABLE [dbo].[Contact] DISABLE TRIGGER [TRContactID];
+GO
+
+ALTER TABLE [dbo].[Contact] ENABLE TRIGGER [TRContactID];
+GO
+
+ALTER TABLE [dbo].[Contact] DISABLE TRIGGER ALL;
+GO
+
+ALTER TABLE [dbo].[Contact] ENABLE TRIGGER ALL;
+GO
+
+ALTER TABLE [dbo].[Contact] ENABLE TRIGGER [t1], [t2];
+GO

--- a/test/fixtures/dialects/tsql/alter_table_enable_disable_trigger.yml
+++ b/test/fixtures/dialects/tsql/alter_table_enable_disable_trigger.yml
@@ -1,0 +1,88 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: b805a53b7f3cb19848a5c5e083a891e9e9405796b276d0134edba6d1e26d5c6d
+file:
+- batch:
+    statement:
+      alter_table_statement:
+      - keyword: ALTER
+      - keyword: TABLE
+      - table_reference:
+        - quoted_identifier: '[dbo]'
+        - dot: .
+        - quoted_identifier: '[Contact]'
+      - keyword: DISABLE
+      - keyword: TRIGGER
+      - trigger_reference:
+          quoted_identifier: '[TRContactID]'
+    statement_terminator: ;
+    go_statement:
+      keyword: GO
+- batch:
+    statement:
+      alter_table_statement:
+      - keyword: ALTER
+      - keyword: TABLE
+      - table_reference:
+        - quoted_identifier: '[dbo]'
+        - dot: .
+        - quoted_identifier: '[Contact]'
+      - keyword: ENABLE
+      - keyword: TRIGGER
+      - trigger_reference:
+          quoted_identifier: '[TRContactID]'
+    statement_terminator: ;
+    go_statement:
+      keyword: GO
+- batch:
+    statement:
+      alter_table_statement:
+      - keyword: ALTER
+      - keyword: TABLE
+      - table_reference:
+        - quoted_identifier: '[dbo]'
+        - dot: .
+        - quoted_identifier: '[Contact]'
+      - keyword: DISABLE
+      - keyword: TRIGGER
+      - keyword: ALL
+    statement_terminator: ;
+    go_statement:
+      keyword: GO
+- batch:
+    statement:
+      alter_table_statement:
+      - keyword: ALTER
+      - keyword: TABLE
+      - table_reference:
+        - quoted_identifier: '[dbo]'
+        - dot: .
+        - quoted_identifier: '[Contact]'
+      - keyword: ENABLE
+      - keyword: TRIGGER
+      - keyword: ALL
+    statement_terminator: ;
+    go_statement:
+      keyword: GO
+- batch:
+    statement:
+      alter_table_statement:
+      - keyword: ALTER
+      - keyword: TABLE
+      - table_reference:
+        - quoted_identifier: '[dbo]'
+        - dot: .
+        - quoted_identifier: '[Contact]'
+      - keyword: ENABLE
+      - keyword: TRIGGER
+      - trigger_reference:
+          quoted_identifier: '[t1]'
+      - comma: ','
+      - trigger_reference:
+          quoted_identifier: '[t2]'
+    statement_terminator: ;
+    go_statement:
+      keyword: GO


### PR DESCRIPTION
### Brief summary of the change made

Adds support for the T-SQL `ALTER TABLE ... { ENABLE | DISABLE } TRIGGER` clause, which was previously not recognized by the parser.

Fixes #7804

### What changed

Added a new grammar branch to `AlterTableStatementSegment` in `dialect_tsql.py` that matches:
- `ALTER TABLE <table> ENABLE TRIGGER <trigger>`
- `ALTER TABLE <table> DISABLE TRIGGER <trigger>`  
- `ALTER TABLE <table> ENABLE TRIGGER ALL`
- `ALTER TABLE <table> DISABLE TRIGGER ALL`
- `ALTER TABLE <table> ENABLE TRIGGER <t1>, <t2>`

Reference: https://learn.microsoft.com/en-us/sql/t-sql/statements/alter-table-transact-sql

### Are there any other side effects of this change that we should be aware of?

No. This only adds a new branch to the existing `OneOf` inside `AlterTableStatementSegment`, so existing ALTER TABLE parsing is unaffected.

### Pull Request checklist
- [x] Included test cases: `.sql`/`.yml` parser test cases in `test/fixtures/dialects/tsql/`
- [ ] Added appropriate documentation for the change. (Not needed for dialect parser fixes)
- [ ] Created GitHub issues for any relevant followup/future enhancements if appropriate. (N/A)

AI-assisted disclosure: AI tools were used to help understand the issue and develop the fix. The code was manually validated against the test cases from the issue and the official Microsoft T-SQL documentation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds T-SQL parser support for ALTER TABLE ... ENABLE/DISABLE TRIGGER, including ALL and comma-separated trigger names, so these statements parse correctly. Fixes #7804.

- **Bug Fixes**
  - Added grammar to handle ENABLE/DISABLE TRIGGER {ALL | trigger_name[, ...n]} in `AlterTableStatementSegment`.
  - Covered with parser fixtures for single, ALL, and multiple triggers.
  - No changes to other ALTER TABLE parsing.

<sup>Written for commit 71a8de92519a8514e7f78da4105b75d870ae4aec. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

