### PR TITLE
perf: cache terminator match results in greedy_match_table_driven

### DIFF
--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/match_algorithms.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/match_algorithms.rs
@@ -204,35 +204,51 @@ impl Parser<'_> {
                     term_id,
                     i
                 );
-                if let Ok(end_pos) = self.try_match_grammar_table_driven(term_id, i, terminators) {
-                    if end_pos > i {
-                        // If the matched terminator is a simple all-alphabetic token and the
-                        // token is not preceded by whitespace, reject it. This prevents
-                        // accidental matches of bare word tokens (e.g. identifiers) by
-                        // string-based terminators when the string matcher does not enforce
-                        // token-type constraints. Terminators implemented as TypedParser
-                        // (which match by token type rather than raw text) are exempt.
-                        let tok_is_alpha = tokens[i].is_code()
-                            && !tokens[i].raw().is_empty()
-                            && tokens[i].raw().chars().all(|c| c.is_ascii_alphabetic());
-                        if tok_is_alpha && !self.is_preceded_by_whitespace(tokens, i, start_idx) {
-                            let tables = self.grammar_ctx.tables();
-                            let variant = tables.get_inst(term_id).variant;
-                            if variant != GrammarVariant::TypedParser {
-                                vdebug!(
-                                    "[GREEDY_MATCH_TABLE] greedy_match_table_driven: skipping {:?} at {} — all-alpha token not preceded by whitespace",
-                                    term_id, i
-                                );
-                                continue;
-                            }
+                let cache_key = (i, term_id.0);
+                let cached = self
+                    .terminator_match_cache
+                    .borrow()
+                    .get(&cache_key)
+                    .copied();
+                let matched = if let Some(hit) = cached {
+                    hit
+                } else {
+                    let result = self
+                        .try_match_grammar_table_driven(term_id, i, terminators)
+                        .map(|end_pos| end_pos > i)
+                        .unwrap_or(false);
+                    self.terminator_match_cache
+                        .borrow_mut()
+                        .insert(cache_key, result);
+                    result
+                };
+                if matched {
+                    // If the matched terminator is a simple all-alphabetic token and the
+                    // token is not preceded by whitespace, reject it. This prevents
+                    // accidental matches of bare word tokens (e.g. identifiers) by
+                    // string-based terminators when the string matcher does not enforce
+                    // token-type constraints. Terminators implemented as TypedParser
+                    // (which match by token type rather than raw text) are exempt.
+                    let tok_is_alpha = tokens[i].is_code()
+                        && !tokens[i].raw().is_empty()
+                        && tokens[i].raw().chars().all(|c| c.is_ascii_alphabetic());
+                    if tok_is_alpha && !self.is_preceded_by_whitespace(tokens, i, start_idx) {
+                        let tables = self.grammar_ctx.tables();
+                        let variant = tables.get_inst(term_id).variant;
+                        if variant != GrammarVariant::TypedParser {
+                            vdebug!(
+                                "[GREEDY_MATCH_TABLE] greedy_match_table_driven: skipping {:?} at {} — all-alpha token not preceded by whitespace",
+                                term_id, i
+                            );
+                            continue;
                         }
-                        vdebug!(
-                            "[GREEDY_MATCH_TABLE] greedy_match_table_driven: terminator {:?} matched at {}",
-                            term_id, i
-                        );
-                        let last_code_idx = skip_stop_index_backward_to_code(tokens, i, start_idx);
-                        return Ok((i, last_code_idx + 1));
                     }
+                    vdebug!(
+                        "[GREEDY_MATCH_TABLE] greedy_match_table_driven: terminator {:?} matched at {}",
+                        term_id, i
+                    );
+                    let last_code_idx = skip_stop_index_backward_to_code(tokens, i, start_idx);
+                    return Ok((i, last_code_idx + 1));
                 }
             }
             i += 1;


### PR DESCRIPTION
Stacked on top of https://github.com/sqlfluff/sqlfluff/pull/7924

## Summary

Caches terminator match results inside `greedy_match_table_driven`. Previously, each call to the function re-evaluated `try_match_grammar_table_driven` for every `(token_position, terminator_id)` pair it encountered. The parser calls `greedy_match_table_driven` repeatedly during a single file parse, so the same pairs are tested many times. This change wraps each `try_match_grammar_table_driven` call with a lookup into `terminator_match_cache` (keyed on `(position, terminator_id)`), and stores the result on a miss. Subsequent calls for the same pair return the cached boolean immediately, skipping the match attempt entirely.

## Benchmark results

Baseline is `perf/benchmark-baseline`. Prior branch numbers are from `perf/oneof-terminator-route`'.

| Suite | Baseline (ms) | Prior (ms) | This run (ms) | vs Baseline | vs Prior |
|---|---|---|---|---|---|
| athena/parse_athena_query | 20228.6 | 19829.6 | 4152.5 | -79.5% | -79.1% |
| tpcds/parse_tpcds_99 | 1858.4 | 1799.3 | 1531.6 | -17.6% | -14.9% |
| tpch/parse_tpch_22 | 171.7 | 167.1 | 147.6 | -14.0% | -11.6% |

Lex changes are within measurement noise; the optimization is parse-only. The athena regression on lex is noise (wide CI: [3291.4, 3455.7]).

```
athena/parse_athena_query  time: [   4112.9ms   4152.5ms   4206.7ms ]
tpcds/parse_tpcds_99       time: [   1525.6ms   1531.6ms   1538.8ms ]
tpch/parse_tpch_22         time: [    147.0ms    147.6ms    148.4ms ]
```

## Correctness

`cargo test`: PASS.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caches terminator matches in the table-driven greedy matcher to avoid re-checking the same pair, significantly speeding up parsing on large suites. No behavior changes; tests pass.

- **Performance**
  - Memoizes results per (token_position, terminator_id) in `greedy_match_table_driven` and skips repeated `try_match_grammar_table_driven` calls.
  - Uses the cached boolean to short-circuit; existing alpha-word/whitespace guard remains.
  - Parse speedups: Athena ~80% faster; TPC-DS/TPCH show double-digit gains. Lexing unchanged.

- **New Features**
  - Added `tpc_bench` Criterion benchmark and `time_tpc` example for TPC-H/TPC-DS timing.
  - Added TPC-DS SQL fixtures and a README with attribution for performance testing.

<sup>Written for commit a95eb010a9fb7f3a46585d66b8af5075aaa63ccb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/7925?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



