### PR TITLE
Fix more duplicate-word typos in documentation

### DIFF
--- a/docs/source/guides/contributing/git.rst
+++ b/docs/source/guides/contributing/git.rst
@@ -184,7 +184,7 @@ At the bottom of the Conversation tab you will see the following:
 This shows on this PR that all checks have passed and this is ready to merge.
 Clicking the big green "Squash and Merge" button will copy (the "Merge" part)
 all this code into :code:`main` branch with one single commit (the "Squash"
-part). Usually you don't need to have all the 100s of commits you have have
+part). Usually you don't need to have all the 100s of commits you have
 done while developing this code change so "Squash" is what you want but you
 can change it if you want.
 
@@ -734,7 +734,7 @@ aware that it is meant with the best possible intention to provide feedback
 to you for this and future commits, and to keep our codebase to a high
 standard. It is not a personal sleight upon you or your code, and if you
 are getting annoyed with feedback I suggest you take a break and step away
-and read it again later, in a fresh light. Of course if if you feel that a
+and read it again later, in a fresh light. Of course if you feel that a
 reviewer is acting inappropriately then please raise it - we have a
 `Code of Conduct`_ and want all contributors to feel welcome. Feel free to
 also reach out to a maintainer if you would like to discuss something

--- a/docsv/development/dialect.md
+++ b/docsv/development/dialect.md
@@ -253,7 +253,7 @@ this (showing `"NAN"` has not been added as a Keyword in this dialect)
 RuntimeError: Grammar refers to 'NanKeywordSegment' which was not found in the redshift dialect
 ```
 
-Also if editing the main ANSI dialect, and adding the the ANSI keyword list,
+Also if editing the main ANSI dialect, and adding the ANSI keyword list,
 then take care to consider if it needs added to the other dialects if they
 will inherit this syntax - usually yes unless explicitly overridden in those
 dialects.

--- a/docsv/usage/ci-cd.md
+++ b/docsv/usage/ci-cd.md
@@ -14,7 +14,7 @@ There are two way to utilize SQLFluff to annotate Github PRs.
 At present (December 2023), limitations put in place by Github mean that only the
 first 10 annotations will be displayed if the first option (using
 `github-annotation-native`) is used. This is a not something that SQLFluff
-can control itself and so we currently recommend using the the second option
+can control itself and so we currently recommend using the second option
 above and the [action from yuzutech](https://github.com/yuzutech/annotations-action).
 
 There is an [open feature request](https://github.com/orgs/community/discussions/68471)

--- a/docsv/usage/diff-quality.md
+++ b/docsv/usage/diff-quality.md
@@ -7,7 +7,7 @@ of unrelated quality issues.
 
 To support this use case, SQLFluff integrates with a quality checking tool
 called `diff-quality`. By running SQLFluff using `diff-quality` (rather
-than running it directly), you can limit the the output to the new or modified
+than running it directly), you can limit the output to the new or modified
 SQL in the branch (aka pull request or PR) containing the proposed changes.
 
 Currently, `diff-quality` requires that you are using `git` for version


### PR DESCRIPTION
Corrects five more instances of accidentally repeated words found in documentation files.

## Changes

- `docs/contributing/git.rst` (line 187): "commits you have have done" -> "commits you have done"
- `docs/contributing/git.rst` (line 737): "Of course if if you feel" -> "Of course if you feel"
- `docsv/development/dialect.md`: "adding the the ANSI keyword list" -> "adding the ANSI keyword list"
- `docsv/usage/ci-cd.md`: "recommend using the the second option" -> "recommend using the second option"
- `docsv/usage/diff-quality.md`: "you can limit the the output" -> "you can limit the output"

No functional changes -- only documentation text is affected.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes five duplicate-word typos across the docs to improve clarity and readability. Documentation-only; no functional changes.

<sup>Written for commit 45dcc8828b341a185b7f49bf531f6bbcf9dd12eb. Summary will update on new commits. <a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/7889?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

