### PR TITLE
rust: move parser metrics into its own struct

### DIFF
--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/core.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/core.rs
@@ -15,9 +15,9 @@ use crate::parser::{MatchResult, MetaSegment};
 use super::{cache::TableParseCache, Node, ParseError};
 use sqlfluffrs_dialects::Dialect;
 use sqlfluffrs_types::regex::RegexMode;
-use sqlfluffrs_types::{SimpleHint, Token};
+use sqlfluffrs_types::Token;
 // NEW: Table-driven grammar support
-use sqlfluffrs_types::{GrammarContext, GrammarId, GrammarVariant, RootGrammar};
+use sqlfluffrs_types::{GrammarContext, GrammarId, GrammarVariant};
 
 /// Read a string-id list from aux_data region starting at ``offset``.
 /// Layout is ``[count, string_id_0, string_id_1, ...]``.
@@ -44,67 +44,90 @@ fn read_string_ids_from_aux(
         .collect()
 }
 
-/// A checkpoint in the collection history that tracks which tokens were collected
-/// at a specific point. Used for backtracking.
-#[derive(Debug, Clone)]
-pub struct CollectionCheckpoint {
-    /// Frame ID associated with this checkpoint
-    pub frame_id: usize,
-    /// Token positions that were marked as collected at this checkpoint
-    pub positions: Vec<usize>,
+/// Diagnostic counters accumulated during a parse.
+///
+/// Pure instrumentation: nothing here affects parse results, so every field is a
+/// `Cell<usize>` updated through `&self`. Grouped into one struct to keep the
+/// `Parser` struct focused on parsing state and to expose the counters as a unit
+/// via [`Parser::diagnostics`] rather than field-by-field across the FFI boundary.
+#[derive(Debug, Default)]
+pub(crate) struct ParserMetrics {
+    /// Number of `prune_options` calls.
+    pub pruning_calls: std::cell::Cell<usize>,
+    /// Total options considered across all prune calls.
+    pub pruning_total: std::cell::Cell<usize>,
+    /// Options kept after pruning.
+    pub pruning_kept: std::cell::Cell<usize>,
+    /// Options that had a simple hint.
+    pub pruning_hinted: std::cell::Cell<usize>,
+    /// Options that returned None (too complex to hint).
+    pub pruning_complex: std::cell::Cell<usize>,
+    /// Match attempts (mirrors Python's `longest_match` accounting).
+    pub match_attempts: std::cell::Cell<usize>,
+    /// Successful matches.
+    pub match_successes: std::cell::Cell<usize>,
+    /// Early exits taken on an already-complete match.
+    pub complete_match_early_exits: std::cell::Cell<usize>,
+    /// Terminator checks performed.
+    pub terminator_checks: std::cell::Cell<usize>,
+    /// Terminator hits (early exits caused by a terminator).
+    pub terminator_hits: std::cell::Cell<usize>,
 }
+
+impl ParserMetrics {
+    /// Snapshot the counters as a name -> value map (for debug/FFI reporting).
+    fn as_map(&self) -> std::collections::HashMap<String, usize> {
+        let mut m = std::collections::HashMap::new();
+        m.insert("pruning_calls".to_string(), self.pruning_calls.get());
+        m.insert("pruning_total".to_string(), self.pruning_total.get());
+        m.insert("pruning_kept".to_string(), self.pruning_kept.get());
+        m.insert("pruning_hinted".to_string(), self.pruning_hinted.get());
+        m.insert("pruning_complex".to_string(), self.pruning_complex.get());
+        m.insert("match_attempts".to_string(), self.match_attempts.get());
+        m.insert("match_successes".to_string(), self.match_successes.get());
+        m.insert(
+            "complete_match_early_exits".to_string(),
+            self.complete_match_early_exits.get(),
+        );
+        m.insert("terminator_checks".to_string(), self.terminator_checks.get());
+        m.insert("terminator_hits".to_string(), self.terminator_hits.get());
+        m
+    }
+}
+
 /// The main parser struct that holds parsing state and provides parsing methods.
+///
+/// Fields are `pub(crate)`: the parser's public API is the methods re-exported from
+/// [`crate::parser`] (plus the `PyParser` bindings), not its internal state.
 pub struct Parser<'a> {
-    pub simple_hint_cache: hashbrown::HashMap<u64, Option<SimpleHint>>,
-    pub tokens: &'a [Token],
-    pub pos: usize, // current position in tokens
-    pub dialect: Dialect,
-    pub table_cache: TableParseCache, // Frame-level cache
-    pub cache_enabled: bool,
-    pub collected_transparent_positions: Vec<usize>, // Track which token positions have had transparent tokens collected (Vec for O(1) truncate)
-    /// Stack of collection checkpoints for backtracking.
-    /// Each checkpoint records which tokens were marked as collected at that point.
-    pub collection_stack: Vec<CollectionCheckpoint>,
-    pub pruning_calls: std::cell::Cell<usize>, // Track number of prune_options calls
-    pub pruning_total: std::cell::Cell<usize>, // Total options considered
-    pub pruning_kept: std::cell::Cell<usize>,  // Options kept after pruning
-    pub pruning_hinted: std::cell::Cell<usize>, // Options that had hints
-    pub pruning_complex: std::cell::Cell<usize>, // Options that returned None (complex)
-    pub match_attempts: std::cell::Cell<usize>, // Track number of match attempts (like Python's longest_match)
-    pub match_successes: std::cell::Cell<usize>, // Track number of successful matches
-    pub complete_match_early_exits: std::cell::Cell<usize>, // Track early exits from complete matches
-    pub terminator_checks: std::cell::Cell<usize>,          // Track number of terminator checks
-    pub terminator_hits: std::cell::Cell<usize>, // Track number of terminator hits (early exits)
+    pub(crate) tokens: &'a [Token],
+    pub(crate) pos: usize, // current position in tokens
+    pub(crate) dialect: Dialect,
+    pub(crate) table_cache: TableParseCache, // Frame-level cache
+    pub(crate) cache_enabled: bool,
+    /// Diagnostic counters (instrumentation only; see [`ParserMetrics`]).
+    pub(crate) metrics: ParserMetrics,
     /// Cache for terminator match results: (position, grammar_id) -> matches
     /// Key insight: the same terminator at the same position will always give the same result.
     /// This avoids redundant parse_table_iterative calls from nested Delimited grammars.
-    pub terminator_match_cache: std::cell::RefCell<hashbrown::HashMap<(usize, u32), bool>>,
-    /// Cache for terminator hash computation: Vec<GrammarId> -> u64
-    /// Many grammars share the same terminators, so we cache the computed hashes.
-    /// OPTIMIZATION: This avoids recomputing the same hash thousands of times in
-    /// expression-heavy queries (arithmetic_a.sql, expression_recursion.sql).
-    pub terminator_hash_cache: std::cell::RefCell<hashbrown::HashMap<Vec<u32>, u64>>,
+    pub(crate) terminator_match_cache: std::cell::RefCell<hashbrown::HashMap<(usize, u32), bool>>,
     // Table-driven grammar support
-    pub grammar_ctx: GrammarContext<'static>,
+    pub(crate) grammar_ctx: GrammarContext<'static>,
     /// Indentation configuration (key -> enabled)
     /// Used by conditional meta segments (e.g., indented_joins=true enables Indent/Dedent)
-    pub indent_config: hashbrown::HashMap<&'static str, bool>,
-    /// Optional owned RootGrammar. When present, callers can use `parse_root`
-    /// to parse starting from this root without having to pass grammar ids
-    /// or contexts manually.
-    pub root: Option<RootGrammar>,
+    pub(crate) indent_config: hashbrown::HashMap<&'static str, bool>,
     // Regex cache for table-driven RegexParser (pattern_string -> compiled RegexMode)
     regex_cache: std::cell::RefCell<hashbrown::HashMap<String, RegexMode>>,
     /// Maximum number of main-loop iterations before aborting.
     /// Configurable via `rust_parser_max_iterations` in `.sqlfluff`.
-    pub max_parser_iterations: usize,
+    pub(crate) max_parser_iterations: usize,
     /// Iteration count at which a warning is emitted (the former hard limit).
     /// Configurable via `rust_parser_warn_threshold` in `.sqlfluff`.
-    pub parser_warn_threshold: usize,
+    pub(crate) parser_warn_threshold: usize,
     /// Maximum parse depth (frame stack). 0 = no limit. Used for DoS mitigation.
-    pub max_parse_depth: usize,
+    pub(crate) max_parse_depth: usize,
     /// Maximum parse nodes in the accepted parse tree. 0 = no limit.
-    pub max_parse_nodes: usize,
+    pub(crate) max_parse_nodes: usize,
 }
 
 impl<'a> Parser<'a> {
@@ -141,25 +164,11 @@ impl<'a> Parser<'a> {
             pos: 0,
             dialect,
             table_cache: TableParseCache::new(),
-            collected_transparent_positions: Vec::new(),
-            collection_stack: Vec::new(),
-            pruning_calls: std::cell::Cell::new(0),
-            pruning_total: std::cell::Cell::new(0),
-            pruning_kept: std::cell::Cell::new(0),
-            pruning_hinted: std::cell::Cell::new(0),
-            pruning_complex: std::cell::Cell::new(0),
-            match_attempts: std::cell::Cell::new(0),
-            match_successes: std::cell::Cell::new(0),
-            complete_match_early_exits: std::cell::Cell::new(0),
-            terminator_checks: std::cell::Cell::new(0),
-            terminator_hits: std::cell::Cell::new(0),
+            metrics: ParserMetrics::default(),
             terminator_match_cache: std::cell::RefCell::new(hashbrown::HashMap::new()),
-            terminator_hash_cache: std::cell::RefCell::new(hashbrown::HashMap::new()),
-            simple_hint_cache: hashbrown::HashMap::new(),
             cache_enabled: true,
             grammar_ctx,
             indent_config,
-            root: None,
             regex_cache: std::cell::RefCell::new(hashbrown::HashMap::new()),
             max_parser_iterations: 3_000_000,
             parser_warn_threshold: 2_000_000,
@@ -235,6 +244,19 @@ impl<'a> Parser<'a> {
     /// Enable or disable the parse cache (for debugging)
     pub fn set_cache_enabled(&mut self, enabled: bool) {
         self.cache_enabled = enabled;
+    }
+
+    /// Current position in the token stream (index of the next token to consume).
+    pub fn position(&self) -> usize {
+        self.pos
+    }
+
+    /// Snapshot the parser's diagnostic counters as a name -> value map.
+    ///
+    /// Pure instrumentation; the values have no effect on parse results. Used by the
+    /// Python bindings and perf debugging instead of reaching into individual counters.
+    pub fn diagnostics(&self) -> std::collections::HashMap<String, usize> {
+        self.metrics.as_map()
     }
 
     /// Parse and return MatchResult

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/core.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/core.rs
@@ -89,7 +89,10 @@ impl ParserMetrics {
             "complete_match_early_exits".to_string(),
             self.complete_match_early_exits.get(),
         );
-        m.insert("terminator_checks".to_string(), self.terminator_checks.get());
+        m.insert(
+            "terminator_checks".to_string(),
+            self.terminator_checks.get(),
+        );
         m.insert("terminator_hits".to_string(), self.terminator_hits.get());
         m
     }

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/helpers.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/helpers.rs
@@ -25,12 +25,12 @@ impl<'a> Parser<'a> {
         println!();
 
         // Print pruning stats
-        let calls = self.pruning_calls.get();
-        let total = self.pruning_total.get();
-        let kept = self.pruning_kept.get();
+        let calls = self.metrics.pruning_calls.get();
+        let total = self.metrics.pruning_total.get();
+        let kept = self.metrics.pruning_kept.get();
         let pruned = total.saturating_sub(kept);
-        let hinted = self.pruning_hinted.get();
-        let complex = self.pruning_complex.get();
+        let hinted = self.metrics.pruning_hinted.get();
+        let complex = self.metrics.pruning_complex.get();
 
         if calls > 0 {
             println!("SimpleHint Pruning Statistics:");
@@ -271,17 +271,17 @@ impl<'a> Parser<'a> {
     /// This is the table-driven equivalent of prune_options().
     pub(crate) fn prune_options(&mut self, options: &[GrammarId]) -> Vec<GrammarId> {
         // Track stats
-        self.pruning_calls.set(self.pruning_calls.get() + 1);
-        self.pruning_total
-            .set(self.pruning_total.get() + options.len());
+        self.metrics.pruning_calls.set(self.metrics.pruning_calls.get() + 1);
+        self.metrics.pruning_total
+            .set(self.metrics.pruning_total.get() + options.len());
 
         // Find first code token
         let first_code_token = self.tokens.iter().skip(self.pos).find(|t| t.is_code());
 
         // If no code token found, can't prune - return all options
         let Some(first_token) = first_code_token else {
-            self.pruning_kept
-                .set(self.pruning_kept.get() + options.len());
+            self.metrics.pruning_kept
+                .set(self.metrics.pruning_kept.get() + options.len());
             return options.to_vec();
         };
 
@@ -307,7 +307,7 @@ impl<'a> Parser<'a> {
             if let Some(tables) = tables {
                 if let Some(hint) = tables.get_simple_hint_for_grammar(opt_id) {
                     // We have a hint - track it
-                    self.pruning_hinted.set(self.pruning_hinted.get() + 1);
+                    self.metrics.pruning_hinted.set(self.metrics.pruning_hinted.get() + 1);
                     // Use hint to filter
                     if tables.hint_can_match(hint, &first_raw, &first_types) {
                         available_options.push(opt_id);
@@ -317,12 +317,12 @@ impl<'a> Parser<'a> {
                     }
                 } else {
                     // No hint = complex grammar, must try it
-                    self.pruning_complex.set(self.pruning_complex.get() + 1);
+                    self.metrics.pruning_complex.set(self.metrics.pruning_complex.get() + 1);
                     available_options.push(opt_id);
                 }
             } else {
                 // No tables available - keep all options (conservative)
-                self.pruning_complex.set(self.pruning_complex.get() + 1);
+                self.metrics.pruning_complex.set(self.metrics.pruning_complex.get() + 1);
                 available_options.push(opt_id);
             }
         }
@@ -365,8 +365,8 @@ impl<'a> Parser<'a> {
             );
         }
 
-        self.pruning_kept
-            .set(self.pruning_kept.get() + available_options.len());
+        self.metrics.pruning_kept
+            .set(self.metrics.pruning_kept.get() + available_options.len());
 
         available_options
     }
@@ -375,7 +375,7 @@ impl<'a> Parser<'a> {
     ///
     /// This is the table-driven equivalent of is_terminated_with_elements().
     pub(crate) fn is_terminated(&mut self, terminators: &[GrammarId]) -> bool {
-        self.terminator_checks.set(self.terminator_checks.get() + 1);
+        self.metrics.terminator_checks.set(self.metrics.terminator_checks.get() + 1);
         let init_pos = self.pos;
 
         // CRITICAL: Check for GrammarId::NONCODE BEFORE skipping transparent tokens!
@@ -397,7 +397,7 @@ impl<'a> Parser<'a> {
                 );
                 if !is_code {
                     vdebug!("  TERMED NONCODE found non-code token at current position");
-                    self.terminator_hits.set(self.terminator_hits.get() + 1);
+                    self.metrics.terminator_hits.set(self.metrics.terminator_hits.get() + 1);
                     return true;
                 }
             }
@@ -425,7 +425,7 @@ impl<'a> Parser<'a> {
         if self.is_at_end() {
             vdebug!("  TERMED Reached end of file");
             self.pos = init_pos;
-            self.terminator_hits.set(self.terminator_hits.get() + 1);
+            self.metrics.terminator_hits.set(self.metrics.terminator_hits.get() + 1);
             return true;
         }
 
@@ -434,7 +434,7 @@ impl<'a> Parser<'a> {
             if tok.get_type() == "end_of_file" {
                 vdebug!("  TERMED Found end_of_file token");
                 self.pos = init_pos;
-                self.terminator_hits.set(self.terminator_hits.get() + 1);
+                self.metrics.terminator_hits.set(self.metrics.terminator_hits.get() + 1);
                 return true;
             }
         }
@@ -512,7 +512,7 @@ impl<'a> Parser<'a> {
                 if cached_result {
                     vdebug!("  TERMED Terminator matched (cached): {:?}", term_id);
                     self.pos = init_pos;
-                    self.terminator_hits.set(self.terminator_hits.get() + 1);
+                    self.metrics.terminator_hits.set(self.metrics.terminator_hits.get() + 1);
                     return true;
                 }
                 // Cached false - skip this terminator
@@ -535,7 +535,7 @@ impl<'a> Parser<'a> {
                 if !is_empty {
                     vdebug!("  TERMED Terminator matched (table-driven): {:?}", term_id);
                     self.pos = init_pos;
-                    self.terminator_hits.set(self.terminator_hits.get() + 1);
+                    self.metrics.terminator_hits.set(self.metrics.terminator_hits.get() + 1);
                     return true;
                 }
             } else {

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/helpers.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/helpers.rs
@@ -271,8 +271,11 @@ impl<'a> Parser<'a> {
     /// This is the table-driven equivalent of prune_options().
     pub(crate) fn prune_options(&mut self, options: &[GrammarId]) -> Vec<GrammarId> {
         // Track stats
-        self.metrics.pruning_calls.set(self.metrics.pruning_calls.get() + 1);
-        self.metrics.pruning_total
+        self.metrics
+            .pruning_calls
+            .set(self.metrics.pruning_calls.get() + 1);
+        self.metrics
+            .pruning_total
             .set(self.metrics.pruning_total.get() + options.len());
 
         // Find first code token
@@ -280,7 +283,8 @@ impl<'a> Parser<'a> {
 
         // If no code token found, can't prune - return all options
         let Some(first_token) = first_code_token else {
-            self.metrics.pruning_kept
+            self.metrics
+                .pruning_kept
                 .set(self.metrics.pruning_kept.get() + options.len());
             return options.to_vec();
         };
@@ -307,7 +311,9 @@ impl<'a> Parser<'a> {
             if let Some(tables) = tables {
                 if let Some(hint) = tables.get_simple_hint_for_grammar(opt_id) {
                     // We have a hint - track it
-                    self.metrics.pruning_hinted.set(self.metrics.pruning_hinted.get() + 1);
+                    self.metrics
+                        .pruning_hinted
+                        .set(self.metrics.pruning_hinted.get() + 1);
                     // Use hint to filter
                     if tables.hint_can_match(hint, &first_raw, &first_types) {
                         available_options.push(opt_id);
@@ -317,12 +323,16 @@ impl<'a> Parser<'a> {
                     }
                 } else {
                     // No hint = complex grammar, must try it
-                    self.metrics.pruning_complex.set(self.metrics.pruning_complex.get() + 1);
+                    self.metrics
+                        .pruning_complex
+                        .set(self.metrics.pruning_complex.get() + 1);
                     available_options.push(opt_id);
                 }
             } else {
                 // No tables available - keep all options (conservative)
-                self.metrics.pruning_complex.set(self.metrics.pruning_complex.get() + 1);
+                self.metrics
+                    .pruning_complex
+                    .set(self.metrics.pruning_complex.get() + 1);
                 available_options.push(opt_id);
             }
         }
@@ -365,7 +375,8 @@ impl<'a> Parser<'a> {
             );
         }
 
-        self.metrics.pruning_kept
+        self.metrics
+            .pruning_kept
             .set(self.metrics.pruning_kept.get() + available_options.len());
 
         available_options
@@ -375,7 +386,9 @@ impl<'a> Parser<'a> {
     ///
     /// This is the table-driven equivalent of is_terminated_with_elements().
     pub(crate) fn is_terminated(&mut self, terminators: &[GrammarId]) -> bool {
-        self.metrics.terminator_checks.set(self.metrics.terminator_checks.get() + 1);
+        self.metrics
+            .terminator_checks
+            .set(self.metrics.terminator_checks.get() + 1);
         let init_pos = self.pos;
 
         // CRITICAL: Check for GrammarId::NONCODE BEFORE skipping transparent tokens!
@@ -397,7 +410,9 @@ impl<'a> Parser<'a> {
                 );
                 if !is_code {
                     vdebug!("  TERMED NONCODE found non-code token at current position");
-                    self.metrics.terminator_hits.set(self.metrics.terminator_hits.get() + 1);
+                    self.metrics
+                        .terminator_hits
+                        .set(self.metrics.terminator_hits.get() + 1);
                     return true;
                 }
             }
@@ -425,7 +440,9 @@ impl<'a> Parser<'a> {
         if self.is_at_end() {
             vdebug!("  TERMED Reached end of file");
             self.pos = init_pos;
-            self.metrics.terminator_hits.set(self.metrics.terminator_hits.get() + 1);
+            self.metrics
+                .terminator_hits
+                .set(self.metrics.terminator_hits.get() + 1);
             return true;
         }
 
@@ -434,7 +451,9 @@ impl<'a> Parser<'a> {
             if tok.get_type() == "end_of_file" {
                 vdebug!("  TERMED Found end_of_file token");
                 self.pos = init_pos;
-                self.metrics.terminator_hits.set(self.metrics.terminator_hits.get() + 1);
+                self.metrics
+                    .terminator_hits
+                    .set(self.metrics.terminator_hits.get() + 1);
                 return true;
             }
         }
@@ -512,7 +531,9 @@ impl<'a> Parser<'a> {
                 if cached_result {
                     vdebug!("  TERMED Terminator matched (cached): {:?}", term_id);
                     self.pos = init_pos;
-                    self.metrics.terminator_hits.set(self.metrics.terminator_hits.get() + 1);
+                    self.metrics
+                        .terminator_hits
+                        .set(self.metrics.terminator_hits.get() + 1);
                     return true;
                 }
                 // Cached false - skip this terminator
@@ -535,7 +556,9 @@ impl<'a> Parser<'a> {
                 if !is_empty {
                     vdebug!("  TERMED Terminator matched (table-driven): {:?}", term_id);
                     self.pos = init_pos;
-                    self.metrics.terminator_hits.set(self.metrics.terminator_hits.get() + 1);
+                    self.metrics
+                        .terminator_hits
+                        .set(self.metrics.terminator_hits.get() + 1);
                     return true;
                 }
             } else {

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/python.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/python.rs
@@ -576,22 +576,8 @@ impl PyParser {
         stats.insert("cache_hits".to_string(), cache_hits);
         stats.insert("cache_misses".to_string(), cache_misses);
         stats.insert("cache_entries".to_string(), cache_entries);
-        stats.insert("pruning_calls".to_string(), parser.pruning_calls.get());
-        stats.insert("pruning_total".to_string(), parser.pruning_total.get());
-        stats.insert("pruning_kept".to_string(), parser.pruning_kept.get());
-        stats.insert("pruning_hinted".to_string(), parser.pruning_hinted.get());
-        stats.insert("pruning_complex".to_string(), parser.pruning_complex.get());
-        stats.insert("match_attempts".to_string(), parser.match_attempts.get());
-        stats.insert("match_successes".to_string(), parser.match_successes.get());
-        stats.insert(
-            "complete_match_early_exits".to_string(),
-            parser.complete_match_early_exits.get(),
-        );
-        stats.insert(
-            "terminator_checks".to_string(),
-            parser.terminator_checks.get(),
-        );
-        stats.insert("terminator_hits".to_string(), parser.terminator_hits.get());
+        // Diagnostic counters are owned by the parser; pull them as a unit.
+        stats.extend(parser.diagnostics());
 
         Ok((PyMatchResult(match_result), stats))
     }

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/oneof.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/oneof.rs
@@ -132,8 +132,8 @@ impl Parser<'_> {
         }
 
         // Track match attempts (like Python's longest_match - each option is an attempt)
-        self.match_attempts
-            .set(self.match_attempts.get() + pruned_children.len());
+        self.metrics.match_attempts
+            .set(self.metrics.match_attempts.get() + pruned_children.len());
 
         // Save first child before moving pruned_children into context
         let first_child = pruned_children[0];
@@ -269,8 +269,8 @@ impl Parser<'_> {
                 max_idx
             );
             // Track early exit for stats
-            self.complete_match_early_exits
-                .set(self.complete_match_early_exits.get() + 1);
+            self.metrics.complete_match_early_exits
+                .set(self.metrics.complete_match_early_exits.get() + 1);
             *longest_match = Some((child_match_rc, consumed, current_child));
             // Skip directly to Combining state
             frame.state = FrameState::Combining;
@@ -399,7 +399,7 @@ impl Parser<'_> {
         let result_match = if let Some((best_match, best_consumed, _best_child_id)) = longest_match
         {
             // Track successful match (like Python's longest_match returning a match)
-            self.match_successes.set(self.match_successes.get() + 1);
+            self.metrics.match_successes.set(self.metrics.match_successes.get() + 1);
             self.pos = post_skip_pos + best_consumed;
 
             best_match

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/oneof.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/oneof.rs
@@ -132,7 +132,8 @@ impl Parser<'_> {
         }
 
         // Track match attempts (like Python's longest_match - each option is an attempt)
-        self.metrics.match_attempts
+        self.metrics
+            .match_attempts
             .set(self.metrics.match_attempts.get() + pruned_children.len());
 
         // Save first child before moving pruned_children into context
@@ -269,7 +270,8 @@ impl Parser<'_> {
                 max_idx
             );
             // Track early exit for stats
-            self.metrics.complete_match_early_exits
+            self.metrics
+                .complete_match_early_exits
                 .set(self.metrics.complete_match_early_exits.get() + 1);
             *longest_match = Some((child_match_rc, consumed, current_child));
             // Skip directly to Combining state
@@ -399,7 +401,9 @@ impl Parser<'_> {
         let result_match = if let Some((best_match, best_consumed, _best_child_id)) = longest_match
         {
             // Track successful match (like Python's longest_match returning a match)
-            self.metrics.match_successes.set(self.metrics.match_successes.get() + 1);
+            self.metrics
+                .match_successes
+                .set(self.metrics.match_successes.get() + 1);
             self.pos = post_skip_pos + best_consumed;
 
             best_match

--- a/sqlfluffrs/tests/test_bracketed_sequence.rs
+++ b/sqlfluffrs/tests/test_bracketed_sequence.rs
@@ -40,7 +40,7 @@ fn test_bracketed_implicit_sequence() {
 
             println!(
                 "\n=== Parser position: {} / {} ===",
-                parser.pos,
+                parser.position(),
                 tokens.len()
             );
 


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
This moves the metrics on the rust parser into a dedicated struct. This also drops unused items on the `Parser` struct and makes them crate internal.

### Are there any other side effects of this change that we should be aware of?
None

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved parser metrics into a dedicated `ParserMetrics` struct and added a `diagnostics()` snapshot to simplify `Parser` and isolate instrumentation. Tightened internal visibility and removed unused fields with no behavior changes.

- **Refactors**
  - Introduced `ParserMetrics`; `Parser` counters consolidated under `metrics`.
  - Added `diagnostics()` to return metrics as a map; Python bindings now use it.
  - Added `position()` accessor for the current token index.
  - Removed unused fields: `simple_hint_cache`, `terminator_hash_cache`, `collected_transparent_positions`, `collection_stack`, and `root`.
  - Made parser fields `pub(crate)` to limit API surface; updated helpers to use `metrics`.

- **Migration**
  - Replace direct `parser.pos` access with `parser.position()`.
  - For metrics, use `parser.diagnostics()` instead of reading individual counters.

<sup>Written for commit a479d4cdaa790aad3e486342a9fcabad4df2def6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/7981?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

