### PR TITLE
fix(flink): support backtick-quoted identifiers in ROW type and add CREATE FUNCTION

### DIFF
--- a/src/sqlfluff/dialects/dialect_flink.py
+++ b/src/sqlfluff/dialects/dialect_flink.py
@@ -433,6 +433,40 @@ class SetStatementSegment(BaseSegment):
     )
 
 
+class CreateFunctionStatementSegment(BaseSegment):
+    """A `CREATE FUNCTION` statement for FlinkSQL.
+
+    FlinkSQL syntax:
+        CREATE [OR REPLACE] [TEMPORARY|TEMPORARY SYSTEM] FUNCTION
+        [IF NOT EXISTS] function_name AS 'class_name'
+        [LANGUAGE language_name];
+    """
+
+    type = "create_function_statement"
+    match_grammar = Sequence(
+        "CREATE",
+        Ref("OrReplaceGrammar", optional=True),
+        OneOf(
+            Sequence("TEMPORARY", "SYSTEM"),
+            Ref.keyword("TEMPORARY"),
+            optional=True,
+        ),
+        "FUNCTION",
+        Ref("IfNotExistsGrammar", optional=True),
+        Ref("FunctionNameSegment"),
+        "AS",
+        Ref("QuotedLiteralSegment"),
+        Sequence(
+            "LANGUAGE",
+            Ref("NakedIdentifierSegment"),
+            optional=True,
+        ),
+    )
+
+
+
+
+
 class StatementSegment(ansi.StatementSegment):
     """A generic segment, to any of its child subsegments."""
 
@@ -441,6 +475,7 @@ class StatementSegment(ansi.StatementSegment):
             # FlinkSQL-specific statements
             Ref("CreateCatalogStatementSegment"),
             Ref("CreateDatabaseStatementSegment"),
+            Ref("CreateFunctionStatementSegment"),
             Ref("DescribeStatementSegment"),
             Ref("ShowStatementsSegment"),
             Ref("SetStatementSegment"),
