### PR TITLE
refactor(rust): Drop unused `transparent_positions` frame field

### DIFF
--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/bracketed.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/bracketed.rs
@@ -664,7 +664,6 @@ fn create_table_driven_child_frame(
         parent_max_idx, // Propagate parent's limit!
         calculated_max_idx: None,
         end_pos: None,
-        transparent_positions: None,
         element_key: None,
         parse_mode_override, // Propagate parse mode override!
     }

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/frame.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/frame.rs
@@ -374,8 +374,6 @@ pub struct TableParseFrame {
     pub calculated_max_idx: Option<usize>,
     /// End position for this parse (used when transitioning to Complete state)
     pub end_pos: Option<usize>,
-    /// Transparent token positions collected during this parse
-    pub transparent_positions: Option<Vec<usize>>,
     /// Element key for this match (used by AnyNumberOf to track per-element counts)
     /// Set by OneOf when storing its result, propagated to parent via results map
     pub element_key: Option<u64>,
@@ -405,7 +403,6 @@ impl TableParseFrame {
             parent_max_idx,
             calculated_max_idx: None,
             end_pos: None,
-            transparent_positions: None,
             element_key: None,
             parse_mode_override: None,
         }

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/iterative.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/iterative.rs
@@ -106,7 +106,6 @@ impl Parser<'_> {
             parent_max_idx: None, // No parent constraint at top level - let handler calculate
             calculated_max_idx: None, // Will be set by handler after calculation
             end_pos: None,
-            transparent_positions: None,
             element_key: None,
             parse_mode_override: None, // No override for top-level frame
         });


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
`TableParseFrame.transparent_positions: Option<Vec<usize>>` has been dead state since I removed transparent collection from parse frames a while ago. This removes the unused field from the struct definition and from all of its construction sites.

### Are there any other side effects of this change that we should be aware of?
None. This has never been read since the initial removal.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the unused `transparent_positions` field from `TableParseFrame` and all frame initializers to clean up dead state and slightly reduce memory usage. No behavior change; this field hasn’t been read since transparent collection was removed.

<sup>Written for commit c7550e688ab3e03b1faf545a0cf0051afc4f2b55. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/7936?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

