### PR TITLE
ci: build multiple docker images

### DIFF
--- a/.github/workflows/publish-sqlfluff-docker-image-to-dockerhub.yaml
+++ b/.github/workflows/publish-sqlfluff-docker-image-to-dockerhub.yaml
@@ -6,13 +6,34 @@ on:
       - published
   workflow_dispatch:
 
-# Create tag for integration test.
-env:
-  TEST_TAG: ${{ secrets.DOCKERHUB_USERNAME }}/sqlfluff:test
-
 jobs:
   docker:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: standard
+            cache_tag: latest
+            suffix: ""
+            test_label: standard
+            builder_base: python:3.14-slim-trixie
+            final_base: python:3.14-slim-trixie
+            desc_suffix: ""
+          - name: dhi
+            cache_tag: latest-dhi
+            suffix: -dhi
+            test_label: DHI
+            builder_base: dhi.io/python:3.14-debian13-dev
+            final_base: dhi.io/python:3.14-debian13
+            desc_suffix: " (DHI image)"
+          - name: dhi-dev
+            cache_tag: latest-dhi-dev
+            suffix: -dhi-dev
+            test_label: DHI-dev
+            builder_base: dhi.io/python:3.14-debian13-dev
+            final_base: dhi.io/python:3.14-debian13-dev
+            desc_suffix: " (DHI image with shell)"
     permissions:
       contents: read
       packages: write
@@ -60,40 +81,52 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       # Build amd64 image to use in the integration test.
-      - name: Build and export to Docker
-        id: docker_build
+      - name: Build and export ${{ matrix.name }} image to Docker
+        id: docker_build_test
         uses: docker/build-push-action@v6
         with:
           load: true
-          tags: ${{ env.TEST_TAG }}
-          cache-from: type=registry,ref=${{ secrets.DOCKERHUB_USERNAME }}/sqlfluff:latest
+          file: Dockerfile
+          build-args: |
+            BUILDER_BASE=${{ matrix.builder_base }}
+            FINAL_BASE=${{ matrix.final_base }}
+            DESC_SUFFIX=${{ matrix.desc_suffix }}
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/sqlfluff:test${{ matrix.suffix }}
+          cache-from: type=registry,ref=${{ secrets.DOCKERHUB_USERNAME }}/sqlfluff:${{ matrix.cache_tag }}
           cache-to: type=inline
 
-      # Integration test to validate newly created image is working.
-      - name: Test Docker image
+      # Integration test to validate the image is working.
+      - name: Test ${{ matrix.test_label }} Docker image
         id: docker_test
+        env:
+          TEST_TAG: ${{ secrets.DOCKERHUB_USERNAME }}/sqlfluff:test${{ matrix.suffix }}
         run: |
           echo "SELECT 1" > test.sql
-          docker run --rm -i -v $PWD:/sql ${{ env.TEST_TAG }} lint --dialect ansi /sql/test.sql
+          docker run --rm -i -v $PWD:/sql "$TEST_TAG" lint --dialect ansi /sql/test.sql
 
-      # Build arm64 image (amd64 is cached from docker_build step) and export to DockerHub and GHCR.
-      # N.B. We tag this image as both latest and with its version number.
-      - name: Build and push
+      # Build and push image to DockerHub and GHCR.
+      # N.B. We tag each image as both latest and with its version number.
+      - name: Build and push (${{ matrix.name }} image)
         id: docker_build_push
         uses: docker/build-push-action@v6
         with:
           push: true
           platforms: linux/amd64,linux/arm64
+          file: Dockerfile
+          build-args: |
+            BUILDER_BASE=${{ matrix.builder_base }}
+            FINAL_BASE=${{ matrix.final_base }}
+            DESC_SUFFIX=${{ matrix.desc_suffix }}
           tags: |
-            ${{ secrets.DOCKERHUB_USERNAME }}/sqlfluff:latest
-            ${{ secrets.DOCKERHUB_USERNAME }}/sqlfluff:${{ steps.latest_release.outputs.release }}
-            ghcr.io/${{ github.repository }}:latest
-            ghcr.io/${{ github.repository }}:${{ steps.latest_release.outputs.release }}
-          cache-from: type=registry,ref=${{ secrets.DOCKERHUB_USERNAME }}/sqlfluff:latest
+            ${{ secrets.DOCKERHUB_USERNAME }}/sqlfluff:latest${{ matrix.suffix }}
+            ${{ secrets.DOCKERHUB_USERNAME }}/sqlfluff:${{ steps.latest_release.outputs.release }}${{ matrix.suffix }}
+            ghcr.io/${{ github.repository }}:latest${{ matrix.suffix }}
+            ghcr.io/${{ github.repository }}:${{ steps.latest_release.outputs.release }}${{ matrix.suffix }}
+          cache-from: type=registry,ref=${{ secrets.DOCKERHUB_USERNAME }}/sqlfluff:${{ matrix.cache_tag }}
           cache-to: type=inline
 
-      # Add artifact attestation for GHCR
-      - name: Generate artifact attestation
+      # Add artifact attestation for GHCR image.
+      - name: Generate artifact attestation (${{ matrix.name }})
         uses: actions/attest-build-provenance@v2
         with:
           subject-name: ghcr.io/${{ github.repository }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
-FROM dhi.io/python:3.14-debian13-dev AS build
+ARG BUILDER_BASE=python:3.14-slim-trixie
+ARG FINAL_BASE=python:3.14-slim-trixie
+
+FROM ${BUILDER_BASE} AS build
 
 WORKDIR /app
 
@@ -23,11 +26,12 @@ COPY src ./src
 # Install sqlfluff package.
 RUN pip install --no-cache-dir --no-dependencies .
 
-FROM dhi.io/python:3.14-debian13
+FROM ${FINAL_BASE}
 # OCI annotations
+ARG DESC_SUFFIX
 LABEL org.opencontainers.image.title="sqlfluff" \
       org.opencontainers.image.authors="sqlfluff Community" \
-      org.opencontainers.image.description="A modular SQL linter and auto-formatter with support for multiple dialects and templated code" \
+      org.opencontainers.image.description="A modular SQL linter and auto-formatter with support for multiple dialects and templated code${DESC_SUFFIX}" \
       org.opencontainers.image.source="https://github.com/sqlfluff/sqlfluff" \
       org.opencontainers.image.documentation="https://docs.sqlfluff.com/en/stable/"
 


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
This builds multiple docker images so you can choose your own adventure as far as dhi is concerned.
- fixes #7868

### Are there any other side effects of this change that we should be aware of?
This reverts `latest` to be the non-dhi version, but I found other repos that build a specific dhi tag. I tested the builds locally, but can only assume the attestation for ghcr.io is correct for the multiple builds.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Build and publish three Docker images (standard, DHI, DHI-dev) to DockerHub and `ghcr.io` with clear tags. `latest` now points to the standard image; DHI variants are tagged `-dhi` and `-dhi-dev` (fixes #7868).

- New Features
  - Matrix build and test for standard, DHI, and DHI-dev; pushes both `latest` and versioned tags for each variant to DockerHub and `ghcr.io`, with provenance attestation.
  - Dockerfile now parameterized via `BUILDER_BASE`, `FINAL_BASE`, and `DESC_SUFFIX` to switch bases and annotate image descriptions.

- Migration
  - If you need DHI, pull `sqlfluff:latest-dhi` or `sqlfluff:<version>-dhi` (or `-dhi-dev`). `sqlfluff:latest` is now the non-DHI image.

<sup>Written for commit 09323ba26451fe69b0c19dbbd14ab49ff467a7d1. Summary will update on new commits. <a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/7872?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

