### PR TITLE
perf(rust): defer RawSegment.representation to cached_property and replace uuid4 with os.urandom

### DIFF
--- a/src/sqlfluff/core/parser/segments/base.py
+++ b/src/sqlfluff/core/parser/segments/base.py
@@ -12,6 +12,7 @@ Here we define:
 from __future__ import annotations
 
 import logging
+import os
 import weakref
 from collections.abc import Iterator, Sequence
 from dataclasses import dataclass
@@ -27,7 +28,6 @@ from typing import (
     Union,
     cast,
 )
-from uuid import uuid4
 
 from sqlfluff.core.helpers.slice import is_zero_slice
 from sqlfluff.core.parser.context import ParseContext
@@ -142,7 +142,7 @@ class SegmentMetaclass(type, Matchable):
         # Create a cache uuid on definition.
         # We do it here so every _definition_ of a segment
         # gets a unique UUID regardless of dialect.
-        class_dict["_cache_key"] = uuid4().hex
+        class_dict["_cache_key"] = os.urandom(16).hex()
 
         # Populate the `_class_types` property on creation.
         added_type = class_dict.get("type", None)
@@ -217,7 +217,7 @@ class BaseSegment(metaclass=SegmentMetaclass):
         # Tracker for matching when things start moving.
         # NOTE: We're storing the .int attribute so that it's swifter
         # for comparisons.
-        self.uuid = uuid or uuid4().int
+        self.uuid = uuid or int.from_bytes(os.urandom(16), "big")
 
         self.set_as_parent(recurse=False)
         self.validate_non_code_ends()

--- a/src/sqlfluff/core/parser/segments/raw.py
+++ b/src/sqlfluff/core/parser/segments/raw.py
@@ -4,8 +4,9 @@ This is designed to be the root segment, without
 any children, and the output of the lexer.
 """
 
+import functools
+import os
 from typing import TYPE_CHECKING, Any, Callable, Optional, Union, cast
-from uuid import uuid4
 
 import regex as re
 
@@ -74,14 +75,18 @@ class RawSegment(BaseSegment):
         # Keep track of any source fixes
         self._source_fixes = source_fixes
         # UUID for matching (the int attribute of it)
-        self.uuid = uuid or uuid4().int
-        self.representation = "<{}: ({}) {!r}>".format(
-            self.__class__.__name__, self.pos_marker, self.raw
-        )
+        self.uuid = uuid or int.from_bytes(os.urandom(16), "big")
         self.quoted_value = quoted_value
         self.escape_replacements = escape_replacements
         self.casefold = casefold
         self._raw_value: str = self.normalize()
+
+    @functools.cached_property
+    def representation(self) -> str:
+        """Lazy string representation, computed once on first access."""
+        return "<{}: ({}) {!r}>".format(
+            self.__class__.__name__, self.pos_marker, self.raw
+        )
 
     def __repr__(self) -> str:
         # This is calculated at __init__, because all elements are immutable


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
Two changes:

* **Deferred representation string.** `RawSegment.__init__` previously computed `self.representation = "<{}: ({}) {!r}>".format(...)` unconditionally for every token produced by the lexer. This string is only accessed when repr() is called on a segment, which happens during debug logging and error reporting but not during normal parsing or linting. The field is converted to a
`@functools.cached_property` so the format call is deferred to first access and free for tokens whose repr is never needed.

* **Replace uuid4 with os.urandom.** `uuid4()` acquires an internal lock for entropy collection on CPython. Both `BaseSegment` and `RawSegment` generated a UUID per instance. Replacing with `int.from_bytes(os.urandom(16), "big")` and
`os.urandom(16).hex()` removes the lock contention and is marginally faster for workloads that create many segments.

| Benchmark | Before | After | Change |                                                                                                                                           
|---|---|---|---|
| athena/lex_athena | 3.394 s | 3.141 s | -7.4% |
| tpch/lex_tpch_22 | 22.10 ms | 20.55 ms | -7.0% |
| tpcds/lex_tpcds_99 | 188.0 ms | 180.3 ms | -4.1% |

### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Defers building repr strings and replaces `uuid4()` with `os.urandom` to cut lock contention and reduce overhead during parsing and linting.

- **Refactors**
  - Make `RawSegment.representation` a `functools.cached_property` so it’s computed on first access only.
  - Replace `uuid4()` with `os.urandom(16)` for `uuid` and `_cache_key` in `BaseSegment` and `RawSegment` to avoid UUID locks and speed up instance creation.

<sup>Written for commit 8d0960ba67608de346260333249ff35d1afff94c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/7988?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

