### PR TITLE
Split PG01 foreign key NOT VALID check

### DIFF
--- a/src/sqlfluff/core/default_config.cfg
+++ b/src/sqlfluff/core/default_config.cfg
@@ -436,6 +436,14 @@ force_enable = False
 # SQL type casting
 preferred_type_casting_style = consistent
 
+[sqlfluff:rules:postgres.excessive_locks]
+# Avoid PostgreSQL DDL statements that take heavier locks than needed.
+force_enable = False
+
+[sqlfluff:rules:postgres.not_valid_foreign_key]
+# Create PostgreSQL foreign keys as NOT VALID before validating separately.
+force_enable = False
+
 [sqlfluff:rules:references.from]
 # References must be in FROM clause
 # Disabled for some dialects (e.g. bigquery)

--- a/src/sqlfluff/rules/postgres/PG01.py
+++ b/src/sqlfluff/rules/postgres/PG01.py
@@ -23,7 +23,8 @@ class Rule_PG01(BaseRule):
     * ``REINDEX`` → use ``CONCURRENTLY``
     * ``REFRESH MATERIALIZED VIEW`` → use ``CONCURRENTLY``
 
-    This rule only applies to the ``postgres`` dialect.
+    This rule only applies to the ``postgres`` dialect and is disabled by
+    default. Enable it with the ``force_enable = True`` flag.
 
     **Anti-pattern**
 
@@ -58,6 +59,7 @@ class Rule_PG01(BaseRule):
     name = "postgres.excessive_locks"
     aliases = ()
     groups = ("all", "postgres")
