### PR TITLE
Support Oracle LANGUAGE JAVA NAME function clauses

### DIFF
--- a/src/sqlfluff/dialects/dialect_oracle.py
+++ b/src/sqlfluff/dialects/dialect_oracle.py
@@ -2670,8 +2670,19 @@ class CreateFunctionStatementSegment(BaseSegment):
             optional=True,
         ),
         OneOf("IS", "AS", optional=True),
-        AnyNumberOf(Ref("DeclareSegment"), optional=True),
-        Ref("BeginEndSegment", optional=True),
+        OneOf(
+            Sequence(
+                "LANGUAGE",
+                "JAVA",
+                "NAME",
+                Ref("QuotedLiteralSegment"),
+            ),
+            Sequence(
+                AnyNumberOf(Ref("DeclareSegment"), optional=True),
+                Ref("BeginEndSegment", optional=True),
+            ),
+            optional=True,
+        ),
         Ref("DelimiterGrammar", optional=True),
     )
 

--- a/src/sqlfluff/dialects/dialect_oracle.py
+++ b/src/sqlfluff/dialects/dialect_oracle.py
@@ -2677,10 +2677,7 @@ class CreateFunctionStatementSegment(BaseSegment):
                 "NAME",
                 Ref("QuotedLiteralSegment"),
             ),
-            Sequence(
-                AnyNumberOf(Ref("DeclareSegment"), optional=True),
-                Ref("BeginEndSegment", optional=True),
-            ),
+            Ref("BeginEndSegment"),
             optional=True,
         ),
         Ref("DelimiterGrammar", optional=True),

--- a/test/fixtures/dialects/oracle/assignment.yml
+++ b/test/fixtures/dialects/oracle/assignment.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: bfbf650d3b90eadefaad14e52bb3e4016107c0ab9ee240647a97f007d6f23706
+_hash: 02638b4bd8ef4d40723402128c1093b73f9341156fd016fd57838dc2f18258aa
 file:
 - batch:
     statement:
@@ -466,12 +466,12 @@ file:
       - data_type:
           data_type_identifier: NUMBER
       - keyword: AS
-      - declare_segment:
-          naked_identifier: result_bonus
-          data_type:
-            data_type_identifier: NUMBER
-          statement_terminator: ;
       - begin_end_block:
+        - declare_segment:
+            naked_identifier: result_bonus
+            data_type:
+              data_type_identifier: NUMBER
+            statement_terminator: ;
         - keyword: BEGIN
         - statement:
             assignment_segment_statement:

--- a/test/fixtures/dialects/oracle/collections.yml
+++ b/test/fixtures/dialects/oracle/collections.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: db85c171633dd113466faa2967db83a2092957beb77a9faf7956335b8fef56a3
+_hash: e5ab5335dffbb28f013bacd3b11906004a8152f6de4fad4148cd51ceae393dde
 file:
 - batch:
     statement:
@@ -233,12 +233,12 @@ file:
           - data_type:
               data_type_identifier: sum_multiples
           - keyword: IS
-          - declare_segment:
-              naked_identifier: s
-              data_type:
-                data_type_identifier: sum_multiples
-              statement_terminator: ;
           - begin_end_block:
+            - declare_segment:
+                naked_identifier: s
+                data_type:
+                  data_type_identifier: sum_multiples
+                statement_terminator: ;
             - keyword: BEGIN
             - statement:
                 for_loop_statement:

--- a/test/fixtures/dialects/oracle/create_function.sql
+++ b/test/fixtures/dialects/oracle/create_function.sql
@@ -87,3 +87,6 @@ BEGIN
   END LOOP;
 END;
 /
+
+FUNCTION ex_func(some_string IN VARCHAR2) RETURN RAW
+AS LANGUAGE JAVA NAME 'exClass.someMethod(java.lang.String) return byte[]';

--- a/test/fixtures/dialects/oracle/create_function.yml
+++ b/test/fixtures/dialects/oracle/create_function.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 230b371ef56f7f00f959006d83d10674ef97d677c7a1e8be8ebad27162afed9a
+_hash: 679a6c9e0fccf2a6664fe43c91d3a7d7548f1dc843176fb77ecbdc40bc2e3c51
 file:
 - batch:
     statement:
