### PR TITLE
Fix LT05 breaking SQL at literal/Jinja boundaries

### DIFF
--- a/src/sqlfluff/utils/reflow/reindent.py
+++ b/src/sqlfluff/utils/reflow/reindent.py
@@ -2448,29 +2448,33 @@ def _fix_long_line_with_integer_targets(
 def _is_templated_safe_break(elements: ReflowSequenceType, e_idx: int) -> bool:
     """Check if inserting a line break at e_idx is safe for templated files.
 
-    A break point is unsafe if BOTH adjacent content segments are non-literal
-    (i.e., the break is within a template expansion). Inserting a line break
-    within rendered template content cannot be mapped back to the source file
-    correctly, which can lead to content duplication or corruption.
+    A break point is unsafe if EITHER adjacent content segment is non-literal
+    (i.e., at least one side is within a template expansion). Inserting a line
+    break at a boundary involving rendered template content cannot always be
+    mapped back to the source file correctly, which can lead to content
+    duplication or corruption.
+
+    The original guard (#7640) only blocked breaks where BOTH sides were
+    non-literal. However, breaks at literal/non-literal boundaries can also
+    corrupt dbt models with mixed SQL + Jinja (e.g. a long SELECT with
+    inline macro calls).
 
     See: https://github.com/sqlfluff/sqlfluff/issues/7639
+    See: https://github.com/sqlfluff/sqlfluff/issues/7971
     """
     # Check the segment before the break point.
-    before_literal = True
     if e_idx > 0 and elements[e_idx - 1].segments:
         seg_before = elements[e_idx - 1].segments[-1]
         if seg_before.pos_marker and not seg_before.pos_marker.is_literal():
-            before_literal = False
+            return False
 
     # Check the segment after the break point.
-    after_literal = True
     if e_idx + 1 < len(elements) and elements[e_idx + 1].segments:
         seg_after = elements[e_idx + 1].segments[0]
         if seg_after.pos_marker and not seg_after.pos_marker.is_literal():
-            after_literal = False
+            return False
 
-    # Unsafe only if BOTH sides are non-literal (within template expansion).
-    return before_literal or after_literal
+    return True
 
 
 def lint_line_length(

--- a/test/fixtures/rules/std_rule_cases/LT05.yml
+++ b/test/fixtures/rules/std_rule_cases/LT05.yml
@@ -814,3 +814,12 @@ test_fail_no_fix_jinja_macro_with_brackets:
             {{ cast_tz("cast(source.order_arrived_date || ' ' || source.order_arrived_time as timestamp)") }}
         )
     FROM source
+
+test_fail_no_fix_mixed_literal_jinja:
+  # Test that LT05 doesn't attempt to fix lines with a mix of literal SQL
+  # and Jinja template content. Breaking at a literal/non-literal boundary
+  # can corrupt the source file (duplication, truncation).
+  # https://github.com/sqlfluff/sqlfluff/issues/7971
+  fail_str: |
+    SELECT message.identifier AS entity_uri, message.entity_type, {{ dbt_utils.generate_surrogate_key(['message.identifier', 'message.event_type']) }} AS surrogate_key, TIMESTAMP_MILLIS(context.time) AS event_timestamp
+    FROM source


### PR DESCRIPTION
## Description

The `_is_templated_safe_break` guard from #7640 only blocked line breaks where **both** adjacent segments were non-literal (within a template expansion). Breaks at literal/non-literal boundaries were still allowed, which can corrupt dbt models containing a mix of SQL and Jinja macros on long lines.

We observed three corruption patterns when running `sqlfluff fix` on ~268 dbt model files (BigQuery dialect, dbt templater, sqlfluff 4.2.2):

1. Duplicated lines
2. Truncated trailing clauses
3. Silent semantic changes (SQL compiles and runs but produces wrong results)

All affected files had long lines mixing literal SQL with Jinja macros (e.g., `SELECT col1, {{ macro() }}, TIMESTAMP_MILLIS(context.time)`).

## Fix

Tighten `_is_templated_safe_break` to block breaks where **either** side is non-literal, not just both. This is more conservative — some previously fixable long lines will now be reported as unfixable — but it prevents corruption at all template boundaries.

## Test

Added `test_fail_no_fix_mixed_literal_jinja` to verify that LT05 reports but does not fix lines with mixed literal SQL and Jinja content.

Fixes #7971

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent `LT05` from inserting line breaks at SQL/Jinja boundaries to avoid corrupting dbt-templated files. Any break where either side is non-literal is now treated as unsafe, and mixed lines are reported but not auto-fixed.

- **Bug Fixes**
  - Tighten `_is_templated_safe_break` to block breaks when either adjacent segment is non-literal.
  - Prevents duplicated lines, truncated clauses, and silent semantic changes on long mixed SQL/Jinja lines.
  - Add `test_fail_no_fix_mixed_literal_jinja` to ensure `LT05` reports without fixing.
  - Fixes #7971.

<sup>Written for commit 53fe546abbe90c82d9766930d5451883efd9c060. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/7972?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

