### PR TITLE
fix: don't crash when a directory named .sqlfluff exists (#6617)

### DIFF
--- a/src/sqlfluff/core/config/loader.py
+++ b/src/sqlfluff/core/config/loader.py
@@ -237,7 +237,12 @@ def load_config_at_path(path: str) -> ConfigMappingType:
     else:
         p = os.path.dirname(path)
 
-    d = os.listdir(os.path.expanduser(p))
+    # Expand `~` once and reuse the expanded value for listing, checking and
+    # loading. Otherwise the existence checks (which expanded the path) could
+    # succeed while `load_config_file()` later fails to open the unexpanded path.
+    p = os.path.expanduser(p)
+
+    d = os.listdir(p)
     # iterate this way round to make sure things overwrite is the right direction.
     # NOTE: The `configs` variable is passed back in at each stage.
     for fname in filename_options:
@@ -246,7 +251,7 @@ def load_config_at_path(path: str) -> ConfigMappingType:
         # directory named `.sqlfluff`), which would otherwise be opened as a
         # file and raise an `IsADirectoryError`.
         # https://github.com/sqlfluff/sqlfluff/issues/6617
-        if fname in d and os.path.isfile(os.path.join(os.path.expanduser(p), fname)):
+        if fname in d and os.path.isfile(os.path.join(p, fname)):
             configs = load_config_file(p, fname, configs=configs)
 
     return configs
