### PR TITLE
Fix MySQL ALTER TABLE parsing with ALGORITHM and LOCK options

### DIFF
--- a/src/sqlfluff/dialects/dialect_mysql.py
+++ b/src/sqlfluff/dialects/dialect_mysql.py
@@ -1813,6 +1813,25 @@ class TableOptionsSegment(BaseSegment):
     )
 
 
+class AlterTableOnlineDDLOptionSegment(BaseSegment):
+    """MySQL online DDL options for ALTER TABLE statements."""
+
+    type = "alter_table_online_ddl_option"
+
+    match_grammar = OneOf(
+        Sequence(
+            "ALGORITHM",
+            Ref("EqualsSegment", optional=True),
+            OneOf("DEFAULT", "INPLACE", "COPY", "INSTANT"),
+        ),
+        Sequence(
+            "LOCK",
+            Ref("EqualsSegment", optional=True),
+            OneOf("DEFAULT", "NONE", "SHARED", "EXCLUSIVE"),
+        ),
+    )
+
+
 class AlterTableStatementSegment(BaseSegment):
     """An `ALTER TABLE .. ALTER COLUMN` statement.
 
@@ -1832,6 +1851,8 @@ class AlterTableStatementSegment(BaseSegment):
             OneOf(
                 # Table options
                 Ref("TableOptionsSegment"),
+                # Online DDL options
+                Ref("AlterTableOnlineDDLOptionSegment"),
                 # Add column
                 Sequence(
                     "ADD",

--- a/test/fixtures/dialects/mysql/alter_table.sql
+++ b/test/fixtures/dialects/mysql/alter_table.sql
@@ -50,7 +50,15 @@ KEY_BLOCK_SIZE 8;
 ALTER TABLE `foo`.`bar` ADD INDEX `index_name`(`col_1`, `col_2`, `col_3`)
 KEY_BLOCK_SIZE 8 COMMENT 'index for col_1, col_2, col_3';
 
+ALTER TABLE my_table
+ADD INDEX idx_timestamp (`timestamp`),
+ALGORITHM = INPLACE, LOCK = NONE;
+
 ALTER TABLE `foo`.`bar` DROP INDEX `index_name`;
+
+ALTER TABLE my_table
+DROP INDEX idx_timestamp,
+ALGORITHM = INPLACE, LOCK = NONE;
 
 ALTER TABLE `foo`.`bar` RENAME INDEX `index_name` to `new_index_name`;
 
@@ -63,6 +71,10 @@ ALTER TABLE `users`
 
 ALTER TABLE `users`
     ADD COLUMN IF NOT EXISTS `active` tinyint(1) DEFAULT '0';
+
+ALTER TABLE my_table
+ADD COLUMN created_at TIMESTAMP,
+ALGORITHM = INPLACE, LOCK = NONE;
 
 ALTER TABLE `foo` ADD `bar` INT FIRST;
 

--- a/test/fixtures/dialects/mysql/alter_table.yml
+++ b/test/fixtures/dialects/mysql/alter_table.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 58b78cce5b8979d036330220bbca8fbd5934bc641e4da86a65186e7a41f11176
+_hash: 23a2e19183755f32759d022d7e56863c90016a037fe176f5b72ba110e6c30626
 file:
 - statement:
     alter_table_statement:
@@ -423,6 +423,35 @@ file:
     - keyword: ALTER
     - keyword: TABLE
     - table_reference:
+        naked_identifier: my_table
+    - keyword: ADD
+    - table_constraint:
+        keyword: INDEX
+        index_reference:
+          naked_identifier: idx_timestamp
+        bracketed:
+          start_bracket: (
+          column_reference:
+            quoted_identifier: '`timestamp`'
+          end_bracket: )
+    - comma: ','
+    - alter_table_online_ddl_option:
+      - keyword: ALGORITHM
+      - comparison_operator:
+          raw_comparison_operator: '='
+      - keyword: INPLACE
+    - comma: ','
+    - alter_table_online_ddl_option:
+      - keyword: LOCK
+      - comparison_operator:
+          raw_comparison_operator: '='
+      - keyword: NONE
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
       - quoted_identifier: '`foo`'
       - dot: .
       - quoted_identifier: '`bar`'
@@ -430,6 +459,29 @@ file:
     - keyword: INDEX
     - index_reference:
         quoted_identifier: '`index_name`'
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: my_table
+    - keyword: DROP
+    - keyword: INDEX
+    - index_reference:
+        naked_identifier: idx_timestamp
+    - comma: ','
+    - alter_table_online_ddl_option:
+      - keyword: ALGORITHM
+      - comparison_operator:
+          raw_comparison_operator: '='
+      - keyword: INPLACE
+    - comma: ','
+    - alter_table_online_ddl_option:
+      - keyword: LOCK
+      - comparison_operator:
+          raw_comparison_operator: '='
+      - keyword: NONE
 - statement_terminator: ;
 - statement:
     alter_table_statement:
@@ -532,6 +584,30 @@ file:
         column_constraint_segment:
           keyword: DEFAULT
           quoted_literal: "'0'"
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: my_table
+    - keyword: ADD
+    - keyword: COLUMN
+    - column_definition:
+        naked_identifier: created_at
+        keyword: TIMESTAMP
+    - comma: ','
+    - alter_table_online_ddl_option:
+      - keyword: ALGORITHM
+      - comparison_operator:
+          raw_comparison_operator: '='
+      - keyword: INPLACE
+    - comma: ','
+    - alter_table_online_ddl_option:
+      - keyword: LOCK
+      - comparison_operator:
+          raw_comparison_operator: '='
+      - keyword: NONE
 - statement_terminator: ;
 - statement:
     alter_table_statement:


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->

Fixes a MySQL dialect parser regression where `ALTER TABLE` statements failed to parse comma-separated online DDL options after table alteration operations.

The regression was introduced by commit [`b0a995e`](https://github.com/sqlfluff/sqlfluff/commit/b0a995efd367e055612bd1b11dc31a07ee05af03), which added table option parsing to MySQL/MariaDB `ALTER TABLE`.

MySQL 8.0 allows `ALGORITHM` and `LOCK` clauses at the end of `ALTER TABLE` statements, separated from table and column specifications by commas. For example:

```sql
ALTER TABLE my_table
ADD INDEX idx_timestamp (`timestamp`),
ALGORITHM = INPLACE, LOCK = NONE;
```

This PR adds MySQL `ALTER TABLE` grammar support for:

- `ALGORITHM [=] {DEFAULT | INPLACE | COPY | INSTANT}`
- `LOCK [=] {DEFAULT | NONE | SHARED | EXCLUSIVE}`

It also adds parser fixture coverage for trailing online DDL options after:

- `ADD INDEX`
- `ADD COLUMN`
- `DROP INDEX`

Reference: https://dev.mysql.com/doc/refman/8.0/en/innodb-online-ddl.html

### Are there any other side effects of this change that we should be aware of?

No known side effects. The new grammar is scoped to MySQL `ALTER TABLE` and treats online DDL clauses as additional comma-delimited alter-table options.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.


Validation performed:

```text
uv run --with pytest python test/generate_parse_fixture_yml.py -d mysql
uv run --with pytest pytest -q test/dialects/dialects_test.py -k "alter_table and mysql"
uv run --with ruff ruff format --check src/sqlfluff/dialects/dialect_mysql.py
uv run --with ruff ruff check src/sqlfluff/dialects/dialect_mysql.py
git diff --check
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a MySQL parser regression where `ALTER TABLE` statements failed when trailing online DDL options were present. Adds support for comma-separated `ALGORITHM` and `LOCK` options after table changes.

- **Bug Fixes**
  - Added `AlterTableOnlineDDLOptionSegment` and integrated it into MySQL `ALTER TABLE`.
  - Supports `ALGORITHM [=] {DEFAULT|INPLACE|COPY|INSTANT}` and `LOCK [=] {DEFAULT|NONE|SHARED|EXCLUSIVE}`.
  - Added fixtures for trailing options after `ADD INDEX`, `ADD COLUMN`, and `DROP INDEX`.

<sup>Written for commit bcea318788ddb9ecc0d41bff8afa5d54543df217. Summary will update on new commits. <a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/7864?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

