### PR TITLE
fix(tsql): parse label following SELECT without semicolon

### DIFF
--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -2058,7 +2058,13 @@ class SelectClauseElementSegment(ansi.SelectClauseElementSegment):
         ),
         Sequence(
             Ref("BaseExpressionElementGrammar"),
-            Ref("AliasExpressionSegment", optional=True),
+            # Exclude label patterns (identifier immediately followed by colon)
+            # so that `SELECT 1\nlabel:` doesn't consume `label` as a column alias.
+            Ref(
+                "AliasExpressionSegment",
+                optional=True,
+                exclude=Ref("LabelStatementSegment"),
+            ),
         ),
     )
 

--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -544,6 +544,12 @@ tsql_dialect.add(
     CursorBracketedSetExpressionGrammar=Bracketed(
         Ref("CursorUnorderedSetExpressionGrammar")
     ),
+    # AliasExpressionSegment that excludes label patterns (identifier followed by
+    # colon). Used wherever an alias can trail a statement-final expression so
+    # that a next-line label is not swallowed as an alias.
+    LabelSafeAliasExpressionGrammar=Ref(
+        "AliasExpressionSegment", exclude=Ref("LabelStatementSegment")
+    ),
 )
 
 tsql_dialect.replace(
@@ -2058,13 +2064,7 @@ class SelectClauseElementSegment(ansi.SelectClauseElementSegment):
         ),
         Sequence(
             Ref("BaseExpressionElementGrammar"),
-            # Exclude label patterns (identifier immediately followed by colon)
-            # so that `SELECT 1\nlabel:` doesn't consume `label` as a column alias.
-            Ref(
-                "AliasExpressionSegment",
-                optional=True,
-                exclude=Ref("LabelStatementSegment"),
-            ),
+            Ref("LabelSafeAliasExpressionGrammar", optional=True),
         ),
     )
 
@@ -7492,7 +7492,7 @@ class OutputClauseSegment(BaseSegment):
                     Ref("ExpressionSegment"),
                 ),
                 # [ [ AS ] column_alias_identifier ]
-                Ref("AliasExpressionSegment", optional=True),
+                Ref("LabelSafeAliasExpressionGrammar", optional=True),
             ),
             terminators=[Ref.keyword("INTO"), Ref.keyword("FROM")],
         ),

--- a/test/fixtures/dialects/tsql/output_clause.sql
+++ b/test/fixtures/dialects/tsql/output_clause.sql
@@ -163,3 +163,20 @@ OUTPUT INSERTED.ProductID,
        SYSTEM_USER AS UpdatedBy
 WHERE ProductID = 680;
 GO
+
+-- Example 15: DELETE with OUTPUT followed by a label on the next line (no semicolon)
+BEGIN
+    DELETE Sales.ShoppingCartItem
+    OUTPUT DELETED.ProductID
+    next_step:
+END
+GO
+
+-- Example 16: UPDATE with OUTPUT followed by a label on the next line (no semicolon)
+BEGIN
+    UPDATE HumanResources.Employee
+    SET VacationHours = VacationHours + 8
+    OUTPUT INSERTED.BusinessEntityID, INSERTED.VacationHours
+    next_step:
+END
+GO

--- a/test/fixtures/dialects/tsql/output_clause.yml
+++ b/test/fixtures/dialects/tsql/output_clause.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: f8b2ed0cb4bac89e058a421e58baa8496f76b7c599ee31012b38cb1163fd19e0
+_hash: 32aaf947839da38aae5f95caca33cccefa1c52e611a3321b1ff6aa0e0405d60a
 file:
 - batch:
     statement:
@@ -938,5 +938,67 @@ file:
               raw_comparison_operator: '='
             integer_literal: '680'
     statement_terminator: ;
+    go_statement:
+      keyword: GO
+- batch:
+    statement:
+      begin_end_block:
+      - keyword: BEGIN
+      - statement:
+          delete_statement:
+            keyword: DELETE
+            table_reference:
+            - naked_identifier: Sales
+            - dot: .
+            - naked_identifier: ShoppingCartItem
+            output_clause:
+            - keyword: OUTPUT
+            - keyword: DELETED
+            - dot: .
+            - naked_identifier: ProductID
+      - statement:
+          label_segment:
+            naked_identifier: next_step
+            colon: ':'
+      - keyword: END
+    go_statement:
+      keyword: GO
+- batch:
+    statement:
+      begin_end_block:
+      - keyword: BEGIN
+      - statement:
+          update_statement:
+            keyword: UPDATE
+            table_reference:
+            - naked_identifier: HumanResources
+            - dot: .
+            - naked_identifier: Employee
+            set_clause_list:
+              keyword: SET
+              set_clause:
+                column_reference:
+                  naked_identifier: VacationHours
+                assignment_operator:
+                  raw_comparison_operator: '='
+                expression:
+                  column_reference:
+                    naked_identifier: VacationHours
+                  binary_operator: +
+                  integer_literal: '8'
+            output_clause:
+            - keyword: OUTPUT
+            - keyword: INSERTED
+            - dot: .
+            - naked_identifier: BusinessEntityID
+            - comma: ','
+            - keyword: INSERTED
+            - dot: .
+            - naked_identifier: VacationHours
+      - statement:
+          label_segment:
+            naked_identifier: next_step
+            colon: ':'
+      - keyword: END
     go_statement:
       keyword: GO

