### PR TITLE
fix(snowflake): support SELECT * ILIKE '<pattern>' syntax

### DIFF
--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -2062,11 +2062,29 @@ class WildcardExpressionSegment(ansi.WildcardExpressionSegment):
 
     match_grammar = ansi.WildcardExpressionSegment.match_grammar.copy(
         insert=[
-            # Optional Exclude or Rename clause
-            Ref("ExcludeClauseSegment", optional=True),
+            # Optional ILIKE, EXCLUDE, REPLACE or RENAME clause.
+            # ILIKE and EXCLUDE are mutually exclusive.
+            OneOf(
+                Ref("IlikeClauseSegment"),
+                Ref("ExcludeClauseSegment"),
+                optional=True,
+            ),
             Ref("ReplaceClauseSegment", optional=True),
             Ref("RenameClauseSegment", optional=True),
         ]
+    )
+
+
+class IlikeClauseSegment(BaseSegment):
+    """A snowflake SELECT ILIKE clause.
+
+    https://docs.snowflake.com/en/sql-reference/sql/select.html
+    """
+
+    type = "select_ilike_clause"
+    match_grammar = Sequence(
+        "ILIKE",
+        Ref("QuotedLiteralSegment"),
     )
 
 

--- a/test/fixtures/dialects/snowflake/select_ilike.sql
+++ b/test/fixtures/dialects/snowflake/select_ilike.sql
@@ -1,0 +1,14 @@
+select * ilike 'col_%' from table1;
+
+select t.* ilike '%suffix' from table1 as t;
+
+select
+    * ilike 'col_%',
+    1 as one,
+    b.* ilike '%some%'
+from a
+left join b on a.id = b.id;
+
+select * ilike 'col_%' replace (1 as col1) from table1;
+
+select * ilike 'col_%' replace (1 as col1) rename col1 as col2 from table1;

--- a/test/fixtures/dialects/snowflake/select_ilike.yml
+++ b/test/fixtures/dialects/snowflake/select_ilike.yml
@@ -1,0 +1,168 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 12e1f1a5f1affe0b1a92f63881155358402655e58ac3a532240c723d30f0655f
+file:
+- statement:
+    select_statement:
+      select_clause:
+        keyword: select
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+            select_ilike_clause:
+              keyword: ilike
+              quoted_literal: "'col_%'"
+      from_clause:
+        keyword: from
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: table1
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: select
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              naked_identifier: t
+              dot: .
+              star: '*'
+            select_ilike_clause:
+              keyword: ilike
+              quoted_literal: "'%suffix'"
+      from_clause:
+        keyword: from
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: table1
+            alias_expression:
+              alias_operator:
+                keyword: as
+              naked_identifier: t
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: select
+      - select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+            select_ilike_clause:
+              keyword: ilike
+              quoted_literal: "'col_%'"
+      - comma: ','
+      - select_clause_element:
+          numeric_literal: '1'
+          alias_expression:
+            alias_operator:
+              keyword: as
+            naked_identifier: one
+      - comma: ','
+      - select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              naked_identifier: b
+              dot: .
+              star: '*'
+            select_ilike_clause:
+              keyword: ilike
+              quoted_literal: "'%some%'"
+      from_clause:
+        keyword: from
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: a
+          join_clause:
+          - keyword: left
+          - keyword: join
+          - from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: b
+          - join_on_condition:
+              keyword: 'on'
+              expression:
+              - column_reference:
+                - naked_identifier: a
+                - dot: .
+                - naked_identifier: id
+              - comparison_operator:
+                  raw_comparison_operator: '='
+              - column_reference:
+                - naked_identifier: b
+                - dot: .
+                - naked_identifier: id
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: select
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+            select_ilike_clause:
+              keyword: ilike
+              quoted_literal: "'col_%'"
+            select_replace_clause:
+              keyword: replace
+              bracketed:
+                start_bracket: (
+                expression:
+                  numeric_literal: '1'
+                keyword: as
+                naked_identifier: col1
+                end_bracket: )
+      from_clause:
+        keyword: from
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: table1
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: select
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+            select_ilike_clause:
+              keyword: ilike
+              quoted_literal: "'col_%'"
+            select_replace_clause:
+              keyword: replace
+              bracketed:
+                start_bracket: (
+                expression:
+                  numeric_literal: '1'
+                keyword: as
+                naked_identifier: col1
+                end_bracket: )
+            select_rename_clause:
+            - keyword: rename
+            - naked_identifier: col1
+            - keyword: as
+            - naked_identifier: col2
+      from_clause:
+        keyword: from
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: table1
+- statement_terminator: ;


### PR DESCRIPTION
### Brief summary of the change made

Snowflake supports `SELECT * ILIKE '<pattern>'` clause ([Snowflake docs](https://docs.snowflake.com/en/sql-reference/sql/select)).

This PR adds `IlikeClauseSegment` and updates `WildcardExpressionSegment` to support all possible
`SELECT` extensions as documented by Snowflake.

The order of operations in Snowflake according to the docs is:

```
[ ILIKE ... | EXCLUDE ... ] [ REPLACE ... ] [ RENAME ... ]
```

Notice, how `ILIKE` and `EXCLUDE` are [mutually exclusive](https://docs.snowflake.com/en/sql-reference/sql/select#selecting-all-columns).

### Are there any other side effects of this change that we should be aware of?
None expected.

### Pull Request checklist

- [x] Parser test cases added as `test/fixtures/dialects/snowflake/select_ilike.{sql,yml}` (YML regenerated via `tox -e generate-fixture-yml`).