### PR TITLE
Fix Athena property name capitalisation

### DIFF
--- a/src/sqlfluff/dialects/dialect_athena.py
+++ b/src/sqlfluff/dialects/dialect_athena.py
@@ -66,7 +66,7 @@ athena_dialect.bracket_sets("angle_bracket_pairs").update(
     ]
 )
 
-_CTAS_PROPERTY_NAMES = (
+_CTAS_COMMON_PROPERTY_NAMES = (
     "format",
     "partitioned_by",
     "bucketed_by",
@@ -78,21 +78,15 @@ _CTAS_PROPERTY_NAMES = (
     "field_delimiter",
     "is_external",
     "table_type",
+)
+
+_CTAS_PROPERTY_NAMES = (
+    *_CTAS_COMMON_PROPERTY_NAMES,
     "external_location",
 )
 
 _CTAS_ICEBERG_PROPERTY_NAMES = (
-    "format",
-    "partitioned_by",
-    "bucketed_by",
-    "bucket_count",
-    "write_compression",
-    "orc_compression",
-    "parquet_compression",
-    "compression_level",
-    "field_delimiter",
-    "is_external",
-    "table_type",
+    *_CTAS_COMMON_PROPERTY_NAMES,
     "location",
     "partitioning",
     "vacuum_max_snapshot_age_seconds",

--- a/src/sqlfluff/dialects/dialect_athena.py
+++ b/src/sqlfluff/dialects/dialect_athena.py
@@ -16,6 +16,7 @@ from sqlfluff.core.parser import (
     KeywordSegment,
     LiteralSegment,
     Matchable,
+    MultiStringParser,
     Nothing,
     OneOf,
     OptionallyBracketed,
@@ -105,20 +106,6 @@ _UNLOAD_PROPERTY_NAMES = (
 )
 
 
-def _property_name_segments(*property_names: str) -> Matchable:
-    """Match Athena property keys without treating them as SQL keywords."""
-    return OneOf(
-        *(
-            StringParser(
-                property_name,
-                IdentifierSegment,
-                type="property_name_identifier",
-            )
-            for property_name in property_names
-        )
-    )
-
-
 athena_dialect.add(
     StartAngleBracketSegment=StringParser(
         "<", SymbolSegment, type="start_angle_bracket"
@@ -144,14 +131,20 @@ athena_dialect.add(
     ),
     LocationGrammar=Sequence("LOCATION", Ref("QuotedLiteralSegment")),
     BracketedPropertyListGrammar=Bracketed(Delimited(Ref("PropertyGrammar"))),
-    CTASPropertyNameGrammar=_property_name_segments(*_CTAS_PROPERTY_NAMES),
+    CTASPropertyNameGrammar=MultiStringParser(
+        _CTAS_PROPERTY_NAMES,
+        IdentifierSegment,
+        type="property_name_identifier",
+    ),
     CTASPropertyGrammar=Sequence(
         Ref("CTASPropertyNameGrammar"),
         Ref("EqualsSegment"),
         Ref("LiteralGrammar"),
     ),
-    CTASIcebergPropertyNameGrammar=_property_name_segments(
-        *_CTAS_ICEBERG_PROPERTY_NAMES
+    CTASIcebergPropertyNameGrammar=MultiStringParser(
+        _CTAS_ICEBERG_PROPERTY_NAMES,
+        IdentifierSegment,
+        type="property_name_identifier",
     ),
     CTASIcebergPropertyGrammar=Sequence(
         Ref("CTASIcebergPropertyNameGrammar"),
@@ -168,7 +161,11 @@ athena_dialect.add(
             ),
         ),
     ),
-    UnloadPropertyNameGrammar=_property_name_segments(*_UNLOAD_PROPERTY_NAMES),
+    UnloadPropertyNameGrammar=MultiStringParser(
+        _UNLOAD_PROPERTY_NAMES,
+        IdentifierSegment,
+        type="property_name_identifier",
+    ),
     UnloadPropertyGrammar=Sequence(
         Ref("UnloadPropertyNameGrammar"),
         Ref("EqualsSegment"),

--- a/src/sqlfluff/dialects/dialect_athena.py
+++ b/src/sqlfluff/dialects/dialect_athena.py
@@ -66,6 +66,65 @@ athena_dialect.bracket_sets("angle_bracket_pairs").update(
     ]
 )
 
+_CTAS_PROPERTY_NAMES = (
+    "format",
+    "partitioned_by",
+    "bucketed_by",
+    "bucket_count",
+    "write_compression",
+    "orc_compression",
+    "parquet_compression",
+    "compression_level",
+    "field_delimiter",
+    "is_external",
+    "table_type",
+    "external_location",
+)
+
+_CTAS_ICEBERG_PROPERTY_NAMES = (
+    "format",
+    "partitioned_by",
+    "bucketed_by",
+    "bucket_count",
+    "write_compression",
+    "orc_compression",
+    "parquet_compression",
+    "compression_level",
+    "field_delimiter",
+    "is_external",
+    "table_type",
+    "location",
+    "partitioning",
+    "vacuum_max_snapshot_age_seconds",
+    "vacuum_min_snapshots_to_keep",
+    "optimize_rewrite_min_data_file_size_bytes",
+    "optimize_rewrite_max_data_file_size_bytes",
+    "optimize_rewrite_data_file_threshold",
+    "optimize_rewrite_delete_file_threshold",
+)
+
+_UNLOAD_PROPERTY_NAMES = (
+    "format",
+    "partitioned_by",
+    "compression",
+    "field_delimiter",
+)
+
+
+def _property_name_segments(*property_names: str) -> Matchable:
+    """Match Athena property keys without treating them as SQL keywords."""
+    return OneOf(
+        *(
+            StringParser(
+                property_name,
+                IdentifierSegment,
+                type="property_name_identifier",
+            )
+            for property_name in property_names
+        )
+    )
+
+
 athena_dialect.add(
     StartAngleBracketSegment=StringParser(
         "<", SymbolSegment, type="start_angle_bracket"
@@ -91,47 +150,17 @@ athena_dialect.add(
     ),
     LocationGrammar=Sequence("LOCATION", Ref("QuotedLiteralSegment")),
     BracketedPropertyListGrammar=Bracketed(Delimited(Ref("PropertyGrammar"))),
+    CTASPropertyNameGrammar=_property_name_segments(*_CTAS_PROPERTY_NAMES),
     CTASPropertyGrammar=Sequence(
-        OneOf(
-            "format",
-            "partitioned_by",
-            "bucketed_by",
-            "bucket_count",
-            "write_compression",
-            "orc_compression",
-            "parquet_compression",
-            "compression_level",
-            "field_delimiter",
-            "is_external",
-            "table_type",
-            "external_location",
-        ),
+        Ref("CTASPropertyNameGrammar"),
         Ref("EqualsSegment"),
         Ref("LiteralGrammar"),
     ),
+    CTASIcebergPropertyNameGrammar=_property_name_segments(
+        *_CTAS_ICEBERG_PROPERTY_NAMES
+    ),
     CTASIcebergPropertyGrammar=Sequence(
-        OneOf(
-            "format",
-            "partitioned_by",
-            "bucketed_by",
-            "bucket_count",
-            "write_compression",
-            "orc_compression",
-            "parquet_compression",
-            "compression_level",
-            "field_delimiter",
-            "is_external",
-            "table_type",
-            # Iceberg-specific properties
-            "location",
-            "partitioning",
-            "vacuum_max_snapshot_age_seconds",
-            "vacuum_min_snapshots_to_keep",
-            "optimize_rewrite_min_data_file_size_bytes",
-            "optimize_rewrite_max_data_file_size_bytes",
-            "optimize_rewrite_data_file_threshold",
-            "optimize_rewrite_delete_file_threshold",
-        ),
+        Ref("CTASIcebergPropertyNameGrammar"),
         Ref("EqualsSegment"),
         Ref("LiteralGrammar"),
     ),
@@ -145,13 +174,9 @@ athena_dialect.add(
             ),
         ),
     ),
+    UnloadPropertyNameGrammar=_property_name_segments(*_UNLOAD_PROPERTY_NAMES),
     UnloadPropertyGrammar=Sequence(
-        OneOf(
-            "format",
-            "partitioned_by",
-            "compression",
-            "field_delimiter",
-        ),
+        Ref("UnloadPropertyNameGrammar"),
         Ref("EqualsSegment"),
         Ref("LiteralGrammar"),
     ),

--- a/test/fixtures/dialects/athena/create_external_table.yml
+++ b/test/fixtures/dialects/athena/create_external_table.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 3ff2a7e34890b9b31fa6b988a66eb82060240c1259c3c6fcfe2d012fd7d579f3
+_hash: a5b8aee0b1db8336786bf573d07bdf97b469d8666401a3f503adb253f66244cf
 file:
 - statement:
     create_table_statement:
@@ -71,7 +71,7 @@ file:
     - keyword: WITH
     - bracketed:
       - start_bracket: (
-      - keyword: bucketed_by
+      - property_name_identifier: bucketed_by
       - comparison_operator:
           raw_comparison_operator: '='
       - typed_array_literal:
@@ -83,17 +83,17 @@ file:
               naked_identifier: column_name
             end_square_bracket: ']'
       - comma: ','
-      - keyword: bucket_count
+      - property_name_identifier: bucket_count
       - comparison_operator:
           raw_comparison_operator: '='
       - numeric_literal: '30'
       - comma: ','
-      - keyword: format
+      - property_name_identifier: format
       - comparison_operator:
           raw_comparison_operator: '='
       - quoted_literal: "'PARQUET'"
       - comma: ','
-      - keyword: external_location
+      - property_name_identifier: external_location
       - comparison_operator:
           raw_comparison_operator: '='
       - quoted_literal: "'s3://DOC-EXAMPLE-BUCKET/tables/parquet_table/'"

--- a/test/fixtures/dialects/athena/create_partitioned_table.yml
+++ b/test/fixtures/dialects/athena/create_partitioned_table.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 3498f71e1d7ea6840645cc414479dd2074b58164fe31a46fb3df6e9470d7c02d
+_hash: 2db21cff5deef3ca4a18aab416d79de9350100cac38fe08bcd4014181c1740b0
 file:
 - statement:
     create_table_statement:
@@ -14,7 +14,7 @@ file:
     - keyword: WITH
     - bracketed:
         start_bracket: (
-        keyword: partitioned_by
+        property_name_identifier: partitioned_by
         comparison_operator:
           raw_comparison_operator: '='
         typed_array_literal:
@@ -137,27 +137,27 @@ file:
     - keyword: WITH
     - bracketed:
       - start_bracket: (
-      - keyword: table_type
+      - property_name_identifier: table_type
       - comparison_operator:
           raw_comparison_operator: '='
       - quoted_literal: "'ICEBERG'"
       - comma: ','
-      - keyword: format
+      - property_name_identifier: format
       - comparison_operator:
           raw_comparison_operator: '='
       - quoted_literal: "'PARQUET'"
       - comma: ','
-      - keyword: location
+      - property_name_identifier: location
       - comparison_operator:
           raw_comparison_operator: '='
       - quoted_literal: "'s3://my_athena_results/ctas_iceberg_parquet/'"
       - comma: ','
-      - keyword: is_external
+      - property_name_identifier: is_external
       - comparison_operator:
           raw_comparison_operator: '='
       - boolean_literal: 'false'
       - comma: ','
-      - keyword: partitioning
+      - property_name_identifier: partitioning
       - comparison_operator:
           raw_comparison_operator: '='
       - typed_array_literal:
@@ -168,12 +168,12 @@ file:
             quoted_literal: "'month(dt)'"
             end_square_bracket: ']'
       - comma: ','
-      - keyword: vacuum_min_snapshots_to_keep
+      - property_name_identifier: vacuum_min_snapshots_to_keep
       - comparison_operator:
           raw_comparison_operator: '='
       - numeric_literal: '10'
       - comma: ','
-      - keyword: vacuum_max_snapshot_age_seconds
+      - property_name_identifier: vacuum_max_snapshot_age_seconds
       - comparison_operator:
           raw_comparison_operator: '='
       - numeric_literal: '259200'

--- a/test/fixtures/dialects/athena/create_table_as_select.yml
+++ b/test/fixtures/dialects/athena/create_table_as_select.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 22fa674be23f5ccea3ac46cf23b246375654df63fa579095b1378e0b931438aa
+_hash: 631250f36abb20c7f0026ffca873349e31948d9f95dc29c72e3dada53fdf26d9
 file:
   statement:
     create_table_statement:
@@ -14,17 +14,17 @@ file:
     - keyword: WITH
     - bracketed:
       - start_bracket: (
-      - keyword: format
+      - property_name_identifier: format
       - comparison_operator:
           raw_comparison_operator: '='
       - quoted_literal: "'Parquet'"
       - comma: ','
-      - keyword: external_location
+      - property_name_identifier: external_location
       - comparison_operator:
           raw_comparison_operator: '='
       - quoted_literal: "'s3://my-bucket/my-path-level-1/my-path-level-2'"
       - comma: ','
-      - keyword: partitioned_by
+      - property_name_identifier: partitioned_by
       - comparison_operator:
           raw_comparison_operator: '='
       - typed_array_literal:

--- a/test/fixtures/dialects/athena/prepared_statements.yml
+++ b/test/fixtures/dialects/athena/prepared_statements.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: cfd7ab01c93d5e69da42578d477561782550c6935dcd9450b5470d064ffbea20
+_hash: 23652970e397c714e26d2b142f48ae948426db122e8579b2f1458ca82cf6ad33
 file:
 - statement:
     prepare_statement:
@@ -173,7 +173,7 @@ file:
       - keyword: WITH
       - bracketed:
           start_bracket: (
-          keyword: format
+          property_name_identifier: format
           comparison_operator:
             raw_comparison_operator: '='
           quoted_literal: "'PARQUET'"

--- a/test/fixtures/dialects/athena/unload_select.yml
+++ b/test/fixtures/dialects/athena/unload_select.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 0b7b6bddcb121899fc43e2267dc5effd92040e2e6121585928a4fd8b5c3afced
+_hash: 531d30e991cce102c0195c77369bcbc2c615d44130b589829a367ef706aca064
 file:
   statement:
     unload_statement:
@@ -33,22 +33,22 @@ file:
     - keyword: WITH
     - bracketed:
       - start_bracket: (
-      - keyword: format
+      - property_name_identifier: format
       - comparison_operator:
           raw_comparison_operator: '='
       - quoted_literal: "'CSV'"
       - comma: ','
-      - keyword: compression
+      - property_name_identifier: compression
       - comparison_operator:
           raw_comparison_operator: '='
       - quoted_literal: "'gzip'"
       - comma: ','
-      - keyword: field_delimiter
+      - property_name_identifier: field_delimiter
       - comparison_operator:
           raw_comparison_operator: '='
       - quoted_literal: "','"
       - comma: ','
-      - keyword: partitioned_by
+      - property_name_identifier: partitioned_by
       - comparison_operator:
           raw_comparison_operator: '='
       - typed_array_literal:

--- a/test/fixtures/rules/std_rule_cases/CP01.yml
+++ b/test/fixtures/rules/std_rule_cases/CP01.yml
@@ -81,6 +81,30 @@ test_pass_bigquery_date:
       capitalisation.keywords:
         capitalisation_policy: upper
 
+test_fail_athena_ctas_property_names_preserve_case:
+  fail_str: |
+    create table example
+    with (
+        format = 'PARQUET',
+        write_compression = 'ZSTD',
+        external_location = 's3://bucket/athena-results/run/example'
+    ) as
+    select * from example_table;
+  fix_str: |
+    CREATE TABLE example
+    WITH (
+        format = 'PARQUET',
+        write_compression = 'ZSTD',
+        external_location = 's3://bucket/athena-results/run/example'
+    ) AS
+    SELECT * FROM example_table;
+  configs:
+    core:
+      dialect: athena
+    rules:
+      capitalisation.keywords:
+        capitalisation_policy: upper
+
 test_pass_ignore_word:
   pass_str: SeleCT 1
   configs:


### PR DESCRIPTION
### Brief summary of the change made
Fixes #4818.

Athena CTAS and UNLOAD property keys are now parsed as property name identifiers instead of SQL keywords. This keeps `sqlfluff fix` from rewriting option keys such as `format`, `write_compression`, and `external_location` when CP01 fixes keyword capitalisation.

I also regenerated the affected Athena parse fixtures and added a CP01 regression case covering the reported CTAS pattern.

### Are there any other side effects of this change that we should be aware of?
UNLOAD option keys now use the same property-name treatment, so CP01 will avoid rewriting those option names as well.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.

AI assistance was used for implementation and test drafting; I reviewed the parser changes, regenerated fixtures, and validated the behavior with targeted tests.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Treat Athena CTAS (including Iceberg) and UNLOAD option keys as identifiers instead of keywords so CP01 doesn’t uppercase names like format, write_compression, and external_location. Fixes #4818.

- Bug Fixes
  - Use MultiStringParser-based property-name grammars for CTAS, Iceberg, and UNLOAD; share common names and emit property_name_identifier tokens.
  - Regenerated Athena fixtures and added a CP01 regression test to verify option keys keep their case.

<sup>Written for commit 028e65382fcd89cd02fa12506672b4e34b5ba700. Summary will update on new commits. <a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/7875?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

