### PR TITLE
codegen: Error on missing grammar handlers at build time

### DIFF
--- a/utils/build_parsers.py
+++ b/utils/build_parsers.py
@@ -1328,6 +1328,21 @@ class TableBuilder:
         """Run sanity checks on generated tables."""
         errors = []
 
+        # Unknown grammar classes fall back to a "Missing" instruction
+        # (see _handle_missing) so that a single run can report every
+        # unsupported class at once. Any Missing instruction in the final
+        # tables means the Rust parser cannot match that grammar — fail
+        # loudly here, at codegen time, rather than as a silent wrong
+        # parse later. The comment carries the offending class name.
+        missing = [
+            f"Inst {i}: unsupported grammar class {inst.comment}"
+            f" — add a handler in build_parsers.py and a matching"
+            f" GrammarVariant handler in sqlfluffrs_parser"
+            for i, inst in enumerate(self.instructions)
+            if inst.variant == "Missing"
+        ]
+        errors.extend(missing)
+
         for i, inst in enumerate(self.instructions):
             # Check children bounds
             if inst.first_child_idx + inst.child_count > len(self.child_ids):


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
When `build_parsers.py` encounters a grammar class it doesn't know how to translate, it currently emits a `Missing` instruction so a single run can collect every unsupported class. But a `Missing` instruction in the final tables means the Rust parser will fail to match that grammar at runtime.

This adds a sanity check that fails codegen loudly when any `Missing` instruction survives into the generated tables, naming the offending grammar class and pointing the contributor at the two places a handler is needed (build_parsers.py and the matching `GrammarVariant` handler in `sqlfluffrs_parser`). Surfaces the problem at build time instead of as a wrong parse later.

### Are there any other side effects of this change that we should be aware of?
Codegen now hard-fails if the grammar tables reference an unsupported class that previously generated silently. This is the intended behavior. Any existing `Missing` instruction was already a latent parser bug.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fail codegen when a "Missing" instruction remains in the generated grammar tables. This surfaces unsupported grammar classes at build time and prevents wrong parses at runtime.

- **Bug Fixes**
  - Added validation in `utils/build_parsers.py` to error if any instruction variant is "Missing", listing the class name and where to add handlers (`build_parsers.py` and `sqlfluffrs_parser` `GrammarVariant`).
  - Codegen now hard-fails on unsupported classes that previously generated silently.

<sup>Written for commit 16eab000eeb9e854e4c34a6b6f11e33b088e1e54. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/7935?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

