### PR TITLE
AI-generated possible solution for #7691 (A)

### DIFF
--- a/src/sqlfluff/rules/references/RF04.py
+++ b/src/sqlfluff/rules/references/RF04.py
@@ -12,10 +12,11 @@ from sqlfluff.utils.identifers import identifiers_policy_applicable
 class Rule_RF04(BaseRule):
     """Keywords should not be used as identifiers.
 
-    Although `unreserved` keywords `can` be used as identifiers,
-    and `reserved words` can be used as quoted identifiers,
-    best practice is to avoid where possible, to avoid any
-    misunderstandings as to what the alias represents.
+    This rule flags `reserved` keywords and `future reserved` keywords
+    when used as quoted identifiers, as these words are reserved for
+    SQL syntax use. Unreserved (non-reserved) keywords are explicitly
+    allowed as identifiers by the SQL standard and are therefore not
+    flagged by this rule.
 
     .. note::
        Note that `reserved` keywords cannot be used as unquoted identifiers
@@ -23,17 +24,17 @@ class Rule_RF04(BaseRule):
 
     **Anti-pattern**
 
-    In this example, ``SUM`` (built-in function) is used as an alias.
+    In this example, ``CASE`` (a reserved keyword) is used as an alias.
 
     .. code-block:: sql
 
         SELECT
-            sum.a
-        FROM foo AS sum
+            "case".a
+        FROM foo AS "case"
 
     **Best practice**
 
-    Avoid keywords as the name of an alias.
+    Avoid reserved keywords as the name of an alias.
 
     .. code-block:: sql
 
@@ -64,6 +65,13 @@ class Rule_RF04(BaseRule):
         if len(context.segment.raw) == 1:
             return LintResult(memory=context.memory)
 
+        # Get the identifier text, stripping quotes for quoted identifiers
+        is_quoted = context.segment.is_type("quoted_identifier")
+        if is_quoted:
+            identifier_text = context.segment.raw[1:-1]
+        else:
+            identifier_text = context.segment.raw
+
         # Get the ignore list configuration and cache it
         try:
             ignore_words_list = self.ignore_words_list
@@ -73,41 +81,26 @@ class Rule_RF04(BaseRule):
             ignore_words_list = self._init_ignore_string()
 
         # Skip if in ignore list
-        if ignore_words_list and context.segment.raw.lower() in ignore_words_list:
+        if ignore_words_list and identifier_text.upper() in ignore_words_list:
             return LintResult(memory=context.memory)
 
         # Skip if matches ignore regex
         if self.ignore_words_regex and regex.search(
-            self.ignore_words_regex, context.segment.raw
+            self.ignore_words_regex, identifier_text
         ):
             return LintResult(memory=context.memory)
 
         if (
-            (
-                context.segment.is_type("naked_identifier")
-                and identifiers_policy_applicable(
-                    self.unquoted_identifiers_policy,  # type: ignore
-                    context.parent_stack,
-                )
-                and (
-                    context.segment.raw.upper()
-                    in context.dialect.sets("unreserved_keywords")
-                )
+            is_quoted
+            and identifiers_policy_applicable(
+                self.quoted_identifiers_policy,  # type: ignore
+                context.parent_stack,
             )
-            or (
-                context.segment.is_type("quoted_identifier")
-                and identifiers_policy_applicable(
-                    self.quoted_identifiers_policy,  # type: ignore
-                    context.parent_stack,
-                )
-                and (
-                    context.segment.raw.upper()[1:-1]
-                    in context.dialect.sets("unreserved_keywords")
-                    or context.segment.raw.upper()[1:-1]
-                    in context.dialect.sets("reserved_keywords")
-                    or context.segment.raw.upper()[1:-1]
-                    in context.dialect.sets("future_reserved_keywords")
-                )
+            and (
+                identifier_text.upper()
+                in context.dialect.sets("reserved_keywords")
+                or identifier_text.upper()
+                in context.dialect.sets("future_reserved_keywords")
             )
         ):
             return LintResult(anchor=context.segment)
@@ -120,7 +113,7 @@ class Rule_RF04(BaseRule):
         ignore_words_config = str(getattr(self, "ignore_words"))
         if ignore_words_config and ignore_words_config != "None":
             self.ignore_words_list = self.split_comma_separated_string(
-                ignore_words_config.lower()
+                ignore_words_config.upper()
             )
         else:
             self.ignore_words_list = []

--- a/test/fixtures/rules/std_rule_cases/RF04.yml
+++ b/test/fixtures/rules/std_rule_cases/RF04.yml
@@ -1,37 +1,36 @@
 rule: RF04
 
-test_pass_valid_identifier:
+test_pass_valid_unquoted_identifier:
   pass_str: CREATE TABLE artist(artist_name TEXT)
 
-test_fail_keyword_as_identifier_column:
-  fail_str: CREATE TABLE artist(create TEXT)
+test_pass_unreserved_keyword_as_unquoted_identifier_column:
+  pass_str: CREATE TABLE artist(create TEXT)
 
-test_fail_keyword_as_identifier_column_alias:
-  fail_str: SELECT 1 as parameter
+test_pass_unreserved_keyword_as_unquoted_identifier_column_alias:
+  pass_str: SELECT 1 as parameter
 
-test_fail_keyword_as_identifier_table_alias:
-  fail_str: SELECT x FROM tbl AS parameter
+test_pass_unreserved_keyword_as_unquoted_identifier_table_alias:
+  pass_str: SELECT x FROM tbl AS parameter
 
-test_pass_valid_identifier_not_alias:
-  # should pass on default config as not alias
+test_pass_valid_unquoted_identifier_not_alias:
   pass_str: SELECT parameter
 
-test_fail_keyword_as_identifier_not_alias_all:
-  fail_str: SELECT parameter
+test_pass_unreserved_keyword_as_unquoted_identifier_not_alias_all:
+  pass_str: SELECT parameter
   configs:
     rules:
       references.keywords:
         unquoted_identifiers_policy: all
 
-test_pass_valid_identifier_table_alias_column_alias_config:
+test_pass_valid_unquoted_identifier_table_alias_column_alias_config:
   pass_str: SELECT x FROM tbl AS parameter
   configs:
     rules:
       references.keywords:
         unquoted_identifiers_policy: column_aliases
 
-test_fail_keyword_as_identifier_column_alias_config:
-  fail_str: SELECT x AS date FROM tbl AS parameter
+test_pass_unreserved_keyword_as_unquoted_column_alias_config:
+  pass_str: SELECT x AS date FROM tbl AS parameter
   configs:
     rules:
       references.keywords:
@@ -46,22 +45,22 @@ test_pass_valid_quoted_identifier:
     core:
       dialect: tsql
 
-test_fail_keyword_as_quoted_identifier_column:
-  fail_str: CREATE TABLE "artist"("create" TEXT)
+test_fail_reserved_keyword_as_quoted_identifier_column:
+  fail_str: CREATE TABLE "artist"("CASE" TEXT)
   configs:
     rules:
       references.keywords:
         quoted_identifiers_policy: aliases
 
-test_pass_keyword_as_quoted_identifier_column_none_policy:
-  pass_str: CREATE TABLE "artist"("create" TEXT)
+test_pass_reserved_keyword_as_quoted_identifier_column_none_policy:
+  pass_str: CREATE TABLE "artist"("CASE" TEXT)
   configs:
     rules:
       references.keywords:
         quoted_identifiers_policy: none
 
-test_fail_keyword_as_quoted_identifier_column_alias:
-  fail_str: SELECT 1 as [parameter]
+test_fail_reserved_keyword_as_quoted_identifier_column_alias:
+  fail_str: SELECT 1 as [CASE]
   configs:
     rules:
       references.keywords:
@@ -69,8 +68,8 @@ test_fail_keyword_as_quoted_identifier_column_alias:
     core:
       dialect: tsql
 
-test_fail_keyword_as_quoted_identifier_table_alias:
-  fail_str: SELECT [x] FROM [tbl] AS [parameter]
+test_fail_reserved_keyword_as_quoted_identifier_table_alias:
+  fail_str: SELECT [x] FROM [tbl] AS [CASE]
   configs:
     rules:
       references.keywords:
@@ -79,8 +78,7 @@ test_fail_keyword_as_quoted_identifier_table_alias:
       dialect: tsql
 
 test_pass_valid_quoted_identifier_not_alias:
-  # should pass on default config as not alias
-  pass_str: SELECT [parameter]
+  pass_str: SELECT [CASE]
   configs:
     rules:
       references.keywords:
@@ -88,8 +86,8 @@ test_pass_valid_quoted_identifier_not_alias:
     core:
       dialect: tsql
 
-test_fail_keyword_as_quoted_identifier_not_alias_all:
-  fail_str: SELECT [parameter]
+test_fail_reserved_keyword_as_quoted_identifier_not_alias_all:
+  fail_str: SELECT [CASE]
   configs:
     rules:
       references.keywords:
@@ -98,7 +96,7 @@ test_fail_keyword_as_quoted_identifier_not_alias_all:
       dialect: tsql
 
 test_pass_valid_quoted_identifier_table_alias_column_alias_config:
-  pass_str: SELECT [x] FROM [tbl] AS [parameter]
+  pass_str: SELECT [x] FROM [tbl] AS [CASE]
   configs:
     rules:
       references.keywords:
@@ -106,8 +104,8 @@ test_pass_valid_quoted_identifier_table_alias_column_alias_config:
     core:
       dialect: tsql
 
-test_fail_keyword_as_quoted_identifier_column_alias_config:
-  fail_str: SELECT [x] AS [date] FROM [tbl] AS [parameter]
+test_fail_reserved_keyword_as_quoted_identifier_column_alias_config:
+  fail_str: SELECT [x] AS [CASE] FROM [tbl] AS [JOIN]
   configs:
     rules:
       references.keywords:
@@ -115,35 +113,21 @@ test_fail_keyword_as_quoted_identifier_column_alias_config:
     core:
       dialect: tsql
 
-test_pass_ignore_word1:
-  pass_str: CREATE TABLE artist(create TEXT)
+test_pass_ignore_word:
+  pass_str: CREATE TABLE "artist"("CASE" TEXT)
   configs:
     rules:
       references.keywords:
-        ignore_words: create
+        ignore_words: CASE
+        quoted_identifiers_policy: aliases
 
-
-test_pass_ignore_word2:
-  pass_str: SELECT col1 AS date FROM table1
+test_pass_ignore_words_regex:
+  pass_str: CREATE TABLE "artist"("CASE" TEXT)
   configs:
     rules:
       references.keywords:
-        ignore_words: date
-
-test_pass_ignore_words_regex1:
-  pass_str: CREATE TABLE artist(create TEXT)
-  configs:
-    rules:
-      references.keywords:
-        ignore_words_regex: ^cr
-
-
-test_pass_ignore_words_regex2:
-  pass_str: SELECT col1 AS date FROM table1
-  configs:
-    rules:
-      references.keywords:
-        ignore_words_regex: ^da
+        ignore_words_regex: ^CA
+        quoted_identifiers_policy: aliases
 
 test_pass_one_character_identifier:
   pass_str: SELECT d.col1 FROM table1 d
@@ -151,8 +135,8 @@ test_pass_one_character_identifier:
     core:
       dialect: snowflake
 
-test_fail_keyword_as_column_name_postgres:
-  fail_str: CREATE TABLE test_table (type varchar(30) NOT NULL)
+test_pass_unreserved_keyword_as_column_name_postgres:
+  pass_str: CREATE TABLE test_table (provider varchar(30) NOT NULL)
   configs:
     core:
       dialect: postgres


### PR DESCRIPTION
Hi,

We're a research team at JetBrains studying how maintainers evaluate AI-generated code.

We opened two pull requests as possible solutions to the corresponding issue, each taking a different approach. Both were generated by AI and have not yet been manually reviewed by a human. We’d like to get your perspective on these two solutions via a 10-minute survey. Regardless of your role, we want to know which solution actually saves you work, and which qualities of AI-generated code matter most when working with the codebase.

If you're open to participating in our study, just reply "I'm interested" here, and we'll send the details to the contact specified in your GitHub profile. If you'd rather not take part, feel free to close the PRs – we won’t post them again.

Thanks!

Issue #7691


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tightens RF04 to flag only reserved and future-reserved keywords when used as quoted identifiers, avoiding false positives on unreserved and unquoted identifiers. Updates ignore handling and tests; addresses #7691.

- **Bug Fixes**
  - Flag only quoted identifiers that appear in dialect `reserved_keywords` or `future_reserved_keywords` and when `quoted_identifiers_policy` applies.
  - Allow unreserved keywords and all unquoted identifiers to pass.
  - Normalize `ignore_words` to uppercase and apply both `ignore_words` and `ignore_words_regex` to the stripped identifier text (no quotes). Updated T-SQL and Postgres test cases accordingly.

<sup>Written for commit 03fa6fd7fa69ab5eb9f433799ca7d0190d281644. Summary will update on new commits. <a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/7891?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

