### PR TITLE
feat(mysql): add support for CURRENT_TIMESTAMP in ALTER TABLE statements

### DIFF
--- a/src/sqlfluff/dialects/dialect_mysql.py
+++ b/src/sqlfluff/dialects/dialect_mysql.py
@@ -166,6 +166,14 @@ mysql_dialect.sets("date_part_function_name").update(
     ]
 )
 
+mysql_dialect.sets("bare_functions").update(
+    [
+        "NOW",
+        "LOCALTIME",
+        "LOCALTIMESTAMP",
+    ]
+)
+
 mysql_dialect.replace(
     QuotedIdentifierSegment=TypedParser(
         "back_quote",
@@ -403,10 +411,10 @@ class AliasExpressionSegment(ansi.AliasExpressionSegment):
     )
 
 
-class BareCurrentTimestampLikeFunctionSegment(BaseSegment):
-    """MySQL bare timestamp function forms."""
+class CurrentTimestampLikeFunctionNameSegment(BaseSegment):
+    """MySQL timestamp function names used in column defaults."""
 
-    type = "bare_function"
+    type = "function_name"
     match_grammar = OneOf(
         Ref.keyword("CURRENT_TIMESTAMP"),
         Ref.keyword("NOW"),
@@ -415,18 +423,20 @@ class BareCurrentTimestampLikeFunctionSegment(BaseSegment):
     )
 
 
+class CurrentTimestampLikeFunctionContentsSegment(BaseSegment):
+    """MySQL timestamp function contents used in column defaults."""
+
+    type = "function_contents"
+    match_grammar = Bracketed(Ref("NumericLiteralSegment", optional=True))
+
+
 class CurrentTimestampLikeFunctionSegment(BaseSegment):
     """MySQL parenthesized timestamp function forms."""
 
     type = "function"
     match_grammar = Sequence(
-        OneOf(
-            Ref.keyword("CURRENT_TIMESTAMP"),
-            Ref.keyword("NOW"),
-            Ref.keyword("LOCALTIME"),
-            Ref.keyword("LOCALTIMESTAMP"),
-        ),
-        Bracketed(Ref("NumericLiteralSegment", optional=True)),
+        Ref("CurrentTimestampLikeFunctionNameSegment"),
+        Ref("CurrentTimestampLikeFunctionContentsSegment"),
     )
 
 
@@ -452,7 +462,7 @@ class ColumnDefinitionSegment(BaseSegment):
                         "DEFAULT",
                         OneOf(
                             Ref("CurrentTimestampLikeFunctionSegment"),
-                            Ref("BareCurrentTimestampLikeFunctionSegment"),
+                            Ref("BareFunctionSegment"),
                             Ref("NumericLiteralSegment"),
                             Ref("QuotedLiteralSegment"),
                             "NULL",
@@ -464,7 +474,7 @@ class ColumnDefinitionSegment(BaseSegment):
                         "UPDATE",
                         OneOf(
                             Ref("CurrentTimestampLikeFunctionSegment"),
-                            Ref("BareCurrentTimestampLikeFunctionSegment"),
+                            Ref("BareFunctionSegment"),
                         ),
                         optional=True,
                     ),

--- a/src/sqlfluff/dialects/dialect_mysql.py
+++ b/src/sqlfluff/dialects/dialect_mysql.py
@@ -403,6 +403,33 @@ class AliasExpressionSegment(ansi.AliasExpressionSegment):
     )
 
 
+class BareCurrentTimestampLikeFunctionSegment(BaseSegment):
+    """MySQL bare timestamp function forms."""
+
+    type = "bare_function"
+    match_grammar = OneOf(
+        Ref.keyword("CURRENT_TIMESTAMP"),
+        Ref.keyword("NOW"),
+        Ref.keyword("LOCALTIME"),
+        Ref.keyword("LOCALTIMESTAMP"),
+    )
+
+
+class CurrentTimestampLikeFunctionSegment(BaseSegment):
+    """MySQL parenthesized timestamp function forms."""
+
+    type = "function"
+    match_grammar = Sequence(
+        OneOf(
+            Ref.keyword("CURRENT_TIMESTAMP"),
+            Ref.keyword("NOW"),
+            Ref.keyword("LOCALTIME"),
+            Ref.keyword("LOCALTIMESTAMP"),
+        ),
+        Bracketed(Ref("NumericLiteralSegment", optional=True)),
+    )
+
+
 class ColumnDefinitionSegment(BaseSegment):
     """A column definition, e.g. for CREATE TABLE or ALTER TABLE."""
 
@@ -424,13 +451,8 @@ class ColumnDefinitionSegment(BaseSegment):
                     Sequence(
                         "DEFAULT",
                         OneOf(
-                            Sequence(
-                                OneOf("CURRENT_TIMESTAMP", "NOW"),
-                                Bracketed(
-                                    Ref("NumericLiteralSegment", optional=True),
-                                    optional=True,
-                                ),
-                            ),
+                            Ref("CurrentTimestampLikeFunctionSegment"),
+                            Ref("BareCurrentTimestampLikeFunctionSegment"),
                             Ref("NumericLiteralSegment"),
                             Ref("QuotedLiteralSegment"),
                             "NULL",
@@ -441,12 +463,8 @@ class ColumnDefinitionSegment(BaseSegment):
                         "ON",
                         "UPDATE",
                         OneOf(
-                            "CURRENT_TIMESTAMP",
-                            "NOW",
-                            Bracketed(
-                                Ref("NumericLiteralSegment", optional=True),
-                                optional=True,
-                            ),
+                            Ref("CurrentTimestampLikeFunctionSegment"),
+                            Ref("BareCurrentTimestampLikeFunctionSegment"),
                         ),
                         optional=True,
                     ),

--- a/test/fixtures/dialects/doris/create_table_advanced_aggregate.yml
+++ b/test/fixtures/dialects/doris/create_table_advanced_aggregate.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: fb654a26ce80d5fa3e8afd0e30be3766909556bddbd5273c65f948c094062c54
+_hash: 127a2d4eb1ea1daa98cb0bcd50670266991e548d663f65cb3e6b71223a27fee0
 file:
   statement:
     create_table_statement:
@@ -99,16 +99,19 @@ file:
         - naked_identifier: created_at
         - keyword: DATETIME
         - keyword: DEFAULT
-        - keyword: CURRENT_TIMESTAMP
+        - bare_function:
+            keyword: CURRENT_TIMESTAMP
       - comma: ','
       - column_definition:
         - naked_identifier: updated_at
         - keyword: DATETIME
         - keyword: DEFAULT
-        - keyword: CURRENT_TIMESTAMP
+        - bare_function:
+            keyword: CURRENT_TIMESTAMP
         - keyword: 'ON'
         - keyword: UPDATE
-        - keyword: CURRENT_TIMESTAMP
+        - bare_function:
+            keyword: CURRENT_TIMESTAMP
       - end_bracket: )
     - keyword: AGGREGATE
     - keyword: KEY

--- a/test/fixtures/dialects/doris/create_table_advanced_aggregate.yml
+++ b/test/fixtures/dialects/doris/create_table_advanced_aggregate.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 127a2d4eb1ea1daa98cb0bcd50670266991e548d663f65cb3e6b71223a27fee0
+_hash: 3a0130c5512539257c5ff78ec424f9b10f653f91159adabae23376eab2a5f62a
 file:
   statement:
     create_table_statement:
@@ -99,19 +99,16 @@ file:
         - naked_identifier: created_at
         - keyword: DATETIME
         - keyword: DEFAULT
-        - bare_function:
-            keyword: CURRENT_TIMESTAMP
+        - bare_function: CURRENT_TIMESTAMP
       - comma: ','
       - column_definition:
         - naked_identifier: updated_at
         - keyword: DATETIME
         - keyword: DEFAULT
-        - bare_function:
-            keyword: CURRENT_TIMESTAMP
+        - bare_function: CURRENT_TIMESTAMP
         - keyword: 'ON'
         - keyword: UPDATE
-        - bare_function:
-            keyword: CURRENT_TIMESTAMP
+        - bare_function: CURRENT_TIMESTAMP
       - end_bracket: )
     - keyword: AGGREGATE
     - keyword: KEY

--- a/test/fixtures/dialects/mariadb/alter_table.sql
+++ b/test/fixtures/dialects/mariadb/alter_table.sql
@@ -86,6 +86,18 @@ ALTER TABLE `foo` CONVERT TO CHARACTER SET 'utf8mb4' COLLATE 'utf8mb4_unicode_ci
 
 ALTER TABLE `foo` CONVERT TO CHARACTER SET "utf8mb4" COLLATE "utf8mb4_unicode_ci";
 
+ALTER TABLE t MODIFY time_updated timestamp NOT NULL
+DEFAULT current_timestamp()
+ON UPDATE current_timestamp();
+
+ALTER TABLE t MODIFY time_updated timestamp NOT NULL
+DEFAULT localtime
+ON UPDATE localtime();
+
+ALTER TABLE t MODIFY time_updated timestamp NOT NULL
+DEFAULT localtimestamp
+ON UPDATE localtimestamp();
+
 ALTER TABLE `foo`
 ENGINE = 'InnoDB'
 AUTO_INCREMENT = 1

--- a/test/fixtures/dialects/mariadb/alter_table.yml
+++ b/test/fixtures/dialects/mariadb/alter_table.yml
@@ -3,1307 +3,1313 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: f0d073a6827b43981eaaae08c322ea0bef8204fd11176c0d9774ad82e28b9f55
+_hash: 240c31e6518c25cc685ad9949dd5a53309cd62388a669d82f44944e564ee71fb
 file:
