### PR TITLE
perf(python): guard linter stringify calls behind isEnabledFor

### DIFF
--- a/src/sqlfluff/core/linter/linter.py
+++ b/src/sqlfluff/core/linter/linter.py
@@ -309,8 +309,9 @@ class Linter:
         if parsed is None:  # pragma: no cover
             return None, violations
 
-        linter_logger.info("\n###\n#\n# {}\n#\n###".format("Parsed Tree:"))
-        linter_logger.info("\n" + parsed.stringify())
+        if linter_logger.isEnabledFor(logging.INFO):
+            linter_logger.info("\n###\n#\n# {}\n#\n###".format("Parsed Tree:"))
+            linter_logger.info("\n" + parsed.stringify())
         # We may succeed parsing, but still have unparsable segments. Extract them
         # here.
         for unparsable in parsed.iter_unparsables():
@@ -331,8 +332,9 @@ class Linter:
                     segment=unparsable,
                 )
             )
-            linter_logger.info("Found unparsable segment...")
-            linter_logger.info(unparsable.stringify())
+            if linter_logger.isEnabledFor(logging.INFO):
+                linter_logger.info("Found unparsable segment...")
+                linter_logger.info(unparsable.stringify())
         return parsed, violations
 
     @staticmethod
@@ -699,8 +701,9 @@ class Linter:
         if config.get("ignore_templated_areas", default=True):
             initial_linting_errors = cls.remove_templated_errors(initial_linting_errors)
 
-        linter_logger.info("\n###\n#\n# {}\n#\n###".format("Fixed Tree:"))
-        linter_logger.info("\n" + tree.stringify())
+        if linter_logger.isEnabledFor(logging.INFO):
+            linter_logger.info("\n###\n#\n# {}\n#\n###".format("Fixed Tree:"))
+            linter_logger.info("\n" + tree.stringify())
 
         return tree, initial_linting_errors, ignore_mask, rule_timings
 


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
Wraps the three `linter_logger.info("\n" + tree.stringify())` calls in `linter.py` with an explicit `linter_logger.isEnabledFor(logging.INFO)` guard. Python evaluates function arguments before checking whether a log record will be emitted, so `tree.stringify()` was being called unconditionally even when no handler was listening at INFO level. `stringify()` traverses the entire parse tree to build a human-readable string, making it O(n) in tree size. This change makes the cost conditional on INFO logging actually being enabled, which it is not in normal production use.

Unfortunately, in this instance I can't change the `__str__` or `__repr__` functions as they are already used across the codebase and it is expected to behave a certain way.

### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Avoid unnecessary parse tree traversal by guarding three `linter_logger.info(...)` calls in `linter.py` with `linter_logger.isEnabledFor(logging.INFO)`. This skips `parsed.stringify()`, `unparsable.stringify()`, and `tree.stringify()` when INFO logging is off, reducing O(n) work in normal runs.

<sup>Written for commit a88d47696f6e8f89e031403177ca8a852d2c3e99. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/7989?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

