### PR TITLE
Support Databricks infix collation

### DIFF
--- a/src/sqlfluff/dialects/dialect_databricks.py
+++ b/src/sqlfluff/dialects/dialect_databricks.py
@@ -167,6 +167,7 @@ databricks_dialect.replace(
             Ref("ParameterizedSegment"),
         ]
     ),
+    CollateGrammar=Sequence("COLLATE", Ref("CollationReferenceSegment")),
 )
 
 databricks_dialect.add(

--- a/src/sqlfluff/dialects/dialect_databricks.py
+++ b/src/sqlfluff/dialects/dialect_databricks.py
@@ -1952,7 +1952,7 @@ class ColumnPropertiesSegment(BaseSegment):
             "DEFAULT",
             Ref("ColumnConstraintDefaultGrammar"),
         ),
-        Sequence("COLLATE", Ref("CollationReferenceSegment")),
+        Ref("CollateGrammar"),
         Ref("CommentGrammar"),
         Ref("ColumnConstraintSegment"),
         Ref("MaskStatementSegment"),

--- a/test/fixtures/dialects/databricks/select.sql
+++ b/test/fixtures/dialects/databricks/select.sql
@@ -9,3 +9,8 @@ FROM IDENTIFIER('table_name')
 SELECT *
 FROM IDENTIFIER('schema_name' || '.table_name')
 ;
+
+CREATE OR REFRESH MATERIALIZED VIEW my_view AS
+SELECT
+    id COLLATE UTF8_LCASE
+FROM my_source;

--- a/test/fixtures/dialects/databricks/select.yml
+++ b/test/fixtures/dialects/databricks/select.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 3fd3588bcd6512e79a25b1f94526827b0f94bc8ca91f212860b16c21c4636cda
+_hash: eba1226a205a6e3dba51158078eb36d0b0c344d24948975a8e2478947efbe63e
 file:
 - statement:
     select_statement:
@@ -68,4 +68,32 @@ file:
                     - pipe: '|'
                   - quoted_literal: "'.table_name'"
                   end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_materialized_view_statement:
+    - keyword: CREATE
+    - keyword: OR
+    - keyword: REFRESH
+    - keyword: MATERIALIZED
+    - keyword: VIEW
+    - table_reference:
+        naked_identifier: my_view
+    - keyword: AS
+    - select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            expression:
+              column_reference:
+                naked_identifier: id
+              keyword: COLLATE
+              collation_reference:
+                naked_identifier: UTF8_LCASE
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: my_source
 - statement_terminator: ;


### PR DESCRIPTION
## Problem

Databricks supports infix collation expressions like `id COLLATE UTF8_LCASE`, but the Databricks dialect only accepted `COLLATE` in column/table definitions. In a SELECT target, the expression tail failed to parse and left the collation name as an unparsable segment.

## Fix

Enable the existing expression-level `CollateGrammar` hook for the Databricks dialect using `COLLATE CollationReferenceSegment`.

## Test

- `uv run --with-editable . --with pytest --with click --with pyyaml pytest -q test/dialects/dialects_test.py -k 'databricks and select'`
- `uv run --with ruff ruff check src/sqlfluff/dialects/dialect_databricks.py test/generate_parse_fixture_yml.py`
- `git diff --check`

## Risk

Low. This is scoped to the Databricks dialect and uses an existing ANSI grammar hook that is disabled by default.

## AI assistance

Used AI assistance to prepare the patch; I reviewed the code path and validated it with the tests above.

Closes #7941.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes parsing for Databricks infix COLLATE so expressions like id COLLATE UTF8_LCASE work in SELECTs and materialized view definitions. Reuses a shared CollateGrammar in expressions and column properties for consistent COLLATE handling across the dialect.

<sup>Written for commit 2e5a2d874d780467327f854c236828fee5f77c86. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/7943?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

