### PR TITLE
Support Databricks TEMP VIEW

### DIFF
--- a/src/sqlfluff/dialects/dialect_databricks.py
+++ b/src/sqlfluff/dialects/dialect_databricks.py
@@ -855,7 +855,7 @@ class CreateViewStatementSegment(BaseSegment):
     match_grammar = Sequence(
         "CREATE",
         Ref("OrReplaceGrammar", optional=True),
-        Ref.keyword("TEMPORARY", optional=True),
+        Ref("TemporaryGrammar", optional=True),
         "VIEW",
         Ref("IfNotExistsGrammar", optional=True),
         Ref("TableReferenceSegment"),

--- a/test/fixtures/dialects/databricks/create_view.sql
+++ b/test/fixtures/dialects/databricks/create_view.sql
@@ -10,6 +10,9 @@ SELECT id, name FROM my_table;
 CREATE TEMPORARY VIEW temp_view AS
 SELECT * FROM my_table WHERE active = true;
 
+CREATE TEMP VIEW short_temp_view AS
+SELECT 1 AS x;
+
 CREATE VIEW IF NOT EXISTS my_view AS
 SELECT * FROM my_table;
 

--- a/test/fixtures/dialects/databricks/create_view.yml
+++ b/test/fixtures/dialects/databricks/create_view.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: a6f228b8ba181084afd530dc7e9fecb235e923bbf02ac445162da00345043d11
+_hash: a49075281a63bf5771627f5fcd4511135014998598777840aafd3d0bcfff031e
 file:
 - statement:
     create_view_statement:
@@ -84,6 +84,24 @@ file:
             comparison_operator:
               raw_comparison_operator: '='
             boolean_literal: 'true'
+- statement_terminator: ;
+- statement:
+    create_view_statement:
+    - keyword: CREATE
+    - keyword: TEMP
+    - keyword: VIEW
+    - table_reference:
+        naked_identifier: short_temp_view
+    - keyword: AS
+    - select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            numeric_literal: '1'
+            alias_expression:
+              alias_operator:
+                keyword: AS
+              naked_identifier: x
 - statement_terminator: ;
 - statement:
     create_view_statement:


### PR DESCRIPTION
Problem
Databricks accepts both `CREATE TEMPORARY VIEW` and `CREATE TEMP VIEW`, but the Databricks dialect only parsed the long form. Issue #7948 reports `CREATE TEMP VIEW v AS SELECT 1 AS x` as unparsable while SparkSQL accepts it.


Fix
Use the existing `TemporaryGrammar` in the Databricks `CREATE VIEW` grammar so both `TEMP` and `TEMPORARY` are accepted, then add a parser fixture for the short form.

Tests
- `uv run python test/generate_parse_fixture_yml.py -f create_view.sql -d databricks`
- `uv run pytest test/dialects/dialects_test.py -k 'databricks and create_view'`\n- `uvx ruff check src/sqlfluff/dialects/dialect_databricks.py`\n- `git diff --check`\n\nRisk\nLow. This reuses an existing grammar helper already intended for temp/temporary aliases and only broadens a Databricks `CREATE VIEW` optional keyword.

Closes #7948.

AI assistance: used for drafting the small patch; manually reviewed and validated with the checks above.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Support `CREATE TEMP VIEW` in the Databricks dialect by using `TemporaryGrammar` in the `CREATE VIEW` parser. This fixes parsing errors for the short `TEMP` form and aligns with Databricks/Spark SQL.

- **Bug Fixes**
  - Replaced the `TEMPORARY` keyword match with `TemporaryGrammar` so both `TEMP` and `TEMPORARY` are accepted.
  - Added a parse fixture for `CREATE TEMP VIEW` to cover the short form.

<sup>Written for commit 1f4cba65281454440d0caebc946bbd41505ee595. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/7951?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

