### PR TITLE
fix(postgres): support psql variable placeholders in COPY FROM/TO targets

### DIFF
--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -5846,7 +5846,9 @@ class CopyStatementSegment(BaseSegment):
     type = "copy_statement"
 
     _target_subset = OneOf(
-        Ref("QuotedLiteralSegment"), Sequence("PROGRAM", Ref("QuotedLiteralSegment"))
+        Ref("QuotedLiteralSegment"),
+        Sequence("PROGRAM", Ref("QuotedLiteralSegment")),
+        Ref("PsqlVariableGrammar"),
     )
 
     _table_definition = Sequence(
@@ -5988,6 +5990,7 @@ class CopyStatementSegment(BaseSegment):
                 "FROM",
                 OneOf(
                     Ref("QuotedLiteralSegment"),
+                    Ref("PsqlVariableGrammar"),
                     Sequence("STDIN"),
                 ),
                 _postgres9_compatible_stdin_options,
@@ -6006,6 +6009,7 @@ class CopyStatementSegment(BaseSegment):
                 "TO",
                 OneOf(
                     Ref("QuotedLiteralSegment"),
+                    Ref("PsqlVariableGrammar"),
                     Sequence("STDOUT"),
                 ),
                 _postgres9_compatible_stdout_options,

--- a/test/fixtures/dialects/postgres/copy_psql_variable.sql
+++ b/test/fixtures/dialects/postgres/copy_psql_variable.sql
@@ -1,0 +1,3 @@
+COPY tmp_table FROM :source;
+COPY tmp_table FROM :'filename' WITH delimiter E'\t' csv;
+COPY tmp_table TO :"filename" WITH (FORMAT csv);

--- a/test/fixtures/dialects/postgres/copy_psql_variable.yml
+++ b/test/fixtures/dialects/postgres/copy_psql_variable.yml
@@ -1,0 +1,47 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 2552567d8ba88d29f964c9730cf4fc7fa99621129eb7dfb7840dafabb8550534
+file:
+- statement:
+    copy_statement:
+    - keyword: COPY
+    - table_reference:
+        naked_identifier: tmp_table
+    - keyword: FROM
+    - psql_variable:
+        colon: ':'
+        parameter: source
+- statement_terminator: ;
+- statement:
+    copy_statement:
+    - keyword: COPY
+    - table_reference:
+        naked_identifier: tmp_table
+    - keyword: FROM
+    - psql_variable:
+        colon: ':'
+        quoted_literal: "'filename'"
+    - keyword: WITH
+    - keyword: delimiter
+    - quoted_literal: "E'\\t'"
+    - keyword: csv
+- statement_terminator: ;
+- statement:
+    copy_statement:
+    - keyword: COPY
+    - table_reference:
+        naked_identifier: tmp_table
+    - keyword: TO
+    - psql_variable:
+        colon: ':'
+        parameter: '"filename"'
+    - keyword: WITH
+    - bracketed:
+        start_bracket: (
+        keyword: FORMAT
+        naked_identifier: csv
+        end_bracket: )
+- statement_terminator: ;


### PR DESCRIPTION
Fixes #7696

Allow psql variable placeholders (`:variable`, `:'variable'`, `:"variable"`) as COPY FROM/TO target paths, in addition to string literals. This enables parsing of scripts like:

```sql
COPY tmp_table FROM :source;
COPY tmp_table FROM :'filename' WITH delimiter E'\t' csv;
COPY tmp_table TO :"filename" WITH (FORMAT csv);
```

**Changes:**
- Added `Ref("PsqlVariableGrammar")` to `CopyStatementSegment._target_subset` (used by both FROM and TO with the new-style `WITH (options)` syntax)
- Added `Ref("PsqlVariableGrammar")` to the PostgreSQL 9-compatible FROM and TO variants that directly reference `QuotedLiteralSegment`

All 495 PostgreSQL dialect tests pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for psql variable placeholders (:variable, :'variable', :"variable") as COPY FROM/TO targets, fixing parsing errors in psql scripts. Fixes #7696.

- **Bug Fixes**
  - Updated `CopyStatementSegment` to accept `PsqlVariableGrammar` for FROM/TO targets, including Postgres 9-compatible variants alongside `QuotedLiteralSegment`.
  - Added tests covering variable targets for COPY FROM and TO with both legacy and `WITH (options)` syntax.

<sup>Written for commit 8386eed2642310901d8a26aa2a54c2800d76fc7b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

