### PR TITLE
fix(clickhouse): allow WHERE/PREWHERE after ARRAY JOIN

### DIFF
--- a/src/sqlfluff/dialects/dialect_clickhouse.py
+++ b/src/sqlfluff/dialects/dialect_clickhouse.py
@@ -209,7 +209,6 @@ clickhouse_dialect.replace(
             Ref("ArrayJoinClauseSegment"),
             min_times=1,
         ),
-        Ref("AliasExpressionSegment", optional=True),
     ),
     QuotedLiteralSegment=OneOf(
         TypedParser(

--- a/test/fixtures/dialects/clickhouse/join.sql
+++ b/test/fixtures/dialects/clickhouse/join.sql
@@ -115,3 +115,7 @@ SELECT * FROM (SELECT [1, 2] AS arr, [3, 4] AS arr2) AS t1 ARRAY JOIN arr, arr2;
 SELECT x, y FROM (SELECT [1, 2] AS arr, [3, 4] AS arr2) AS t1 ARRAY JOIN arr AS x, arr2 AS y;
 SELECT *,ch,cg FROM (SELECT 1) ARRAY JOIN ['1','2'] as cg, splitByChar(',','1,2') as ch;
 SELECT * FROM (SELECT [1,2] x) AS t1 ARRAY JOIN t1.*;
+-- ARRAY join followed by WHERE / PREWHERE / GROUP BY (regression for #7836)
+SELECT col FROM (SELECT [1, 2] AS arr) AS t1 ARRAY JOIN arr AS col WHERE col != 0;
+SELECT col FROM (SELECT [1, 2] AS arr) AS t1 LEFT ARRAY JOIN arr AS col PREWHERE col > 0;
+SELECT col, count(*) AS cnt FROM (SELECT [1, 1, 2] AS arr) AS t1 ARRAY JOIN arr AS col WHERE col > 0 GROUP BY col ORDER BY col;

--- a/test/fixtures/dialects/clickhouse/join.yml
+++ b/test/fixtures/dialects/clickhouse/join.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 82a0d04e0efa48e7c7ab723e92edbf36134c8df2a274c2481deed302c8a8a1f4
+_hash: 9b8d62a8f48bab490c167d5f10c95358fb6a391b998f99356dc4cdf93ebdaf0c
 file:
 - statement:
     select_statement:
@@ -3549,4 +3549,188 @@ file:
                   naked_identifier: t1
                   dot: .
                   star: '*'
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          column_reference:
+            naked_identifier: col
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              bracketed:
+                start_bracket: (
+                select_statement:
+                  select_clause:
+                    keyword: SELECT
+                    select_clause_element:
+                      array_literal:
+                      - start_square_bracket: '['
+                      - numeric_literal: '1'
+                      - comma: ','
+                      - numeric_literal: '2'
+                      - end_square_bracket: ']'
+                      alias_expression:
+                        alias_operator:
+                          keyword: AS
+                        naked_identifier: arr
+                end_bracket: )
+            alias_expression:
+              alias_operator:
+                keyword: AS
+              naked_identifier: t1
+          array_join_clause:
+          - keyword: ARRAY
+          - keyword: JOIN
+          - select_clause_element:
+              column_reference:
+                naked_identifier: arr
+              alias_expression:
+                alias_operator:
+                  keyword: AS
+                naked_identifier: col
+      where_clause:
+        keyword: WHERE
+        expression:
+          column_reference:
+            naked_identifier: col
+          comparison_operator:
+          - raw_comparison_operator: '!'
+          - raw_comparison_operator: '='
+          numeric_literal: '0'
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          column_reference:
+            naked_identifier: col
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              bracketed:
+                start_bracket: (
+                select_statement:
+                  select_clause:
+                    keyword: SELECT
+                    select_clause_element:
+                      array_literal:
+                      - start_square_bracket: '['
+                      - numeric_literal: '1'
+                      - comma: ','
+                      - numeric_literal: '2'
+                      - end_square_bracket: ']'
+                      alias_expression:
+                        alias_operator:
+                          keyword: AS
+                        naked_identifier: arr
+                end_bracket: )
+            alias_expression:
+              alias_operator:
+                keyword: AS
+              naked_identifier: t1
+          array_join_clause:
+          - keyword: LEFT
+          - keyword: ARRAY
+          - keyword: JOIN
+          - select_clause_element:
+              column_reference:
+                naked_identifier: arr
+              alias_expression:
+                alias_operator:
+                  keyword: AS
+                naked_identifier: col
+      prewhere_clause:
+        keyword: PREWHERE
+        expression:
+          column_reference:
+            naked_identifier: col
+          comparison_operator:
+            raw_comparison_operator: '>'
+          numeric_literal: '0'
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            naked_identifier: col
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: count
+            function_contents:
+              bracketed:
+                start_bracket: (
+                star: '*'
+                end_bracket: )
+          alias_expression:
+            alias_operator:
+              keyword: AS
+            naked_identifier: cnt
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              bracketed:
+                start_bracket: (
+                select_statement:
+                  select_clause:
+                    keyword: SELECT
+                    select_clause_element:
+                      array_literal:
+                      - start_square_bracket: '['
+                      - numeric_literal: '1'
+                      - comma: ','
+                      - numeric_literal: '1'
+                      - comma: ','
+                      - numeric_literal: '2'
+                      - end_square_bracket: ']'
+                      alias_expression:
+                        alias_operator:
+                          keyword: AS
+                        naked_identifier: arr
+                end_bracket: )
+            alias_expression:
+              alias_operator:
+                keyword: AS
+              naked_identifier: t1
+          array_join_clause:
+          - keyword: ARRAY
+          - keyword: JOIN
+          - select_clause_element:
+              column_reference:
+                naked_identifier: arr
+              alias_expression:
+                alias_operator:
+                  keyword: AS
+                naked_identifier: col
+      where_clause:
+        keyword: WHERE
+        expression:
+          column_reference:
+            naked_identifier: col
+          comparison_operator:
+            raw_comparison_operator: '>'
+          numeric_literal: '0'
+      groupby_clause:
+      - keyword: GROUP
+      - keyword: BY
+      - column_reference:
+          naked_identifier: col
+      orderby_clause:
+      - keyword: ORDER
+      - keyword: BY
+      - column_reference:
+          naked_identifier: col
 - statement_terminator: ;


### PR DESCRIPTION
Fixes #7836.

## Problem

`JoinLikeClauseGrammar` ended with an optional `AliasExpressionSegment`, which greedily consumed the following `WHERE` / `PREWHERE` / `GROUP BY` etc. keyword as a `naked_identifier` alias on the ARRAY JOIN clause. The predicate body that followed was then left as an unparsable section.

Repro from the issue:

```sql
SELECT item
FROM some_table
ARRAY JOIN line_items AS item
WHERE item != ''
```

Before this PR, the parse tree showed:

```
                    array_join_clause:
                        keyword:                              'ARRAY'
                        keyword:                              'JOIN'
                        select_clause_element:
                            ...
                    alias_expression:
                        naked_identifier:                     'WHERE'   <-- bug
            unparsable:
                word:                                         'item'
                not:                                          '!'
                equals:                                       '='
                single_quote:                                 "''"
```

## Fix

ClickHouse's [ARRAY JOIN syntax](https://clickhouse.com/docs/sql-reference/statements/select/array-join) does not support a clause-level alias. Aliases apply to individual array elements inside the clause, which the existing `Delimited(SelectClauseElementSegment)` already handles. The trailing `Ref("AliasExpressionSegment", optional=True)` in `JoinLikeClauseGrammar` was dead code that never matched legitimately but greedily swallowed reserved keywords.

The fix removes the dead alias slot — one line deletion.

## Verification

- All 138 existing clickhouse dialect tests pass.
- Regenerating all 46 clickhouse fixture YAMLs produces zero diffs (confirmed via `git diff --stat`), proving the removed grammar branch was dead code.
- A spot check of every ARRAY JOIN line in `test/fixtures/dialects/clickhouse/join.sql` shows zero usage of clause-level aliasing.
- After the fix, `WHERE` parses as `where_clause` rather than `alias_expression { naked_identifier: 'WHERE' }`.

## New regression fixtures

Three cases added to `test/fixtures/dialects/clickhouse/join.sql`:

```sql
-- ARRAY join followed by WHERE / PREWHERE / GROUP BY (regression for #7836)
SELECT col FROM (SELECT [1, 2] AS arr) AS t1 ARRAY JOIN arr AS col WHERE col != 0;
SELECT col FROM (SELECT [1, 2] AS arr) AS t1 LEFT ARRAY JOIN arr AS col PREWHERE col > 0;
SELECT col, count(*) AS cnt FROM (SELECT [1, 1, 2] AS arr) AS t1 ARRAY JOIN arr AS col WHERE col > 0 GROUP BY col ORDER BY col;
```

Generated YAMLs are included in the diff.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix ClickHouse parsing so `WHERE`/`PREWHERE`/`GROUP BY` can follow `ARRAY JOIN` without being misread as an alias. Removes a dead alias parse branch that swallowed these keywords. Fixes #7836.

- **Bug Fixes**
  - Removed the optional `AliasExpressionSegment` from `JoinLikeClauseGrammar` (ClickHouse does not allow clause-level aliases on `ARRAY JOIN`).
  - Added three regression cases covering `ARRAY JOIN` followed by `WHERE`, `PREWHERE`, and `GROUP BY/ORDER BY`.

<sup>Written for commit 78a126be03bea92b4e88198ac4022576dce560e5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

