### PR TITLE
perf(rust): wrap cached RegexMode entries in Arc to avoid cloning on cache hit

### DIFF
--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/core.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/core.rs
@@ -120,7 +120,7 @@ pub struct Parser<'a> {
     /// Used by conditional meta segments (e.g., indented_joins=true enables Indent/Dedent)
     pub(crate) indent_config: hashbrown::HashMap<&'static str, bool>,
     // Regex cache for table-driven RegexParser (pattern_string -> compiled RegexMode)
-    regex_cache: std::cell::RefCell<hashbrown::HashMap<String, RegexMode>>,
+    regex_cache: std::cell::RefCell<hashbrown::HashMap<String, std::sync::Arc<RegexMode>>>,
     /// Maximum number of main-loop iterations before aborting.
     /// Configurable via `rust_parser_max_iterations` in `.sqlfluff`.
     pub(crate) max_parser_iterations: usize,
@@ -1151,7 +1151,7 @@ impl<'a> Parser<'a> {
             let comp_key = normalize_for_compile(&pattern_str).to_string();
             cache
                 .entry(comp_key.clone())
-                .or_insert_with(|| RegexMode::new(&comp_key))
+                .or_insert_with(|| std::sync::Arc::new(RegexMode::new(&comp_key)))
                 .clone()
         };
 
@@ -1161,7 +1161,7 @@ impl<'a> Parser<'a> {
             Some(
                 cache
                     .entry(comp_key.clone())
-                    .or_insert_with(|| RegexMode::new(&comp_key))
+                    .or_insert_with(|| std::sync::Arc::new(RegexMode::new(&comp_key)))
                     .clone(),
             )
         } else {


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
Wraps compiled `RegexMode` entries in `Arc<RegexMode>` inside the parser's regex cache. Previously a cache hit returned a clone of the compiled regex, which copies the internal matcher state. With `Arc`, a cache hit is a reference-count increment only instead of a heap allocation and full struct copy. The regex cache is consulted on every `RegexParser` match attempt, so this is in the hot path for SQL with significant regex-matched token types.


### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Store compiled `RegexMode` entries in the parser cache as `Arc<RegexMode>` to avoid cloning on cache hits. This removes heap allocations and matcher-state copies in a hot path (`RegexParser` lookups), improving match performance.

<sup>Written for commit a255794c34212849161ab3a90b7c2e30baf862d8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/7990?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

