### PR TITLE
fix(oracle): parse PIVOT/UNPIVOT with WHERE or num label (#7973)

### DIFF
--- a/src/sqlfluff/dialects/dialect_oracle.py
+++ b/src/sqlfluff/dialects/dialect_oracle.py
@@ -210,9 +210,11 @@ oracle_dialect.add(
     ),
     IntervalUnitsGrammar=OneOf("YEAR", "MONTH", "DAY", "HOUR", "MINUTE", "SECOND"),
     TriggerCorrelationReferenceSegment=Ref("TriggerCorrelationReferenceSegment"),
-    PivotForInGrammar=Sequence(
+    PivotForGrammar=Sequence(
         "FOR",
         OptionallyBracketed(Delimited(Ref("ColumnReferenceSegment"))),
+    ),
+    PivotInGrammar=Sequence(
         "IN",
         Bracketed(
             Delimited(
@@ -220,6 +222,36 @@ oracle_dialect.add(
                     Ref("Expression_D_Grammar"),
                     Ref("AliasExpressionSegment", optional=True),
                 )
+            )
+        ),
+    ),
+    UnpivotAsCharacterLiteralGrammar=Delimited(
+        Sequence(
+            OptionallyBracketed(Delimited(Ref("ColumnReferenceSegment"))),
+            Sequence(
+                "AS",
+                OptionallyBracketed(Delimited(Ref("QuotedLiteralSegment"))),
+                optional=True,
+            ),
+        ),
+    ),
+    UnpivotAsNumericLiteralGrammar=Delimited(
+        Sequence(
+            OptionallyBracketed(Delimited(Ref("ColumnReferenceSegment"))),
+            Sequence(
+                "AS",
+                OptionallyBracketed(Delimited(Ref("NumericLiteralSegment"))),
+                optional=True,
+            ),
+        ),
+    ),
+    UnpivotInGrammar=Sequence(
+        "IN",
+        Bracketed(
+            # Literals have to be either all characters or all numeric
+            OneOf(
+                Ref("UnpivotAsCharacterLiteralGrammar"),
+                Ref("UnpivotAsNumericLiteralGrammar"),
             )
         ),
     ),
@@ -661,6 +693,14 @@ oracle_dialect.replace(
     ),
     ParameterNameSegment=RegexParser(
         r'[A-Z_][A-Z0-9_$]*|"[^"]*"', CodeSegment, type="parameter"
+    ),
+    JoinLikeClauseGrammar=Sequence(
+        AnyNumberOf(
+            Ref("PivotSegment"),
+            Ref("UnpivotSegment"),
+            min_times=1,
+        ),
+        Ref("AliasExpressionSegment", optional=True),
     ),
     LiteralGrammar=ansi_dialect.get_grammar("LiteralGrammar").copy(
         insert=[
@@ -1688,14 +1728,10 @@ class UnorderedSelectStatementSegment(ansi.UnorderedSelectStatementSegment):
     match_grammar = ansi.UnorderedSelectStatementSegment.match_grammar.copy(
         insert=[
             Ref("HierarchicalQueryClauseSegment", optional=True),
-            Ref("PivotSegment", optional=True),
-            Ref("UnpivotSegment", optional=True),
         ],
         before=Ref("GroupByClauseSegment", optional=True),
         terminators=[
             Ref("HierarchicalQueryClauseSegment"),
-            Ref("PivotSegment", optional=True),
-            Ref("UnpivotSegment", optional=True),
             "LOG",
         ],
     ).copy(
@@ -1789,7 +1825,8 @@ class PivotSegment(BaseSegment):
                     Ref("FunctionSegment"), Ref("AliasExpressionSegment", optional=True)
                 )
             ),
-            Ref("PivotForInGrammar"),
+            Ref("PivotForGrammar"),
+            Ref("PivotInGrammar"),
         ),
     )
 
@@ -1831,7 +1868,8 @@ class UnpivotSegment(BaseSegment):
         Ref("UnpivotNullsGrammar", optional=True),
         Bracketed(
             OptionallyBracketed(Delimited(Ref("ColumnReferenceSegment"))),
-            Ref("PivotForInGrammar"),
+            Ref("PivotForGrammar"),
+            Ref("UnpivotInGrammar"),
         ),
     )
 

