### PR TITLE
build(docs): Deploy Docs CI with pnpm build approvals

### DIFF
--- a/docsv/pnpm-workspace.yaml
+++ b/docsv/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+allowBuilds:
+  esbuild: true
+  keytar: false


### PR DESCRIPTION
### Brief summary of the change made

pnpm 10’s strict dependency-build policy requires explicit approval file at `pnpm-workspace.yaml` so the docs app allows esbuild to run and explicitly denies keytar.

### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Docs CI by configuring `pnpm` v10 strict build approvals so the docs app can build reliably. Adds `allowBuilds` to allow `esbuild` and block `keytar`.

<sup>Written for commit d449baa63011d95367f30df3fc99f383037d7310. Summary will update on new commits. <a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/7874?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

