### PR TITLE
Support DROP CREDENTIAL in T-SQL dialect

### DIFF
--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -899,6 +899,7 @@ class StatementSegment(ansi.StatementSegment):
             Ref("DropSecurityPolicySegment"),
             Ref("CreateSynonymStatementSegment"),
             Ref("DropSynonymStatementSegment"),
+            Ref("DropCredentialStatementSegment"),
             Ref("CreateServerRoleStatementSegment"),
             Ref("CreateXmlSchemaCollectionStatementSegment"),
             Ref("AlterXmlSchemaCollectionStatementSegment"),
@@ -8154,6 +8155,18 @@ class DropSynonymStatementSegment(BaseSegment):
         "SYNONYM",
         Ref("IfExistsGrammar", optional=True),
         Ref("SynonymReferenceSegment"),
+    )
+
+
+class DropCredentialStatementSegment(BaseSegment):
+    """A `DROP CREDENTIAL` statement."""
+
+    type = "drop_credential_statement"
+    # https://learn.microsoft.com/en-us/sql/t-sql/statements/drop-credential-transact-sql
+    match_grammar: Matchable = Sequence(
+        "DROP",
+        "CREDENTIAL",
+        Ref("SingleIdentifierGrammar"),
     )
 
 

--- a/test/fixtures/dialects/tsql/drop_credential.sql
+++ b/test/fixtures/dialects/tsql/drop_credential.sql
@@ -1,0 +1,3 @@
+DROP CREDENTIAL Saddles;
+
+DROP CREDENTIAL [Sales Credential];

--- a/test/fixtures/dialects/tsql/drop_credential.yml
+++ b/test/fixtures/dialects/tsql/drop_credential.yml
@@ -1,0 +1,20 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 5e2a3ae9749cc7cbc020542a4f3417ad349032b8dc7020f7777f4b32e14d59ac
+file:
+  batch:
+  - statement:
+      drop_credential_statement:
+      - keyword: DROP
+      - keyword: CREDENTIAL
+      - naked_identifier: Saddles
+  - statement_terminator: ;
+  - statement:
+      drop_credential_statement:
+      - keyword: DROP
+      - keyword: CREDENTIAL
+      - quoted_identifier: '[Sales Credential]'
+  - statement_terminator: ;


### PR DESCRIPTION
### Brief summary of the change made

Adds support for parsing `DROP CREDENTIAL <name>` in the T-SQL dialect.

Before, SQLFluff reported an unparsable section:

```console
$ echo "DROP CREDENTIAL Saddles" | sqlfluff parse --dialect tsql -
[L:  1, P:  1]      |    unparsable: ... Found unparsable section: 'DROP CREDENTIAL Saddles'
```

After, it parses cleanly as a `drop_credential_statement`.

### Are there any other side effects of this change that we should be aware of?

No. The change adds one new statement segment and registers it in the
T-SQL statement grammar. `CREDENTIAL` was already a reserved keyword, so
no keyword list change was needed. The full T-SQL dialect test suite
passes with no regressions.

### What changed

- `DropCredentialStatementSegment` added to `dialect_tsql.py`, modelled
  on the existing `DropSynonymStatementSegment`, and registered in the
  statement grammar.
- Parse fixture `test/fixtures/dialects/tsql/drop_credential.sql` (+ the
  generated `.yml`) covering both naked and bracket-quoted credential
  names. Generated via `test/generate_parse_fixture_yml.py`.

Reference: [DROP CREDENTIAL (Transact-SQL)](https://learn.microsoft.com/en-us/sql/t-sql/statements/drop-credential-transact-sql)

Fixes #7903


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add T‑SQL support for `DROP CREDENTIAL <name>` so these statements parse as `drop_credential_statement` instead of being marked unparsable. Introduces `DropCredentialStatementSegment` and tests covering unquoted and bracket‑quoted credential names.

<sup>Written for commit 1d04ecf5ce1426a62028c85ae21ed214f79e7805. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/7905?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