--- a/test/fixtures/dialects/oracle/pivot_unpivot.sql
+++ b/test/fixtures/dialects/oracle/pivot_unpivot.sql
@@ -1,17 +1,21 @@
 select * from (
-    select times_purchased, state_code
-    from customers t
-)
+    select
+        times_purchased,
+        state_code
+    from customers
+) purchases
 pivot
 (
     count(state_code)
-    for state_code in ('NY' as new_york,'CT','NJ','FL','MO')
+    for state_code in ('NY' as new_york, 'CT', 'NJ', 'FL', 'MO')
 );
 
 select * from (
-    select times_purchased, state_code
-    from customers t
-)
+    select
+        times_purchased,
+        state_code
+    from customers
+) purchases
 pivot
 (
     count(state_code)
@@ -19,59 +23,156 @@ pivot
 );
 
 select * from (
-    select times_purchased, state_code
-    from customers t
+    select
+        times_purchased,
+        state_code
+    from customers
+) purchases
+pivot
+(
+    count(state_code)
+    for state_code in (select distinct state_code from state)
 )
+where
+    state_code in ('NY', 'CT', 'NJ', 'FL', 'MO');
+
+select * from (
+    select
+        times_purchased,
+        state_code
+    from customers
+) purchases
 pivot
 (
     count(state_code)
     for state_code in (any)
 );
 
-select *
-from   sale_stats
+select * from (
+    select
+        times_purchased,
+        state_code
+    from customers
+) purchases
+pivot
+(
+    count(state_code) as state_code
+    for state_code in (any)
+);
+
+
+select
+    quantity,
+    product_code
+from sale_stats
 unpivot
 (
     quantity
     for product_code
     in (
-        product_a AS 'A',
-        product_b AS 'B',
-        product_c AS 'C'
+        product_a as 'A',
+        product_b as 'B',
+        product_c as 'C'
     )
 );
 
-select *
-from   sale_stats
+select
+    quantity,
+    product_code
+from sale_stats
+unpivot
+(
+    quantity
+    for product_code
+    in (
+        product_a as 'A',
+        product_b as 'B',
+        product_c as 'C'
+    )
+)
+where
+    quantity > 0;
+
+select
+    quantity,
+    product_code
+from sale_stats
 unpivot include nulls
 (
     quantity
     for product_code
     in (
-        product_a AS 'A',
-        product_b AS 'B',
-        product_c AS 'C'
+        product_a as 'A',
+        product_b as 'B',
+        product_c as 'C'
     )
 );
 
-select *
-from   sale_stats
+select
+    quantity,
+    product_id
+from sale_stats
 unpivot
 (
-    (quantity, amount)
-    for product_code
+    quantity
+    for product_id
     in (
-        (a_qty, a_value) as 'A',
-        (b_qty, b_value) as 'B'
+        product_a as 1,
+        product_b as 2,
+        product_c as 3
     )
 );
 
-select * from (
-    select times_purchased, state_code
-    from customers t
-)
-pivot
+select
+    quantity,
+    amount
+from sale_stats
+unpivot
 (
-    count(state_code) as state_code
-    for state_code in (any)
+    quantity, amount
+    for product_code
+    in (
+        a_qty, a_value as 'A',
+        b_qty, b_value as 'B'
+    )
+);
+
+select
+    quantity,
+    amount
+from sale_stats
+unpivot
+(
+    quantity, amount
+    for product_code
+    in (
+        a_qty, a_value as 1,
+        b_qty, b_value as 2
+    )
+);
+
+select
+    quantity,
+    product_code
+from sale_stats
+unpivot
+(
+    quantity
+    for product_code
+    in (product_a, product_b, product_c)
+);
+
+select
+    quantity,
+    amount,
+    product_code
+from sale_stats
+unpivot
+(
+    quantity, amount
+    for product_code
+    in (
+        (a_qty, a_value),
+        (b_qty, b_value)
+    )
 );

