### PR TITLE
Don't flag required alias on T-SQL table-valued XML methods (AL05)

### DIFF
--- a/src/sqlfluff/rules/aliasing/AL05.py
+++ b/src/sqlfluff/rules/aliasing/AL05.py
@@ -69,6 +69,12 @@ class Rule_AL05(BaseRule):
         "postgres",
         "mariadb",
     ]
+    # T-SQL datatype methods that produce a rowset and therefore require a
+    # correlation name in the FROM clause. This is deliberately an allowlist:
+    # most datatype methods (`query`, `value`, spatial and `hierarchyid`
+    # methods, ...) are scalar-valued and are not table expressions, so only
+    # the rowset-producing `nodes` belongs here (issue #6733).
+    _tsql_rowset_datatype_methods = frozenset({"nodes"})
     # Dialects where a bare table alias can be used as a whole-row/composite
     # value (e.g. `SELECT to_json(t) FROM tbl AS t`). In these dialects such a
     # reference is a legitimate use of the alias, so AL05 must not flag it as
@@ -251,12 +257,18 @@ class Rule_AL05(BaseRule):
                         for seg in openrowset.recursive_crawl("keyword")
                     ):
                         return True
-                    # A table-valued XML method such as `@x.nodes('...')` must be
-                    # given a correlation name in T-SQL; removing the alias
-                    # produces invalid syntax, so the alias is required even when
-                    # it is not otherwise referenced (issue #6733).
-                    if next(segment.recursive_crawl("datatype_method"), None):
-                        return True
+                    # A rowset-producing datatype method such as
+                    # `@x.nodes('...')` must be given a correlation name in
+                    # T-SQL; removing the alias produces invalid syntax, so the
+                    # alias is required even when it is not otherwise referenced
+                    # (issue #6733).
+                    for method in segment.recursive_crawl("datatype_method"):
+                        name = method.get_child("datatype_method_name_identifier")
+                        if (
+                            name is not None
+                            and name.raw.lower() in self._tsql_rowset_datatype_methods
+                        ):
+                            return True
                 # Found a table expression. Does it have a VALUES clause?
                 if segment.get_child("values_clause"):
                     # Found a VALUES clause. Is this a dialect that requires

--- a/src/sqlfluff/rules/aliasing/AL05.py
+++ b/src/sqlfluff/rules/aliasing/AL05.py
@@ -251,6 +251,12 @@ class Rule_AL05(BaseRule):
                         for seg in openrowset.recursive_crawl("keyword")
                     ):
                         return True
+                    # A table-valued XML method such as `@x.nodes('...')` must be
+                    # given a correlation name in T-SQL; removing the alias
+                    # produces invalid syntax, so the alias is required even when
+                    # it is not otherwise referenced (issue #6733).
+                    if next(segment.recursive_crawl("datatype_method"), None):
+                        return True
                 # Found a table expression. Does it have a VALUES clause?
                 if segment.get_child("values_clause"):
                     # Found a VALUES clause. Is this a dialect that requires

--- a/test/fixtures/rules/std_rule_cases/AL05.yml
+++ b/test/fixtures/rules/std_rule_cases/AL05.yml
@@ -1314,10 +1314,22 @@ test_pass_postgres_wildcard_row_passed_to_function:
 test_pass_tsql_nodes_method_requires_alias:
   # https://github.com/sqlfluff/sqlfluff/issues/6733
   # A table-valued XML method (`.nodes()`) must be given a correlation name in
-  # T-SQL. The alias is syntactically required, so it must not be flagged as
-  # unused -- removing it (as the autofix did) produces invalid SQL.
+  # T-SQL, whose official syntax names both the table and its column:
+  # `nodes(XQuery) AS Table(Column)`. The alias is syntactically required, so it
+  # must not be flagged as unused -- removing it (as the autofix did) produces
+  # invalid SQL.
   pass_str: |
