### PR TITLE
fix(postgres): move FOREIGN KEY NOT VALID check from PG01 to new PG02 rule

### DIFF
--- a/src/sqlfluff/rules/postgres/PG01.py
+++ b/src/sqlfluff/rules/postgres/PG01.py
@@ -16,13 +16,19 @@ class Rule_PG01(BaseRule):
 
     Several PostgreSQL DDL operations acquire locks that block reads or writes
     for the duration of the operation. On large tables this can cause significant
-    downtime. This rule flags statements that should use safer alternatives:
+    downtime. This rule flags statements that should use ``CONCURRENTLY``:
 
     * ``CREATE INDEX`` → use ``CONCURRENTLY`` (``CREATE UNIQUE INDEX`` excluded)
     * ``DROP INDEX`` → use ``CONCURRENTLY``
     * ``REINDEX`` → use ``CONCURRENTLY``
     * ``REFRESH MATERIALIZED VIEW`` → use ``CONCURRENTLY``
-    * ``ALTER TABLE ... ADD CONSTRAINT ... FOREIGN KEY`` → use ``NOT VALID``
+
+    .. note::
+
+       The ``ALTER TABLE ... ADD CONSTRAINT ... FOREIGN KEY`` check was moved
+       to :class:`Rule_PG02 <sqlfluff.rules.postgres.PG02.Rule_PG02>` because
+       ``NOT VALID`` alone is insufficient — it must be followed by
+       ``VALIDATE CONSTRAINT``.
 
     This rule only applies to the ``postgres`` dialect.
 
@@ -40,12 +46,9 @@ class Rule_PG01(BaseRule):
 
         REFRESH MATERIALIZED VIEW my_view;
 
-        ALTER TABLE foo ADD CONSTRAINT fk_bar
-            FOREIGN KEY (bar_id) REFERENCES bar (id);
-
     **Best practice**
 
-    Use non-blocking alternatives.
+    Use ``CONCURRENTLY``.
 
     .. code-block:: sql
 
@@ -56,9 +59,6 @@ class Rule_PG01(BaseRule):
         REINDEX INDEX CONCURRENTLY idx_foo;
 
         REFRESH MATERIALIZED VIEW CONCURRENTLY my_view;
