### PR TITLE
Fix ST11 false positives for LEFT SEMI and LEFT ANTI joins

### DIFF
--- a/src/sqlfluff/rules/structure/ST11.py
+++ b/src/sqlfluff/rules/structure/ST11.py
@@ -178,8 +178,14 @@ class Rule_ST11(BaseRule):
                 ):
                     ref = self._extract_references_from_expression(from_expression_elem)
                     # Only mark it as a possible issue if it's an explicit LEFT, RIGHT
-                    # or FULL join.
-                    if ref and join_keywords.intersection({"FULL", "LEFT", "RIGHT"}):
+                    # or FULL join. Exclude SEMI and ANTI joins because they are
+                    # expected to filter rows without projecting columns from the
+                    # joined table.
+                    if (
+                        ref
+                        and join_keywords.intersection({"FULL", "LEFT", "RIGHT"})
+                        and not join_keywords.intersection({"ANTI", "SEMI"})
+                    ):
                         joined_tables.append((ref, from_expression_elem))
                         _this_clause_refs.append(ref)
                     # If we have functions in the table_expression, we referenced them,

--- a/test/fixtures/rules/std_rule_cases/ST11.yml
+++ b/test/fixtures/rules/std_rule_cases/ST11.yml
@@ -78,6 +78,32 @@ test_pass_inner_unreferenced:
     from a
     inner join b using(x)
 
+test_pass_left_semi_unreferenced:
+  # LEFT SEMI joins filter rows from the left side, so they do not need
+  # to project columns from the joined table.
+  pass_str: |
+    SELECT
+        employee.id
+    FROM employee
+    LEFT SEMI JOIN department
+        ON employee.deptno = department.deptno
+  configs:
+    core:
+      dialect: sparksql
+
+test_pass_left_anti_unreferenced:
+  # LEFT ANTI joins filter rows from the left side, so they do not need
+  # to project columns from the joined table.
+  pass_str: |
+    SELECT
+        employee.id
+    FROM employee
+    LEFT ANTI JOIN department
+        ON employee.deptno = department.deptno
+  configs:
+    core:
+      dialect: sparksql
+
 test_pass_unqualified_unreferenced:
   # Same as above, but an implicit INNER (unqualified joins are usually
   # interpreted as inner joins).


### PR DESCRIPTION
### Brief summary of the change made

Fixes #7886.

ST11 (`structure.unused_join`) now excludes `SEMI` and `ANTI` joins from its unused outer-join checks, so dialects such as SparkSQL no longer report false positives for `LEFT SEMI JOIN` and `LEFT ANTI JOIN` patterns that intentionally filter rows without projecting columns from the joined table.

Added focused ST11 regression cases for SparkSQL `LEFT SEMI` and `LEFT ANTI` joins.

### Are there any other side effects of this change that we should be aware of?

No expected side effects. This only narrows ST11's candidate joined tables by skipping joins whose keyword set includes `SEMI` or `ANTI`.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - [x] `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - [ ] `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - [ ] Full autofix test cases in `test/fixtures/linter/autofix`.
  - [ ] Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.

### Validation

- `python -m pytest test/rules/yaml_test_cases_test.py -k ST11 -q` — `32 passed, 2148 deselected`
- `git diff --check` — passed

### AI-assisted contribution disclosure

This contribution was AI-assisted using Hermes Agent. The code change, regression tests, duplicate-PR gate checks, and validation commands above were reviewed and run locally before opening this PR.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #7886. ST11 now ignores LEFT SEMI and LEFT ANTI joins when checking for unused outer joins, removing false positives in SparkSQL.

- **Bug Fixes**
  - Skip joins whose keywords include SEMI or ANTI when evaluating unused LEFT/RIGHT/FULL joins.
  - Added SparkSQL regression tests for LEFT SEMI and LEFT ANTI cases.

<sup>Written for commit 4cc43ec30c6052d457f257c52829d56873a9289e. Summary will update on new commits. <a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/7887?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

