### PR TITLE
rust: Don't strip debuginfo on bench for flamegraph

### DIFF
--- a/sqlfluffrs/Cargo.toml
+++ b/sqlfluffrs/Cargo.toml
@@ -77,6 +77,8 @@ harness = false
 
 [profile.bench]
 debug = true
+strip = false
+
 [profile.release]
 debug = false
 strip = true


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Previously we were stripping debuginfo from bench builds. This retains the debuginfo for use in flamegraph.

Verified this going from 0 symbols to 14,576 symbols on a bench build.

### Are there any other side effects of this change that we should be aware of?
None

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep debug symbols in Rust benchmark builds by setting `strip = false` in `sqlfluffrs/Cargo.toml` `[profile.bench]`, so flamegraphs include function names. Release builds are unchanged and still strip symbols.

<sup>Written for commit 228a966e7ea8a8da1a574e918b2da3fd20feb6f4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/7963?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

