### PR TITLE
fix(dbt-templater): honor DBT_TARGET / DBT_TARGET_PATH env vars

### DIFF
--- a/plugins/sqlfluff-templater-dbt/sqlfluff_templater_dbt/templater.py
+++ b/plugins/sqlfluff-templater-dbt/sqlfluff_templater_dbt/templater.py
@@ -420,14 +420,20 @@ class DbtTemplater(JinjaTemplater):
 
     def _get_target(self):
         """Get a dbt target name from the configuration."""
-        return self.sqlfluff_config.get_section(
-            (self.templater_selector, self.name, "target")
+        return (
+            self.sqlfluff_config.get_section(
+                (self.templater_selector, self.name, "target")
+            )
+            or os.getenv("DBT_TARGET")
         )
 
     def _get_target_path(self):
         """Get a dbt target path from the configuration."""
-        return self.sqlfluff_config.get_section(
-            (self.templater_selector, self.name, "target_path")
+        return (
+            self.sqlfluff_config.get_section(
+                (self.templater_selector, self.name, "target_path")
+            )
+            or os.getenv("DBT_TARGET_PATH")
         )
 
     def _get_threads(self) -> Optional[int]:

--- a/plugins/sqlfluff-templater-dbt/sqlfluff_templater_dbt/templater.py
+++ b/plugins/sqlfluff-templater-dbt/sqlfluff_templater_dbt/templater.py
@@ -420,21 +420,15 @@ class DbtTemplater(JinjaTemplater):
 
     def _get_target(self):
         """Get a dbt target name from the configuration."""
-        return (
-            self.sqlfluff_config.get_section(
-                (self.templater_selector, self.name, "target")
-            )
-            or os.getenv("DBT_TARGET")
-        )
+        return self.sqlfluff_config.get_section(
+            (self.templater_selector, self.name, "target")
+        ) or os.getenv("DBT_TARGET")
 
     def _get_target_path(self):
         """Get a dbt target path from the configuration."""
-        return (
-            self.sqlfluff_config.get_section(
-                (self.templater_selector, self.name, "target_path")
-            )
-            or os.getenv("DBT_TARGET_PATH")
-        )
+        return self.sqlfluff_config.get_section(
+            (self.templater_selector, self.name, "target_path")
+        ) or os.getenv("DBT_TARGET_PATH")
 
     def _get_threads(self) -> Optional[int]:
         """Get the dbt threads value from the configuration.

--- a/plugins/sqlfluff-templater-dbt/test/templater_test.py
+++ b/plugins/sqlfluff-templater-dbt/test/templater_test.py
@@ -693,6 +693,32 @@ def test__project_dir_from_env(dbt_templater, project_dir, monkeypatch):
     assert dbt_templater._get_project_dir() == os.path.abspath(project_dir)
 
 
+def test__target_from_env(dbt_templater, monkeypatch):
+    """Test possibility to set target from DBT_TARGET env variable."""
+    dbt_templater.sqlfluff_config = FluffConfig(
+        configs={
+            "core": {"dialect": "ansi"},
+            "templater": {"dbt": {"target": None}},
+        }
+    )
+    assert dbt_templater._get_target() is None
+    monkeypatch.setenv("DBT_TARGET", "dev")
+    assert dbt_templater._get_target() == "dev"
+
+
+def test__target_path_from_env(dbt_templater, monkeypatch):
+    """Test possibility to set target_path from DBT_TARGET_PATH env variable."""
+    dbt_templater.sqlfluff_config = FluffConfig(
+        configs={
+            "core": {"dialect": "ansi"},
+            "templater": {"dbt": {"target_path": None}},
+        }
+    )
+    assert dbt_templater._get_target_path() is None
+    monkeypatch.setenv("DBT_TARGET_PATH", "custom_target")
+    assert dbt_templater._get_target_path() == "custom_target"
+
+
 def test__project_dir_does_not_exist_error(dbt_templater):
     """Test an error is logged if the given dbt project directory doesn't exist."""
     dbt_templater.sqlfluff_config = FluffConfig(


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

Thanks for maintaining this project! Hoping this small consistency fix is welcome — happy to adjust based on review.

### Brief summary of the change made

The dbt templater already honors `DBT_PROJECT_DIR` and `DBT_PROFILES_DIR` as fallbacks when the corresponding values are not set under `[sqlfluff:templater:dbt]`. However `target` and `target_path` were read from sqlfluff config only, and the matching `DBT_TARGET` / `DBT_TARGET_PATH` environment variables were ignored.

This is inconvenient when running sqlfluff in environments (CI, dev shells, etc.) where the dbt target is controlled via the standard dbt environment variables. Without setting `target` explicitly in `.sqlfluff`, sqlfluff falls back to the default target in `profiles.yml`, which can break macros that depend on the active target (for example `dbt_utils.star` resolving against the wrong warehouse).

This change extends `_get_target()` and `_get_target_path()` to fall back to `DBT_TARGET` / `DBT_TARGET_PATH` when no value is configured in `.sqlfluff`, mirroring the existing behavior of `_get_project_dir()` and `_get_profiles_dir()`. Precedence is unchanged where a value is set: `.sqlfluff` config still wins over the environment variable.

### Are there any other side effects of this change that we should be aware of?

No behavioral change for users who already set `target` / `target_path` in `.sqlfluff` — the sqlfluff config still takes precedence. The new behavior only activates when those keys are unset, so previously sqlfluff would return `None` (deferring entirely to `profiles.yml`); now the dbt environment variables are consulted first, matching how dbt itself resolves these values.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other: added `test__target_from_env` and `test__target_path_from_env` in `plugins/sqlfluff-templater-dbt/test/templater_test.py`, mirroring the existing `test__project_dir_from_env`.
- [ ] Added appropriate documentation for the change.
- [ ] Created GitHub issues for any relevant followup/future enhancements if appropriate.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Honor `DBT_TARGET` and `DBT_TARGET_PATH` in the dbt templater when `target` or `target_path` are unset in `.sqlfluff`. Matches env fallbacks for `project_dir`/`profiles_dir` and avoids using the wrong dbt target in CI/dev shells.

- **Bug Fixes**
  - `_get_target()` and `_get_target_path()` now fall back to `DBT_TARGET` / `DBT_TARGET_PATH` if not set in `.sqlfluff`; `.sqlfluff` still takes precedence.
  - Added tests: `test__target_from_env`, `test__target_path_from_env`.

- **Refactors**
  - Applied ruff formatting to `_get_target()` and `_get_target_path()`.

<sup>Written for commit 5cfaac75391c4c29ed78b671e74581f4c690f7de. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/7900?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