-    - statement:
-          alter_table_statement:
-              - keyword: ALTER
-              - keyword: TABLE
-              - table_reference:
-                    quoted_identifier: "`users`"
-              - keyword: MODIFY
-              - keyword: COLUMN
-              - column_definition:
-                    quoted_identifier: "`name`"
-                    data_type:
-                        data_type_identifier: varchar
-                        bracketed_arguments:
-                            bracketed:
-                                start_bracket: (
-                                numeric_literal: "255"
-                                end_bracket: )
-                    column_constraint_segment:
-                        - keyword: NOT
-                        - keyword: "NULL"
-              - comma: ","
-              - table_options:
-                    keyword: COMMENT
-                    quoted_literal: '"name of user"'
-    - statement_terminator: ;
-    - statement:
-          alter_table_statement:
-              - keyword: ALTER
-              - keyword: TABLE
-              - table_reference:
-                    quoted_identifier: "`users`"
-              - keyword: MODIFY
-              - column_definition:
-                    quoted_identifier: "`name`"
-                    data_type:
-                        data_type_identifier: varchar
-                        bracketed_arguments:
-                            bracketed:
-                                start_bracket: (
-                                numeric_literal: "255"
-                                end_bracket: )
-                    column_constraint_segment:
-                        - keyword: NOT
-                        - keyword: "NULL"
-              - keyword: FIRST
-    - statement_terminator: ;
-    - statement:
-          alter_table_statement:
-              - keyword: ALTER
-              - keyword: TABLE
-              - table_reference:
-                    quoted_identifier: "`users`"
-              - keyword: RENAME
-              - keyword: TO
-              - table_reference:
-                    quoted_identifier: "`user`"
-    - statement_terminator: ;
-    - statement:
-          alter_table_statement:
-              - keyword: ALTER
-              - keyword: TABLE
-              - table_reference:
-                    quoted_identifier: "`user`"
-              - keyword: RENAME
-              - keyword: AS
-              - table_reference:
-                    quoted_identifier: "`users`"
-    - statement_terminator: ;
-    - statement:
-          alter_table_statement:
-              - keyword: ALTER
-              - keyword: TABLE
-              - table_reference:
-                    quoted_identifier: "`users`"
-              - keyword: RENAME
-              - table_reference:
-                    quoted_identifier: "`user`"
-    - statement_terminator: ;
-    - statement:
-          alter_table_statement:
-              - keyword: ALTER
-              - keyword: TABLE
-              - table_reference:
-                    quoted_identifier: "`users`"
-              - keyword: RENAME
-              - keyword: COLUMN
-              - column_reference:
-                    quoted_identifier: "`col_1`"
-              - keyword: TO
-              - column_reference:
-                    quoted_identifier: "`del_col_1`"
-    - statement_terminator: ;
-    - statement:
-          alter_table_statement:
-              - keyword: ALTER
-              - keyword: TABLE
-              - table_reference:
-                    quoted_identifier: "`users`"
-              - keyword: CHANGE
-              - keyword: COLUMN
-              - column_reference:
-                    quoted_identifier: "`birthday`"
-              - column_definition:
-                    - quoted_identifier: "`date_of_birth`"
-                    - data_type:
-                          data_type_identifier: INT
-                          bracketed_arguments:
-                              bracketed:
-                                  start_bracket: (
-                                  numeric_literal: "11"
-                                  end_bracket: )
-                    - column_constraint_segment:
-                          keyword: "NULL"
-                    - column_constraint_segment:
-                          keyword: DEFAULT
-                          null_literal: "NULL"
-    - statement_terminator: ;
-    - statement:
-          alter_table_statement:
-              - keyword: ALTER
-              - keyword: TABLE
-              - table_reference:
-                    quoted_identifier: "`users`"
-              - keyword: CHANGE
-              - keyword: COLUMN
-              - column_reference:
-                    quoted_identifier: "`birthday`"
-              - column_definition:
-                    quoted_identifier: "`date_of_birth`"
-                    data_type:
-                        data_type_identifier: INT
-                        bracketed_arguments:
-                            bracketed:
-                                start_bracket: (
-                                numeric_literal: "11"
-                                end_bracket: )
-                    column_constraint_segment:
-                        - keyword: NOT
-                        - keyword: "NULL"
-    - statement_terminator: ;
-    - statement:
-          alter_table_statement:
-              - keyword: ALTER
-              - keyword: TABLE
-              - table_reference:
-                    quoted_identifier: "`users`"
-              - keyword: CHANGE
-              - keyword: COLUMN
-              - column_reference:
-                    quoted_identifier: "`birthday`"
-              - column_definition:
-                    quoted_identifier: "`date_of_birth`"
-                    data_type:
-                        data_type_identifier: INT
-                        bracketed_arguments:
-                            bracketed:
-                                start_bracket: (
-                                numeric_literal: "11"
-                                end_bracket: )
-              - keyword: FIRST
-    - statement_terminator: ;
-    - statement:
-          alter_table_statement:
-              - keyword: ALTER
-              - keyword: TABLE
-              - table_reference:
-                    quoted_identifier: "`users`"
-              - keyword: CHANGE
-              - keyword: COLUMN
-              - column_reference:
-                    quoted_identifier: "`birthday`"
-              - column_definition:
-                    quoted_identifier: "`date_of_birth`"
-                    data_type:
-                        data_type_identifier: INT
-                        bracketed_arguments:
-                            bracketed:
-                                start_bracket: (
-                                numeric_literal: "11"
-                                end_bracket: )
-              - keyword: AFTER
-              - column_reference:
-                    quoted_identifier: "`name`"
-    - statement_terminator: ;
-    - statement:
-          alter_table_statement:
-              - keyword: ALTER
-              - keyword: TABLE
-              - table_reference:
-                    quoted_identifier: "`users`"
-              - keyword: DROP
-              - keyword: COLUMN
-              - column_reference:
-                    quoted_identifier: "`age`"
-    - statement_terminator: ;
-    - statement:
-          alter_table_statement:
-              - keyword: ALTER
-              - keyword: TABLE
-              - table_reference:
-                    - quoted_identifier: "`foo`"
-                    - dot: .
-                    - quoted_identifier: "`bar`"
-              - keyword: ADD
-              - table_constraint:
-                    - keyword: CONSTRAINT
-                    - object_reference:
-                          quoted_identifier: "`index_name`"
-                    - keyword: UNIQUE
-                    - bracketed:
-                          - start_bracket: (
-                          - column_reference:
-                                quoted_identifier: "`col_1`"
-                          - comma: ","
-                          - column_reference:
-                                quoted_identifier: "`col_2`"
-                          - comma: ","
-                          - column_reference:
-                                quoted_identifier: "`col_3`"
-                          - end_bracket: )
-    - statement_terminator: ;
-    - statement:
-          alter_table_statement:
-              - keyword: ALTER
-              - keyword: TABLE
-              - table_reference:
-                    - quoted_identifier: "`foo`"
-                    - dot: .
-                    - quoted_identifier: "`bar`"
-              - keyword: ADD
-              - table_constraint:
-                    keyword: UNIQUE
-                    index_reference:
-                        quoted_identifier: "`index_name`"
-                    bracketed:
-                        - start_bracket: (
-                        - column_reference:
-                              quoted_identifier: "`col_1`"
-                        - comma: ","
-                        - column_reference:
-                              quoted_identifier: "`col_2`"
-                        - comma: ","
-                        - column_reference:
-                              quoted_identifier: "`col_3`"
-                        - end_bracket: )
-    - statement_terminator: ;
-    - statement:
-          alter_table_statement:
-              - keyword: ALTER
-              - keyword: TABLE
-              - table_reference:
-                    - quoted_identifier: "`foo`"
-                    - dot: .
-                    - quoted_identifier: "`bar`"
-              - keyword: ADD
-              - table_constraint:
-                    - keyword: CONSTRAINT
-                    - object_reference:
-                          quoted_identifier: "`index_name`"
-                    - keyword: UNIQUE
-                    - keyword: INDEX
-                    - bracketed:
-                          - start_bracket: (
-                          - column_reference:
-                                quoted_identifier: "`col_1`"
-                          - comma: ","
-                          - column_reference:
-                                quoted_identifier: "`col_2`"
-                          - comma: ","
-                          - column_reference:
-                                quoted_identifier: "`col_3`"
-                          - end_bracket: )
-    - statement_terminator: ;
-    - statement:
-          alter_table_statement:
-              - keyword: ALTER
-              - keyword: TABLE
-              - table_reference:
-                    - quoted_identifier: "`foo`"
-                    - dot: .
-                    - quoted_identifier: "`bar`"
-              - keyword: ADD
-              - table_constraint:
-                    - keyword: UNIQUE
-                    - keyword: INDEX
-                    - index_reference:
-                          quoted_identifier: "`index_name`"
-                    - bracketed:
-                          - start_bracket: (
-                          - column_reference:
-                                quoted_identifier: "`col_1`"
-                          - comma: ","
-                          - column_reference:
-                                quoted_identifier: "`col_2`"
-                          - comma: ","
-                          - column_reference:
-                                quoted_identifier: "`col_3`"
-                          - end_bracket: )
-    - statement_terminator: ;
-    - statement:
-          alter_table_statement:
-              - keyword: ALTER
-              - keyword: TABLE
-              - table_reference:
-                    - quoted_identifier: "`foo`"
-                    - dot: .
-                    - quoted_identifier: "`bar`"
-              - keyword: ADD
-              - table_constraint:
-                    keyword: INDEX
-                    index_reference:
-                        quoted_identifier: "`index_name`"
-                    bracketed:
-                        - start_bracket: (
-                        - column_reference:
-                              quoted_identifier: "`col_1`"
-                        - comma: ","
-                        - column_reference:
-                              quoted_identifier: "`col_2`"
-                        - comma: ","
-                        - column_reference:
-                              quoted_identifier: "`col_3`"
-                        - end_bracket: )
-    - statement_terminator: ;
-    - statement:
-          alter_table_statement:
-              - keyword: ALTER
-              - keyword: TABLE
-              - table_reference:
-                    - quoted_identifier: "`foo`"
-                    - dot: .
-                    - quoted_identifier: "`bar`"
-              - keyword: ADD
-              - table_constraint:
-                    keyword: INDEX
-                    index_reference:
-                        quoted_identifier: "`index_name`"
-                    bracketed:
-                        - start_bracket: (
-                        - column_reference:
-                              quoted_identifier: "`col_1`"
-                        - comma: ","
-                        - column_reference:
-                              quoted_identifier: "`col_2`"
-                        - comma: ","
-                        - column_reference:
-                              quoted_identifier: "`col_3`"
-                        - end_bracket: )
-                    index_option:
-                        keyword: KEY_BLOCK_SIZE
-                        comparison_operator:
-                            raw_comparison_operator: "="
-                        numeric_literal: "8"
-    - statement_terminator: ;
-    - statement:
-          alter_table_statement:
-              - keyword: ALTER
-              - keyword: TABLE
-              - table_reference:
-                    - quoted_identifier: "`foo`"
-                    - dot: .
-                    - quoted_identifier: "`bar`"
-              - keyword: ADD
-              - table_constraint:
-                    keyword: INDEX
-                    index_reference:
-                        quoted_identifier: "`index_name`"
-                    bracketed:
-                        - start_bracket: (
-                        - column_reference:
-                              quoted_identifier: "`col_1`"
-                        - comma: ","
-                        - column_reference:
-                              quoted_identifier: "`col_2`"
-                        - comma: ","
-                        - column_reference:
-                              quoted_identifier: "`col_3`"
-                        - end_bracket: )
-                    index_option:
-                        keyword: KEY_BLOCK_SIZE
-                        numeric_literal: "8"
-    - statement_terminator: ;
-    - statement:
-          alter_table_statement:
-              - keyword: ALTER
-              - keyword: TABLE
-              - table_reference:
-                    - quoted_identifier: "`foo`"
-                    - dot: .
-                    - quoted_identifier: "`bar`"
-              - keyword: ADD
-              - table_constraint:
-                    keyword: INDEX
-                    index_reference:
-                        quoted_identifier: "`index_name`"
-                    bracketed:
-                        - start_bracket: (
-                        - column_reference:
-                              quoted_identifier: "`col_1`"
-                        - comma: ","
-                        - column_reference:
-                              quoted_identifier: "`col_2`"
-                        - comma: ","
-                        - column_reference:
-                              quoted_identifier: "`col_3`"
-                        - end_bracket: )
-                    index_option:
-                        keyword: KEY_BLOCK_SIZE
-                        numeric_literal: "8"
-                        comment_clause:
-                            keyword: COMMENT
-                            quoted_literal: "'index for col_1, col_2, col_3'"
-    - statement_terminator: ;
-    - statement:
-          alter_table_statement:
-              - keyword: ALTER
-              - keyword: TABLE
-              - table_reference:
-                    - quoted_identifier: "`foo`"
-                    - dot: .
-                    - quoted_identifier: "`bar`"
-              - keyword: DROP
-              - keyword: INDEX
-              - index_reference:
-                    quoted_identifier: "`index_name`"
-    - statement_terminator: ;
-    - statement:
-          alter_table_statement:
-              - keyword: ALTER
-              - keyword: TABLE
-              - table_reference:
-                    - quoted_identifier: "`foo`"
-                    - dot: .
-                    - quoted_identifier: "`bar`"
-              - keyword: RENAME
-              - keyword: INDEX
-              - index_reference:
-                    quoted_identifier: "`index_name`"
-              - keyword: to
-              - index_reference:
-                    quoted_identifier: "`new_index_name`"
-    - statement_terminator: ;
-    - statement:
-          alter_table_statement:
-              - keyword: ALTER
-              - keyword: TABLE
-              - table_reference:
-                    - quoted_identifier: "`foo`"
-                    - dot: .
-                    - quoted_identifier: "`bar`"
-              - keyword: RENAME
-              - keyword: KEY
-              - index_reference:
-                    quoted_identifier: "`key_name`"
-              - keyword: to
-              - index_reference:
-                    quoted_identifier: "`new_key_name`"
-    - statement_terminator: ;
-    - statement:
-          alter_table_statement:
-              - keyword: ALTER
-              - keyword: TABLE
-              - table_reference:
-                    quoted_identifier: "`x`"
-              - keyword: ADD
-              - table_constraint:
-                    - keyword: CONSTRAINT
-                    - keyword: FOREIGN
-                    - keyword: KEY
-                    - bracketed:
-                          start_bracket: (
-                          column_reference:
-                              quoted_identifier: "`xk`"
-                          end_bracket: )
-                    - keyword: REFERENCES
-                    - column_reference:
-                          quoted_identifier: "`y`"
-                    - bracketed:
-                          start_bracket: (
-                          column_reference:
-                              quoted_identifier: "`yk`"
-                          end_bracket: )
-    - statement_terminator: ;
-    - statement:
-          alter_table_statement:
-              - keyword: ALTER
-              - keyword: TABLE
-              - table_reference:
-                    quoted_identifier: "`users`"
-              - keyword: ADD
-              - keyword: COLUMN
-              - column_definition:
-                    quoted_identifier: "`active`"
-                    data_type:
-                        data_type_identifier: tinyint
-                        bracketed_arguments:
-                            bracketed:
-                                start_bracket: (
-                                numeric_literal: "1"
-                                end_bracket: )
-                    column_constraint_segment:
-                        keyword: DEFAULT
-                        quoted_literal: "'0'"
-    - statement_terminator: ;
-    - statement:
-          alter_table_statement:
-              - keyword: ALTER
-              - keyword: TABLE
-              - table_reference:
-                    quoted_identifier: "`users`"
-              - keyword: ADD
-              - keyword: COLUMN
-              - keyword: IF
-              - keyword: NOT
-              - keyword: EXISTS
-              - column_definition:
-                    quoted_identifier: "`active`"
-                    data_type:
-                        data_type_identifier: tinyint
-                        bracketed_arguments:
-                            bracketed:
-                                start_bracket: (
-                                numeric_literal: "1"
-                                end_bracket: )
-                    column_constraint_segment:
-                        keyword: DEFAULT
-                        quoted_literal: "'0'"
-    - statement_terminator: ;
-    - statement:
-          alter_table_statement:
-              - keyword: ALTER
-              - keyword: TABLE
-              - table_reference:
-                    quoted_identifier: "`foo`"
-              - keyword: ADD
-              - column_definition:
-                    quoted_identifier: "`bar`"
-                    data_type:
-                        data_type_identifier: INT
-              - keyword: FIRST
-    - statement_terminator: ;
-    - statement:
-          alter_table_statement:
-              - keyword: ALTER
-              - keyword: TABLE
-              - table_reference:
-                    quoted_identifier: "`foo`"
-              - keyword: ADD
-              - keyword: COLUMN
-              - column_definition:
-                    naked_identifier: d
-                    data_type:
-                        data_type_identifier: INT
-                    column_constraint_segment:
-                        - keyword: GENERATED
-                        - keyword: ALWAYS
-                        - keyword: AS
-                        - bracketed:
-                              start_bracket: (
-                              expression:
-                                  column_reference:
-                                      naked_identifier: a
-                                  binary_operator: "*"
-                                  function:
-                                      function_name:
-                                          function_name_identifier: abs
-                                      function_contents:
-                                          bracketed:
-                                              start_bracket: (
-                                              expression:
-                                                  column_reference:
-                                                      naked_identifier: b
-                                              end_bracket: )
-                              end_bracket: )
-                        - keyword: VIRTUAL
-    - statement_terminator: ;
-    - statement:
-          alter_table_statement:
-              - keyword: ALTER
-              - keyword: TABLE
-              - table_reference:
-                    quoted_identifier: "`foo`"
-              - keyword: ADD
-              - keyword: COLUMN
-              - column_definition:
-                    naked_identifier: e
-                    data_type:
-                        data_type_identifier: TEXT
-                    column_constraint_segment:
-                        - keyword: GENERATED
-                        - keyword: ALWAYS
-                        - keyword: AS
-                        - bracketed:
-                              start_bracket: (
-                              expression:
-                                  function:
-                                      function_name:
-                                          function_name_identifier: substr
-                                      function_contents:
-                                          bracketed:
-                                              - start_bracket: (
-                                              - expression:
-                                                    column_reference:
-                                                        naked_identifier: c
-                                              - comma: ","
-                                              - expression:
-                                                    column_reference:
-                                                        naked_identifier: b
-                                              - comma: ","
-                                              - expression:
-                                                    column_reference:
-                                                        naked_identifier: b
-                                                    binary_operator: +
-                                                    numeric_literal: "1"
-                                              - end_bracket: )
-                              end_bracket: )
-                        - keyword: STORED
-    - statement_terminator: ;
-    - statement:
-          alter_table_statement:
-              - keyword: ALTER
-              - keyword: TABLE
-              - table_reference:
-                    quoted_identifier: "`foo`"
-              - keyword: ADD
-              - keyword: COLUMN
-              - column_definition:
-                    naked_identifier: e
-                    data_type:
-                        data_type_identifier: TEXT
-                    column_constraint_segment:
-                        - keyword: GENERATED
-                        - keyword: ALWAYS
-                        - keyword: AS
-                        - bracketed:
-                              start_bracket: (
-                              expression:
-                                  function:
-                                      function_name:
-                                          function_name_identifier: substr
-                                      function_contents:
-                                          bracketed:
-                                              - start_bracket: (
-                                              - expression:
-                                                    column_reference:
-                                                        naked_identifier: c
-                                              - comma: ","
-                                              - expression:
-                                                    column_reference:
-                                                        naked_identifier: b
-                                              - comma: ","
-                                              - expression:
-                                                    column_reference:
-                                                        naked_identifier: b
-                                                    binary_operator: +
-                                                    numeric_literal: "1"
-                                              - end_bracket: )
-                              end_bracket: )
-                        - keyword: PERSISTENT
-    - statement_terminator: ;
-    - statement:
-          alter_table_statement:
-              - keyword: ALTER
-              - keyword: TABLE
-              - table_reference:
-                    quoted_identifier: "`foo`"
-              - keyword: ADD
-              - keyword: COLUMN
-              - column_definition:
-                    naked_identifier: d
-                    data_type:
-                        data_type_identifier: INT
-                    column_constraint_segment:
-                        keyword: AS
-                        bracketed:
-                            start_bracket: (
-                            expression:
-                                column_reference:
-                                    naked_identifier: a
-                                binary_operator: "*"
-                                function:
-                                    function_name:
-                                        function_name_identifier: abs
-                                    function_contents:
-                                        bracketed:
-                                            start_bracket: (
-                                            expression:
-                                                column_reference:
-                                                    naked_identifier: b
-                                            end_bracket: )
-                            end_bracket: )
-    - statement_terminator: ;
-    - statement:
-          alter_table_statement:
-              - keyword: ALTER
-              - keyword: TABLE
-              - table_reference:
-                    quoted_identifier: "`foo`"
-              - keyword: ADD
-              - keyword: COLUMN
-              - column_definition:
-                    naked_identifier: e
-                    data_type:
-                        data_type_identifier: TEXT
-                    column_constraint_segment:
-                        - keyword: AS
-                        - bracketed:
-                              start_bracket: (
-                              expression:
-                                  function:
-                                      function_name:
-                                          function_name_identifier: substr
-                                      function_contents:
-                                          bracketed:
-                                              - start_bracket: (
-                                              - expression:
-                                                    column_reference:
-                                                        naked_identifier: c
-                                              - comma: ","
-                                              - expression:
-                                                    column_reference:
-                                                        naked_identifier: b
-                                              - comma: ","
-                                              - expression:
-                                                    column_reference:
-                                                        naked_identifier: b
-                                                    binary_operator: +
-                                                    numeric_literal: "1"
-                                              - end_bracket: )
-                              end_bracket: )
-                        - keyword: STORED
-    - statement_terminator: ;
-    - statement:
-          alter_table_statement:
-              - keyword: ALTER
-              - keyword: TABLE
-              - table_reference:
-                    quoted_identifier: "`foo`"
-              - keyword: ADD
-              - keyword: COLUMN
-              - column_definition:
-                    naked_identifier: e
-                    data_type:
-                        data_type_identifier: TEXT
-                    column_constraint_segment:
-                        - keyword: AS
-                        - bracketed:
-                              start_bracket: (
-                              expression:
-                                  function:
-                                      function_name:
-                                          function_name_identifier: substr
-                                      function_contents:
-                                          bracketed:
-                                              - start_bracket: (
-                                              - expression:
-                                                    column_reference:
-                                                        naked_identifier: c
-                                              - comma: ","
-                                              - expression:
-                                                    column_reference:
-                                                        naked_identifier: b
-                                              - comma: ","
-                                              - expression:
-                                                    column_reference:
-                                                        naked_identifier: b
-                                                    binary_operator: +
-                                                    numeric_literal: "1"
-                                              - end_bracket: )
-                              end_bracket: )
-                        - keyword: PERSISTENT
-    - statement_terminator: ;
-    - statement:
-          alter_table_statement:
-              - keyword: ALTER
-              - keyword: TABLE
-              - table_reference:
-                    quoted_identifier: "`foo`"
-              - keyword: CONVERT
-              - keyword: TO
-              - alter_option_segment:
-                    - keyword: CHARACTER
-                    - keyword: SET
-                    - naked_identifier: utf8mb4
-              - alter_option_segment:
-                    keyword: COLLATE
-                    collation_reference:
-                        naked_identifier: utf8mb4_unicode_ci
-    - statement_terminator: ;
-    - statement:
-          alter_table_statement:
-              - keyword: ALTER
-              - keyword: TABLE
-              - table_reference:
-                    quoted_identifier: "`foo`"
-              - keyword: CONVERT
-              - keyword: TO
-              - alter_option_segment:
-                    - keyword: CHARACTER
-                    - keyword: SET
-                    - quoted_identifier: "`utf8mb4`"
-              - alter_option_segment:
-                    keyword: COLLATE
-                    collation_reference:
-                        quoted_identifier: "`utf8mb4_unicode_ci`"
-    - statement_terminator: ;
-    - statement:
-          alter_table_statement:
-              - keyword: ALTER
-              - keyword: TABLE
-              - table_reference:
-                    quoted_identifier: "`foo`"
-              - keyword: CONVERT
-              - keyword: TO
-              - alter_option_segment:
-                    - keyword: CHARACTER
-                    - keyword: SET
-                    - quoted_identifier: "'utf8mb4'"
-              - alter_option_segment:
-                    keyword: COLLATE
-                    collation_reference:
-                        quoted_literal: "'utf8mb4_unicode_ci'"
-    - statement_terminator: ;
-    - statement:
-          alter_table_statement:
-              - keyword: ALTER
-              - keyword: TABLE
-              - table_reference:
-                    quoted_identifier: "`foo`"
-              - keyword: CONVERT
-              - keyword: TO
-              - alter_option_segment:
-                    - keyword: CHARACTER
-                    - keyword: SET
-                    - quoted_identifier: '"utf8mb4"'
-              - alter_option_segment:
-                    keyword: COLLATE
-                    collation_reference:
-                        quoted_literal: '"utf8mb4_unicode_ci"'
-    - statement_terminator: ;
-    - statement:
-          alter_table_statement:
-              - keyword: ALTER
-              - keyword: TABLE
-              - table_reference:
-                    naked_identifier: t
-              - keyword: MODIFY
-              - column_definition:
-                    - naked_identifier: time_updated
-                    - keyword: timestamp
-                    - keyword: NOT
-                    - keyword: "NULL"
-                    - keyword: DEFAULT
-                    - function:
-                          keyword: current_timestamp
-                          bracketed:
-                              start_bracket: (
-                              end_bracket: )
-                    - keyword: "ON"
-                    - keyword: UPDATE
-                    - function:
-                          keyword: current_timestamp
-                          bracketed:
-                              start_bracket: (
-                              end_bracket: )
-    - statement_terminator: ;
-    - statement:
-          alter_table_statement:
-              - keyword: ALTER
-              - keyword: TABLE
-              - table_reference:
-                    naked_identifier: t
-              - keyword: MODIFY
-              - column_definition:
-                    - naked_identifier: time_updated
-                    - keyword: timestamp
-                    - keyword: NOT
-                    - keyword: "NULL"
-                    - keyword: DEFAULT
-                    - bare_function:
-                          keyword: localtime
-                    - keyword: "ON"
-                    - keyword: UPDATE
-                    - function:
-                          keyword: localtime
-                          bracketed:
-                              start_bracket: (
-                              end_bracket: )
-    - statement_terminator: ;
-    - statement:
-          alter_table_statement:
-              - keyword: ALTER
-              - keyword: TABLE
-              - table_reference:
-                    naked_identifier: t
-              - keyword: MODIFY
-              - column_definition:
-                    - naked_identifier: time_updated
-                    - keyword: timestamp
-                    - keyword: NOT
-                    - keyword: "NULL"
-                    - keyword: DEFAULT
-                    - bare_function:
-                          keyword: localtimestamp
-                    - keyword: "ON"
-                    - keyword: UPDATE
-                    - function:
-                          keyword: localtimestamp
-                          bracketed:
-                              start_bracket: (
-                              end_bracket: )
-    - statement_terminator: ;
-    - statement:
-          alter_table_statement:
-              - keyword: ALTER
-              - keyword: TABLE
-              - table_reference:
-                    quoted_identifier: "`foo`"
-              - table_options:
-                    - keyword: ENGINE
-                    - comparison_operator:
-                          raw_comparison_operator: "="
-                    - quoted_literal: "'InnoDB'"
-                    - keyword: AUTO_INCREMENT
-                    - comparison_operator:
-                          raw_comparison_operator: "="
-                    - numeric_literal: "1"
-                    - keyword: AVG_ROW_LENGTH
-                    - comparison_operator:
-                          raw_comparison_operator: "="
-                    - numeric_literal: "10"
-                    - keyword: DEFAULT
-                    - keyword: CHARACTER
-                    - keyword: SET
-                    - comparison_operator:
-                          raw_comparison_operator: "="
-                    - quoted_literal: "'utf8_unicode_ci'"
-                    - keyword: CHECKSUM
-                    - comparison_operator:
-                          raw_comparison_operator: "="
-                    - numeric_literal: "1"
-                    - keyword: DEFAULT
-                    - keyword: COLLATE
-                    - comparison_operator:
-                          raw_comparison_operator: "="
-                    - quoted_literal: "'utf8mb4_unicode_ci'"
-                    - keyword: COMMENT
-                    - comparison_operator:
-                          raw_comparison_operator: "="
-                    - quoted_literal: "'comment'"
-                    - keyword: CONNECTION
-                    - comparison_operator:
-                          raw_comparison_operator: "="
-                    - quoted_literal: "'connection_string'"
-                    - keyword: DELAY_KEY_WRITE
-                    - comparison_operator:
-                          raw_comparison_operator: "="
-                    - numeric_literal: "0"
-                    - keyword: ENCRYPTED
-                    - comparison_operator:
-                          raw_comparison_operator: "="
-                    - keyword: "NO"
-                    - keyword: ENCRYPTION_KEY_ID
-                    - comparison_operator:
-                          raw_comparison_operator: "="
-                    - numeric_literal: "1234"
-                    - keyword: IETF_QUOTES
-                    - comparison_operator:
-                          raw_comparison_operator: "="
-                    - keyword: "YES"
-                    - keyword: INDEX
-                    - keyword: DIRECTORY
-                    - comparison_operator:
-                          raw_comparison_operator: "="
-                    - quoted_literal: "'path/to/dir'"
-                    - keyword: INSERT_METHOD
-                    - comparison_operator:
-                          raw_comparison_operator: "="
-                    - keyword: LAST
-                    - keyword: KEY_BLOCK_SIZE
-                    - comparison_operator:
-                          raw_comparison_operator: "="
-                    - numeric_literal: "1024"
-                    - keyword: MAX_ROWS
-                    - comparison_operator:
-                          raw_comparison_operator: "="
-                    - numeric_literal: "100000"
-                    - keyword: MIN_ROWS
-                    - comparison_operator:
-                          raw_comparison_operator: "="
-                    - numeric_literal: "1"
-                    - keyword: PACK_KEYS
-                    - comparison_operator:
-                          raw_comparison_operator: "="
-                    - numeric_literal: "1"
-                    - keyword: PAGE_CHECKSUM
-                    - comparison_operator:
-                          raw_comparison_operator: "="
-                    - numeric_literal: "1"
-                    - keyword: PAGE_COMPRESSED
-                    - comparison_operator:
-                          raw_comparison_operator: "="
-                    - numeric_literal: "0"
-                    - keyword: PAGE_COMPRESSION_LEVEL
-                    - comparison_operator:
-                          raw_comparison_operator: "="
-                    - numeric_literal: "9"
-                    - keyword: PASSWORD
-                    - comparison_operator:
-                          raw_comparison_operator: "="
-                    - quoted_literal: "'password'"
-                    - keyword: ROW_FORMAT
-                    - comparison_operator:
-                          raw_comparison_operator: "="
-                    - keyword: DYNAMIC
-                    - keyword: SEQUENCE
-                    - comparison_operator:
-                          raw_comparison_operator: "="
-                    - numeric_literal: "1"
-                    - keyword: STATS_AUTO_RECALC
-                    - comparison_operator:
-                          raw_comparison_operator: "="
-                    - numeric_literal: "1"
-                    - keyword: STATS_PERSISTENT
-                    - comparison_operator:
-                          raw_comparison_operator: "="
-                    - numeric_literal: "1"
-                    - keyword: STATS_SAMPLE_PAGES
-                    - comparison_operator:
-                          raw_comparison_operator: "="
-                    - numeric_literal: "4"
-                    - keyword: TABLESPACE
-                    - naked_identifier: tablespace_name
-                    - keyword: TRANSACTIONAL
-                    - comparison_operator:
-                          raw_comparison_operator: "="
-                    - numeric_literal: "1"
-                    - keyword: UNION
-                    - comparison_operator:
-                          raw_comparison_operator: "="
-                    - bracketed:
-                          - start_bracket: (
-                          - table_reference:
-                                quoted_identifier: "`tbl1`"
-                          - comma: ","
-                          - table_reference:
-                                quoted_identifier: "`tbl2`"
-                          - end_bracket: )
-                    - keyword: WITH
-                    - keyword: SYSTEM
-                    - keyword: VERSIONING
-    - statement_terminator: ;
-    - statement:
-          alter_table_statement:
-              - keyword: ALTER
-              - keyword: TABLE
-              - table_reference:
-                    naked_identifier: user
-              - table_options:
-                    - keyword: CHARSET
-                    - keyword: DEFAULT
-    - statement_terminator: ;
-    - statement:
-          alter_table_statement:
-              - keyword: ALTER
-              - keyword: TABLE
-              - table_reference:
-                    naked_identifier: user
-              - table_options:
-                    - keyword: CHARSET
-                    - keyword: DEFAULT
-                    - keyword: COLLATE
-                    - keyword: DEFAULT
-    - statement_terminator: ;
-    - statement:
-          alter_table_statement:
-              - keyword: ALTER
-              - keyword: TABLE
-              - table_reference:
-                    naked_identifier: user
-              - table_options:
-                    - keyword: DEFAULT
-                    - keyword: CHARSET
-                    - keyword: DEFAULT
-                    - keyword: COLLATE
-                    - keyword: DEFAULT
-    - statement_terminator: ;
-    - statement:
-          alter_table_statement:
-              - keyword: ALTER
-              - keyword: TABLE
-              - table_reference:
-                    naked_identifier: user
-              - table_options:
-                    - keyword: DEFAULT
-                    - keyword: CHARSET
-                    - keyword: DEFAULT
-                    - keyword: DEFAULT
-                    - keyword: COLLATE
-                    - keyword: DEFAULT
-    - statement_terminator: ;
-    - statement:
-          alter_table_statement:
-              - keyword: ALTER
-              - keyword: TABLE
-              - table_reference:
-                    naked_identifier: user
-              - table_options:
-                    - keyword: CHARSET
-                    - keyword: DEFAULT
-                    - keyword: COLLATE
-                    - keyword: DEFAULT
-    - statement_terminator: ;
-    - statement:
-          alter_table_statement:
-              - keyword: ALTER
-              - keyword: TABLE
-              - table_reference:
-                    naked_identifier: user
-              - table_options:
-                    - keyword: CHARACTER
-                    - keyword: SET
-                    - keyword: DEFAULT
-    - statement_terminator: ;
-    - statement:
-          alter_table_statement:
-              - keyword: ALTER
-              - keyword: TABLE
-              - table_reference:
-                    naked_identifier: user
-              - table_options:
-                    - keyword: CHARACTER
-                    - keyword: SET
-                    - keyword: DEFAULT
-                    - keyword: COLLATE
-                    - keyword: DEFAULT
-    - statement_terminator: ;
-    - statement:
-          alter_table_statement:
-              - keyword: ALTER
-              - keyword: TABLE
-              - table_reference:
-                    naked_identifier: user
-              - table_options:
-                    - keyword: DEFAULT
-                    - keyword: CHARACTER
-                    - keyword: SET
-                    - keyword: DEFAULT
-                    - keyword: COLLATE
-                    - keyword: DEFAULT
-    - statement_terminator: ;
-    - statement:
-          alter_table_statement:
-              - keyword: ALTER
-              - keyword: TABLE
-              - table_reference:
-                    naked_identifier: user
-              - table_options:
-                    - keyword: DEFAULT
-                    - keyword: CHARACTER
-                    - keyword: SET
-                    - keyword: DEFAULT
-                    - keyword: DEFAULT
-                    - keyword: COLLATE
-                    - keyword: DEFAULT
-    - statement_terminator: ;
-    - statement:
-          alter_table_statement:
-              - keyword: ALTER
-              - keyword: TABLE
-              - table_reference:
-                    naked_identifier: user
-              - table_options:
-                    - keyword: CHARACTER
-                    - keyword: SET
-                    - keyword: DEFAULT
-                    - keyword: COLLATE
-                    - keyword: DEFAULT
-    - statement_terminator: ;
-    - statement:
-          alter_table_statement:
-              - keyword: ALTER
-              - keyword: TABLE
-              - table_reference:
-                    naked_identifier: user
-              - table_options:
-                    keyword: CHARSET
-                    naked_identifier: utf8mb4
-    - statement_terminator: ;
-    - statement:
-          alter_table_statement:
-              - keyword: ALTER
-              - keyword: TABLE
-              - table_reference:
-                    naked_identifier: user
-              - table_options:
-                    - keyword: CHARACTER
-                    - keyword: SET
-                    - naked_identifier: utf8mb4
-    - statement_terminator: ;
-    - statement:
-          alter_table_statement:
-              - keyword: ALTER
-              - keyword: TABLE
-              - table_reference:
-                    naked_identifier: user
-              - table_options:
-                    - keyword: CHARSET
-                    - naked_identifier: utf8mb4
-                    - keyword: COLLATE
-                    - naked_identifier: utf8mb4_unicode_ci
-    - statement_terminator: ;
-    - statement:
-          alter_table_statement:
-              - keyword: ALTER
-              - keyword: TABLE
-              - table_reference:
-                    naked_identifier: user
-              - table_options:
-                    - keyword: DEFAULT
-                    - keyword: CHARACTER
-                    - keyword: SET
-                    - naked_identifier: utf8mb4
-                    - keyword: COLLATE
-                    - naked_identifier: utf8mb4_general_ci
-    - statement_terminator: ;
-    - statement:
-          alter_table_statement:
-              - keyword: ALTER
-              - keyword: TABLE
-              - table_reference:
-                    naked_identifier: user
-              - table_options:
-                    keyword: CHARSET
-                    comparison_operator:
-                        raw_comparison_operator: "="
-                    naked_identifier: utf8mb4
-    - statement_terminator: ;
-    - statement:
-          alter_table_statement:
-              - keyword: ALTER
-              - keyword: TABLE
-              - table_reference:
-                    naked_identifier: user
-              - table_options:
-                    - keyword: CHARACTER
-                    - keyword: SET
-                    - comparison_operator:
-                          raw_comparison_operator: "="
-                    - naked_identifier: utf8mb4
-    - statement_terminator: ;
-    - statement:
-          alter_table_statement:
-              - keyword: ALTER
-              - keyword: TABLE
-              - table_reference:
-                    naked_identifier: user
-              - table_options:
-                    - keyword: DEFAULT
-                    - keyword: CHARSET
-                    - comparison_operator:
-                          raw_comparison_operator: "="
-                    - naked_identifier: utf8mb4
-                    - keyword: COLLATE
-                    - comparison_operator:
-                          raw_comparison_operator: "="
-                    - naked_identifier: utf8mb4_unicode_ci
-    - statement_terminator: ;
-    - statement:
-          alter_table_statement:
-              - keyword: ALTER
-              - keyword: TABLE
-              - table_reference:
-                    naked_identifier: user
-              - table_options:
-                    - keyword: DEFAULT
-                    - keyword: CHARACTER
-                    - keyword: SET
-                    - comparison_operator:
-                          raw_comparison_operator: "="
-                    - naked_identifier: utf8mb4
-    - statement_terminator: ;
-    - statement:
-          alter_table_statement:
-              - keyword: ALTER
-              - keyword: TABLE
-              - table_reference:
-                    naked_identifier: foo
-              - keyword: ADD
-              - keyword: SYSTEM
-              - keyword: VERSIONING
-    - statement_terminator: ;
-    - statement:
-          alter_table_statement:
-              - keyword: ALTER
-              - keyword: TABLE
-              - table_reference:
-                    naked_identifier: foo
-              - keyword: DROP
-              - keyword: SYSTEM
-              - keyword: VERSIONING
-    - statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        quoted_identifier: '`users`'
+    - keyword: MODIFY
+    - keyword: COLUMN
+    - column_definition:
+        quoted_identifier: '`name`'
+        data_type:
+          data_type_identifier: varchar
+          bracketed_arguments:
+            bracketed:
+              start_bracket: (
+              numeric_literal: '255'
+              end_bracket: )
+        column_constraint_segment:
+        - keyword: NOT
+        - keyword: 'NULL'
+    - comma: ','
+    - table_options:
+        keyword: COMMENT
+        quoted_literal: '"name of user"'
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        quoted_identifier: '`users`'
+    - keyword: MODIFY
+    - column_definition:
+        quoted_identifier: '`name`'
+        data_type:
+          data_type_identifier: varchar
+          bracketed_arguments:
+            bracketed:
+              start_bracket: (
+              numeric_literal: '255'
+              end_bracket: )
+        column_constraint_segment:
+        - keyword: NOT
+        - keyword: 'NULL'
+    - keyword: FIRST
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        quoted_identifier: '`users`'
+    - keyword: RENAME
+    - keyword: TO
+    - table_reference:
+        quoted_identifier: '`user`'
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        quoted_identifier: '`user`'
+    - keyword: RENAME
+    - keyword: AS
+    - table_reference:
+        quoted_identifier: '`users`'
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        quoted_identifier: '`users`'
+    - keyword: RENAME
+    - table_reference:
+        quoted_identifier: '`user`'
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        quoted_identifier: '`users`'
+    - keyword: RENAME
+    - keyword: COLUMN
+    - column_reference:
+        quoted_identifier: '`col_1`'
+    - keyword: TO
+    - column_reference:
+        quoted_identifier: '`del_col_1`'
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        quoted_identifier: '`users`'
+    - keyword: CHANGE
+    - keyword: COLUMN
+    - column_reference:
+        quoted_identifier: '`birthday`'
+    - column_definition:
+      - quoted_identifier: '`date_of_birth`'
+      - data_type:
+          data_type_identifier: INT
+          bracketed_arguments:
+            bracketed:
+              start_bracket: (
+              numeric_literal: '11'
+              end_bracket: )
+      - column_constraint_segment:
+          keyword: 'NULL'
+      - column_constraint_segment:
+          keyword: DEFAULT
+          null_literal: 'NULL'
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        quoted_identifier: '`users`'
+    - keyword: CHANGE
+    - keyword: COLUMN
+    - column_reference:
+        quoted_identifier: '`birthday`'
+    - column_definition:
+        quoted_identifier: '`date_of_birth`'
+        data_type:
+          data_type_identifier: INT
+          bracketed_arguments:
+            bracketed:
+              start_bracket: (
+              numeric_literal: '11'
+              end_bracket: )
+        column_constraint_segment:
+        - keyword: NOT
+        - keyword: 'NULL'
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        quoted_identifier: '`users`'
+    - keyword: CHANGE
+    - keyword: COLUMN
+    - column_reference:
+        quoted_identifier: '`birthday`'
+    - column_definition:
+        quoted_identifier: '`date_of_birth`'
+        data_type:
+          data_type_identifier: INT
+          bracketed_arguments:
+            bracketed:
+              start_bracket: (
+              numeric_literal: '11'
+              end_bracket: )
+    - keyword: FIRST
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        quoted_identifier: '`users`'
+    - keyword: CHANGE
+    - keyword: COLUMN
+    - column_reference:
+        quoted_identifier: '`birthday`'
+    - column_definition:
+        quoted_identifier: '`date_of_birth`'
+        data_type:
+          data_type_identifier: INT
+          bracketed_arguments:
+            bracketed:
+              start_bracket: (
+              numeric_literal: '11'
+              end_bracket: )
+    - keyword: AFTER
+    - column_reference:
+        quoted_identifier: '`name`'
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        quoted_identifier: '`users`'
+    - keyword: DROP
+    - keyword: COLUMN
+    - column_reference:
+        quoted_identifier: '`age`'
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+      - quoted_identifier: '`foo`'
+      - dot: .
+      - quoted_identifier: '`bar`'
+    - keyword: ADD
+    - table_constraint:
+      - keyword: CONSTRAINT
+      - object_reference:
+          quoted_identifier: '`index_name`'
+      - keyword: UNIQUE
+      - bracketed:
+        - start_bracket: (
+        - column_reference:
+            quoted_identifier: '`col_1`'
+        - comma: ','
+        - column_reference:
+            quoted_identifier: '`col_2`'
+        - comma: ','
+        - column_reference:
+            quoted_identifier: '`col_3`'
+        - end_bracket: )
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+      - quoted_identifier: '`foo`'
+      - dot: .
+      - quoted_identifier: '`bar`'
+    - keyword: ADD
+    - table_constraint:
+        keyword: UNIQUE
+        index_reference:
+          quoted_identifier: '`index_name`'
+        bracketed:
+        - start_bracket: (
+        - column_reference:
+            quoted_identifier: '`col_1`'
+        - comma: ','
+        - column_reference:
+            quoted_identifier: '`col_2`'
+        - comma: ','
+        - column_reference:
+            quoted_identifier: '`col_3`'
+        - end_bracket: )
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+      - quoted_identifier: '`foo`'
+      - dot: .
+      - quoted_identifier: '`bar`'
+    - keyword: ADD
+    - table_constraint:
+      - keyword: CONSTRAINT
+      - object_reference:
+          quoted_identifier: '`index_name`'
+      - keyword: UNIQUE
+      - keyword: INDEX
+      - bracketed:
+        - start_bracket: (
+        - column_reference:
+            quoted_identifier: '`col_1`'
+        - comma: ','
+        - column_reference:
+            quoted_identifier: '`col_2`'
+        - comma: ','
+        - column_reference:
+            quoted_identifier: '`col_3`'
+        - end_bracket: )
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+      - quoted_identifier: '`foo`'
+      - dot: .
+      - quoted_identifier: '`bar`'
+    - keyword: ADD
+    - table_constraint:
+      - keyword: UNIQUE
+      - keyword: INDEX
+      - index_reference:
+          quoted_identifier: '`index_name`'
+      - bracketed:
+        - start_bracket: (
+        - column_reference:
+            quoted_identifier: '`col_1`'
+        - comma: ','
+        - column_reference:
+            quoted_identifier: '`col_2`'
+        - comma: ','
+        - column_reference:
+            quoted_identifier: '`col_3`'
+        - end_bracket: )
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+      - quoted_identifier: '`foo`'
+      - dot: .
+      - quoted_identifier: '`bar`'
+    - keyword: ADD
+    - table_constraint:
+        keyword: INDEX
+        index_reference:
+          quoted_identifier: '`index_name`'
+        bracketed:
+        - start_bracket: (
+        - column_reference:
+            quoted_identifier: '`col_1`'
+        - comma: ','
+        - column_reference:
+            quoted_identifier: '`col_2`'
+        - comma: ','
+        - column_reference:
+            quoted_identifier: '`col_3`'
+        - end_bracket: )
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+      - quoted_identifier: '`foo`'
+      - dot: .
+      - quoted_identifier: '`bar`'
+    - keyword: ADD
+    - table_constraint:
+        keyword: INDEX
+        index_reference:
+          quoted_identifier: '`index_name`'
+        bracketed:
+        - start_bracket: (
+        - column_reference:
+            quoted_identifier: '`col_1`'
+        - comma: ','
+        - column_reference:
+            quoted_identifier: '`col_2`'
+        - comma: ','
+        - column_reference:
+            quoted_identifier: '`col_3`'
+        - end_bracket: )
+        index_option:
+          keyword: KEY_BLOCK_SIZE
+          comparison_operator:
+            raw_comparison_operator: '='
+          numeric_literal: '8'
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+      - quoted_identifier: '`foo`'
+      - dot: .
+      - quoted_identifier: '`bar`'
+    - keyword: ADD
+    - table_constraint:
+        keyword: INDEX
+        index_reference:
+          quoted_identifier: '`index_name`'
+        bracketed:
+        - start_bracket: (
+        - column_reference:
+            quoted_identifier: '`col_1`'
+        - comma: ','
+        - column_reference:
+            quoted_identifier: '`col_2`'
+        - comma: ','
+        - column_reference:
+            quoted_identifier: '`col_3`'
+        - end_bracket: )
+        index_option:
+          keyword: KEY_BLOCK_SIZE
+          numeric_literal: '8'
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+      - quoted_identifier: '`foo`'
+      - dot: .
+      - quoted_identifier: '`bar`'
+    - keyword: ADD
+    - table_constraint:
+        keyword: INDEX
+        index_reference:
+          quoted_identifier: '`index_name`'
+        bracketed:
+        - start_bracket: (
+        - column_reference:
+            quoted_identifier: '`col_1`'
+        - comma: ','
+        - column_reference:
+            quoted_identifier: '`col_2`'
+        - comma: ','
+        - column_reference:
+            quoted_identifier: '`col_3`'
+        - end_bracket: )
+        index_option:
+          keyword: KEY_BLOCK_SIZE
+          numeric_literal: '8'
+          comment_clause:
+            keyword: COMMENT
+            quoted_literal: "'index for col_1, col_2, col_3'"
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+      - quoted_identifier: '`foo`'
+      - dot: .
+      - quoted_identifier: '`bar`'
+    - keyword: DROP
+    - keyword: INDEX
+    - index_reference:
+        quoted_identifier: '`index_name`'
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+      - quoted_identifier: '`foo`'
+      - dot: .
+      - quoted_identifier: '`bar`'
+    - keyword: RENAME
+    - keyword: INDEX
+    - index_reference:
+        quoted_identifier: '`index_name`'
+    - keyword: to
+    - index_reference:
+        quoted_identifier: '`new_index_name`'
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+      - quoted_identifier: '`foo`'
+      - dot: .
+      - quoted_identifier: '`bar`'
+    - keyword: RENAME
+    - keyword: KEY
+    - index_reference:
+        quoted_identifier: '`key_name`'
+    - keyword: to
+    - index_reference:
+        quoted_identifier: '`new_key_name`'
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        quoted_identifier: '`x`'
+    - keyword: ADD
+    - table_constraint:
+      - keyword: CONSTRAINT
+      - keyword: FOREIGN
+      - keyword: KEY
+      - bracketed:
+          start_bracket: (
+          column_reference:
+            quoted_identifier: '`xk`'
+          end_bracket: )
+      - keyword: REFERENCES
+      - column_reference:
+          quoted_identifier: '`y`'
+      - bracketed:
+          start_bracket: (
+          column_reference:
+            quoted_identifier: '`yk`'
+          end_bracket: )
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        quoted_identifier: '`users`'
+    - keyword: ADD
+    - keyword: COLUMN
+    - column_definition:
+        quoted_identifier: '`active`'
+        data_type:
+          data_type_identifier: tinyint
+          bracketed_arguments:
+            bracketed:
+              start_bracket: (
+              numeric_literal: '1'
+              end_bracket: )
+        column_constraint_segment:
+          keyword: DEFAULT
+          quoted_literal: "'0'"
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        quoted_identifier: '`users`'
+    - keyword: ADD
+    - keyword: COLUMN
+    - keyword: IF
+    - keyword: NOT
+    - keyword: EXISTS
+    - column_definition:
+        quoted_identifier: '`active`'
+        data_type:
+          data_type_identifier: tinyint
+          bracketed_arguments:
+            bracketed:
+              start_bracket: (
+              numeric_literal: '1'
+              end_bracket: )
+        column_constraint_segment:
+          keyword: DEFAULT
+          quoted_literal: "'0'"
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        quoted_identifier: '`foo`'
+    - keyword: ADD
+    - column_definition:
+        quoted_identifier: '`bar`'
+        data_type:
+          data_type_identifier: INT
+    - keyword: FIRST
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        quoted_identifier: '`foo`'
+    - keyword: ADD
+    - keyword: COLUMN
+    - column_definition:
+        naked_identifier: d
+        data_type:
+          data_type_identifier: INT
+        column_constraint_segment:
+        - keyword: GENERATED
+        - keyword: ALWAYS
+        - keyword: AS
+        - bracketed:
+            start_bracket: (
+            expression:
+              column_reference:
+                naked_identifier: a
+              binary_operator: '*'
+              function:
+                function_name:
+                  function_name_identifier: abs
+                function_contents:
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                      column_reference:
+                        naked_identifier: b
+                    end_bracket: )
+            end_bracket: )
+        - keyword: VIRTUAL
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        quoted_identifier: '`foo`'
+    - keyword: ADD
+    - keyword: COLUMN
+    - column_definition:
+        naked_identifier: e
+        data_type:
+          data_type_identifier: TEXT
+        column_constraint_segment:
+        - keyword: GENERATED
+        - keyword: ALWAYS
+        - keyword: AS
+        - bracketed:
+            start_bracket: (
+            expression:
+              function:
+                function_name:
+                  function_name_identifier: substr
+                function_contents:
+                  bracketed:
+                  - start_bracket: (
+                  - expression:
+                      column_reference:
+                        naked_identifier: c
+                  - comma: ','
+                  - expression:
+                      column_reference:
+                        naked_identifier: b
+                  - comma: ','
+                  - expression:
+                      column_reference:
+                        naked_identifier: b
+                      binary_operator: +
+                      numeric_literal: '1'
+                  - end_bracket: )
+            end_bracket: )
+        - keyword: STORED
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        quoted_identifier: '`foo`'
+    - keyword: ADD
+    - keyword: COLUMN
+    - column_definition:
+        naked_identifier: e
+        data_type:
+          data_type_identifier: TEXT
+        column_constraint_segment:
+        - keyword: GENERATED
+        - keyword: ALWAYS
+        - keyword: AS
+        - bracketed:
+            start_bracket: (
+            expression:
+              function:
+                function_name:
+                  function_name_identifier: substr
+                function_contents:
+                  bracketed:
+                  - start_bracket: (
+                  - expression:
+                      column_reference:
+                        naked_identifier: c
+                  - comma: ','
+                  - expression:
+                      column_reference:
+                        naked_identifier: b
+                  - comma: ','
+                  - expression:
+                      column_reference:
+                        naked_identifier: b
+                      binary_operator: +
+                      numeric_literal: '1'
+                  - end_bracket: )
+            end_bracket: )
+        - keyword: PERSISTENT
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        quoted_identifier: '`foo`'
+    - keyword: ADD
+    - keyword: COLUMN
+    - column_definition:
+        naked_identifier: d
+        data_type:
+          data_type_identifier: INT
+        column_constraint_segment:
+          keyword: AS
+          bracketed:
+            start_bracket: (
+            expression:
+              column_reference:
+                naked_identifier: a
+              binary_operator: '*'
+              function:
+                function_name:
+                  function_name_identifier: abs
+                function_contents:
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                      column_reference:
+                        naked_identifier: b
+                    end_bracket: )
+            end_bracket: )
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        quoted_identifier: '`foo`'
+    - keyword: ADD
+    - keyword: COLUMN
+    - column_definition:
+        naked_identifier: e
+        data_type:
+          data_type_identifier: TEXT
+        column_constraint_segment:
+        - keyword: AS
+        - bracketed:
+            start_bracket: (
+            expression:
+              function:
+                function_name:
+                  function_name_identifier: substr
+                function_contents:
+                  bracketed:
+                  - start_bracket: (
+                  - expression:
+                      column_reference:
+                        naked_identifier: c
+                  - comma: ','
+                  - expression:
+                      column_reference:
+                        naked_identifier: b
+                  - comma: ','
+                  - expression:
+                      column_reference:
+                        naked_identifier: b
+                      binary_operator: +
+                      numeric_literal: '1'
+                  - end_bracket: )
+            end_bracket: )
+        - keyword: STORED
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        quoted_identifier: '`foo`'
+    - keyword: ADD
+    - keyword: COLUMN
+    - column_definition:
+        naked_identifier: e
+        data_type:
+          data_type_identifier: TEXT
+        column_constraint_segment:
+        - keyword: AS
+        - bracketed:
+            start_bracket: (
+            expression:
+              function:
+                function_name:
+                  function_name_identifier: substr
+                function_contents:
+                  bracketed:
+                  - start_bracket: (
+                  - expression:
+                      column_reference:
+                        naked_identifier: c
+                  - comma: ','
+                  - expression:
+                      column_reference:
+                        naked_identifier: b
+                  - comma: ','
+                  - expression:
+                      column_reference:
+                        naked_identifier: b
+                      binary_operator: +
+                      numeric_literal: '1'
+                  - end_bracket: )
+            end_bracket: )
+        - keyword: PERSISTENT
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        quoted_identifier: '`foo`'
+    - keyword: CONVERT
+    - keyword: TO
+    - alter_option_segment:
+      - keyword: CHARACTER
+      - keyword: SET
+      - naked_identifier: utf8mb4
+    - alter_option_segment:
+        keyword: COLLATE
+        collation_reference:
+          naked_identifier: utf8mb4_unicode_ci
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        quoted_identifier: '`foo`'
+    - keyword: CONVERT
+    - keyword: TO
+    - alter_option_segment:
+      - keyword: CHARACTER
+      - keyword: SET
+      - quoted_identifier: '`utf8mb4`'
+    - alter_option_segment:
+        keyword: COLLATE
+        collation_reference:
+          quoted_identifier: '`utf8mb4_unicode_ci`'
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        quoted_identifier: '`foo`'
+    - keyword: CONVERT
+    - keyword: TO
+    - alter_option_segment:
+      - keyword: CHARACTER
+      - keyword: SET
+      - quoted_identifier: "'utf8mb4'"
+    - alter_option_segment:
+        keyword: COLLATE
+        collation_reference:
+          quoted_literal: "'utf8mb4_unicode_ci'"
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        quoted_identifier: '`foo`'
+    - keyword: CONVERT
+    - keyword: TO
+    - alter_option_segment:
+      - keyword: CHARACTER
+      - keyword: SET
+      - quoted_identifier: '"utf8mb4"'
+    - alter_option_segment:
+        keyword: COLLATE
+        collation_reference:
+          quoted_literal: '"utf8mb4_unicode_ci"'
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: t
+    - keyword: MODIFY
+    - column_definition:
+      - naked_identifier: time_updated
+      - keyword: timestamp
+      - keyword: NOT
+      - keyword: 'NULL'
+      - keyword: DEFAULT
+      - function:
+          function_name:
+            keyword: current_timestamp
+          function_contents:
+            bracketed:
+              start_bracket: (
+              end_bracket: )
+      - keyword: 'ON'
+      - keyword: UPDATE
+      - function:
+          function_name:
+            keyword: current_timestamp
+          function_contents:
+            bracketed:
+              start_bracket: (
+              end_bracket: )
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: t
+    - keyword: MODIFY
+    - column_definition:
+      - naked_identifier: time_updated
+      - keyword: timestamp
+      - keyword: NOT
+      - keyword: 'NULL'
+      - keyword: DEFAULT
+      - bare_function: localtime
+      - keyword: 'ON'
+      - keyword: UPDATE
+      - function:
+          function_name:
+            keyword: localtime
+          function_contents:
+            bracketed:
+              start_bracket: (
+              end_bracket: )
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: t
+    - keyword: MODIFY
+    - column_definition:
+      - naked_identifier: time_updated
+      - keyword: timestamp
+      - keyword: NOT
+      - keyword: 'NULL'
+      - keyword: DEFAULT
+      - bare_function: localtimestamp
+      - keyword: 'ON'
+      - keyword: UPDATE
+      - function:
+          function_name:
+            keyword: localtimestamp
+          function_contents:
+            bracketed:
+              start_bracket: (
+              end_bracket: )
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        quoted_identifier: '`foo`'
+    - table_options:
+      - keyword: ENGINE
+      - comparison_operator:
+          raw_comparison_operator: '='
+      - quoted_literal: "'InnoDB'"
+      - keyword: AUTO_INCREMENT
+      - comparison_operator:
+          raw_comparison_operator: '='
+      - numeric_literal: '1'
+      - keyword: AVG_ROW_LENGTH
+      - comparison_operator:
+          raw_comparison_operator: '='
+      - numeric_literal: '10'
+      - keyword: DEFAULT
+      - keyword: CHARACTER
+      - keyword: SET
+      - comparison_operator:
+          raw_comparison_operator: '='
+      - quoted_literal: "'utf8_unicode_ci'"
+      - keyword: CHECKSUM
+      - comparison_operator:
+          raw_comparison_operator: '='
+      - numeric_literal: '1'
+      - keyword: DEFAULT
+      - keyword: COLLATE
+      - comparison_operator:
+          raw_comparison_operator: '='
+      - quoted_literal: "'utf8mb4_unicode_ci'"
+      - keyword: COMMENT
+      - comparison_operator:
+          raw_comparison_operator: '='
+      - quoted_literal: "'comment'"
+      - keyword: CONNECTION
+      - comparison_operator:
+          raw_comparison_operator: '='
+      - quoted_literal: "'connection_string'"
+      - keyword: DELAY_KEY_WRITE
+      - comparison_operator:
+          raw_comparison_operator: '='
+      - numeric_literal: '0'
+      - keyword: ENCRYPTED
+      - comparison_operator:
+          raw_comparison_operator: '='
+      - keyword: 'NO'
+      - keyword: ENCRYPTION_KEY_ID
+      - comparison_operator:
+          raw_comparison_operator: '='
+      - numeric_literal: '1234'
+      - keyword: IETF_QUOTES
+      - comparison_operator:
+          raw_comparison_operator: '='
+      - keyword: 'YES'
+      - keyword: INDEX
+      - keyword: DIRECTORY
+      - comparison_operator:
+          raw_comparison_operator: '='
+      - quoted_literal: "'path/to/dir'"
+      - keyword: INSERT_METHOD
+      - comparison_operator:
+          raw_comparison_operator: '='
+      - keyword: LAST
+      - keyword: KEY_BLOCK_SIZE
+      - comparison_operator:
+          raw_comparison_operator: '='
+      - numeric_literal: '1024'
+      - keyword: MAX_ROWS
+      - comparison_operator:
+          raw_comparison_operator: '='
+      - numeric_literal: '100000'
+      - keyword: MIN_ROWS
+      - comparison_operator:
+          raw_comparison_operator: '='
+      - numeric_literal: '1'
+      - keyword: PACK_KEYS
+      - comparison_operator:
+          raw_comparison_operator: '='
+      - numeric_literal: '1'
+      - keyword: PAGE_CHECKSUM
+      - comparison_operator:
+          raw_comparison_operator: '='
+      - numeric_literal: '1'
+      - keyword: PAGE_COMPRESSED
+      - comparison_operator:
+          raw_comparison_operator: '='
+      - numeric_literal: '0'
+      - keyword: PAGE_COMPRESSION_LEVEL
+      - comparison_operator:
+          raw_comparison_operator: '='
+      - numeric_literal: '9'
+      - keyword: PASSWORD
+      - comparison_operator:
+          raw_comparison_operator: '='
+      - quoted_literal: "'password'"
+      - keyword: ROW_FORMAT
+      - comparison_operator:
+          raw_comparison_operator: '='
+      - keyword: DYNAMIC
+      - keyword: SEQUENCE
+      - comparison_operator:
+          raw_comparison_operator: '='
+      - numeric_literal: '1'
+      - keyword: STATS_AUTO_RECALC
+      - comparison_operator:
+          raw_comparison_operator: '='
+      - numeric_literal: '1'
+      - keyword: STATS_PERSISTENT
+      - comparison_operator:
+          raw_comparison_operator: '='
+      - numeric_literal: '1'
+      - keyword: STATS_SAMPLE_PAGES
+      - comparison_operator:
+          raw_comparison_operator: '='
+      - numeric_literal: '4'
+      - keyword: TABLESPACE
+      - naked_identifier: tablespace_name
+      - keyword: TRANSACTIONAL
+      - comparison_operator:
+          raw_comparison_operator: '='
+      - numeric_literal: '1'
+      - keyword: UNION
+      - comparison_operator:
+          raw_comparison_operator: '='
+      - bracketed:
+        - start_bracket: (
+        - table_reference:
+            quoted_identifier: '`tbl1`'
+        - comma: ','
+        - table_reference:
+            quoted_identifier: '`tbl2`'
+        - end_bracket: )
+      - keyword: WITH
+      - keyword: SYSTEM
+      - keyword: VERSIONING
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: user
+    - table_options:
+      - keyword: CHARSET
+      - keyword: DEFAULT
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: user
+    - table_options:
+      - keyword: CHARSET
+      - keyword: DEFAULT
+      - keyword: COLLATE
+      - keyword: DEFAULT
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: user
+    - table_options:
+      - keyword: DEFAULT
+      - keyword: CHARSET
+      - keyword: DEFAULT
+      - keyword: COLLATE
+      - keyword: DEFAULT
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: user
+    - table_options:
+      - keyword: DEFAULT
+      - keyword: CHARSET
+      - keyword: DEFAULT
+      - keyword: DEFAULT
+      - keyword: COLLATE
+      - keyword: DEFAULT
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: user
+    - table_options:
+      - keyword: CHARSET
+      - keyword: DEFAULT
+      - keyword: COLLATE
+      - keyword: DEFAULT
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: user
+    - table_options:
+      - keyword: CHARACTER
+      - keyword: SET
+      - keyword: DEFAULT
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: user
+    - table_options:
+      - keyword: CHARACTER
+      - keyword: SET
+      - keyword: DEFAULT
+      - keyword: COLLATE
+      - keyword: DEFAULT
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: user
+    - table_options:
+      - keyword: DEFAULT
+      - keyword: CHARACTER
+      - keyword: SET
+      - keyword: DEFAULT
+      - keyword: COLLATE
+      - keyword: DEFAULT
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: user
+    - table_options:
+      - keyword: DEFAULT
+      - keyword: CHARACTER
+      - keyword: SET
+      - keyword: DEFAULT
+      - keyword: DEFAULT
+      - keyword: COLLATE
+      - keyword: DEFAULT
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: user
+    - table_options:
+      - keyword: CHARACTER
+      - keyword: SET
+      - keyword: DEFAULT
+      - keyword: COLLATE
+      - keyword: DEFAULT
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: user
+    - table_options:
+        keyword: CHARSET
+        naked_identifier: utf8mb4
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: user
+    - table_options:
+      - keyword: CHARACTER
+      - keyword: SET
+      - naked_identifier: utf8mb4
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: user
+    - table_options:
+      - keyword: CHARSET
+      - naked_identifier: utf8mb4
+      - keyword: COLLATE
+      - naked_identifier: utf8mb4_unicode_ci
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: user
+    - table_options:
+      - keyword: DEFAULT
+      - keyword: CHARACTER
+      - keyword: SET
+      - naked_identifier: utf8mb4
+      - keyword: COLLATE
+      - naked_identifier: utf8mb4_general_ci
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: user
+    - table_options:
+        keyword: CHARSET
+        comparison_operator:
+          raw_comparison_operator: '='
+        naked_identifier: utf8mb4
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: user
+    - table_options:
+      - keyword: CHARACTER
+      - keyword: SET
+      - comparison_operator:
+          raw_comparison_operator: '='
+      - naked_identifier: utf8mb4
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: user
+    - table_options:
+      - keyword: DEFAULT
+      - keyword: CHARSET
+      - comparison_operator:
+          raw_comparison_operator: '='
+      - naked_identifier: utf8mb4
+      - keyword: COLLATE
+      - comparison_operator:
+          raw_comparison_operator: '='
+      - naked_identifier: utf8mb4_unicode_ci
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: user
+    - table_options:
+      - keyword: DEFAULT
+      - keyword: CHARACTER
+      - keyword: SET
+      - comparison_operator:
+          raw_comparison_operator: '='
+      - naked_identifier: utf8mb4
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: foo
+    - keyword: ADD
+    - keyword: SYSTEM
+    - keyword: VERSIONING
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: foo
+    - keyword: DROP
+    - keyword: SYSTEM
+    - keyword: VERSIONING
+- statement_terminator: ;

