### PR TITLE
Fix RF03 false positive on whole-row references (e.g. postgres `->>`)

### DIFF
--- a/src/sqlfluff/rules/references/RF03.py
+++ b/src/sqlfluff/rules/references/RF03.py
@@ -193,6 +193,13 @@ def _check_references(
         # are not real column references and should not be qualified or flagged.
         if this_ref_type == "unqualified" and ref.is_templated:
             continue
+        # Skip whole-row references: a bare reference matching the single table's
+        # own alias/name (e.g. ``tbl ->> 'k'`` in postgres, or ``SELECT tbl FROM
+        # tbl``) refers to the whole row, not a column. It neither needs
+        # qualification nor counts towards single-table consistency, so qualifying
+        # it as ``tbl.tbl`` would be invalid.
+        if this_ref_type == "unqualified" and ref.raw == table_ref_str:
+            continue
         if this_ref_type == "qualified" and is_struct_dialect:
             # If this col appears "qualified" check if it is more logically a struct.
             if next(ref.iter_raw_references()).part != table_ref_str:

--- a/src/sqlfluff/rules/references/RF03.py
+++ b/src/sqlfluff/rules/references/RF03.py
@@ -198,7 +198,10 @@ def _check_references(
         # tbl``) refers to the whole row, not a column. It neither needs
         # qualification nor counts towards single-table consistency, so qualifying
         # it as ``tbl.tbl`` would be invalid.
-        if this_ref_type == "unqualified" and ref.raw == table_ref_str:
+        if (
+            this_ref_type == "unqualified"
+            and ref.raw_normalized(casefold=False) == table_ref_str
+        ):
             continue
         if this_ref_type == "qualified" and is_struct_dialect:
             # If this col appears "qualified" check if it is more logically a struct.

--- a/test/fixtures/rules/std_rule_cases/RF03.yml
+++ b/test/fixtures/rules/std_rule_cases/RF03.yml
@@ -648,3 +648,25 @@ test_pass_placeholder_colon_double_colon_cast:
     templater:
       placeholder:
         param_style: colon
+
+test_pass_postgres_whole_row_json_operator:
+  # A bare reference matching the table's own alias is a whole-row reference
+  # (here the left operand of the `->>` JSON operator), not a column, so RF03
+  # must not flag it or "qualify" it as the invalid `pattern_obj.pattern_obj`.
+  # https://github.com/sqlfluff/sqlfluff/issues/6904
+  pass_str: |
+    SELECT pattern_obj ->> 'col' AS c
+    FROM jsonb_array_elements('[]'::jsonb) AS pattern_obj
+  configs:
+    core:
+      dialect: postgres
+    rules:
+      references.consistent:
+        single_table_references: qualified
+
+test_pass_whole_row_reference_mixed_qualification:
+  # `tbl` is a whole-row reference matching the single table's name, so even when
+  # it appears before the qualified `tbl.a` it must not count as an unqualified
+  # column reference (and so must not be "fixed" to `tbl.tbl`).
+  # https://github.com/sqlfluff/sqlfluff/issues/6904
+  pass_str: SELECT tbl, tbl.a FROM tbl

--- a/test/fixtures/rules/std_rule_cases/RF03.yml
+++ b/test/fixtures/rules/std_rule_cases/RF03.yml
@@ -160,7 +160,6 @@ test_tsql_pivot_are_excluded:
     core:
       dialect: tsql
 
-
 test_date_functions_are_excluded:
   # This should pass as date keywords columns do not need to be
   # qualified
@@ -657,6 +656,19 @@ test_pass_postgres_whole_row_json_operator:
   pass_str: |
     SELECT pattern_obj ->> 'col' AS c
     FROM jsonb_array_elements('[]'::jsonb) AS pattern_obj
+  configs:
+    core:
+      dialect: postgres
+    rules:
+      references.consistent:
+        single_table_references: qualified
+
+test_pass_postgres_quoted_whole_row_json_operator:
+  # Quoted aliases should use normalized identifier matching for the same
+  # whole-row-reference exemption, rather than comparing the quoted raw text.
+  pass_str: |
+    SELECT "Pattern_Obj" ->> 'col' AS c
+    FROM jsonb_array_elements('[]'::jsonb) AS "Pattern_Obj"
   configs:
     core:
       dialect: postgres


### PR DESCRIPTION
### Brief summary of the change made

Fixes #6904

RF03 (`references.consistent`) was treating a *whole-row reference* — a bare
reference whose name matches the single table's own alias/name — as an
unqualified column reference. The clearest example is the left operand of
PostgreSQL's `->>` JSON operator:

```sql
SELECT pattern_obj ->> 'col'
FROM jsonb_array_elements(...) AS pattern_obj
```

Here `pattern_obj` is the table(-function) alias and `pattern_obj ->> 'col'`
reads from the whole row — it is not a column. RF03 nonetheless:

- counted it as an `unqualified` reference (making genuinely qualified
  references in the same statement look "inconsistent"), and
- under a `qualified` target, auto-"fixed" it to the invalid
  `pattern_obj.pattern_obj`.

The fix skips such whole-row references in `_check_references` (right next to the
existing templated-reference skip), so they are neither flagged nor rewritten and
do not affect the single-table consistency check. This also covers the plain
`SELECT tbl FROM tbl` whole-row case.

### Are there any other side effects of this change that we should be aware of?

No. The guard only skips a bare, unqualified reference whose raw text equals the
single table's own alias/name. Genuine unqualified column references (whose name
differs from the table) are still flagged and fixed exactly as before — verified
by the existing RF03 suite (all passing) plus a check that `SELECT bar FROM
my_tbl` is still reported under a `qualified` target.

### Pull Request checklist

- [x] Included test cases to demonstrate the code change:
  - [x] `.yml` rule test cases in `test/fixtures/rules/std_rule_cases` (`RF03.yml`):
    a PostgreSQL `->>` whole-row case (`qualified` target) and a
    mixed-qualification case where the whole-row reference precedes a qualified
    column.
- [x] No documentation change needed — this is a false-positive fix with no new
  config option or message.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a false positive in RF03 (`references.consistent`) when a bare reference equals the single table alias/name (a whole-row reference), including quoted aliases, e.g., the left operand of Postgres `->>` or `SELECT tbl FROM tbl`. Prevents invalid auto-qualification like `tbl.tbl` and keeps single-table consistency checks accurate. Closes #6904.

- **Bug Fixes**
  - Skip whole-row unqualified refs in `_check_references` so they’re neither flagged nor rewritten, including when the alias is quoted.
  - Added tests for Postgres `->>`, quoted alias matching, and a mixed-qualification example; genuine unqualified columns are unchanged.

<sup>Written for commit 7d4600e33c35410b3e83bd9fb240e0d4e71a2824. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/7921?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