--- a/test/fixtures/dialects/oracle/pivot_unpivot.yml
+++ b/test/fixtures/dialects/oracle/pivot_unpivot.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 1a2550044a87327b4a547d9bacd638b1ec8e0024bd5497d0499b69953f7c508d
+_hash: 53ca7c25e54378562755e620c050dee5b4f0591d01a54b68d8f6a8a54059e560
 file:
   batch:
   - statement:
@@ -38,34 +38,199 @@ file:
                           table_expression:
                             table_reference:
                               naked_identifier: customers
-                          alias_expression:
-                            naked_identifier: t
                   end_bracket: )
-        pivot_clause:
-          keyword: pivot
-          bracketed:
-          - start_bracket: (
-          - function:
-              function_name:
-                function_name_identifier: count
-              function_contents:
+              alias_expression:
+                naked_identifier: purchases
+            pivot_clause:
+              keyword: pivot
+              bracketed:
+              - start_bracket: (
+              - function:
+                  function_name:
+                    function_name_identifier: count
+                  function_contents:
+                    bracketed:
+                      start_bracket: (
+                      expression:
+                        column_reference:
+                          naked_identifier: state_code
+                      end_bracket: )
+              - keyword: for
+              - column_reference:
+                  naked_identifier: state_code
+              - keyword: in
+              - bracketed:
+                - start_bracket: (
+                - quoted_literal: "'NY'"
+                - alias_expression:
+                    alias_operator:
+                      keyword: as
+                    naked_identifier: new_york
+                - comma: ','
+                - quoted_literal: "'CT'"
+                - comma: ','
+                - quoted_literal: "'NJ'"
+                - comma: ','
+                - quoted_literal: "'FL'"
+                - comma: ','
+                - quoted_literal: "'MO'"
+                - end_bracket: )
+              - end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: select
+          select_clause_element:
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+        from_clause:
+          keyword: from
+          from_expression:
+            from_expression_element:
+              table_expression:
                 bracketed:
                   start_bracket: (
-                  expression:
-                    column_reference:
-                      naked_identifier: state_code
+                  select_statement:
+                    select_clause:
+                    - keyword: select
+                    - select_clause_element:
+                        column_reference:
+                          naked_identifier: times_purchased
+                    - comma: ','
+                    - select_clause_element:
+                        column_reference:
+                          naked_identifier: state_code
+                    from_clause:
+                      keyword: from
+                      from_expression:
+                        from_expression_element:
+                          table_expression:
+                            table_reference:
+                              naked_identifier: customers
                   end_bracket: )
-          - keyword: for
-          - column_reference:
+              alias_expression:
+                naked_identifier: purchases
+            pivot_clause:
+              keyword: pivot
+              bracketed:
+              - start_bracket: (
+              - function:
+                  function_name:
+                    function_name_identifier: count
+                  function_contents:
+                    bracketed:
+                      start_bracket: (
+                      expression:
+                        column_reference:
+                          naked_identifier: state_code
+                      end_bracket: )
+              - keyword: for
+              - column_reference:
+                  naked_identifier: state_code
+              - keyword: in
+              - bracketed:
+                  start_bracket: (
+                  select_statement:
+                    select_clause:
+                      keyword: select
+                      select_clause_modifier:
+                        keyword: distinct
+                      select_clause_element:
+                        column_reference:
+                          naked_identifier: state_code
+                    from_clause:
+                      keyword: from
+                      from_expression:
+                        from_expression_element:
+                          table_expression:
+                            table_reference:
+                              naked_identifier: state
+                  end_bracket: )
+              - end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: select
+          select_clause_element:
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+        from_clause:
+          keyword: from
+          from_expression:
+            from_expression_element:
+              table_expression:
+                bracketed:
+                  start_bracket: (
+                  select_statement:
+                    select_clause:
+                    - keyword: select
+                    - select_clause_element:
+                        column_reference:
+                          naked_identifier: times_purchased
+                    - comma: ','
+                    - select_clause_element:
+                        column_reference:
+                          naked_identifier: state_code
+                    from_clause:
+                      keyword: from
+                      from_expression:
+                        from_expression_element:
+                          table_expression:
+                            table_reference:
+                              naked_identifier: customers
+                  end_bracket: )
+              alias_expression:
+                naked_identifier: purchases
+            pivot_clause:
+              keyword: pivot
+              bracketed:
+              - start_bracket: (
+              - function:
+                  function_name:
+                    function_name_identifier: count
+                  function_contents:
+                    bracketed:
+                      start_bracket: (
+                      expression:
+                        column_reference:
+                          naked_identifier: state_code
+                      end_bracket: )
+              - keyword: for
+              - column_reference:
+                  naked_identifier: state_code
+              - keyword: in
+              - bracketed:
+                  start_bracket: (
+                  select_statement:
+                    select_clause:
+                      keyword: select
+                      select_clause_modifier:
+                        keyword: distinct
+                      select_clause_element:
+                        column_reference:
+                          naked_identifier: state_code
+                    from_clause:
+                      keyword: from
+                      from_expression:
+                        from_expression_element:
+                          table_expression:
+                            table_reference:
+                              naked_identifier: state
+                  end_bracket: )
+              - end_bracket: )
+        where_clause:
+          keyword: where
+          expression:
+            column_reference:
               naked_identifier: state_code
-          - keyword: in
-          - bracketed:
+            keyword: in
+            bracketed:
             - start_bracket: (
             - quoted_literal: "'NY'"
-            - alias_expression:
-                alias_operator:
-                  keyword: as
-                naked_identifier: new_york
             - comma: ','
             - quoted_literal: "'CT'"
             - comma: ','
@@ -75,7 +240,6 @@ file:
             - comma: ','
             - quoted_literal: "'MO'"
             - end_bracket: )
-          - end_bracket: )
   - statement_terminator: ;
   - statement:
       select_statement:
@@ -109,46 +273,32 @@ file:
                           table_expression:
                             table_reference:
                               naked_identifier: customers
-                          alias_expression:
-                            naked_identifier: t
                   end_bracket: )
-        pivot_clause:
-          keyword: pivot
-          bracketed:
-          - start_bracket: (
-          - function:
-              function_name:
-                function_name_identifier: count
-              function_contents:
-                bracketed:
+              alias_expression:
+                naked_identifier: purchases
+            pivot_clause:
+              keyword: pivot
+              bracketed:
+              - start_bracket: (
+              - function:
+                  function_name:
+                    function_name_identifier: count
+                  function_contents:
+                    bracketed:
+                      start_bracket: (
+                      expression:
+                        column_reference:
+                          naked_identifier: state_code
+                      end_bracket: )
+              - keyword: for
+              - column_reference:
+                  naked_identifier: state_code
+              - keyword: in
+              - bracketed:
                   start_bracket: (
-                  expression:
-                    column_reference:
-                      naked_identifier: state_code
+                  keyword: any
                   end_bracket: )
-          - keyword: for
-          - column_reference:
-              naked_identifier: state_code
-          - keyword: in
-          - bracketed:
-              start_bracket: (
-              select_statement:
-                select_clause:
-                  keyword: select
-                  select_clause_modifier:
-                    keyword: distinct
-                  select_clause_element:
-                    column_reference:
-                      naked_identifier: state_code
-                from_clause:
-                  keyword: from
-                  from_expression:
-                    from_expression_element:
-                      table_expression:
-                        table_reference:
-                          naked_identifier: state
-              end_bracket: )
-          - end_bracket: )
+              - end_bracket: )
   - statement_terminator: ;
   - statement:
       select_statement:
@@ -182,91 +332,48 @@ file:
                           table_expression:
                             table_reference:
                               naked_identifier: customers
-                          alias_expression:
-                            naked_identifier: t
                   end_bracket: )
