### PR TITLE
Fix Teradata BTEQ commands with arguments

### DIFF
--- a/src/sqlfluff/dialects/dialect_teradata.py
+++ b/src/sqlfluff/dialects/dialect_teradata.py
@@ -24,7 +24,6 @@ from sqlfluff.core.parser import (
     ImplicitIndent,
     Indent,
     Matchable,
-    NewlineSegment,
     OneOf,
     OptionallyBracketed,
     Ref,
@@ -32,6 +31,7 @@ from sqlfluff.core.parser import (
     Sequence,
     StringParser,
     TypedParser,
+    WordSegment,
 )
 from sqlfluff.dialects import dialect_ansi as ansi
 
@@ -169,10 +169,15 @@ teradata_dialect.add(
     NotEqualToSegment_a=StringParser("NE", ComparisonOperatorSegment),
     NotEqualToSegment_b=StringParser("NOT=", ComparisonOperatorSegment),
     NotEqualToSegment_c=StringParser("^=", ComparisonOperatorSegment),
-    BteqCommandTerminatorNewline=TypedParser(
-        "newline",
-        NewlineSegment,
-        type="newline",
+    BteqCommandArgumentSegment=TypedParser(
+        "word",
+        WordSegment,
+        type="word",
+    ),
+    BteqCommandEqualsSegment=TypedParser(
+        "equals",
+        CodeSegment,
+        type="equals",
     ),
 )
 
@@ -240,10 +245,14 @@ class BteqStatementSegment(BaseSegment):
             ),
             optional=True,
         ),
-        Anything(
+        AnyNumberOf(
+            OneOf(
+                Ref("BteqCommandArgumentSegment"),
+                Ref("BteqCommandEqualsSegment"),
+                Ref("LiteralGrammar"),
+            ),
             terminators=[
                 Ref("DelimiterGrammar"),
-                Ref("BteqCommandTerminatorNewline"),
             ],
             optional=True,
         ),

--- a/src/sqlfluff/dialects/dialect_teradata.py
+++ b/src/sqlfluff/dialects/dialect_teradata.py
@@ -33,6 +33,7 @@ from sqlfluff.core.parser import (
     TypedParser,
     WordSegment,
 )
+from sqlfluff.core.parser.segments import NewlineSegment
 from sqlfluff.dialects import dialect_ansi as ansi
 
 ansi_dialect = load_raw_dialect("ansi")
@@ -179,6 +180,11 @@ teradata_dialect.add(
         CodeSegment,
         type="equals",
     ),
+    BteqCommandNewlineSegment=TypedParser(
+        "newline",
+        NewlineSegment,
+        type="newline",
+    ),
 )
 
 
@@ -243,6 +249,10 @@ class BteqStatementSegment(BaseSegment):
             Sequence(
                 Ref("ComparisonOperatorGrammar"), Ref("LiteralGrammar"), optional=True
             ),
+            terminators=[
+                Ref("BteqCommandNewlineSegment"),
+                Ref("SemicolonSegment"),
+            ],
             optional=True,
         ),
         AnyNumberOf(
@@ -250,9 +260,15 @@ class BteqStatementSegment(BaseSegment):
                 Ref("BteqCommandArgumentSegment"),
                 Ref("BteqCommandEqualsSegment"),
                 Ref("LiteralGrammar"),
+                Ref("DotSegment"),
+                Ref("CommaSegment"),
+                Ref("ColonSegment"),
+                Ref("MinusSegment"),
+                Ref("DivideSegment"),
             ),
             terminators=[
-                Ref("DelimiterGrammar"),
+                Ref("BteqCommandNewlineSegment"),
+                Ref("SemicolonSegment"),
             ],
             optional=True,
         ),