@@ -502,3 +502,26 @@ file:
     statement_terminator: ;
     slash_buffer_executor:
       slash: /
+- batch:
+    statement:
+      create_function_statement:
+      - keyword: FUNCTION
+      - function_name:
+          function_name_identifier: ex_func
+      - function_parameter_list:
+          bracketed:
+            start_bracket: (
+            parameter: some_string
+            keyword: IN
+            data_type:
+              data_type_identifier: VARCHAR2
+            end_bracket: )
+      - keyword: RETURN
+      - data_type:
+          data_type_identifier: RAW
+      - keyword: AS
+      - keyword: LANGUAGE
+      - keyword: JAVA
+      - keyword: NAME
+      - quoted_literal: "'exClass.someMethod(java.lang.String) return byte[]'"
+      - statement_terminator: ;

--- a/test/fixtures/dialects/oracle/create_function.yml
+++ b/test/fixtures/dialects/oracle/create_function.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 679a6c9e0fccf2a6664fe43c91d3a7d7548f1dc843176fb77ecbdc40bc2e3c51
+_hash: b1550643161e2db593460a29ec13691a0b356c1008165e68c07d96cd34cd9fed
 file:
 - batch:
     statement:
@@ -27,19 +27,19 @@ file:
       - data_type:
           data_type_identifier: NUMBER
       - keyword: IS
-      - declare_segment:
-          naked_identifier: acc_bal
-          data_type:
-            data_type_identifier: NUMBER
-            bracketed_arguments:
-              bracketed:
-              - start_bracket: (
-              - numeric_literal: '11'
-              - comma: ','
-              - numeric_literal: '2'
-              - end_bracket: )
-          statement_terminator: ;
       - begin_end_block:
+        - declare_segment:
+            naked_identifier: acc_bal
+            data_type:
+              data_type_identifier: NUMBER
+              bracketed_arguments:
+                bracketed:
+                - start_bracket: (
+                - numeric_literal: '11'
+                - comma: ','
+                - numeric_literal: '2'
+                - end_bracket: )
+            statement_terminator: ;
         - keyword: BEGIN
         - statement:
             select_statement:
@@ -148,12 +148,12 @@ file:
           - data_type:
               data_type_identifier: NUMBER
           - keyword: AS
-          - declare_segment:
-              naked_identifier: original_squared
-              data_type:
-                data_type_identifier: NUMBER
-              statement_terminator: ;
           - begin_end_block:
+            - declare_segment:
+                naked_identifier: original_squared
+                data_type:
+                  data_type_identifier: NUMBER
+                statement_terminator: ;
             - keyword: BEGIN
             - statement:
                 assignment_segment_statement:

--- a/test/fixtures/dialects/oracle/create_package_body.yml
+++ b/test/fixtures/dialects/oracle/create_package_body.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 14ee570b92ab80717d7b1b81cbbe87069329ea9f6f9d7cd77aa51c9ac3c5f44c
+_hash: 0c26399034de07c8c1df551ba8c6670411aea124f1686bd20e087c87439f43e9
 file:
 - batch:
     statement:
@@ -215,12 +215,12 @@ file:
           - data_type:
               data_type_identifier: NUMBER
           - keyword: IS
-          - declare_segment:
-              naked_identifier: new_empno
-              data_type:
-                data_type_identifier: NUMBER
-              statement_terminator: ;
           - begin_end_block:
+            - declare_segment:
+                naked_identifier: new_empno
+                data_type:
+                  data_type_identifier: NUMBER
+                statement_terminator: ;
             - keyword: BEGIN
             - statement:
                 select_statement:
@@ -335,12 +335,12 @@ file:
           - data_type:
               data_type_identifier: NUMBER
           - keyword: IS
-          - declare_segment:
-              naked_identifier: new_deptno
-              data_type:
-                data_type_identifier: NUMBER
-              statement_terminator: ;
           - begin_end_block:
+            - declare_segment:
+                naked_identifier: new_deptno
+                data_type:
+                  data_type_identifier: NUMBER
+                statement_terminator: ;
             - keyword: BEGIN
             - statement:
                 select_statement:
@@ -767,15 +767,15 @@ file:
           - data_type:
               data_type_identifier: VARCHAR2
           - keyword: IS
-          - declare_segment:
-              naked_identifier: var_1
-              data_type:
-                data_type_identifier: NUMBER
-              assignment_operator: :=
-              expression:
-                numeric_literal: '0'
-              statement_terminator: ;
           - begin_end_block:
+            - declare_segment:
+                naked_identifier: var_1
+                data_type:
+                  data_type_identifier: NUMBER
+                assignment_operator: :=
+                expression:
+                  numeric_literal: '0'
+                statement_terminator: ;
             - keyword: BEGIN
             - statement:
                 begin_end_block:

--- a/test/fixtures/dialects/oracle/create_type_body.yml
+++ b/test/fixtures/dialects/oracle/create_type_body.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 6ea33a02b369ee6ed39800e2379c99469ece95d170df7ee508568216a85ba498
+_hash: 7fe520be110e6920982705704b59e9e06f66d04a0a2e52bd0a990bb23dd275f9
 file:
 - batch:
     statement:
@@ -71,12 +71,12 @@ file:
         - data_type:
             data_type_identifier: NUMBER
         - keyword: IS
-        - declare_segment:
-            naked_identifier: x
-            data_type:
-              data_type_identifier: NUMBER
-            statement_terminator: ;
         - begin_end_block:
+          - declare_segment:
+              naked_identifier: x
+              data_type:
+                data_type_identifier: NUMBER
+              statement_terminator: ;
           - keyword: BEGIN
           - statement:
               select_statement:

--- a/test/fixtures/dialects/oracle/fetch.yml
+++ b/test/fixtures/dialects/oracle/fetch.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 1e77b27479364356fca323db7399f8f8ce901d963ec3bd00b9a5ede25ecddc11
+_hash: a5f4b230145663d66043d7982c252a1965109e6f2e9e8667ce2c0a21cba8a595
 file:
 - batch:
     statement:
@@ -90,12 +90,12 @@ file:
           - data_type:
               data_type_identifier: EmpRecTyp
           - keyword: IS
-          - declare_segment:
-              naked_identifier: emp_rec
-              data_type:
-                data_type_identifier: EmpRecTyp
-              statement_terminator: ;
           - begin_end_block:
+            - declare_segment:
+                naked_identifier: emp_rec
+                data_type:
+                  data_type_identifier: EmpRecTyp
+                statement_terminator: ;
             - keyword: BEGIN
             - statement:
                 open_statement:


### PR DESCRIPTION
Fixes #7938.

This change adds Oracle parser support for LANGUAGE JAVA NAME call specifications in CREATE FUNCTION statements.

Changes:

* add a LANGUAGE JAVA NAME <quoted literal> alternative to the Oracle CreateFunctionStatementSegment
* add a regression fixture for the issue reproduction
* update the generated Oracle create_function.yml parse fixture

Validation:

* targeted Oracle create_function fixture: 3 passed
* all Oracle fixtures: 267 passed
* ruff lint
* ruff format check
* git diff –check

Notes:

* The issue reproduction produced Found unparsable section before the fix and parses fully after the change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Oracle parser support for `LANGUAGE JAVA NAME` call specs in `CREATE FUNCTION` and simplify the function body grammar. This fixes parsing for Java-based functions and standardizes declarations inside `BEGIN...END` blocks.

- **Bug Fixes**
  - Accept `LANGUAGE JAVA NAME '<quoted literal>'` as an alternative to a PL/SQL block in `CREATE FUNCTION`.
  - Add a regression test and update `oracle/create_function` fixtures; all Oracle fixtures pass.

- **Refactors**
  - Move top-level `DECLARE` items into the `BEGIN...END` block by using the existing block grammar.
  - Update affected Oracle fixtures: `assignment.yml`, `collections.yml`, `create_package_body.yml`, `create_type_body.yml`, `fetch.yml`.

<sup>Written for commit abdbbe248a0e251008965611d7eae7d79febc810. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/7944?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