-        pivot_clause:
-          keyword: pivot
-          bracketed:
-          - start_bracket: (
-          - function:
-              function_name:
-                function_name_identifier: count
-              function_contents:
-                bracketed:
+              alias_expression:
+                naked_identifier: purchases
+            pivot_clause:
+              keyword: pivot
+              bracketed:
+              - start_bracket: (
+              - function:
+                  function_name:
+                    function_name_identifier: count
+                  function_contents:
+                    bracketed:
+                      start_bracket: (
+                      expression:
+                        column_reference:
+                          naked_identifier: state_code
+                      end_bracket: )
+              - alias_expression:
+                  alias_operator:
+                    keyword: as
+                  naked_identifier: state_code
+              - keyword: for
+              - column_reference:
+                  naked_identifier: state_code
+              - keyword: in
+              - bracketed:
                   start_bracket: (
-                  expression:
-                    column_reference:
-                      naked_identifier: state_code
+                  keyword: any
                   end_bracket: )
-          - keyword: for
-          - column_reference:
-              naked_identifier: state_code
-          - keyword: in
-          - bracketed:
-              start_bracket: (
-              keyword: any
-              end_bracket: )
-          - end_bracket: )
+              - end_bracket: )
   - statement_terminator: ;
   - statement:
       select_statement:
         select_clause:
-          keyword: select
-          select_clause_element:
-            wildcard_expression:
-              wildcard_identifier:
-                star: '*'
-        from_clause:
-          keyword: from
-          from_expression:
-            from_expression_element:
-              table_expression:
-                table_reference:
-                  naked_identifier: sale_stats
-        unpivot_clause:
-          keyword: unpivot
-          bracketed:
-          - start_bracket: (
-          - column_reference:
+        - keyword: select
+        - select_clause_element:
+            column_reference:
               naked_identifier: quantity
-          - keyword: for
-          - column_reference:
+        - comma: ','
+        - select_clause_element:
+            column_reference:
               naked_identifier: product_code
-          - keyword: in
-          - bracketed:
-            - start_bracket: (
-            - column_reference:
-                naked_identifier: product_a
-            - alias_expression:
-                alias_operator:
-                  keyword: AS
-                quoted_identifier: "'A'"
-            - comma: ','
-            - column_reference:
-                naked_identifier: product_b
-            - alias_expression:
-                alias_operator:
-                  keyword: AS
-                quoted_identifier: "'B'"
-            - comma: ','
-            - column_reference:
-                naked_identifier: product_c
-            - alias_expression:
-                alias_operator:
-                  keyword: AS
-                quoted_identifier: "'C'"
-            - end_bracket: )
-          - end_bracket: )
-  - statement_terminator: ;
-  - statement:
-      select_statement:
-        select_clause:
-          keyword: select
-          select_clause_element:
-            wildcard_expression:
-              wildcard_identifier:
-                star: '*'
         from_clause:
           keyword: from
           from_expression:
@@ -274,51 +381,46 @@ file:
               table_expression:
                 table_reference:
                   naked_identifier: sale_stats