+    config_keywords = ["force_enable"]
     crawl_behaviour = SegmentSeekerCrawler(
         {
             "create_index_statement",
@@ -70,6 +72,11 @@ class Rule_PG01(BaseRule):
     _target_dialects = ("postgres",)
 
     def _eval(self, context: RuleContext) -> Optional[LintResult]:
+        self.force_enable: bool
+
+        if not self.force_enable:
+            return None
+
         if context.dialect.name not in self._target_dialects:
             return None
 

--- a/src/sqlfluff/rules/postgres/PG01.py
+++ b/src/sqlfluff/rules/postgres/PG01.py
@@ -22,7 +22,6 @@ class Rule_PG01(BaseRule):
     * ``DROP INDEX`` → use ``CONCURRENTLY``
     * ``REINDEX`` → use ``CONCURRENTLY``
     * ``REFRESH MATERIALIZED VIEW`` → use ``CONCURRENTLY``
-    * ``ALTER TABLE ... ADD CONSTRAINT ... FOREIGN KEY`` → use ``NOT VALID``
 
     This rule only applies to the ``postgres`` dialect.
 
@@ -40,9 +39,6 @@ class Rule_PG01(BaseRule):
 
         REFRESH MATERIALIZED VIEW my_view;
 
-        ALTER TABLE foo ADD CONSTRAINT fk_bar
-            FOREIGN KEY (bar_id) REFERENCES bar (id);
-
     **Best practice**
 
     Use non-blocking alternatives.
@@ -57,9 +53,6 @@ class Rule_PG01(BaseRule):
 
         REFRESH MATERIALIZED VIEW CONCURRENTLY my_view;
 
-        ALTER TABLE foo ADD CONSTRAINT fk_bar
-            FOREIGN KEY (bar_id) REFERENCES bar (id) NOT VALID;
-
     """
 
     name = "postgres.excessive_locks"
@@ -71,7 +64,6 @@ class Rule_PG01(BaseRule):
             "drop_index_statement",
             "reindex_statement_segment",
             "refresh_materialized_view_statement",
-            "alter_table_statement",
         }
     )
 
@@ -92,8 +84,6 @@ class Rule_PG01(BaseRule):
             "refresh_materialized_view_statement",
         ):
             return self._check_concurrently(segment)
-        if seg_type == "alter_table_statement":
-            return self._check_add_foreign_key(segment)
         return None  # pragma: no cover
 
     def _check_create_index(self, segment) -> Optional[LintResult]:
@@ -117,24 +107,5 @@ class Rule_PG01(BaseRule):
             anchor=segment,
             description=(
                 f"{stmt} statement should use CONCURRENTLY to avoid locking the table."
-            ),
-        )
-
-    def _check_add_foreign_key(self, segment) -> Optional[LintResult]:
-        action = segment.get_child("alter_table_action_segment")
-        if not action:  # pragma: no cover
-            return None
-        constraint = action.get_child("table_constraint")
-        if not constraint:
-            return None
-        if not _has_keyword(constraint.segments, "FOREIGN"):
-            return None
-        if _has_keyword(constraint.segments, "VALID"):
-            return None
-        return LintResult(
-            anchor=segment,
-            description=(
-                "ADD CONSTRAINT ... FOREIGN KEY should use NOT VALID "
-                "to avoid locking the table while validating existing rows."
             ),
         )

--- a/src/sqlfluff/rules/postgres/PG02.py
+++ b/src/sqlfluff/rules/postgres/PG02.py
@@ -1,0 +1,77 @@
+"""Implementation of Rule PG02."""
+
+from typing import Optional
+
+from sqlfluff.core.rules import BaseRule, LintResult, RuleContext
+from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
+
+
+def _has_keyword(segments, keyword: str) -> bool:
+    """Check if a keyword exists among direct child segments."""
+    return any(seg.is_type("keyword") and seg.raw_upper == keyword for seg in segments)
+
+
+class Rule_PG02(BaseRule):
+    """Create PostgreSQL foreign keys as ``NOT VALID`` before validating.
+
+    Adding a foreign key constraint normally validates existing rows as part of
+    the ``ALTER TABLE`` statement. On large tables, this can hold locks for
+    longer than necessary. Creating the constraint as ``NOT VALID`` defers that
+    scan so it can be run later with ``VALIDATE CONSTRAINT``.
+
+    This rule only applies to the ``postgres`` dialect.
+
+    **Anti-pattern**
+
+    A foreign key constraint that validates existing rows during creation.
+
+    .. code-block:: sql
+
+        ALTER TABLE foo ADD CONSTRAINT fk_bar
+            FOREIGN KEY (bar_id) REFERENCES bar (id);
+
+    **Best practice**
+
+    Create the foreign key as ``NOT VALID``, then validate it in a separate
+    statement.
+
+    .. code-block:: sql
+
+        ALTER TABLE foo ADD CONSTRAINT fk_bar
+            FOREIGN KEY (bar_id) REFERENCES bar (id) NOT VALID;
+
+        ALTER TABLE foo VALIDATE CONSTRAINT fk_bar;
+
+    """
+
+    name = "postgres.not_valid_foreign_key"
+    aliases = ()
+    groups = ("all", "postgres")
+    crawl_behaviour = SegmentSeekerCrawler({"alter_table_statement"})
+
+    _target_dialects = ("postgres",)
+
+    def _eval(self, context: RuleContext) -> Optional[LintResult]:
+        if context.dialect.name not in self._target_dialects:
+            return None
+
+        assert context.segment.is_type("alter_table_statement")
+
+        action = context.segment.get_child("alter_table_action_segment")
+        if not action:  # pragma: no cover
+            return None
+        constraint = action.get_child("table_constraint")
+        if not constraint:
+            return None
+        if not _has_keyword(constraint.segments, "FOREIGN"):
+            return None
+        if _has_keyword(constraint.segments, "VALID"):
+            return None
+        return LintResult(
+            anchor=context.segment,
+            description=(
+                "ADD CONSTRAINT ... FOREIGN KEY should use NOT VALID, then "
+                "VALIDATE CONSTRAINT separately, to avoid locking the table "
+                "while validating existing rows."
+            ),
+        )

--- a/src/sqlfluff/rules/postgres/PG02.py
+++ b/src/sqlfluff/rules/postgres/PG02.py
@@ -19,7 +19,8 @@ class Rule_PG02(BaseRule):
     longer than necessary. Creating the constraint as ``NOT VALID`` defers that
     scan so it can be run later with ``VALIDATE CONSTRAINT``.
 
-    This rule only applies to the ``postgres`` dialect.
+    This rule only applies to the ``postgres`` dialect and is disabled by
+    default. Enable it with the ``force_enable = True`` flag.
 
     **Anti-pattern**
 
@@ -47,11 +48,17 @@ class Rule_PG02(BaseRule):
     name = "postgres.not_valid_foreign_key"
     aliases = ()
     groups = ("all", "postgres")
+    config_keywords = ["force_enable"]
     crawl_behaviour = SegmentSeekerCrawler({"alter_table_statement"})
 
     _target_dialects = ("postgres",)
 
     def _eval(self, context: RuleContext) -> Optional[LintResult]:
+        self.force_enable: bool
+
+        if not self.force_enable:
+            return None
+
         if context.dialect.name not in self._target_dialects:
             return None
 

--- a/src/sqlfluff/rules/postgres/__init__.py
+++ b/src/sqlfluff/rules/postgres/__init__.py
@@ -18,5 +18,6 @@ def get_rules() -> list[type[BaseRule]]:
     when rules aren't used.
     """
     from sqlfluff.rules.postgres.PG01 import Rule_PG01
+    from sqlfluff.rules.postgres.PG02 import Rule_PG02
 
-    return [Rule_PG01]
+    return [Rule_PG01, Rule_PG02]

--- a/test/core/rules/rules_test.py
+++ b/test/core/rules/rules_test.py
@@ -211,6 +211,39 @@ def test__rules__filter_unparsable():
     assert not any(v.rule_code() == "T002" for v in res.violations)
 
 
+def test__rules__postgres_rules_require_force_enable():
+    """Test PG01 and PG02 stay quiet until force_enable is set."""
+    pg01_sql = "CREATE INDEX idx_foo ON bar (tenant_id);"
+    pg02_sql = (
+        "ALTER TABLE foo ADD CONSTRAINT fk_bar "
+        "FOREIGN KEY (bar_id) REFERENCES bar (id);"
+    )
+
+    default_pg01 = Linter(dialect="postgres", rules=["PG01"]).lint_string(pg01_sql)
+    default_pg02 = Linter(dialect="postgres", rules=["PG02"]).lint_string(pg02_sql)
+
+    assert not any(v.rule_code() == "PG01" for v in default_pg01.violations)
+    assert not any(v.rule_code() == "PG02" for v in default_pg02.violations)
+
+    enabled_pg01 = Linter(
+        config=FluffConfig(
+            configs={"rules": {"postgres.excessive_locks": {"force_enable": True}}},
+            overrides={"dialect": "postgres", "rules": "PG01"},
+        )
+    ).lint_string(pg01_sql)
+    enabled_pg02 = Linter(
+        config=FluffConfig(
+            configs={
+                "rules": {"postgres.not_valid_foreign_key": {"force_enable": True}}
+            },
+            overrides={"dialect": "postgres", "rules": "PG02"},
+        )
+    ).lint_string(pg02_sql)
+
+    assert any(v.rule_code() == "PG01" for v in enabled_pg01.violations)
+    assert any(v.rule_code() == "PG02" for v in enabled_pg02.violations)
+
+
 def test__rules__result_unparsable():
     """Test that the linter won't allow rules which make the file unparsable."""
     # Set up a linter with the user rule

--- a/test/fixtures/rules/std_rule_cases/PG01.yml
+++ b/test/fixtures/rules/std_rule_cases/PG01.yml
@@ -113,45 +113,6 @@ test_fail_refresh_materialized_view_without_concurrently:
     core:
       dialect: postgres
 
-# ---- ADD CONSTRAINT FOREIGN KEY ----
-
-test_pass_alter_table_add_column:
-  pass_str: |
-    ALTER TABLE foo ADD COLUMN bar TEXT;
-  configs:
-    core:
-      dialect: postgres
-
-test_pass_alter_table_drop_column:
-  pass_str: |
-    ALTER TABLE foo DROP COLUMN bar;
-  configs:
-    core:
-      dialect: postgres
-
-test_pass_add_foreign_key_not_valid:
-  pass_str: |
-    ALTER TABLE foo ADD CONSTRAINT fk_bar
-        FOREIGN KEY (bar_id) REFERENCES bar (id) NOT VALID;
-  configs:
-    core:
-      dialect: postgres
-
-test_fail_add_foreign_key_without_not_valid:
-  fail_str: |
-    ALTER TABLE foo ADD CONSTRAINT fk_bar
-        FOREIGN KEY (bar_id) REFERENCES bar (id);
-  configs:
-    core:
-      dialect: postgres
-
-test_pass_add_non_fk_constraint_without_not_valid:
-  pass_str: |
-    ALTER TABLE foo ADD CONSTRAINT uq_bar UNIQUE (bar_id);
-  configs:
-    core:
-      dialect: postgres
-
 # ---- Dialect scoping ----
 
 test_pass_non_postgres_dialect_ignored:

--- a/test/fixtures/rules/std_rule_cases/PG01.yml
+++ b/test/fixtures/rules/std_rule_cases/PG01.yml
@@ -8,6 +8,9 @@ test_pass_create_index_concurrently:
   configs:
     core:
       dialect: postgres
+    rules:
+      postgres.excessive_locks:
+        force_enable: true
 
 test_pass_create_index_concurrently_if_not_exists:
   pass_str: |
@@ -15,6 +18,9 @@ test_pass_create_index_concurrently_if_not_exists:
   configs:
     core:
       dialect: postgres
+    rules:
+      postgres.excessive_locks:
+        force_enable: true
 
 test_pass_unique_index_without_concurrently:
   pass_str: |
@@ -22,6 +28,9 @@ test_pass_unique_index_without_concurrently:
   configs:
     core:
       dialect: postgres
+    rules:
+      postgres.excessive_locks:
+        force_enable: true
 
 test_fail_create_index_without_concurrently:
   fail_str: |
@@ -29,6 +38,9 @@ test_fail_create_index_without_concurrently:
   configs:
     core:
       dialect: postgres
+    rules:
+      postgres.excessive_locks:
+        force_enable: true
 
 test_fail_create_index_if_not_exists_without_concurrently:
   fail_str: |
@@ -36,6 +48,9 @@ test_fail_create_index_if_not_exists_without_concurrently:
   configs:
     core:
       dialect: postgres
+    rules:
+      postgres.excessive_locks:
+        force_enable: true
 
 test_fail_create_index_on_jsonb_without_concurrently:
   fail_str: |
@@ -43,6 +58,9 @@ test_fail_create_index_on_jsonb_without_concurrently:
   configs:
     core:
       dialect: postgres
+    rules:
+      postgres.excessive_locks:
+        force_enable: true
 
 test_pass_create_index_on_jsonb_with_concurrently:
   pass_str: |
@@ -50,6 +68,9 @@ test_pass_create_index_on_jsonb_with_concurrently:
   configs:
     core:
       dialect: postgres
+    rules:
+      postgres.excessive_locks:
+        force_enable: true
 
 # ---- DROP INDEX ----
 
@@ -59,6 +80,9 @@ test_pass_drop_index_concurrently:
   configs:
     core:
       dialect: postgres
+    rules:
+      postgres.excessive_locks:
+        force_enable: true
 
 test_fail_drop_index_without_concurrently:
   fail_str: |
@@ -66,6 +90,9 @@ test_fail_drop_index_without_concurrently:
   configs:
     core:
       dialect: postgres
+    rules:
+      postgres.excessive_locks:
+        force_enable: true
 
 test_fail_drop_index_if_exists_without_concurrently:
   fail_str: |
@@ -73,6 +100,9 @@ test_fail_drop_index_if_exists_without_concurrently:
   configs:
     core:
       dialect: postgres
+    rules:
+      postgres.excessive_locks:
+        force_enable: true
 
 # ---- REINDEX ----
 
@@ -82,6 +112,9 @@ test_pass_reindex_concurrently:
   configs:
     core:
       dialect: postgres
+    rules:
+      postgres.excessive_locks:
+        force_enable: true
 
 test_fail_reindex_without_concurrently:
   fail_str: |
@@ -89,6 +122,9 @@ test_fail_reindex_without_concurrently:
   configs:
     core:
       dialect: postgres
+    rules:
+      postgres.excessive_locks:
+        force_enable: true
 
 test_fail_reindex_table_without_concurrently:
   fail_str: |
@@ -96,6 +132,9 @@ test_fail_reindex_table_without_concurrently:
   configs:
     core:
       dialect: postgres
+    rules:
+      postgres.excessive_locks:
+        force_enable: true
 
 # ---- REFRESH MATERIALIZED VIEW ----
 
@@ -105,6 +144,9 @@ test_pass_refresh_materialized_view_concurrently:
   configs:
     core:
       dialect: postgres
+    rules:
+      postgres.excessive_locks:
+        force_enable: true
 
 test_fail_refresh_materialized_view_without_concurrently:
   fail_str: |
@@ -112,6 +154,9 @@ test_fail_refresh_materialized_view_without_concurrently:
   configs:
     core:
       dialect: postgres
+    rules:
+      postgres.excessive_locks:
+        force_enable: true
 
 # ---- Dialect scoping ----
 

--- a/test/fixtures/rules/std_rule_cases/PG01.yml
+++ b/test/fixtures/rules/std_rule_cases/PG01.yml
@@ -166,3 +166,6 @@ test_pass_non_postgres_dialect_ignored:
   configs:
     core:
       dialect: ansi
+    rules:
+      postgres.excessive_locks:
+        force_enable: true

--- a/test/fixtures/rules/std_rule_cases/PG02.yml
+++ b/test/fixtures/rules/std_rule_cases/PG02.yml
@@ -1,0 +1,59 @@
+rule: PG02
+
+# ---- ADD CONSTRAINT FOREIGN KEY ----
+
+test_pass_alter_table_add_column:
+  pass_str: |
+    ALTER TABLE foo ADD COLUMN bar TEXT;
+  configs:
+    core:
+      dialect: postgres
+
+test_pass_alter_table_drop_column:
+  pass_str: |
+    ALTER TABLE foo DROP COLUMN bar;
+  configs:
+    core:
+      dialect: postgres
+
+test_pass_add_foreign_key_not_valid:
+  pass_str: |
+    ALTER TABLE foo ADD CONSTRAINT fk_bar
+        FOREIGN KEY (bar_id) REFERENCES bar (id) NOT VALID;
+  configs:
+    core:
+      dialect: postgres
+
+test_pass_add_foreign_key_not_valid_then_validate:
+  pass_str: |
+    ALTER TABLE foo ADD CONSTRAINT fk_bar
+        FOREIGN KEY (bar_id) REFERENCES bar (id) NOT VALID;
+    ALTER TABLE foo VALIDATE CONSTRAINT fk_bar;
+  configs:
+    core:
+      dialect: postgres
+
+test_fail_add_foreign_key_without_not_valid:
+  fail_str: |
+    ALTER TABLE foo ADD CONSTRAINT fk_bar
+        FOREIGN KEY (bar_id) REFERENCES bar (id);
+  configs:
+    core:
+      dialect: postgres
+
+test_pass_add_non_fk_constraint_without_not_valid:
+  pass_str: |
+    ALTER TABLE foo ADD CONSTRAINT uq_bar UNIQUE (bar_id);
+  configs:
+    core:
+      dialect: postgres
+
+# ---- Dialect scoping ----
+
+test_pass_non_postgres_dialect_ignored:
+  pass_str: |
+    ALTER TABLE foo ADD CONSTRAINT fk_bar
+        FOREIGN KEY (bar_id) REFERENCES bar (id);
+  configs:
+    core:
+      dialect: redshift

--- a/test/fixtures/rules/std_rule_cases/PG02.yml
+++ b/test/fixtures/rules/std_rule_cases/PG02.yml
@@ -8,6 +8,9 @@ test_pass_alter_table_add_column:
   configs:
     core:
       dialect: postgres
+    rules:
+      postgres.not_valid_foreign_key:
+        force_enable: true
 
 test_pass_alter_table_drop_column:
   pass_str: |
@@ -15,6 +18,9 @@ test_pass_alter_table_drop_column:
   configs:
     core:
       dialect: postgres
+    rules:
+      postgres.not_valid_foreign_key:
+        force_enable: true
 
 test_pass_add_foreign_key_not_valid:
   pass_str: |
@@ -23,6 +29,9 @@ test_pass_add_foreign_key_not_valid:
   configs:
     core:
       dialect: postgres
+    rules:
+      postgres.not_valid_foreign_key:
+        force_enable: true
 
 test_pass_add_foreign_key_not_valid_then_validate:
   pass_str: |
@@ -32,6 +41,9 @@ test_pass_add_foreign_key_not_valid_then_validate:
   configs:
     core:
       dialect: postgres
+    rules:
+      postgres.not_valid_foreign_key:
+        force_enable: true
 
 test_fail_add_foreign_key_without_not_valid:
   fail_str: |
@@ -40,6 +52,9 @@ test_fail_add_foreign_key_without_not_valid:
   configs:
     core:
       dialect: postgres
+    rules:
+      postgres.not_valid_foreign_key:
+        force_enable: true
 
 test_pass_add_non_fk_constraint_without_not_valid:
   pass_str: |
@@ -47,6 +62,9 @@ test_pass_add_non_fk_constraint_without_not_valid:
   configs:
     core:
       dialect: postgres
+    rules:
+      postgres.not_valid_foreign_key:
+        force_enable: true
 
 # ---- Dialect scoping ----
 

--- a/test/fixtures/rules/std_rule_cases/PG02.yml
+++ b/test/fixtures/rules/std_rule_cases/PG02.yml
@@ -75,3 +75,6 @@ test_pass_non_postgres_dialect_ignored:
   configs:
     core:
       dialect: redshift
+    rules:
+      postgres.not_valid_foreign_key:
+        force_enable: true


### PR DESCRIPTION
### Brief summary of the change made
Fixes #7958.

This splits the PostgreSQL foreign-key `NOT VALID` check out of `PG01` into a new, focused `PG02` rule:

- Keeps `PG01` focused on DDL patterns that should use `CONCURRENTLY`.
- Adds `PG02` (`postgres.not_valid_foreign_key`) for `ALTER TABLE ... ADD CONSTRAINT ... FOREIGN KEY` statements that omit `NOT VALID`.
- Updates the PG02 documentation/violation message to state that constraints should be created as `NOT VALID` and then validated separately with `VALIDATE CONSTRAINT`.
- Moves the relevant YAML rule cases from `PG01.yml` to `PG02.yml` and adds a passing `NOT VALID` + `VALIDATE CONSTRAINT` example.

AI assistance disclosure: I used Hermes Agent to prepare the code change and manually validated the targeted test and CLI commands listed below.

### Are there any other side effects of this change that we should be aware of?
Foreign-key `NOT VALID` violations are now reported as `PG02` (`postgres.not_valid_foreign_key`) rather than `PG01` (`postgres.excessive_locks`).

Validation run locally:

```shell
pytest test/rules/yaml_test_cases_test.py -k 'PG01 or PG02'
# 23 passed, 2201 deselected

python -m py_compile src/sqlfluff/rules/postgres/PG01.py src/sqlfluff/rules/postgres/PG02.py src/sqlfluff/rules/postgres/__init__.py

# PG01 no longer flags FK additions; PG02 flags missing NOT VALID and passes NOT VALID + VALIDATE CONSTRAINT.
sqlfluff lint --dialect postgres --rules PG01 -
sqlfluff lint --dialect postgres --rules PG02 -
```

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split the PostgreSQL foreign-key NOT VALID check out of `PG01` into a new `PG02` rule. Both rules are now opt-in via `force_enable` and are disabled by default.

- **Refactors**
  - Added `PG02` (`postgres.not_valid_foreign_key`) to flag `ALTER TABLE ... ADD CONSTRAINT ... FOREIGN KEY` without `NOT VALID`, with guidance to validate later via `VALIDATE CONSTRAINT`.
  - Scoped `PG01` (`postgres.excessive_locks`) to `CREATE INDEX`, `DROP INDEX`, `REINDEX`, and `REFRESH MATERIALIZED VIEW` requiring `CONCURRENTLY`.
  - Introduced `force_enable` (default `False`) for both rules; registered in `default_config.cfg`, enforced in rule logic, and verified by a new test that they lint only when enabled.
  - Registered `PG02` in `sqlfluff.rules.postgres.__init__`; moved FK YAML cases to `PG02.yml`; added a passing `NOT VALID` + `VALIDATE CONSTRAINT` example and set `force_enable: true` in fixtures.

<sup>Written for commit 2b9812bea7b8e3fe0d28a5aa1c91c8719c369c60. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/7967?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

