### PR TITLE
chore: bump dependency click<8.5.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,7 @@ dependencies = [
     "chardet",
     # Click can include breaking changes in minor releases. Make sure to test
     # well before updating upper bound.
-    "click<8.4.0",
+    "click<8.5.0",
     "colorama>=0.3",
     # Used for diffcover plugin
     "diff-cover>=2.5.0",


### PR DESCRIPTION

<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
This bumps `click` to <8.5.0. 8.4.0 had no visible breaking changes.
- closes #7960

### Are there any other side effects of this change that we should be aware of?
None

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raise the upper bound from `click<8.4.0` to `click<8.5.0` to allow `click` 8.4.x, which has no breaking changes for us. Closes #7960.

<sup>Written for commit 614822faa715ef15fd0e078b3ed8905bbfcc2278. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/7961?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

