### PR TITLE
reflow: Support strict fixes; LT03 add pipe operator

### DIFF
--- a/src/sqlfluff/core/default_config.cfg
+++ b/src/sqlfluff/core/default_config.cfg
@@ -130,6 +130,9 @@ line_position = leading
 spacing_within = touch
 line_position = leading
 
+[sqlfluff:layout:type:pipe_operator]
+line_position = leading:attached:strict
+
 [sqlfluff:layout:type:statement_terminator]
 spacing_before = touch
 line_position = trailing

--- a/src/sqlfluff/rules/layout/LT03.py
+++ b/src/sqlfluff/rules/layout/LT03.py
@@ -61,7 +61,12 @@ class Rule_LT03(BaseRule):
     aliases = ("L007",)
     groups = ("all", "layout")
     crawl_behaviour = SegmentSeekerCrawler(
-        {"binary_operator", "comparison_operator", "assignment_operator"}
+        {
+            "binary_operator",
+            "comparison_operator",
+            "assignment_operator",
+            "pipe_operator",
+        }
     )
     is_fix_compatible = True
 
@@ -99,33 +104,29 @@ class Rule_LT03(BaseRule):
             parent: The parent segment (must contain `segment`).
             line_position: The `line_position` config for the segment.
         """
-        idx = parent.segments.index(segment)
         base_position = line_position.split(":")[0]
+        if base_position not in ("leading", "trailing"):
+            return False
         attached = "attached" in line_position
+        strict = line_position.endswith("strict")
+
+        # `leading`/`trailing` are mirror images, so resolve the sides relative
+        # to the desired position and share the logic.
+        idx = parent.segments.index(segment)
         has_newline_before = self._seek_newline(parent.segments, idx, dir=-1)
         has_newline_after = self._seek_newline(parent.segments, idx, dir=1)
-
-        # Shortcut #1: Leading.
         if base_position == "leading":
-            if attached:
-                # leading:attached: shortcut when mid-line or truly leading.
-                # Must reflow when trailing or on its own line (no newline after
-                # means it cannot be standalone or trailing).
-                return not has_newline_after
-            # Standard: OK unless trailing (no newline before, but newline after).
-            return has_newline_before or not has_newline_after
+            in_position, opposite = has_newline_before, has_newline_after
+        else:
+            in_position, opposite = has_newline_after, has_newline_before
 
-        # Shortcut #2: Trailing.
-        elif base_position == "trailing":
-            if attached:
-                # trailing:attached: shortcut when mid-line or truly trailing.
-                # Must reflow when leading or on its own line (no newline before
-                # means it cannot be standalone or leading).
-                return not has_newline_before
-            # Standard: OK unless leading (no newline after, but newline before).
-            return has_newline_after or not has_newline_before
-
-        return False
+        if attached:
+            # `attached` also forbids floating alone on its own line.
+            if opposite:
+                return False
+            return in_position or not strict
+        # OK unless mispositioned; `strict` also rejects mid-line.
+        return in_position or (not strict and not opposite)
 
     def _eval(self, context: RuleContext) -> list[LintResult]:
         """Operators should follow a standard for being before/after newlines.
@@ -138,31 +139,21 @@ class Rule_LT03(BaseRule):
         # NOTE: These shortcuts assume that any newlines will be direct
         # siblings of the operator in question. This isn't _always_ the case
         # but is true often enough to have meaningful upside from early
