### PR TITLE
Force color output when --color is requested

### DIFF
--- a/src/sqlfluff/cli/commands.py
+++ b/src/sqlfluff/cli/commands.py
@@ -178,8 +178,9 @@ def set_logging_level(
     # Don't propagate logging
     fluff_logger.propagate = False
 
-    # Enable colorama
-    colorama.init()
+    # Enable colorama. Respect explicit --color/--nocolor decisions so
+    # colorama does not strip forced ANSI output from piped stdout.
+    colorama.init(strip=formatter.plain_output)
 
     # Set up the log handler which is able to print messages without overlapping
     # with progressbars.

--- a/src/sqlfluff/cli/formatters.py
+++ b/src/sqlfluff/cli/formatters.py
@@ -88,7 +88,7 @@ class OutputStreamFormatter(FormatterInterface):
     def __init__(
         self,
         output_stream: OutputStream,
-        nocolor: bool,
+        nocolor: Optional[bool],
         verbosity: int = 0,
         filter_empty: bool = True,
         output_line_length: int = 80,
@@ -102,11 +102,13 @@ class OutputStreamFormatter(FormatterInterface):
         self.show_lint_violations = show_lint_violations
 
     @staticmethod
-    def should_produce_plain_output(nocolor: bool) -> bool:
+    def should_produce_plain_output(nocolor: Optional[bool]) -> bool:
         """Returns True if text output should be plain (not colored)."""
-        # If `--color` is specified (nocolor is False), we ignore `NO_COLOR`
-        env_nocolor = bool(os.getenv("NO_COLOR")) and nocolor is not False
-        return nocolor or not sys.stdout.isatty() or env_nocolor
+        if nocolor is False:
+            return False
+        if nocolor is True:
+            return True
+        return not sys.stdout.isatty() or bool(os.getenv("NO_COLOR"))
 
     def _dispatch(self, s: str) -> None:
         """Dispatch a string to the callback.

--- a/src/sqlfluff/core/config/fluffconfig.py
+++ b/src/sqlfluff/core/config/fluffconfig.py
@@ -126,8 +126,9 @@ class FluffConfig:
             defaults, configs or empty_config, overrides or empty_overrides
         )
         # Some configs require special treatment
+        nocolor = self._configs["core"].get("nocolor", None)
         self._configs["core"]["color"] = (
-            False if self._configs["core"].get("nocolor", False) else None
+            False if nocolor is True else True if nocolor is False else None
         )
         # Handle inputs which are potentially comma separated strings
         self._handle_comma_separated_values()

--- a/test/cli/commands_test.py
+++ b/test/cli/commands_test.py
@@ -1787,34 +1787,35 @@ def test__cli__command_invalid_pyproject_toml_user_error(monkeypatch):
 @patch("click.utils.should_strip_ansi")
 @patch("sys.stdout.isatty")
 @pytest.mark.parametrize(
-    "flag, env_var, has_color",
+    "flag, env_var, is_tty, has_color",
     [
-        (None, None, True),
-        ("--nocolor", None, False),
-        ("--color", None, True),
-        (None, "1", False),
-        (None, "true", False),
-        (None, "True", False),
-        (None, "False", False),
-        (None, "anything", False),
-        (None, "", True),
-        ("--color", "1", True),
+        (None, None, True, True),
+        (None, None, False, False),
+        ("--nocolor", None, True, False),
+        ("--color", None, True, True),
+        ("--color", None, False, True),
+        (None, "1", True, False),
+        (None, "true", True, False),
+        (None, "True", True, False),
+        (None, "False", True, False),
+        (None, "anything", True, False),
+        (None, "", True, True),
+        ("--color", "1", True, True),
+        ("--color", "1", False, True),
     ],
 )
 def test__cli__command_lint_nocolor(
-    isatty, should_strip_ansi, capsys, tmpdir, flag, env_var, has_color
+    isatty, should_strip_ansi, capsys, tmpdir, flag, env_var, is_tty, has_color
 ):
     """Test the --nocolor option prevents color output."""
-    # Patch these two functions to make it think every output stream is a TTY.
-    # In spite of this, the output should not contain ANSI color codes because
-    # we specify "--nocolor" below.
+    # Patch these two functions to control whether output behaves like a TTY.
     no_color_flag = [flag] if flag else []
     if env_var is not None:
         os.environ["NO_COLOR"] = env_var
     elif "NO_COLOR" in os.environ:
         os.environ.pop("NO_COLOR")
 
-    isatty.return_value = True
+    isatty.return_value = is_tty
     should_strip_ansi.return_value = False
     fpath = "test/fixtures/linter/indentation_errors.sql"
     output_file = str(tmpdir / "result.txt")
@@ -2320,6 +2321,15 @@ def test_cli_get_default_config():
     )
     assert config.get("nocolor") is True
     assert config.get("verbose") == 2
+
+
+def test_cli_get_config_color_override():
+    """`--color` and `--nocolor` set click's output color behavior explicitly."""
+    color_config = get_config(None, True, nocolor=False, require_dialect=False)
+    no_color_config = get_config(None, True, nocolor=True, require_dialect=False)
+
+    assert color_config.get("color") is True
+    assert no_color_config.get("color") is False
 
 
 @patch(

--- a/test/cli/formatters_test.py
+++ b/test/cli/formatters_test.py
@@ -70,6 +70,33 @@ def test__cli__helpers__colorize(tmpdir):
     assert formatter.colorize("foo", Color.red) == "\u001b[31mfoo\u001b[0m"
 
 
+@pytest.mark.parametrize(
+    "nocolor,isatty,no_color_env,expected_plain_output",
+    [
+        (None, True, None, False),
+        (None, False, None, True),
+        (True, True, None, True),
+        (False, False, None, False),
+        (False, False, "1", False),
+        (None, True, "1", True),
+    ],
+)
+def test__cli__helpers__plain_output_color_decision(
+    monkeypatch, nocolor, isatty, no_color_env, expected_plain_output
+):
+    """Test when output should be plain rather than colored."""
+    monkeypatch.setattr("sys.stdout.isatty", lambda: isatty)
+    if no_color_env is None:
+        monkeypatch.delenv("NO_COLOR", raising=False)
+    else:
+        monkeypatch.setenv("NO_COLOR", no_color_env)
+
+    assert (
+        OutputStreamFormatter.should_produce_plain_output(nocolor)
+        is expected_plain_output
+    )
+
+
 def test__cli__helpers__cli_table(tmpdir):
     """Test making tables."""
     vals = [("a", 3), ("b", "c"), ("d", 4.7654), ("e", 9)]


### PR DESCRIPTION
### Brief summary of the change made

Fixes #7871.

`--color` now forces colored output even when stdout is not a TTY, such as `sqlfluff lint --color | tee .result`. The change keeps `--nocolor` and `NO_COLOR` behavior intact when color is not explicitly forced.

Implementation details:
- Treat `nocolor=False` as an explicit force-color request in `OutputStreamFormatter`.
- Preserve that decision in `FluffConfig.get("color")` so Click does not strip ANSI escapes on piped stdout.
- Pass the formatter plain-output decision into `colorama.init()` so colorama does not strip forced ANSI output either.

### Are there any other side effects of this change that we should be aware of?

Default non-TTY output remains plain unless `--color` is passed. `--nocolor` still strips color, and `NO_COLOR` still disables color unless `--color` is explicitly supplied.

AI assistance was used to prepare this PR. I reviewed the code and validated the behavior manually and with tests.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - Other: CLI formatter/config tests for forced color and non-TTY behavior.
- Added appropriate documentation for the change. Existing `--color` help text already describes the option, so no documentation changes were needed.
- Created GitHub issues for any relevant followup/future enhancements if appropriate. Not applicable.

### Validation

- `.venv/bin/python -m pytest test/cli/formatters_test.py -q -k plain_output_color_decision`
- `.venv/bin/python -m pytest test/cli/commands_test.py::test_cli_get_config_color_override -q`
- `.venv/bin/python -m pytest test/cli/commands_test.py -q -k lint_nocolor`
- `.venv/bin/python -m pytest test/cli/formatters_test.py test/cli/commands_test.py -q -k "color or nocolor"`
- `.venv/bin/python -m pytest test/cli/formatters_test.py -q`
- `.venv/bin/python -m pytest test/cli/commands_test.py -q`
- `.venv/bin/ruff check src/sqlfluff/cli/commands.py src/sqlfluff/cli/formatters.py src/sqlfluff/core/config/fluffconfig.py test/cli/formatters_test.py test/cli/commands_test.py`
- `.venv/bin/ruff format --check src/sqlfluff/cli/commands.py src/sqlfluff/cli/formatters.py src/sqlfluff/core/config/fluffconfig.py test/cli/formatters_test.py test/cli/commands_test.py`
- `.venv/bin/mypy src/sqlfluff/cli/commands.py src/sqlfluff/cli/formatters.py src/sqlfluff/core/config/fluffconfig.py`
- Manual subprocess smoke: `sqlfluff lint --dialect ansi --color -` on piped stdin returns ANSI output; `--nocolor` does not.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Forces colored output when `--color` is passed, even if stdout is not a TTY (e.g., `sqlfluff lint --color | tee result`). Default piped output stays plain unless forced; `--nocolor` and `NO_COLOR` still disable color unless `--color` is explicitly used.

- **Bug Fixes**
  - Treat `--color` (`nocolor=False`) as an explicit force-color request in the formatter.
  - Preserve the decision in config (`color=True/False`) so `click` does not strip ANSI on piped output.
  - Initialize `colorama` with `strip=formatter.plain_output` to avoid stripping when color is forced.

<sup>Written for commit ca8cafb8ff0b555b56f1689283af7b1fd964133f. Summary will update on new commits. <a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/7873?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