-        unpivot_clause:
-        - keyword: unpivot
-        - keyword: include
-        - keyword: nulls
-        - bracketed:
-          - start_bracket: (
-          - column_reference:
+            unpivot_clause:
+              keyword: unpivot
+              bracketed:
+              - start_bracket: (
+              - column_reference:
+                  naked_identifier: quantity
+              - keyword: for
+              - column_reference:
+                  naked_identifier: product_code
+              - keyword: in
+              - bracketed:
+                - start_bracket: (
+                - column_reference:
+                    naked_identifier: product_a
+                - keyword: as
+                - quoted_literal: "'A'"
+                - comma: ','
+                - column_reference:
+                    naked_identifier: product_b
+                - keyword: as
+                - quoted_literal: "'B'"
+                - comma: ','
+                - column_reference:
+                    naked_identifier: product_c
+                - keyword: as
+                - quoted_literal: "'C'"
+                - end_bracket: )
+              - end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+        - keyword: select
+        - select_clause_element:
+            column_reference:
               naked_identifier: quantity
-          - keyword: for
-          - column_reference:
+        - comma: ','
+        - select_clause_element:
+            column_reference:
               naked_identifier: product_code
-          - keyword: in
-          - bracketed:
-            - start_bracket: (
-            - column_reference:
-                naked_identifier: product_a
-            - alias_expression:
-                alias_operator:
-                  keyword: AS
-                quoted_identifier: "'A'"
-            - comma: ','
-            - column_reference:
-                naked_identifier: product_b
-            - alias_expression:
-                alias_operator:
-                  keyword: AS
-                quoted_identifier: "'B'"
-            - comma: ','
-            - column_reference:
-                naked_identifier: product_c
-            - alias_expression:
-                alias_operator:
-                  keyword: AS
-                quoted_identifier: "'C'"
-            - end_bracket: )
-          - end_bracket: )
-  - statement_terminator: ;
-  - statement:
-      select_statement:
-        select_clause:
-          keyword: select
-          select_clause_element:
-            wildcard_expression:
-              wildcard_identifier:
-                star: '*'
         from_clause:
           keyword: from
           from_expression:
@@ -326,112 +428,336 @@ file:
               table_expression:
                 table_reference:
                   naked_identifier: sale_stats
-        unpivot_clause:
-          keyword: unpivot
-          bracketed:
-          - start_bracket: (
-          - bracketed:
-            - start_bracket: (
-            - column_reference:
-                naked_identifier: quantity
-            - comma: ','
-            - column_reference:
-                naked_identifier: amount
-            - end_bracket: )
-          - keyword: for
-          - column_reference:
+            unpivot_clause:
+              keyword: unpivot
+              bracketed:
+              - start_bracket: (
+              - column_reference:
+                  naked_identifier: quantity
+              - keyword: for
+              - column_reference:
+                  naked_identifier: product_code
+              - keyword: in
+              - bracketed:
+                - start_bracket: (
+                - column_reference:
+                    naked_identifier: product_a
+                - keyword: as
+                - quoted_literal: "'A'"
+                - comma: ','
+                - column_reference:
+                    naked_identifier: product_b
+                - keyword: as
+                - quoted_literal: "'B'"
+                - comma: ','
+                - column_reference:
+                    naked_identifier: product_c
+                - keyword: as
+                - quoted_literal: "'C'"
+                - end_bracket: )
+              - end_bracket: )
+        where_clause:
+          keyword: where
+          expression:
+            column_reference:
+              naked_identifier: quantity
+            comparison_operator:
+              raw_comparison_operator: '>'
+            numeric_literal: '0'
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+        - keyword: select
+        - select_clause_element:
+            column_reference:
+              naked_identifier: quantity
+        - comma: ','
+        - select_clause_element:
+            column_reference:
               naked_identifier: product_code
-          - keyword: in
-          - bracketed:
-            - start_bracket: (
+        from_clause:
+          keyword: from
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: sale_stats
+            unpivot_clause:
+            - keyword: unpivot
+            - keyword: include
+            - keyword: nulls
             - bracketed:
               - start_bracket: (
               - column_reference:
-                  naked_identifier: a_qty
-              - comma: ','
+                  naked_identifier: quantity
+              - keyword: for
               - column_reference:
-                  naked_identifier: a_value
+                  naked_identifier: product_code
+              - keyword: in
+              - bracketed:
+                - start_bracket: (
+                - column_reference:
+                    naked_identifier: product_a
+                - keyword: as
+                - quoted_literal: "'A'"
+                - comma: ','
+                - column_reference:
+                    naked_identifier: product_b
+                - keyword: as
+                - quoted_literal: "'B'"
+                - comma: ','
+                - column_reference:
+                    naked_identifier: product_c
+                - keyword: as
+                - quoted_literal: "'C'"
+                - end_bracket: )
               - end_bracket: )
-            - alias_expression:
-                alias_operator:
-                  keyword: as
-                quoted_identifier: "'A'"
-            - comma: ','
-            - bracketed:
-              - start_bracket: (
-              - column_reference:
-                  naked_identifier: b_qty
-              - comma: ','
-              - column_reference:
-                  naked_identifier: b_value
-              - end_bracket: )
-            - alias_expression:
-                alias_operator:
-                  keyword: as
-                quoted_identifier: "'B'"
-            - end_bracket: )
-          - end_bracket: )
   - statement_terminator: ;
   - statement:
       select_statement:
         select_clause:
-          keyword: select
-          select_clause_element:
-            wildcard_expression:
-              wildcard_identifier:
-                star: '*'
+        - keyword: select
+        - select_clause_element:
+            column_reference:
+              naked_identifier: quantity
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+              naked_identifier: product_id
         from_clause:
           keyword: from
           from_expression:
             from_expression_element:
               table_expression:
-                bracketed:
-                  start_bracket: (
-                  select_statement:
-                    select_clause:
-                    - keyword: select
-                    - select_clause_element:
-                        column_reference:
-                          naked_identifier: times_purchased
-                    - comma: ','
-                    - select_clause_element:
-                        column_reference:
-                          naked_identifier: state_code
-                    from_clause:
-                      keyword: from
-                      from_expression:
-                        from_expression_element:
-                          table_expression:
-                            table_reference:
-                              naked_identifier: customers
-                          alias_expression:
-                            naked_identifier: t
-                  end_bracket: )
-        pivot_clause:
-          keyword: pivot
-          bracketed:
-          - start_bracket: (
-          - function:
-              function_name:
-                function_name_identifier: count
-              function_contents:
-                bracketed:
-                  start_bracket: (
-                  expression:
-                    column_reference:
-                      naked_identifier: state_code
-                  end_bracket: )
-          - alias_expression:
-              alias_operator:
-                keyword: as
-              naked_identifier: state_code
-          - keyword: for
-          - column_reference:
-              naked_identifier: state_code
-          - keyword: in
-          - bracketed:
-              start_bracket: (
-              keyword: any
-              end_bracket: )
-          - end_bracket: )
+                table_reference:
+                  naked_identifier: sale_stats
+            unpivot_clause:
+              keyword: unpivot
+              bracketed:
+              - start_bracket: (
+              - column_reference:
+                  naked_identifier: quantity
+              - keyword: for
+              - column_reference:
+                  naked_identifier: product_id
+              - keyword: in
+              - bracketed:
+                - start_bracket: (
+                - column_reference:
+                    naked_identifier: product_a
+                - keyword: as
+                - numeric_literal: '1'
+                - comma: ','
+                - column_reference:
+                    naked_identifier: product_b
+                - keyword: as
+                - numeric_literal: '2'
+                - comma: ','
+                - column_reference:
+                    naked_identifier: product_c
+                - keyword: as
+                - numeric_literal: '3'
+                - end_bracket: )
+              - end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+        - keyword: select
+        - select_clause_element:
+            column_reference:
+              naked_identifier: quantity
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+              naked_identifier: amount
+        from_clause:
+          keyword: from
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: sale_stats
+            unpivot_clause:
+              keyword: unpivot
+              bracketed:
+              - start_bracket: (
+              - column_reference:
+                  naked_identifier: quantity
+              - comma: ','
+              - column_reference:
+                  naked_identifier: amount
+              - keyword: for
+              - column_reference:
+                  naked_identifier: product_code
+              - keyword: in
+              - bracketed:
+                - start_bracket: (
+                - column_reference:
+                    naked_identifier: a_qty
+                - comma: ','
+                - column_reference:
+                    naked_identifier: a_value
+                - keyword: as
+                - quoted_literal: "'A'"
+                - comma: ','
+                - column_reference:
+                    naked_identifier: b_qty
+                - comma: ','
+                - column_reference:
+                    naked_identifier: b_value
+                - keyword: as
+                - quoted_literal: "'B'"
+                - end_bracket: )
+              - end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+        - keyword: select
+        - select_clause_element:
+            column_reference:
+              naked_identifier: quantity
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+              naked_identifier: amount
+        from_clause:
+          keyword: from
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: sale_stats
+            unpivot_clause:
+              keyword: unpivot
+              bracketed:
+              - start_bracket: (
+              - column_reference:
+                  naked_identifier: quantity
+              - comma: ','
+              - column_reference:
+                  naked_identifier: amount
+              - keyword: for
+              - column_reference:
+                  naked_identifier: product_code
+              - keyword: in
+              - bracketed:
+                - start_bracket: (
+                - column_reference:
+                    naked_identifier: a_qty
+                - comma: ','
+                - column_reference:
+                    naked_identifier: a_value
+                - keyword: as
+                - numeric_literal: '1'
+                - comma: ','
+                - column_reference:
+                    naked_identifier: b_qty
+                - comma: ','
+                - column_reference:
+                    naked_identifier: b_value
+                - keyword: as
+                - numeric_literal: '2'
+                - end_bracket: )
+              - end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+        - keyword: select
+        - select_clause_element:
+            column_reference:
+              naked_identifier: quantity
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+              naked_identifier: product_code
+        from_clause:
+          keyword: from
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: sale_stats
+            unpivot_clause:
+              keyword: unpivot
+              bracketed:
+              - start_bracket: (
+              - column_reference:
+                  naked_identifier: quantity
+              - keyword: for
+              - column_reference:
+                  naked_identifier: product_code
+              - keyword: in
+              - bracketed:
+                - start_bracket: (
+                - column_reference:
+                    naked_identifier: product_a
+                - comma: ','
+                - column_reference:
+                    naked_identifier: product_b
+                - comma: ','
+                - column_reference:
+                    naked_identifier: product_c
+                - end_bracket: )
+              - end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+        - keyword: select
+        - select_clause_element:
+            column_reference:
+              naked_identifier: quantity
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+              naked_identifier: amount
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+              naked_identifier: product_code
+        from_clause:
+          keyword: from
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: sale_stats
+            unpivot_clause:
+              keyword: unpivot
+              bracketed:
+              - start_bracket: (
+              - column_reference:
+                  naked_identifier: quantity
+              - comma: ','
+              - column_reference:
+                  naked_identifier: amount
+              - keyword: for
+              - column_reference:
+                  naked_identifier: product_code
+              - keyword: in
+              - bracketed:
+                - start_bracket: (
+                - bracketed:
+                  - start_bracket: (
+                  - column_reference:
+                      naked_identifier: a_qty
+                  - comma: ','
+                  - column_reference:
+                      naked_identifier: a_value
+                  - end_bracket: )
+                - comma: ','
+                - bracketed:
+                  - start_bracket: (
+                  - column_reference:
+                      naked_identifier: b_qty
+                  - comma: ','
+                  - column_reference:
+                      naked_identifier: b_value
+                  - end_bracket: )
+                - end_bracket: )
+              - end_bracket: )
   - statement_terminator: ;


### PR DESCRIPTION


<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Fixes #7973 

- Moved the pivot and unpivot segments to a `JoinLikeClauseGrammar` matching the way it is done in several dialects. 
  - This solves PIVOT/UNPIVOT not being able to parse when a WHERE clause is involved and correctly places them under the FROM clause in the parsed tree.
- Split `PivotForInGrammar` into `PivotForGrammar`, `PivotInGrammar`, and `UnpivotInGrammar` to account for the nuances between PIVOT and UNPIVOT.
- Specifically, reworked the Unpivot grammar to match the oracle reference, swapping identifiers for literals, but only quoted or numeric, and making sure that mixing and matching is disallowed.
  - This solves labels being parsed incorrectly.
- Added missing test cases.

Documentation is available here for reference: https://docs.oracle.com/en/database/oracle/oracle-database/21/sqlrf/SELECT.html

### Are there any other side effects of this change that we should be aware of?
None that I can think about.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - [ ] `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - [x] `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - [ ] Full autofix test cases in `test/fixtures/linter/autofix`.
  - [ ] Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.

### AI use disclosure

Agentic AI was involved in expanding the test cases.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #7973 by correcting Oracle PIVOT/UNPIVOT parsing with WHERE clauses and improving label handling. Adds support for PIVOT IN (ANY) and IN (subquery), and for UNPIVOT with numeric or quoted labels (no mixing), unlabeled entries, and multi-column pairs.

- **Bug Fixes**
  - PIVOT/UNPIVOT now parse with WHERE by treating them as join-like clauses under FROM.
  - UNPIVOT labels parse correctly; supports all-quoted or all-numeric labels, plus unlabeled and multi-column entries; PIVOT supports IN (ANY) and IN (subquery).

- **Refactors**
  - Split `PivotForInGrammar` into `PivotForGrammar`, `PivotInGrammar`, and `UnpivotInGrammar`; added `UnpivotAsCharacterLiteralGrammar` and `UnpivotAsNumericLiteralGrammar`.
  - Introduced `JoinLikeClauseGrammar` to host PIVOT/UNPIVOT and added tests aligned with Oracle docs.

<sup>Written for commit 40485bcaf7395380658ab1411c8d17071b4dd9a6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/7974?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

