### PR TITLE
perf: replace inline OneOf terminator check with is_terminated_table_driven

### DIFF
--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/oneof.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/oneof.rs
@@ -313,55 +313,10 @@ impl Parser<'_> {
                     consumed
                 );
 
-                // Python parity: Check for early termination with terminators
-                // If we have a match and there's a terminator at the next position,
-                // we can stop trying other options (significant performance improvement)
-                let next_pos_after_match = child_end_pos_val;
-
-                // Skip to next code position to check for terminators
                 let next_code_pos =
-                    self.skip_start_index_forward_to_code(next_pos_after_match, *max_idx);
-
-                // If we've reached the end, consider it terminated
-                if next_code_pos >= self.tokens.len() {
-                    vdebug!("OneOf[table]: Early termination - reached end of tokens");
-                    should_early_terminate = true;
-                } else if !frame.table_terminators.is_empty() {
-                    // Check if any terminator matches at this position
-                    for terminator_id in &frame.table_terminators {
-                        // Skip NONCODE sentinel value - it's handled separately in is_terminated
-                        if *terminator_id == sqlfluffrs_types::GrammarId::NONCODE {
-                            // Check if there's a non-code token at the current position
-                            if next_code_pos < self.tokens.len() {
-                                let tok = &self.tokens[next_code_pos];
-                                if !tok.is_code() {
-                                    vdebug!(
-                                        "OneOf[table]: Early termination - NONCODE terminator matched non-code token at pos {}",
-                                        next_code_pos
-                                    );
-                                    should_early_terminate = true;
-                                    break;
-                                }
-                            }
-                            continue;
-                        }
-
-                        self.pos = next_code_pos;
-                        if let Ok(term_result) =
-                            self.parse_table_iterative_match_result(*terminator_id, &[])
-                        {
-                            if !term_result.is_empty() {
-                                vdebug!(
-                                    "OneOf[table]: Early termination - terminator {} matched at pos {}",
-                                    terminator_id.0,
-                                    next_code_pos
-                                );
-                                should_early_terminate = true;
-                                break;
-                            }
-                        }
-                    }
-                }
+                    self.skip_start_index_forward_to_code(child_end_pos_val, *max_idx);
+                self.pos = next_code_pos;
+                should_early_terminate = self.is_terminated_table_driven(&frame.table_terminators);
             }
         }
 


### PR DESCRIPTION
Stacked on top of https://github.com/sqlfluff/sqlfluff/pull/7923

## Summary

Replaces the inline terminator loop in `handle_oneof_table_driven_waiting_for_child` with a single call to `is_terminated_table_driven`. The inline loop manually handled NONCODE, and called `parse_table_iterative_match_result` per terminator without cache access. `is_terminated_table_driven` already does all of this and additionally consults the terminator match cache, so the replacement gets cache hits on positions already checked earlier in the same parse, which is where the gain comes from.

## Benchmark results

Baseline is `perf/benchmark-baseline`. This is branch 1 in the series; prior branch is identical to the baseline, so vs-prior matches vs-baseline.

| Suite | Baseline (ms) | Prior (ms) | This run (ms) | vs Baseline | vs Prior |
|---|---|---|---|---|---|
| athena/parse_athena_query | 20228.6 | 20228.6 | 19829.6 | -2.0% | -2.0% |
| tpcds/parse_tpcds_99 | 1858.4 | 1858.4 | 1799.3 | -3.2% | -3.2% |
| tpch/parse_tpch_22 | 171.7 | 171.7 | 167.1 | -2.7% | -2.7% |

Lex changes are within measurement noise; the optimization is parse-only.

```
athena/parse_athena_query  time: [  19730.1ms  19829.6ms  19936.6ms ]
tpcds/parse_tpcds_99       time: [   1794.8ms   1799.3ms   1803.9ms ]
tpch/parse_tpch_22         time: [    166.4ms    167.1ms    167.7ms ]
```

## Correctness

`cargo test`: PASS.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the inline OneOf terminator loop with a single `is_terminated_table_driven` call that uses the terminator-match cache to avoid re-parsing. Improves parse speed by ~2–3% on TPC-DS/TPCH/Athena; lexing is unchanged.

- **Refactors**
  - Simplify table-driven OneOf early-termination by using `is_terminated_table_driven`, reusing cached matches and handling NONCODE consistently.

<sup>Written for commit fc939e29c560ce3bccba3df50c60708f0ceba63b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/7924?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



