### PR TITLE
fix(oracle): support DEFAULT keyword in pragma restrict_references (fixes #7957)

### DIFF
--- a/src/sqlfluff/dialects/dialect_oracle.py
+++ b/src/sqlfluff/dialects/dialect_oracle.py
@@ -649,6 +649,7 @@ oracle_dialect.replace(
     FunctionContentsExpressionGrammar=OneOf(
         Ref("ExpressionSegment"),
         Ref("NamedArgumentSegment"),
+        Ref.keyword("DEFAULT"),
     ),
     FunctionContentsGrammar=ansi_dialect.get_grammar("FunctionContentsGrammar").copy(
         insert=[Ref("ListaggOverflowClauseSegment"), Ref("JSONObjectContentSegment")]

--- a/test/fixtures/dialects/oracle/pragma_restrict_references_default.sql
+++ b/test/fixtures/dialects/oracle/pragma_restrict_references_default.sql
@@ -1,0 +1,3 @@
+create or replace package ex_pkg is
+    pragma restrict_references(default);
+end ex_pgk;

--- a/test/fixtures/dialects/oracle/pragma_restrict_references_default.yml
+++ b/test/fixtures/dialects/oracle/pragma_restrict_references_default.yml
@@ -1,0 +1,32 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 8fea9c1ab8f82357d19f68a008d76c04a579f2eed3281ea490e6b5e17467aff8
+file:
+  batch:
+    statement:
+      create_package_statement:
+      - keyword: create
+      - keyword: or
+      - keyword: replace
+      - keyword: package
+      - package_reference:
+          naked_identifier: ex_pkg
+      - keyword: is
+      - declare_segment:
+          keyword: pragma
+          function:
+            function_name:
+              function_name_identifier: restrict_references
+            function_contents:
+              bracketed:
+                start_bracket: (
+                keyword: default
+                end_bracket: )
+          statement_terminator: ;
+      - keyword: end
+      - package_reference:
+          naked_identifier: ex_pgk
+    statement_terminator: ;


### PR DESCRIPTION
The Oracle parser treated `pragma restrict_references(default)` as
unparsable because the `DEFAULT` keyword was not recognized as a
valid function argument. Per Oracle documentation, the
`restrict_references` pragma accepts `DEFAULT` as an argument to
apply the assertion to all subprograms in the package.

## Before
```sql
create or replace package ex_pkg is
    pragma restrict_references(default);
end ex_pgk;
```
→ `Found unparsable section`

## After
Parses successfully, with `default` recognized as a keyword argument
inside the function contents.

The fix adds `DEFAULT` to the Oracle dialect's
`FunctionContentsExpressionGrammar`.

This pull request includes code written with the assistance of AI
under my direction.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow `DEFAULT` as a valid argument in Oracle `pragma restrict_references(...)`. This fixes parsing errors for `pragma restrict_references(default)` and resolves #7957.

- **Bug Fixes**
  - Updated Oracle `FunctionContentsExpressionGrammar` to accept the `DEFAULT` keyword.
  - Added fixture tests for `pragma restrict_references(default)`.

<sup>Written for commit 9551468c9109591d7890c389d7bb1237a0c4fdf7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/7965?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