--- a/test/fixtures/dialects/mariadb/alter_table.yml
+++ b/test/fixtures/dialects/mariadb/alter_table.yml
@@ -3,1235 +3,1307 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: e99d4983802a42751de1ec91051f3b2ea3e93165d2ea79328eb57c0190a896dc
+_hash: 5e573d68c2432a18ba47c3100a4bbd32fedce7003e52c813edde83c949ed2ae2
 file:
-- statement:
-    alter_table_statement:
-    - keyword: ALTER
-    - keyword: TABLE
-    - table_reference:
-        quoted_identifier: '`users`'
-    - keyword: MODIFY
-    - keyword: COLUMN
-    - column_definition:
-        quoted_identifier: '`name`'
-        data_type:
-          data_type_identifier: varchar
-          bracketed_arguments:
-            bracketed:
-              start_bracket: (
-              numeric_literal: '255'
-              end_bracket: )
-        column_constraint_segment:
-        - keyword: NOT
-        - keyword: 'NULL'
-    - comma: ','
-    - table_options:
-        keyword: COMMENT
-        quoted_literal: '"name of user"'
-- statement_terminator: ;
-- statement:
-    alter_table_statement:
-    - keyword: ALTER
-    - keyword: TABLE
-    - table_reference:
-        quoted_identifier: '`users`'
-    - keyword: MODIFY
-    - column_definition:
-        quoted_identifier: '`name`'
-        data_type:
-          data_type_identifier: varchar
-          bracketed_arguments:
-            bracketed:
-              start_bracket: (
-              numeric_literal: '255'
-              end_bracket: )
-        column_constraint_segment:
-        - keyword: NOT
-        - keyword: 'NULL'
-    - keyword: FIRST
-- statement_terminator: ;
-- statement:
-    alter_table_statement:
-    - keyword: ALTER
-    - keyword: TABLE
-    - table_reference:
-        quoted_identifier: '`users`'
-    - keyword: RENAME
-    - keyword: TO
-    - table_reference:
-        quoted_identifier: '`user`'
-- statement_terminator: ;
-- statement:
-    alter_table_statement:
-    - keyword: ALTER
-    - keyword: TABLE
-    - table_reference:
-        quoted_identifier: '`user`'
-    - keyword: RENAME
-    - keyword: AS
-    - table_reference:
-        quoted_identifier: '`users`'
-- statement_terminator: ;
-- statement:
-    alter_table_statement:
-    - keyword: ALTER
-    - keyword: TABLE
-    - table_reference:
-        quoted_identifier: '`users`'
-    - keyword: RENAME
-    - table_reference:
-        quoted_identifier: '`user`'
-- statement_terminator: ;
-- statement:
-    alter_table_statement:
-    - keyword: ALTER
-    - keyword: TABLE
-    - table_reference:
-        quoted_identifier: '`users`'
-    - keyword: RENAME
-    - keyword: COLUMN
-    - column_reference:
-        quoted_identifier: '`col_1`'
-    - keyword: TO
-    - column_reference:
-        quoted_identifier: '`del_col_1`'
-- statement_terminator: ;
-- statement:
-    alter_table_statement:
-    - keyword: ALTER
-    - keyword: TABLE
-    - table_reference:
-        quoted_identifier: '`users`'
-    - keyword: CHANGE
-    - keyword: COLUMN
-    - column_reference:
-        quoted_identifier: '`birthday`'
-    - column_definition:
-      - quoted_identifier: '`date_of_birth`'
-      - data_type:
-          data_type_identifier: INT
-          bracketed_arguments:
-            bracketed:
-              start_bracket: (
-              numeric_literal: '11'
-              end_bracket: )
-      - column_constraint_segment:
-          keyword: 'NULL'
-      - column_constraint_segment:
-          keyword: DEFAULT
-          null_literal: 'NULL'
-- statement_terminator: ;
-- statement:
-    alter_table_statement:
-    - keyword: ALTER
-    - keyword: TABLE
-    - table_reference:
-        quoted_identifier: '`users`'
-    - keyword: CHANGE
-    - keyword: COLUMN
-    - column_reference:
-        quoted_identifier: '`birthday`'
-    - column_definition:
-        quoted_identifier: '`date_of_birth`'
-        data_type:
-          data_type_identifier: INT
-          bracketed_arguments:
-            bracketed:
-              start_bracket: (
-              numeric_literal: '11'
-              end_bracket: )
-        column_constraint_segment:
-        - keyword: NOT
-        - keyword: 'NULL'
-- statement_terminator: ;
-- statement:
-    alter_table_statement:
-    - keyword: ALTER
-    - keyword: TABLE
-    - table_reference:
-        quoted_identifier: '`users`'
-    - keyword: CHANGE
-    - keyword: COLUMN
-    - column_reference:
-        quoted_identifier: '`birthday`'
-    - column_definition:
-        quoted_identifier: '`date_of_birth`'
-        data_type:
-          data_type_identifier: INT
-          bracketed_arguments:
-            bracketed:
-              start_bracket: (
-              numeric_literal: '11'
-              end_bracket: )
-    - keyword: FIRST
-- statement_terminator: ;
-- statement:
-    alter_table_statement:
-    - keyword: ALTER
-    - keyword: TABLE
-    - table_reference:
-        quoted_identifier: '`users`'
-    - keyword: CHANGE
-    - keyword: COLUMN
-    - column_reference:
-        quoted_identifier: '`birthday`'
-    - column_definition:
-        quoted_identifier: '`date_of_birth`'
-        data_type:
-          data_type_identifier: INT
-          bracketed_arguments:
-            bracketed:
-              start_bracket: (
-              numeric_literal: '11'
-              end_bracket: )
-    - keyword: AFTER
-    - column_reference:
-        quoted_identifier: '`name`'
-- statement_terminator: ;
-- statement:
-    alter_table_statement:
-    - keyword: ALTER
-    - keyword: TABLE
-    - table_reference:
-        quoted_identifier: '`users`'
-    - keyword: DROP
-    - keyword: COLUMN
-    - column_reference:
-        quoted_identifier: '`age`'
-- statement_terminator: ;
-- statement:
-    alter_table_statement:
-    - keyword: ALTER
-    - keyword: TABLE
-    - table_reference:
-      - quoted_identifier: '`foo`'
-      - dot: .
-      - quoted_identifier: '`bar`'
-    - keyword: ADD
-    - table_constraint:
-      - keyword: CONSTRAINT
-      - object_reference:
-          quoted_identifier: '`index_name`'
-      - keyword: UNIQUE
-      - bracketed:
-        - start_bracket: (
-        - column_reference:
-            quoted_identifier: '`col_1`'
-        - comma: ','
-        - column_reference:
-            quoted_identifier: '`col_2`'
-        - comma: ','
-        - column_reference:
-            quoted_identifier: '`col_3`'
-        - end_bracket: )
-- statement_terminator: ;
-- statement:
-    alter_table_statement:
-    - keyword: ALTER
-    - keyword: TABLE
-    - table_reference:
-      - quoted_identifier: '`foo`'
-      - dot: .
-      - quoted_identifier: '`bar`'
-    - keyword: ADD
-    - table_constraint:
-        keyword: UNIQUE
-        index_reference:
-          quoted_identifier: '`index_name`'
-        bracketed:
-        - start_bracket: (
-        - column_reference:
-            quoted_identifier: '`col_1`'
-        - comma: ','
-        - column_reference:
-            quoted_identifier: '`col_2`'
-        - comma: ','
-        - column_reference:
-            quoted_identifier: '`col_3`'
-        - end_bracket: )
-- statement_terminator: ;
-- statement:
-    alter_table_statement:
-    - keyword: ALTER
-    - keyword: TABLE
-    - table_reference:
-      - quoted_identifier: '`foo`'
-      - dot: .
-      - quoted_identifier: '`bar`'
-    - keyword: ADD
-    - table_constraint:
-      - keyword: CONSTRAINT
-      - object_reference:
-          quoted_identifier: '`index_name`'
-      - keyword: UNIQUE
-      - keyword: INDEX
-      - bracketed:
-        - start_bracket: (
-        - column_reference:
-            quoted_identifier: '`col_1`'
-        - comma: ','
-        - column_reference:
-            quoted_identifier: '`col_2`'
-        - comma: ','
-        - column_reference:
-            quoted_identifier: '`col_3`'
-        - end_bracket: )
-- statement_terminator: ;
-- statement:
-    alter_table_statement:
-    - keyword: ALTER
-    - keyword: TABLE
-    - table_reference:
-      - quoted_identifier: '`foo`'
-      - dot: .
-      - quoted_identifier: '`bar`'
-    - keyword: ADD
-    - table_constraint:
-      - keyword: UNIQUE
-      - keyword: INDEX
-      - index_reference:
-          quoted_identifier: '`index_name`'
-      - bracketed:
-        - start_bracket: (
-        - column_reference:
-            quoted_identifier: '`col_1`'
-        - comma: ','
-        - column_reference:
-            quoted_identifier: '`col_2`'
-        - comma: ','
-        - column_reference:
-            quoted_identifier: '`col_3`'
-        - end_bracket: )
-- statement_terminator: ;
-- statement:
-    alter_table_statement:
-    - keyword: ALTER
-    - keyword: TABLE
-    - table_reference:
-      - quoted_identifier: '`foo`'
-      - dot: .
-      - quoted_identifier: '`bar`'
-    - keyword: ADD
-    - table_constraint:
-        keyword: INDEX
-        index_reference:
-          quoted_identifier: '`index_name`'
-        bracketed:
-        - start_bracket: (
-        - column_reference:
-            quoted_identifier: '`col_1`'
-        - comma: ','
-        - column_reference:
-            quoted_identifier: '`col_2`'
-        - comma: ','
-        - column_reference:
-            quoted_identifier: '`col_3`'
-        - end_bracket: )
-- statement_terminator: ;
-- statement:
-    alter_table_statement:
-    - keyword: ALTER
-    - keyword: TABLE
-    - table_reference:
-      - quoted_identifier: '`foo`'
-      - dot: .
-      - quoted_identifier: '`bar`'
-    - keyword: ADD
-    - table_constraint:
-        keyword: INDEX
-        index_reference:
-          quoted_identifier: '`index_name`'
-        bracketed:
-        - start_bracket: (
-        - column_reference:
-            quoted_identifier: '`col_1`'
-        - comma: ','
-        - column_reference:
-            quoted_identifier: '`col_2`'
-        - comma: ','
-        - column_reference:
-            quoted_identifier: '`col_3`'
-        - end_bracket: )
-        index_option:
-          keyword: KEY_BLOCK_SIZE
-          comparison_operator:
-            raw_comparison_operator: '='
-          numeric_literal: '8'
-- statement_terminator: ;
-- statement:
-    alter_table_statement:
-    - keyword: ALTER
-    - keyword: TABLE
-    - table_reference:
-      - quoted_identifier: '`foo`'
-      - dot: .
-      - quoted_identifier: '`bar`'
-    - keyword: ADD
-    - table_constraint:
-        keyword: INDEX
-        index_reference:
-          quoted_identifier: '`index_name`'
-        bracketed:
-        - start_bracket: (
-        - column_reference:
-            quoted_identifier: '`col_1`'
-        - comma: ','
-        - column_reference:
-            quoted_identifier: '`col_2`'
-        - comma: ','
-        - column_reference:
-            quoted_identifier: '`col_3`'
-        - end_bracket: )
-        index_option:
-          keyword: KEY_BLOCK_SIZE
-          numeric_literal: '8'
-- statement_terminator: ;
-- statement:
-    alter_table_statement:
-    - keyword: ALTER
-    - keyword: TABLE
-    - table_reference:
-      - quoted_identifier: '`foo`'
-      - dot: .
-      - quoted_identifier: '`bar`'
-    - keyword: ADD
-    - table_constraint:
-        keyword: INDEX
-        index_reference:
-          quoted_identifier: '`index_name`'
-        bracketed:
-        - start_bracket: (
-        - column_reference:
-            quoted_identifier: '`col_1`'
-        - comma: ','
-        - column_reference:
-            quoted_identifier: '`col_2`'
-        - comma: ','
-        - column_reference:
-            quoted_identifier: '`col_3`'
-        - end_bracket: )
-        index_option:
-          keyword: KEY_BLOCK_SIZE
-          numeric_literal: '8'
-          comment_clause:
-            keyword: COMMENT
-            quoted_literal: "'index for col_1, col_2, col_3'"
-- statement_terminator: ;
-- statement:
-    alter_table_statement:
-    - keyword: ALTER
-    - keyword: TABLE
-    - table_reference:
-      - quoted_identifier: '`foo`'
-      - dot: .
-      - quoted_identifier: '`bar`'
-    - keyword: DROP
-    - keyword: INDEX
-    - index_reference:
-        quoted_identifier: '`index_name`'
-- statement_terminator: ;
-- statement:
-    alter_table_statement:
-    - keyword: ALTER
-    - keyword: TABLE
-    - table_reference:
-      - quoted_identifier: '`foo`'
-      - dot: .
-      - quoted_identifier: '`bar`'
-    - keyword: RENAME
-    - keyword: INDEX
-    - index_reference:
-        quoted_identifier: '`index_name`'
-    - keyword: to
-    - index_reference:
-        quoted_identifier: '`new_index_name`'
-- statement_terminator: ;
-- statement:
-    alter_table_statement:
-    - keyword: ALTER
-    - keyword: TABLE
-    - table_reference:
-      - quoted_identifier: '`foo`'
-      - dot: .
-      - quoted_identifier: '`bar`'
-    - keyword: RENAME
-    - keyword: KEY
-    - index_reference:
-        quoted_identifier: '`key_name`'
-    - keyword: to
-    - index_reference:
-        quoted_identifier: '`new_key_name`'
-- statement_terminator: ;
-- statement:
-    alter_table_statement:
-    - keyword: ALTER
-    - keyword: TABLE
-    - table_reference:
-        quoted_identifier: '`x`'
-    - keyword: ADD
-    - table_constraint:
-      - keyword: CONSTRAINT
-      - keyword: FOREIGN
-      - keyword: KEY
-      - bracketed:
-          start_bracket: (
-          column_reference:
-            quoted_identifier: '`xk`'
-          end_bracket: )
-      - keyword: REFERENCES
-      - column_reference:
-          quoted_identifier: '`y`'
-      - bracketed:
-          start_bracket: (
-          column_reference:
-            quoted_identifier: '`yk`'
-          end_bracket: )
-- statement_terminator: ;
-- statement:
-    alter_table_statement:
-    - keyword: ALTER
-    - keyword: TABLE
-    - table_reference:
-        quoted_identifier: '`users`'
-    - keyword: ADD
-    - keyword: COLUMN
-    - column_definition:
-        quoted_identifier: '`active`'
-        data_type:
-          data_type_identifier: tinyint
-          bracketed_arguments:
-            bracketed:
-              start_bracket: (
-              numeric_literal: '1'
-              end_bracket: )
-        column_constraint_segment:
-          keyword: DEFAULT
-          quoted_literal: "'0'"
-- statement_terminator: ;
-- statement:
-    alter_table_statement:
-    - keyword: ALTER
-    - keyword: TABLE
-    - table_reference:
-        quoted_identifier: '`users`'
-    - keyword: ADD
-    - keyword: COLUMN
-    - keyword: IF
-    - keyword: NOT
-    - keyword: EXISTS
-    - column_definition:
-        quoted_identifier: '`active`'
-        data_type:
-          data_type_identifier: tinyint
-          bracketed_arguments:
-            bracketed:
-              start_bracket: (
-              numeric_literal: '1'
-              end_bracket: )
-        column_constraint_segment:
-          keyword: DEFAULT
-          quoted_literal: "'0'"
-- statement_terminator: ;
-- statement:
-    alter_table_statement:
-    - keyword: ALTER
-    - keyword: TABLE
-    - table_reference:
-        quoted_identifier: '`foo`'
-    - keyword: ADD
-    - column_definition:
-        quoted_identifier: '`bar`'
-        data_type:
-          data_type_identifier: INT
-    - keyword: FIRST
-- statement_terminator: ;
-- statement:
-    alter_table_statement:
-    - keyword: ALTER
-    - keyword: TABLE
-    - table_reference:
-        quoted_identifier: '`foo`'
-    - keyword: ADD
-    - keyword: COLUMN
-    - column_definition:
-        naked_identifier: d
-        data_type:
-          data_type_identifier: INT
-        column_constraint_segment:
-        - keyword: GENERATED
-        - keyword: ALWAYS
-        - keyword: AS
-        - bracketed:
-            start_bracket: (
-            expression:
-              column_reference:
-                naked_identifier: a
-              binary_operator: '*'
-              function:
-                function_name:
-                  function_name_identifier: abs
-                function_contents:
-                  bracketed:
-                    start_bracket: (
-                    expression:
-                      column_reference:
-                        naked_identifier: b
-                    end_bracket: )
-            end_bracket: )
-        - keyword: VIRTUAL
-- statement_terminator: ;
-- statement:
-    alter_table_statement:
-    - keyword: ALTER
-    - keyword: TABLE
-    - table_reference:
-        quoted_identifier: '`foo`'
-    - keyword: ADD
-    - keyword: COLUMN
-    - column_definition:
-        naked_identifier: e
-        data_type:
-          data_type_identifier: TEXT
-        column_constraint_segment:
-        - keyword: GENERATED
-        - keyword: ALWAYS
-        - keyword: AS
-        - bracketed:
-            start_bracket: (
-            expression:
-              function:
-                function_name:
-                  function_name_identifier: substr
-                function_contents:
-                  bracketed:
-                  - start_bracket: (
-                  - expression:
-                      column_reference:
-                        naked_identifier: c
-                  - comma: ','
-                  - expression:
-                      column_reference:
-                        naked_identifier: b
-                  - comma: ','
-                  - expression:
-                      column_reference:
-                        naked_identifier: b
-                      binary_operator: +
-                      numeric_literal: '1'
-                  - end_bracket: )
-            end_bracket: )
-        - keyword: STORED
-- statement_terminator: ;
-- statement:
-    alter_table_statement:
-    - keyword: ALTER
-    - keyword: TABLE
-    - table_reference:
-        quoted_identifier: '`foo`'
-    - keyword: ADD
-    - keyword: COLUMN
-    - column_definition:
-        naked_identifier: e
-        data_type:
-          data_type_identifier: TEXT
-        column_constraint_segment:
-        - keyword: GENERATED
-        - keyword: ALWAYS
-        - keyword: AS
-        - bracketed:
-            start_bracket: (
-            expression:
-              function:
-                function_name:
-                  function_name_identifier: substr
-                function_contents:
-                  bracketed:
-                  - start_bracket: (
-                  - expression:
-                      column_reference:
-                        naked_identifier: c
-                  - comma: ','
-                  - expression:
-                      column_reference:
-                        naked_identifier: b
-                  - comma: ','
-                  - expression:
-                      column_reference:
-                        naked_identifier: b
-                      binary_operator: +
-                      numeric_literal: '1'
-                  - end_bracket: )
-            end_bracket: )
-        - keyword: PERSISTENT
-- statement_terminator: ;
-- statement:
-    alter_table_statement:
-    - keyword: ALTER
-    - keyword: TABLE
-    - table_reference:
-        quoted_identifier: '`foo`'
-    - keyword: ADD
-    - keyword: COLUMN
-    - column_definition:
-        naked_identifier: d
-        data_type:
-          data_type_identifier: INT
-        column_constraint_segment:
-          keyword: AS
-          bracketed:
-            start_bracket: (
-            expression:
-              column_reference:
-                naked_identifier: a
-              binary_operator: '*'
-              function:
-                function_name:
-                  function_name_identifier: abs
-                function_contents:
-                  bracketed:
-                    start_bracket: (
-                    expression:
-                      column_reference:
-                        naked_identifier: b
-                    end_bracket: )
-            end_bracket: )
-- statement_terminator: ;
-- statement:
-    alter_table_statement:
-    - keyword: ALTER
-    - keyword: TABLE
-    - table_reference:
-        quoted_identifier: '`foo`'
-    - keyword: ADD
-    - keyword: COLUMN
-    - column_definition:
-        naked_identifier: e
-        data_type:
-          data_type_identifier: TEXT
-        column_constraint_segment:
-        - keyword: AS
-        - bracketed:
-            start_bracket: (
-            expression:
-              function:
-                function_name:
-                  function_name_identifier: substr
-                function_contents:
-                  bracketed:
-                  - start_bracket: (
-                  - expression:
-                      column_reference:
-                        naked_identifier: c
-                  - comma: ','
-                  - expression:
-                      column_reference:
-                        naked_identifier: b
-                  - comma: ','
-                  - expression:
-                      column_reference:
-                        naked_identifier: b
-                      binary_operator: +
-                      numeric_literal: '1'
-                  - end_bracket: )
-            end_bracket: )
-        - keyword: STORED
-- statement_terminator: ;
-- statement:
-    alter_table_statement:
-    - keyword: ALTER
-    - keyword: TABLE
-    - table_reference:
-        quoted_identifier: '`foo`'
-    - keyword: ADD
-    - keyword: COLUMN
-    - column_definition:
-        naked_identifier: e
-        data_type:
-          data_type_identifier: TEXT
-        column_constraint_segment:
-        - keyword: AS
-        - bracketed:
-            start_bracket: (
-            expression:
-              function:
-                function_name:
-                  function_name_identifier: substr
-                function_contents:
-                  bracketed:
-                  - start_bracket: (
-                  - expression:
-                      column_reference:
-                        naked_identifier: c
-                  - comma: ','
-                  - expression:
-                      column_reference:
-                        naked_identifier: b
-                  - comma: ','
-                  - expression:
-                      column_reference:
-                        naked_identifier: b
-                      binary_operator: +
-                      numeric_literal: '1'
-                  - end_bracket: )
-            end_bracket: )
-        - keyword: PERSISTENT
-- statement_terminator: ;
-- statement:
-    alter_table_statement:
-    - keyword: ALTER
-    - keyword: TABLE
-    - table_reference:
-        quoted_identifier: '`foo`'
-    - keyword: CONVERT
-    - keyword: TO
-    - alter_option_segment:
-      - keyword: CHARACTER
-      - keyword: SET
-      - naked_identifier: utf8mb4
-    - alter_option_segment:
-        keyword: COLLATE
-        collation_reference:
-          naked_identifier: utf8mb4_unicode_ci
-- statement_terminator: ;
-- statement:
-    alter_table_statement:
-    - keyword: ALTER
-    - keyword: TABLE
-    - table_reference:
-        quoted_identifier: '`foo`'
-    - keyword: CONVERT
-    - keyword: TO
-    - alter_option_segment:
-      - keyword: CHARACTER
-      - keyword: SET
-      - quoted_identifier: '`utf8mb4`'
-    - alter_option_segment:
-        keyword: COLLATE
-        collation_reference:
-          quoted_identifier: '`utf8mb4_unicode_ci`'
-- statement_terminator: ;
-- statement:
-    alter_table_statement:
-    - keyword: ALTER
-    - keyword: TABLE
-    - table_reference:
-        quoted_identifier: '`foo`'
-    - keyword: CONVERT
-    - keyword: TO
-    - alter_option_segment:
-      - keyword: CHARACTER
-      - keyword: SET
-      - quoted_identifier: "'utf8mb4'"
-    - alter_option_segment:
-        keyword: COLLATE
-        collation_reference:
-          quoted_literal: "'utf8mb4_unicode_ci'"
-- statement_terminator: ;
-- statement:
-    alter_table_statement:
-    - keyword: ALTER
-    - keyword: TABLE
-    - table_reference:
-        quoted_identifier: '`foo`'
-    - keyword: CONVERT
-    - keyword: TO
-    - alter_option_segment:
-      - keyword: CHARACTER
-      - keyword: SET
-      - quoted_identifier: '"utf8mb4"'
-    - alter_option_segment:
-        keyword: COLLATE
-        collation_reference:
-          quoted_literal: '"utf8mb4_unicode_ci"'
-- statement_terminator: ;
-- statement:
-    alter_table_statement:
-    - keyword: ALTER
-    - keyword: TABLE
-    - table_reference:
-        quoted_identifier: '`foo`'
-    - table_options:
-      - keyword: ENGINE
-      - comparison_operator:
-          raw_comparison_operator: '='
-      - quoted_literal: "'InnoDB'"
-      - keyword: AUTO_INCREMENT
-      - comparison_operator:
-          raw_comparison_operator: '='
-      - numeric_literal: '1'
-      - keyword: AVG_ROW_LENGTH
-      - comparison_operator:
-          raw_comparison_operator: '='
-      - numeric_literal: '10'
-      - keyword: DEFAULT
-      - keyword: CHARACTER
-      - keyword: SET
-      - comparison_operator:
-          raw_comparison_operator: '='
-      - quoted_literal: "'utf8_unicode_ci'"
-      - keyword: CHECKSUM
-      - comparison_operator:
-          raw_comparison_operator: '='
-      - numeric_literal: '1'
-      - keyword: DEFAULT
-      - keyword: COLLATE
-      - comparison_operator:
-          raw_comparison_operator: '='
-      - quoted_literal: "'utf8mb4_unicode_ci'"
-      - keyword: COMMENT
-      - comparison_operator:
-          raw_comparison_operator: '='
-      - quoted_literal: "'comment'"
-      - keyword: CONNECTION
-      - comparison_operator:
-          raw_comparison_operator: '='
-      - quoted_literal: "'connection_string'"
-      - keyword: DELAY_KEY_WRITE
-      - comparison_operator:
-          raw_comparison_operator: '='
-      - numeric_literal: '0'
-      - keyword: ENCRYPTED
-      - comparison_operator:
-          raw_comparison_operator: '='
-      - keyword: 'NO'
-      - keyword: ENCRYPTION_KEY_ID
-      - comparison_operator:
-          raw_comparison_operator: '='
-      - numeric_literal: '1234'
-      - keyword: IETF_QUOTES
-      - comparison_operator:
-          raw_comparison_operator: '='
-      - keyword: 'YES'
-      - keyword: INDEX
-      - keyword: DIRECTORY
-      - comparison_operator:
-          raw_comparison_operator: '='
-      - quoted_literal: "'path/to/dir'"
-      - keyword: INSERT_METHOD
-      - comparison_operator:
-          raw_comparison_operator: '='
-      - keyword: LAST
-      - keyword: KEY_BLOCK_SIZE
-      - comparison_operator:
-          raw_comparison_operator: '='
-      - numeric_literal: '1024'
-      - keyword: MAX_ROWS
-      - comparison_operator:
-          raw_comparison_operator: '='
-      - numeric_literal: '100000'
-      - keyword: MIN_ROWS
-      - comparison_operator:
-          raw_comparison_operator: '='
-      - numeric_literal: '1'
-      - keyword: PACK_KEYS
-      - comparison_operator:
-          raw_comparison_operator: '='
-      - numeric_literal: '1'
-      - keyword: PAGE_CHECKSUM
-      - comparison_operator:
-          raw_comparison_operator: '='
-      - numeric_literal: '1'
-      - keyword: PAGE_COMPRESSED
-      - comparison_operator:
-          raw_comparison_operator: '='
-      - numeric_literal: '0'
-      - keyword: PAGE_COMPRESSION_LEVEL
-      - comparison_operator:
-          raw_comparison_operator: '='
-      - numeric_literal: '9'
-      - keyword: PASSWORD
-      - comparison_operator:
-          raw_comparison_operator: '='
-      - quoted_literal: "'password'"
-      - keyword: ROW_FORMAT
-      - comparison_operator:
-          raw_comparison_operator: '='
-      - keyword: DYNAMIC
-      - keyword: SEQUENCE
-      - comparison_operator:
-          raw_comparison_operator: '='
-      - numeric_literal: '1'
-      - keyword: STATS_AUTO_RECALC
-      - comparison_operator:
-          raw_comparison_operator: '='
-      - numeric_literal: '1'
-      - keyword: STATS_PERSISTENT
-      - comparison_operator:
-          raw_comparison_operator: '='
-      - numeric_literal: '1'
-      - keyword: STATS_SAMPLE_PAGES
-      - comparison_operator:
-          raw_comparison_operator: '='
-      - numeric_literal: '4'
-      - keyword: TABLESPACE
-      - naked_identifier: tablespace_name
-      - keyword: TRANSACTIONAL
-      - comparison_operator:
-          raw_comparison_operator: '='
-      - numeric_literal: '1'
-      - keyword: UNION
-      - comparison_operator:
-          raw_comparison_operator: '='
-      - bracketed:
-        - start_bracket: (
-        - table_reference:
-            quoted_identifier: '`tbl1`'
-        - comma: ','
-        - table_reference:
-            quoted_identifier: '`tbl2`'
-        - end_bracket: )
-      - keyword: WITH
-      - keyword: SYSTEM
-      - keyword: VERSIONING
-- statement_terminator: ;
-- statement:
-    alter_table_statement:
-    - keyword: ALTER
-    - keyword: TABLE
-    - table_reference:
-        naked_identifier: user
-    - table_options:
-      - keyword: CHARSET
-      - keyword: DEFAULT
-- statement_terminator: ;
-- statement:
-    alter_table_statement:
-    - keyword: ALTER
-    - keyword: TABLE
-    - table_reference:
-        naked_identifier: user
-    - table_options:
-      - keyword: CHARSET
-      - keyword: DEFAULT
-      - keyword: COLLATE
-      - keyword: DEFAULT
-- statement_terminator: ;
-- statement:
-    alter_table_statement:
-    - keyword: ALTER
-    - keyword: TABLE
-    - table_reference:
-        naked_identifier: user
-    - table_options:
-      - keyword: DEFAULT
-      - keyword: CHARSET
-      - keyword: DEFAULT
-      - keyword: COLLATE
-      - keyword: DEFAULT
-- statement_terminator: ;
-- statement:
-    alter_table_statement:
-    - keyword: ALTER
-    - keyword: TABLE
-    - table_reference:
-        naked_identifier: user
-    - table_options:
-      - keyword: DEFAULT
-      - keyword: CHARSET
-      - keyword: DEFAULT
-      - keyword: DEFAULT
-      - keyword: COLLATE
-      - keyword: DEFAULT
-- statement_terminator: ;
-- statement:
-    alter_table_statement:
-    - keyword: ALTER
-    - keyword: TABLE
-    - table_reference:
-        naked_identifier: user
-    - table_options:
-      - keyword: CHARSET
-      - keyword: DEFAULT
-      - keyword: COLLATE
-      - keyword: DEFAULT
-- statement_terminator: ;
-- statement:
-    alter_table_statement:
-    - keyword: ALTER
-    - keyword: TABLE
-    - table_reference:
-        naked_identifier: user
-    - table_options:
-      - keyword: CHARACTER
-      - keyword: SET
-      - keyword: DEFAULT
-- statement_terminator: ;
-- statement:
-    alter_table_statement:
-    - keyword: ALTER
-    - keyword: TABLE
-    - table_reference:
-        naked_identifier: user
-    - table_options:
-      - keyword: CHARACTER
-      - keyword: SET
-      - keyword: DEFAULT
-      - keyword: COLLATE
-      - keyword: DEFAULT
-- statement_terminator: ;
-- statement:
-    alter_table_statement:
-    - keyword: ALTER
-    - keyword: TABLE
-    - table_reference:
-        naked_identifier: user
-    - table_options:
-      - keyword: DEFAULT
-      - keyword: CHARACTER
-      - keyword: SET
-      - keyword: DEFAULT
-      - keyword: COLLATE
-      - keyword: DEFAULT
-- statement_terminator: ;
-- statement:
-    alter_table_statement:
-    - keyword: ALTER
-    - keyword: TABLE
-    - table_reference:
-        naked_identifier: user
-    - table_options:
-      - keyword: DEFAULT
-      - keyword: CHARACTER
-      - keyword: SET
-      - keyword: DEFAULT
-      - keyword: DEFAULT
-      - keyword: COLLATE
-      - keyword: DEFAULT
-- statement_terminator: ;
-- statement:
-    alter_table_statement:
-    - keyword: ALTER
-    - keyword: TABLE
-    - table_reference:
-        naked_identifier: user
-    - table_options:
-      - keyword: CHARACTER
-      - keyword: SET
-      - keyword: DEFAULT
-      - keyword: COLLATE
-      - keyword: DEFAULT
-- statement_terminator: ;
-- statement:
-    alter_table_statement:
-    - keyword: ALTER
-    - keyword: TABLE
-    - table_reference:
-        naked_identifier: user
-    - table_options:
-        keyword: CHARSET
-        naked_identifier: utf8mb4
-- statement_terminator: ;
-- statement:
-    alter_table_statement:
-    - keyword: ALTER
-    - keyword: TABLE
-    - table_reference:
-        naked_identifier: user
-    - table_options:
-      - keyword: CHARACTER
-      - keyword: SET
-      - naked_identifier: utf8mb4
-- statement_terminator: ;
-- statement:
-    alter_table_statement:
-    - keyword: ALTER
-    - keyword: TABLE
-    - table_reference:
-        naked_identifier: user
-    - table_options:
-      - keyword: CHARSET
-      - naked_identifier: utf8mb4
-      - keyword: COLLATE
-      - naked_identifier: utf8mb4_unicode_ci
-- statement_terminator: ;
-- statement:
-    alter_table_statement:
-    - keyword: ALTER
-    - keyword: TABLE
-    - table_reference:
-        naked_identifier: user
-    - table_options:
-      - keyword: DEFAULT
-      - keyword: CHARACTER
-      - keyword: SET
-      - naked_identifier: utf8mb4
-      - keyword: COLLATE
-      - naked_identifier: utf8mb4_general_ci
-- statement_terminator: ;
-- statement:
-    alter_table_statement:
-    - keyword: ALTER
-    - keyword: TABLE
-    - table_reference:
-        naked_identifier: user
-    - table_options:
-        keyword: CHARSET
-        comparison_operator:
-          raw_comparison_operator: '='
-        naked_identifier: utf8mb4
-- statement_terminator: ;
-- statement:
-    alter_table_statement:
-    - keyword: ALTER
-    - keyword: TABLE
-    - table_reference:
-        naked_identifier: user
-    - table_options:
-      - keyword: CHARACTER
-      - keyword: SET
-      - comparison_operator:
-          raw_comparison_operator: '='
-      - naked_identifier: utf8mb4
-- statement_terminator: ;
-- statement:
-    alter_table_statement:
-    - keyword: ALTER
-    - keyword: TABLE
-    - table_reference:
-        naked_identifier: user
-    - table_options:
-      - keyword: DEFAULT
-      - keyword: CHARSET
-      - comparison_operator:
-          raw_comparison_operator: '='
-      - naked_identifier: utf8mb4
-      - keyword: COLLATE
-      - comparison_operator:
-          raw_comparison_operator: '='
-      - naked_identifier: utf8mb4_unicode_ci
-- statement_terminator: ;
-- statement:
-    alter_table_statement:
-    - keyword: ALTER
-    - keyword: TABLE
-    - table_reference:
-        naked_identifier: user
-    - table_options:
-      - keyword: DEFAULT
-      - keyword: CHARACTER
-      - keyword: SET
-      - comparison_operator:
-          raw_comparison_operator: '='
-      - naked_identifier: utf8mb4
-- statement_terminator: ;
-- statement:
-    alter_table_statement:
-    - keyword: ALTER
-    - keyword: TABLE
-    - table_reference:
-        naked_identifier: foo
-    - keyword: ADD
-    - keyword: SYSTEM
-    - keyword: VERSIONING
-- statement_terminator: ;
-- statement:
-    alter_table_statement:
-    - keyword: ALTER
-    - keyword: TABLE
-    - table_reference:
-        naked_identifier: foo
-    - keyword: DROP
-    - keyword: SYSTEM
-    - keyword: VERSIONING
-- statement_terminator: ;
+    - statement:
+          alter_table_statement:
+              - keyword: ALTER
+              - keyword: TABLE
+              - table_reference:
+                    quoted_identifier: "`users`"
+              - keyword: MODIFY
+              - keyword: COLUMN
+              - column_definition:
+                    quoted_identifier: "`name`"
+                    data_type:
+                        data_type_identifier: varchar
+                        bracketed_arguments:
+                            bracketed:
+                                start_bracket: (
+                                numeric_literal: "255"
+                                end_bracket: )
+                    column_constraint_segment:
+                        - keyword: NOT
+                        - keyword: "NULL"
+              - comma: ","
+              - table_options:
+                    keyword: COMMENT
+                    quoted_literal: '"name of user"'
+    - statement_terminator: ;
+    - statement:
+          alter_table_statement:
+              - keyword: ALTER
+              - keyword: TABLE
+              - table_reference:
+                    quoted_identifier: "`users`"
+              - keyword: MODIFY
+              - column_definition:
+                    quoted_identifier: "`name`"
+                    data_type:
+                        data_type_identifier: varchar
+                        bracketed_arguments:
+                            bracketed:
+                                start_bracket: (
+                                numeric_literal: "255"
+                                end_bracket: )
+                    column_constraint_segment:
+                        - keyword: NOT
+                        - keyword: "NULL"
+              - keyword: FIRST
+    - statement_terminator: ;
+    - statement:
+          alter_table_statement:
+              - keyword: ALTER
+              - keyword: TABLE
+              - table_reference:
+                    quoted_identifier: "`users`"
+              - keyword: RENAME
+              - keyword: TO
+              - table_reference:
+                    quoted_identifier: "`user`"
+    - statement_terminator: ;
+    - statement:
+          alter_table_statement:
+              - keyword: ALTER
+              - keyword: TABLE
+              - table_reference:
+                    quoted_identifier: "`user`"
+              - keyword: RENAME
+              - keyword: AS
+              - table_reference:
+                    quoted_identifier: "`users`"
+    - statement_terminator: ;
+    - statement:
+          alter_table_statement:
+              - keyword: ALTER
+              - keyword: TABLE
+              - table_reference:
+                    quoted_identifier: "`users`"
+              - keyword: RENAME
+              - table_reference:
+                    quoted_identifier: "`user`"
+    - statement_terminator: ;
+    - statement:
+          alter_table_statement:
+              - keyword: ALTER
+              - keyword: TABLE
+              - table_reference:
+                    quoted_identifier: "`users`"
+              - keyword: RENAME
+              - keyword: COLUMN
+              - column_reference:
+                    quoted_identifier: "`col_1`"
+              - keyword: TO
+              - column_reference:
+                    quoted_identifier: "`del_col_1`"
+    - statement_terminator: ;
+    - statement:
+          alter_table_statement:
+              - keyword: ALTER
+              - keyword: TABLE
+              - table_reference:
+                    quoted_identifier: "`users`"
+              - keyword: CHANGE
+              - keyword: COLUMN
+              - column_reference:
+                    quoted_identifier: "`birthday`"
+              - column_definition:
+                    - quoted_identifier: "`date_of_birth`"
+                    - data_type:
+                          data_type_identifier: INT
+                          bracketed_arguments:
+                              bracketed:
+                                  start_bracket: (
+                                  numeric_literal: "11"
+                                  end_bracket: )
+                    - column_constraint_segment:
+                          keyword: "NULL"
+                    - column_constraint_segment:
+                          keyword: DEFAULT
+                          null_literal: "NULL"
+    - statement_terminator: ;
+    - statement:
+          alter_table_statement:
+              - keyword: ALTER
+              - keyword: TABLE
+              - table_reference:
+                    quoted_identifier: "`users`"
+              - keyword: CHANGE
+              - keyword: COLUMN
+              - column_reference:
+                    quoted_identifier: "`birthday`"
+              - column_definition:
+                    quoted_identifier: "`date_of_birth`"
+                    data_type:
+                        data_type_identifier: INT
+                        bracketed_arguments:
+                            bracketed:
+                                start_bracket: (
+                                numeric_literal: "11"
+                                end_bracket: )
+                    column_constraint_segment:
+                        - keyword: NOT
+                        - keyword: "NULL"
+    - statement_terminator: ;
+    - statement:
+          alter_table_statement:
+              - keyword: ALTER
+              - keyword: TABLE
+              - table_reference:
+                    quoted_identifier: "`users`"
+              - keyword: CHANGE
+              - keyword: COLUMN
+              - column_reference:
+                    quoted_identifier: "`birthday`"
+              - column_definition:
+                    quoted_identifier: "`date_of_birth`"
+                    data_type:
+                        data_type_identifier: INT
+                        bracketed_arguments:
+                            bracketed:
+                                start_bracket: (
+                                numeric_literal: "11"
+                                end_bracket: )
+              - keyword: FIRST
+    - statement_terminator: ;
+    - statement:
+          alter_table_statement:
+              - keyword: ALTER
+              - keyword: TABLE
+              - table_reference:
+                    quoted_identifier: "`users`"
+              - keyword: CHANGE
+              - keyword: COLUMN
+              - column_reference:
+                    quoted_identifier: "`birthday`"
+              - column_definition:
+                    quoted_identifier: "`date_of_birth`"
+                    data_type:
+                        data_type_identifier: INT
+                        bracketed_arguments:
+                            bracketed:
+                                start_bracket: (
+                                numeric_literal: "11"
+                                end_bracket: )
+              - keyword: AFTER
+              - column_reference:
+                    quoted_identifier: "`name`"
+    - statement_terminator: ;
+    - statement:
+          alter_table_statement:
+              - keyword: ALTER
+              - keyword: TABLE
+              - table_reference:
+                    quoted_identifier: "`users`"
+              - keyword: DROP
+              - keyword: COLUMN
+              - column_reference:
+                    quoted_identifier: "`age`"
+    - statement_terminator: ;
+    - statement:
+          alter_table_statement:
+              - keyword: ALTER
+              - keyword: TABLE
+              - table_reference:
+                    - quoted_identifier: "`foo`"
+                    - dot: .
+                    - quoted_identifier: "`bar`"
+              - keyword: ADD
+              - table_constraint:
+                    - keyword: CONSTRAINT
+                    - object_reference:
+                          quoted_identifier: "`index_name`"
+                    - keyword: UNIQUE
+                    - bracketed:
+                          - start_bracket: (
+                          - column_reference:
+                                quoted_identifier: "`col_1`"
+                          - comma: ","
+                          - column_reference:
+                                quoted_identifier: "`col_2`"
+                          - comma: ","
+                          - column_reference:
+                                quoted_identifier: "`col_3`"
+                          - end_bracket: )
+    - statement_terminator: ;
+    - statement:
+          alter_table_statement:
+              - keyword: ALTER
+              - keyword: TABLE
+              - table_reference:
+                    - quoted_identifier: "`foo`"
+                    - dot: .
+                    - quoted_identifier: "`bar`"
+              - keyword: ADD
+              - table_constraint:
+                    keyword: UNIQUE
+                    index_reference:
+                        quoted_identifier: "`index_name`"
+                    bracketed:
+                        - start_bracket: (
+                        - column_reference:
+                              quoted_identifier: "`col_1`"
+                        - comma: ","
+                        - column_reference:
+                              quoted_identifier: "`col_2`"
+                        - comma: ","
+                        - column_reference:
+                              quoted_identifier: "`col_3`"
+                        - end_bracket: )
+    - statement_terminator: ;
+    - statement:
+          alter_table_statement:
+              - keyword: ALTER
+              - keyword: TABLE
+              - table_reference:
+                    - quoted_identifier: "`foo`"
+                    - dot: .
+                    - quoted_identifier: "`bar`"
+              - keyword: ADD
+              - table_constraint:
+                    - keyword: CONSTRAINT
+                    - object_reference:
+                          quoted_identifier: "`index_name`"
+                    - keyword: UNIQUE
+                    - keyword: INDEX
+                    - bracketed:
+                          - start_bracket: (
+                          - column_reference:
+                                quoted_identifier: "`col_1`"
+                          - comma: ","
+                          - column_reference:
+                                quoted_identifier: "`col_2`"
+                          - comma: ","
+                          - column_reference:
+                                quoted_identifier: "`col_3`"
+                          - end_bracket: )
+    - statement_terminator: ;
+    - statement:
+          alter_table_statement:
+              - keyword: ALTER
+              - keyword: TABLE
+              - table_reference:
+                    - quoted_identifier: "`foo`"
+                    - dot: .
+                    - quoted_identifier: "`bar`"
+              - keyword: ADD
+              - table_constraint:
+                    - keyword: UNIQUE
+                    - keyword: INDEX
+                    - index_reference:
+                          quoted_identifier: "`index_name`"
+                    - bracketed:
+                          - start_bracket: (
+                          - column_reference:
+                                quoted_identifier: "`col_1`"
+                          - comma: ","
+                          - column_reference:
+                                quoted_identifier: "`col_2`"
+                          - comma: ","
+                          - column_reference:
+                                quoted_identifier: "`col_3`"
+                          - end_bracket: )
+    - statement_terminator: ;
+    - statement:
+          alter_table_statement:
+              - keyword: ALTER
+              - keyword: TABLE
+              - table_reference:
+                    - quoted_identifier: "`foo`"
+                    - dot: .
+                    - quoted_identifier: "`bar`"
+              - keyword: ADD
+              - table_constraint:
+                    keyword: INDEX
+                    index_reference:
+                        quoted_identifier: "`index_name`"
+                    bracketed:
+                        - start_bracket: (
+                        - column_reference:
+                              quoted_identifier: "`col_1`"
+                        - comma: ","
+                        - column_reference:
+                              quoted_identifier: "`col_2`"
+                        - comma: ","
+                        - column_reference:
+                              quoted_identifier: "`col_3`"
+                        - end_bracket: )
+    - statement_terminator: ;
+    - statement:
+          alter_table_statement:
+              - keyword: ALTER
+              - keyword: TABLE
+              - table_reference:
+                    - quoted_identifier: "`foo`"
+                    - dot: .
+                    - quoted_identifier: "`bar`"
+              - keyword: ADD
+              - table_constraint:
+                    keyword: INDEX
+                    index_reference:
+                        quoted_identifier: "`index_name`"
+                    bracketed:
+                        - start_bracket: (
+                        - column_reference:
+                              quoted_identifier: "`col_1`"
+                        - comma: ","
+                        - column_reference:
+                              quoted_identifier: "`col_2`"
+                        - comma: ","
+                        - column_reference:
+                              quoted_identifier: "`col_3`"
+                        - end_bracket: )
+                    index_option:
+                        keyword: KEY_BLOCK_SIZE
+                        comparison_operator:
+                            raw_comparison_operator: "="
+                        numeric_literal: "8"
+    - statement_terminator: ;
+    - statement:
+          alter_table_statement:
+              - keyword: ALTER
+              - keyword: TABLE
+              - table_reference:
+                    - quoted_identifier: "`foo`"
+                    - dot: .
+                    - quoted_identifier: "`bar`"
+              - keyword: ADD
+              - table_constraint:
+                    keyword: INDEX
+                    index_reference:
+                        quoted_identifier: "`index_name`"
+                    bracketed:
+                        - start_bracket: (
+                        - column_reference:
+                              quoted_identifier: "`col_1`"
+                        - comma: ","
+                        - column_reference:
+                              quoted_identifier: "`col_2`"
+                        - comma: ","
+                        - column_reference:
+                              quoted_identifier: "`col_3`"
+                        - end_bracket: )
+                    index_option:
+                        keyword: KEY_BLOCK_SIZE
+                        numeric_literal: "8"
+    - statement_terminator: ;
+    - statement:
+          alter_table_statement:
+              - keyword: ALTER
+              - keyword: TABLE
+              - table_reference:
+                    - quoted_identifier: "`foo`"
+                    - dot: .
+                    - quoted_identifier: "`bar`"
+              - keyword: ADD
+              - table_constraint:
+                    keyword: INDEX
+                    index_reference:
+                        quoted_identifier: "`index_name`"
+                    bracketed:
+                        - start_bracket: (
+                        - column_reference:
+                              quoted_identifier: "`col_1`"
+                        - comma: ","
+                        - column_reference:
+                              quoted_identifier: "`col_2`"
+                        - comma: ","
+                        - column_reference:
+                              quoted_identifier: "`col_3`"
+                        - end_bracket: )
+                    index_option:
+                        keyword: KEY_BLOCK_SIZE
+                        numeric_literal: "8"
+                        comment_clause:
+                            keyword: COMMENT
+                            quoted_literal: "'index for col_1, col_2, col_3'"
+    - statement_terminator: ;
+    - statement:
+          alter_table_statement:
+              - keyword: ALTER
+              - keyword: TABLE
+              - table_reference:
+                    - quoted_identifier: "`foo`"
+                    - dot: .
+                    - quoted_identifier: "`bar`"
+              - keyword: DROP
+              - keyword: INDEX
+              - index_reference:
+                    quoted_identifier: "`index_name`"
+    - statement_terminator: ;
+    - statement:
+          alter_table_statement:
+              - keyword: ALTER
+              - keyword: TABLE
+              - table_reference:
+                    - quoted_identifier: "`foo`"
+                    - dot: .
+                    - quoted_identifier: "`bar`"
+              - keyword: RENAME
+              - keyword: INDEX
+              - index_reference:
+                    quoted_identifier: "`index_name`"
+              - keyword: to
+              - index_reference:
+                    quoted_identifier: "`new_index_name`"
+    - statement_terminator: ;
+    - statement:
+          alter_table_statement:
+              - keyword: ALTER
+              - keyword: TABLE
+              - table_reference:
+                    - quoted_identifier: "`foo`"
+                    - dot: .
+                    - quoted_identifier: "`bar`"
+              - keyword: RENAME
+              - keyword: KEY
+              - index_reference:
+                    quoted_identifier: "`key_name`"
+              - keyword: to
+              - index_reference:
+                    quoted_identifier: "`new_key_name`"
+    - statement_terminator: ;
+    - statement:
+          alter_table_statement:
+              - keyword: ALTER
+              - keyword: TABLE
+              - table_reference:
+                    quoted_identifier: "`x`"
+              - keyword: ADD
+              - table_constraint:
+                    - keyword: CONSTRAINT
+                    - keyword: FOREIGN
+                    - keyword: KEY
+                    - bracketed:
+                          start_bracket: (
+                          column_reference:
+                              quoted_identifier: "`xk`"
+                          end_bracket: )
+                    - keyword: REFERENCES
+                    - column_reference:
+                          quoted_identifier: "`y`"
+                    - bracketed:
+                          start_bracket: (
+                          column_reference:
+                              quoted_identifier: "`yk`"
+                          end_bracket: )
+    - statement_terminator: ;
+    - statement:
+          alter_table_statement:
+              - keyword: ALTER
+              - keyword: TABLE
+              - table_reference:
+                    quoted_identifier: "`users`"
+              - keyword: ADD
+              - keyword: COLUMN
+              - column_definition:
+                    quoted_identifier: "`active`"
+                    data_type:
+                        data_type_identifier: tinyint
+                        bracketed_arguments:
+                            bracketed:
+                                start_bracket: (
+                                numeric_literal: "1"
+                                end_bracket: )
+                    column_constraint_segment:
+                        keyword: DEFAULT
+                        quoted_literal: "'0'"
+    - statement_terminator: ;
+    - statement:
+          alter_table_statement:
+              - keyword: ALTER
+              - keyword: TABLE
+              - table_reference:
+                    quoted_identifier: "`users`"
+              - keyword: ADD
+              - keyword: COLUMN
+              - keyword: IF
+              - keyword: NOT
+              - keyword: EXISTS
+              - column_definition:
+                    quoted_identifier: "`active`"
+                    data_type:
+                        data_type_identifier: tinyint
+                        bracketed_arguments:
+                            bracketed:
+                                start_bracket: (
+                                numeric_literal: "1"
+                                end_bracket: )
+                    column_constraint_segment:
+                        keyword: DEFAULT
+                        quoted_literal: "'0'"
+    - statement_terminator: ;
+    - statement:
+          alter_table_statement:
+              - keyword: ALTER
+              - keyword: TABLE
+              - table_reference:
+                    quoted_identifier: "`foo`"
+              - keyword: ADD
+              - column_definition:
+                    quoted_identifier: "`bar`"
+                    data_type:
+                        data_type_identifier: INT
+              - keyword: FIRST
+    - statement_terminator: ;
+    - statement:
+          alter_table_statement:
+              - keyword: ALTER
+              - keyword: TABLE
+              - table_reference:
+                    quoted_identifier: "`foo`"
+              - keyword: ADD
+              - keyword: COLUMN
+              - column_definition:
+                    naked_identifier: d
+                    data_type:
+                        data_type_identifier: INT
+                    column_constraint_segment:
+                        - keyword: GENERATED
+                        - keyword: ALWAYS
+                        - keyword: AS
+                        - bracketed:
+                              start_bracket: (
+                              expression:
+                                  column_reference:
+                                      naked_identifier: a
+                                  binary_operator: "*"
+                                  function:
+                                      function_name:
+                                          function_name_identifier: abs
+                                      function_contents:
+                                          bracketed:
+                                              start_bracket: (
+                                              expression:
+                                                  column_reference:
+                                                      naked_identifier: b
+                                              end_bracket: )
+                              end_bracket: )
+                        - keyword: VIRTUAL
+    - statement_terminator: ;
+    - statement:
+          alter_table_statement:
+              - keyword: ALTER
+              - keyword: TABLE
+              - table_reference:
+                    quoted_identifier: "`foo`"
+              - keyword: ADD
+              - keyword: COLUMN
+              - column_definition:
+                    naked_identifier: e
+                    data_type:
+                        data_type_identifier: TEXT
+                    column_constraint_segment:
+                        - keyword: GENERATED
+                        - keyword: ALWAYS
+                        - keyword: AS
+                        - bracketed:
+                              start_bracket: (
+                              expression:
+                                  function:
+                                      function_name:
+                                          function_name_identifier: substr
+                                      function_contents:
+                                          bracketed:
+                                              - start_bracket: (
+                                              - expression:
+                                                    column_reference:
+                                                        naked_identifier: c
+                                              - comma: ","
+                                              - expression:
+                                                    column_reference:
+                                                        naked_identifier: b
+                                              - comma: ","
+                                              - expression:
+                                                    column_reference:
+                                                        naked_identifier: b
+                                                    binary_operator: +
+                                                    numeric_literal: "1"
+                                              - end_bracket: )
+                              end_bracket: )
+                        - keyword: STORED
+    - statement_terminator: ;
+    - statement:
+          alter_table_statement:
+              - keyword: ALTER
+              - keyword: TABLE
+              - table_reference:
+                    quoted_identifier: "`foo`"
+              - keyword: ADD
+              - keyword: COLUMN
+              - column_definition:
+                    naked_identifier: e
+                    data_type:
+                        data_type_identifier: TEXT
+                    column_constraint_segment:
+                        - keyword: GENERATED
+                        - keyword: ALWAYS
+                        - keyword: AS
+                        - bracketed:
+                              start_bracket: (
+                              expression:
+                                  function:
+                                      function_name:
+                                          function_name_identifier: substr
+                                      function_contents:
+                                          bracketed:
+                                              - start_bracket: (
+                                              - expression:
+                                                    column_reference:
+                                                        naked_identifier: c
+                                              - comma: ","
+                                              - expression:
+                                                    column_reference:
+                                                        naked_identifier: b
+                                              - comma: ","
+                                              - expression:
+                                                    column_reference:
+                                                        naked_identifier: b
+                                                    binary_operator: +
+                                                    numeric_literal: "1"
+                                              - end_bracket: )
+                              end_bracket: )
+                        - keyword: PERSISTENT
+    - statement_terminator: ;
+    - statement:
+          alter_table_statement:
+              - keyword: ALTER
+              - keyword: TABLE
+              - table_reference:
+                    quoted_identifier: "`foo`"
+              - keyword: ADD
+              - keyword: COLUMN
+              - column_definition:
+                    naked_identifier: d
+                    data_type:
+                        data_type_identifier: INT
+                    column_constraint_segment:
+                        keyword: AS
+                        bracketed:
+                            start_bracket: (
+                            expression:
+                                column_reference:
+                                    naked_identifier: a
+                                binary_operator: "*"
+                                function:
+                                    function_name:
+                                        function_name_identifier: abs
+                                    function_contents:
+                                        bracketed:
+                                            start_bracket: (
+                                            expression:
+                                                column_reference:
+                                                    naked_identifier: b
+                                            end_bracket: )
+                            end_bracket: )
+    - statement_terminator: ;
+    - statement:
+          alter_table_statement:
+              - keyword: ALTER
+              - keyword: TABLE
+              - table_reference:
+                    quoted_identifier: "`foo`"
+              - keyword: ADD
+              - keyword: COLUMN
+              - column_definition:
+                    naked_identifier: e
+                    data_type:
+                        data_type_identifier: TEXT
+                    column_constraint_segment:
+                        - keyword: AS
+                        - bracketed:
+                              start_bracket: (
+                              expression:
+                                  function:
+                                      function_name:
+                                          function_name_identifier: substr
+                                      function_contents:
+                                          bracketed:
+                                              - start_bracket: (
+                                              - expression:
+                                                    column_reference:
+                                                        naked_identifier: c
+                                              - comma: ","
+                                              - expression:
+                                                    column_reference:
+                                                        naked_identifier: b
+                                              - comma: ","
+                                              - expression:
+                                                    column_reference:
+                                                        naked_identifier: b
+                                                    binary_operator: +
+                                                    numeric_literal: "1"
+                                              - end_bracket: )
+                              end_bracket: )
+                        - keyword: STORED
+    - statement_terminator: ;
+    - statement:
+          alter_table_statement:
+              - keyword: ALTER
+              - keyword: TABLE
+              - table_reference:
+                    quoted_identifier: "`foo`"
+              - keyword: ADD
+              - keyword: COLUMN
+              - column_definition:
+                    naked_identifier: e
+                    data_type:
+                        data_type_identifier: TEXT
+                    column_constraint_segment:
+                        - keyword: AS
+                        - bracketed:
+                              start_bracket: (
+                              expression:
+                                  function:
+                                      function_name:
+                                          function_name_identifier: substr
+                                      function_contents:
+                                          bracketed:
+                                              - start_bracket: (
+                                              - expression:
+                                                    column_reference:
+                                                        naked_identifier: c
+                                              - comma: ","
+                                              - expression:
+                                                    column_reference:
+                                                        naked_identifier: b
+                                              - comma: ","
+                                              - expression:
+                                                    column_reference:
+                                                        naked_identifier: b
+                                                    binary_operator: +
+                                                    numeric_literal: "1"
+                                              - end_bracket: )
+                              end_bracket: )
+                        - keyword: PERSISTENT
+    - statement_terminator: ;
+    - statement:
+          alter_table_statement:
+              - keyword: ALTER
+              - keyword: TABLE
+              - table_reference:
+                    quoted_identifier: "`foo`"
+              - keyword: CONVERT
+              - keyword: TO
+              - alter_option_segment:
+                    - keyword: CHARACTER
+                    - keyword: SET
+                    - naked_identifier: utf8mb4
+              - alter_option_segment:
+                    keyword: COLLATE
+                    collation_reference:
+                        naked_identifier: utf8mb4_unicode_ci
+    - statement_terminator: ;
+    - statement:
+          alter_table_statement:
+              - keyword: ALTER
+              - keyword: TABLE
+              - table_reference:
+                    quoted_identifier: "`foo`"
+              - keyword: CONVERT
+              - keyword: TO
+              - alter_option_segment:
+                    - keyword: CHARACTER
+                    - keyword: SET
+                    - quoted_identifier: "`utf8mb4`"
+              - alter_option_segment:
+                    keyword: COLLATE
+                    collation_reference:
+                        quoted_identifier: "`utf8mb4_unicode_ci`"
+    - statement_terminator: ;
+    - statement:
+          alter_table_statement:
+              - keyword: ALTER
+              - keyword: TABLE
+              - table_reference:
+                    quoted_identifier: "`foo`"
+              - keyword: CONVERT
+              - keyword: TO
+              - alter_option_segment:
+                    - keyword: CHARACTER
+                    - keyword: SET
+                    - quoted_identifier: "'utf8mb4'"
+              - alter_option_segment:
+                    keyword: COLLATE
+                    collation_reference:
+                        quoted_literal: "'utf8mb4_unicode_ci'"
+    - statement_terminator: ;
+    - statement:
+          alter_table_statement:
+              - keyword: ALTER
+              - keyword: TABLE
+              - table_reference:
+                    quoted_identifier: "`foo`"
+              - keyword: CONVERT
+              - keyword: TO
+              - alter_option_segment:
+                    - keyword: CHARACTER
+                    - keyword: SET
+                    - quoted_identifier: '"utf8mb4"'
+              - alter_option_segment:
+                    keyword: COLLATE
+                    collation_reference:
+                        quoted_literal: '"utf8mb4_unicode_ci"'
+    - statement_terminator: ;
+    - statement:
+          alter_table_statement:
+              - keyword: ALTER
+              - keyword: TABLE
+              - table_reference:
+                    naked_identifier: t
+              - keyword: MODIFY
+              - column_definition:
+                    - naked_identifier: time_updated
+                    - keyword: timestamp
+                    - keyword: NOT
+                    - keyword: "NULL"
+                    - keyword: DEFAULT
+                    - function:
+                          keyword: current_timestamp
+                          bracketed:
+                              start_bracket: (
+                              end_bracket: )
+                    - keyword: "ON"
+                    - keyword: UPDATE
+                    - function:
+                          keyword: current_timestamp
+                          bracketed:
+                              start_bracket: (
+                              end_bracket: )
+    - statement_terminator: ;
+    - statement:
+          alter_table_statement:
+              - keyword: ALTER
+              - keyword: TABLE
+              - table_reference:
+                    naked_identifier: t
+              - keyword: MODIFY
+              - column_definition:
+                    - naked_identifier: time_updated
+                    - keyword: timestamp
+                    - keyword: NOT
+                    - keyword: "NULL"
+                    - keyword: DEFAULT
+                    - bare_function:
+                          keyword: localtime
+                    - keyword: "ON"
+                    - keyword: UPDATE
+                    - function:
+                          keyword: localtime
+                          bracketed:
+                              start_bracket: (
+                              end_bracket: )
+    - statement_terminator: ;
+    - statement:
+          alter_table_statement:
+              - keyword: ALTER
+              - keyword: TABLE
+              - table_reference:
+                    naked_identifier: t
+              - keyword: MODIFY
+              - column_definition:
+                    - naked_identifier: time_updated
+                    - keyword: timestamp
+                    - keyword: NOT
+                    - keyword: "NULL"
+                    - keyword: DEFAULT
+                    - bare_function:
+                          keyword: localtimestamp
+                    - keyword: "ON"
+                    - keyword: UPDATE
+                    - function:
+                          keyword: localtimestamp
+                          bracketed:
+                              start_bracket: (
+                              end_bracket: )
+    - statement_terminator: ;
+    - statement:
+          alter_table_statement:
+              - keyword: ALTER
+              - keyword: TABLE
+              - table_reference:
+                    quoted_identifier: "`foo`"
+              - table_options:
+                    - keyword: ENGINE
+                    - comparison_operator:
+                          raw_comparison_operator: "="
+                    - quoted_literal: "'InnoDB'"
+                    - keyword: AUTO_INCREMENT
+                    - comparison_operator:
+                          raw_comparison_operator: "="
+                    - numeric_literal: "1"
+                    - keyword: AVG_ROW_LENGTH
+                    - comparison_operator:
+                          raw_comparison_operator: "="
+                    - numeric_literal: "10"
+                    - keyword: DEFAULT
+                    - keyword: CHARACTER
+                    - keyword: SET
+                    - comparison_operator:
+                          raw_comparison_operator: "="
+                    - quoted_literal: "'utf8_unicode_ci'"
+                    - keyword: CHECKSUM
+                    - comparison_operator:
+                          raw_comparison_operator: "="
+                    - numeric_literal: "1"
+                    - keyword: DEFAULT
+                    - keyword: COLLATE
+                    - comparison_operator:
+                          raw_comparison_operator: "="
+                    - quoted_literal: "'utf8mb4_unicode_ci'"
+                    - keyword: COMMENT
+                    - comparison_operator:
+                          raw_comparison_operator: "="
+                    - quoted_literal: "'comment'"
+                    - keyword: CONNECTION
+                    - comparison_operator:
+                          raw_comparison_operator: "="
+                    - quoted_literal: "'connection_string'"
+                    - keyword: DELAY_KEY_WRITE
+                    - comparison_operator:
+                          raw_comparison_operator: "="
+                    - numeric_literal: "0"
+                    - keyword: ENCRYPTED
+                    - comparison_operator:
+                          raw_comparison_operator: "="
+                    - keyword: "NO"
+                    - keyword: ENCRYPTION_KEY_ID
+                    - comparison_operator:
+                          raw_comparison_operator: "="
+                    - numeric_literal: "1234"
+                    - keyword: IETF_QUOTES
+                    - comparison_operator:
+                          raw_comparison_operator: "="
+                    - keyword: "YES"
+                    - keyword: INDEX
+                    - keyword: DIRECTORY
+                    - comparison_operator:
+                          raw_comparison_operator: "="
+                    - quoted_literal: "'path/to/dir'"
+                    - keyword: INSERT_METHOD
+                    - comparison_operator:
+                          raw_comparison_operator: "="
+                    - keyword: LAST
+                    - keyword: KEY_BLOCK_SIZE
+                    - comparison_operator:
+                          raw_comparison_operator: "="
+                    - numeric_literal: "1024"
+                    - keyword: MAX_ROWS
+                    - comparison_operator:
+                          raw_comparison_operator: "="
+                    - numeric_literal: "100000"
+                    - keyword: MIN_ROWS
+                    - comparison_operator:
+                          raw_comparison_operator: "="
+                    - numeric_literal: "1"
+                    - keyword: PACK_KEYS
+                    - comparison_operator:
+                          raw_comparison_operator: "="
+                    - numeric_literal: "1"
+                    - keyword: PAGE_CHECKSUM
+                    - comparison_operator:
+                          raw_comparison_operator: "="
+                    - numeric_literal: "1"
+                    - keyword: PAGE_COMPRESSED
+                    - comparison_operator:
+                          raw_comparison_operator: "="
+                    - numeric_literal: "0"
+                    - keyword: PAGE_COMPRESSION_LEVEL
+                    - comparison_operator:
+                          raw_comparison_operator: "="
+                    - numeric_literal: "9"
+                    - keyword: PASSWORD
+                    - comparison_operator:
+                          raw_comparison_operator: "="
+                    - quoted_literal: "'password'"
+                    - keyword: ROW_FORMAT
+                    - comparison_operator:
+                          raw_comparison_operator: "="
+                    - keyword: DYNAMIC
+                    - keyword: SEQUENCE
+                    - comparison_operator:
+                          raw_comparison_operator: "="
+                    - numeric_literal: "1"
+                    - keyword: STATS_AUTO_RECALC
+                    - comparison_operator:
+                          raw_comparison_operator: "="
+                    - numeric_literal: "1"
+                    - keyword: STATS_PERSISTENT
+                    - comparison_operator:
+                          raw_comparison_operator: "="
+                    - numeric_literal: "1"
+                    - keyword: STATS_SAMPLE_PAGES
+                    - comparison_operator:
+                          raw_comparison_operator: "="
+                    - numeric_literal: "4"
+                    - keyword: TABLESPACE
+                    - naked_identifier: tablespace_name
+                    - keyword: TRANSACTIONAL
+                    - comparison_operator:
+                          raw_comparison_operator: "="
+                    - numeric_literal: "1"
+                    - keyword: UNION
+                    - comparison_operator:
+                          raw_comparison_operator: "="
+                    - bracketed:
+                          - start_bracket: (
+                          - table_reference:
+                                quoted_identifier: "`tbl1`"
+                          - comma: ","
+                          - table_reference:
+                                quoted_identifier: "`tbl2`"
+                          - end_bracket: )
+                    - keyword: WITH
+                    - keyword: SYSTEM
+                    - keyword: VERSIONING
+    - statement_terminator: ;
+    - statement:
+          alter_table_statement:
+              - keyword: ALTER
+              - keyword: TABLE
+              - table_reference:
+                    naked_identifier: user
+              - table_options:
+                    - keyword: CHARSET
+                    - keyword: DEFAULT
+    - statement_terminator: ;
+    - statement:
+          alter_table_statement:
+              - keyword: ALTER
+              - keyword: TABLE
+              - table_reference:
+                    naked_identifier: user
+              - table_options:
+                    - keyword: CHARSET
+                    - keyword: DEFAULT
+                    - keyword: COLLATE
+                    - keyword: DEFAULT
+    - statement_terminator: ;
+    - statement:
+          alter_table_statement:
+              - keyword: ALTER
+              - keyword: TABLE
+              - table_reference:
+                    naked_identifier: user
+              - table_options:
+                    - keyword: DEFAULT
+                    - keyword: CHARSET
+                    - keyword: DEFAULT
+                    - keyword: COLLATE
+                    - keyword: DEFAULT
+    - statement_terminator: ;
+    - statement:
+          alter_table_statement:
+              - keyword: ALTER
+              - keyword: TABLE
+              - table_reference:
+                    naked_identifier: user
+              - table_options:
+                    - keyword: DEFAULT
+                    - keyword: CHARSET
+                    - keyword: DEFAULT
+                    - keyword: DEFAULT
+                    - keyword: COLLATE
+                    - keyword: DEFAULT
+    - statement_terminator: ;
+    - statement:
+          alter_table_statement:
+              - keyword: ALTER
+              - keyword: TABLE
+              - table_reference:
+                    naked_identifier: user
+              - table_options:
+                    - keyword: CHARSET
+                    - keyword: DEFAULT
+                    - keyword: COLLATE
+                    - keyword: DEFAULT
+    - statement_terminator: ;
+    - statement:
+          alter_table_statement:
+              - keyword: ALTER
+              - keyword: TABLE
+              - table_reference:
+                    naked_identifier: user
+              - table_options:
+                    - keyword: CHARACTER
+                    - keyword: SET
+                    - keyword: DEFAULT
+    - statement_terminator: ;
+    - statement:
+          alter_table_statement:
+              - keyword: ALTER
+              - keyword: TABLE
+              - table_reference:
+                    naked_identifier: user
+              - table_options:
+                    - keyword: CHARACTER
+                    - keyword: SET
+                    - keyword: DEFAULT
+                    - keyword: COLLATE
+                    - keyword: DEFAULT
+    - statement_terminator: ;
+    - statement:
+          alter_table_statement:
+              - keyword: ALTER
+              - keyword: TABLE
+              - table_reference:
+                    naked_identifier: user
+              - table_options:
+                    - keyword: DEFAULT
+                    - keyword: CHARACTER
+                    - keyword: SET
+                    - keyword: DEFAULT
+                    - keyword: COLLATE
+                    - keyword: DEFAULT
+    - statement_terminator: ;
+    - statement:
+          alter_table_statement:
+              - keyword: ALTER
+              - keyword: TABLE
+              - table_reference:
+                    naked_identifier: user
+              - table_options:
+                    - keyword: DEFAULT
+                    - keyword: CHARACTER
+                    - keyword: SET
+                    - keyword: DEFAULT
+                    - keyword: DEFAULT
+                    - keyword: COLLATE
+                    - keyword: DEFAULT
+    - statement_terminator: ;
+    - statement:
+          alter_table_statement:
+              - keyword: ALTER
+              - keyword: TABLE
+              - table_reference:
+                    naked_identifier: user
+              - table_options:
+                    - keyword: CHARACTER
+                    - keyword: SET
+                    - keyword: DEFAULT
+                    - keyword: COLLATE
+                    - keyword: DEFAULT
+    - statement_terminator: ;
+    - statement:
+          alter_table_statement:
+              - keyword: ALTER
+              - keyword: TABLE
+              - table_reference:
+                    naked_identifier: user
+              - table_options:
+                    keyword: CHARSET
+                    naked_identifier: utf8mb4
+    - statement_terminator: ;
+    - statement:
+          alter_table_statement:
+              - keyword: ALTER
+              - keyword: TABLE
+              - table_reference:
+                    naked_identifier: user
+              - table_options:
+                    - keyword: CHARACTER
+                    - keyword: SET
+                    - naked_identifier: utf8mb4
+    - statement_terminator: ;
+    - statement:
+          alter_table_statement:
+              - keyword: ALTER
+              - keyword: TABLE
+              - table_reference:
+                    naked_identifier: user
+              - table_options:
+                    - keyword: CHARSET
+                    - naked_identifier: utf8mb4
+                    - keyword: COLLATE
+                    - naked_identifier: utf8mb4_unicode_ci
+    - statement_terminator: ;
+    - statement:
+          alter_table_statement:
+              - keyword: ALTER
+              - keyword: TABLE
+              - table_reference:
+                    naked_identifier: user
+              - table_options:
+                    - keyword: DEFAULT
+                    - keyword: CHARACTER
+                    - keyword: SET
+                    - naked_identifier: utf8mb4
+                    - keyword: COLLATE
+                    - naked_identifier: utf8mb4_general_ci
+    - statement_terminator: ;
+    - statement:
+          alter_table_statement:
+              - keyword: ALTER
+              - keyword: TABLE
+              - table_reference:
+                    naked_identifier: user
+              - table_options:
+                    keyword: CHARSET
+                    comparison_operator:
+                        raw_comparison_operator: "="
+                    naked_identifier: utf8mb4
+    - statement_terminator: ;
+    - statement:
+          alter_table_statement:
+              - keyword: ALTER
+              - keyword: TABLE
+              - table_reference:
+                    naked_identifier: user
+              - table_options:
+                    - keyword: CHARACTER
+                    - keyword: SET
+                    - comparison_operator:
+                          raw_comparison_operator: "="
+                    - naked_identifier: utf8mb4
+    - statement_terminator: ;
+    - statement:
+          alter_table_statement:
+              - keyword: ALTER
+              - keyword: TABLE
+              - table_reference:
+                    naked_identifier: user
+              - table_options:
+                    - keyword: DEFAULT
+                    - keyword: CHARSET
+                    - comparison_operator:
+                          raw_comparison_operator: "="
+                    - naked_identifier: utf8mb4
+                    - keyword: COLLATE
+                    - comparison_operator:
+                          raw_comparison_operator: "="
+                    - naked_identifier: utf8mb4_unicode_ci
+    - statement_terminator: ;
+    - statement:
+          alter_table_statement:
+              - keyword: ALTER
+              - keyword: TABLE
+              - table_reference:
+                    naked_identifier: user
+              - table_options:
+                    - keyword: DEFAULT
+                    - keyword: CHARACTER
+                    - keyword: SET
+                    - comparison_operator:
+                          raw_comparison_operator: "="
+                    - naked_identifier: utf8mb4
+    - statement_terminator: ;
+    - statement:
+          alter_table_statement:
+              - keyword: ALTER
+              - keyword: TABLE
+              - table_reference:
+                    naked_identifier: foo
+              - keyword: ADD
+              - keyword: SYSTEM
+              - keyword: VERSIONING
+    - statement_terminator: ;
+    - statement:
+          alter_table_statement:
+              - keyword: ALTER
+              - keyword: TABLE
+              - table_reference:
+                    naked_identifier: foo
+              - keyword: DROP
+              - keyword: SYSTEM
+              - keyword: VERSIONING
+    - statement_terminator: ;

