### PR TITLE
chore(rust): bump pyo3 to 0.29.0

### DIFF
--- a/sqlfluffrs/Cargo.lock
+++ b/sqlfluffrs/Cargo.lock
@@ -1565,9 +1565,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.28.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf85e27e86080aafd5a22eae58a162e133a589551542b3e5cee4beb27e54f8e1"
+checksum = "cd274650b21d4bfc26a0a47587962c1edb425f69287324355cd040c3ea66071c"
 dependencies = [
  "hashbrown 0.16.1",
  "libc",
@@ -1581,18 +1581,18 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.28.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bf94ee265674bf76c09fa430b0e99c26e319c945d96ca0d5a8215f31bf81cf7"
+checksum = "c5e2a7d2f0d013342f295c048ad19237add5154a55b1c5a254c0ec93d4109078"
 dependencies = [
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.28.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "491aa5fc66d8059dd44a75f4580a2962c1862a1c2945359db36f6c2818b748dc"
+checksum = "ca85c467da1bbc8d866eea5deff9cf29ea5f7785054a17da36e65bda9c05845b"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -1600,9 +1600,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-log"
-version = "0.13.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26c2ec80932c5c3b2d4fbc578c9b56b2d4502098587edb8bef5b6bfcad43682e"
+checksum = "f64083bd3a16a353d9d62335808e8e13d0552d2a2b83fdb084496192dcfa9fcd"
 dependencies = [
  "arc-swap",
  "log",
@@ -1611,9 +1611,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.28.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5d671734e9d7a43449f8480f8b38115df67bef8d21f76837fa75ee7aaa5e52e"
+checksum = "9ac53762fd065daa3194dd09337a38bd793a188100fd1a9304c4ab312d901771"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -1623,13 +1623,12 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.28.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22faaa1ce6c430a1f71658760497291065e6450d7b5dc2bcf254d49f66ee700a"
+checksum = "4ca3a1557399783172dc5bf39cfca835157732532cba56b71d2292161e53b362"
 dependencies = [
  "heck",
  "proc-macro2",
- "pyo3-build-config",
  "quote",
  "syn",
 ]

--- a/sqlfluffrs/Cargo.toml
+++ b/sqlfluffrs/Cargo.toml
@@ -47,13 +47,13 @@ smallvec = "1.15.1"
 # NOTE: Update the abi3 version as we deprecate old python versions.
 # It should match the oldest currently supported python version.
 # This is also necessary in the child packages.
-pyo3 = { version = "0.28.2", optional = true, features = [
+pyo3 = { version = "0.29.0", optional = true, features = [
     "abi3-py310",
     "hashbrown",
     "extension-module",
     "uuid",
 ] }
-pyo3-log = { version = "0.13.3", optional = true }
+pyo3-log = { version = "0.13.4", optional = true }
 uuid = { version = "1.22.0", features = ["v4"] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"

--- a/sqlfluffrs/sqlfluffrs_lexer/Cargo.toml
+++ b/sqlfluffrs/sqlfluffrs_lexer/Cargo.toml
@@ -17,8 +17,8 @@ sqlfluffrs_dialects = { path = "../sqlfluffrs_dialects" }
 sqlfluffrs_python = { path = "../sqlfluffrs_python", optional = true }
 # NOTE: Update the abi3 version as we deprecate old python versions.
 # It should match the oldest currently supported python version.
-pyo3 = { version = "0.28.2", optional = true, features = ["abi3-py310", "hashbrown", "extension-module", "uuid"] }
-pyo3-log = { version = "0.13.3", optional = true }
+pyo3 = { version = "0.29.0", optional = true, features = ["abi3-py310", "hashbrown", "extension-module", "uuid"] }
+pyo3-log = { version = "0.13.4", optional = true }
 
 [features]
 unicode = []

--- a/sqlfluffrs/sqlfluffrs_parser/Cargo.toml
+++ b/sqlfluffrs/sqlfluffrs_parser/Cargo.toml
@@ -17,7 +17,7 @@ serde_yaml_ng = "0.10.0"
 regex = { version = "1.12.3", features = ["perf"] }
 # NOTE: Update the abi3 version as we deprecate old python versions.
 # It should match the oldest currently supported python version.
-pyo3 = { version = "0.28.2", optional = true, features = ["abi3-py310", "hashbrown", "extension-module", "uuid"] }
+pyo3 = { version = "0.29.0", optional = true, features = ["abi3-py310", "hashbrown", "extension-module", "uuid"] }
 
 [features]
 python = ["pyo3", "sqlfluffrs_python", "sqlfluffrs_lexer/python"]

--- a/sqlfluffrs/sqlfluffrs_python/Cargo.toml
+++ b/sqlfluffrs/sqlfluffrs_python/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 # NOTE: Update the abi3 version as we deprecate old python versions.
 # It should match the oldest currently supported python version.
-pyo3 = { version = "0.28.2", features = ["abi3-py310", "hashbrown", "extension-module", "uuid"] }
+pyo3 = { version = "0.29.0", features = ["abi3-py310", "hashbrown", "extension-module", "uuid"] }
 sqlfluffrs_types = { path = "../sqlfluffrs_types" }
 hashbrown = "0.16.1"
 uuid = { version = "1.22.0", features = ["v4"] }


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
This upgrades pyo3 to 0.29.0. We aren't impacted by the CVE, but good to preemptively update.

### Are there any other side effects of this change that we should be aware of?
None

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade `pyo3` to 0.29.0 across the workspace and bump `pyo3-log` to 0.13.4 to keep Python bindings current and ahead of advisories. No functional changes expected.

- **Dependencies**
  - `pyo3`: 0.28.2 → 0.29.0 in root, `sqlfluffrs_lexer`, `sqlfluffrs_parser`, `sqlfluffrs_python`
  - `pyo3-log`: 0.13.3 → 0.13.4
  - Updated `Cargo.lock`

<sup>Written for commit 4ee71b5500f2fb0a028d1992227bd8e13b3ae4e2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/7954?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

