### PR TITLE
fix(postgres): parse \crosstabview after WITH compound statement (CTE)

### DIFF
--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -6973,7 +6973,10 @@ class MetaCommandQueryBufferStatement(BaseSegment):
     match_grammar = Sequence(
         AnyNumberOf(
             Sequence(
-                Ref("SelectStatementSegment"),
+                OneOf(
+                    Ref("WithCompoundStatementSegment"),
+                    Ref("SelectStatementSegment"),
+                ),
                 Ref("MetaCommandQueryBufferSegment", optional=True),
             )
         )

--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -6973,10 +6973,7 @@ class MetaCommandQueryBufferStatement(BaseSegment):
     match_grammar = Sequence(
         AnyNumberOf(
             Sequence(
-                OneOf(
-                    Ref("WithCompoundStatementSegment"),
-                    Ref("SelectStatementSegment"),
-                ),
+                Ref("SelectableGrammar"),
                 Ref("MetaCommandQueryBufferSegment", optional=True),
             )
         )

--- a/test/fixtures/dialects/postgres/meta_commands_query_buffer.sql
+++ b/test/fixtures/dialects/postgres/meta_commands_query_buffer.sql
@@ -45,3 +45,13 @@ SELECT
 FROM entries
 ORDER BY 1
 \crosstabview
+
+SELECT 1, 2, 3
+UNION ALL
+SELECT 4, 5, 6
+\crosstabview
+
+INSERT INTO x
+VALUES (1, 2, 3), (4, 5, 6)
+RETURNING a, b, c
+\crosstabview

--- a/test/fixtures/dialects/postgres/meta_commands_query_buffer.sql
+++ b/test/fixtures/dialects/postgres/meta_commands_query_buffer.sql
@@ -28,3 +28,20 @@ ORDER BY 1
 \crosstabview
 
 SELECT a, b FROM t \crosstabview
+
+SELECT
+    a,
+    b,
+    c
+FROM mytable
+ORDER BY 1
+\crosstabview
+
+WITH entries AS (SELECT 1, 2, 3)
+SELECT
+    a,
+    b,
+    c
+FROM entries
+ORDER BY 1
+\crosstabview

--- a/test/fixtures/dialects/postgres/meta_commands_query_buffer.yml
+++ b/test/fixtures/dialects/postgres/meta_commands_query_buffer.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 67289ded332e2eb1712a69ad6f9d7088792e7fc3e78b405c508b50aff4a9d839
+_hash: ea6327f25ad6d1824bfb39a6994aaffbda61fcd1ab2e0b6b85854ab8cd52d3bc
 file:
 - statement:
     meta_command_statement:
@@ -341,4 +341,74 @@ file:
           - keyword: ORDER
           - keyword: BY
           - numeric_literal: '1'
+    - meta_command: \crosstabview
+    - set_expression:
+      - select_statement:
+          select_clause:
+          - keyword: SELECT
+          - select_clause_element:
+              numeric_literal: '1'
+          - comma: ','
+          - select_clause_element:
+              numeric_literal: '2'
+          - comma: ','
+          - select_clause_element:
+              numeric_literal: '3'
+      - set_operator:
+        - keyword: UNION
+        - keyword: ALL
+      - select_statement:
+          select_clause:
+          - keyword: SELECT
+          - select_clause_element:
+              numeric_literal: '4'
+          - comma: ','
+          - select_clause_element:
+              numeric_literal: '5'
+          - comma: ','
+          - select_clause_element:
+              numeric_literal: '6'
+    - meta_command: \crosstabview
+    - insert_statement:
+      - keyword: INSERT
+      - keyword: INTO
+      - table_reference:
+          naked_identifier: x
+      - values_clause:
+        - keyword: VALUES
+        - bracketed:
+          - start_bracket: (
+          - expression:
+              numeric_literal: '1'
+          - comma: ','
+          - expression:
+              numeric_literal: '2'
+          - comma: ','
+          - expression:
+              numeric_literal: '3'
+          - end_bracket: )
+        - comma: ','
+        - bracketed:
+          - start_bracket: (
+          - expression:
+              numeric_literal: '4'
+          - comma: ','
+          - expression:
+              numeric_literal: '5'
+          - comma: ','
+          - expression:
+              numeric_literal: '6'
+          - end_bracket: )
+      - keyword: RETURNING
+      - expression:
+          column_reference:
+            naked_identifier: a
+      - comma: ','
+      - expression:
+          column_reference:
+            naked_identifier: b
+      - comma: ','
+      - expression:
+          column_reference:
+            naked_identifier: c
     - meta_command: \crosstabview

--- a/test/fixtures/dialects/postgres/meta_commands_query_buffer.yml
+++ b/test/fixtures/dialects/postgres/meta_commands_query_buffer.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 090459a2a205b0ae7969cd661949d871d2a2b7c78de6d43ef5638f8445310961
+_hash: 67289ded332e2eb1712a69ad6f9d7088792e7fc3e78b405c508b50aff4a9d839
 file:
 - statement:
     meta_command_statement:
@@ -270,4 +270,75 @@ file:
               table_expression:
                 table_reference:
                   naked_identifier: t
+    - meta_command: \crosstabview
+    - select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            column_reference:
+              naked_identifier: a
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+              naked_identifier: b
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+              naked_identifier: c
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: mytable
+        orderby_clause:
+        - keyword: ORDER
+        - keyword: BY
+        - numeric_literal: '1'
+    - meta_command: \crosstabview
+    - with_compound_statement:
+        keyword: WITH
+        common_table_expression:
+          naked_identifier: entries
+          keyword: AS
+          bracketed:
+            start_bracket: (
+            select_statement:
+              select_clause:
+              - keyword: SELECT
+              - select_clause_element:
+                  numeric_literal: '1'
+              - comma: ','
+              - select_clause_element:
+                  numeric_literal: '2'
+              - comma: ','
+              - select_clause_element:
+                  numeric_literal: '3'
+            end_bracket: )
+        select_statement:
+          select_clause:
+          - keyword: SELECT
+          - select_clause_element:
+              column_reference:
+                naked_identifier: a
+          - comma: ','
+          - select_clause_element:
+              column_reference:
+                naked_identifier: b
+          - comma: ','
+          - select_clause_element:
+              column_reference:
+                naked_identifier: c
+          from_clause:
+            keyword: FROM
+            from_expression:
+              from_expression_element:
+                table_expression:
+                  table_reference:
+                    naked_identifier: entries
+          orderby_clause:
+          - keyword: ORDER
+          - keyword: BY
+          - numeric_literal: '1'
     - meta_command: \crosstabview


### PR DESCRIPTION
## Summary

Fixes #7876.

`MetaCommandQueryBufferStatement` only matched `SelectStatementSegment` as the query preceding `\crosstabview` (and `\gset`/`\gexec`). A query that starts with `WITH` (a CTE) is parsed as `WithCompoundStatementSegment`, not `SelectStatementSegment`, so it failed to parse.

- Updated `MetaCommandQueryBufferStatement.match_grammar` to accept `OneOf(WithCompoundStatementSegment, SelectStatementSegment)`.
- Added test cases: a plain multi-line SELECT + `\crosstabview` (regression guard), and the CTE case from the issue report.

## Test plan

- [ ] `python -m pytest test/dialects/dialects_test.py -k "postgres and meta_commands_query_buffer"` — 3 passed
- [ ] `python -m pytest test/dialects/dialects_test.py -k "postgres"` — 492 passed, no regressions
- [ ] Manually verified the exact SQL from the issue parses with zero violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes parsing of Postgres `\crosstabview` after any selectable query, not just plain SELECT. CTEs, set operations, and DML with `RETURNING` now parse correctly before the meta command. Fixes #7876.

- **Bug Fixes**
  - Switched `MetaCommandQueryBufferStatement` to use `SelectableGrammar`, enabling CTEs, set expressions (e.g., `UNION ALL`), and DML with `RETURNING` before `\crosstabview` (and related meta commands).
  - Added tests for multi-line SELECT, CTE, `UNION ALL`, and `INSERT ... RETURNING` cases.

<sup>Written for commit 29e39b514db18a951cad33763cd7ade0f317ba3d. Summary will update on new commits. <a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/7895?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

