### PR TITLE
fix: ST10 false positive when RHS operand is part of a binary expression

### DIFF
--- a/src/sqlfluff/rules/structure/ST10.py
+++ b/src/sqlfluff/rules/structure/ST10.py
@@ -74,15 +74,15 @@ class Rule_ST10(BaseRule):
                     (None, None),
                 )
 
-                rhs = next(
+                rhs_idx, rhs = next(
                     (
-                        subsegments[i]
+                        (i, subsegments[i])
                         for i in range(idx + 1, count_subsegments, 1)
                         if not subsegments[i].is_whitespace
                     ),
-                    None,
+                    (None, None),
                 )
-                if lhs is None or rhs is None or lhs_idx is None:
+                if lhs is None or rhs is None or lhs_idx is None or rhs_idx is None:
                     # Should be unreachable with correctly parsed tree
                     continue  # pragma: no cover
 
@@ -102,13 +102,29 @@ class Rule_ST10(BaseRule):
                     else None
                 )
 
+                next_after_rhs = next(
+                    (
+                        subsegments[i]
+                        for i in range(rhs_idx + 1, count_subsegments, 1)
+                        if not subsegments[i].is_whitespace
+                    ),
+                    None,
+                )
+
                 # We treat the pieces immediately left and right of `=` as its operands.
                 # After AND or OR, that is correct (e.g. `... OR 1 = 2`).
-                # After other binary operators, it is not correct (e.g. `num % 2 = 0`).
+                # After other binary operators, it is not correct (e.g. `num % 2 = 0`
+                # on the left, or `flags = flags & @mask` on the right).
                 if (
                     prev_before_lhs is not None
                     and prev_before_lhs.is_type("binary_operator")
                     and prev_before_lhs.raw_normalized().upper() not in ("AND", "OR")
+                ):
+                    continue
+                if (
+                    next_after_rhs is not None
+                    and next_after_rhs.is_type("binary_operator")
+                    and next_after_rhs.raw_normalized().upper() not in ("AND", "OR")
                 ):
                     continue
 

--- a/test/fixtures/rules/std_rule_cases/ST10.yml
+++ b/test/fixtures/rules/std_rule_cases/ST10.yml
@@ -131,6 +131,20 @@ test_other_operators_with_bracketed_precedence:
         end as test
     from cte
 
+test_other_operators_on_rhs:
+  # The right-hand operand is part of a larger expression, so the comparison
+  # is not redundant even though the same column appears on both sides.
+  # https://github.com/sqlfluff/sqlfluff/issues/7910
+  pass_str: |
+    SELECT flags FROM t WHERE flags = flags & 4
+
+test_bitwise_operator_on_rhs_tsql:
+  pass_str: |
+    SELECT BitFlagValue FROM Dbo.BitFlags WHERE BitFlagValue = BitFlagValue & @Mask
+  configs:
+    core:
+      dialect: tsql
+
 test_pass_templated_queries:
   pass_str: |
     SELECT a, col FROM t WHERE a = :a


### PR DESCRIPTION
### Brief summary of the change made

Fixes #7910.

ST10 (`structure.constant_expression`) treats the segments immediately left and right of the comparison operator as its operands. It already skips the case where the **left** operand is part of a larger binary expression (e.g. `num % 2 = 0`), but had no symmetric check for the **right** operand. So:

```sql
SELECT BitFlagValue FROM Dbo.BitFlags WHERE BitFlagValue = BitFlagValue & @Mask
```

was reported as a redundant constant expression — the rule compared `BitFlagValue` against `BitFlagValue` and ignored the trailing `& @Mask`, even though the two sides differ.

The fix adds the symmetric guard: skip when the segment following the RHS operand is a binary operator other than `AND`/`OR`, mirroring the existing left-hand check.

### Are there any other side effects of this change that we should be aware of?

No. Genuine redundancy is still caught (`col = col`, `col = col OR x = y` both still flag), the existing left-hand exception (`num % 2 = 0`) is unchanged, and `AND`/`OR` after the RHS is still treated as a boundary so `... OR a = a` continues to be flagged. The full ST10 test suite passes (23 cases including the two added below).

### Pull Request checklist
- Included test cases: two `.yml` rule cases in `test/fixtures/rules/std_rule_cases/ST10.yml` (`test_other_operators_on_rhs`, `test_bitwise_operator_on_rhs_tsql`).
- Verified locally: `ruff check`, `ruff format --check`, and `mypy` all clean on the changed rule; ST10 yaml cases pass.

### AI assistance disclosure

Per the AI-assisted contributions policy: this change was drafted with AI assistance (Claude Code). The root cause was identified from the parse tree, and the fix, the regression tests, and the full verification (reproduction of the false positive, confirming no over-suppression, running the ST10 suite + ruff + mypy) were reviewed and validated manually by me.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a false positive in ST10 where comparisons like `flags = flags & @Mask` were flagged as redundant when the RHS was part of a larger binary expression. Preserves existing behavior for `AND`/`OR` and left-hand exceptions. Fixes #7910.

- **Bug Fixes**
  - Add symmetric RHS guard: if a binary operator (other than `AND`/`OR`) follows the RHS, skip the rule, mirroring the existing LHS check.
  - Add tests: `flags = flags & 4` and T-SQL `BitFlagValue = BitFlagValue & @Mask`.

<sup>Written for commit 9d89e904c62e06541884e0937fb89f31a9b598cc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/7918?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