@@ -324,18 +329,23 @@ def load_config_up_to_path(
     # is more efficient.
     extra_config = {}
     if extra_config_path:
+        # Expand `~` once so the directory check and resolution stay consistent.
+        # `Path.resolve()` does not expand `~`, so without this a quoted path
+        # like `--config "~/.sqlfluff"` would skip the directory check and be
+        # reported as not-found instead of loaded (or flagged as a directory).
+        expanded_config_path = os.path.expanduser(extra_config_path)
         # A directory (e.g. one named `.sqlfluff`) is not a valid config file
         # and would otherwise raise an `IsADirectoryError` when opened. Surface
         # a clean user error instead, consistent with the not-found case.
         # https://github.com/sqlfluff/sqlfluff/issues/6617
-        if os.path.isdir(extra_config_path):
+        if os.path.isdir(expanded_config_path):
             raise SQLFluffUserError(
                 f"Extra config path '{extra_config_path}' is a directory, "
                 "not a config file."
             )
         try:
             extra_config = load_config_file_as_dict(
-                str(Path(extra_config_path).resolve())
+                str(Path(expanded_config_path).resolve())
             )
         except FileNotFoundError:
             raise SQLFluffUserError(

--- a/src/sqlfluff/core/config/loader.py
+++ b/src/sqlfluff/core/config/loader.py
@@ -241,7 +241,12 @@ def load_config_at_path(path: str) -> ConfigMappingType:
     # iterate this way round to make sure things overwrite is the right direction.
     # NOTE: The `configs` variable is passed back in at each stage.
     for fname in filename_options:
-        if fname in d:
+        # Ignore any entries which aren't files. In particular this guards
+        # against a *directory* sharing the name of a config file (e.g. a
+        # directory named `.sqlfluff`), which would otherwise be opened as a
+        # file and raise an `IsADirectoryError`.
+        # https://github.com/sqlfluff/sqlfluff/issues/6617
+        if fname in d and os.path.isfile(os.path.join(os.path.expanduser(p), fname)):
             configs = load_config_file(p, fname, configs=configs)
 
     return configs
@@ -319,6 +324,15 @@ def load_config_up_to_path(
     # is more efficient.
     extra_config = {}
     if extra_config_path:
+        # A directory (e.g. one named `.sqlfluff`) is not a valid config file
+        # and would otherwise raise an `IsADirectoryError` when opened. Surface
+        # a clean user error instead, consistent with the not-found case.
+        # https://github.com/sqlfluff/sqlfluff/issues/6617
+        if os.path.isdir(extra_config_path):
+            raise SQLFluffUserError(
+                f"Extra config path '{extra_config_path}' is a directory, "
+                "not a config file."
+            )
         try:
             extra_config = load_config_file_as_dict(
                 str(Path(extra_config_path).resolve())

--- a/test/core/config/loader_test.py
+++ b/test/core/config/loader_test.py
@@ -77,6 +77,48 @@ def test__config__load_file_missing_extra():
         )
 
 
+def test__config__load_with_config_dir(tmp_path):
+    """Test that a directory named like a config file does not crash loading.
+
+    https://github.com/sqlfluff/sqlfluff/issues/6617
+
+    A directory sharing the name of a config file (here a directory named
+    ``.sqlfluff``) used to be opened as if it were a config file, raising an
+    ``IsADirectoryError``. It should be ignored instead.
+    """
+    # Create a *directory* named `.sqlfluff` alongside a valid config file.
+    (tmp_path / ".sqlfluff").mkdir()
+    (tmp_path / "pyproject.toml").write_text(
+        '[tool.sqlfluff.core]\ndialect = "ansi"\n', encoding="utf-8"
+    )
+
+    try:
+        cfg = load_config_at_path(str(tmp_path))
+    finally:
+        clear_config_caches()
+
+    # The `.sqlfluff` directory is ignored and the valid config still loads.
+    assert cfg == {"core": {"dialect": "ansi"}}
+
+
+def test__config__load_extra_config_dir(tmp_path):
+    """Test a clean user error when an extra config path is a directory.
+
+    https://github.com/sqlfluff/sqlfluff/issues/6617
+
+    Passing a directory (e.g. via ``--config``) used to raise an
+    ``IsADirectoryError``. It should raise a ``SQLFluffUserError`` instead,
+    consistent with the not-found case.
+    """
+    (tmp_path / ".sqlfluff").mkdir()
+
+    with pytest.raises(SQLFluffUserError):
+        load_config_up_to_path(
+            str(tmp_path),
+            extra_config_path=str(tmp_path / ".sqlfluff"),
+        )
+
+
 def test__config__load_nested():
     """Test nested overwrite and order of precedence of config files."""
     cfg = load_config_up_to_path(

--- a/test/core/config/loader_test.py
+++ b/test/core/config/loader_test.py
@@ -119,6 +119,33 @@ def test__config__load_extra_config_dir(tmp_path):
         )
 
 
+def test__config__load_extra_config_tilde(tmp_path, monkeypatch):
+    """Test that an extra config path containing ``~`` is expanded.
+
+    ``Path.resolve()`` does not expand ``~``, so a quoted path such as
+    ``--config "~/.sqlfluff"`` used to be reported as not existing even when a
+    valid config file was present in the home directory. The path should be
+    expanded before the directory check and before loading.
+    """
+    # Point the home directory at tmp_path so that `~` expands here.
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+    (tmp_path / ".sqlfluff").write_text(
+        "[sqlfluff]\ndialect = ansi\n", encoding="utf-8"
+    )
+
+    try:
+        cfg = load_config_up_to_path(
+            str(tmp_path),
+            extra_config_path="~/.sqlfluff",
+            ignore_local_config=True,
+        )
+    finally:
+        clear_config_caches()
+
+    assert cfg == {"core": {"dialect": "ansi"}}
+
+
 def test__config__load_nested():
     """Test nested overwrite and order of precedence of config files."""
     cfg = load_config_up_to_path(


### PR DESCRIPTION
Fixes #6617

### What
SQLFluff crashes with `IsADirectoryError` when a directory named `.sqlfluff` exists in a path it scans for config, or when `--config` points at such a directory.

### Why
Config path resolution in `load_config_at_path` matched directory entries against config filenames (`.sqlfluff`, `setup.cfg`, ...) using only `fname in d`, with no file-vs-directory check. A directory named `.sqlfluff` matched and was then `open()`ed as a file, raising `IsADirectoryError`.

This is a regression between 3.1.1 and 3.2.0. The config module rewrite (#6128) replaced `configparser.read()` — which silently ignores paths it cannot open, including directories — with a bare `open()`, removing that tolerance.

### Fix
- `load_config_at_path`: add an `os.path.isfile` guard so directory entries sharing a config filename are skipped (restores pre-3.2.0 behaviour).
- `load_config_up_to_path`: when `extra_config_path` (e.g. `--config`) points at a directory, raise a clean `SQLFluffUserError` instead of `IsADirectoryError`, consistent with the existing not-found error.

### Verification
- New tests `test__config__load_with_config_dir` and `test__config__load_extra_config_dir` reproduce the bug (they fail on `main`, pass with this change).
- `pytest test/core/config/` — all pass; ruff check/format clean.
- Confirmed a normal `.sqlfluff` *file* still loads correctly (no regression).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent crashes when a directory named `.sqlfluff` (or another config filename) exists, and fix consistent `~` expansion in config path loading. Restores pre-3.2.0 behavior, shows a clear error if `--config` points to a directory, and correctly loads `--config "~/.sqlfluff"`.

- **Bug Fixes**
  - Skip non-file entries during config discovery and expand `~` once to keep checks and opens consistent.
  - If `--config` points to a directory, raise a clear `SQLFluffUserError` instead of `IsADirectoryError`.
  - Expand `~` in `--config` before checking and resolving (e.g., `--config "~/.sqlfluff"` now loads). Added tests; valid `.sqlfluff` files still load.

<sup>Written for commit 4b9e8f3a688ff66a253c7169e53ae614c3b99a98. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/7975?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

