### PR TITLE
parser: Increase default max_parse_depth to `600`

### DIFF
--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/core.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/core.rs
@@ -109,10 +109,10 @@ pub struct Parser<'a> {
 
 impl<'a> Parser<'a> {
     /// Default max parse depth when not specified (DoS mitigation; matches Python config default).
-    pub const DEFAULT_MAX_PARSE_DEPTH: usize = 255;
+    pub const DEFAULT_MAX_PARSE_DEPTH: usize = 600;
 
     /// Create a new Parser instance with table-driven grammar support.
-    /// Uses DEFAULT_MAX_PARSE_DEPTH (255) unless overridden via new_with_max_parse_depth.
+    /// Uses DEFAULT_MAX_PARSE_DEPTH (600) unless overridden via new_with_max_parse_depth.
     pub fn new(
         tokens: &'a [Token],
         dialect: Dialect,

--- a/sqlfluffrs/tests/fixture_tests.rs
+++ b/sqlfluffrs/tests/fixture_tests.rs
@@ -510,7 +510,7 @@ impl FixtureTest {
         }
 
         // Use a generous depth limit so stress-test fixtures like
-        // expression_recursion don't hit the DoS guard (default 255).
+        // expression_recursion don't hit the DoS guard (default 600).
         let mut parser = Parser::new_with_max_parse_depth(
             &tokens,
             dialect,

--- a/src/sqlfluff/core/default_config.cfg
+++ b/src/sqlfluff/core/default_config.cfg
@@ -1,8 +1,8 @@
 [sqlfluff]
 # Set the Python recursion limit for parsing deeply nested SQL. If not set, Python's default is used.
 recursion_limit = None
-# Maximum parse depth (grammar + bracket nesting). Prevents DoS from deeply nested SQL. Set to 0 or empty to disable. Default 255 (Oracle WHERE subquery limit).
-max_parse_depth = 255
+# Maximum parse depth (grammar + bracket nesting). Prevents DoS from deeply nested SQL. Set to 0 or empty to disable. Default 600 (headroom for normal nested function calls while still bounding pathological input).
+max_parse_depth = 600
 # Maximum parse nodes in the final parse tree. Prevents DoS from unusually wide or expansive SQL. Set to 0 or empty to disable. Default is intentionally high to avoid normal queries.
 max_parse_nodes = 100000
 # verbose is an integer (0-2) indicating the level of log output

--- a/test/core/parser/max_parse_depth_test.py
+++ b/test/core/parser/max_parse_depth_test.py
@@ -44,8 +44,40 @@ def test_max_parse_depth_simple_sql_parses():
     assert not parsed.violations
 
 
+def test_max_parse_depth_default_allows_nested_function_calls():
+    """Modestly nested function calls parse under the default limit (issue #7805).
+
+    Uses the shipped default, since dialect fixtures parse at a depth of 1024 and
+    wouldn't catch the default being too low.
+    """
+    sql = """CREATE FUNCTION [dbo].[fn_StringWithoutSpace]
+(
+    @string NVARCHAR(MAX)
+)
+RETURNS NVARCHAR(MAX)
+WITH INLINE = OFF
+AS
+BEGIN
+    RETURN (
+        SELECT LTRIM(RTRIM(REPLACE(REPLACE(REPLACE(REPLACE(
+            @string,
+            CHAR(160), CHAR(32)),
+            CHAR(32),  '()'),
+            ')(',      ''),
+            '()',      CHAR(32))))
+    )
+END
+"""
+    linter = Linter(config=FluffConfig(overrides={"dialect": "tsql"}))
+    parsed = linter.parse_string(sql)
+    assert not any(
+        isinstance(v, SQLParseError) and MESSAGE_PREFIX in v.desc()
+        for v in parsed.violations
+    )
+
+
 def test_max_parse_depth_default_allows_simple_sql():
-    """With default limit (255), simple SQL parses."""
+    """With default limit (600), simple SQL parses."""
     linter = Linter(config=FluffConfig(overrides={"dialect": "ansi"}))
     parsed = linter.parse_string("SELECT 1 FROM t")
     assert not parsed.violations
@@ -54,7 +86,7 @@ def test_max_parse_depth_default_allows_simple_sql():
 def test_default_max_parse_depth_matches_config_default():
     """FluffConfig exposes the shipped default config value."""
     config = FluffConfig(overrides={"dialect": "ansi"})
-    assert config.get("max_parse_depth") == 255
+    assert config.get("max_parse_depth") == 600
 
 
 def test_max_parse_depth_rust_parser_exceeds_limit():


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Based on the discussion in #7813, setting a `max_parse_depth` of 600 was the preferred solution to prevent reopening the DOS CVE. While Rust and Python have different counting mechanics, having them matched is currently preferred.
- fixes #7805

### Are there any other side effects of this change that we should be aware of?
None

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase the default `max_parse_depth` from 255 to 600 in Python and `sqlfluffrs` so typical nested SQL (e.g., T-SQL function chains) parses cleanly while preserving DoS protections. Fixes #7805.

- **Bug Fixes**
  - Align defaults between Python config and Rust parser (`DEFAULT_MAX_PARSE_DEPTH = 600`).
  - Add a test for nested function calls and update existing tests/comments for the new default.

<sup>Written for commit d9beb6bef5c88cbe5fae4ff7141ab83754e154be. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/7922?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

