### PR TITLE
ci: Add Rust fmt/clippy/unit-test job for sqlfluffrs

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -81,6 +81,66 @@ jobs:
     - name: Run the tests
       run: tox -e ${{ matrix.job }}
 
+  rust-lint:
+    # Rust formatting, lints and unit tests for the sqlfluffrs workspace.
+    # Integration tests (sqlfluffrs/tests/*.rs) are not run here; parity is
+    # covered by the python -rust suites below.
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.14'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          cache-dependency-glob: |
+            requirements_dev.txt
+            pyproject.toml
+            constraints/*.txt
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: "sqlfluffrs"
+          cache-on-failure: true
+
+      # Clippy and the unit tests compile the whole workspace, which
+      # includes the generated dialect tables (not in VCS).
+      - name: Generate Rust dialect files
+        run: |
+          uv pip install --system -e .
+          python utils/rustify.py build
+
+      - name: Check formatting
+        working-directory: sqlfluffrs
+        run: cargo fmt --all --check
+
+      - name: Clippy (informational)
+        # Advisory for now: surfaces lints in the log without failing the
+        # build. Flip to `-- -D warnings` once the existing warning
+        # surface is cleaned up.
+        working-directory: sqlfluffrs
+        continue-on-error: true
+        run: cargo clippy --workspace --all-targets
+
+      - name: Run unit tests
+        working-directory: sqlfluffrs
+        run: cargo test --workspace --lib
+
   rs-build-linux-x86_64:
     # Fast build for CI testing (always runs)
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Adds a rust-lint CI job covering the sqlfluffrs workspace, which previously had no CI coverage.

The job:

- generates the Rust dialect tables (`utils/rustify.py build`, we need to actually build it, not just use the pre-built `.so`)
- enforces `cargo fmt --all --check`,
- runs `cargo clippy --workspace --all-targets` as advisory (continue-on-error, to be flipped to -D warnings once the existing warning surface is cleaned up),
- runs `cargo test --workspace --lib`.
- makes progress on #7933 
- closes #7932
- makes progress on #7931

Note:
Integration tests (sqlfluffrs/tests/*.rs) are currently excluded; cross-parser parity is already covered by the Python `pyXXX-rust` suites.

### Are there any other side effects of this change that we should be aware of?
This introduces a new CI run.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