-
-        ALTER TABLE foo ADD CONSTRAINT fk_bar
-            FOREIGN KEY (bar_id) REFERENCES bar (id) NOT VALID;
 
     """
 
@@ -71,7 +71,6 @@ class Rule_PG01(BaseRule):
             "drop_index_statement",
             "reindex_statement_segment",
             "refresh_materialized_view_statement",
-            "alter_table_statement",
         }
     )
 
@@ -92,8 +91,6 @@ class Rule_PG01(BaseRule):
             "refresh_materialized_view_statement",
         ):
             return self._check_concurrently(segment)
-        if seg_type == "alter_table_statement":
-            return self._check_add_foreign_key(segment)
         return None  # pragma: no cover
 
     def _check_create_index(self, segment) -> Optional[LintResult]:
@@ -120,21 +117,3 @@ class Rule_PG01(BaseRule):
             ),
         )
 
-    def _check_add_foreign_key(self, segment) -> Optional[LintResult]:
-        action = segment.get_child("alter_table_action_segment")
-        if not action:  # pragma: no cover
-            return None
-        constraint = action.get_child("table_constraint")
-        if not constraint:
-            return None
-        if not _has_keyword(constraint.segments, "FOREIGN"):
-            return None
-        if _has_keyword(constraint.segments, "VALID"):
-            return None
-        return LintResult(
-            anchor=segment,
-            description=(
-                "ADD CONSTRAINT ... FOREIGN KEY should use NOT VALID "
-                "to avoid locking the table while validating existing rows."
-            ),
-        )

--- a/src/sqlfluff/rules/postgres/PG01.py
+++ b/src/sqlfluff/rules/postgres/PG01.py
@@ -116,4 +116,3 @@ class Rule_PG01(BaseRule):
                 f"{stmt} statement should use CONCURRENTLY to avoid locking the table."
             ),
         )
-

--- a/src/sqlfluff/rules/postgres/PG02.py
+++ b/src/sqlfluff/rules/postgres/PG02.py
@@ -1,0 +1,90 @@
+"""Implementation of Rule PG02."""
+
+from typing import Optional
+
+from sqlfluff.core.rules import BaseRule, LintResult, RuleContext
+from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
+
+
+def _has_keyword(segments, keyword: str) -> bool:
+    """Check if a keyword exists among direct child segments."""
+    return any(seg.is_type("keyword") and seg.raw_upper == keyword for seg in segments)
+
+
+class Rule_PG02(BaseRule):
+    """Avoid blocking table scans when adding foreign key constraints.
+
+    ``ALTER TABLE ... ADD CONSTRAINT ... FOREIGN KEY`` acquires an
+    ``ACCESS EXCLUSIVE`` lock and validates existing rows by scanning the
+    entire table, which can cause extended downtime on large tables.
+
+    The recommended approach is a two-step process:
+
+    1. Add the constraint with ``NOT VALID`` to skip the initial scan
+       while still enforcing the constraint for new writes.
+    2. Run ``VALIDATE CONSTRAINT`` later (e.g. during a maintenance
+       window) to validate any pre-existing rows.
+
+    .. code-block:: sql
+
+        ALTER TABLE foo ADD CONSTRAINT fk_bar
+            FOREIGN KEY (bar_id) REFERENCES bar (id) NOT VALID;
+        -- later, after verifying existing data:
+        ALTER TABLE foo VALIDATE CONSTRAINT fk_bar;
+
+    This rule was split from ``PG01`` in version 4.2.3. PG01 continues
+    to check for ``CONCURRENTLY`` on index-related DDL statements.
+
+    This rule only applies to the ``postgres`` dialect.
+
+    **Anti-pattern**
+
+    .. code-block:: sql
+
+        ALTER TABLE foo ADD CONSTRAINT fk_bar
+            FOREIGN KEY (bar_id) REFERENCES bar (id);
+
+    **Best practice**
+
+    .. code-block:: sql
+
+        ALTER TABLE foo ADD CONSTRAINT fk_bar
+            FOREIGN KEY (bar_id) REFERENCES bar (id) NOT VALID;
+
+    """
+
+    name = "postgres.foreign_key_not_valid"
+    aliases = ()
+    groups = ("all", "postgres")
+    crawl_behaviour = SegmentSeekerCrawler(
+        {
+            "alter_table_statement",
+        }
+    )
+
+    _target_dialects = ("postgres",)
+
+    def _eval(self, context: RuleContext) -> Optional[LintResult]:
+        if context.dialect.name not in self._target_dialects:
+            return None
+
+        segment = context.segment
+
+        action = segment.get_child("alter_table_action_segment")
+        if not action:  # pragma: no cover
+            return None
+        constraint = action.get_child("table_constraint")
+        if not constraint:
+            return None
+        if not _has_keyword(constraint.segments, "FOREIGN"):
+            return None
+        if _has_keyword(constraint.segments, "VALID"):
+            return None
+        return LintResult(
+            anchor=segment,
+            description=(
+                "ADD CONSTRAINT ... FOREIGN KEY should use NOT VALID "
+                "to avoid blocking scans while validating existing rows. "
+                "Follow with VALIDATE CONSTRAINT afterwards."
+            ),
+        )

--- a/src/sqlfluff/rules/postgres/__init__.py
+++ b/src/sqlfluff/rules/postgres/__init__.py
@@ -18,5 +18,6 @@ def get_rules() -> list[type[BaseRule]]:
     when rules aren't used.
     """
     from sqlfluff.rules.postgres.PG01 import Rule_PG01
+    from sqlfluff.rules.postgres.PG02 import Rule_PG02
 
-    return [Rule_PG01]
+    return [Rule_PG01, Rule_PG02]

--- a/test/fixtures/rules/std_rule_cases/PG01.yml
+++ b/test/fixtures/rules/std_rule_cases/PG01.yml
@@ -113,45 +113,6 @@ test_fail_refresh_materialized_view_without_concurrently:
     core:
       dialect: postgres
 