--- a/test/fixtures/dialects/mariadb/alter_table.yml
+++ b/test/fixtures/dialects/mariadb/alter_table.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 5e573d68c2432a18ba47c3100a4bbd32fedce7003e52c813edde83c949ed2ae2
+_hash: f0d073a6827b43981eaaae08c322ea0bef8204fd11176c0d9774ad82e28b9f55
 file:
     - statement:
           alter_table_statement:

--- a/test/fixtures/dialects/mariadb/create_table_datetime.yml
+++ b/test/fixtures/dialects/mariadb/create_table_datetime.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 0081f1d35223a72ab130763009bc76ec88ce9353a4fb0a93d2391c7471e4cac1
+_hash: af439b25493cbb1c345f13de8641105858fabbfda94e6df7b9531102c87ede63
 file:
   statement:
     create_table_statement:
@@ -17,8 +17,7 @@ file:
         - naked_identifier: created_date
         - keyword: DATETIME
         - keyword: DEFAULT
-        - bare_function:
-            keyword: CURRENT_TIMESTAMP
+        - bare_function: CURRENT_TIMESTAMP
         - keyword: NOT
         - keyword: 'NULL'
       - comma: ','
@@ -26,37 +25,31 @@ file:
         - naked_identifier: ts1
         - keyword: TIMESTAMP
         - keyword: DEFAULT
