### PR TITLE
Fix Teradata date cast parsing

### DIFF
--- a/src/sqlfluff/dialects/dialect_teradata.py
+++ b/src/sqlfluff/dialects/dialect_teradata.py
@@ -468,7 +468,14 @@ class TeradataCastSegment(BaseSegment):
     """
 
     type = "cast_expression"
-    match_grammar = Bracketed(Ref("DatatypeSegment"))
+    match_grammar = Bracketed(
+        Ref("DatatypeSegment"),
+        Sequence(
+            Ref("CommaSegment"),
+            Ref("CharCharacterSetGrammar"),
+            optional=True,
+        ),
+    )
 
 
 class ExpressionSegment(BaseSegment):

--- a/test/fixtures/dialects/teradata/select.sql
+++ b/test/fixtures/dialects/teradata/select.sql
@@ -2,7 +2,9 @@ SELECT DATE;
 
 CREATE TABLE t1 (f1 DATE);
 
-SELECT DATE (FORMAT 'MMMbdd,bYYYY') (CHAR(12), UC); -- https://docs.teradata.com/r/S0Fw2AVH8ff3MDA0wDOHlQ/ryoeKJsEr22NqKahaktP5g
+-- https://docs.teradata.com/r/Enterprise_IntelliFlex_VMware/SQL-Data-Types-and-Literals/Data-Type-Formats-and-Format-Phrases/FORMAT-Phrase-and-DateTime-Formats/Examples-Querying-Using-Date-Formats
+SELECT DATE (FORMAT 'MMMbdd,bYYYY');
+SELECT DATE (FORMAT 'MMMbdd,bYYYY') (CHAR(12), UC);
 
 SELECT
     ADD_MONTHS(abandono.FEC_CIERRE_EST, -12) AS FEC_CIERRE_EST_ULT12,

--- a/test/fixtures/dialects/teradata/select.sql
+++ b/test/fixtures/dialects/teradata/select.sql
@@ -2,8 +2,7 @@ SELECT DATE;
 
 CREATE TABLE t1 (f1 DATE);
 
-SELECT DATE (FORMAT 'MMMbdd,bYYYY'); -- (CHAR(12), UC);  -- https://docs.teradata.com/r/S0Fw2AVH8ff3MDA0wDOHlQ/ryoeKJsEr22NqKahaktP5g
--- Disabled CHAR(12, UC) for now, see #1665
+SELECT DATE (FORMAT 'MMMbdd,bYYYY') (CHAR(12), UC); -- https://docs.teradata.com/r/S0Fw2AVH8ff3MDA0wDOHlQ/ryoeKJsEr22NqKahaktP5g
 
 SELECT
     ADD_MONTHS(abandono.FEC_CIERRE_EST, -12) AS FEC_CIERRE_EST_ULT12,

--- a/test/fixtures/dialects/teradata/select.yml
+++ b/test/fixtures/dialects/teradata/select.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 0653acb67db77c9a799b7702cda6ed63cf249e6ff11cd1e1ef77313fc690566c
+_hash: 46556b472be85c20e254e549fb1b3724fc3f8046b2653da129a546e4f1c0d9be
 file:
 - statement:
     select_statement:
@@ -32,16 +32,30 @@ file:
       select_clause:
         keyword: SELECT
         select_clause_element:
-          function:
-            function_name:
-              function_name_identifier: DATE
-            function_contents:
+          expression:
+            function:
+              function_name:
+                function_name_identifier: DATE
+              function_contents:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    data_type:
+                      data_type_identifier: FORMAT
+                    quoted_literal: "'MMMbdd,bYYYY'"
+                  end_bracket: )
+            cast_expression:
               bracketed:
                 start_bracket: (
-                expression:
-                  data_type:
-                    data_type_identifier: FORMAT
-                  quoted_literal: "'MMMbdd,bYYYY'"
+                data_type:
+                  data_type_identifier: CHAR
+                  bracketed_arguments:
+                    bracketed:
+                      start_bracket: (
+                      numeric_literal: '12'
+                      end_bracket: )
+                comma: ','
+                keyword: UC
                 end_bracket: )
 - statement_terminator: ;
 - statement:

--- a/test/fixtures/dialects/teradata/select.yml
+++ b/test/fixtures/dialects/teradata/select.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 46556b472be85c20e254e549fb1b3724fc3f8046b2653da129a546e4f1c0d9be
+_hash: a4f1dd26b122f7470b7588effba64428b62653c93de579d96674a070c77be187
 file:
 - statement:
     select_statement:
@@ -26,6 +26,23 @@ file:
           data_type:
             data_type_identifier: DATE
         end_bracket: )
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: DATE
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  data_type:
+                    data_type_identifier: FORMAT
+                  quoted_literal: "'MMMbdd,bYYYY'"
+                end_bracket: )
 - statement_terminator: ;
 - statement:
     select_statement:


### PR DESCRIPTION
Fixes #1665

### Summary

This PR fixes parsing for Teradata date conversion syntax with a comma-separated character attribute:

```sql
SELECT DATE (FORMAT 'MMMbdd,bYYYY') (CHAR(12), UC);
```

The Teradata cast grammar already supported character attributes such as `UC`, but did not handle the comma-separated form `(CHAR(12), UC)`.

This change:
- Allows an optional comma followed by `CharCharacterSetGrammar` inside `TeradataCastSegment`.
- Re-enables the existing Teradata fixture example for issue #1665.
- Regenerates the Teradata `select.yml` parse fixture.

### Tests

```bash
tox -e generate-fixture-yml -- -d teradata
tox -e winpy313 -- test/dialects/dialects_test.py -k "teradata and select"
tox -e winpy313 -- test/dialects/dialects_test.py -k "teradata"
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #1665. Adds support for comma-separated character attributes in Teradata DATE casts so queries like SELECT DATE (FORMAT 'MMMbdd,bYYYY') (CHAR(12), UC) parse correctly.

- **Bug Fixes**
  - Update `TeradataCastSegment` to allow an optional comma followed by `CharCharacterSetGrammar` after the datatype inside casts.
  - Update Teradata fixtures: enable the `(CHAR(12), UC)` example in `select.sql` and regenerate `select.yml`.

<sup>Written for commit 1d4f97a3a4e21e87e03cdbe1817877a6b31a103d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/7919?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

