### PR TITLE
Support T-SQL DROP CREDENTIAL

### DIFF
--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -944,6 +944,7 @@ class StatementSegment(ansi.StatementSegment):
             Ref("LabelStatementSegment"),
             Ref("CreateTypeStatementSegment"),
             Ref("CreateDatabaseScopedCredentialStatementSegment"),
+            Ref("DropCredentialStatementSegment"),
             Ref("CreateExternalDataSourceStatementSegment"),
             Ref("SqlcmdCommandSegment"),
             Ref("CreateExternalFileFormat"),
@@ -8258,6 +8259,20 @@ class CreateDatabaseScopedCredentialStatementSegment(BaseSegment):
         Ref("ObjectReferenceSegment"),
         "WITH",
         Ref("CredentialGrammar"),
+    )
+
+
+class DropCredentialStatementSegment(BaseSegment):
+    """A `DROP CREDENTIAL` statement.
+
+    https://learn.microsoft.com/en-us/sql/t-sql/statements/drop-credential-transact-sql
+    """
+
+    type = "drop_credential_statement"
+    match_grammar: Matchable = Sequence(
+        "DROP",
+        "CREDENTIAL",
+        Ref("ObjectReferenceSegment"),
     )
 
 

--- a/test/fixtures/dialects/tsql/drop_credential.sql
+++ b/test/fixtures/dialects/tsql/drop_credential.sql
@@ -1,0 +1,1 @@
+DROP CREDENTIAL Saddles;

--- a/test/fixtures/dialects/tsql/drop_credential.yml
+++ b/test/fixtures/dialects/tsql/drop_credential.yml
@@ -1,0 +1,15 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 7276895370cba7c1645ca8b492cfde3a5e88bd8c3eca066e3d8aa682187f5023
+file:
+  batch:
+    statement:
+      drop_credential_statement:
+      - keyword: DROP
+      - keyword: CREDENTIAL
+      - object_reference:
+          naked_identifier: Saddles
+    statement_terminator: ;


### PR DESCRIPTION
### Brief summary of the change made

Fixes #7903.

Adds T-SQL parser support for `DROP CREDENTIAL <credential_name>` and includes a new dialect parse fixture for the reported syntax.

### Are there any other side effects of this change that we should be aware of?

No.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.

Tested with:

```
uv run sqlfluff parse --dialect tsql -
uv run --with pytest pytest test/dialects/dialects_test.py::test__dialect__base_file_parse test/dialects/dialects_test.py::test__dialect__base_parse_struct -q -k 'tsql and drop_credential'
uv run --with pytest pytest test/dialects/dialects_test.py::test__dialect__base_file_parse test/dialects/dialects_test.py::test__dialect__base_parse_struct -q -k tsql
git diff --check
```


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds T-SQL parser support for DROP CREDENTIAL statements so they parse and lint correctly. Fixes #7903.

<sup>Written for commit fbe372ff3c893be49561fb18e73d6647470e2210. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/7904?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

