### PR TITLE
Fix duplicate-word typos in docstrings and documentation

### DIFF
--- a/docs/source/guides/contributing/dialect.rst
+++ b/docs/source/guides/contributing/dialect.rst
@@ -234,7 +234,7 @@ to deal with that whole comment as one lexed block and so we don't need to
 define how to parse it (we even give that a parsing segment name here -
 :code:`CommentSegment`).
 
-For simple grammar addition, you won't need to to touch the lexing definitions
+For simple grammar addition, you won't need to touch the lexing definitions
 as they usually cover most common ones already. But for slightly more
 complicated ones, you may have to add to this. So if you see lexing errors
 then you may have to add something here.

--- a/docs/source/guides/contributing/git.rst
+++ b/docs/source/guides/contributing/git.rst
@@ -207,7 +207,7 @@ GitHub Forks
 As well as branches, GitHub has the concept of *forks*, which basically
 means taking a complete copy of the repo (and all its branches at that
 time) into your own GitHub account. You can then create a branch in that
-fork, and then open a pull request to to merge code from your branch on
+fork, and then open a pull request to merge code from your branch on
 your fork, all the way back to the original repo (called the *upstream*
 repo). It may sound like an Inception level of abstraction and confusion
 but it actually works quite well once you get your head around it.

--- a/docsv/development/dialect.md
+++ b/docsv/development/dialect.md
@@ -201,7 +201,7 @@ to deal with that whole comment as one lexed block and so we don't need to
 define how to parse it (we even give that a parsing segment name here -
 `CommentSegment`).
 
-For simple grammar addition, you won't need to to touch the lexing definitions
+For simple grammar addition, you won't need to touch the lexing definitions
 as they usually cover most common ones already. But for slightly more
 complicated ones, you may have to add to this. So if you see lexing errors
 then you may have to add something here.

--- a/src/sqlfluff/cli/commands.py
+++ b/src/sqlfluff/cli/commands.py
@@ -170,7 +170,7 @@ def set_logging_level(
 
     Implementation: If `logger` is not specified, the handler
     is attached to the `sqlfluff` logger. If it is specified
-    then it attaches the the logger in question. In addition
+    then it attaches the logger in question. In addition
     if `logger` is specified, then that logger will also
     not propagate.
     """

--- a/src/sqlfluff/core/config/loader.py
+++ b/src/sqlfluff/core/config/loader.py
@@ -178,7 +178,7 @@ def load_config_string(
 
     Args:
         config_string (str): The raw config file as a string. The content
-            is assumed to be in the the ``.ini`` format of a ``.sqlfluff``
+            is assumed to be in the ``.ini`` format of a ``.sqlfluff``
             file (i.e. not in ``.toml`` format).
         configs (ConfigMappingType, optional): A base set of configs to
             merge the loaded configs onto. If not provided, the result

--- a/src/sqlfluff/core/parser/grammar/sequence.py
+++ b/src/sqlfluff/core/parser/grammar/sequence.py
@@ -379,7 +379,7 @@ class Bracketed(Sequence):
 
     Changelog:
     - Post 0.3.2: Bracketed inherits from Sequence and anything within
-      the the `Bracketed()` expression is treated as a sequence. For the
+      the `Bracketed()` expression is treated as a sequence. For the
       content of the Brackets, we call the `match()` method of the sequence
       grammar.
     - Post 0.1.0: Bracketed was separate from sequence, and the content

--- a/src/sqlfluff/core/templaters/python.py
+++ b/src/sqlfluff/core/templaters/python.py
@@ -583,7 +583,7 @@ class PythonTemplater(RawTemplater):
         """Split a sliced file on its invariant literals.
 
         We prioritise the _longest_ invariants first as they
-        are more likely to the the anchors.
+        are more likely to be the anchors.
         """
         # Calculate invariants
         invariants = [

--- a/src/sqlfluff/dialects/dialect_sparksql.py
+++ b/src/sqlfluff/dialects/dialect_sparksql.py
@@ -3503,7 +3503,7 @@ class RestoreTableStatementSegment(BaseSegment):
 
 
 class ConstraintStatementSegment(BaseSegment):
-    """A `CONSTRAINT` statement to to define data quality on data contents.
+    """A `CONSTRAINT` statement to define data quality on data contents.
 
     https://docs.databricks.com/workflows/delta-live-tables/delta-live-tables-expectations.html#manage-data-quality-with-delta-live-tables
     """


### PR DESCRIPTION
Corrects seven instances of accidentally repeated words in docstrings and .rst documentation files.

## Changes

- `cli/commands.py`: "attaches the the logger" -> "attaches the logger"
- `core/templaters/python.py`: "likely to the the anchors" -> "likely to be the anchors"
- `core/config/loader.py`: "in the the .ini format" -> "in the .ini format"
- `dialects/dialect_sparksql.py`: "statement to to define" -> "statement to define"
- `core/parser/grammar/sequence.py`: "the the Bracketed()" -> "the Bracketed()"
- `docs/contributing/dialect.rst`: "need to to touch" -> "need to touch"
- `docs/contributing/git.rst`: "pull request to to merge" -> "pull request to merge"

No functional changes -- only docstrings and documentation text are affected.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix duplicate-word typos in docstrings and docs (`.rst`, `.md`) across the repo (e.g., "the the", "to to") to improve clarity. No functional changes.

<sup>Written for commit 5464a100c2bc05f48fe9c8741a08e150f43899d5. Summary will update on new commits. <a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/7888?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