-        - bare_function:
-            keyword: CURRENT_TIMESTAMP
+        - bare_function: CURRENT_TIMESTAMP
         - keyword: 'ON'
         - keyword: UPDATE
-        - bare_function:
-            keyword: CURRENT_TIMESTAMP
+        - bare_function: CURRENT_TIMESTAMP
       - comma: ','
       - column_definition:
         - naked_identifier: dt1
         - keyword: DATETIME
         - keyword: DEFAULT
-        - bare_function:
-            keyword: CURRENT_TIMESTAMP
+        - bare_function: CURRENT_TIMESTAMP
         - keyword: 'ON'
         - keyword: UPDATE
-        - bare_function:
-            keyword: CURRENT_TIMESTAMP
+        - bare_function: CURRENT_TIMESTAMP
       - comma: ','
       - column_definition:
         - naked_identifier: ts2
         - keyword: TIMESTAMP
         - keyword: DEFAULT
-        - bare_function:
-            keyword: CURRENT_TIMESTAMP
+        - bare_function: CURRENT_TIMESTAMP
       - comma: ','
       - column_definition:
         - naked_identifier: dt2
         - keyword: DATETIME
         - keyword: DEFAULT
-        - bare_function:
-            keyword: CURRENT_TIMESTAMP
+        - bare_function: CURRENT_TIMESTAMP
       - comma: ','
       - column_definition:
         - naked_identifier: ts3
