### PR TITLE
fix: parse `table.*` in expressions as a wildcard identifier

### DIFF
--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -1851,6 +1851,29 @@ class WildcardExpressionSegment(BaseSegment):
     )
 
 
+class SingleIdentifierWildcardSegment(WildcardIdentifierSegment):
+    """A wildcard identifier qualified by a single name, e.g. ``a.*``.
+
+    Unlike :class:`WildcardIdentifierSegment`, this does not allow a bare
+    ``*`` (which would be ambiguous with multiplication in an expression
+    context) or a multi-part reference such as ``a.b.*``. It is used inside
+    general expressions, for example ``NEW.*`` in a trigger condition or
+    ``my_table.*`` when a whole row is passed to a function such as
+    ``to_jsonb(my_table.*)``.
+
+    It keeps the ``wildcard_identifier`` segment type (and the reference
+    helpers inherited from :class:`ObjectReferenceSegment`) so that reference
+    analysis -- and the rules built on it, such as AL05 and ST11 -- treat the
+    qualifier as a used table reference rather than as orphaned raw segments.
+    """
+
+    match_grammar: Matchable = Sequence(
+        Ref("SingleIdentifierGrammar"),
+        Ref("ObjectReferenceDelimiterGrammar"),
+        Ref("StarSegment"),
+    )
+
+
 class SelectClauseElementSegment(BaseSegment):
     """An element in the targets of a select statement."""
 
@@ -2377,13 +2400,13 @@ ansi_dialect.add(
             ),
             # Allow potential select statement without brackets
             Ref("Expression_D_Potential_Select_Statement_Without_Brackets"),
-            # For triggers, we allow "NEW.*" but not just "*" nor "a.b.*"
-            # So can't use WildcardIdentifierSegment nor WildcardExpressionSegment
-            Sequence(
-                Ref("SingleIdentifierGrammar"),
-                Ref("ObjectReferenceDelimiterGrammar"),
-                Ref("StarSegment"),
-            ),
+            # For triggers we allow "NEW.*", and for expressions which pass a
+            # whole row to a function we allow "my_table.*". A dedicated segment
+            # is used (rather than a bare Sequence) so reference analysis sees
+            # the qualifier as a used table reference. We can't reuse
+            # WildcardIdentifierSegment / WildcardExpressionSegment here because
+            # they also permit a bare "*" and multi-part "a.b.*".
+            Ref("SingleIdentifierWildcardSegment"),
             Sequence(
                 OneOf(Ref("StructTypeSegment"), Ref("MapTypeSegment")),
                 Bracketed(Delimited(Ref("ExpressionSegment"))),

--- a/src/sqlfluff/rules/structure/ST11.py
+++ b/src/sqlfluff/rules/structure/ST11.py
@@ -111,10 +111,19 @@ class Rule_ST11(BaseRule):
         self, segment: BaseSegment, allow_unqualified: bool = False
     ) -> Iterator[str]:
         # NOTE: Here we _may_ recurse into subqueries to find references.
-        for ref in segment.recursive_crawl("column_reference"):
+        # We also pick up qualified wildcards (e.g. ``my_table.*``), which
+        # reference their qualifying table just like a column reference does.
+        # This matters when a whole row is passed to a function, such as
+        # ``to_jsonb(my_table.*)``.
+        for ref in segment.recursive_crawl("column_reference", "wildcard_identifier"):
             obj_ref = cast(ObjectReferenceSegment, ref)
             parts = list(obj_ref.iter_raw_references())
             if len(parts) < 2:
+                # A bare wildcard (``*``) doesn't identify a table on its own;
+                # select-clause wildcards are resolved separately via
+                # ``get_wildcard_info()``, so just skip it here.
+                if ref.is_type("wildcard_identifier"):
+                    continue
                 if allow_unqualified:
                     continue
                 else:

--- a/test/fixtures/dialects/postgres/create_trigger.yml
+++ b/test/fixtures/dialects/postgres/create_trigger.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 56480788d573c81c4ae61f3a8b80adf517b9075a2f420a82aaef1ee3889e0602
+_hash: 10478fab0c3ecd77a59bc55401b57ae5cc14a6758db39597fa5dea0c32936659
 file:
 - statement:
     create_trigger:
@@ -519,15 +519,17 @@ file:
     - bracketed:
         start_bracket: (
         expression:
-        - naked_identifier: OLD
-        - dot: .
-        - star: '*'
+        - wildcard_identifier:
+            naked_identifier: OLD
+            dot: .
+            star: '*'
         - keyword: IS
         - keyword: DISTINCT
         - keyword: FROM
-        - naked_identifier: NEW
-        - dot: .
-        - star: '*'
+        - wildcard_identifier:
+            naked_identifier: NEW
+            dot: .
+            star: '*'
         end_bracket: )
     - keyword: EXECUTE
     - keyword: FUNCTION

--- a/test/fixtures/dialects/snowflake/match_recognize.yml
+++ b/test/fixtures/dialects/snowflake/match_recognize.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: ce10bb5484b8bbd9a672ef2983dd6b3db6f37aae6800b37b1d6b95b930b8595f
+_hash: c1eed933b10d2613ceb4aa51f99e01832131bb17dfd04015e15ccc1dd9e07393
 file:
 - statement:
     select_statement:
@@ -103,9 +103,10 @@ file:
                     bracketed:
                       start_bracket: (
                       expression:
-                        naked_identifier: row_with_price_decrease
-                        dot: .
-                        star: '*'
+                        wildcard_identifier:
+                          naked_identifier: row_with_price_decrease
+                          dot: .
+                          star: '*'
                       end_bracket: )
             - alias_expression:
                 alias_operator:
@@ -120,9 +121,10 @@ file:
                     bracketed:
                       start_bracket: (
                       expression:
-                        naked_identifier: row_with_price_increase
-                        dot: .
-                        star: '*'
+                        wildcard_identifier:
+                          naked_identifier: row_with_price_increase
+                          dot: .
+                          star: '*'
                       end_bracket: )
             - alias_expression:
                 alias_operator:
@@ -773,9 +775,10 @@ file:
                     bracketed:
                       start_bracket: (
                       expression:
-                        naked_identifier: row_with_price_decrease
-                        dot: .
-                        star: '*'
+                        wildcard_identifier:
+                          naked_identifier: row_with_price_decrease
+                          dot: .
+                          star: '*'
                       end_bracket: )
             - alias_expression:
                 alias_operator:
@@ -790,9 +793,10 @@ file:
                     bracketed:
                       start_bracket: (
                       expression:
-                        naked_identifier: row_with_price_increase
-                        dot: .
-                        star: '*'
+                        wildcard_identifier:
+                          naked_identifier: row_with_price_increase
+                          dot: .
+                          star: '*'
                       end_bracket: )
             - alias_expression:
                 alias_operator:
@@ -988,9 +992,10 @@ file:
                     bracketed:
                       start_bracket: (
                       expression:
-                        naked_identifier: row_with_price_decrease
-                        dot: .
-                        star: '*'
+                        wildcard_identifier:
+                          naked_identifier: row_with_price_decrease
+                          dot: .
+                          star: '*'
                       end_bracket: )
             - alias_expression:
                 alias_operator:
@@ -1005,9 +1010,10 @@ file:
                     bracketed:
                       start_bracket: (
                       expression:
-                        naked_identifier: row_with_price_increase
-                        dot: .
-                        star: '*'
+                        wildcard_identifier:
+                          naked_identifier: row_with_price_increase
+                          dot: .
+                          star: '*'
                       end_bracket: )
             - alias_expression:
                 alias_operator:
@@ -1199,9 +1205,10 @@ file:
                     bracketed:
                       start_bracket: (
                       expression:
-                        naked_identifier: row_with_price_decrease
-                        dot: .
-                        star: '*'
+                        wildcard_identifier:
+                          naked_identifier: row_with_price_decrease
+                          dot: .
+                          star: '*'
                       end_bracket: )
             - alias_expression:
                 alias_operator:
@@ -1216,9 +1223,10 @@ file:
                     bracketed:
                       start_bracket: (
                       expression:
-                        naked_identifier: row_with_price_increase
-                        dot: .
-                        star: '*'
+                        wildcard_identifier:
+                          naked_identifier: row_with_price_increase
+                          dot: .
+                          star: '*'
                       end_bracket: )
             - alias_expression:
                 alias_operator:
@@ -1396,9 +1404,10 @@ file:
                     bracketed:
                       start_bracket: (
                       expression:
-                        naked_identifier: row_with_price_decrease
-                        dot: .
-                        star: '*'
+                        wildcard_identifier:
+                          naked_identifier: row_with_price_decrease
+                          dot: .
+                          star: '*'
                       end_bracket: )
             - alias_expression:
                 alias_operator:
@@ -1413,9 +1422,10 @@ file:
                     bracketed:
                       start_bracket: (
                       expression:
-                        naked_identifier: row_with_price_increase
-                        dot: .
-                        star: '*'
+                        wildcard_identifier:
+                          naked_identifier: row_with_price_increase
+                          dot: .
+                          star: '*'
                       end_bracket: )
             - alias_expression:
                 alias_operator:

--- a/test/fixtures/rules/std_rule_cases/AL05.yml
+++ b/test/fixtures/rules/std_rule_cases/AL05.yml
@@ -1257,3 +1257,16 @@ test_pass_redshift_array_value:
   configs:
     core:
       dialect: redshift
+
+test_pass_postgres_wildcard_row_passed_to_function:
+  # https://github.com/sqlfluff/sqlfluff/issues/7235
+  # `mot.*` passes the whole row of the aliased table to a function, so the
+  # alias *is* used and should not be flagged.
+  pass_str: |
+    SELECT
+      to_jsonb(mot.*)
+    FROM my_table
+    JOIN my_other_table AS mot ON (TRUE)
+  configs:
+    core:
+      dialect: postgres

--- a/test/fixtures/rules/std_rule_cases/ST11.yml
+++ b/test/fixtures/rules/std_rule_cases/ST11.yml
@@ -159,6 +159,15 @@ test_pass_wildcard_6511:
     core:
       dialect: snowflake
 
+test_pass_bare_select_wildcard:
+  # A bare select-clause wildcard (`*`) should not be treated as an
+  # unqualified table reference while ST11 scans references.
+  pass_str: |
+    SELECT *
+    FROM a
+    LEFT JOIN b
+        ON a.id = b.id
+
 test_pass_cross_join_6511:
   pass_str: |
     select

--- a/test/fixtures/rules/std_rule_cases/ST11.yml
+++ b/test/fixtures/rules/std_rule_cases/ST11.yml
@@ -275,3 +275,28 @@ test_fail_placeholder_templater_unused_join:
       placeholder:
         param_style: dollar
         CATALOG: my_catalog
+
+test_pass_wildcard_row_passed_to_function:
+  # https://github.com/sqlfluff/sqlfluff/issues/7234
+  # `other_table.*` passes the whole row of the joined table to a function,
+  # which counts as a reference to that table.
+  pass_str: |
+    SELECT
+        to_jsonb(other_table.*) AS other_table_jsonb
+    FROM my_table
+    LEFT JOIN other_table ON (other_table.my_table_id = my_table.id)
+  configs:
+    core:
+      dialect: postgres
+
+test_fail_wildcard_row_from_unrelated_table:
+  # A qualified wildcard for a *different* table should still leave the
+  # joined table flagged as unused.
+  fail_str: |
+    SELECT
+        to_jsonb(my_table.*) AS my_table_jsonb
+    FROM my_table
+    LEFT JOIN other_table ON (other_table.my_table_id = my_table.id)
+  configs:
+    core:
+      dialect: postgres


