### PR TITLE
Support for `DBT_ENGINE_` configs and additional `DBT_ENGINE_PROFILE`

### DIFF
--- a/docs/source/configuration/templating/dbt.rst
+++ b/docs/source/configuration/templating/dbt.rst
@@ -75,11 +75,21 @@ You can set the dbt project directory, profiles directory and profile with:
 .. code-block:: cfg
 
     [sqlfluff:templater:dbt]
-    project_dir = <relative or absolute path to dbt_project directory, can be overridden by env var DBT_PROJECT_DIR>
-    profiles_dir = <relative or absolute path to the directory that contains the profiles.yml file, can be overridden by env var DBT_PROFILES_DIR>
+    project_dir = <relative or absolute path to dbt_project directory>
+    profiles_dir = <relative or absolute path to the directory that contains the profiles.yml file>
     profile = <dbt profile>
     target = <dbt target>
     dbt_skip_compilation_error = <True or False, default is True>
+
+.. note::
+
+    If any of the settings above are omitted, SQLFluff also supports some dbt
+    equivalent environment variables. The ``DBT_ENGINE_*`` variables introduced
+    in dbt Core 1.11.8 take precedence over the legacy ``DBT_*`` variables, while
+    explicit SQLFluff configuration still takes precedence over both. For example,
+    ``profiles_dir`` can be set by ``DBT_ENGINE_PROFILES_DIR`` or
+    ``DBT_PROFILES_DIR``, and ``profile`` can be set by ``DBT_ENGINE_PROFILE``
+    or ``DBT_PROFILE``.
 
 .. note::
 

--- a/docsv/configuration/templating/dbt.md
+++ b/docsv/configuration/templating/dbt.md
@@ -83,12 +83,23 @@ You can set the dbt project directory, profiles directory and profile with:
 
 ```ini
 [sqlfluff:templater:dbt]
-project_dir = <relative or absolute path to dbt_project directory, can be overridden by env var DBT_PROJECT_DIR>
-profiles_dir = <relative or absolute path to the directory that contains the profiles.yml file, can be overridden by env var DBT_PROFILES_DIR>
+project_dir = <relative or absolute path to dbt_project directory>
+profiles_dir = <relative or absolute path to the directory that contains the profiles.yml file>
 profile = <dbt profile>
 target = <dbt target>
 dbt_skip_compilation_error = <True or False, default is True>
 ```
+
+::: tip NOTE
+
+If any of the settings above are omitted, SQLFluff also supports some dbt
+equivalent environment variables. The `DBT_ENGINE_*` variables introduced
+in dbt Core 1.11.8 take precedence over the legacy `DBT_*` variables, while
+explicit SQLFluff configuration still takes precedence over both. For example,
+`profiles_dir` can be set by `DBT_ENGINE_PROFILES_DIR` or
+`DBT_PROFILES_DIR`, and `profile` can be set by `DBT_ENGINE_PROFILE`
+or `DBT_PROFILE`.
+:::
 
 ::: tip NOTE
 

--- a/plugins/sqlfluff-templater-dbt/sqlfluff_templater_dbt/templater.py
+++ b/plugins/sqlfluff-templater-dbt/sqlfluff_templater_dbt/templater.py
@@ -356,9 +356,7 @@ class DbtTemplater(JinjaTemplater):
 
         The default is `~/.dbt` but we use the
         default_profiles_dir from the dbt library to
-        support a change of default in the future, as well
-        as to support the same overwriting mechanism as
-        dbt (currently an environment variable).
+        support a change of default in the future.
         """
         # Where default_profiles_dir is available, use it. For dbt 1.2 and
         # earlier, it is not, so fall back to the flags option which should
@@ -375,10 +373,7 @@ class DbtTemplater(JinjaTemplater):
 
         dbt_profiles_dir = os.path.abspath(
             os.path.expanduser(
-                self.sqlfluff_config.get_section(
-                    (self.templater_selector, self.name, "profiles_dir")
-                )
-                or (os.getenv("DBT_PROFILES_DIR") or default_dir)
+                self._get_dbt_config_value("profiles_dir", "PROFILES_DIR", default_dir)
             )
         )
 
@@ -390,6 +385,25 @@ class DbtTemplater(JinjaTemplater):
 
         return dbt_profiles_dir
 
+    def _get_dbt_config_value(
+        self, config_key: str, env_var_suffix: str, default: Optional[str] = None
+    ) -> Optional[str]:
+        """Get a dbt config value from SQLFluff config or dbt env vars.
+
+        SQLFluff config acts like an explicit dbt CLI value, so it takes
+        precedence over environment variables. dbt 1.11 introduced the
+        DBT_ENGINE_* prefix as the preferred env var namespace, while keeping
+        the legacy DBT_* variables for compatibility.
+        """
+        return (
+            self.sqlfluff_config.get_section(
+                (self.templater_selector, self.name, config_key)
+            )
+            or os.getenv(f"DBT_ENGINE_{env_var_suffix}")
+            or os.getenv(f"DBT_{env_var_suffix}")
+            or default
+        )
+
     def _get_project_dir(self):
         """Get the dbt project directory from the configuration.
 
