### PR TITLE
fix(LT02): indent oscillation for loop-conditional trailing commas

### DIFF
--- a/src/sqlfluff/utils/reflow/reindent.py
+++ b/src/sqlfluff/utils/reflow/reindent.py
@@ -631,6 +631,47 @@ def _revise_templated_lines(
             lines.remove(line)
 
 
+def _revise_loop_repeated_lines(
+    lines: list[_IndentLine], elements: ReflowSequenceType
+) -> None:
+    """Align repeated loop renderings of the same source line.
+
+    When loop-conditional content is suppressed (e.g. a trailing comma on
+    its final iteration), that rendering can resolve to a different indent
+    balance, making the fix oscillate. Trust the renderings which carry
+    content and align the suppressed ones to them.
+    """
+    # Group lines by the source slice of their first block. Repeated loop
+    # renderings of one source line share an identical slice.
+    groups: DefaultDict[tuple[int, int], list[int]] = defaultdict(list)
+    for idx, line in enumerate(lines):
+        first_block = next(line.iter_blocks(elements), None)
+        if first_block is None:
+            continue
+        pos_marker = first_block.segments[0].pos_marker
+        if not pos_marker:  # pragma: no cover
+            continue
+        source_slice = pos_marker.source_slice
+        groups[(source_slice.start, source_slice.stop)].append(idx)
+
+    for group in groups.values():
+        if len(group) < 2:
+            continue
+        rendered = [idx for idx in group if not lines[idx].is_all_templates(elements)]
+        unrendered = [idx for idx in group if lines[idx].is_all_templates(elements)]
+        # Only act on suppressed content; leave all-rendered groups alone.
+        if not rendered or not unrendered:
+            continue
+        rendered_balances = [lines[idx].initial_indent_balance for idx in rendered]
+        target = max(set(rendered_balances), key=rendered_balances.count)
+        for idx in unrendered:
+            if lines[idx].initial_indent_balance != target:
+                reflow_logger.debug(
+                    "    Reconciling repeated line %s to balance %s", idx, target
+                )
+                lines[idx].initial_indent_balance = target
+
+
 def _revise_skipped_source_lines(
     lines: list[_IndentLine],
     elements: ReflowSequenceType,
@@ -1817,6 +1858,7 @@ def lint_indent_points(
     # off the detection algorithm.
     _revise_skipped_source_lines(lines, elements)
     _revise_templated_lines(lines, elements)
+    _revise_loop_repeated_lines(lines, elements)
     # Revise comment indents
     _revise_comment_lines(lines, elements, ignore_comment_lines=ignore_comment_lines)
 

--- a/src/sqlfluff/utils/reflow/reindent.py
+++ b/src/sqlfluff/utils/reflow/reindent.py
@@ -663,7 +663,10 @@ def _revise_loop_repeated_lines(
         if not rendered or not unrendered:
             continue
         rendered_balances = [lines[idx].initial_indent_balance for idx in rendered]
-        target = max(set(rendered_balances), key=rendered_balances.count)
+        # Most common balance, breaking ties on the larger balance for determinism.
+        target = max(
+            set(rendered_balances), key=lambda b: (rendered_balances.count(b), b)
+        )
         for idx in unrendered:
             if lines[idx].initial_indent_balance != target:
                 reflow_logger.debug(

--- a/test/fixtures/rules/std_rule_cases/LT02-indent.yml
+++ b/test/fixtures/rules/std_rule_cases/LT02-indent.yml
@@ -2504,6 +2504,60 @@ test_pass_loop_indent_6:
         {% endfor %}
     from foo
 
+test_pass_loop_indent_trailing_comma_own_line:
+  # A trailing comma guarded by `loop.last` on its own line. The final
+  # iteration renders the comma empty, which previously shifted the indent
+  # balance and made the fix flip-flop between runs. See issue #7870.
+  pass_str: |
+    select
+    {%- for i in range(1, 3) %}
+            a
+                as {{ "col" ~ i }}
+            {{- "," if not loop.last }}
+    {%- endfor %}
+    from foo
+  configs:
+    core:
+      dialect: bigquery
+
+test_fail_loop_indent_trailing_comma_own_line:
+  # The under-indented variant of the case above. It should settle on a
+  # single, stable indent rather than oscillating (issue #7870).
+  fail_str: |
+    select
+    {%- for i in range(1, 3) %}
+            a
+                as {{ "col" ~ i }}
+        {{- "," if not loop.last }}
+    {%- endfor %}
+    from foo
+  fix_str: |
+    select
+    {%- for i in range(1, 3) %}
+            a
+                as {{ "col" ~ i }}
+            {{- "," if not loop.last }}
+    {%- endfor %}
+    from foo
+  configs:
+    core:
+      dialect: bigquery
+
+test_pass_loop_indent_trailing_comma_single_iteration:
+  # Single-iteration loop: the comma is always suppressed, so there's only
+  # one rendering to reconcile against.
+  pass_str: |
+    select
+    {%- for i in range(1, 2) %}
+            a
+                as {{ "col" ~ i }}
+        {{- "," if not loop.last }}
+    {%- endfor %}
+    from foo
+  configs:
+    core:
+      dialect: bigquery
+
 test_fail_sqlite_update_returning:
   fail_str: |
     UPDATE

--- a/test/rules/std_LT02_oscillation_test.py
+++ b/test/rules/std_LT02_oscillation_test.py
@@ -1,0 +1,86 @@
+"""Regression test for LT02 indent oscillation.
+
+See https://github.com/sqlfluff/sqlfluff/issues/7870 - a trailing comma
+guarded by ``loop.last`` and rendered on its own line used to flip-flop
+between two indent depths on successive ``fix`` runs. The YAML fixtures in
+``LT02-indent.yml`` exercise a single fix pass; this test additionally
+asserts the *roundtrip* property, i.e. that re-fixing a fixed file is a
+no-op.
+"""
+
+from sqlfluff.core import FluffConfig, Linter
+
+# The reproduction from the issue, with the trailing-comma line *under*
+# indented (4 spaces). Fixing this should settle on the stable form below.
+_UNDER_INDENTED = """{%- set extraction_list = [
+    ('Compound', 'Canonicalized', 'ival'),
+    ('IUPAC Name', 'Allowed', 'sval'),
+    ('InChI', 'Standard', 'sval')
+] %}
+
+{{ config(cluster_by=['cid']) }}
+
+SELECT
+{%- for label, name, field in extraction_list %}
+        (
+            SELECT
+                p.value.{{ field }}
+            FROM UNNEST(props) AS p
+            WHERE
+                p.urn.label = '{{ label }}'
+                AND p.urn.name = '{{ name }}'
+            LIMIT 1
+        )
+            AS {{ (label ~ '_' ~ name) | lower | replace(' ', '_') | replace('-','_') }}
+    {{- "," if not loop.last }}
+{%- endfor %}
+FROM {{ ref('pubchem_compound_raw') }}
+"""
+
+# The stable form: the trailing-comma line indented to 8 spaces.
+_STABLE = """{%- set extraction_list = [
+    ('Compound', 'Canonicalized', 'ival'),
+    ('IUPAC Name', 'Allowed', 'sval'),
+    ('InChI', 'Standard', 'sval')
+] %}
+
+{{ config(cluster_by=['cid']) }}
+
+SELECT
+{%- for label, name, field in extraction_list %}
+        (
+            SELECT
+                p.value.{{ field }}
+            FROM UNNEST(props) AS p
+            WHERE
+                p.urn.label = '{{ label }}'
+                AND p.urn.name = '{{ name }}'
+            LIMIT 1
+        )
+            AS {{ (label ~ '_' ~ name) | lower | replace(' ', '_') | replace('-','_') }}
+        {{- "," if not loop.last }}
+{%- endfor %}
+FROM {{ ref('pubchem_compound_raw') }}
+"""
+
+
+def test_rules_std_LT02_loop_comma_no_oscillation() -> None:
+    """Fixing the loop trailing-comma indent must converge, not oscillate."""
+    cfg = FluffConfig(
+        overrides={"dialect": "bigquery", "rules": "LT02", "templater": "jinja"}
+    )
+    linter = Linter(config=cfg)
+
+    # The under-indented variant should report a single LT02 violation and
+    # fix to the stable form.
+    linted = linter.lint_string(_UNDER_INDENTED, fix=True)
+    assert linted.check_tuples() == [("LT02", 20, 89)]
+    fixed, _ = linted.fix_string()
+    assert fixed == _STABLE
+
+    # Re-fixing the stable form must be a no-op: no violations and no change.
+    # Without the fix this oscillated straight back to the 4-space indent.
+    relinted = linter.lint_string(_STABLE, fix=True)
+    assert relinted.check_tuples() == []
+    refixed, _ = relinted.fix_string()
+    assert refixed == _STABLE


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
This PR makes it so empty rendered templated lines no longer oscillate for indentation amounts. While this makes the majority of cases balance out nicely, some cases such as only having one line in a loop may be indented less than expected due to no content. The challenge here is that zero width template loop output exists in the same position as a zero width meta dedent and the dedent happens first.
- fixes #7870
- makes progress on #5371 

### Are there any other side effects of this change that we should be aware of?
None

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes LT02 indent oscillation when Jinja `loop.last` suppresses a trailing comma. Suppressed iterations now inherit the indent balance from rendered iterations with deterministic tie-breaking, so autofix is stable and consistent.

- **Bug Fixes**
  - Group repeated loop renderings by source slice, reconcile template-only lines to the majority indent balance, and break ties deterministically (prefer larger balance); applied in `lint_indent_points()`.
  - Added tests: YAML cases for a trailing comma on its own line and single-iteration loops, plus a roundtrip regression test to ensure re-fixing is a no-op. Fixes #7870 and improves #5371.

<sup>Written for commit fe2e620dbc3957b6af914f5d84b63d3d684f477a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/7928?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