--- a/src/sqlfluff/dialects/dialect_teradata.py
+++ b/src/sqlfluff/dialects/dialect_teradata.py
@@ -24,6 +24,7 @@ from sqlfluff.core.parser import (
     ImplicitIndent,
     Indent,
     Matchable,
+    NewlineSegment,
     OneOf,
     OptionallyBracketed,
     Ref,
@@ -168,6 +169,11 @@ teradata_dialect.add(
     NotEqualToSegment_a=StringParser("NE", ComparisonOperatorSegment),
     NotEqualToSegment_b=StringParser("NOT=", ComparisonOperatorSegment),
     NotEqualToSegment_c=StringParser("^=", ComparisonOperatorSegment),
+    BteqCommandTerminatorNewline=TypedParser(
+        "newline",
+        NewlineSegment,
+        type="newline",
+    ),
 )
 
 
@@ -232,6 +238,13 @@ class BteqStatementSegment(BaseSegment):
             Sequence(
                 Ref("ComparisonOperatorGrammar"), Ref("LiteralGrammar"), optional=True
             ),
+            optional=True,
+        ),
+        Anything(
+            terminators=[
+                Ref("DelimiterGrammar"),
+                Ref("BteqCommandTerminatorNewline"),
+            ],
             optional=True,
         ),
     )

--- a/src/sqlfluff/dialects/dialect_teradata.py
+++ b/src/sqlfluff/dialects/dialect_teradata.py
@@ -54,6 +54,13 @@ teradata_dialect.patch_lexer_matchers(
     ]
 )
 