@@ -397,11 +411,7 @@ class DbtTemplater(JinjaTemplater):
         """
         dbt_project_dir = os.path.abspath(
             os.path.expanduser(
-                self.sqlfluff_config.get_section(
-                    (self.templater_selector, self.name, "project_dir")
-                )
-                or os.getenv("DBT_PROJECT_DIR")
-                or os.getcwd()
+                self._get_dbt_config_value("project_dir", "PROJECT_DIR", os.getcwd())
             )
         )
         if not os.path.exists(dbt_project_dir):
@@ -414,21 +424,15 @@ class DbtTemplater(JinjaTemplater):
 
     def _get_profile(self):
         """Get a dbt profile name from the configuration."""
-        return self.sqlfluff_config.get_section(
-            (self.templater_selector, self.name, "profile")
-        )
+        return self._get_dbt_config_value("profile", "PROFILE")
 
     def _get_target(self):
         """Get a dbt target name from the configuration."""
-        return self.sqlfluff_config.get_section(
-            (self.templater_selector, self.name, "target")
-        ) or os.getenv("DBT_TARGET")
+        return self._get_dbt_config_value("target", "TARGET")
 
     def _get_target_path(self):
         """Get a dbt target path from the configuration."""
-        return self.sqlfluff_config.get_section(
-            (self.templater_selector, self.name, "target_path")
-        ) or os.getenv("DBT_TARGET_PATH")
+        return self._get_dbt_config_value("target_path", "TARGET_PATH")
 
     def _get_threads(self) -> Optional[int]:
         """Get the dbt threads value from the configuration.

--- a/plugins/sqlfluff-templater-dbt/test/templater_test.py
+++ b/plugins/sqlfluff-templater-dbt/test/templater_test.py
@@ -63,6 +63,65 @@ def test__templater_dbt_profiles_dir_expanded(dbt_templater):
     assert dbt_templater._get_target_path() == "target"
 
 
