### PR TITLE
Added support for INSERT ... BY NAME for SparkSQL

### DIFF
--- a/src/sqlfluff/dialects/dialect_sparksql.py
+++ b/src/sqlfluff/dialects/dialect_sparksql.py
@@ -1882,7 +1882,11 @@ class InsertStatementSegment(BaseSegment):
         OneOf(
             Sequence(
                 Ref("PartitionSpecGrammar", optional=True),
-                Ref("BracketedColumnReferenceListGrammar", optional=True),
+                OneOf(
+                    Ref("BracketedColumnReferenceListGrammar"),
+                    Sequence("BY", "NAME"),
+                    optional=True,
+                ),
                 Ref("InsertSourceGrammar"),
             ),
             Sequence(

--- a/test/fixtures/dialects/sparksql/insert_table.sql
+++ b/test/fixtures/dialects/sparksql/insert_table.sql
@@ -48,6 +48,19 @@ SELECT
 name, address, id
 WHERE qualified = TRUE;
 
+-- Insert By Name
+INSERT INTO students BY NAME
+SELECT address, name FROM persons;
+
+INSERT OVERWRITE students BY NAME
+SELECT address, name FROM persons;
+
+INSERT INTO students PARTITION (student_id = 222222) BY NAME
+SELECT address, name FROM persons;
+
+INSERT OVERWRITE students PARTITION (student_id = 222222) BY NAME
+SELECT address, name FROM persons;
+
 -- Insert Using a Typed Date Literal for a Partition Column Value
 INSERT INTO students PARTITION (birthday = DATE '2019-01-02')
 VALUES ('Amy Smith', '123 Park Ave, San Jose');

--- a/test/fixtures/dialects/sparksql/insert_table.yml
+++ b/test/fixtures/dialects/sparksql/insert_table.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 7d1f784da0d1a5b69542c47e576be28a6593442bb78ea5a2ef95440385e8704f
+_hash: 88a76f283a61b56059c86b7c039904a1cf2e086dad0bfbc65cfe890d7f7a4284
 file:
 - statement:
     insert_statement:
@@ -285,6 +285,128 @@ file:
           comparison_operator:
             raw_comparison_operator: '='
           boolean_literal: 'TRUE'
+- statement_terminator: ;
+- statement:
+    insert_statement:
+    - keyword: INSERT
+    - keyword: INTO
+    - table_reference:
+        naked_identifier: students
+    - keyword: BY
+    - keyword: NAME
+    - select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            column_reference:
+              naked_identifier: address
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+              naked_identifier: name
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: persons
+- statement_terminator: ;
+- statement:
+    insert_statement:
+    - keyword: INSERT
+    - keyword: OVERWRITE
+    - table_reference:
+        naked_identifier: students
+    - keyword: BY
+    - keyword: NAME
+    - select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            column_reference:
+              naked_identifier: address
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+              naked_identifier: name
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: persons
+- statement_terminator: ;
+- statement:
+    insert_statement:
+    - keyword: INSERT
+    - keyword: INTO
+    - table_reference:
+        naked_identifier: students
+    - keyword: PARTITION
+    - bracketed:
+        start_bracket: (
+        column_reference:
+          naked_identifier: student_id
+        comparison_operator:
+          raw_comparison_operator: '='
+        numeric_literal: '222222'
+        end_bracket: )
+    - keyword: BY
+    - keyword: NAME
+    - select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            column_reference:
+              naked_identifier: address
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+              naked_identifier: name
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: persons
+- statement_terminator: ;
+- statement:
+    insert_statement:
+    - keyword: INSERT
+    - keyword: OVERWRITE
+    - table_reference:
+        naked_identifier: students
+    - keyword: PARTITION
+    - bracketed:
+        start_bracket: (
+        column_reference:
+          naked_identifier: student_id
+        comparison_operator:
+          raw_comparison_operator: '='
+        numeric_literal: '222222'
+        end_bracket: )
+    - keyword: BY
+    - keyword: NAME
+    - select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            column_reference:
+              naked_identifier: address
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+              naked_identifier: name
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: persons
 - statement_terminator: ;
 - statement:
     insert_statement:


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
Adds support to the SparkSQL dialect for 'INSERT ... BY NAME'.

Spark SQL documents BY NAME as a valid alternative to an explicit insert column list in `INSERT TABLE` statements (see [INSERT TABLE - Spark latest](https://spark.apache.org/docs/latest/sql-ref-syntax-dml-insert-table.html)). This is also useful for the Databricks dialect, which inherits from SparkSQL in SQLFluff and supports BY NAME as well.


### Are there any other side effects of this change that we should be aware of?
No


### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds parser support for SparkSQL `INSERT ... BY NAME`, allowing name-based column mapping as an alternative to an explicit column list. Works with `INSERT INTO` and `INSERT OVERWRITE`, with or without `PARTITION`, and is available in the Databricks dialect that inherits SparkSQL.

<sup>Written for commit 8ec61487546545bf931f332aeee052e0d2181e89. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/7959?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

