### PR TITLE
Support Oracle slash batch delimiter after views

### DIFF
--- a/src/sqlfluff/dialects/dialect_oracle.py
+++ b/src/sqlfluff/dialects/dialect_oracle.py
@@ -1411,7 +1411,9 @@ class CreateViewStatementSegment(ansi.CreateViewStatementSegment):
         # Optional list of column names
         Ref("BracketedColumnReferenceListGrammar", optional=True),
         "AS",
-        OptionallyBracketed(Ref("SelectableGrammar")),
+        OptionallyBracketed(
+            Ref("SelectableGrammar"), terminators=[Ref("BatchDelimiterGrammar")]
+        ),
         Ref("WithNoSchemaBindingClauseSegment", optional=True),
     )
 

--- a/test/fixtures/dialects/oracle/slash_batch_delimiter.sql
+++ b/test/fixtures/dialects/oracle/slash_batch_delimiter.sql
@@ -1,0 +1,10 @@
+create or replace view example as
+select smthng
+from smwhr
+/
+
+comment on table example is 'abc'
+/
+
+create or replace public synonym example for example
+/

--- a/test/fixtures/dialects/oracle/slash_batch_delimiter.yml
+++ b/test/fixtures/dialects/oracle/slash_batch_delimiter.yml
@@ -1,0 +1,59 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 39952379cbb396da12521214e71093dfaa5817bb574a5470c18612a7fba7898a
+file:
+- batch:
+    statement:
+      create_view_statement:
+      - keyword: create
+      - keyword: or
+      - keyword: replace
+      - keyword: view
+      - table_reference:
+          naked_identifier: example
+      - keyword: as
+      - select_statement:
+          select_clause:
+            keyword: select
+            select_clause_element:
+              column_reference:
+                naked_identifier: smthng
+          from_clause:
+            keyword: from
+            from_expression:
+              from_expression_element:
+                table_expression:
+                  table_reference:
+                    naked_identifier: smwhr
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      comment_statement:
+      - keyword: comment
+      - keyword: 'on'
+      - keyword: table
+      - table_reference:
+          naked_identifier: example
+      - keyword: is
+      - quoted_literal: "'abc'"
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      create_synonym_statement:
+      - keyword: create
+      - keyword: or
+      - keyword: replace
+      - keyword: public
+      - keyword: synonym
+      - object_reference:
+          naked_identifier: example
+      - keyword: for
+      - object_reference:
+          naked_identifier: example
+    slash_buffer_executor:
+      slash: /


### PR DESCRIPTION
### Brief summary of the change made

Fixes #7937.

Oracle scripts can use a standalone `/` line as a SQL*Plus batch delimiter. When a `CREATE VIEW ... AS SELECT ...` statement was followed by `/`, the selectable inside the view kept parsing past the slash and swallowed the next statements as an unparsable section.

This updates Oracle `CREATE VIEW` parsing so the selectable stops at the existing `BatchDelimiterGrammar`, then adds a parser fixture covering a view, a comment statement, and a synonym separated by `/`.

### Are there any other side effects of this change that we should be aware of?

Low risk: scoped to Oracle `CREATE VIEW` parsing and reuses the existing Oracle batch delimiter grammar.

### Pull Request checklist

- [x] Please confirm you have completed any relevant tests.
- [x] Please confirm you have followed the commit message policy in `CONTRIBUTING.md`.

Tests:

- `uv run --with-editable . --with pytest --with click --with pyyaml python test/generate_parse_fixture_yml.py -d oracle --filter slash_batch_delimiter.sql`
- `uv run --with-editable . --with pytest --with click --with pyyaml sqlfluff parse --dialect oracle test/fixtures/dialects/oracle/slash_batch_delimiter.sql`
- `uv run --with-editable . --with pytest --with click --with pyyaml pytest -q test/dialects/dialects_test.py -k 'oracle and slash_batch_delimiter'`\n- `uv run --with ruff ruff check src/sqlfluff/dialects/dialect_oracle.py test/generate_parse_fixture_yml.py`\n- `git diff --check`\n\n### AI assistance disclosure\n\nUsed AI assistance to inspect the parser failure and draft the narrow grammar change; I manually reproduced the issue, edited the patch, generated the fixture, and ran the tests listed above.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops Oracle `CREATE VIEW` parsing at the `/` batch delimiter so the view’s SELECT doesn’t consume following statements. Fixes #7937 and prevents unparsable sections in SQL*Plus-style scripts.

- **Bug Fixes**
  - `CreateViewStatementSegment` now terminates `SelectableGrammar` on `BatchDelimiterGrammar`.
  - Added parser fixture with a view, a comment, and a synonym separated by `/`.

<sup>Written for commit 0e311491c2b19d3be0b95da9bd3274593fe630fa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/7945?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