+teradata_dialect.insert_lexer_matchers(
+    [
+        RegexLexer("backslash", r"\\", CodeSegment),
+    ],
+    before="word",
+)
+
 # Remove unused keywords from the dialect.
 teradata_dialect.sets("unreserved_keywords").difference_update(
     [
@@ -180,6 +187,16 @@ teradata_dialect.add(
         CodeSegment,
         type="equals",
     ),
+    BteqCommandBackslashSegment=TypedParser(
+        "backslash",
+        CodeSegment,
+        type="backslash",
+    ),
+    BteqCommandQuotedArgumentSegment=TypedParser(
+        "double_quote",
+        CodeSegment,
+        type="quoted_argument",
+    ),
     BteqCommandNewlineSegment=TypedParser(
         "newline",
         NewlineSegment,
@@ -259,6 +276,8 @@ class BteqStatementSegment(BaseSegment):
             OneOf(
                 Ref("BteqCommandArgumentSegment"),
                 Ref("BteqCommandEqualsSegment"),
+                Ref("BteqCommandBackslashSegment"),
+                Ref("BteqCommandQuotedArgumentSegment"),
                 Ref("LiteralGrammar"),
                 Ref("DotSegment"),
                 Ref("CommaSegment"),

--- a/test/dialects/teradata_test.py
+++ b/test/dialects/teradata_test.py
@@ -1,0 +1,10 @@
+"""Tests for the Teradata dialect."""
+
+from sqlfluff.core import Linter
+
+
+def test_teradata_bteq_command_with_arguments_parses():
+    """BTEQ dot commands may have arguments after the command keyword."""
+    parsed = Linter(dialect="teradata").parse_string(".RUN FILE=POSTING\n")
+
+    assert not [violation for violation in parsed.violations if violation.rule_code() == "PRS"]

--- a/test/dialects/teradata_test.py
+++ b/test/dialects/teradata_test.py
@@ -1,11 +1,21 @@
 """Tests for the Teradata dialect."""
 
+import pytest
+
 from sqlfluff.core import Linter
 
 
-def test_teradata_bteq_command_with_arguments_parses():
+@pytest.mark.parametrize(
+    "sql",
+    [
+        ".RUN FILE=POSTING.SQL\n",
+        ".RUN FILE=../posting-file.sql\n",
+        ".EXPORT REPORT FILE=reports/out,summary.txt\n",
+    ],
+)
+def test_teradata_bteq_command_with_arguments_parses(sql):
     """BTEQ dot commands may have arguments after the command keyword."""
-    parsed = Linter(dialect="teradata").parse_string(".RUN FILE=POSTING\n")
+    parsed = Linter(dialect="teradata").parse_string(sql)
 
     assert not [
         violation for violation in parsed.violations if violation.rule_code() == "PRS"

--- a/test/dialects/teradata_test.py
+++ b/test/dialects/teradata_test.py
@@ -7,4 +7,6 @@ def test_teradata_bteq_command_with_arguments_parses():
     """BTEQ dot commands may have arguments after the command keyword."""
     parsed = Linter(dialect="teradata").parse_string(".RUN FILE=POSTING\n")
 
-    assert not [violation for violation in parsed.violations if violation.rule_code() == "PRS"]
+    assert not [
+        violation for violation in parsed.violations if violation.rule_code() == "PRS"
+    ]

--- a/test/dialects/teradata_test.py
+++ b/test/dialects/teradata_test.py
@@ -10,6 +10,8 @@ from sqlfluff.core import Linter
     [
         ".RUN FILE=POSTING.SQL\n",
         ".RUN FILE=../posting-file.sql\n",
+        '.RUN FILE="reports/out summary.txt"\n',
+        ".RUN FILE=C:\\reports\\out-summary.txt\n",
         ".EXPORT REPORT FILE=reports/out,summary.txt\n",
     ],
 )

--- a/test/fixtures/dialects/teradata/bteq.sql
+++ b/test/fixtures/dialects/teradata/bteq.sql
@@ -1,2 +1,5 @@
 .if errorcode > 0 then .quit 4;
-.RUN FILE=POSTING
+.RUN FILE=POSTING;
+.RUN FILE=POSTING.SQL;
+.RUN FILE=../posting-file.sql;
+.EXPORT REPORT FILE=reports/out,summary.txt

--- a/test/fixtures/dialects/teradata/bteq.sql
+++ b/test/fixtures/dialects/teradata/bteq.sql
@@ -2,4 +2,6 @@
 .RUN FILE=POSTING;
 .RUN FILE=POSTING.SQL;
 .RUN FILE=../posting-file.sql;
+.RUN FILE="reports/out summary.txt";
+.RUN FILE=C:\reports\out-summary.txt;
 .EXPORT REPORT FILE=reports/out,summary.txt

--- a/test/fixtures/dialects/teradata/bteq.sql
+++ b/test/fixtures/dialects/teradata/bteq.sql
@@ -1,1 +1,2 @@
 .if errorcode > 0 then .quit 4;
+.RUN FILE=POSTING

--- a/test/fixtures/dialects/teradata/bteq.yml
+++ b/test/fixtures/dialects/teradata/bteq.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 328c0611f27b0b6a06ece5b28e9d0e5e7b13b658f8be22279089ca68a409fa07
+_hash: f992f83e6acc7c9019ae682c59ba26defbb6fd554386893338194e65b401ea66
 file:
 - statement:
     bteq_statement:
@@ -30,3 +30,46 @@ file:
     - word: FILE
     - equals: '='
     - word: POSTING
+- statement_terminator: ;
+- statement:
+    bteq_statement:
+    - dot: .
+    - bteq_key_word_segment:
+        keyword: RUN
+    - word: FILE
+    - equals: '='
+    - word: POSTING
+    - dot: .
+    - word: SQL
+- statement_terminator: ;
+- statement:
+    bteq_statement:
+    - dot: .
+    - bteq_key_word_segment:
+        keyword: RUN
+    - word: FILE
+    - equals: '='
+    - dot: .
+    - dot: .
+    - binary_operator: /
+    - word: posting
+    - binary_operator: '-'
+    - word: file
+    - dot: .
+    - word: sql
+- statement_terminator: ;
+- statement:
+    bteq_statement:
+    - dot: .
+    - bteq_key_word_segment:
+        keyword: EXPORT
+    - word: REPORT
+    - word: FILE
+    - equals: '='
+    - word: reports
+    - binary_operator: /
+    - word: out
+    - comma: ','
+    - word: summary
+    - dot: .
+    - word: txt

--- a/test/fixtures/dialects/teradata/bteq.yml
+++ b/test/fixtures/dialects/teradata/bteq.yml
@@ -3,9 +3,9 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 5c9454897c6fb0804ca61cd756db50740fc13aabf09a5232ea602068cc2fa713
+_hash: 328c0611f27b0b6a06ece5b28e9d0e5e7b13b658f8be22279089ca68a409fa07
 file:
-  statement:
+- statement:
     bteq_statement:
     - dot: .
     - bteq_key_word_segment:
@@ -21,4 +21,12 @@ file:
         dot: .
         keyword: quit
         numeric_literal: '4'
-  statement_terminator: ;
+- statement_terminator: ;
+- statement:
+    bteq_statement:
+    - dot: .
+    - bteq_key_word_segment:
+        keyword: RUN
+    - word: FILE
+    - equals: '='
+    - word: POSTING

--- a/test/fixtures/dialects/teradata/bteq.yml
+++ b/test/fixtures/dialects/teradata/bteq.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: f992f83e6acc7c9019ae682c59ba26defbb6fd554386893338194e65b401ea66
+_hash: 202b402a4fa09ffe23460a5d56a9544644bb4660653c84c76eb28c5e723e7dc6
 file:
 - statement:
     bteq_statement:
@@ -57,6 +57,33 @@ file:
     - word: file
     - dot: .
     - word: sql
+- statement_terminator: ;
+- statement:
+    bteq_statement:
+      dot: .
+      bteq_key_word_segment:
+        keyword: RUN
+      word: FILE
+      equals: '='
+      quoted_argument: '"reports/out summary.txt"'
+- statement_terminator: ;
+- statement:
+    bteq_statement:
+    - dot: .
+    - bteq_key_word_segment:
+        keyword: RUN
+    - word: FILE
+    - equals: '='
+    - word: C
+    - colon: ':'
+    - backslash: \
+    - word: reports
+    - backslash: \
+    - word: out
+    - binary_operator: '-'
+    - word: summary
+    - dot: .
+    - word: txt
 - statement_terminator: ;
 - statement:
     bteq_statement:


### PR DESCRIPTION
## Summary
- allow Teradata BTEQ dot commands to consume same-line command arguments such as `FILE=POSTING`
- keep the existing structured parsing for known BTEQ keywords and comparisons
- add direct parser coverage and regenerate the Teradata `bteq` fixture

Fixes #1673

## Tests
- `.venv/bin/python -m pytest test/dialects/teradata_test.py -q`
- `.venv/bin/python -m pytest test/dialects/dialects_test.py -q -k teradata`
- `.venv/bin/sqlfluff parse --dialect teradata - <<'SQL'` with `.RUN FILE=POSTING`
- `git diff --check`

AI assistance was used to inspect the dialect grammar and draft this patch. I reviewed the generated diff, regenerated the fixture with the project script, ran the tests above, and take responsibility for the contribution.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable parsing of Teradata BTEQ dot commands with same-line arguments, including file paths, quoted paths with spaces, Windows paths, and comma-separated lists. Fixes #1673.

- **Bug Fixes**
  - Enumerate allowed argument tokens and stop at newline/semicolon (no catch-all), supporting `word`, `=`, literals, `.`, `/`, `-`, `,`, `:`, `\`, and quoted strings.
  - Add a dedicated `backslash` lexer; add parser tests and refresh `bteq` fixtures, including `.RUN FILE=POSTING.SQL` and `.EXPORT REPORT FILE=reports/out,summary.txt`.

<sup>Written for commit 6b1ef9e97c23c77af1bba5327a66e580ae2fb171. Summary will update on new commits. <a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/7890?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

