### PR TITLE
Fix typo: 'the the' -> 'the' in test comment

### DIFF
--- a/test/core/parser/grammar/grammar_other_test.py
+++ b/test/core/parser/grammar/grammar_other_test.py
@@ -100,7 +100,7 @@ def test__parser__grammar_delimited(
             ["a"],
             (),
         ),
-        # NOTE: the the  "c" terminator won't match because "c" is
+        # NOTE: the "c" terminator won't match because "c" is
         # a keyword and therefore is required to have whitespace
         # before it.
         # See `greedy_match()` for details.


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

#### Brief summary of the change made
Fixed a typo in a code comment in `test/core/parser/grammar/grammar_other_test.py`.
Changed "the the" to "the".

### Are there any other side effects of this change that we should be aware of?
No. This is purely a comment typo fix and does not affect any code behavior or tests.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Other (typo fix in a code comment, no functional changes).
- [x] Added appropriate documentation for the change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix a typo in a test comment in `test/core/parser/grammar/grammar_other_test.py` ('the the' -> 'the'). No functional changes.

<sup>Written for commit 78ff8f4ac60e4fe76f755708485b6b0f584bae04. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/7908?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