+def test__templater_dbt_profiles_dir_from_dbt_engine_env_var(
+    dbt_templater, tmp_path, monkeypatch
+):
+    """Check that the profiles_dir can be set by DBT_ENGINE_PROFILES_DIR."""
+    profiles_dir = tmp_path / "engine_profiles"
+    profiles_dir.mkdir()
+    monkeypatch.setenv("DBT_ENGINE_PROFILES_DIR", str(profiles_dir))
+    dbt_templater.sqlfluff_config = FluffConfig(
+        configs={
+            "core": {"dialect": "ansi"},
+            "templater": {"dbt": {"profiles_dir": None}},
+        },
+    )
+
+    assert dbt_templater._get_profiles_dir() == os.path.abspath(profiles_dir)
+
+
+def test__templater_dbt_profiles_dir_dbt_engine_env_var_precedence(
+    dbt_templater, tmp_path, monkeypatch
+):
+    """Check DBT_ENGINE_PROFILES_DIR takes precedence over DBT_PROFILES_DIR."""
+    engine_profiles_dir = tmp_path / "engine_profiles"
+    legacy_profiles_dir = tmp_path / "legacy_profiles"
+    engine_profiles_dir.mkdir()
+    legacy_profiles_dir.mkdir()
+    monkeypatch.setenv("DBT_ENGINE_PROFILES_DIR", str(engine_profiles_dir))
+    monkeypatch.setenv("DBT_PROFILES_DIR", str(legacy_profiles_dir))
+    dbt_templater.sqlfluff_config = FluffConfig(
+        configs={
+            "core": {"dialect": "ansi"},
+            "templater": {"dbt": {"profiles_dir": None}},
+        },
+    )
+
+    assert dbt_templater._get_profiles_dir() == os.path.abspath(engine_profiles_dir)
+
+
+def test__templater_dbt_profiles_dir_config_precedence(
+    dbt_templater, tmp_path, monkeypatch
+):
+    """Check SQLFluff profiles_dir config takes precedence over dbt env vars."""
+    config_profiles_dir = tmp_path / "config_profiles"
+    engine_profiles_dir = tmp_path / "engine_profiles"
+    legacy_profiles_dir = tmp_path / "legacy_profiles"
+    config_profiles_dir.mkdir()
+    engine_profiles_dir.mkdir()
+    legacy_profiles_dir.mkdir()
+    monkeypatch.setenv("DBT_ENGINE_PROFILES_DIR", str(engine_profiles_dir))
+    monkeypatch.setenv("DBT_PROFILES_DIR", str(legacy_profiles_dir))
+    dbt_templater.sqlfluff_config = FluffConfig(
+        configs={
+            "core": {"dialect": "ansi"},
+            "templater": {"dbt": {"profiles_dir": str(config_profiles_dir)}},
+        },
+    )
+
+    assert dbt_templater._get_profiles_dir() == os.path.abspath(config_profiles_dir)
+
+
 @pytest.mark.parametrize(
     "fname",
     [
@@ -107,25 +166,23 @@ def test__templater_dbt_templating_result(
 
 
 def test_dbt_profiles_dir_env_var_uppercase(
-    project_dir,
     dbt_templater,
     tmpdir,
     monkeypatch,
-    dbt_fluff_config,
-    dbt_project_folder,
     profiles_dir,
 ):
     """Tests specifying the dbt profile dir with env var."""
     sub_profiles_dir = tmpdir.mkdir("SUBDIR")  # Use uppercase to test issue 2253
     monkeypatch.setenv("DBT_PROFILES_DIR", str(sub_profiles_dir))
     shutil.copy(os.path.join(profiles_dir, "profiles.yml"), str(sub_profiles_dir))
-    _run_templater_and_verify_result(
-        dbt_templater,
-        project_dir,
-        "use_dbt_utils.sql",
-        dbt_fluff_config,
-        dbt_project_folder,
+    dbt_templater.sqlfluff_config = FluffConfig(
+        configs={
+            "core": {"dialect": "ansi"},
+            "templater": {"dbt": {"profiles_dir": None}},
+        },
     )
+
+    assert dbt_templater._get_profiles_dir() == os.path.abspath(str(sub_profiles_dir))
 
 
 def _run_templater_and_verify_result(
@@ -691,10 +748,41 @@ def test__project_dir_from_env(dbt_templater, project_dir, monkeypatch):
     assert dbt_templater._get_project_dir() == os.path.abspath(os.getcwd())
     monkeypatch.setenv("DBT_PROJECT_DIR", project_dir)
     assert dbt_templater._get_project_dir() == os.path.abspath(project_dir)
+    monkeypatch.setenv("DBT_ENGINE_PROJECT_DIR", os.getcwd())
+    assert dbt_templater._get_project_dir() == os.path.abspath(os.getcwd())
+
+
+def test__profile_from_env(dbt_templater, monkeypatch):
+    """Test possibility to set profile from dbt profile env variables."""
+    dbt_templater.sqlfluff_config = FluffConfig(
+        configs={
+            "core": {"dialect": "ansi"},
+            "templater": {"dbt": {"profile": None}},
+        }
+    )
+    assert dbt_templater._get_profile() is None
+    monkeypatch.setenv("DBT_PROFILE", "legacy_profile")
+    assert dbt_templater._get_profile() == "legacy_profile"
+    monkeypatch.setenv("DBT_ENGINE_PROFILE", "engine_profile")
+    assert dbt_templater._get_profile() == "engine_profile"
+
+
+def test__profile_config_precedence(dbt_templater, monkeypatch):
+    """Test SQLFluff profile config takes precedence over dbt profile env vars."""
+    monkeypatch.setenv("DBT_ENGINE_PROFILE", "engine_profile")
+    monkeypatch.setenv("DBT_PROFILE", "legacy_profile")
+    dbt_templater.sqlfluff_config = FluffConfig(
+        configs={
+            "core": {"dialect": "ansi"},
+            "templater": {"dbt": {"profile": "config_profile"}},
+        }
+    )
+
+    assert dbt_templater._get_profile() == "config_profile"
 
 
 def test__target_from_env(dbt_templater, monkeypatch):
-    """Test possibility to set target from DBT_TARGET env variable."""
+    """Test possibility to set target from dbt target env variables."""
     dbt_templater.sqlfluff_config = FluffConfig(
         configs={
             "core": {"dialect": "ansi"},
@@ -704,10 +792,12 @@ def test__target_from_env(dbt_templater, monkeypatch):
     assert dbt_templater._get_target() is None
     monkeypatch.setenv("DBT_TARGET", "dev")
     assert dbt_templater._get_target() == "dev"
+    monkeypatch.setenv("DBT_ENGINE_TARGET", "prod")
+    assert dbt_templater._get_target() == "prod"
 
 
 def test__target_path_from_env(dbt_templater, monkeypatch):
-    """Test possibility to set target_path from DBT_TARGET_PATH env variable."""
+    """Test possibility to set target_path from dbt target path env variables."""
     dbt_templater.sqlfluff_config = FluffConfig(
         configs={
             "core": {"dialect": "ansi"},
@@ -717,6 +807,8 @@ def test__target_path_from_env(dbt_templater, monkeypatch):
     assert dbt_templater._get_target_path() is None
     monkeypatch.setenv("DBT_TARGET_PATH", "custom_target")
     assert dbt_templater._get_target_path() == "custom_target"
+    monkeypatch.setenv("DBT_ENGINE_TARGET_PATH", "engine_target")
+    assert dbt_templater._get_target_path() == "engine_target"
 
 
 def test__project_dir_does_not_exist_error(dbt_templater):

--- a/plugins/sqlfluff-templater-dbt/test/templater_test.py
+++ b/plugins/sqlfluff-templater-dbt/test/templater_test.py
@@ -166,23 +166,25 @@ def test__templater_dbt_templating_result(
 
 
 def test_dbt_profiles_dir_env_var_uppercase(
+    project_dir,
     dbt_templater,
     tmpdir,
     monkeypatch,
+    dbt_fluff_config,
+    dbt_project_folder,
     profiles_dir,
 ):
     """Tests specifying the dbt profile dir with env var."""
     sub_profiles_dir = tmpdir.mkdir("SUBDIR")  # Use uppercase to test issue 2253
     monkeypatch.setenv("DBT_PROFILES_DIR", str(sub_profiles_dir))
     shutil.copy(os.path.join(profiles_dir, "profiles.yml"), str(sub_profiles_dir))
-    dbt_templater.sqlfluff_config = FluffConfig(
-        configs={
-            "core": {"dialect": "ansi"},
-            "templater": {"dbt": {"profiles_dir": None}},
-        },
+    _run_templater_and_verify_result(
+        dbt_templater,
+        project_dir,
+        "use_dbt_utils.sql",
+        dbt_fluff_config,
+        dbt_project_folder,
     )
-
-    assert dbt_templater._get_profiles_dir() == os.path.abspath(str(sub_profiles_dir))
 
 
 def _run_templater_and_verify_result(


### PR DESCRIPTION

### Brief summary of the change made
This PR adds support for the `DBT_ENGINE_` config. Old `DBT_` config is still support for legacy reasons. Additionally support for DBT_ENGINE_PROFILE is added.

### Are there any other side effects of this change that we should be aware of?
If a user is on a old dbt version (below 1.11) and has mistakenly set `DBT_ENGINE_` this PR causes unexpected behaviour.
The dbt change is documented here: https://docs.getdbt.com/reference/global-configs/about-global-configs?version=1.12&name=Core

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for `DBT_ENGINE_*` environment variables and `DBT_ENGINE_PROFILE` in the dbt templater, with clear precedence: SQLFluff config > `DBT_ENGINE_*` > `DBT_*`. Docs updated to reflect the behavior and examples per dbt Core 1.11.8.

- New Features
  - Read `profiles_dir`, `project_dir`, `profile`, `target`, and `target_path` from `DBT_ENGINE_*`; fall back to `DBT_*` if not set.
  - SQLFluff config still overrides env vars.
  - Docs updated to explain precedence with examples.

- Migration
  - No action required; existing `DBT_*` env vars keep working.
  - Prefer `DBT_ENGINE_*` on dbt Core 1.11.8+; avoid setting them on older dbt versions.

<sup>Written for commit f6d7e45ae546577eca03c60b6a201c62b0a7bf9f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/7907?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

