### PR TITLE
fix(rust): Update stale GrammarTables::new test calls

### DIFF
--- a/sqlfluffrs/sqlfluffrs_types/src/grammar_tables.rs
+++ b/sqlfluffrs/sqlfluffrs_types/src/grammar_tables.rs
@@ -617,6 +617,8 @@ mod tests {
             CASEFOLD_SPARSE,
             TRIM_CHARS_SPARSE,
             TRIM_CHARS_DATA,
+            &[], // segment_class_types_sparse
+            &[], // segment_class_types_data
         );
 
         assert_eq!(tables.instructions.len(), 3);
@@ -684,6 +686,8 @@ mod tests {
             CASEFOLD_SPARSE,
             TRIM_CHARS_SPARSE,
             TRIM_CHARS_DATA,
+            &[], // segment_class_types_sparse
+            &[], // segment_class_types_data
         );
 
         let stats = tables.memory_stats();


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
`GrammarTables::new` gained two parameters (`segment_class_types_sparse` and `segment_class_types_data`) in #7599, but the unit tests in grammar_tables.rs (`test_grammar_tables_basic` and `test_memory_stats`) were never updated to pass them.

This updates both test call sites to pass empty slices (&[]) for the two new parameters, matching the current constructor signature. 

- makes progress on #7931

### Are there any other side effects of this change that we should be aware of?
None

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update `GrammarTables::new` test calls to include the new `segment_class_types_sparse` and `segment_class_types_data` params by passing empty slices. Fixes stale unit tests in `grammar_tables.rs` so they compile and run against the current constructor.

<sup>Written for commit b7fc8cc548b9035f2be19ddd1bbd7550b712c1be. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/7934?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

