### PR TITLE
fix(postgres): don't flag 'provider' as a keyword violation (RF04)

### DIFF
--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -17,6 +17,7 @@ from sqlfluff.core.parser import (
     IdentifierSegment,
     ImplicitIndent,
     Indent,
+    KeywordSegment,
     LiteralKeywordSegment,
     LiteralSegment,
     Matchable,
@@ -498,6 +499,7 @@ postgres_dialect.add(
     CreateForeignTableGrammar=Sequence("CREATE", "FOREIGN", "TABLE"),
     IntervalUnitsGrammar=OneOf("YEAR", "MONTH", "DAY", "HOUR", "MINUTE", "SECOND"),
     WalrusOperatorSegment=StringParser(":=", SymbolSegment, type="assignment_operator"),
+    ProviderKeywordSegment=StringParser("provider", KeywordSegment),
     MetaCommandQueryBufferSegment=TypedParser(
         "meta_command_query_buffer", SymbolSegment, type="meta_command"
     ),

--- a/src/sqlfluff/dialects/dialect_postgres_keywords.py
+++ b/src/sqlfluff/dialects/dialect_postgres_keywords.py
@@ -979,7 +979,7 @@ postgres_nondocs_keywords = [
     ("NOSUPERUSER", "non-reserved"),
     ("PLAIN", "non-reserved"),
     ("PROCESS_TOAST", "non-reserved"),
-    ("PROVIDER", "non-reserved"),
+    ("PROVIDER", "not-keyword"),
     ("PUBLIC", "non-reserved"),
     ("REMAINDER", "non-reserved"),
     ("REPLICATION", "non-reserved"),

--- a/test/fixtures/rules/std_rule_cases/RF04.yml
+++ b/test/fixtures/rules/std_rule_cases/RF04.yml
@@ -156,3 +156,10 @@ test_fail_keyword_as_column_name_postgres:
   configs:
     core:
       dialect: postgres
+
+test_pass_provider_not_keyword_postgres:
+  # provider is not a PostgreSQL keyword, should not be flagged by RF04
+  pass_str: CREATE TABLE test (provider TEXT NOT NULL)
+  configs:
+    core:
+      dialect: postgres


### PR DESCRIPTION
### Brief summary of the change made

Stops RF04 (references.keywords) from incorrectly flagging `provider` as a keyword when used as an identifier in PostgreSQL.

Fixes #7691

### What changed

1. Moved `PROVIDER` from `non-reserved` to `not-keyword` in the PostgreSQL keyword list. `PROVIDER` is not listed as a keyword in the official PostgreSQL documentation — it was added to sqlfluff's keyword list solely to make the `CREATE COLLATION ... PROVIDER = ...` grammar work.

2. Manually registered `ProviderKeywordSegment` in the postgres dialect using `StringParser("provider", KeywordSegment)`. This ensures the parser still recognizes `PROVIDER` as a keyword in the `CREATE COLLATION` context, while removing it from the `unreserved_keywords` set that RF04 checks against.

3. Added a test case to `RF04.yml` confirming that `provider` as a column name does not trigger RF04 in the postgres dialect.

### Are there any other side effects of this change that we should be aware of?

No. The parse tree is unchanged — `PROVIDER` is still parsed as a keyword in `CREATE COLLATION` statements and as an `naked_identifier` elsewhere. All 164 postgres dialect fixtures were regenerated and remain unchanged.

### Pull Request checklist
- [x] Included test cases: RF04 rule test case in `test/fixtures/rules/std_rule_cases/RF04.yml`
- [ ] Added appropriate documentation for the change. (Not needed for keyword classification fixes)
- [ ] Created GitHub issues for any relevant followup/future enhancements if appropriate. (N/A)

AI-assisted disclosure: AI tools were used to help understand the issue and develop the fix. The approach was manually validated against both the PostgreSQL documentation and the sqlfluff test suite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a false positive in RF04 by ensuring `provider` is not treated as a PostgreSQL keyword. `CREATE COLLATION ... PROVIDER = ...` continues to parse correctly.

- **Bug Fixes**
  - Reclassify `PROVIDER` from `non-reserved` to `not-keyword` in the Postgres keyword list.
  - Register `ProviderKeywordSegment` via `StringParser("provider", KeywordSegment)` to preserve `CREATE COLLATION` parsing; add an RF04 test allowing `provider` as a column name.

<sup>Written for commit 8bb7213df8e0680e8d6726dfb99943a73d43d80d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

