### PR TITLE
Update so that sqlfluff can parse backquoted databricks function argu…

### DIFF
--- a/src/sqlfluff/dialects/dialect_databricks.py
+++ b/src/sqlfluff/dialects/dialect_databricks.py
@@ -1677,7 +1677,7 @@ class NamedArgumentSegment(BaseSegment):
 
     type = "named_argument"
     match_grammar = Sequence(
-        Ref("NakedIdentifierSegment"),
+        OneOf(Ref("NakedIdentifierSegment"), Ref("BackQuotedIdentifierSegment")),
         Ref("RightArrowSegment"),
         Ref("ExpressionSegment"),
     )

--- a/src/sqlfluff/dialects/dialect_databricks.py
+++ b/src/sqlfluff/dialects/dialect_databricks.py
@@ -1677,7 +1677,7 @@ class NamedArgumentSegment(BaseSegment):
 
     type = "named_argument"
     match_grammar = Sequence(
-        OneOf(Ref("NakedIdentifierSegment"), Ref("BackQuotedIdentifierSegment")),
+        Ref("VariableNameIdentifierSegment"),
         Ref("RightArrowSegment"),
         Ref("ExpressionSegment"),
     )

--- a/test/fixtures/dialects/databricks/select_from_read_file.sql
+++ b/test/fixtures/dialects/databricks/select_from_read_file.sql
@@ -35,3 +35,14 @@ SELECT * FROM read_files(
 
 -- Reads a streaming table
 SELECT * FROM STREAM read_files('gs://my-bucket/avroData', includeExistingFiles => false);
+
+-- Reads files from a path using a back quoted identifier.
+-- Example: https://docs.databricks.com/aws/en/ingestion/sharepoint#read-sharepoint-files-using-spark-sql
+CREATE TABLE my_table AS
+SELECT * FROM read_files(
+  "https://mytenant.sharepoint.com/sites/Marketing/Shared%20Documents",
+  `databricks.connection` => "my_sharepoint_conn",
+  format => "binaryFile",
+  pathGlobFilter => "*.pdf", -- optional. Example: only ingest PDFs
+  schemaEvolutionMode => "none"
+);

--- a/test/fixtures/dialects/databricks/select_from_read_file.yml
+++ b/test/fixtures/dialects/databricks/select_from_read_file.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 174100b63d83fe671aa54d8162a534325ffad2cbbbcc12cbf31e20122e995016
+_hash: ca15af693067e1762cb4bb7006e8896aabf2430bc2bfb9a5f71361af684bc8ba
 file:
 - statement:
     select_statement:
@@ -260,4 +260,57 @@ file:
                       expression:
                         boolean_literal: 'false'
                     end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: my_table
+    - keyword: AS
+    - select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                function:
+                  function_name:
+                    function_name_identifier: read_files
+                  function_contents:
+                    bracketed:
+                    - start_bracket: (
+                    - expression:
+                        quoted_literal: '"https://mytenant.sharepoint.com/sites/Marketing/Shared%20Documents"'
+                    - comma: ','
+                    - named_argument:
+                        quoted_identifier: '`databricks.connection`'
+                        right_arrow: =>
+                        expression:
+                          quoted_literal: '"my_sharepoint_conn"'
+                    - comma: ','
+                    - named_argument:
+                        naked_identifier: format
+                        right_arrow: =>
+                        expression:
+                          quoted_literal: '"binaryFile"'
+                    - comma: ','
+                    - named_argument:
+                        naked_identifier: pathGlobFilter
+                        right_arrow: =>
+                        expression:
+                          quoted_literal: '"*.pdf"'
+                    - comma: ','
+                    - named_argument:
+                        naked_identifier: schemaEvolutionMode
+                        right_arrow: =>
+                        expression:
+                          quoted_literal: '"none"'
+                    - end_bracket: )
 - statement_terminator: ;


### PR DESCRIPTION
Parse backquoted databricks function arguments


<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->

Some argument to e.g. read_files for data contain a "." on the argument name. To handle these argument names, its expected in databricks sql to use back quoted argument name. See example here 
https://docs.databricks.com/aws/en/ingestion/sharepoint#read-sharepoint-files-using-spark-sql

### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable `sqlfluff` to parse backquoted Databricks named argument keys with dots in functions like `read_files`, e.g., `\`databricks.connection\`` => "my_sharepoint_conn".

- **New Features**
  - Use `VariableNameIdentifierSegment` for named argument keys in the Databricks dialect to support backquoted keys with dots.
  - Add parser tests for `read_files` with backquoted keys (SharePoint).

<sup>Written for commit 32c715cd8cf29027b2447c9e735afe7d6cd62a63. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/7917?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

