### PR TITLE
Improve versioned docs publishing

### DIFF
--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -9,6 +9,25 @@ on:
     types:
       - published
   workflow_dispatch:
+    inputs:
+      version:
+        description: Release tag to rebuild. Leave empty to publish latest from the selected ref.
+        required: false
+        type: string
+      refresh_stable:
+        description: Also refresh /en/stable/ from the selected release tag.
+        required: false
+        default: false
+        type: boolean
+      prerelease:
+        description: Mark the manually rebuilt version as a prerelease.
+        required: false
+        default: false
+        type: boolean
+      published_at:
+        description: Optional published_at timestamp to preserve in versions.json.
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -32,7 +51,55 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          ref: ${{ github.event_name == 'release' && github.event.release.tag_name || github.ref }}
+          ref: ${{ github.event_name == 'release' && github.event.release.tag_name || inputs.version || github.ref }}
+
+      - name: Determine docs publish target
+        id: docs-target
+        env:
+          DISPATCH_VERSION: ${{ inputs.version }}
+          DISPATCH_REFRESH_STABLE: ${{ inputs.refresh_stable }}
+          DISPATCH_PRERELEASE: ${{ inputs.prerelease }}
+          DISPATCH_PUBLISHED_AT: ${{ inputs.published_at }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_PRERELEASE: ${{ github.event.release.prerelease }}
+          RELEASE_PUBLISHED_AT: ${{ github.event.release.published_at }}
+        run: |
+          if [ "${{ github.event_name }}" = "release" ]; then
+              version="${RELEASE_TAG}"
+              prerelease="${RELEASE_PRERELEASE}"
+              published_at="${RELEASE_PUBLISHED_AT}"
+              build_latest=false
+              build_release=true
+              if [ "${RELEASE_PRERELEASE}" = "true" ]; then
+                  build_stable=false
+              else
+                  build_stable=true
+              fi
+          elif [ -n "${DISPATCH_VERSION}" ]; then
+              version="${DISPATCH_VERSION}"
+              prerelease="${DISPATCH_PRERELEASE}"
+              published_at="${DISPATCH_PUBLISHED_AT}"
+              build_latest=false
+              build_release=true
+              build_stable="${DISPATCH_REFRESH_STABLE}"
+          else
+              version=latest
+              prerelease=false
+              published_at=
+              build_latest=true
+              build_release=false
+              build_stable=false
+          fi
+
+          {
+              echo "version=${version}"
+              echo "release_base=/en/${version}/"
+              echo "prerelease=${prerelease}"
+              echo "published_at=${published_at}"
+              echo "build_latest=${build_latest}"
+              echo "build_release=${build_release}"
+              echo "build_stable=${build_stable}"
+          } >> "${GITHUB_OUTPUT}"
 
       - name: 📦 Enable corepack
         run: corepack enable
@@ -72,7 +139,7 @@ jobs:
           --endpoint-url https://${{ secrets.R2_ACCOUNT_ID }}.r2.cloudflarestorage.com
 
       - name: ⚒️ Build VitePress latest docs
-        if: ${{ github.event_name != 'release' }}
+        if: ${{ steps.docs-target.outputs.build_latest == 'true' }}
         env:
           SQLFLUFF_DOCS_BASE: /en/latest/
           SQLFLUFF_DOCS_NOINDEX: ${{ env.SQLFLUFF_DOCS_NOINDEX }}
@@ -80,7 +147,7 @@ jobs:
         run: corepack pnpm run docs:build
 
       - name: Assemble latest site
-        if: ${{ github.event_name != 'release' }}
+        if: ${{ steps.docs-target.outputs.build_latest == 'true' }}
         run: >-
           python docsv/scripts/assemble-site.py
           --vitepress-dist docsv/.vitepress/dist
@@ -90,27 +157,27 @@ jobs:
           --kind channel
 
       - name: ⚒️ Build VitePress release docs
-        if: ${{ github.event_name == 'release' }}
+        if: ${{ steps.docs-target.outputs.build_release == 'true' }}
         env:
-          SQLFLUFF_DOCS_BASE: /en/${{ github.event.release.tag_name }}/
+          SQLFLUFF_DOCS_BASE: ${{ steps.docs-target.outputs.release_base }}
           SQLFLUFF_DOCS_NOINDEX: ${{ env.SQLFLUFF_DOCS_NOINDEX }}
         working-directory: docsv
         run: corepack pnpm run docs:build
 
       - name: Assemble release site
-        if: ${{ github.event_name == 'release' }}
+        if: ${{ steps.docs-target.outputs.build_release == 'true' }}
         run: >-
           python docsv/scripts/assemble-site.py
           --vitepress-dist docsv/.vitepress/dist
           --output-dir ${{ env.DOCS_SITE_DIR }}
-          --channel ${{ github.event.release.tag_name }}
-          --title ${{ github.event.release.tag_name }}
+          --channel ${{ steps.docs-target.outputs.version }}
+          --title ${{ steps.docs-target.outputs.version }}
           --kind release
-          --published-at ${{ github.event.release.published_at }}
-          ${{ github.event.release.prerelease && '--prerelease' || '' }}
+          ${{ steps.docs-target.outputs.published_at && format('--published-at {0}', steps.docs-target.outputs.published_at) || '' }}
+          ${{ steps.docs-target.outputs.prerelease == 'true' && '--prerelease' || '' }}
 
       - name: ⚒️ Build VitePress stable docs
-        if: ${{ github.event_name == 'release' && !github.event.release.prerelease }}
+        if: ${{ steps.docs-target.outputs.build_stable == 'true' }}
         env:
           SQLFLUFF_DOCS_BASE: /en/stable/
           SQLFLUFF_DOCS_NOINDEX: ${{ env.SQLFLUFF_DOCS_NOINDEX }}
@@ -118,7 +185,7 @@ jobs:
         run: corepack pnpm run docs:build
 
       - name: Assemble stable site
-        if: ${{ github.event_name == 'release' && !github.event.release.prerelease }}
+        if: ${{ steps.docs-target.outputs.build_stable == 'true' }}
         run: >-
           python docsv/scripts/assemble-site.py
           --vitepress-dist docsv/.vitepress/dist
@@ -126,7 +193,12 @@ jobs:
           --channel stable
           --title Stable
           --kind channel
-          --stable-release ${{ github.event.release.tag_name }}
+          --stable-release ${{ steps.docs-target.outputs.version }}
+
+      - name: Smoke check assembled site
+        run: >-
+          python docsv/scripts/smoke-check-assembled-site.py
+          --site-dir ${{ env.DOCS_SITE_DIR }}
 
       - name: ⬆️ Upload assembled site artifact
         uses: actions/upload-artifact@v4

--- a/docsv/.vitepress/config.ts
+++ b/docsv/.vitepress/config.ts
@@ -72,7 +72,7 @@ const REFERENCES: DefaultTheme.NavItemWithLink[] = [
     { text: 'Release Notes', link: '/reference/release-notes' },
 ]
 
-const docsBase = normalizeBase(process.env.SQLFLUFF_DOCS_BASE, '/sqlfluff/')
+const docsBase = normalizeBase(process.env.SQLFLUFF_DOCS_BASE, '/en/latest/')
 const noIndex = process.env.SQLFLUFF_DOCS_NOINDEX === '1'
 
 const head: [string, Record<string, string>][] = [

--- a/docsv/.vitepress/theme/ThemeLayout.vue
+++ b/docsv/.vitepress/theme/ThemeLayout.vue
@@ -6,11 +6,11 @@ import VersionPicker from './VersionPicker.vue'
 
 <template>
   <DefaultTheme.Layout>
-    <template #nav-bar-content-after>
-      <VersionPicker :show-label="false" :inline="true" />
+    <template #nav-bar-content-before>
+      <VersionPicker class="version-picker--desktop" :show-label="false" />
     </template>
 
-    <template #nav-screen-content-after>
+    <template #nav-screen-content-before>
       <VersionPicker class="version-picker--mobile" />
     </template>
 
@@ -21,7 +21,24 @@ import VersionPicker from './VersionPicker.vue'
 </template>
 
 <style scoped>
+.version-picker--desktop {
+  display: none;
+  margin-right: auto;
+  margin-left: 0.75rem;
+}
+
 .version-picker--mobile {
-  padding: 0.75rem 0 0;
+  display: flex;
+  padding: 0 0 1rem;
+}
+
+@media (min-width: 768px) {
+  .version-picker--desktop {
+    display: flex;
+  }
+
+  .version-picker--mobile {
+    display: none;
+  }
 }
 </style>

--- a/docsv/.vitepress/theme/VersionPicker.vue
+++ b/docsv/.vitepress/theme/VersionPicker.vue
@@ -26,6 +26,7 @@ const manifest = ref<VersionManifest | null>(null)
 const isOpen = ref(false)
 const menuRef = ref<HTMLElement | null>(null)
 const rootRef = ref<HTMLElement | null>(null)
+const triggerRef = ref<HTMLButtonElement | null>(null)
 const route = useRoute()
 const { site } = useData()
 const currentPath = ref(normalizeBase(route.path, '/'))
@@ -87,22 +88,59 @@ function navigateToVersion(version: VersionEntry): void {
     window.location.href = version.path
 }
 
-function toggleMenu(): void {
-    isOpen.value = !isOpen.value
+function menuOptions(): HTMLButtonElement[] {
+    return Array.from(menuRef.value?.querySelectorAll<HTMLButtonElement>('.version-picker__option') || [])
+}
 
-    if (!isOpen.value) {
+function focusMenuOption(index: number): void {
+    const options = menuOptions()
+
+    if (!options.length) {
         return
     }
 
+    const nextIndex = (index + options.length) % options.length
+    options[nextIndex]?.focus()
+}
+
+function focusSelectedOrFallback(fallbackIndex = 0): void {
+    const options = menuOptions()
+
+    if (!options.length) {
+        return
+    }
+
+    const selectedIndex = options.findIndex((option) => option.getAttribute('aria-checked') === 'true')
+    focusMenuOption(selectedIndex >= 0 ? selectedIndex : fallbackIndex)
+}
+
+function openMenu(fallbackIndex = 0): void {
+    if (isOpen.value) {
+        return
+    }
+
+    isOpen.value = true
+
     void nextTick(() => {
-        menuRef.value
-            ?.querySelector<HTMLButtonElement>('.version-picker__option[aria-checked="true"]')
-            ?.focus()
+        focusSelectedOrFallback(fallbackIndex)
     })
 }
 
-function closeMenu(): void {
+function toggleMenu(): void {
+    if (isOpen.value) {
+        closeMenu()
+        return
+    }
+
+    openMenu()
+}
+
+function closeMenu(focusTrigger = false): void {
     isOpen.value = false
+
+    if (focusTrigger) {
+        triggerRef.value?.focus()
+    }
 }
 
 function onDocumentPointerDown(event: PointerEvent): void {
@@ -113,7 +151,51 @@ function onDocumentPointerDown(event: PointerEvent): void {
 
 function onDocumentKeyDown(event: KeyboardEvent): void {
     if (event.key === 'Escape') {
-        closeMenu()
+        closeMenu(true)
+    }
+}
+
+function onTriggerKeyDown(event: KeyboardEvent): void {
+    if (event.key === 'ArrowDown') {
+        event.preventDefault()
+        openMenu(0)
+        return
+    }
+
+    if (event.key === 'ArrowUp') {
+        event.preventDefault()
+        openMenu(versions.value.length - 1)
+    }
+}
+
+function onOptionKeyDown(event: KeyboardEvent, index: number): void {
+    if (event.key === 'ArrowDown') {
+        event.preventDefault()
+        focusMenuOption(index + 1)
+        return
+    }
+
+    if (event.key === 'ArrowUp') {
+        event.preventDefault()
+        focusMenuOption(index - 1)
+        return
+    }
+
+    if (event.key === 'Home') {
+        event.preventDefault()
+        focusMenuOption(0)
+        return
+    }
+
+    if (event.key === 'End') {
+        event.preventDefault()
+        focusMenuOption(versions.value.length - 1)
+        return
+    }
+
+    if (event.key === 'Escape') {
+        event.preventDefault()
+        closeMenu(true)
     }
 }
 
@@ -158,13 +240,14 @@ onBeforeUnmount(() => {
         <span v-if="props.showLabel" class="version-picker__label">Version</span>
         <div class="version-picker__control">
             <button
+                ref="triggerRef"
                 class="version-picker__trigger"
                 type="button"
                 aria-haspopup="menu"
                 :aria-expanded="isOpen"
                 :aria-label="props.showLabel ? undefined : 'Version'"
                 @click="toggleMenu"
-                @keydown.down.prevent="toggleMenu"
+                @keydown="onTriggerKeyDown"
             >
                 <span class="version-picker__current">{{ currentLabel }}</span>
                 <span class="version-picker__chevron" :class="{ 'version-picker__chevron--open': isOpen }" aria-hidden="true"></span>
@@ -178,13 +261,14 @@ onBeforeUnmount(() => {
                 aria-label="Available versions"
             >
                 <button
-                    v-for="version in versions"
+                    v-for="(version, index) in versions"
                     :key="version.key"
                     class="version-picker__option"
                     type="button"
                     role="menuitemradio"
                     :aria-checked="selectedVersion?.key === version.key"
                     @click="onSelect(version)"
+                    @keydown="onOptionKeyDown($event, index)"
                 >
                     <span>{{ version.label }}</span>
                 </button>

--- a/docsv/.vitepress/theme/VersionPicker.vue
+++ b/docsv/.vitepress/theme/VersionPicker.vue
@@ -1,15 +1,13 @@
 <script setup lang="ts">
-import { computed, onMounted, ref } from 'vue'
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { useData, useRoute } from 'vitepress'
 import { manifestPath, normalizeBase } from '../path-utils'
 
 const props = withDefaults(
     defineProps<{
-        inline?: boolean
         showLabel?: boolean
     }>(),
     {
-        inline: false,
         showLabel: true,
     }
 )
@@ -25,9 +23,12 @@ interface VersionManifest {
 }
 
 const manifest = ref<VersionManifest | null>(null)
+const isOpen = ref(false)
+const menuRef = ref<HTMLElement | null>(null)
+const rootRef = ref<HTMLElement | null>(null)
 const route = useRoute()
 const { site } = useData()
-const currentPath = ref('/')
+const currentPath = ref(normalizeBase(route.path, '/'))
 
 const docsBase = computed(() => normalizeBase(site.value.base, '/'))
 
@@ -81,21 +82,63 @@ async function loadManifest(): Promise<void> {
     throw new Error(`Failed to load versions manifest from ${manifestPath(docsBase.value)}`)
 }
 
-function onChange(event: Event): void {
-    const target = event.target as HTMLSelectElement
-    const version = versions.value.find((entry) => entry.key === target.value)
+function navigateToVersion(version: VersionEntry): void {
+    isOpen.value = false
+    window.location.href = version.path
+}
 
+function toggleMenu(): void {
+    isOpen.value = !isOpen.value
+
+    if (!isOpen.value) {
+        return
+    }
+
+    void nextTick(() => {
+        menuRef.value
+            ?.querySelector<HTMLButtonElement>('.version-picker__option[aria-checked="true"]')
+            ?.focus()
+    })
+}
+
+function closeMenu(): void {
+    isOpen.value = false
+}
+
+function onDocumentPointerDown(event: PointerEvent): void {
+    if (!rootRef.value?.contains(event.target as Node)) {
+        closeMenu()
+    }
+}
+
+function onDocumentKeyDown(event: KeyboardEvent): void {
+    if (event.key === 'Escape') {
+        closeMenu()
+    }
+}
+
+function onSelect(version: VersionEntry): void {
     if (!version) {
         return
     }
 
-    window.location.href = version.path
+    navigateToVersion(version)
 }
 
 const currentLabel = computed(() => selectedVersion.value?.label || 'Version')
 
+watch(
+    () => route.path,
+    (path) => {
+        currentPath.value = normalizeBase(path, '/')
+        closeMenu()
+    }
+)
+
 onMounted(async () => {
     currentPath.value = normalizeBase(window.location.pathname || route.path, '/')
+    document.addEventListener('pointerdown', onDocumentPointerDown)
+    document.addEventListener('keydown', onDocumentKeyDown)
 
     try {
         await loadManifest()
@@ -103,28 +146,49 @@ onMounted(async () => {
         console.error(error)
     }
 })
+
+onBeforeUnmount(() => {
+    document.removeEventListener('pointerdown', onDocumentPointerDown)
+    document.removeEventListener('keydown', onDocumentKeyDown)
+})
 </script>
 
 <template>
-    <div v-if="versions.length" :class="['version-picker', { 'version-picker--inline': props.inline }]">
-        <label v-if="props.showLabel" class="version-picker__label" for="version-picker-select">Version</label>
+    <div v-if="versions.length" ref="rootRef" class="version-picker">
+        <span v-if="props.showLabel" class="version-picker__label">Version</span>
         <div class="version-picker__control">
-            <span v-if="props.inline" class="version-picker__current">{{ currentLabel }}</span>
-            <select
-                id="version-picker-select"
-                class="version-picker__select"
-                :value="selectedVersion?.key"
+            <button
+                class="version-picker__trigger"
+                type="button"
+                aria-haspopup="menu"
+                :aria-expanded="isOpen"
                 :aria-label="props.showLabel ? undefined : 'Version'"
-                @change="onChange"
+                @click="toggleMenu"
+                @keydown.down.prevent="toggleMenu"
             >
-                <option
+                <span class="version-picker__current">{{ currentLabel }}</span>
+                <span class="version-picker__chevron" :class="{ 'version-picker__chevron--open': isOpen }" aria-hidden="true"></span>
+            </button>
+
+            <div
+                v-if="isOpen"
+                ref="menuRef"
+                class="version-picker__menu"
+                role="menu"
+                aria-label="Available versions"
+            >
+                <button
                     v-for="version in versions"
                     :key="version.key"
-                    :value="version.key"
+                    class="version-picker__option"
+                    type="button"
+                    role="menuitemradio"
+                    :aria-checked="selectedVersion?.key === version.key"
+                    @click="onSelect(version)"
                 >
-                    {{ version.label }}
-                </option>
-            </select>
+                    <span>{{ version.label }}</span>
+                </button>
+            </div>
         </div>
     </div>
 </template>
@@ -135,10 +199,6 @@ onMounted(async () => {
     align-items: center;
     gap: 0.5rem;
     padding: 0.5rem 0;
-}
-
-.version-picker--inline {
-    padding: 0;
 }
 
 .version-picker__label {
@@ -153,54 +213,100 @@ onMounted(async () => {
     align-items: center;
 }
 
-.version-picker__control::after {
-    position: absolute;
-    right: 0.7rem;
-    width: 0.45rem;
-    height: 0.45rem;
-    border-right: 1.5px solid var(--vp-c-text-2);
-    border-bottom: 1.5px solid var(--vp-c-text-2);
-    content: "";
-    pointer-events: none;
-    transform: translateY(-0.15rem) rotate(45deg);
-}
-
 .version-picker__current {
-    position: absolute;
-    left: 0.7rem;
     color: var(--vp-c-text-1);
     font-size: 0.875rem;
     font-weight: 600;
-    pointer-events: none;
 }
 
-.version-picker__select {
+.version-picker__trigger {
+    display: inline-flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
     min-width: 7.5rem;
     height: 2rem;
-    padding: 0.35rem 2rem 0.35rem 0.7rem;
-    border: 1px solid var(--vp-c-divider);
-    border-radius: 6px;
-    appearance: none;
-    background: var(--vp-c-bg-soft);
+    padding: 0 0.75rem;
+    border: 0;
+    border-radius: 999px;
+    background: color-mix(in srgb, var(--vp-c-default-soft) 78%, transparent);
+    color: var(--vp-c-text-1);
+    cursor: pointer;
+    transition: background-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+    box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--vp-c-divider) 88%, transparent);
+}
+
+.version-picker__trigger:hover {
+    background: color-mix(in srgb, var(--vp-c-default-soft) 94%, var(--vp-c-brand-soft));
+}
+
+.version-picker__trigger:focus-visible,
+.version-picker__option:focus-visible {
+    outline: none;
+    box-shadow: inset 0 0 0 2px var(--vp-c-brand-1);
+}
+
+.version-picker__chevron {
+    width: 0.5rem;
+    height: 0.5rem;
+    border-right: 1.5px solid currentColor;
+    border-bottom: 1.5px solid currentColor;
+    transform: translateY(-0.1rem) rotate(45deg);
+    transition: transform 0.2s ease;
+}
+
+.version-picker__chevron--open {
+    transform: translateY(0.1rem) rotate(-135deg);
+}
+
+.version-picker__menu {
+    position: absolute;
+    top: calc(100% + 0.125rem);
+    left: 0;
+    z-index: 30;
+    display: flex;
+    flex-direction: column;
+    min-width: 9rem;
+    padding: 0.25rem;
+    border-radius: 14px;
+    background: color-mix(in srgb, var(--vp-c-bg-elv) 92%, var(--vp-c-bg));
+    box-shadow: 0 16px 40px rgba(15, 23, 42, 0.16);
+    border: 1px solid color-mix(in srgb, var(--vp-c-divider) 85%, transparent);
+}
+
+.version-picker__option {
+    display: flex;
+    align-items: center;
+    width: 100%;
+    padding: 0.45rem 0.625rem;
+    border: 0;
+    border-radius: 10px;
+    background: transparent;
     color: var(--vp-c-text-1);
     font-size: 0.875rem;
+    font-weight: 600;
     line-height: 1.25rem;
+    text-align: left;
+    cursor: pointer;
 }
 
-.version-picker--inline .version-picker__select {
-    min-width: 6.5rem;
-    color: transparent;
-    background: transparent;
+.version-picker__option:hover {
+    background: color-mix(in srgb, var(--vp-c-brand-soft) 68%, transparent);
 }
 
-.version-picker__select:focus {
-    outline: 2px solid var(--vp-c-brand-1);
-    outline-offset: 2px;
+.version-picker__option[aria-checked="true"] {
+    background: color-mix(in srgb, var(--vp-c-brand-soft) 88%, transparent);
+    color: var(--vp-c-brand-1);
 }
 
 @media (max-width: 960px) {
     .version-picker {
         justify-content: space-between;
+    }
+
+    .version-picker__menu {
+        left: auto;
+        right: 0;
     }
 }
 </style>

--- a/docsv/.vitepress/theme/VersionPicker.vue
+++ b/docsv/.vitepress/theme/VersionPicker.vue
@@ -92,6 +92,8 @@ function onChange(event: Event): void {
     window.location.href = version.path
 }
 
+const currentLabel = computed(() => selectedVersion.value?.label || 'Version')
+
 onMounted(async () => {
     currentPath.value = normalizeBase(window.location.pathname || route.path, '/')
 
@@ -104,23 +106,27 @@ onMounted(async () => {
 </script>
 
 <template>
-        <div v-if="versions.length" :class="['version-picker', { 'version-picker--inline': props.inline }]">
+    <div v-if="versions.length" :class="['version-picker', { 'version-picker--inline': props.inline }]">
         <label v-if="props.showLabel" class="version-picker__label" for="version-picker-select">Version</label>
-                <select
-                        id="version-picker-select"
-                        class="version-picker__select"
-                        :value="selectedVersion?.key"
-                        @change="onChange"
+        <div class="version-picker__control">
+            <span v-if="props.inline" class="version-picker__current">{{ currentLabel }}</span>
+            <select
+                id="version-picker-select"
+                class="version-picker__select"
+                :value="selectedVersion?.key"
+                :aria-label="props.showLabel ? undefined : 'Version'"
+                @change="onChange"
+            >
+                <option
+                    v-for="version in versions"
+                    :key="version.key"
+                    :value="version.key"
                 >
-                        <option
-                                v-for="version in versions"
-                                :key="version.key"
-                                :value="version.key"
-                        >
-                                {{ version.label }}
-                        </option>
-                </select>
+                    {{ version.label }}
+                </option>
+            </select>
         </div>
+    </div>
 </template>
 
 <style scoped>
@@ -141,19 +147,49 @@ onMounted(async () => {
     color: var(--vp-c-text-2);
 }
 
+.version-picker__control {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+}
+
+.version-picker__control::after {
+    position: absolute;
+    right: 0.7rem;
+    width: 0.45rem;
+    height: 0.45rem;
+    border-right: 1.5px solid var(--vp-c-text-2);
+    border-bottom: 1.5px solid var(--vp-c-text-2);
+    content: "";
+    pointer-events: none;
+    transform: translateY(-0.15rem) rotate(45deg);
+}
+
+.version-picker__current {
+    position: absolute;
+    left: 0.7rem;
+    color: var(--vp-c-text-1);
+    font-size: 0.875rem;
+    font-weight: 600;
+    pointer-events: none;
+}
+
 .version-picker__select {
-    min-width: 7rem;
-    padding: 0.35rem 2rem 0.35rem 0.65rem;
+    min-width: 7.5rem;
+    height: 2rem;
+    padding: 0.35rem 2rem 0.35rem 0.7rem;
     border: 1px solid var(--vp-c-divider);
-    border-radius: 999px;
+    border-radius: 6px;
+    appearance: none;
     background: var(--vp-c-bg-soft);
     color: var(--vp-c-text-1);
     font-size: 0.875rem;
+    line-height: 1.25rem;
 }
 
 .version-picker--inline .version-picker__select {
-    min-width: 5.5rem;
-    padding-right: 1.5rem;
+    min-width: 6.5rem;
+    color: transparent;
     background: transparent;
 }
 

--- a/docsv/package.json
+++ b/docsv/package.json
@@ -5,8 +5,9 @@
     "type": "module",
     "scripts": {
         "docs:prebuild": "python scripts/generate-all-docs.py",
-        "docs:dev": "vitepress dev",
+        "docs:dev": "vitepress dev --base /en/latest/",
         "docs:build": "python scripts/generate-all-docs.py && vitepress build",
+        "docs:build:latest": "python scripts/generate-all-docs.py && vitepress build --base /en/latest/",
         "docs:preview": "vitepress preview"
     },
     "devDependencies": {

--- a/docsv/scripts/smoke-check-assembled-site.py
+++ b/docsv/scripts/smoke-check-assembled-site.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Smoke check the assembled versioned docs site."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--site-dir",
+        type=Path,
+        required=True,
+        help="Path to the assembled site tree.",
+    )
+    parser.add_argument(
+        "--language",
+        default="en",
+        help="Top-level language segment to validate.",
+    )
+    return parser.parse_args()
+
+
+def load_manifest(site_dir: Path, language: str) -> dict[str, Any]:
+    """Load and minimally validate the versions manifest."""
+    manifest_path = site_dir / language / "versions.json"
+
+    if not manifest_path.is_file():
+        raise FileNotFoundError(f"Missing versions manifest: {manifest_path}")
+
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    versions = manifest.get("versions")
+
+    if not isinstance(versions, list) or not versions:
+        raise ValueError("versions.json must include at least one version entry")
+
+    return manifest
+
+
+def assert_path_exists(site_dir: Path, url_path: str, description: str) -> None:
+    """Assert a published URL path maps to an existing file or directory."""
+    relative_path = url_path.strip("/")
+    path = site_dir / relative_path
+
+    if path.is_dir():
+        path = path / "index.html"
+
+    if not path.is_file():
+        raise FileNotFoundError(f"Missing {description}: {path}")
+
+
+def smoke_check(site_dir: Path, language: str) -> None:
+    """Validate the important assembled docs outputs."""
+    manifest = load_manifest(site_dir, language)
+
+    for entry in manifest["versions"]:
+        key = entry.get("key")
+        path = entry.get("path")
+
+        if not key or not path:
+            raise ValueError(f"Version entry must include key and path: {entry!r}")
+
+        assert_path_exists(site_dir, str(path), f"index page for {key}")
+
+    redirects_path = site_dir / "_redirects"
+
+    if not redirects_path.is_file():
+        raise FileNotFoundError(f"Missing Netlify redirects file: {redirects_path}")
+
+    redirects = redirects_path.read_text(encoding="utf-8")
+    default = str(manifest.get("default") or manifest.get("latest") or "latest")
+    default_path = f"/{language}/{default}/"
+
+    if not re.search(rf"^/ {re.escape(default_path)} 302$", redirects, re.MULTILINE):
+        raise ValueError(f"Missing root redirect to {default_path}")
+
+    assert_path_exists(site_dir, default_path, "default redirect target")
+
+    headers_path = site_dir / "_headers"
+
+    if not headers_path.is_file():
+        raise FileNotFoundError(f"Missing Netlify headers file: {headers_path}")
+
+
+def main() -> int:
+    """Main entry point."""
+    args = parse_args()
+    smoke_check(args.site_dir, args.language.strip("/"))
+    print(f"Smoke check passed for {args.site_dir}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

This follows up on the maintainer feedback in #7912:

- default the local VitePress docs base to `/en/latest/` and add explicit local latest scripts
- add `workflow_dispatch` inputs so manual runs can rebuild a release tag and optionally refresh `stable`
- route release, latest, and stable publishing through a single computed docs target
- add a post-assembly smoke check for the version manifest, redirects, headers, and published index targets
- tighten the version picker styling and inline accessibility

## Testing

- `python3 -m json.tool docsv/package.json`
- `python3 -m py_compile docsv/scripts/smoke-check-assembled-site.py docsv/scripts/assemble-site.py`
- `python3 docsv/scripts/assemble-site.py --vitepress-dist docsv/.vitepress/dist --output-dir /tmp/sqlfluff-docs-smoke --channel latest --title Development --kind channel`
- `python3 docsv/scripts/smoke-check-assembled-site.py --site-dir /tmp/sqlfluff-docs-smoke`

Could not run the full VitePress build in this WSL shell because the available Windows npm shim reports WSL 1 is unsupported and `corepack`/`node` are not on PATH.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Streamlines versioned docs publishing into a single CI path with manual rebuild controls and a pre-upload smoke check. Defaults local docs to `/en/latest/` and ships a new, accessible VersionPicker with desktop/mobile placement and full keyboard navigation.

- **New Features**
  - Unified CI routing for release/latest/stable via a computed target; `workflow_dispatch` inputs: `version`, `refresh_stable`, `prerelease`, `published_at`.
  - Added a smoke check script to validate `versions.json`, `_redirects`, `_headers`, and default/index targets before upload.
  - Default local docs base to `/en/latest/` in `config.ts`; `docs:dev` runs `vitepress dev --base /en/latest/`; added `docs:build:latest` in `package.json`.
  - Reworked VersionPicker into a dropdown with ARIA roles and full keyboard support (Arrow keys, Home/End, Escape), outside-click close, and focus management; placed for desktop (`nav-bar-content-before`) and mobile (`nav-screen-content-before`).

<sup>Written for commit c38953320d8f66e78fb847deaf629ea06aaac366. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/7915?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

