### PR TITLE
fix(rust): Bracket optimization shouldn't match non-code.

### DIFF
--- a/sqlfluffrs/sqlfluffrs_lexer/src/lexer.rs
+++ b/sqlfluffrs/sqlfluffrs_lexer/src/lexer.rs
@@ -384,6 +384,13 @@ impl Lexer {
         let mut bracket_stack: Vec<(usize, char)> = Vec::new();
 
         for idx in 0..tokens.len() {
+            // Only code tokens can be brackets. Skipping non-code tokens (notably
+            // comments) prevents bracket characters inside a block/inline comment -
+            // e.g. `min(` / `)` - from being paired with real brackets in the SQL.
+            if !tokens[idx].is_code() {
+                continue;
+            }
+
             let raw = tokens[idx].raw();
 
             // Check if this is an opening bracket

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/python.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/python.rs
@@ -662,6 +662,13 @@ fn compute_bracket_pairs(tokens: &mut [Token]) {
     let mut bracket_stack: Vec<(usize, char)> = Vec::new();
 
     for idx in 0..tokens.len() {
+        // Only code tokens can be brackets. Skipping non-code tokens (notably
+        // comments) prevents bracket characters inside a block/inline comment -
+        // e.g. `min(` / `)` - from being paired with real brackets in the SQL.
+        if !tokens[idx].is_code() {
+            continue;
+        }
+
         let raw = tokens[idx].raw();
 
         // Check if this is an opening bracket

--- a/test/fixtures/dialects/athena/create_table_as_select_with_block_comment.sql
+++ b/test/fixtures/dialects/athena/create_table_as_select_with_block_comment.sql
@@ -1,0 +1,14 @@
+-- Block comments containing bracket characters (e.g. `min(` and `)`) must not be
+-- treated as real brackets by the parser's bracket-matching optimisation.
+-- See https://github.com/sqlfluff/sqlfluff/issues/7914
+CREATE TABLE table_b
+AS (
+  SELECT
+      col_a
+      /*
+      min(
+      )
+      AS type_arr
+      */
+  FROM table_a
+)

--- a/test/fixtures/dialects/athena/create_table_as_select_with_block_comment.yml
+++ b/test/fixtures/dialects/athena/create_table_as_select_with_block_comment.yml
@@ -1,0 +1,30 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 84494734a8224372a18669522741f9b7b6cb92213d91fdf483601a64e323d91f
+file:
+  statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: table_b
+    - keyword: AS
+    - bracketed:
+        start_bracket: (
+        select_statement:
+          select_clause:
+            keyword: SELECT
+            select_clause_element:
+              column_reference:
+                naked_identifier: col_a
+          from_clause:
+            keyword: FROM
+            from_expression:
+              from_expression_element:
+                table_expression:
+                  table_reference:
+                    naked_identifier: table_a
+        end_bracket: )


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
This fixes the bracket search optimization to not include non-code tokens.
- fixes #7914

### Are there any other side effects of this change that we should be aware of?
None

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop the bracket-matching optimization from considering non-code tokens (e.g., comments) to prevent false bracket pairs during parsing. Fixes #7914.

- **Bug Fixes**
  - Skip tokens where `!is_code()` when computing bracket pairs in `sqlfluffrs_lexer/src/lexer.rs` and `sqlfluffrs_parser/src/parser/python.rs`.
  - Add Athena fixture with a block comment containing `min(` and `)` to verify comments don't affect bracket matching.

<sup>Written for commit 2ffd36a9deea96f0748bde5eb7a4cfe462879020. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/7916?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

