### PR TITLE
TSQL: enable parameters in CONTAINSTABLE

### DIFF
--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -8608,6 +8608,16 @@ class ContainstableSegment(BaseSegment):
         Ref("StarSegment"),
     )
 
+    _search_condition = OneOf(
+        Ref("QuotedLiteralSegmentOptWithN"),
+        Ref("ParameterNameSegment"),
+    )
+
+    _top_n_by_rank_term = OneOf(
+        Ref("NumericLiteralSegment"),
+        Ref("ParameterNameSegment"),
+    )
+
     match_grammar = Sequence(
         "CONTAINSTABLE",
         Bracketed(
@@ -8615,7 +8625,7 @@ class ContainstableSegment(BaseSegment):
             Ref("CommaSegment"),
             _column_specification,
             Ref("CommaSegment"),
-            Ref("QuotedLiteralSegmentOptWithN"),
+            _search_condition,
             Sequence(
                 Ref("CommaSegment"),
                 "LANGUAGE",
@@ -8624,7 +8634,7 @@ class ContainstableSegment(BaseSegment):
             ),
             Sequence(
                 Ref("CommaSegment"),
-                Ref("NumericLiteralSegment"),
+                _top_n_by_rank_term,
                 optional=True,
             ),
         ),

--- a/test/fixtures/dialects/tsql/containstable.sql
+++ b/test/fixtures/dialects/tsql/containstable.sql
@@ -4,6 +4,9 @@ SELECT *
 FROM CONTAINSTABLE(Flags, FlagColors, 'Green') AS KEY_TBL
 ORDER BY KEY_TBL.RANK DESC;
 
+SELECT *
+FROM CONTAINSTABLE(Flags, FlagColors, @contains_query, @candidate_cap) AS KEY_TBL
+
 SELECT FT_TBL.Name,
        KEY_TBL.RANK
 FROM Production.Product AS FT_TBL

--- a/test/fixtures/dialects/tsql/containstable.yml
+++ b/test/fixtures/dialects/tsql/containstable.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: f142f8944ed6dd987eb9ebf6e3813dce9a7ced06c05c349707584592b4f892e5
+_hash: fee386820ed9a731e30968feef48c2e499fbc9d0e822974186be9ad5d9ada6b0
 file:
   batch:
   - statement:
@@ -44,6 +44,37 @@ file:
           - naked_identifier: RANK
         - keyword: DESC
   - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                containstable_segment:
+                  keyword: CONTAINSTABLE
+                  bracketed:
+                  - start_bracket: (
+                  - table_reference:
+                      naked_identifier: Flags
+                  - comma: ','
+                  - column_reference:
+                      naked_identifier: FlagColors
+                  - comma: ','
+                  - parameter: '@contains_query'
+                  - comma: ','
+                  - parameter: '@candidate_cap'
+                  - end_bracket: )
+              alias_expression:
+                alias_operator:
+                  keyword: AS
+                naked_identifier: KEY_TBL
   - statement:
       select_statement:
         select_clause:


### PR DESCRIPTION
### Brief summary of the change made

This PR enables to use parameters also in `CONTAINSTABLE` grammar, not just string literals / intergers.

### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable parameters in T‑SQL CONTAINSTABLE for both the search condition and the TOP N BY RANK argument. Queries can now use variables like @contains_query and @candidate_cap instead of only literals, with parser support and tests added.

<sup>Written for commit 5369a5fcd6086f8bea734d9502abcd7f5b84d2ce. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