@@ -77,8 +70,7 @@ file:
         - numeric_literal: '0'
         - keyword: 'ON'
         - keyword: UPDATE
-        - bare_function:
-            keyword: CURRENT_TIMESTAMP
+        - bare_function: CURRENT_TIMESTAMP
       - comma: ','
       - column_definition:
         - naked_identifier: dt4
@@ -87,16 +79,14 @@ file:
         - numeric_literal: '0'
         - keyword: 'ON'
         - keyword: UPDATE
-        - bare_function:
-            keyword: CURRENT_TIMESTAMP
+        - bare_function: CURRENT_TIMESTAMP
       - comma: ','
       - column_definition:
         - naked_identifier: ts5
         - keyword: TIMESTAMP
         - keyword: 'ON'
         - keyword: UPDATE
-        - bare_function:
-            keyword: CURRENT_TIMESTAMP
+        - bare_function: CURRENT_TIMESTAMP
       - comma: ','
       - column_definition:
         - naked_identifier: ts6
@@ -104,16 +94,14 @@ file:
         - keyword: 'NULL'
         - keyword: 'ON'
         - keyword: UPDATE
-        - bare_function:
-            keyword: CURRENT_TIMESTAMP
+        - bare_function: CURRENT_TIMESTAMP
       - comma: ','
       - column_definition:
         - naked_identifier: dt5
         - keyword: DATETIME
         - keyword: 'ON'
         - keyword: UPDATE
