### PR TITLE
fix(mysql): support JSON_VALUE with RETURNING clause

### DIFF
--- a/src/sqlfluff/dialects/dialect_mysql.py
+++ b/src/sqlfluff/dialects/dialect_mysql.py
@@ -2782,6 +2782,75 @@ class DropProcedureStatementSegment(BaseSegment):
     )
 
 
+class JsonValueFunctionContentsSegment(BaseSegment):
+    """JSON_VALUE function contents for MySQL.
+
+    https://dev.mysql.com/doc/refman/8.0/en/json-search-functions.html#function_json-value
+
+    JSON_VALUE(json_doc, path [RETURNING type])
+    """
+
+    type = "function_contents"
+
+    match_grammar = Bracketed(
+        Ref("ExpressionSegment"),  # JSON expression
+        Ref("CommaSegment"),
+        Ref("ExpressionSegment"),  # JSON path
+        Sequence(
+            "RETURNING",
+            Ref("DatatypeSegment"),
+            Sequence(
+                "CHARACTER",
+                "SET",
+                Ref("ObjectReferenceSegment"),
+                optional=True,
+            ),
+            optional=True,
+        ),
+    )
+
+
+class JsonValueFunctionNameSegment(ansi.FunctionNameSegment):
+    """JSON_VALUE function name segment for MySQL."""
+
+    type = "function_name"
+    match_grammar = Sequence(
+        "JSON_VALUE",
+    )
+
+
+class FunctionSegment(ansi.FunctionSegment):
+    """A scalar or aggregate function for MySQL."""
+
+    type = "function"
+    match_grammar: Matchable = OneOf(
+        Sequence(
+            Ref("DatePartFunctionNameSegment"),
+            Ref("DateTimeFunctionContentsSegment"),
+        ),
+        Ref("ColumnsExpressionGrammar"),
+        Sequence(
+            Ref("JsonValueFunctionNameSegment"),
+            Ref("JsonValueFunctionContentsSegment"),
+        ),
+        Sequence(
+            Sequence(
+                Ref(
+                    "FunctionNameSegment",
+                    exclude=OneOf(
+                        Ref("DatePartFunctionNameSegment"),
+                        Ref("ColumnsExpressionFunctionNameSegment"),
+                        Ref("ValuesClauseSegment"),
+                        Ref("JsonValueFunctionNameSegment"),
+                    ),
+                ),
+                Ref("FunctionContentsSegment"),
+            ),
+            Ref("PostFunctionGrammar", optional=True),
+        ),
+    )
+
+
 class DropFunctionStatementSegment(BaseSegment):
     """A `DROP` statement that addresses loadable functions.
 

--- a/src/sqlfluff/dialects/dialect_mysql.py
+++ b/src/sqlfluff/dialects/dialect_mysql.py
@@ -2802,7 +2802,7 @@ class JsonValueFunctionContentsSegment(BaseSegment):
             Sequence(
                 "CHARACTER",
                 "SET",
-                Ref("ObjectReferenceSegment"),
+                Ref("NakedIdentifierSegment"),
                 optional=True,
             ),
             optional=True,

--- a/test/fixtures/dialects/mysql/json_value_returning.sql
+++ b/test/fixtures/dialects/mysql/json_value_returning.sql
@@ -1,0 +1,5 @@
+SELECT JSON_VALUE('{"a":"b"}', '$.a') AS basic_example;
+SELECT JSON_VALUE('{"a":"b"}', '$.a' RETURNING CHAR) AS returning_char;
+SELECT JSON_VALUE('{"a":"b"}', '$.a' RETURNING CHAR(255) CHARACTER SET utf8mb4) AS returning_charset;
+SELECT JSON_VALUE('{"a":"1"}', '$.a' RETURNING UNSIGNED) AS returning_unsigned;
+SELECT JSON_VALUE('{"a":"1"}', '$.a' RETURNING SIGNED) AS returning_signed;

--- a/test/fixtures/dialects/mysql/json_value_returning.yml
+++ b/test/fixtures/dialects/mysql/json_value_returning.yml
@@ -1,0 +1,138 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: dfae350152e53209d6f7365eb527df0a8f40d637dcce2f65991b100a548e7baa
+file:
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          function:
+            function_name:
+              keyword: JSON_VALUE
+            function_contents:
+              bracketed:
+              - start_bracket: (
+              - expression:
+                  quoted_literal: "'{\"a\":\"b\"}'"
+              - comma: ','
+              - expression:
+                  quoted_literal: "'$.a'"
+              - end_bracket: )
+          alias_expression:
+            alias_operator:
+              keyword: AS
+            naked_identifier: basic_example
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          function:
+            function_name:
+              keyword: JSON_VALUE
+            function_contents:
+              bracketed:
+              - start_bracket: (
+              - expression:
+                  quoted_literal: "'{\"a\":\"b\"}'"
+              - comma: ','
+              - expression:
+                  quoted_literal: "'$.a'"
+              - keyword: RETURNING
+              - data_type:
+                  data_type_identifier: CHAR
+              - end_bracket: )
+          alias_expression:
+            alias_operator:
+              keyword: AS
+            naked_identifier: returning_char
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          function:
+            function_name:
+              keyword: JSON_VALUE
+            function_contents:
+              bracketed:
+              - start_bracket: (
+              - expression:
+                  quoted_literal: "'{\"a\":\"b\"}'"
+              - comma: ','
+              - expression:
+                  quoted_literal: "'$.a'"
+              - keyword: RETURNING
+              - data_type:
+                  data_type_identifier: CHAR
+                  bracketed_arguments:
+                    bracketed:
+                      start_bracket: (
+                      numeric_literal: '255'
+                      end_bracket: )
+              - keyword: CHARACTER
+              - keyword: SET
+              - object_reference:
+                  naked_identifier: utf8mb4
+              - end_bracket: )
+          alias_expression:
+            alias_operator:
+              keyword: AS
+            naked_identifier: returning_charset
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          function:
+            function_name:
+              keyword: JSON_VALUE
+            function_contents:
+              bracketed:
+              - start_bracket: (
+              - expression:
+                  quoted_literal: "'{\"a\":\"1\"}'"
+              - comma: ','
+              - expression:
+                  quoted_literal: "'$.a'"
+              - keyword: RETURNING
+              - data_type:
+                  keyword: UNSIGNED
+              - end_bracket: )
+          alias_expression:
+            alias_operator:
+              keyword: AS
+            naked_identifier: returning_unsigned
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          function:
+            function_name:
+              keyword: JSON_VALUE
+            function_contents:
+              bracketed:
+              - start_bracket: (
+              - expression:
+                  quoted_literal: "'{\"a\":\"1\"}'"
+              - comma: ','
+              - expression:
+                  quoted_literal: "'$.a'"
+              - keyword: RETURNING
+              - data_type:
+                  keyword: SIGNED
+              - end_bracket: )
+          alias_expression:
+            alias_operator:
+              keyword: AS
+            naked_identifier: returning_signed
+- statement_terminator: ;


### PR DESCRIPTION
Fixes #5832

Add JSON_VALUE function parsing for MySQL, including the `RETURNING` clause with type specification.

**Supported syntax:**
- `JSON_VALUE(json_doc, path)` — basic form
- `JSON_VALUE(json_doc, path RETURNING type)` — with type
- `JSON_VALUE(json_doc, path RETURNING CHAR(255) CHARACTER SET utf8mb4)` — with charset
- `JSON_VALUE(json_doc, path RETURNING UNSIGNED)` — with unsigned
- `JSON_VALUE(json_doc, path RETURNING SIGNED)` — with signed

**Changes:**
- Added `JsonValueFunctionNameSegment` and `JsonValueFunctionContentsSegment` classes to the MySQL dialect
- Overrode `FunctionSegment` in MySQL to include JSON_VALUE function handling
- Added test fixtures for JSON_VALUE with various RETURNING clauses

All 623 MySQL dialect tests pass. All 625 MariaDB tests pass (MariaDB inherits from MySQL).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds MySQL `JSON_VALUE` parsing with full `RETURNING` clause support, so valid queries with type, charset, and signed/unsigned options parse correctly.

- **New Features**
  - Parse `JSON_VALUE(json_doc, path)` and `JSON_VALUE(json_doc, path RETURNING type)`.
  - Support `CHAR(...) CHARACTER SET ...`, `SIGNED`, and `UNSIGNED` in `RETURNING`.
  - Add `JsonValueFunctionNameSegment` and `JsonValueFunctionContentsSegment`, override MySQL `FunctionSegment`, and add fixtures; all MySQL and MariaDB tests pass.

<sup>Written for commit 59fd8f33cfd8c94be91f2fd7039d175c1e1fec23. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