-    SELECT 1 FROM @Xml.nodes('a') AS FN;
+    SELECT Col.value('.', 'NVARCHAR(MAX)') AS V
+    FROM @Xml.nodes('/a') AS Tbl(Col);
+  configs:
+    core:
+      dialect: tsql
+
+test_pass_tsql_nodes_method_requires_alias_unreferenced:
+  # The alias is still required even when neither the table nor its column is
+  # referenced in the select list (the case AL05's autofix used to corrupt).
+  pass_str: |
+    SELECT 1 FROM @Xml.nodes('a') AS Tbl(Col);
   configs:
     core:
       dialect: tsql

--- a/test/fixtures/rules/std_rule_cases/AL05.yml
+++ b/test/fixtures/rules/std_rule_cases/AL05.yml
@@ -1310,3 +1310,14 @@ test_pass_postgres_wildcard_row_passed_to_function:
   configs:
     core:
       dialect: postgres
+
+test_pass_tsql_nodes_method_requires_alias:
+  # https://github.com/sqlfluff/sqlfluff/issues/6733
+  # A table-valued XML method (`.nodes()`) must be given a correlation name in
+  # T-SQL. The alias is syntactically required, so it must not be flagged as
+  # unused -- removing it (as the autofix did) produces invalid SQL.
+  pass_str: |
+    SELECT 1 FROM @Xml.nodes('a') AS FN;
+  configs:
+    core:
+      dialect: tsql


### PR DESCRIPTION
## Summary

Fixes the AL05 (`aliasing.unused`) false positive and corrupting autofix reported in #6733.

In T-SQL, a table-valued XML method such as `@x.nodes('...')` must be given a correlation name when used in a `FROM` clause; without one SQL Server raises a syntax error. AL05 treated that alias as unused (it frequently is not referenced in the select list) and proposed deleting it, so `sqlfluff fix` turned valid SQL into invalid SQL:

```sql
-- before
SELECT 1 FROM @Xml.nodes('a') AS FN;

-- after `sqlfluff fix --rules AL05` (invalid: .nodes() now has no alias)
SELECT 1 FROM @Xml.nodes('a');
```

## Fix

`_is_alias_required` already enumerates the cases where a `FROM` alias must be kept (VALUES clauses in dialects that require them, derived tables, and T-SQL `OPENROWSET ... BULK`). This adds one more T-SQL case: when the `FROM` expression contains a `datatype_method` segment (the `.nodes()` style XML method), the alias is required and must not be reported as unused. Genuinely unused aliases on ordinary tables are still flagged, in T-SQL and every other dialect.

## Tests

Added `test_pass_tsql_nodes_method_requires_alias` to `test/fixtures/rules/std_rule_cases/AL05.yml`. It fails on `main` (AL05 flags and then deletes the required alias) and passes with this change. The full AL05 suite (138 cases) and the combined AL04/AL05 alias-rule tests (148 cases) pass locally.

## Note on the other symptoms in #6733

On current `main` the "Found unparsable section" parse error and the RF05 finding from the issue no longer reproduce for me (`@x.nodes('...') AS r(c)` parses cleanly), so this PR targets the remaining live problem: the AL05 corrupting autofix. Happy to adjust the scope or wording.

## AI assistance disclosure

I prepared this change with AI assistance under my direction. I reviewed and validated the root cause, the fix, and the test myself (confirming the red/green behaviour and that ordinary unused aliases are still reported), and I ran the rule test suite locally.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent AL05 (`aliasing.unused`) from deleting the required alias on T‑SQL XML rowset method `@x.nodes('...')`, which produced invalid SQL. Update `_is_alias_required` to require an alias only when the `FROM` expression contains a rowset `datatype_method` from an allowlist (currently `nodes`), and add T‑SQL tests for the official `nodes(...) AS Table(Column)` syntax and an unreferenced‑alias case.

<sup>Written for commit a7c9e34d7cdfac1ba068f94006ccfcae522ac517. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/7955?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



