### PR TITLE
fix: AL05 false positive on whole-row alias references (postgres)

### DIFF
--- a/src/sqlfluff/rules/aliasing/AL05.py
+++ b/src/sqlfluff/rules/aliasing/AL05.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass, field
 from typing import cast
 
 from sqlfluff.core.dialects.common import AliasInfo
-from sqlfluff.core.parser.segments import BaseSegment, RawSegment
+from sqlfluff.core.parser.segments import BaseSegment
 from sqlfluff.core.rules import (
     BaseRule,
     EvalResultType,
@@ -318,7 +318,7 @@ class Rule_AL05(BaseRule):
                 cast(AL05Query, child), allow_row_references=allow_row_references
             )
 
-    def _resolve_and_mark_reference(self, query: AL05Query, ref: RawSegment) -> None:
+    def _resolve_and_mark_reference(self, query: AL05Query, ref: BaseSegment) -> None:
         # Does this query define the referenced alias?
         _ref = self._cs_str_id(ref)
         if any(_ref == self._cs_str_id(a.segment) for a in query.aliases if a.segment):

--- a/src/sqlfluff/rules/aliasing/AL05.py
+++ b/src/sqlfluff/rules/aliasing/AL05.py
@@ -69,6 +69,16 @@ class Rule_AL05(BaseRule):
         "postgres",
         "mariadb",
     ]
+    # Dialects where a bare table alias can be used as a whole-row/composite
+    # value (e.g. `SELECT to_json(t) FROM tbl AS t`). In these dialects such a
+    # reference is a legitimate use of the alias, so AL05 must not flag it as
+    # unused (issue #7039). In standard SQL this is not generally valid, so the
+    # behaviour stays opt-in per dialect to avoid masking genuinely unused
+    # aliases (see test_ansi_function_not_table_parameter).
+    _dialects_with_row_references = [
+        "postgres",
+        "redshift",
+    ]
     is_fix_compatible = True
 
     # config
@@ -87,7 +97,11 @@ class Rule_AL05(BaseRule):
         query = cast(
             AL05Query, AL05Query.from_segment(context.segment, dialect=context.dialect)
         )
-        self._analyze_table_aliases(query)
+        self._analyze_table_aliases(
+            query,
+            allow_row_references=context.dialect.name
+            in self._dialects_with_row_references,
+        )
 
         if context.dialect.name in ("redshift", "bigquery"):
             # Redshift supports un-nesting using aliases.
@@ -263,7 +277,9 @@ class Rule_AL05(BaseRule):
         # This should never happen. Return False just to be safe.
         return False  # pragma: no cover
 
-    def _analyze_table_aliases(self, query: AL05Query) -> None:
+    def _analyze_table_aliases(
+        self, query: AL05Query, allow_row_references: bool = False
+    ) -> None:
         # Get table aliases defined in query.
         for selectable in query.selectables:
             select_info = selectable.select_info
@@ -277,15 +293,30 @@ class Rule_AL05(BaseRule):
                 for r in (
                     select_info.reference_buffer + select_info.table_reference_buffer
                 ):
-                    for tr in r.extract_possible_references(
+                    table_refs = r.extract_possible_references(
                         level=r.ObjectReferenceLevel.TABLE
-                    ):
+                    )
+                    for tr in table_refs:
                         # This function walks up the query's parent stack if necessary.
                         self._resolve_and_mark_reference(query, tr.segments[0])
+                    # A bare, single-part reference (e.g. `t` in `to_json(t)` or
+                    # a whole-row `SELECT t`) yields no TABLE-level parts above.
+                    # In dialects with composite/row references it can still be a
+                    # use of a table alias, so fall back to treating the lone
+                    # identifier as a possible alias reference rather than
+                    # mis-reporting the alias as unused (issue #7039).
+                    if allow_row_references and not table_refs:
+                        ref_segments = [
+                            seg for seg in r.segments if seg.is_type("identifier")
+                        ]
+                        if len(ref_segments) == 1:
+                            self._resolve_and_mark_reference(query, ref_segments[0])
 
         # Visit children.
         for child in query.children:
-            self._analyze_table_aliases(cast(AL05Query, child))
+            self._analyze_table_aliases(
+                cast(AL05Query, child), allow_row_references=allow_row_references
+            )
 
     def _resolve_and_mark_reference(self, query: AL05Query, ref: RawSegment) -> None:
         # Does this query define the referenced alias?

--- a/test/fixtures/rules/std_rule_cases/AL05.yml
+++ b/test/fixtures/rules/std_rule_cases/AL05.yml
@@ -73,6 +73,28 @@ test_postgres_whole_row_reference:
     core:
       dialect: postgres
 
