### PR TITLE
Cut back the rust wheels distributed and use ABI3

### DIFF
--- a/.github/workflows/ci-test-python.yml
+++ b/.github/workflows/ci-test-python.yml
@@ -61,6 +61,7 @@ jobs:
           constraints/*.txt
 
     - name: Download built wheels
+      # Reuse the Linux x86_64 abi3 wheel across all supported CPython versions.
       if: ${{ inputs.with-rust == '-rust' }}
       uses: actions/download-artifact@v4
       with:

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -120,7 +120,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: x86_64
-          args: --release --out dist --find-interpreter --manifest-path sqlfluffrs/Cargo.toml
+          args: --release --out dist --manifest-path sqlfluffrs/Cargo.toml
           manylinux: auto
         env:
           # Use all 4 cores for parallel Rust compilation
@@ -170,7 +170,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.target }}
-          args: --release --out dist --find-interpreter --manifest-path sqlfluffrs/Cargo.toml
+          args: --release --out dist --manifest-path sqlfluffrs/Cargo.toml
           manylinux: auto
 
       - name: Upload wheels
@@ -222,7 +222,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}
-          args: --release --out dist --find-interpreter --manifest-path sqlfluffrs/Cargo.toml
+          args: --release --out dist --manifest-path sqlfluffrs/Cargo.toml
           manylinux: musllinux_1_2
 
       - name: Upload wheels
@@ -270,7 +270,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}
-          args: --release --out dist --find-interpreter --manifest-path sqlfluffrs/Cargo.toml
+          args: --release --out dist --manifest-path sqlfluffrs/Cargo.toml
 
       - name: Upload wheels
         uses: actions/upload-artifact@v4
@@ -316,7 +316,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}
-          args: --release --out dist --find-interpreter --manifest-path sqlfluffrs/Cargo.toml
+          args: --release --out dist --manifest-path sqlfluffrs/Cargo.toml
 
       - name: Upload wheels
         uses: actions/upload-artifact@v4

--- a/.github/workflows/publish-sqlfluffrs-release-to-pypi.yaml
+++ b/.github/workflows/publish-sqlfluffrs-release-to-pypi.yaml
@@ -77,6 +77,15 @@ jobs:
           architecture: ${{ matrix.platform.arch || null }}
 
       - name: Build wheels
+        if: matrix.platform.runner == 'ubuntu-22.04'
+        uses: PyO3/maturin-action@v1
+        with:
+          target: ${{ matrix.platform.target }}
+          args: --release -i python3.10 --out dist --manifest-path sqlfluffrs/Cargo.toml
+          manylinux: ${{ matrix.platform.manylinux || '' }}
+
+      - name: Build wheels
+        if: matrix.platform.runner != 'ubuntu-22.04'
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}

--- a/.github/workflows/publish-sqlfluffrs-release-to-pypi.yaml
+++ b/.github/workflows/publish-sqlfluffrs-release-to-pypi.yaml
@@ -48,8 +48,6 @@ jobs:
           - {runner: ubuntu-22.04, target: x86, manylinux: auto, artifact: linux-x86}
           - {runner: ubuntu-22.04, target: aarch64, manylinux: auto, artifact: linux-aarch64}
           - {runner: ubuntu-22.04, target: armv7, manylinux: auto, artifact: linux-armv7}
-          - {runner: ubuntu-22.04, target: s390x, manylinux: auto, artifact: linux-s390x}
-          - {runner: ubuntu-22.04, target: ppc64le, manylinux: auto, artifact: linux-ppc64le}
           # Linux (musllinux)
           - {runner: ubuntu-22.04, target: x86_64, manylinux: musllinux_1_2, artifact: musllinux-x86_64}
           - {runner: ubuntu-22.04, target: x86, manylinux: musllinux_1_2, artifact: musllinux-x86}
@@ -57,7 +55,6 @@ jobs:
           - {runner: ubuntu-22.04, target: armv7, manylinux: musllinux_1_2, artifact: musllinux-armv7}
           # Windows
           - {runner: windows-latest, target: x64, manylinux: "", artifact: windows-x64, arch: x64}
-          - {runner: windows-latest, target: x86, manylinux: "", artifact: windows-x86, arch: x86}
           # macOS
           - {runner: macos-15-intel, target: x86_64, manylinux: "", artifact: macos-x86_64}
           - {runner: macos-15, target: aarch64, manylinux: "", artifact: macos-aarch64}

--- a/.github/workflows/publish-sqlfluffrs-release-to-pypi.yaml
+++ b/.github/workflows/publish-sqlfluffrs-release-to-pypi.yaml
@@ -83,7 +83,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}
-          args: --release --out dist --find-interpreter --manifest-path sqlfluffrs/Cargo.toml
+          args: --release --out dist --manifest-path sqlfluffrs/Cargo.toml
           manylinux: ${{ matrix.platform.manylinux || '' }}
 
       - name: Upload wheels

--- a/README.md
+++ b/README.md
@@ -127,6 +127,17 @@ L:   1 | P:  27 | LT12 | Files must end with a single trailing newline.
 All Finished 📜 🎉!
 ```
 
+If you want the optional Rust-backed parser and lexer, install the `rs` extra:
+
+```shell
+$ pip install sqlfluff[rs]
+```
+
+On supported CPython 3.10+ platforms this installs a prebuilt ABI3 wheel. If no
+wheel is published for your platform, `pip` falls back to building `sqlfluffrs`
+from source, which requires a Rust toolchain and a working C/C++ build setup.
+The easiest way to install Rust is with [rustup](https://rustup.rs/).
+
 Alternatively, you can use the [**Official SQLFluff Docker Image**](https://hub.docker.com/r/sqlfluff/sqlfluff)
 or have a play using [**SQLFluff online**](https://online.sqlfluff.com/).
 

--- a/docs/source/gettingstarted.rst
+++ b/docs/source/gettingstarted.rst
@@ -57,6 +57,20 @@ Assuming that python and pip are already installed, then installing
 
     $ pip install sqlfluff
 
+If you want the optional Rust-backed parser and lexer, install the
+:code:`rs` extra:
+
+.. code-block:: text
+
+    $ pip install sqlfluff[rs]
+
+On supported CPython 3.10+ platforms this installs a prebuilt ABI3 wheel.
+If a wheel is not available for your platform, architecture, or Python
+implementation, :code:`pip` falls back to building :code:`sqlfluffrs` from
+source. In that case you will need a Rust toolchain and a working native build
+toolchain for your platform. The easiest way to install Rust is via
+`rustup <https://rustup.rs/>`_.
+
 You can confirm its installation by getting *SQLFluff* to show its
 version number.
 

--- a/docs/source/reference/releasenotes.rst
+++ b/docs/source/reference/releasenotes.rst
@@ -34,10 +34,11 @@ This release is the first where the optional Rust routines are available.
 For most users, no difference will be visible, as currently the rust libraries
 are *opt-in*, and must be explicitly installed with :code:`pip install sqlfluff[rs]`.
 
-Rust libraries are built for most major platforms, and we believe are ready for
-public beta testing, but they should be considered experimental until the 5.x
-release. Performance gains on initial release are not expected to be significant,
-but we do expect they will be significant once the routines are mature.
+Rust libraries are distributed as wheels for supported platforms, and installs
+without a matching wheel will fall back to a local source build. They should be
+considered experimental until the 5.x release. Performance gains on initial
+release are not expected to be significant, but we do expect they will be
+significant once the routines are mature.
 
 Additionally:
 

--- a/docsv/guide/install.md
+++ b/docsv/guide/install.md
@@ -41,11 +41,23 @@ the best instructions for what to do next are [on the python website](https://pi
 ## Installing SQLFluff
 
 Assuming that python and pip are already installed, then installing
-*SQLFluff* is straight forward.
+*SQLFluff* is straightforward.
 
 ```bash
 pip install sqlfluff
 ```
+
+If you want the optional Rust-backed parser and lexer, install the `rs` extra:
+
+```bash
+pip install sqlfluff[rs]
+```
+
+On supported CPython 3.10+ platforms this installs a prebuilt ABI3 wheel. If a
+wheel is not available for your platform, architecture, or Python
+implementation, `pip` falls back to building `sqlfluffrs` from source. In that
+case you will need a Rust toolchain and a working native build toolchain for
+your platform. The easiest way to install Rust is via [rustup](https://rustup.rs/).
 
 You can confirm its installation by getting *SQLFluff* to show its
 version number.

--- a/docsv/reference/release-notes.md
+++ b/docsv/reference/release-notes.md
@@ -25,10 +25,11 @@ This release is the first where the optional Rust routines are available.
 For most users, no difference will be visible, as currently the rust libraries
 are *opt-in*, and must be explicitly installed with `pip install sqlfluff[rs]`.
 
-Rust libraries are built for most major platforms, and we believe are ready for
-public beta testing, but they should be considered experimental until the 5.x
-release. Performance gains on initial release are not expected to be significant,
-but we do expect they will be significant once the routines are mature.
+Rust libraries are distributed as wheels for supported platforms, and installs
+without a matching wheel will fall back to a local source build. They should be
+considered experimental until the 5.x release. Performance gains on initial
+release are not expected to be significant, but we do expect they will be
+significant once the routines are mature.
 
 Additionally:
 

--- a/sqlfluffrs/Cargo.toml
+++ b/sqlfluffrs/Cargo.toml
@@ -44,7 +44,11 @@ hashbrown = "0.16.1"
 itertools = "0.14.0"
 log = "0.4.29"
 smallvec = "1.15.1"
+# NOTE: Update the abi3 version as we deprecate old python versions.
+# It should match the oldest currently supported python version.
+# This is also necessary in the child packages.
 pyo3 = { version = "0.28.2", optional = true, features = [
+    "abi3-py310",
     "hashbrown",
     "extension-module",
     "uuid",

--- a/sqlfluffrs/README.md
+++ b/sqlfluffrs/README.md
@@ -28,6 +28,12 @@ implementation, `pip` falls back to building from source. In that case you need:
 - a working C/C++ compiler toolchain for your platform
 - Python headers and normal build tooling for native extensions
 
+SQLFluff-rs is tested on more platform and architecture combinations than we
+currently publish python wheels for. PyPI project storage limits mean we only
+distribute wheels for the most common targets. Some platforms that are covered
+by CI should therefore still reliably install from source despite not receiving
+a prebuilt wheel.
+
 For example, after installing Rust, a source install can still use the normal
 SQLFluff extra:
 

--- a/sqlfluffrs/README.md
+++ b/sqlfluffrs/README.md
@@ -28,8 +28,8 @@ implementation, `pip` falls back to building from source. In that case you need:
 - a working C/C++ compiler toolchain for your platform
 - Python headers and normal build tooling for native extensions
 
-SQLFluff-rs is tested on more platform and architecture combinations than we
-currently publish python wheels for. PyPI project storage limits mean we only
+SQLFluff-rs is tested on more platforms and architecture combinations than we
+currently publish Python wheels for. PyPI project storage limits mean we only
 distribute wheels for the most common targets. Some platforms that are covered
 by CI should therefore still reliably install from source despite not receiving
 a prebuilt wheel.

--- a/sqlfluffrs/README.md
+++ b/sqlfluffrs/README.md
@@ -8,11 +8,37 @@ SQLFluff-rs serves as a Rust-based component that can be integrated with the mai
 
 ## Installation
 
-This package is automatically handled when installing SQLFluff with the appropriate optional dependencies. Direct installation or standalone usage is not supported.
+This package is automatically handled when installing SQLFluff with the
+appropriate optional dependencies. Direct installation is mainly useful for
+development or debugging and is not the recommended end-user path.
 
 To install from pip:
 ```sh
 pip install sqlfluff[rs]
+```
+
+On supported CPython 3.10+ platforms, this resolves to a prebuilt ABI3 wheel.
+That means the same wheel can be reused across newer CPython versions without a
+separate wheel per interpreter.
+
+If a wheel is not available for your platform, architecture, or Python
+implementation, `pip` falls back to building from source. In that case you need:
+
+- a Rust toolchain, typically installed with `rustup`
+- a working C/C++ compiler toolchain for your platform
+- Python headers and normal build tooling for native extensions
+
+For example, after installing Rust, a source install can still use the normal
+SQLFluff extra:
+
+```sh
+pip install sqlfluff[rs]
+```
+
+Or to build this package directly from a checkout:
+
+```sh
+pip install ./sqlfluffrs
 ```
 
 ## Development Status

--- a/sqlfluffrs/pyproject.toml
+++ b/sqlfluffrs/pyproject.toml
@@ -55,7 +55,9 @@ Source = "https://github.com/sqlfluff/sqlfluff"
 "Issue Tracker" = "https://github.com/sqlfluff/sqlfluff/issues"
 
 [tool.maturin]
-features = ["pyo3/extension-module", "python"]
+# NOTE: Update the abi3 version as we deprecate old python versions.
+# It should match the oldest currently supported python version.
+features = ["pyo3/abi3-py310", "pyo3/extension-module", "python"]
 
 [tool.uv.sources]
 sqlfluff = { workspace = true }

--- a/sqlfluffrs/sqlfluffrs_lexer/Cargo.toml
+++ b/sqlfluffrs/sqlfluffrs_lexer/Cargo.toml
@@ -15,7 +15,9 @@ uuid = { version = "1.22.0", features = ["v4"] }
 sqlfluffrs_types = { path = "../sqlfluffrs_types" }
 sqlfluffrs_dialects = { path = "../sqlfluffrs_dialects" }
 sqlfluffrs_python = { path = "../sqlfluffrs_python", optional = true }
-pyo3 = { version = "0.28.2", optional = true, features = ["hashbrown", "extension-module", "uuid"] }
+# NOTE: Update the abi3 version as we deprecate old python versions.
+# It should match the oldest currently supported python version.
+pyo3 = { version = "0.28.2", optional = true, features = ["abi3-py310", "hashbrown", "extension-module", "uuid"] }
 pyo3-log = { version = "0.13.3", optional = true }
 
 [features]

--- a/sqlfluffrs/sqlfluffrs_parser/Cargo.toml
+++ b/sqlfluffrs/sqlfluffrs_parser/Cargo.toml
@@ -15,7 +15,9 @@ sqlfluffrs_python = { path = "../sqlfluffrs_python", optional = true }
 uuid = { version = "1.22.0", features = ["v4"] }
 serde_yaml_ng = "0.10.0"
 regex = { version = "1.12.3", features = ["perf"] }
-pyo3 = { version = "0.28.2", optional = true, features = ["hashbrown", "extension-module", "uuid"] }
+# NOTE: Update the abi3 version as we deprecate old python versions.
+# It should match the oldest currently supported python version.
+pyo3 = { version = "0.28.2", optional = true, features = ["abi3-py310", "hashbrown", "extension-module", "uuid"] }
 
 [features]
 python = ["pyo3", "sqlfluffrs_python", "sqlfluffrs_lexer/python"]

--- a/sqlfluffrs/sqlfluffrs_parser/src/lib.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/lib.rs
@@ -1,4 +1,4 @@
 pub mod parser;
 
 #[cfg(feature = "python")]
-pub use parser::{PyMatchResult, PyNode, PyParseError, PyParser, RsParseError};
+pub use parser::{PyMatchResult, PyNode, PyParser, RsParseError};

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/mod.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/mod.rs
@@ -35,4 +35,4 @@ pub(crate) use frame::{BracketedState, DelimitedState, FrameContext, FrameState}
 
 // Re-export Python bindings when feature is enabled
 #[cfg(feature = "python")]
-pub use python::{PyMatchResult, PyNode, PyParseError, PyParser, RsParseError};
+pub use python::{PyMatchResult, PyNode, PyParser, RsParseError};

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/python.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/python.rs
@@ -249,38 +249,6 @@ impl From<Node> for PyNode {
     }
 }
 
-/// Python-wrapped ParseError
-#[pyclass(name = "RsParseError", module = "sqlfluffrs", extends=PyException, from_py_object)]
-#[derive(Clone)]
-pub struct PyParseError {
-    #[pyo3(get)]
-    message: String,
-}
-
-#[pymethods]
-impl PyParseError {
-    #[new]
-    fn new(message: String) -> Self {
-        PyParseError { message }
-    }
-
-    fn __str__(&self) -> String {
-        self.message.clone()
-    }
-
-    fn __repr__(&self) -> String {
-        format!("RsParseError('{}')", self.message)
-    }
-}
-
-impl From<ParseError> for PyParseError {
-    fn from(err: ParseError) -> Self {
-        PyParseError {
-            message: err.message,
-        }
-    }
-}
-
 /// Python-wrapped MatchResult for deferred AST construction
 ///
 /// This allows Python code to receive match results and apply them using

--- a/sqlfluffrs/sqlfluffrs_python/Cargo.toml
+++ b/sqlfluffrs/sqlfluffrs_python/Cargo.toml
@@ -4,7 +4,9 @@ version.workspace = true
 edition = "2021"
 
 [dependencies]
-pyo3 = { version = "0.28.2", features = ["hashbrown", "extension-module", "uuid"] }
+# NOTE: Update the abi3 version as we deprecate old python versions.
+# It should match the oldest currently supported python version.
+pyo3 = { version = "0.28.2", features = ["abi3-py310", "hashbrown", "extension-module", "uuid"] }
 sqlfluffrs_types = { path = "../sqlfluffrs_types" }
 hashbrown = "0.16.1"
 uuid = { version = "1.22.0", features = ["v4"] }

--- a/sqlfluffrs/src/python.rs
+++ b/sqlfluffrs/src/python.rs
@@ -1,6 +1,6 @@
 use pyo3::prelude::*;
 use sqlfluffrs_lexer::{PyLexer, PySQLLexError};
-use sqlfluffrs_parser::{PyMatchResult, PyNode, PyParseError, PyParser, RsParseError};
+use sqlfluffrs_parser::{PyMatchResult, PyNode, PyParser, RsParseError};
 use sqlfluffrs_python::marker::PyPositionMarker;
 use sqlfluffrs_python::templater::{
     fileslice::{PyRawFileSlice, PyTemplatedFileSlice},
@@ -27,7 +27,6 @@ fn sqlfluffrs(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyNode>()?;
     m.add_class::<PyMatchResult>()?;
     m.add_class::<PyParser>()?;
-    m.add_class::<PyParseError>()?;
     // Add custom exception
     m.add("RsParseError", m.py().get_type::<RsParseError>())?;
     Ok(())


### PR DESCRIPTION
This pull request improves the packaging, distribution, and documentation for the optional Rust-backed parser and lexer (`sqlfluffrs`) in SQLFluff, focusing on more consistent use of Python ABI3 wheels, build matrix simplification, and clearer installation instructions. It also updates Rust and Python packaging to target CPython 3.10+ for ABI3 wheels and removes some unused or redundant code.

I think this should reduce us down to ~12 wheels from over 100:
- ABI3 means we get one wheel per platform/architecture, rather than seperate ones for each python version.
- I've removed wheels for PyPy, `i686`, `s390x`, `ppc64le` & `windows-x86`.

**Packaging and build system improvements:**

* Updated all `pyo3` dependencies and `pyproject.toml` files in `sqlfluffrs` and sub-crates to use the `abi3-py310` feature, ensuring that built wheels are ABI3-compatible with CPython 3.10+ and reducing the need to build separate wheels per Python version. [[1]](diffhunk://#diff-736d630d5349484eedece480271871d65129b697d69acdc2ed7621a2ebc3dae9R47-R51) [[2]](diffhunk://#diff-016838d87bbdc560e173d1a0f48717226f888deca49710087b56c3fc2f086efbL58-R60) [[3]](diffhunk://#diff-2c8ac909cfee838dd6c3298c34716d8e5fb5ec7d7d06a9b6ddef69819b38c17bL7-R9) [[4]](diffhunk://#diff-3eb971459010603b0f94e73d9b17a7faee18915fa6f49be5775cc1bc31d680ddL18-R20) [[5]](diffhunk://#diff-d63544b7038817bdaacbd9f1df472de50337236efc6f6e83fe8c30fe0fd88780L18-R20)
* Simplified the CI build matrix in `.github/workflows/publish-sqlfluffrs-release-to-pypi.yaml` by removing less common platforms (s390x, ppc64le, windows-x86) and splitting the wheel build step by runner type, specifying Python 3.10 as the interpreter for Linux builds to ensure ABI3 compatibility. [[1]](diffhunk://#diff-e2402790d31913922e13caffe144e9aa4e5ecd205a47c3075cde4025078fcf07L51-L60) [[2]](diffhunk://#diff-e2402790d31913922e13caffe144e9aa4e5ecd205a47c3075cde4025078fcf07R80-R92)
* Removed the `--find-interpreter` argument from all `maturin-action` build steps in CI, as it is no longer needed for ABI3 wheels. [[1]](diffhunk://#diff-03609cb60b0c6e92fb771eb8787d6722b8c31ca4c03eabc788e147acd8c6fb43L123-R123) [[2]](diffhunk://#diff-03609cb60b0c6e92fb771eb8787d6722b8c31ca4c03eabc788e147acd8c6fb43L173-R173) [[3]](diffhunk://#diff-03609cb60b0c6e92fb771eb8787d6722b8c31ca4c03eabc788e147acd8c6fb43L225-R225) [[4]](diffhunk://#diff-03609cb60b0c6e92fb771eb8787d6722b8c31ca4c03eabc788e147acd8c6fb43L273-R273) [[5]](diffhunk://#diff-03609cb60b0c6e92fb771eb8787d6722b8c31ca4c03eabc788e147acd8c6fb43L319-R319)
* Added a comment in `.github/workflows/ci-test-python.yml` explaining the reuse of the Linux x86_64 abi3 wheel across all supported CPython versions.

**Documentation improvements:**

* Added and clarified installation instructions for the Rust-backed parser and lexer in `README.md`, `docsv/guide/install.md`, and `docs/source/gettingstarted.rst`, explaining the use of the `[rs]` extra, ABI3 wheels, and fallback to source builds when needed. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R130-R140) [[2]](diffhunk://#diff-9046c7d708811c4867cdf363f9c4e8511eeaa89062f41e0339531ec7b6f3b082R50-R61) [[3]](diffhunk://#diff-a0eb3bb64d97813d4e12f16f7f32abf4624e017beb6997e975f92bff45e31b57R60-R73) [[4]](diffhunk://#diff-ab124683ab19161bc6e6aa7cf6782bfd31e6cd82dad706e2a0e885eac5975aefL11-R49)
* Updated release notes in both reStructuredText and Markdown to clarify that Rust wheels are distributed for supported platforms, and that source builds are used as a fallback. [[1]](diffhunk://#diff-c0c784063ffccafcd9bc0c1c6a65959d75d2ad4e9b5ad15962f249b4ad7ed02dL37-R41) [[2]](diffhunk://#diff-d585dc13a949e50166a519f2db935583f2cd04e746bd0721d6f88a1f4174ca1bL28-R32)

**Code cleanup:**

* Removed the unused `PyParseError` class and related imports/exports from the Rust parser bindings, since custom exception handling now uses `RsParseError` directly. [[1]](diffhunk://#diff-f394aae78b59522fd581c567b483851f392793f4f3b42b9749814653150af3ffL4-R4) [[2]](diffhunk://#diff-a4add19a23e2124964b20096c8ceb76319f207b67a95be194140fa6c7bcd3cffL38-R38) [[3]](diffhunk://#diff-9756f334ca7f4c28d8b9297676a7aa89feaaf2c3fc7b721e19dbd43b615eab73L252-L283) [[4]](diffhunk://#diff-e2ffaeb2339d720a982b93f55df5623e91487b4d92a2476df9981a039b9ba313L3-R3) [[5]](diffhunk://#diff-e2ffaeb2339d720a982b93f55df5623e91487b4d92a2476df9981a039b9ba313L30)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Move `sqlfluffrs` to ABI3 wheels (CPython 3.10+) and prune release targets to common platforms to reduce wheel count and simplify releases. Also clarify install docs for the Rust extra and remove an unused Python exception.

- **Dependencies**
  - Enable `abi3-py310` for all `pyo3` crates; set `tool.maturin.features` to include `pyo3/abi3-py310`.

- **Refactors**
  - CI: build Linux wheels with `python3.10`, drop `--find-interpreter`, split steps by runner, and stop publishing `s390x`, `ppc64le`, and `windows-x86`; add note about reusing the Linux x86_64 ABI3 wheel in tests.
  - Docs: add `pip install sqlfluff[rs]` instructions; explain ABI3 wheels and source-build fallback; update release notes.
  - Code: remove `PyParseError`; use `RsParseError` and update exports.

<sup>Written for commit 5de35b4362ea56631f984342ec5938d9edf6b129. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