@@ -479,7 +514,7 @@ class RowDataTypeSegment(BaseSegment):
             Bracketed(
                 Delimited(
                     Sequence(
-                        Ref("NakedIdentifierSegment"),  # field name
+                        Ref("SingleIdentifierGrammar"),  # field name
                         Ref("DatatypeSegment"),  # field type
                         Sequence("COMMENT", Ref("QuotedLiteralSegment"), optional=True),
                     ),
@@ -491,7 +526,7 @@ class RowDataTypeSegment(BaseSegment):
             Bracketed(
                 Delimited(
                     Sequence(
-                        Ref("NakedIdentifierSegment"),  # field name
+                        Ref("SingleIdentifierGrammar"),  # field name
                         Ref("DatatypeSegment"),  # field type
                         Sequence("COMMENT", Ref("QuotedLiteralSegment"), optional=True),
                     ),

--- a/test/fixtures/dialects/flink/create_function.sql
+++ b/test/fixtures/dialects/flink/create_function.sql
@@ -1,0 +1,7 @@
+CREATE FUNCTION ARRAY_AGGR AS 'my.udf.ArrayAggr';
+
+CREATE OR REPLACE TEMPORARY FUNCTION my_func AS 'com.example.MyFunc' LANGUAGE JAVA;
+
+CREATE TEMPORARY SYSTEM FUNCTION my_func AS 'com.example.MyFunc';
+
+CREATE FUNCTION IF NOT EXISTS my_func AS 'com.example.MyFunc';

--- a/test/fixtures/dialects/flink/create_function.yml
+++ b/test/fixtures/dialects/flink/create_function.yml
@@ -1,0 +1,53 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 8489b4ff4a8ac8342e88754e8365d906e0c9f52b96060dbe8151928c4cf95584
+file:
+- statement:
+    create_function_statement:
+    - keyword: CREATE
+    - keyword: FUNCTION
+    - function_name:
+        function_name_identifier: ARRAY_AGGR
+    - keyword: AS
+    - quoted_literal: "'my.udf.ArrayAggr'"
+- statement_terminator: ;
+- statement:
+    create_function_statement:
+    - keyword: CREATE
+    - keyword: OR
+    - keyword: REPLACE
+    - keyword: TEMPORARY
+    - keyword: FUNCTION
+    - function_name:
+        function_name_identifier: my_func
+    - keyword: AS
+    - quoted_literal: "'com.example.MyFunc'"
+    - keyword: LANGUAGE
+    - naked_identifier: JAVA
+- statement_terminator: ;
+- statement:
+    create_function_statement:
+    - keyword: CREATE
+    - keyword: TEMPORARY
+    - keyword: SYSTEM
+    - keyword: FUNCTION
+    - function_name:
+        function_name_identifier: my_func
+    - keyword: AS
+    - quoted_literal: "'com.example.MyFunc'"
+- statement_terminator: ;
+- statement:
+    create_function_statement:
+    - keyword: CREATE
+    - keyword: FUNCTION
+    - keyword: IF
+    - keyword: NOT
+    - keyword: EXISTS
+    - function_name:
+        function_name_identifier: my_func
+    - keyword: AS
+    - quoted_literal: "'com.example.MyFunc'"
+- statement_terminator: ;

--- a/test/fixtures/dialects/flink/create_table_row_backtick.sql
+++ b/test/fixtures/dialects/flink/create_table_row_backtick.sql
@@ -1,0 +1,14 @@
+CREATE TABLE mytopic (
+    `metadata1` ROW<`key` STRING, `value` STRING, `unit` STRING>,
+    `metadata2` ARRAY<ROW<`key` STRING, `value` STRING, `unit` STRING>>
+) WITH (
+    'topic' = 'mytopic'
+);
+
+CREATE TABLE t (
+    col ROW<key STRING, value STRING>
+);
+
+CREATE TABLE t (
+    col ROW<`field_name` INT, `another_field` BIGINT>
+);

--- a/test/fixtures/dialects/flink/create_table_row_backtick.yml
+++ b/test/fixtures/dialects/flink/create_table_row_backtick.yml
@@ -1,0 +1,114 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 6dbb5048fe58cc7498b6677676cf662e6c343143a459adf4dbd5dd6418a6b2cb
+file:
+- statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: mytopic
+    - bracketed:
+      - start_bracket: (
+      - column_definition:
+          quoted_identifier: '`metadata1`'
+          data_type:
+            row_data_type:
+            - keyword: ROW
+            - start_angle_bracket: <
+            - quoted_identifier: '`key`'
+            - data_type:
+                data_type_identifier: STRING
+            - comma: ','
+            - quoted_identifier: '`value`'
+            - data_type:
+                data_type_identifier: STRING
+            - comma: ','
+            - quoted_identifier: '`unit`'
+            - data_type:
+                data_type_identifier: STRING
+            - end_angle_bracket: '>'
+      - comma: ','
+      - column_definition:
+          quoted_identifier: '`metadata2`'
+          data_type:
+            keyword: ARRAY
+            start_angle_bracket: <
+            data_type:
+              row_data_type:
+              - keyword: ROW
+              - start_angle_bracket: <
+              - quoted_identifier: '`key`'
+              - data_type:
+                  data_type_identifier: STRING
+              - comma: ','
+              - quoted_identifier: '`value`'
+              - data_type:
+                  data_type_identifier: STRING
+              - comma: ','
+              - quoted_identifier: '`unit`'
+              - data_type:
+                  data_type_identifier: STRING
+              - end_angle_bracket: '>'
+            end_angle_bracket: '>'
+      - end_bracket: )
+    - keyword: WITH
+    - bracketed:
+      - start_bracket: (
+      - quoted_literal: "'topic'"
+      - comparison_operator:
+          raw_comparison_operator: '='
+      - quoted_literal: "'mytopic'"
+      - end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: t
+    - bracketed:
+        start_bracket: (
+        column_definition:
+          naked_identifier: col
+          data_type:
+            row_data_type:
+            - keyword: ROW
+            - start_angle_bracket: <
+            - naked_identifier: key
+            - data_type:
+                data_type_identifier: STRING
+            - comma: ','
+            - naked_identifier: value
+            - data_type:
+                data_type_identifier: STRING
+            - end_angle_bracket: '>'
+        end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: t
+    - bracketed:
+        start_bracket: (
+        column_definition:
+          naked_identifier: col
+          data_type:
+            row_data_type:
+            - keyword: ROW
+            - start_angle_bracket: <
+            - quoted_identifier: '`field_name`'
+            - data_type:
+                data_type_identifier: INT
+            - comma: ','
+            - quoted_identifier: '`another_field`'
+            - data_type:
+                data_type_identifier: BIGINT
+            - end_angle_bracket: '>'
+        end_bracket: )
+- statement_terminator: ;


### PR DESCRIPTION
Partially addresses #7623

Two fixes for the Flink SQL dialect:

1. **ROW type backtick-quoted identifiers**: Changed `RowDataTypeSegment` field names from `NakedIdentifierSegment` to `SingleIdentifierGrammar`, enabling backtick-quoted identifiers like \`key\` and \`value\` in `ROW<...>` and `ARRAY<ROW<...>>` types. This is common in Flink DDL where reserved words like `key` and `value` need quoting.

2. **CREATE FUNCTION statement**: Added `CreateFunctionStatementSegment` for FlinkSQL, supporting:
   - `CREATE FUNCTION name AS 'class';`
   - `CREATE OR REPLACE TEMPORARY FUNCTION name AS 'class' LANGUAGE lang;`
   - `CREATE TEMPORARY SYSTEM FUNCTION name AS 'class';`
   - `CREATE FUNCTION IF NOT EXISTS name AS 'class';`

**Not addressed in this PR**: `EXECUTE STATEMENT SET BEGIN ... END` — this requires more complex grammar changes for compound statements and is left for a future PR.

All 48 Flink dialect tests pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Flink SQL support for backtick-quoted field names in ROW types and parsing for `CREATE FUNCTION`. Fixes common DDL failures and partially addresses #7623.

- **New Features**
  - Parse `CREATE FUNCTION` with optional OR REPLACE, TEMPORARY/TEMPORARY SYSTEM, IF NOT EXISTS, and LANGUAGE.

- **Bug Fixes**
  - Allow backtick-quoted identifiers in `ROW<...>` and `ARRAY<ROW<...>>` field definitions (e.g., `key`, `value`).

<sup>Written for commit 243532fc628b7278beb654523c072c83999663e9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