+test_postgres_row_reference_in_subquery:
+  # Closer reproduction of issue #7039: the row reference is inside a
+  # subquery, and the outer query reads the generated record value.
+  pass_str: |
+    SELECT
+        (x).key
+    FROM (
+        SELECT EACH(HSTORE(t)) AS x
+        FROM member_plan AS t
+    ) AS q
+  configs:
+    core:
+      dialect: postgres
+
+test_redshift_whole_row_reference:
+  # Redshift is also opted into the whole-row alias reference behaviour.
+  pass_str: |
+    SELECT t FROM foo AS t
+  configs:
+    core:
+      dialect: redshift
+
 test_fail_table_alias_not_referenced_2:
   # Similar to test_1, but with implicit alias.
   fail_str: SELECT * FROM my_tbl foo

--- a/test/fixtures/rules/std_rule_cases/AL05.yml
+++ b/test/fixtures/rules/std_rule_cases/AL05.yml
@@ -55,6 +55,24 @@ test_ignore_postgres_value_table_functions_generate_series:
     core:
       dialect: postgres
 
+test_postgres_row_reference_in_function:
+  # AL05 false positive with https://github.com/sqlfluff/sqlfluff/issues/7039
+  # Passing a table alias as a whole-row value to a function is a real use of
+  # the alias in Postgres, so it must not be reported as unused.
+  pass_str: |
+    SELECT each(hstore(t)) AS x FROM member_plan AS t
+  configs:
+    core:
+      dialect: postgres
+
+test_postgres_whole_row_reference:
+  # A bare whole-row reference to the alias is also a use of it.
+  pass_str: |
+    SELECT t FROM foo AS t
+  configs:
+    core:
+      dialect: postgres
+
 test_fail_table_alias_not_referenced_2:
   # Similar to test_1, but with implicit alias.
   fail_str: SELECT * FROM my_tbl foo


### PR DESCRIPTION
## Problem

Fixes #7039.

AL05 (`aliasing.unused`) reports a table alias as unused when it is referenced as a **bare, single-part identifier** rather than a qualified `alias.column`:

```sql
-- both flag `t` as "never used", incorrectly:
SELECT each(hstore(t)) AS x FROM member_plan AS t   -- whole-row value into a function
SELECT t                     FROM foo         AS t   -- whole-row select
```

In Postgres a table alias can be used as a composite/whole-row value (passed to a function, or selected directly). These are genuine uses of the alias, but they parse as a single-segment `column_reference`, so `extract_possible_references(level=TABLE)` returns nothing and `_analyze_table_aliases` never records the reference — the alias looks unused and AL05 even offers to delete it.

## Fix

In `_analyze_table_aliases`, when a reference yields no table-level parts, fall back to treating a lone identifier as a possible alias reference.

This is **gated by dialect** (`postgres`, `redshift`) via a new `_dialects_with_row_references` list and an `allow_row_references` flag, so standard-SQL behaviour is unchanged. In particular ANSI still treats `func(t)` as *not* a table use — preserving the existing `test_ansi_function_not_table_parameter` expectation. Keeping it opt-in avoids masking genuinely unused aliases in dialects without whole-row references.

## Behaviour

| query | dialect | before | after |
|-------|---------|--------|-------|
| `SELECT each(hstore(t)) ... FROM member_plan AS t` | postgres | ❌ flagged | ✅ ok |
| `SELECT t FROM foo AS t` | postgres | ❌ flagged | ✅ ok |
| `SELECT a FROM foo AS t` (truly unused) | postgres | flagged | flagged (unchanged) |
| `SELECT TO_JSON_STRING(t) FROM my_table AS t` | ansi | flagged | flagged (unchanged) |
| `SELECT zoo.a FROM foo AS zoo` | any | ok | ok (unchanged) |

## Tests

- Added `test_postgres_row_reference_in_function` and `test_postgres_whole_row_reference` to `AL05.yml`.
- Full AL05 / aliasing suite passes (135 yaml cases), including the unchanged ANSI case that distinguishes this behaviour.
- `ruff check` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes AL05 false positives in Postgres/Redshift when a table alias is used as a whole-row value, including in subqueries. Bare identifiers like t in SELECT each(hstore(t)) or SELECT t FROM foo AS t are now treated as valid alias uses.

- **Bug Fixes**
  - When no table-level parts are found, treat a lone identifier as a possible alias reference in dialects with row references (postgres, redshift); ANSI unchanged.
  - Propagates this behavior into nested queries.
  - Adds tests for function parameter, whole-row select, subquery, and Redshift cases.

<sup>Written for commit c5ceac8a8349ef8c68a4de8f8921aa820d02eff7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/7906?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

