### PR TITLE
fix(RF01): ignore T-SQL CONTAINSTABLE argument references

### DIFF
--- a/src/sqlfluff/rules/references/RF01.py
+++ b/src/sqlfluff/rules/references/RF01.py
@@ -169,7 +169,10 @@ class Rule_RF01(BaseRule):
         #   statement, thus not expected to match a table in the FROM
         #   clause.
         if ref_path:
-            return any(ps.segment.is_type("into_table_clause") for ps in ref_path)
+            return any(
+                ps.segment.is_type("into_table_clause", "containstable_segment")
+                for ps in ref_path
+            )
         else:
             return False  # pragma: no cover
 

--- a/test/fixtures/rules/std_rule_cases/RF01.yml
+++ b/test/fixtures/rules/std_rule_cases/RF01.yml
@@ -828,3 +828,37 @@ test_fail_databricks_non_metadata_reference:
     rules:
       references.from:
         force_enable: true
+
+test_pass_tsql_containstable_arguments:
+  # CONTAINSTABLE() arguments are function inputs, not FROM-clause references.
+  pass_str: |
+    SELECT
+        [author_id],
+        [rank]
+    FROM CONTAINSTABLE (
+        [dbo].[author_search_documents],
+        [search_text],
+        @contains_query,
+        @candidate_cap
+    );
+  configs:
+    core:
+      dialect: tsql
+
+test_pass_tsql_containstable_join_arguments:
+  # Joined CONTAINSTABLE() calls should also ignore their internal table input.
+  pass_str: |
+    SELECT FT_TBL.Name,
+           KEY_TBL.RANK
+    FROM Production.Product AS FT_TBL
+         INNER JOIN CONTAINSTABLE(
+             Production.Product,
+             (Name, ProductNumber),
+             'ISABOUT (frame WEIGHT (.8), wheel WEIGHT (.4), tire WEIGHT (.2))',
+             LANGUAGE N'English',
+             5
+         ) AS KEY_TBL
+             ON FT_TBL.ProductID = KEY_TBL.[KEY];
+  configs:
+    core:
+      dialect: tsql


### PR DESCRIPTION
### Brief summary of the change made

This PR fixes a false positive in `RF01` for T-SQL `CONTAINSTABLE(...)` usage.

`CONTAINSTABLE` is parsed correctly as a table expression, but `RF01` was still treating object references inside the function arguments as ordinary query references. That caused queries like:


```sql

FROM CONTAINSTABLE (
    [dbo].[author_search_documents],
    [search_text],
    @contains_query,
    @candidate_cap
)
```
to incorrectly raise:

```bash
RF01 | Reference '[dbo].[author_search_documents]' refers to table/view not found in the FROM clause or found in ancestor statement.
```

**What Changed** 

* Updated RF01 to ignore references whose parse path is inside containstable_segment.
* Added regression coverage for:
  * standalone `CONTAINSTABLE(...)` usage
  * joined `CONTAINSTABLE(...)` usage

### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a false positive in RF01 for T‑SQL CONTAINSTABLE() by ignoring references inside its arguments. Valid queries using CONTAINSTABLE no longer raise missing FROM clause errors.

- **Bug Fixes**
  - Skip references under `containstable_segment` in RF01’s FROM-clause checks.
  - Add passing tests for standalone and joined CONTAINSTABLE usage in T‑SQL.

<sup>Written for commit 58d8e656d3e5425daeeeb531cf565df820786564. Summary will update on new commits. <a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/7860?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

