### PR TITLE
Support Databricks ?:: try_cast operator

### DIFF
--- a/src/sqlfluff/core/default_config.cfg
+++ b/src/sqlfluff/core/default_config.cfg
@@ -162,6 +162,10 @@ spacing_before = touch
 spacing_before = touch
 spacing_after = touch:inline
 
+[sqlfluff:layout:type:try_casting_operator]
+spacing_before = touch
+spacing_after = touch:inline
+
 [sqlfluff:layout:type:slice]
 spacing_before = touch
 spacing_after = touch

--- a/src/sqlfluff/dialects/dialect_databricks.py
+++ b/src/sqlfluff/dialects/dialect_databricks.py
@@ -66,6 +66,18 @@ databricks_dialect.insert_lexer_matchers(
 
 
 databricks_dialect.insert_lexer_matchers(
+    # ?:: is the try_cast shorthand (an error-tolerating cast). It must be matched
+    # before the "?" (question) matcher so that "?::" lexes as a single token
+    # rather than as "?" followed by "::".
+    # https://docs.databricks.com/aws/en/sql/language-manual/functions/questiondoublecolonsign
+    [
+        StringLexer("try_casting_operator", "?::", CodeSegment),
+    ],
+    before="question",
+)
+
+
+databricks_dialect.insert_lexer_matchers(
     # Databricks Pipeline Parameters:
     # https://docs.databricks.com/en/delta-live-tables/parameters.html
     # Must come before dollar_quote since both start with $
@@ -136,6 +148,9 @@ databricks_dialect.add(
         type="pipeline_parameter",
     ),
     RightArrowSegment=StringParser("=>", SymbolSegment, type="right_arrow"),
+    TryCastOperatorSegment=StringParser(
+        "?::", SymbolSegment, type="try_casting_operator"
+    ),
     # https://docs.databricks.com/en/sql/language-manual/sql-ref-principal.html
     PrincipalIdentifierSegment=OneOf(
         Ref("NakedIdentifierSegment"),
@@ -490,6 +505,30 @@ class WithinGroupClauseSegment(BaseSegment):
         "WITHIN",
         "GROUP",
         Bracketed(Ref("OrderByClauseSegment")),
+    )
+
+
+class ShorthandCastSegment(ansi.ShorthandCastSegment):
+    """A casting operation using '::' or '?::'.
+
+    '?::' is shorthand for try_cast (an error-tolerating cast).
+    https://docs.databricks.com/aws/en/sql/language-manual/functions/questiondoublecolonsign
+    """
+
+    match_grammar: Matchable = Sequence(
+        OneOf(
+            Ref("Expression_D_Grammar"),
+            Ref("CaseExpressionSegment"),
+        ),
+        AnyNumberOf(
+            Sequence(
+                OneOf(Ref("CastOperatorSegment"), Ref("TryCastOperatorSegment")),
+                Ref("DatatypeSegment"),
+                Ref("TimeZoneGrammar", optional=True),
+                allow_gaps=True,
+            ),
+            min_times=1,
+        ),
     )
 
 

--- a/src/sqlfluff/rules/convention/CV11.py
+++ b/src/sqlfluff/rules/convention/CV11.py
@@ -236,6 +236,13 @@ class Rule_CV11(BaseRule):
             else:
                 current_type_casting_style = None
         elif context.segment.is_type("cast_expression"):
+            # CV11 can only rewrite the standard `::` shorthand. Dialect-specific
+            # variants such as Databricks `?::` (try_cast) and Vertica `::!`
+            # (null cast) are not interchangeable with CAST/CONVERT, so rewriting
+            # them would change semantics (and may even be unparsable). Only treat
+            # the expression as a shorthand cast when it uses the `::` operator.
+            if not context.segment.get_child("casting_operator"):
+                return None
             current_type_casting_style = "shorthand"
         else:  # pragma: no cover
             current_type_casting_style = None

--- a/test/fixtures/dialects/databricks/try_cast_operator.sql
+++ b/test/fixtures/dialects/databricks/try_cast_operator.sql
@@ -1,0 +1,12 @@
+-- ?:: is shorthand for try_cast (an error-tolerating cast)
+-- https://docs.databricks.com/aws/en/sql/language-manual/functions/questiondoublecolonsign
+SELECT 1?::INT;
+
+SELECT '20'?::INTEGER AS a;
+
+SELECT 'twenty'?::INT AS maybe_null;
+
+SELECT my_col?::STRING FROM my_table;
+
+-- mixed with the standard :: cast operator
+SELECT my_col::INT, my_col?::INT FROM my_table;

--- a/test/fixtures/dialects/databricks/try_cast_operator.yml
+++ b/test/fixtures/dialects/databricks/try_cast_operator.yml
@@ -1,0 +1,106 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: ec59c13160daacbf34c2328263325733c7acb4961832c5793931b99226fbf5df
+file:
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+            cast_expression:
+              numeric_literal: '1'
+              try_casting_operator: '?::'
+              data_type:
+                primitive_type:
+                  keyword: INT
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+            cast_expression:
+              quoted_literal: "'20'"
+              try_casting_operator: '?::'
+              data_type:
+                primitive_type:
+                  keyword: INTEGER
+          alias_expression:
+            alias_operator:
+              keyword: AS
+            naked_identifier: a
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+            cast_expression:
+              quoted_literal: "'twenty'"
+              try_casting_operator: '?::'
+              data_type:
+                primitive_type:
+                  keyword: INT
+          alias_expression:
+            alias_operator:
+              keyword: AS
+            naked_identifier: maybe_null
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+            cast_expression:
+              column_reference:
+                naked_identifier: my_col
+              try_casting_operator: '?::'
+              data_type:
+                primitive_type:
+                  keyword: STRING
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: my_table
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          expression:
+            cast_expression:
+              column_reference:
+                naked_identifier: my_col
+              casting_operator: '::'
+              data_type:
+                primitive_type:
+                  keyword: INT
+      - comma: ','
+      - select_clause_element:
+          expression:
+            cast_expression:
+              column_reference:
+                naked_identifier: my_col
+              try_casting_operator: '?::'
+              data_type:
+                primitive_type:
+                  keyword: INT
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: my_table
+- statement_terminator: ;

--- a/test/fixtures/rules/std_rule_cases/CV11.yml
+++ b/test/fixtures/rules/std_rule_cases/CV11.yml
@@ -470,3 +470,45 @@ test_fail_cast_preferred_boolean_shorthand_cast:
     rules:
       convention.casting_style:
         preferred_type_casting_style: cast
+
+test_pass_databricks_try_cast_shorthand_preferred_cast:
+  # https://github.com/sqlfluff/sqlfluff/pull/7927
+  # `?::` is Databricks try_cast (NULL on failure), not interchangeable with
+  # CAST, so CV11 must leave it alone rather than emit an unparsable fix.
+  pass_str: SELECT CAST('20' AS INTEGER), '20'?::INTEGER
+  configs:
+    core:
+      dialect: databricks
+    rules:
+      convention.casting_style:
+        preferred_type_casting_style: cast
+
+test_pass_databricks_try_cast_shorthand_consistent:
+  # try_cast must not establish or be measured against the consistent style.
+  pass_str: SELECT CAST('20' AS INTEGER), '20'?::INTEGER
+  configs:
+    core:
+      dialect: databricks
+
+test_pass_vertica_null_cast_shorthand_preferred_cast:
+  # Vertica `::!` (null cast) is likewise not interchangeable with CAST. Before
+  # this guard CV11 silently rewrote it to `cast('20'::! as INTEGER)`.
+  pass_str: SELECT CAST('20' AS INTEGER), '20'::!INTEGER
+  configs:
+    core:
+      dialect: vertica
+    rules:
+      convention.casting_style:
+        preferred_type_casting_style: cast
+
+test_fail_databricks_plain_shorthand_preferred_cast:
+  # The plain `::` shorthand is still rewritten; only the dialect-specific
+  # operators (`?::`, `::!`) are skipped.
+  fail_str: SELECT '20'::INTEGER
+  fix_str: SELECT cast('20' as INTEGER)
+  configs:
+    core:
+      dialect: databricks
+    rules:
+      convention.casting_style:
+        preferred_type_casting_style: cast

--- a/test/fixtures/rules/std_rule_cases/LT01-excessive.yml
+++ b/test/fixtures/rules/std_rule_cases/LT01-excessive.yml
@@ -81,6 +81,23 @@ test_casting_operator_pass:
     core:
       dialect: postgres
 
+test_try_casting_operator_fix:
+  # Databricks ?:: (try_cast shorthand) is spaced like :: (touch)
+  fail_str: |
+    SELECT '1' ?:: INT;
+  fix_str: |
+    SELECT '1'?::INT;
+  configs:
+    core:
+      dialect: databricks
+
+test_try_casting_operator_pass:
+  pass_str: |
+    SELECT '1'?::INT;
+  configs:
+    core:
+      dialect: databricks
+
 test_fix_tsql_spaced_chars:
   fail_str: |
     SELECT col1 FROM table1 WHERE 1 > = 1


### PR DESCRIPTION
### Brief summary of the change made

Fixes #7926.

`?::` is the [try_cast shorthand](https://docs.databricks.com/aws/en/sql/language-manual/functions/questiondoublecolonsign) in Databricks (Databricks Runtime 15.3 and above). The docs describe it as casting "the value `expr` to the target data type `type` with error toleration", and a synonym for `try_cast` — i.e. the error-tolerating counterpart of `::`. It previously failed to parse:

```sql
SELECT 1?::INT
-- L: 1 | P: 9 | PRS | Found unparsable section: '?::INT'
```

The change mirrors the existing Vertica `::!` (`null_casting_operator`) handling:

- A `?::` lexer matcher, inserted before the `question` (`?`) matcher so `?::` lexes as a single token rather than `?` followed by `::`.
- A `TryCastOperatorSegment` parser and a `ShorthandCastSegment` override accepting `OneOf(CastOperatorSegment, TryCastOperatorSegment)`.
- A `[sqlfluff:layout:type:try_casting_operator]` config entry with the same `touch` spacing as `casting_operator`, so the layout rules treat `?::` like `::`.

### Are there any other side effects of this change that we should be aware of?

No. Plain `::` casts and a standalone `?` are unaffected (the latter still does not parse as an expression on its own — pre-existing behaviour). Without the layout entry, LT01 flags `1?::INT` and `fix` rewrites it to `1 ?:: INT`; with it, `fix` leaves `1?::INT` unchanged.

Note: Vertica's `::!` (`null_casting_operator`) has the same missing layout entry — `fix` currently turns `'1'::!INT` into `'1' ::! INT`. That's out of scope here; happy to address it in a follow-up if useful.

### Pull Request checklist

- Included test cases:
  - `.sql`/`.yml` parser fixture in `test/fixtures/dialects/databricks/try_cast_operator.sql` (literal/string/identifier/alias casts, and a row mixing `::` with `?::`).
  - `.yml` rule cases in `test/fixtures/rules/std_rule_cases/LT01-excessive.yml` (`test_try_casting_operator_fix`, `test_try_casting_operator_pass`).
- Verified locally: reproduced the parse failure on the unpatched tree; `pytest test/dialects -k databricks` (165) and the full LT01 suite (198) pass; `ruff check`, `ruff format --check`, and `mypy` are clean on the changed dialect.

### AI assistance disclosure

Per the AI-assisted contributions policy: this change was drafted with AI assistance (Claude Code). The approach (mirroring the Vertica `::!` operator), the lexer ordering, the layout config, and the tests were reviewed and validated manually by me — including reproducing the parse failure on the unpatched tree, confirming `::`/standalone-`?` are unchanged, checking that `lint`/`fix` treat `?::` like `::`, and running the databricks dialect suite, the LT01 suite, `ruff`, `ruff format`, and `mypy` locally.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Databricks `?::` try_cast shorthand so it parses and formats like `::`. Also updates CV11 to avoid rewriting dialect-specific shorthand casts.

- **New Features**
  - Lexes `?::` as a single `try_casting_operator` (before `?`).
  - Parses via `TryCastOperatorSegment` and an overridden `ShorthandCastSegment` that accepts `::` or `?::`.
  - Adds `[sqlfluff:layout:type:try_casting_operator]` with touch spacing so LT01 treats `?::` like `::`.
  - Adds Databricks parser and LT01 fixtures, including mixed `::`/`?::`.

- **Bug Fixes**
  - CV11 only rewrites shorthand casts using `::`. Skips Databricks `?::` and Vertica `::!` to avoid semantic changes; adds CV11 tests.

<sup>Written for commit 260178bb86143445e25d86106db240791a795869. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/7927?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