--- a/test/fixtures/dialects/tsql/select_label_no_semicolon.sql
+++ b/test/fixtures/dialects/tsql/select_label_no_semicolon.sql
@@ -1,0 +1,4 @@
+BEGIN
+    SELECT 1
+    label:
+END

--- a/test/fixtures/dialects/tsql/select_label_no_semicolon.yml
+++ b/test/fixtures/dialects/tsql/select_label_no_semicolon.yml
@@ -1,0 +1,22 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: d4b1209c8fca8b90d4e67f222463d4a2c11a23593f6e39d8d01b0bd55b67a402
+file:
+  batch:
+    statement:
+      begin_end_block:
+      - keyword: BEGIN
+      - statement:
+          select_statement:
+            select_clause:
+              keyword: SELECT
+              select_clause_element:
+                integer_literal: '1'
+      - statement:
+          label_segment:
+            naked_identifier: label
+            colon: ':'
+      - keyword: END


### PR DESCRIPTION
Fixes https://github.com/sqlfluff/sqlfluff/issues/7857

## Problem

Valid T-SQL code with a `GOTO` label immediately after a `SELECT` statement (without a semicolon) was marked entirely unparsable:

```sql
BEGIN
    SELECT 1
    label:
END
-- Error: Found unparsable section: 'BEGIN\n    SELECT 1\n    label:\nEND'
```

Adding a semicolon after `SELECT 1` worked around the issue, but the semicolonless form is perfectly legal T-SQL.

## Root cause

`SelectClauseElementSegment` in T-SQL allows implicit column aliases (without `AS`), so the last grammar alternative is:

```python
Sequence(
    Ref("BaseExpressionElementGrammar"),
    Ref("AliasExpressionSegment", optional=True),  # matches any identifier
)
```

When the parser processed `SELECT 1\nlabel:`, it greedily consumed `label` as a column alias for `1`, leaving the orphaned `:` token. Since `:` alone doesn't match any statement, the surrounding `BEGIN...END` block failed entirely.

## Fix

Added `exclude=Ref("LabelStatementSegment")` on the optional alias ref:

```python
Ref(
    "AliasExpressionSegment",
    optional=True,
    exclude=Ref("LabelStatementSegment"),
)
```

`LabelStatementSegment` is defined as `Sequence(NakedIdentifier, Colon, allow_gaps=False)` — it only matches `identifier:` when there is **no whitespace** between identifier and colon. The `Ref.exclude` mechanism checks this pattern at the candidate alias start position: if it fires, the alias is skipped and `label:` is left to be parsed as a `LabelStatementSegment` in the next statement slot.

This correctly handles all cases:

| Input | Outcome |
|---|---|
| `SELECT 1\nlabel:` | `1` is the column, `label:` is a label statement ✓ |
| `SELECT 1 my_alias` | `my_alias` is still consumed as alias (no `:` after it) ✓ |
| `SELECT 1 AS label` | `AS label` is consumed as alias (`AS` doesn't match `LabelStatementSegment`) ✓ |

## Testing

- Added `test/fixtures/dialects/tsql/select_label_no_semicolon.sql` with the exact failing example from the issue.
- YAML parse tree auto-generated and verified: `SELECT 1` and `label:` appear as two separate sibling statements inside the `begin_end_block`.
- All 527 existing T-SQL dialect tests continue to pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix T-SQL parsing when a `label:` follows a `SELECT` or an `OUTPUT` clause without a semicolon. Prevents the label from being misread as an implicit alias so `BEGIN...END` blocks parse correctly.

- **Bug Fixes**
  - Introduced `LabelSafeAliasExpressionGrammar` to exclude `LabelStatementSegment` from `AliasExpressionSegment`, and used it in `SelectClauseElementSegment` and `OutputClauseSegment`.
  - Added fixtures for `SELECT 1` then `label:` and for `DELETE/UPDATE ... OUTPUT` followed by a next-line label; updated YAML parse trees and kept all T-SQL tests passing.

<sup>Written for commit 3fd3fb3600be4210a754f079722df191c15d8f73. Summary will update on new commits. <a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/7867?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