-# ---- ADD CONSTRAINT FOREIGN KEY ----
-
-test_pass_alter_table_add_column:
-  pass_str: |
-    ALTER TABLE foo ADD COLUMN bar TEXT;
-  configs:
-    core:
-      dialect: postgres
-
-test_pass_alter_table_drop_column:
-  pass_str: |
-    ALTER TABLE foo DROP COLUMN bar;
-  configs:
-    core:
-      dialect: postgres
-
-test_pass_add_foreign_key_not_valid:
-  pass_str: |
-    ALTER TABLE foo ADD CONSTRAINT fk_bar
-        FOREIGN KEY (bar_id) REFERENCES bar (id) NOT VALID;
-  configs:
-    core:
-      dialect: postgres
-
-test_fail_add_foreign_key_without_not_valid:
-  fail_str: |
-    ALTER TABLE foo ADD CONSTRAINT fk_bar
-        FOREIGN KEY (bar_id) REFERENCES bar (id);
-  configs:
-    core:
-      dialect: postgres
-
-test_pass_add_non_fk_constraint_without_not_valid:
-  pass_str: |
-    ALTER TABLE foo ADD CONSTRAINT uq_bar UNIQUE (bar_id);
-  configs:
-    core:
-      dialect: postgres
-
 # ---- Dialect scoping ----
 
 test_pass_non_postgres_dialect_ignored:

--- a/test/fixtures/rules/std_rule_cases/PG02.yml
+++ b/test/fixtures/rules/std_rule_cases/PG02.yml
@@ -1,0 +1,49 @@
+rule: PG02
+
+# ---- ADD CONSTRAINT FOREIGN KEY ----
+
+test_pass_alter_table_add_column:
+  pass_str: |
+    ALTER TABLE foo ADD COLUMN bar TEXT;
+  configs:
+    core:
+      dialect: postgres
+
+test_pass_alter_table_drop_column:
+  pass_str: |
+    ALTER TABLE foo DROP COLUMN bar;
+  configs:
+    core:
+      dialect: postgres
+
+test_pass_add_foreign_key_not_valid:
+  pass_str: |
+    ALTER TABLE foo ADD CONSTRAINT fk_bar
+        FOREIGN KEY (bar_id) REFERENCES bar (id) NOT VALID;
+  configs:
+    core:
+      dialect: postgres
+
+test_fail_add_foreign_key_without_not_valid:
+  fail_str: |
+    ALTER TABLE foo ADD CONSTRAINT fk_bar
+        FOREIGN KEY (bar_id) REFERENCES bar (id);
+  configs:
+    core:
+      dialect: postgres
+
+test_pass_add_non_fk_constraint_without_not_valid:
+  pass_str: |
+    ALTER TABLE foo ADD CONSTRAINT uq_bar UNIQUE (bar_id);
+  configs:
+    core:
+      dialect: postgres
+
+# ---- Dialect scoping ----
+
+test_pass_non_postgres_dialect_ignored:
+  pass_str: |
+    ALTER TABLE foo ADD COLUMN bar TEXT;
+  configs:
+    core:
+      dialect: ansi


### PR DESCRIPTION
Fixes #7958.

**Changes:**

- Move the `ALTER TABLE ... ADD CONSTRAINT ... FOREIGN KEY` check from `PG01` into a new `PG02` rule.
- PG02 provides a more detailed description of the two-step process: add `NOT VALID` first, then `VALIDATE CONSTRAINT` later.
- PG01 now only covers `CONCURRENTLY` checks for index-related DDL (`CREATE INDEX`, `DROP INDEX`, `REINDEX`, `REFRESH MATERIALIZED VIEW`).
- Updated PG01 rule docstring to reference PG02 for the foreign key case.
- Moved the corresponding YAML test fixtures from PG01.yml to PG02.yml.

Built with SQLFluff under my direction.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split the foreign key NOT VALID check out of `PG01` into a new `PG02` rule. `PG01` now only covers `CONCURRENTLY` checks for index and materialized view DDL, while `PG02` guides the two-step NOT VALID + VALIDATE workflow.

- **Refactors**
  - Added `PG02` to lint `ALTER TABLE ... ADD CONSTRAINT ... FOREIGN KEY` missing `NOT VALID`, and explain follow-up with `VALIDATE CONSTRAINT`.
  - Scoped `PG01` to `CREATE INDEX`, `DROP INDEX`, `REINDEX`, and `REFRESH MATERIALIZED VIEW` with `CONCURRENTLY`; docstring now references `PG02`.
  - Registered `PG02` in `postgres` rules and moved related tests from `PG01.yml` to `PG02.yml`.

- **Bug Fixes**
  - Removed a trailing blank line to satisfy the pre-commit end-of-file-fixer.

<sup>Written for commit cc66a070ba22d0b8078edf4b98ca6543f5990b02. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/7969?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