-        - bare_function:
-            keyword: CURRENT_TIMESTAMP
+        - bare_function: CURRENT_TIMESTAMP
       - comma: ','
       - column_definition:
         - naked_identifier: dt6
@@ -122,8 +110,7 @@ file:
         - keyword: 'NULL'
         - keyword: 'ON'
         - keyword: UPDATE
-        - bare_function:
-            keyword: CURRENT_TIMESTAMP
+        - bare_function: CURRENT_TIMESTAMP
       - comma: ','
       - column_definition:
         - naked_identifier: ts7
@@ -135,19 +122,23 @@ file:
               end_bracket: )
         - keyword: DEFAULT
         - function:
-            keyword: CURRENT_TIMESTAMP
-            bracketed:
-              start_bracket: (
-              numeric_literal: '6'
-              end_bracket: )
+            function_name:
+              keyword: CURRENT_TIMESTAMP
+            function_contents:
+              bracketed:
+                start_bracket: (
+                numeric_literal: '6'
+                end_bracket: )
         - keyword: 'ON'
         - keyword: UPDATE
         - function:
-            keyword: CURRENT_TIMESTAMP
-            bracketed:
-              start_bracket: (
-              numeric_literal: '6'
-              end_bracket: )
+            function_name:
+              keyword: CURRENT_TIMESTAMP
+            function_contents:
+              bracketed:
+                start_bracket: (
+                numeric_literal: '6'
+                end_bracket: )
       - comma: ','
       - column_definition:
         - naked_identifier: ts8
@@ -168,8 +159,7 @@ file:
         - keyword: TIMESTAMP
         - keyword: 'NULL'
         - keyword: DEFAULT
-        - bare_function:
-            keyword: CURRENT_TIMESTAMP
+        - bare_function: CURRENT_TIMESTAMP
       - comma: ','
       - column_definition:
         - naked_identifier: ts11
@@ -177,10 +167,12 @@ file:
         - keyword: 'NULL'
         - keyword: DEFAULT
         - function:
-            keyword: CURRENT_TIMESTAMP
-            bracketed:
-              start_bracket: (
-              end_bracket: )
+            function_name:
+              keyword: CURRENT_TIMESTAMP
+            function_contents:
+              bracketed:
+                start_bracket: (
+                end_bracket: )
       - comma: ','
       - column_definition:
         - naked_identifier: ts12
@@ -194,12 +186,10 @@ file:
         - keyword: TIMESTAMP
         - keyword: 'NULL'
         - keyword: DEFAULT
-        - bare_function:
-            keyword: NOW
+        - bare_function: NOW
         - keyword: 'ON'
         - keyword: UPDATE
-        - bare_function:
-            keyword: NOW
+        - bare_function: NOW
       - comma: ','
       - column_definition:
         - naked_identifier: ts14
@@ -207,17 +197,21 @@ file:
         - keyword: 'NULL'
         - keyword: DEFAULT
         - function:
-            keyword: NOW
-            bracketed:
-              start_bracket: (
-              end_bracket: )
+            function_name:
+              keyword: NOW
+            function_contents:
+              bracketed:
+                start_bracket: (
+                end_bracket: )
         - keyword: 'ON'
         - keyword: UPDATE
         - function:
-            keyword: NOW
-            bracketed:
-              start_bracket: (
-              end_bracket: )
+            function_name:
+              keyword: NOW
+            function_contents:
+              bracketed:
+                start_bracket: (
+                end_bracket: )
       - comma: ','
       - column_definition:
         - naked_identifier: ts15
@@ -225,12 +219,10 @@ file:
         - keyword: NOT
         - keyword: 'NULL'
         - keyword: DEFAULT
-        - bare_function:
-            keyword: CURRENT_TIMESTAMP
+        - bare_function: CURRENT_TIMESTAMP
         - keyword: 'ON'
         - keyword: UPDATE
-        - bare_function:
-            keyword: CURRENT_TIMESTAMP
+        - bare_function: CURRENT_TIMESTAMP
       - comma: ','
       - column_definition:
         - naked_identifier: ts16
@@ -240,6 +232,5 @@ file:
         - keyword: 'NULL'
         - keyword: 'ON'
         - keyword: UPDATE
-        - bare_function:
-            keyword: CURRENT_TIMESTAMP
+        - bare_function: CURRENT_TIMESTAMP
       - end_bracket: )

--- a/test/fixtures/dialects/mariadb/create_table_datetime.yml
+++ b/test/fixtures/dialects/mariadb/create_table_datetime.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 04711fd76a3d8efbe053513b9a50ce0e2aaf4af87a96e105f521c58ca30810c6
+_hash: 0081f1d35223a72ab130763009bc76ec88ce9353a4fb0a93d2391c7471e4cac1
 file:
   statement:
     create_table_statement:
@@ -17,7 +17,8 @@ file:
         - naked_identifier: created_date
         - keyword: DATETIME
         - keyword: DEFAULT
-        - keyword: CURRENT_TIMESTAMP
+        - bare_function:
+            keyword: CURRENT_TIMESTAMP
         - keyword: NOT
         - keyword: 'NULL'
       - comma: ','
@@ -25,31 +26,37 @@ file:
         - naked_identifier: ts1
         - keyword: TIMESTAMP
         - keyword: DEFAULT
-        - keyword: CURRENT_TIMESTAMP
+        - bare_function:
+            keyword: CURRENT_TIMESTAMP
         - keyword: 'ON'
         - keyword: UPDATE
-        - keyword: CURRENT_TIMESTAMP
+        - bare_function:
+            keyword: CURRENT_TIMESTAMP
       - comma: ','
       - column_definition:
         - naked_identifier: dt1
         - keyword: DATETIME
         - keyword: DEFAULT
-        - keyword: CURRENT_TIMESTAMP
+        - bare_function:
+            keyword: CURRENT_TIMESTAMP
         - keyword: 'ON'
         - keyword: UPDATE
-        - keyword: CURRENT_TIMESTAMP
+        - bare_function:
+            keyword: CURRENT_TIMESTAMP
       - comma: ','
       - column_definition:
         - naked_identifier: ts2
         - keyword: TIMESTAMP
         - keyword: DEFAULT
-        - keyword: CURRENT_TIMESTAMP
+        - bare_function:
+            keyword: CURRENT_TIMESTAMP
       - comma: ','
       - column_definition:
         - naked_identifier: dt2
         - keyword: DATETIME
         - keyword: DEFAULT
-        - keyword: CURRENT_TIMESTAMP
+        - bare_function:
+            keyword: CURRENT_TIMESTAMP
       - comma: ','
       - column_definition:
         - naked_identifier: ts3
@@ -70,7 +77,8 @@ file:
         - numeric_literal: '0'
         - keyword: 'ON'
         - keyword: UPDATE
-        - keyword: CURRENT_TIMESTAMP
+        - bare_function:
+            keyword: CURRENT_TIMESTAMP
       - comma: ','
       - column_definition:
         - naked_identifier: dt4
@@ -79,14 +87,16 @@ file:
         - numeric_literal: '0'
         - keyword: 'ON'
         - keyword: UPDATE
-        - keyword: CURRENT_TIMESTAMP
+        - bare_function:
+            keyword: CURRENT_TIMESTAMP
       - comma: ','
       - column_definition:
         - naked_identifier: ts5
         - keyword: TIMESTAMP
         - keyword: 'ON'
         - keyword: UPDATE
-        - keyword: CURRENT_TIMESTAMP
+        - bare_function:
+            keyword: CURRENT_TIMESTAMP
       - comma: ','
       - column_definition:
         - naked_identifier: ts6
@@ -94,14 +104,16 @@ file:
         - keyword: 'NULL'
         - keyword: 'ON'
         - keyword: UPDATE
-        - keyword: CURRENT_TIMESTAMP
+        - bare_function:
+            keyword: CURRENT_TIMESTAMP
       - comma: ','
       - column_definition:
         - naked_identifier: dt5
         - keyword: DATETIME
         - keyword: 'ON'
         - keyword: UPDATE
-        - keyword: CURRENT_TIMESTAMP
+        - bare_function:
+            keyword: CURRENT_TIMESTAMP
       - comma: ','
       - column_definition:
         - naked_identifier: dt6
@@ -110,7 +122,8 @@ file:
         - keyword: 'NULL'
         - keyword: 'ON'
         - keyword: UPDATE
-        - keyword: CURRENT_TIMESTAMP
+        - bare_function:
+            keyword: CURRENT_TIMESTAMP
       - comma: ','
       - column_definition:
         - naked_identifier: ts7
@@ -121,18 +134,20 @@ file:
               numeric_literal: '6'
               end_bracket: )
         - keyword: DEFAULT
-        - keyword: CURRENT_TIMESTAMP
-        - bracketed:
-            start_bracket: (
-            numeric_literal: '6'
-            end_bracket: )
+        - function:
+            keyword: CURRENT_TIMESTAMP
+            bracketed:
+              start_bracket: (
+              numeric_literal: '6'
+              end_bracket: )
         - keyword: 'ON'
         - keyword: UPDATE
-        - keyword: CURRENT_TIMESTAMP
-        - bracketed:
-            start_bracket: (
-            numeric_literal: '6'
-            end_bracket: )
+        - function:
+            keyword: CURRENT_TIMESTAMP
+            bracketed:
+              start_bracket: (
+              numeric_literal: '6'
+              end_bracket: )
       - comma: ','
       - column_definition:
         - naked_identifier: ts8
@@ -153,17 +168,19 @@ file:
         - keyword: TIMESTAMP
         - keyword: 'NULL'
         - keyword: DEFAULT
-        - keyword: CURRENT_TIMESTAMP
+        - bare_function:
+            keyword: CURRENT_TIMESTAMP
       - comma: ','
       - column_definition:
         - naked_identifier: ts11
         - keyword: TIMESTAMP
         - keyword: 'NULL'
         - keyword: DEFAULT
-        - keyword: CURRENT_TIMESTAMP
-        - bracketed:
-            start_bracket: (
-            end_bracket: )
+        - function:
+            keyword: CURRENT_TIMESTAMP
+            bracketed:
+              start_bracket: (
+              end_bracket: )
       - comma: ','
       - column_definition:
         - naked_identifier: ts12
@@ -177,26 +194,30 @@ file:
         - keyword: TIMESTAMP
         - keyword: 'NULL'
         - keyword: DEFAULT
-        - keyword: NOW
+        - bare_function:
+            keyword: NOW
         - keyword: 'ON'
         - keyword: UPDATE
-        - keyword: NOW
+        - bare_function:
+            keyword: NOW
       - comma: ','
       - column_definition:
         - naked_identifier: ts14
         - keyword: TIMESTAMP
         - keyword: 'NULL'
         - keyword: DEFAULT
-        - keyword: NOW
-        - bracketed:
-            start_bracket: (
-            end_bracket: )
+        - function:
+            keyword: NOW
+            bracketed:
+              start_bracket: (
+              end_bracket: )
         - keyword: 'ON'
         - keyword: UPDATE
-        - keyword: NOW
-        - bracketed:
-            start_bracket: (
-            end_bracket: )
+        - function:
+            keyword: NOW
+            bracketed:
+              start_bracket: (
+              end_bracket: )
       - comma: ','
       - column_definition:
         - naked_identifier: ts15
@@ -204,10 +225,12 @@ file:
         - keyword: NOT
         - keyword: 'NULL'
         - keyword: DEFAULT
-        - keyword: CURRENT_TIMESTAMP
+        - bare_function:
+            keyword: CURRENT_TIMESTAMP
         - keyword: 'ON'
         - keyword: UPDATE
-        - keyword: CURRENT_TIMESTAMP
+        - bare_function:
+            keyword: CURRENT_TIMESTAMP
       - comma: ','
       - column_definition:
         - naked_identifier: ts16
@@ -217,5 +240,6 @@ file:
         - keyword: 'NULL'
         - keyword: 'ON'
         - keyword: UPDATE
-        - keyword: CURRENT_TIMESTAMP
+        - bare_function:
+            keyword: CURRENT_TIMESTAMP
       - end_bracket: )

--- a/test/fixtures/dialects/mariadb/create_table_null_position.yml
+++ b/test/fixtures/dialects/mariadb/create_table_null_position.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 15f782abb1331d16b725b8b668192875e574c8c085ef79377398499dd95efbf1
+_hash: ce2b3076718cc8f6e0d3e01b937a19687f7d70cf24f56fc3dc3be627bb4a3738
 file:
   statement:
     create_table_statement:
@@ -22,12 +22,14 @@ file:
         - naked_identifier: updated_at1
         - keyword: timestamp
         - keyword: default
-        - keyword: CURRENT_TIMESTAMP
+        - bare_function:
+            keyword: CURRENT_TIMESTAMP
         - keyword: not
         - keyword: 'null'
         - keyword: 'on'
         - keyword: update
-        - keyword: CURRENT_TIMESTAMP
+        - bare_function:
+            keyword: CURRENT_TIMESTAMP
       - comma: ','
       - column_definition:
         - naked_identifier: updated_at2
@@ -35,19 +37,23 @@ file:
         - keyword: not
         - keyword: 'null'
         - keyword: default
-        - keyword: CURRENT_TIMESTAMP
+        - bare_function:
+            keyword: CURRENT_TIMESTAMP
         - keyword: 'on'
         - keyword: update
-        - keyword: CURRENT_TIMESTAMP
+        - bare_function:
+            keyword: CURRENT_TIMESTAMP
       - comma: ','
       - column_definition:
         - naked_identifier: updated_at3
         - keyword: timestamp
         - keyword: default
-        - keyword: CURRENT_TIMESTAMP
+        - bare_function:
+            keyword: CURRENT_TIMESTAMP
         - keyword: 'on'
         - keyword: update
-        - keyword: CURRENT_TIMESTAMP
+        - bare_function:
+            keyword: CURRENT_TIMESTAMP
         - keyword: not
         - keyword: 'null'
       - comma: ','

--- a/test/fixtures/dialects/mariadb/create_table_null_position.yml
+++ b/test/fixtures/dialects/mariadb/create_table_null_position.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: ce2b3076718cc8f6e0d3e01b937a19687f7d70cf24f56fc3dc3be627bb4a3738
+_hash: c09d2fd204488b6e2d222ab2a42a3d5b0486131e6af9135ce9971bc3f588b50a
 file:
   statement:
     create_table_statement:
@@ -22,14 +22,12 @@ file:
         - naked_identifier: updated_at1
         - keyword: timestamp
         - keyword: default
-        - bare_function:
-            keyword: CURRENT_TIMESTAMP
+        - bare_function: CURRENT_TIMESTAMP
         - keyword: not
         - keyword: 'null'
         - keyword: 'on'
         - keyword: update
-        - bare_function:
-            keyword: CURRENT_TIMESTAMP
+        - bare_function: CURRENT_TIMESTAMP
       - comma: ','
       - column_definition:
         - naked_identifier: updated_at2
@@ -37,23 +35,19 @@ file:
         - keyword: not
         - keyword: 'null'
         - keyword: default
-        - bare_function:
-            keyword: CURRENT_TIMESTAMP
+        - bare_function: CURRENT_TIMESTAMP
         - keyword: 'on'
         - keyword: update
-        - bare_function:
-            keyword: CURRENT_TIMESTAMP
+        - bare_function: CURRENT_TIMESTAMP
       - comma: ','
       - column_definition:
         - naked_identifier: updated_at3
         - keyword: timestamp
         - keyword: default
-        - bare_function:
-            keyword: CURRENT_TIMESTAMP
+        - bare_function: CURRENT_TIMESTAMP
         - keyword: 'on'
         - keyword: update
-        - bare_function:
-            keyword: CURRENT_TIMESTAMP
+        - bare_function: CURRENT_TIMESTAMP
         - keyword: not
         - keyword: 'null'
       - comma: ','

--- a/test/fixtures/dialects/mysql/alter_table.sql
+++ b/test/fixtures/dialects/mysql/alter_table.sql
@@ -108,6 +108,18 @@ ALTER TABLE my_table MODIFY num INT UNSIGNED ZEROFILL NOT NULL;
 
 ALTER TABLE my_table MODIFY num INT ZEROFILL UNSIGNED NOT NULL;
 
+ALTER TABLE t MODIFY time_updated timestamp NOT NULL
+DEFAULT current_timestamp()
+ON UPDATE current_timestamp();
+
+ALTER TABLE t MODIFY time_updated timestamp NOT NULL
+DEFAULT localtime
+ON UPDATE localtime();
+
+ALTER TABLE t MODIFY time_updated timestamp NOT NULL
+DEFAULT localtimestamp
+ON UPDATE localtimestamp();
+
 ALTER TABLE T ALTER C DROP DEFAULT;
 
 ALTER TABLE T ALTER C SET DEFAULT 'some default';

--- a/test/fixtures/dialects/mysql/alter_table.yml
+++ b/test/fixtures/dialects/mysql/alter_table.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 873319102364c0d27163ec2048ed6f4476bb90317363960365987d1f1339127b
+_hash: d588eceffe432f96f6fe07bc8c3e9476e1b5daae278609177a424c616a412074
 file:
 - statement:
     alter_table_statement:
