### PR TITLE
fix(postgres): parse \\crosstabview as query buffer terminator

### DIFF
--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -196,7 +196,8 @@ postgres_dialect.insert_lexer_matchers(
             # them. In future we may want to enhance this to actually parse them to
             # ensure they are valid meta commands.
             "meta_command",
-            r"\\(?!gset|gexec|copy\b|set\b)([^\\\r\n])+((\\\\)|(?=\n)|(?=\r\n))?",
+            r"\\(?!gset|gexec|crosstabview\b|copy\b|set\b)"
+            r"([^\\\r\n])+((\\\\)|(?=\n)|(?=\r\n))?",
             CommentSegment,
         ),
         RegexLexer(

--- a/test/fixtures/dialects/postgres/meta_commands_query_buffer.sql
+++ b/test/fixtures/dialects/postgres/meta_commands_query_buffer.sql
@@ -21,3 +21,10 @@ SELECT :'my_psql_var';
 SELECT relname, relkind FROM pg_class LIMIT 1 \gset
 
 SELECT i FROM generate_series(1,2) i \gset prefix
+
+SELECT a, b, c
+FROM mytable
+ORDER BY 1
+\crosstabview
+
+SELECT a, b FROM t \crosstabview

--- a/test/fixtures/dialects/postgres/meta_commands_query_buffer.yml
+++ b/test/fixtures/dialects/postgres/meta_commands_query_buffer.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: dd92c9922ca49c12d367a27af59354a4b304093756bd24c4a391acfbb9e97b4d
+_hash: 090459a2a205b0ae7969cd661949d871d2a2b7c78de6d43ef5638f8445310961
 file:
 - statement:
     meta_command_statement:
@@ -227,3 +227,47 @@ file:
               alias_expression:
                 naked_identifier: i
     - meta_command: \gset prefix
+    - select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            column_reference:
+              naked_identifier: a
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+              naked_identifier: b
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+              naked_identifier: c
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: mytable
+        orderby_clause:
+        - keyword: ORDER
+        - keyword: BY
+        - numeric_literal: '1'
+    - meta_command: \crosstabview
+    - select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            column_reference:
+              naked_identifier: a
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+              naked_identifier: b
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: t
+    - meta_command: \crosstabview


### PR DESCRIPTION
### Brief summary of the change made

The `\crosstabview` psql meta-command is used like `\gset` / `\gexec` to terminate a query buffer (it executes the current query, then renders the result as a crosstab grid). Previously `\crosstabview` was lexed as a generic `meta_command` (`CommentSegment`) rather than `meta_command_query_buffer`, which prevented multiple `\crosstabview`-terminated statements from parsing in the same file. Format/parse on a file with one or more `\crosstabview` reported `Found unparsable section` starting at the second query.

Added `crosstabview\b` to the negative lookahead in the `meta_command` lexer so it falls through to the `meta_command_query_buffer` matcher, mirroring how `\gset`/`\gexec` are handled.

Fixes #7815

### Are there any other side effects of this change that we should be aware of?

None expected. Existing `\echo`, `\prompt`, `\x`, etc. continue to lex as `meta_command` (CommentSegment) and existing `\gset`/`\gexec` behavior is unchanged. All 513 postgres-related parser tests pass.

### Pull Request checklist

- [x] Parser test cases added to `test/fixtures/dialects/postgres/meta_commands_query_buffer.{sql,yml}` (regenerated via `tox -e generate-fixture-yml`).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Parse PostgreSQL \crosstabview as a query buffer terminator, like \gset and \gexec, so files with multiple \crosstabview commands parse correctly. Updates the Postgres lexer (negative lookahead) and adds fixtures; fixes #7815.

<sup>Written for commit 31d0661b3308fe3664a07aac95679357d6b52aa0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