### PR DESCRIPTION
### Brief summary of the change made

`identifier.*` used inside a general expression — e.g. `NEW.*` in a trigger condition, or `to_jsonb(my_table.*)` where a whole row is passed to a function — was parsed as three orphan raw segments (`naked_identifier`, `dot`, `star`) rather than a reference segment. Reference analysis only collects recognised reference segments, so the qualifier was invisible to it.

As a result two rules produced false positives:

- **AL05** (`aliasing.unused`) flagged the alias in `to_jsonb(mot.*)` as unused
    Fixes #7235
- **ST11** (`structure.unused_join`) flagged the joined table in `to_jsonb(other_table.*)` as not referenced
    Fixes #7234

```sql
SELECT to_jsonb(mot.*)
FROM my_table
JOIN my_other_table AS mot ON (TRUE);   -- AL05 wrongly flagged `mot` as unused
```

**Approach**

- Introduce `SingleIdentifierWildcardSegment`, a `WildcardIdentifierSegment` subclass whose grammar is restricted to a single qualifier (`a.*`). It is used in `Expression_D_Grammar` in place of the previous bare `Sequence`. It deliberately does **not** permit a bare `*` (ambiguous with multiplication in an expression context) or a multi-part `a.b.*`, matching the intent of the original grammar's comment — but because it is now a real segment with type `wildcard_identifier`, reference analysis (and the rules built on it) can see the qualifier as a used table reference.
- `ST11` only crawled `column_reference` segments. It now also crawls `wildcard_identifier`, so a qualified wildcard such as `other_table.*` counts as a use of its table. A bare `*` is skipped there, since select-clause wildcards are already resolved separately via `get_wildcard_info()`.

**Scope / tradeoffs**

The bare-row form `to_jsonb(mot)` (without `.*`, mentioned as a secondary example in #7235) is intentionally **not** changed here. A single-part reference is genuinely ambiguous between a table and a column, and AL05 already treats it dialect-dependently (`test_ansi_function_not_table_parameter` vs `test_bigquery_function_takes_tablealias_parameter`). Folding that into this change would be a larger, separate discussion.

### Are there any other side effects of this change that we should be aware of?

The parse tree for `identifier.*` inside any expression now nests the parts under a `wildcard_identifier` segment instead of leaving them as siblings. Regenerating the dialect fixtures only changed two files (`postgres/create_trigger.yml`, `snowflake/match_recognize.yml`), both purely reflecting this nesting. Full `test/dialects` + `test/rules` suites pass (8877 tests).

### Pull Request checklist

- [x] Included test cases to demonstrate the code changes:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases` (AL05 + ST11, pass and fail cases).
  - `.yml` parser fixtures in `test/fixtures/dialects` regenerated via `generate_parse_fixture_yml.py`.
- [x] No documentation changes needed (rule docstrings unchanged; behaviour now matches their documented intent).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes false positives in AL05 and ST11 by parsing `table.*` inside expressions as a proper wildcard identifier so table aliases and joined tables are recognized. Handles cases like `to_jsonb(mot.*)` and trigger qualifiers like `NEW.*`.

- **Bug Fixes**
  - Added `SingleIdentifierWildcardSegment` to parse only `a.*` in expressions (not bare `*` or `a.b.*`), making the qualifier visible to reference analysis.
  - Updated ST11 to crawl `wildcard_identifier` so `other_table.*` counts as a table reference; bare `*` is skipped.
  - Regenerated fixtures and added tests; restored coverage with no behavior changes.

<sup>Written for commit d303878d28a8a89a765e13a14d52bc1afb348acc. Summary will update on new commits. <a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/7845?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



