### PR TITLE
AI-generated possible solution for #7691 (B)

### DIFF
--- a/src/sqlfluff/dialects/dialect_postgres_keywords.py
+++ b/src/sqlfluff/dialects/dialect_postgres_keywords.py
@@ -979,7 +979,7 @@ postgres_nondocs_keywords = [
     ("NOSUPERUSER", "non-reserved"),
     ("PLAIN", "non-reserved"),
     ("PROCESS_TOAST", "non-reserved"),
-    ("PROVIDER", "non-reserved"),
+    
     ("PUBLIC", "non-reserved"),
     ("REMAINDER", "non-reserved"),
     ("REPLICATION", "non-reserved"),


### PR DESCRIPTION
Hi,

We're a research team at JetBrains studying how maintainers evaluate AI-generated code.

We opened two pull requests as possible solutions to the corresponding issue, each taking a different approach. Both were generated by AI and have not yet been manually reviewed by a human. We’d like to get your perspective on these two solutions via a 10-minute survey. Regardless of your role, we want to know which solution actually saves you work, and which qualities of AI-generated code matter most when working with the codebase.

If you're open to participating in our study, just reply "I'm interested" here, and we'll send the details to the contact specified in your GitHub profile. If you'd rather not take part, feel free to close the PRs – we won’t post them again.

Thanks!

Issue #7691


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed `PROVIDER` from the Postgres dialect keyword list to match PostgreSQL and the expectations in issue #7691. This prevents mis-highlighting and false positives when `provider` is used as an identifier.

<sup>Written for commit 6fb4ca9dfc814af85836cb91b2d83f6e65f94880. Summary will update on new commits. <a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/7892?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