@@ -949,6 +949,78 @@ file:
         column_constraint_segment:
         - keyword: NOT
         - keyword: 'NULL'
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: t
+    - keyword: MODIFY
+    - column_definition:
+      - naked_identifier: time_updated
+      - keyword: timestamp
+      - keyword: NOT
+      - keyword: 'NULL'
+      - keyword: DEFAULT
+      - function:
+          keyword: current_timestamp
+          bracketed:
+            start_bracket: (
+            end_bracket: )
+      - keyword: 'ON'
+      - keyword: UPDATE
+      - function:
+          keyword: current_timestamp
+          bracketed:
+            start_bracket: (
+            end_bracket: )
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: t
+    - keyword: MODIFY
+    - column_definition:
+      - naked_identifier: time_updated
+      - keyword: timestamp
+      - keyword: NOT
+      - keyword: 'NULL'
+      - keyword: DEFAULT
+      - bare_function:
+          keyword: localtime
+      - keyword: 'ON'
+      - keyword: UPDATE
+      - function:
+          keyword: localtime
+          bracketed:
+            start_bracket: (
+            end_bracket: )
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: t
+    - keyword: MODIFY
+    - column_definition:
+      - naked_identifier: time_updated
+      - keyword: timestamp
+      - keyword: NOT
+      - keyword: 'NULL'
+      - keyword: DEFAULT
+      - bare_function:
+          keyword: localtimestamp
+      - keyword: 'ON'
+      - keyword: UPDATE
+      - function:
+          keyword: localtimestamp
+          bracketed:
+            start_bracket: (
+            end_bracket: )
 - statement_terminator: ;
 - statement:
     alter_table_statement:

--- a/test/fixtures/dialects/mysql/alter_table.yml
+++ b/test/fixtures/dialects/mysql/alter_table.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: d588eceffe432f96f6fe07bc8c3e9476e1b5daae278609177a424c616a412074
+_hash: df8a42fc85ecff13b46990c670c67d1e556e4910eca549a220059dad24c33d52
 file:
 - statement:
     alter_table_statement:
@@ -964,17 +964,21 @@ file:
       - keyword: 'NULL'
       - keyword: DEFAULT
       - function:
-          keyword: current_timestamp
-          bracketed:
-            start_bracket: (
-            end_bracket: )
+          function_name:
+            keyword: current_timestamp
+          function_contents:
+            bracketed:
+              start_bracket: (
+              end_bracket: )
       - keyword: 'ON'
       - keyword: UPDATE
       - function:
-          keyword: current_timestamp
-          bracketed:
-            start_bracket: (
-            end_bracket: )
+          function_name:
+            keyword: current_timestamp
+          function_contents:
+            bracketed:
+              start_bracket: (
+              end_bracket: )
 - statement_terminator: ;
 - statement:
     alter_table_statement:
@@ -989,15 +993,16 @@ file:
       - keyword: NOT
       - keyword: 'NULL'
       - keyword: DEFAULT
-      - bare_function:
-          keyword: localtime
+      - bare_function: localtime
       - keyword: 'ON'
       - keyword: UPDATE
       - function:
-          keyword: localtime
-          bracketed:
-            start_bracket: (
-            end_bracket: )
+          function_name:
+            keyword: localtime
+          function_contents:
+            bracketed:
+              start_bracket: (
+              end_bracket: )
 - statement_terminator: ;
 - statement:
     alter_table_statement:
@@ -1012,15 +1017,16 @@ file:
       - keyword: NOT
       - keyword: 'NULL'
       - keyword: DEFAULT
-      - bare_function:
-          keyword: localtimestamp
+      - bare_function: localtimestamp
       - keyword: 'ON'
       - keyword: UPDATE
       - function:
-          keyword: localtimestamp
-          bracketed:
-            start_bracket: (
-            end_bracket: )
+          function_name:
+            keyword: localtimestamp
+          function_contents:
+            bracketed:
+              start_bracket: (
+              end_bracket: )
 - statement_terminator: ;
 - statement:
     alter_table_statement:

--- a/test/fixtures/dialects/mysql/create_table_datetime.yml
+++ b/test/fixtures/dialects/mysql/create_table_datetime.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 0081f1d35223a72ab130763009bc76ec88ce9353a4fb0a93d2391c7471e4cac1
+_hash: af439b25493cbb1c345f13de8641105858fabbfda94e6df7b9531102c87ede63
 file:
   statement:
     create_table_statement:
@@ -17,8 +17,7 @@ file:
         - naked_identifier: created_date
         - keyword: DATETIME
         - keyword: DEFAULT
-        - bare_function:
-            keyword: CURRENT_TIMESTAMP
+        - bare_function: CURRENT_TIMESTAMP
         - keyword: NOT
         - keyword: 'NULL'
       - comma: ','
@@ -26,37 +25,31 @@ file:
         - naked_identifier: ts1
         - keyword: TIMESTAMP
         - keyword: DEFAULT
-        - bare_function:
-            keyword: CURRENT_TIMESTAMP
+        - bare_function: CURRENT_TIMESTAMP
         - keyword: 'ON'
         - keyword: UPDATE
-        - bare_function:
-            keyword: CURRENT_TIMESTAMP
+        - bare_function: CURRENT_TIMESTAMP
       - comma: ','
       - column_definition:
         - naked_identifier: dt1
         - keyword: DATETIME
         - keyword: DEFAULT
-        - bare_function:
-            keyword: CURRENT_TIMESTAMP
+        - bare_function: CURRENT_TIMESTAMP
         - keyword: 'ON'
         - keyword: UPDATE
-        - bare_function:
-            keyword: CURRENT_TIMESTAMP
+        - bare_function: CURRENT_TIMESTAMP
       - comma: ','
       - column_definition:
         - naked_identifier: ts2
         - keyword: TIMESTAMP
         - keyword: DEFAULT
-        - bare_function:
-            keyword: CURRENT_TIMESTAMP
+        - bare_function: CURRENT_TIMESTAMP
       - comma: ','
       - column_definition:
         - naked_identifier: dt2
         - keyword: DATETIME
         - keyword: DEFAULT
-        - bare_function:
-            keyword: CURRENT_TIMESTAMP
+        - bare_function: CURRENT_TIMESTAMP
       - comma: ','
       - column_definition:
         - naked_identifier: ts3
@@ -77,8 +70,7 @@ file:
         - numeric_literal: '0'
         - keyword: 'ON'
         - keyword: UPDATE
-        - bare_function:
-            keyword: CURRENT_TIMESTAMP
+        - bare_function: CURRENT_TIMESTAMP
       - comma: ','
       - column_definition:
         - naked_identifier: dt4
@@ -87,16 +79,14 @@ file:
         - numeric_literal: '0'
         - keyword: 'ON'
         - keyword: UPDATE
-        - bare_function:
-            keyword: CURRENT_TIMESTAMP
+        - bare_function: CURRENT_TIMESTAMP
       - comma: ','
       - column_definition:
         - naked_identifier: ts5
         - keyword: TIMESTAMP
         - keyword: 'ON'
         - keyword: UPDATE
-        - bare_function:
-            keyword: CURRENT_TIMESTAMP
+        - bare_function: CURRENT_TIMESTAMP
       - comma: ','
       - column_definition:
         - naked_identifier: ts6
@@ -104,16 +94,14 @@ file:
         - keyword: 'NULL'
         - keyword: 'ON'
         - keyword: UPDATE
-        - bare_function:
-            keyword: CURRENT_TIMESTAMP
+        - bare_function: CURRENT_TIMESTAMP
       - comma: ','
       - column_definition:
         - naked_identifier: dt5
         - keyword: DATETIME
         - keyword: 'ON'
         - keyword: UPDATE
-        - bare_function:
-            keyword: CURRENT_TIMESTAMP
+        - bare_function: CURRENT_TIMESTAMP
       - comma: ','
       - column_definition:
         - naked_identifier: dt6
@@ -122,8 +110,7 @@ file:
         - keyword: 'NULL'
         - keyword: 'ON'
         - keyword: UPDATE
-        - bare_function:
-            keyword: CURRENT_TIMESTAMP
+        - bare_function: CURRENT_TIMESTAMP
       - comma: ','
       - column_definition:
         - naked_identifier: ts7
@@ -135,19 +122,23 @@ file:
               end_bracket: )
         - keyword: DEFAULT
         - function:
-            keyword: CURRENT_TIMESTAMP
-            bracketed:
-              start_bracket: (
-              numeric_literal: '6'
-              end_bracket: )
+            function_name:
+              keyword: CURRENT_TIMESTAMP
+            function_contents:
+              bracketed:
+                start_bracket: (
+                numeric_literal: '6'
+                end_bracket: )
         - keyword: 'ON'
         - keyword: UPDATE
         - function:
-            keyword: CURRENT_TIMESTAMP
-            bracketed:
-              start_bracket: (
-              numeric_literal: '6'
-              end_bracket: )
+            function_name:
+              keyword: CURRENT_TIMESTAMP
+            function_contents:
+              bracketed:
+                start_bracket: (
+                numeric_literal: '6'
+                end_bracket: )
       - comma: ','
       - column_definition:
         - naked_identifier: ts8
@@ -168,8 +159,7 @@ file:
         - keyword: TIMESTAMP
         - keyword: 'NULL'
         - keyword: DEFAULT
-        - bare_function:
-            keyword: CURRENT_TIMESTAMP
+        - bare_function: CURRENT_TIMESTAMP
       - comma: ','
       - column_definition:
         - naked_identifier: ts11
@@ -177,10 +167,12 @@ file:
         - keyword: 'NULL'
         - keyword: DEFAULT
         - function:
-            keyword: CURRENT_TIMESTAMP
-            bracketed:
-              start_bracket: (
-              end_bracket: )
+            function_name:
+              keyword: CURRENT_TIMESTAMP
+            function_contents:
+              bracketed:
+                start_bracket: (
+                end_bracket: )
       - comma: ','
       - column_definition:
         - naked_identifier: ts12
@@ -194,12 +186,10 @@ file:
         - keyword: TIMESTAMP
         - keyword: 'NULL'
         - keyword: DEFAULT
-        - bare_function:
-            keyword: NOW
+        - bare_function: NOW
         - keyword: 'ON'
         - keyword: UPDATE
-        - bare_function:
-            keyword: NOW
+        - bare_function: NOW
       - comma: ','
       - column_definition:
         - naked_identifier: ts14
@@ -207,17 +197,21 @@ file:
         - keyword: 'NULL'
         - keyword: DEFAULT
         - function:
-            keyword: NOW
-            bracketed:
-              start_bracket: (
-              end_bracket: )
+            function_name:
+              keyword: NOW
+            function_contents:
+              bracketed:
+                start_bracket: (
+                end_bracket: )
         - keyword: 'ON'
         - keyword: UPDATE
         - function:
-            keyword: NOW
-            bracketed:
-              start_bracket: (
-              end_bracket: )
+            function_name:
+              keyword: NOW
+            function_contents:
+              bracketed:
+                start_bracket: (
+                end_bracket: )
       - comma: ','
       - column_definition:
         - naked_identifier: ts15
@@ -225,12 +219,10 @@ file:
         - keyword: NOT
         - keyword: 'NULL'
         - keyword: DEFAULT
-        - bare_function:
-            keyword: CURRENT_TIMESTAMP
+        - bare_function: CURRENT_TIMESTAMP
         - keyword: 'ON'
         - keyword: UPDATE
-        - bare_function:
-            keyword: CURRENT_TIMESTAMP
+        - bare_function: CURRENT_TIMESTAMP
       - comma: ','
       - column_definition:
         - naked_identifier: ts16
@@ -240,6 +232,5 @@ file:
         - keyword: 'NULL'
         - keyword: 'ON'
         - keyword: UPDATE
-        - bare_function:
-            keyword: CURRENT_TIMESTAMP
+        - bare_function: CURRENT_TIMESTAMP
       - end_bracket: )

--- a/test/fixtures/dialects/mysql/create_table_datetime.yml
+++ b/test/fixtures/dialects/mysql/create_table_datetime.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 04711fd76a3d8efbe053513b9a50ce0e2aaf4af87a96e105f521c58ca30810c6
+_hash: 0081f1d35223a72ab130763009bc76ec88ce9353a4fb0a93d2391c7471e4cac1
 file:
   statement:
     create_table_statement:
@@ -17,7 +17,8 @@ file:
         - naked_identifier: created_date
         - keyword: DATETIME
         - keyword: DEFAULT
-        - keyword: CURRENT_TIMESTAMP
+        - bare_function:
+            keyword: CURRENT_TIMESTAMP
         - keyword: NOT
         - keyword: 'NULL'
       - comma: ','
@@ -25,31 +26,37 @@ file:
         - naked_identifier: ts1
         - keyword: TIMESTAMP
         - keyword: DEFAULT
-        - keyword: CURRENT_TIMESTAMP
+        - bare_function:
+            keyword: CURRENT_TIMESTAMP
         - keyword: 'ON'
         - keyword: UPDATE
-        - keyword: CURRENT_TIMESTAMP
+        - bare_function:
+            keyword: CURRENT_TIMESTAMP
       - comma: ','
       - column_definition:
         - naked_identifier: dt1
         - keyword: DATETIME
         - keyword: DEFAULT
-        - keyword: CURRENT_TIMESTAMP
+        - bare_function:
+            keyword: CURRENT_TIMESTAMP
         - keyword: 'ON'
         - keyword: UPDATE
-        - keyword: CURRENT_TIMESTAMP
+        - bare_function:
+            keyword: CURRENT_TIMESTAMP
       - comma: ','
       - column_definition:
         - naked_identifier: ts2
         - keyword: TIMESTAMP
         - keyword: DEFAULT
-        - keyword: CURRENT_TIMESTAMP
+        - bare_function:
+            keyword: CURRENT_TIMESTAMP
       - comma: ','
       - column_definition:
         - naked_identifier: dt2
         - keyword: DATETIME
         - keyword: DEFAULT
-        - keyword: CURRENT_TIMESTAMP
+        - bare_function:
+            keyword: CURRENT_TIMESTAMP
       - comma: ','
       - column_definition:
         - naked_identifier: ts3
@@ -70,7 +77,8 @@ file:
         - numeric_literal: '0'
         - keyword: 'ON'
         - keyword: UPDATE
-        - keyword: CURRENT_TIMESTAMP
+        - bare_function:
+            keyword: CURRENT_TIMESTAMP
       - comma: ','
       - column_definition:
         - naked_identifier: dt4
@@ -79,14 +87,16 @@ file:
         - numeric_literal: '0'
         - keyword: 'ON'
         - keyword: UPDATE
-        - keyword: CURRENT_TIMESTAMP
+        - bare_function:
+            keyword: CURRENT_TIMESTAMP
       - comma: ','
       - column_definition:
         - naked_identifier: ts5
         - keyword: TIMESTAMP
         - keyword: 'ON'
         - keyword: UPDATE
-        - keyword: CURRENT_TIMESTAMP
+        - bare_function:
+            keyword: CURRENT_TIMESTAMP
       - comma: ','
       - column_definition:
         - naked_identifier: ts6
@@ -94,14 +104,16 @@ file:
         - keyword: 'NULL'
         - keyword: 'ON'
         - keyword: UPDATE
-        - keyword: CURRENT_TIMESTAMP
+        - bare_function:
+            keyword: CURRENT_TIMESTAMP
       - comma: ','
       - column_definition:
         - naked_identifier: dt5
         - keyword: DATETIME
         - keyword: 'ON'
         - keyword: UPDATE
-        - keyword: CURRENT_TIMESTAMP
+        - bare_function:
+            keyword: CURRENT_TIMESTAMP
       - comma: ','
       - column_definition:
         - naked_identifier: dt6
@@ -110,7 +122,8 @@ file:
         - keyword: 'NULL'
         - keyword: 'ON'
         - keyword: UPDATE
-        - keyword: CURRENT_TIMESTAMP
+        - bare_function:
+            keyword: CURRENT_TIMESTAMP
       - comma: ','
       - column_definition:
         - naked_identifier: ts7
@@ -121,18 +134,20 @@ file:
               numeric_literal: '6'
               end_bracket: )
         - keyword: DEFAULT
-        - keyword: CURRENT_TIMESTAMP
-        - bracketed:
-            start_bracket: (
-            numeric_literal: '6'
-            end_bracket: )
+        - function:
+            keyword: CURRENT_TIMESTAMP
+            bracketed:
+              start_bracket: (
+              numeric_literal: '6'
+              end_bracket: )
         - keyword: 'ON'
         - keyword: UPDATE
-        - keyword: CURRENT_TIMESTAMP
-        - bracketed:
-            start_bracket: (
-            numeric_literal: '6'
-            end_bracket: )
+        - function:
+            keyword: CURRENT_TIMESTAMP
+            bracketed:
+              start_bracket: (
+              numeric_literal: '6'
+              end_bracket: )
       - comma: ','
       - column_definition:
         - naked_identifier: ts8
@@ -153,17 +168,19 @@ file:
         - keyword: TIMESTAMP
         - keyword: 'NULL'
         - keyword: DEFAULT
-        - keyword: CURRENT_TIMESTAMP
+        - bare_function:
+            keyword: CURRENT_TIMESTAMP
       - comma: ','
       - column_definition:
         - naked_identifier: ts11
         - keyword: TIMESTAMP
         - keyword: 'NULL'
         - keyword: DEFAULT
-        - keyword: CURRENT_TIMESTAMP
-        - bracketed:
-            start_bracket: (
-            end_bracket: )
+        - function:
+            keyword: CURRENT_TIMESTAMP
+            bracketed:
+              start_bracket: (
+              end_bracket: )
       - comma: ','
       - column_definition:
         - naked_identifier: ts12
@@ -177,26 +194,30 @@ file:
         - keyword: TIMESTAMP
         - keyword: 'NULL'
         - keyword: DEFAULT
-        - keyword: NOW
+        - bare_function:
+            keyword: NOW
         - keyword: 'ON'
         - keyword: UPDATE
-        - keyword: NOW
+        - bare_function:
+            keyword: NOW
       - comma: ','
       - column_definition:
         - naked_identifier: ts14
         - keyword: TIMESTAMP
         - keyword: 'NULL'
         - keyword: DEFAULT
-        - keyword: NOW
-        - bracketed:
-            start_bracket: (
-            end_bracket: )
+        - function:
+            keyword: NOW
+            bracketed:
+              start_bracket: (
+              end_bracket: )
         - keyword: 'ON'
         - keyword: UPDATE
-        - keyword: NOW
-        - bracketed:
-            start_bracket: (
-            end_bracket: )
+        - function:
+            keyword: NOW
+            bracketed:
+              start_bracket: (
+              end_bracket: )
       - comma: ','
       - column_definition:
         - naked_identifier: ts15
@@ -204,10 +225,12 @@ file:
         - keyword: NOT
         - keyword: 'NULL'
         - keyword: DEFAULT
-        - keyword: CURRENT_TIMESTAMP
+        - bare_function:
+            keyword: CURRENT_TIMESTAMP
         - keyword: 'ON'
         - keyword: UPDATE
-        - keyword: CURRENT_TIMESTAMP
+        - bare_function:
+            keyword: CURRENT_TIMESTAMP
       - comma: ','
       - column_definition:
         - naked_identifier: ts16
@@ -217,5 +240,6 @@ file:
         - keyword: 'NULL'
         - keyword: 'ON'
         - keyword: UPDATE
-        - keyword: CURRENT_TIMESTAMP
+        - bare_function:
+            keyword: CURRENT_TIMESTAMP
       - end_bracket: )

--- a/test/fixtures/dialects/mysql/create_table_null_position.yml
+++ b/test/fixtures/dialects/mysql/create_table_null_position.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 15f782abb1331d16b725b8b668192875e574c8c085ef79377398499dd95efbf1
+_hash: ce2b3076718cc8f6e0d3e01b937a19687f7d70cf24f56fc3dc3be627bb4a3738
 file:
   statement:
     create_table_statement:
@@ -22,12 +22,14 @@ file:
         - naked_identifier: updated_at1
         - keyword: timestamp
         - keyword: default
-        - keyword: CURRENT_TIMESTAMP
+        - bare_function:
+            keyword: CURRENT_TIMESTAMP
         - keyword: not
         - keyword: 'null'
         - keyword: 'on'
         - keyword: update
-        - keyword: CURRENT_TIMESTAMP
+        - bare_function:
+            keyword: CURRENT_TIMESTAMP
       - comma: ','
       - column_definition:
         - naked_identifier: updated_at2
@@ -35,19 +37,23 @@ file:
         - keyword: not
         - keyword: 'null'
         - keyword: default
-        - keyword: CURRENT_TIMESTAMP
+        - bare_function:
+            keyword: CURRENT_TIMESTAMP
         - keyword: 'on'
         - keyword: update
-        - keyword: CURRENT_TIMESTAMP
+        - bare_function:
+            keyword: CURRENT_TIMESTAMP
       - comma: ','
       - column_definition:
         - naked_identifier: updated_at3
         - keyword: timestamp
         - keyword: default
-        - keyword: CURRENT_TIMESTAMP
+        - bare_function:
+            keyword: CURRENT_TIMESTAMP
         - keyword: 'on'
         - keyword: update
-        - keyword: CURRENT_TIMESTAMP
+        - bare_function:
+            keyword: CURRENT_TIMESTAMP
         - keyword: not
         - keyword: 'null'
       - comma: ','

--- a/test/fixtures/dialects/mysql/create_table_null_position.yml
+++ b/test/fixtures/dialects/mysql/create_table_null_position.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: ce2b3076718cc8f6e0d3e01b937a19687f7d70cf24f56fc3dc3be627bb4a3738
+_hash: c09d2fd204488b6e2d222ab2a42a3d5b0486131e6af9135ce9971bc3f588b50a
 file:
   statement:
     create_table_statement:
@@ -22,14 +22,12 @@ file:
         - naked_identifier: updated_at1
         - keyword: timestamp
         - keyword: default
-        - bare_function:
-            keyword: CURRENT_TIMESTAMP
+        - bare_function: CURRENT_TIMESTAMP
         - keyword: not
         - keyword: 'null'
         - keyword: 'on'
         - keyword: update
-        - bare_function:
-            keyword: CURRENT_TIMESTAMP
+        - bare_function: CURRENT_TIMESTAMP
       - comma: ','
       - column_definition:
         - naked_identifier: updated_at2
@@ -37,23 +35,19 @@ file:
         - keyword: not
         - keyword: 'null'
         - keyword: default
-        - bare_function:
-            keyword: CURRENT_TIMESTAMP
+        - bare_function: CURRENT_TIMESTAMP
         - keyword: 'on'
         - keyword: update
-        - bare_function:
-            keyword: CURRENT_TIMESTAMP
+        - bare_function: CURRENT_TIMESTAMP
       - comma: ','
       - column_definition:
         - naked_identifier: updated_at3
         - keyword: timestamp
         - keyword: default
-        - bare_function:
-            keyword: CURRENT_TIMESTAMP
+        - bare_function: CURRENT_TIMESTAMP
         - keyword: 'on'
         - keyword: update
-        - bare_function:
-            keyword: CURRENT_TIMESTAMP
+        - bare_function: CURRENT_TIMESTAMP
         - keyword: not
         - keyword: 'null'
       - comma: ','


### PR DESCRIPTION
### Brief summary of the change made

- support `CURRENT_TIMESTAMP`, `CURRENT_TIMESTAMP()`, `NOW()`, `LOCALTIME`, `LOCALTIME()`, `LOCALTIMESTAMP`, and `LOCALTIMESTAMP()` in MySQL timestamp/datetime `DEFAULT` and `ON UPDATE` clauses
- simplify the MySQL dialect grammar for these special-case column definitions
- add MySQL and MariaDB fixture coverage for `ALTER TABLE ... MODIFY ...` cases

Fixes #7880

### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds MySQL/MariaDB support for `CURRENT_TIMESTAMP`, `NOW`, `LOCALTIME`, and `LOCALTIMESTAMP` in `DEFAULT` and `ON UPDATE` for both CREATE TABLE and `ALTER TABLE ... MODIFY`, with or without parentheses. Simplifies the grammar and standardizes parse output; fixes #7880.

- New Features
  - Support these functions in `DEFAULT`/`ON UPDATE` for TIMESTAMP/DATETIME in create and alter contexts, including `current_timestamp()` and bare `localtime`/`localtimestamp`.

- Refactors
  - Introduce dedicated segments for function name/contents and use `BareFunctionSegment` for bare forms; add `NOW`, `LOCALTIME`, `LOCALTIMESTAMP` to `bare_functions`; regenerate MySQL/MariaDB and Doris fixtures.

<sup>Written for commit e777fb4badd50c197a33eaaabfd8b93a9b5d0d17. Summary will update on new commits. <a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/7885?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