-        # detection.
-        if context.segment.is_type("comparison_operator"):
-            comparison_positioning = context.config.get(
-                "line_position", ["layout", "type", "comparison_operator"]
-            )
-            if self._check_trail_lead_shortcut(
-                context.segment, context.parent_stack[-1], comparison_positioning
-            ):
-                return [LintResult()]
-        elif context.segment.is_type("binary_operator"):
-            binary_positioning = context.config.get(
-                "line_position", ["layout", "type", "binary_operator"]
-            )
-            if self._check_trail_lead_shortcut(
-                context.segment, context.parent_stack[-1], binary_positioning
-            ):
-                return [LintResult()]
-        elif context.segment.is_type("assignment_operator"):
-            assignment_positioning = context.config.get(
-                "line_position", ["layout", "type", "assignment_operator"]
-            )
-            if self._check_trail_lead_shortcut(
-                context.segment, context.parent_stack[-1], assignment_positioning
-            ):
-                return [LintResult()]
+        # detection. `pipe_operator` has no shortcut and falls through to reflow.
+        for operator_type in (
+            "comparison_operator",
+            "binary_operator",
+            "assignment_operator",
+        ):
+            if context.segment.is_type(operator_type):
+                positioning = context.config.get(
+                    "line_position", ["layout", "type", operator_type]
+                )
+                if self._check_trail_lead_shortcut(
+                    context.segment, context.parent_stack[-1], positioning
+                ):
+                    return [LintResult()]
+                break
 
         return (
             ReflowSequence.from_around_target(

--- a/src/sqlfluff/utils/reflow/rebreak.py
+++ b/src/sqlfluff/utils/reflow/rebreak.py
@@ -457,8 +457,8 @@ def rebreak_sequence(
 
             # Generate the text for any issues.
             pretty_name = loc.pretty_target_name()
-            if loc.strict:  # pragma: no cover
-                # TODO: The 'strict' option isn't widely tested yet.
+            if loc.strict and not elem_buff[loc.next.newline_pt_idx].num_newlines():
+                # Strict and mid-line (no newline on either side).
                 desc = f"{pretty_name.capitalize()} should always start a new line."
             elif loc.attached and elem_buff[loc.prev.newline_pt_idx].num_newlines():
                 # Standalone + leading:attached: operator is on its own line but
@@ -473,10 +473,22 @@ def rebreak_sequence(
                     "near line breaks."
                 )
 
+            # Strict mid-line case: the target has no newline on either side
+            # (only reachable when `strict` is set). There's nothing to "move"
+            # past, so we simply insert a newline _before_ the target so it
+            # leads the following line.
+            if not elem_buff[loc.next.newline_pt_idx].num_newlines():
+                reflow_logger.debug("  Leading Strict Insert Case")
+                new_results, prev_point = prev_point.indent_to(
+                    deduce_line_indent(loc.target.raw_segments[0], root_segment),
+                    before=loc.target,
+                )
+                # Update the point in the buffer
+                elem_buff[loc.prev.adj_pt_idx] = prev_point
             # Is it the simple case with no comments between the
             # old and new desired locations and only a single following
             # whitespace?
-            if (
+            elif (
                 loc.next.adj_pt_idx == loc.next.pre_code_pt_idx
                 and elem_buff[loc.next.newline_pt_idx].num_newlines() == 1
             ):
@@ -571,8 +583,8 @@ def rebreak_sequence(
 
             # Generate the text for any issues.
             pretty_name = loc.pretty_target_name()
-            if loc.strict:  # pragma: no cover
-                # TODO: The 'strict' option isn't widely tested yet.
+            if loc.strict and not elem_buff[loc.prev.newline_pt_idx].num_newlines():
+                # Strict and mid-line (no newline on either side).
                 desc = (
                     f"{pretty_name.capitalize()} should always be at the end of a line."
                 )
@@ -589,9 +601,21 @@ def rebreak_sequence(
                     "near line breaks."
                 )
 
+            # Strict mid-line case: the target has no newline on either side
+            # (only reachable when `strict` is set). There's nothing to "move"
+            # past, so we simply insert a newline _after_ the target so it
+            # trails the current line.
+            if not elem_buff[loc.prev.newline_pt_idx].num_newlines():
+                reflow_logger.debug("  Trailing Strict Insert Case")
+                new_results, next_point = next_point.indent_to(
+                    deduce_line_indent(loc.target.raw_segments[-1], root_segment),
+                    after=loc.target,
+                )
+                # Update the point in the buffer
+                elem_buff[loc.next.adj_pt_idx] = next_point
             # Is it the simple case with no comments between the
             # old and new desired locations and only one previous newline?
-            if (
+            elif (
                 loc.prev.adj_pt_idx == loc.prev.pre_code_pt_idx
                 and elem_buff[loc.prev.newline_pt_idx].num_newlines() == 1
             ):

--- a/test/fixtures/rules/std_rule_cases/LT03.yml
+++ b/test/fixtures/rules/std_rule_cases/LT03.yml
@@ -552,3 +552,141 @@ assignment_operator_snowflake_leading_attached_fails_standalone:
     LET MY_VAR
     := SOME_VALUE;
   configs: *snowflake_leading_attached
+
+test_pass_bigquery_pipe_operator_leading:
+  # `|>` already starts the line - this is correct.
+  pass_str: |
+    FROM my_database.my_table
+    |> WHERE some_condition
+    |> ORDER BY my_column
+  configs:
+    core:
+      dialect: bigquery
+
+test_fail_bigquery_pipe_operator_trailing:
+  # `|>` should start a new line, not trail the previous one.
+  fail_str: |
+    FROM my_database.my_table |>
+    WHERE some_condition
+  fix_str: |
+    FROM my_database.my_table
+    |> WHERE some_condition
+  configs:
+    core:
+      dialect: bigquery
+
+test_fail_bigquery_pipe_operator_inline:
+  # The default `leading:attached:strict` config moves a mid-line `|>` (no
+  # newline on either side) onto its own line.
+  fail_str: |
+    FROM my_database.my_table |> WHERE some_condition |> ORDER BY my_column
+  fix_str: |
+    FROM my_database.my_table
+    |> WHERE some_condition
+    |> ORDER BY my_column
+  configs:
+    core:
+      dialect: bigquery
+
+test_fail_bigquery_pipe_operator_standalone:
+  # The `attached` part of the default config joins a `|>` floating alone on
+  # its own line back onto the following clause keyword.
+  fail_str: |
+    FROM my_database.my_table
+    |>
+    WHERE some_condition
+  fix_str: |
+    FROM my_database.my_table
+    |> WHERE some_condition
+  configs:
+    core:
+      dialect: bigquery
+
+# --- leading:strict / trailing:strict (insert a newline for mid-line operators)
+
+test_fail_binary_operator_leading_strict_inline:
+  # leading:strict moves a mid-line operator onto the start of a new line.
+  fail_str: |
+    SELECT a + b
+  fix_str: |
+    SELECT a
+    + b
+  configs: &binary_leading_strict
+    layout:
+      type:
+        binary_operator:
+          line_position: "leading:strict"
+
+test_pass_binary_operator_leading_strict_already_leading:
+  pass_str: |
+    SELECT a
+    + b
+  configs: *binary_leading_strict
+
+test_fail_binary_operator_trailing_strict_inline:
+  # trailing:strict moves a mid-line operator onto the end of the line.
+  fail_str: |
+    SELECT a + b
+  fix_str: |
+    SELECT a +
+    b
+  configs: &binary_trailing_strict
+    layout:
+      type:
+        binary_operator:
+          line_position: "trailing:strict"
+
+test_pass_binary_operator_trailing_strict_already_trailing:
+  pass_str: |
+    SELECT a +
+    b
+  configs: *binary_trailing_strict
+
+test_fail_binary_operator_leading_attached_strict_inline:
+  # leading:attached:strict on a mid-line operator inserts a newline before it
+  # while keeping it attached to the following token.
+  fail_str: |
+    SELECT a + b
+  fix_str: |
+    SELECT a
+    + b
+  configs:
+    layout:
+      type:
+        binary_operator:
+          line_position: "leading:attached:strict"
+
+test_fail_binary_operator_trailing_attached_strict_inline:
+  # trailing:attached:strict on a mid-line operator inserts a newline after it
+  # while keeping it attached to the preceding token.
+  fail_str: |
+    SELECT a + b
+  fix_str: |
+    SELECT a +
+    b
+  configs:
+    layout:
+      type:
+        binary_operator:
+          line_position: "trailing:attached:strict"
+
+test_fail_binary_operator_leading_strict_inline_block_comment:
+  # A mid-line operator with inline block comments only inserts a newline next
+  # to the operator - the comments are not reordered.
+  fail_str: |
+    SELECT a /* c1 */ + /* c2 */ b
+  fix_str: |
+    SELECT a /* c1 */
+    + /* c2 */ b
+  configs: *binary_leading_strict
+
+test_fail_bigquery_pipe_operator_inline_block_comment:
+  # The default `leading:strict` pipe handling is comment-safe.
+  fail_str: |
+    FROM t /* c */ |> WHERE x
+  fix_str: |
+    FROM t /* c */
+    |> WHERE x
+  configs:
+    core:
+      dialect: bigquery

--- a/test/fixtures/rules/std_rule_cases/LT04.yml
+++ b/test/fixtures/rules/std_rule_cases/LT04.yml
@@ -374,11 +374,15 @@ trailing_comma_no_space_comment:
     FROM t
 
 trailing_comma_strict_tsql_exec:
-  # Regression test for NotImplementedError with trailing:strict
-  # on T-SQL EXEC statements with parameters
-  pass_str: |
+  # `trailing:strict` moves a mid-line comma to the end of the line.
+  # (This T-SQL EXEC input previously raised NotImplementedError.)
+  fail_str: |
     EXEC admin.usp_update_default_dimension_member
         @schema = 'dbo', @table = 'dim_territory';
+  fix_str: |
+    EXEC admin.usp_update_default_dimension_member
+        @schema = 'dbo',
+        @table = 'dim_territory';
   configs:
     core:
       dialect: tsql


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
This is the other half of #6984. It introduces the `pipe_operator` to the LT03 rule for the pipe to be at the beginning of the line by default. We also make this `attached` and `strict`. This way we always have the keyword directly following the pipe operator on the same line. To make the fix work I had to implement the fix logic for the `strict` configuration. As a side effect this fixes the regression test found in LT04.

I also cleaned up some of the repeated paths found in LT03 so it's a bit simpler.

- closes #6984 

### Are there any other side effects of this change that we should be aware of?
This does touch reflow, but just the sparsely tested `strict` logic. I couldn't produce anything that my fix negatively impacted, but there could be something that we don't currently cover.

In the default configuration, this has no conflicts with LT14, but it does have a risk if additional segments are added to the LT14 configuration without excluding the `pipe_operator` it may make a query non-auto-fixable.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add BigQuery `|>` pipe support to `LT03` with a default of leading:attached:strict, and implement strict reflow so mid-line operators are auto-fixed onto the correct line. Closes #6984.

- **New Features**
  - Add `pipe_operator` to `LT03` with default `[sqlfluff:layout:type:pipe_operator] line_position = leading:attached:strict` (pipe starts the line and stays attached to the next keyword).
  - Implement strict reflow behavior: for `leading:strict` insert a newline before mid-line targets; for `trailing:strict` insert after. Works with `attached` and preserves comments.

- **Bug Fixes**
  - Resolve LT04 regression for T-SQL `trailing:strict` (mid-line commas now break correctly).
  - Simplify LT03 shortcut logic and extend it to operators; `pipe_operator` falls through to reflow for robust fixing.

<sup>Written for commit 06dac1ab4ee01bb3bd6147cb3a53c0b8efb0fd0e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/7966?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

