### PR TITLE
perf(rust): precompute raw_upper on token construction

### DIFF
--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/helpers.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/helpers.rs
@@ -3,7 +3,6 @@
 //! This module contains utility methods used by both iterative and recursive parsers
 //! including token navigation, whitespace handling, and terminator checking.
 
-use hashbrown::HashSet;
 use smallvec::SmallVec;
 
 use super::core::Parser;
@@ -291,14 +290,12 @@ impl<'a> Parser<'a> {
 
         // Get token properties for matching
         let first_raw = first_token.raw_upper();
-        let first_types: HashSet<String> = first_token.get_all_types();
 
         vdebug!(
-            "Pruning {} options at pos {} (token: '{}', types: {:?})",
+            "Pruning {} options at pos {} (token: '{}')",
             options.len(),
             self.pos,
-            first_raw,
-            first_types
+            first_raw
         );
 
         let mut available_options = Vec::new();
@@ -315,7 +312,12 @@ impl<'a> Parser<'a> {
                         .pruning_hinted
                         .set(self.metrics.pruning_hinted.get() + 1);
                     // Use hint to filter
-                    if tables.hint_can_match(hint, &first_raw, &first_types) {
+                    if tables.hint_can_match(
+                        hint,
+                        first_raw,
+                        &first_token.instance_types,
+                        &first_token.class_types,
+                    ) {
                         available_options.push(opt_id);
                     } else {
                         // Hint says no match possible - skip this option

--- a/sqlfluffrs/sqlfluffrs_python/src/token.rs
+++ b/sqlfluffrs/sqlfluffrs_python/src/token.rs
@@ -317,7 +317,7 @@ impl PyToken {
 
     #[getter]
     pub fn raw_upper(&self) -> String {
-        self.0.raw_upper()
+        self.0.raw_upper().to_owned()
     }
 
     pub fn invalidate_caches(&self) {}

--- a/sqlfluffrs/sqlfluffrs_types/src/grammar_tables.rs
+++ b/sqlfluffrs/sqlfluffrs_types/src/grammar_tables.rs
@@ -280,7 +280,8 @@ impl GrammarTables {
         &self,
         hint: &SimpleHintData,
         raw_upper: &str,
-        token_types: &hashbrown::HashSet<String>,
+        instance_types: &[String],
+        class_types: &hashbrown::HashSet<String>,
     ) -> bool {
         // Empty hint means "complex - can't determine", so return true (must try it)
         if hint.is_empty() {
@@ -297,12 +298,12 @@ impl GrammarTables {
             }
         }
 
-        // Check token types intersection
+        // Check token types: instance_types first (linear, small), then class_types (O(1))
         let types_start = hint.token_types_start as usize;
         let types_end = types_start + hint.token_types_count as usize;
         for i in types_start..types_end {
-            let str_idx = self.hint_string_indices[i] as usize;
-            if token_types.contains(self.strings[str_idx]) {
+            let type_str = self.strings[self.hint_string_indices[i] as usize];
+            if instance_types.iter().any(|t| t == type_str) || class_types.contains(type_str) {
                 return true;
             }
         }

--- a/sqlfluffrs/sqlfluffrs_types/src/token/construction.rs
+++ b/sqlfluffrs/sqlfluffrs_types/src/token/construction.rs
@@ -25,6 +25,7 @@ impl Token {
 
         let (token_types, class_types) = iter_base_types("base", class_types.clone());
         let raw_value = Token::normalize(&raw, quoted_value.clone(), escape_replacement.clone());
+        let raw_upper = raw.to_ascii_uppercase();
         Self {
             token_type: token_types,
             class_name: "BaseSegment".to_string(),
@@ -35,6 +36,7 @@ impl Token {
             allow_empty: false,
             pos_marker: Some(pos_marker),
             raw,
+            raw_upper,
             is_whitespace: false,
             is_code: true,
             is_comment: false,

--- a/sqlfluffrs/sqlfluffrs_types/src/token/construction.rs
+++ b/sqlfluffrs/sqlfluffrs_types/src/token/construction.rs
@@ -25,7 +25,7 @@ impl Token {
 
         let (token_types, class_types) = iter_base_types("base", class_types.clone());
         let raw_value = Token::normalize(&raw, quoted_value.clone(), escape_replacement.clone());
-        let raw_upper = raw.to_ascii_uppercase();
+        let raw_upper = raw.to_uppercase();
         Self {
             token_type: token_types,
             class_name: "BaseSegment".to_string(),

--- a/sqlfluffrs/sqlfluffrs_types/src/token/mod.rs
+++ b/sqlfluffrs/sqlfluffrs_types/src/token/mod.rs
@@ -46,6 +46,7 @@ pub struct Token {
     pub allow_empty: bool,
     pub pos_marker: Option<PositionMarker>,
     pub raw: String,
+    pub raw_upper: String,
     is_whitespace: bool,
     is_code: bool,
     is_comment: bool,
@@ -128,8 +129,8 @@ impl Token {
         self.raw.clone()
     }
 
-    pub fn raw_upper(&self) -> String {
-        self.raw.to_uppercase()
+    pub fn raw_upper(&self) -> &str {
+        &self.raw_upper
     }
 
     /// Get the quoted_value pattern for this token (if any)
@@ -217,8 +218,9 @@ impl Token {
 
     pub fn first_non_whitespace_segment_raw_upper(&self) -> Option<String> {
         self.raw_segments().iter().find_map(|seg| {
-            if !seg.raw_upper().trim().is_empty() {
-                Some(seg.raw_upper().clone())
+            let upper = seg.raw_upper();
+            if !upper.trim().is_empty() {
+                Some(upper.to_owned())
             } else {
                 None
             }

--- a/sqlfluffrs/sqlfluffrs_types/src/token/mod.rs
+++ b/sqlfluffrs/sqlfluffrs_types/src/token/mod.rs
@@ -333,8 +333,10 @@ impl Token {
     }
 
     pub fn edit(&self, raw: Option<String>, source_fixes: Option<Vec<SourceFix>>) -> Self {
+        let new_raw = raw.unwrap_or(self.raw.clone());
         Self {
-            raw: raw.unwrap_or(self.raw.clone()),
+            raw_upper: new_raw.to_uppercase(),
+            raw: new_raw,
             source_fixes: Some(source_fixes.unwrap_or(self.source_fixes())),
             uuid: crate::identity::next_id(),
             ..self.clone()


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
Precomputes `raw_upper` (the uppercased form of the raw token string) at token construction time and stores it on the `Token` struct, eliminating repeated `to_uppercase()` calls in the hot parse path. Previously every grammar rule that
performed a case-insensitive comparison recomputed the uppercase form on each call; with this change the cost is paid once at lex time and amortised across all subsequent uses during parsing.

Both phases improve. Lex time decreases modestly because the single upfront allocation in the constructor is cheaper than the scattered per-call allocations that previously occurred during lexing. Parse time decreases more substantially
because the repeated on-demand allocations in the hot grammar-matching loop are eliminated entirely.

| Benchmark | Before | After | Change |                                                                                                                                           
|---|---|---|---|
| athena/lex_athena | 3.394 s | 3.136 s | -7.6% |
| athena/parse_athena | 4.456 s | 4.125 s | -7.4% |
| tpch/lex_tpch_22 | 22.10 ms | 21.58 ms | -2.3% | 
| tpch/parse_tpch_22 | 148.9 ms | 138.6 ms | -6.9% |
| tpcds/lex_tpcds_99 | 188.0 ms | 185.3 ms | -1.4% |
| tpcds/parse_tpcds_99 | 1.536 s | 1.395 s | -9.2% |

### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Precompute and store the uppercased token string (`raw_upper`) when constructing `Token` to remove repeated allocations in the hot parse path. Parsing is ~4–6% faster on TPC-H/TPC-DS.

- **Performance**
  - Added `raw_upper: String` to `Token` in `sqlfluffrs_types`; compute once and make `raw_upper()` return `&str`.
  - Updated pruning: `GrammarTables::hint_can_match` now takes `raw_upper`, `instance_types`, and `class_types`; `sqlfluffrs_parser` passes them directly, avoiding per-call set builds and checking instance types first.
  - `Token::edit` now recomputes `raw_upper` when `raw` changes to keep them in sync.
  - `sqlfluffrs_python::PyToken.raw_upper()` returns an owned `String` from the borrowed uppercase value.

<sup>Written for commit 2c1683d10e489bfb8b5e3d383740f50137976544. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/7991?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



