### PR TITLE
Parse Databricks view comments as comment clauses

### DIFF
--- a/src/sqlfluff/dialects/dialect_databricks.py
+++ b/src/sqlfluff/dialects/dialect_databricks.py
@@ -845,7 +845,7 @@ class CreateViewStatementSegment(BaseSegment):
     )
 
     _view_clauses = AnyNumberOf(
-        Ref("CommentGrammar"),
+        Ref("CommentClauseSegment"),
         Sequence(
             "DEFAULT",
             "COLLATION",
@@ -868,7 +868,7 @@ class CreateViewStatementSegment(BaseSegment):
                 Delimited(
                     Sequence(
                         Ref("ColumnReferenceSegment"),
-                        Ref("CommentGrammar", optional=True),
+                        Ref("CommentClauseSegment", optional=True),
                     ),
                 ),
             ),

--- a/test/fixtures/dialects/databricks/create_view.sql
+++ b/test/fixtures/dialects/databricks/create_view.sql
@@ -25,6 +25,10 @@ CREATE VIEW sales_summary
 COMMENT 'Aggregated sales data by region'
 AS SELECT region, SUM(amount) as total FROM sales GROUP BY region;
 
+CREATE VIEW long_comment_view
+COMMENT 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer nec dignissim diam, eu consectetur dolor. Aliquam vestibulum hendrerit massa ac dapibus. Duis luctus ut nunc quis mollis. Pellentesque at ultricies justo. Mauris nulla metus, posuere in lorem eget, mattis eleifend dui. In ullamcorper, enim id posuere mattis, urna ex tempus ipsum, ac bibendum neque arcu at mi. Pellentesque ultricies rutrum nibh a accumsan. Morbi non fermentum eros. Sed at nisl et purus suscipit congue. Vestibulum auctor vehicula maximus. In semper felis neque, eu condimentum lacus pharetra ut. Curabitur nibh metus, dapibus sed tellus ac, commodo porta orci.'
+AS SELECT 1 AS col;
+
 CREATE VIEW audited_view
 TBLPROPERTIES ('created_by' = 'admin', 'purpose' = 'audit')
 AS SELECT * FROM transactions;

--- a/test/fixtures/dialects/databricks/create_view.yml
+++ b/test/fixtures/dialects/databricks/create_view.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: a49075281a63bf5771627f5fcd4511135014998598777840aafd3d0bcfff031e
+_hash: 758894eb16eba25316e25a274e8e2196d72a92bd4be287ee1e295ef191569d7e
 file:
 - statement:
     create_view_statement:
@@ -138,13 +138,15 @@ file:
       - start_bracket: (
       - column_reference:
           naked_identifier: emp_id
-      - keyword: COMMENT
-      - quoted_literal: "'Employee ID'"
+      - comment_clause:
+          keyword: COMMENT
+          quoted_literal: "'Employee ID'"
       - comma: ','
       - column_reference:
           naked_identifier: emp_name
-      - keyword: COMMENT
-      - quoted_literal: "'Full name'"
+      - comment_clause:
+          keyword: COMMENT
+          quoted_literal: "'Full name'"
       - end_bracket: )
     - keyword: AS
     - select_statement:
@@ -171,8 +173,9 @@ file:
     - keyword: VIEW
     - table_reference:
         naked_identifier: sales_summary
-    - keyword: COMMENT
-    - quoted_literal: "'Aggregated sales data by region'"
+    - comment_clause:
+        keyword: COMMENT
+        quoted_literal: "'Aggregated sales data by region'"
     - keyword: AS
     - select_statement:
         select_clause:
@@ -208,6 +211,34 @@ file:
         - keyword: BY
         - column_reference:
             naked_identifier: region
+- statement_terminator: ;
+- statement:
+    create_view_statement:
+    - keyword: CREATE
+    - keyword: VIEW
+    - table_reference:
+        naked_identifier: long_comment_view
+    - comment_clause:
+        keyword: COMMENT
+        quoted_literal: "'Lorem ipsum dolor sit amet, consectetur adipiscing elit.\
+          \ Integer nec dignissim diam, eu consectetur dolor. Aliquam vestibulum hendrerit\
+          \ massa ac dapibus. Duis luctus ut nunc quis mollis. Pellentesque at ultricies\
+          \ justo. Mauris nulla metus, posuere in lorem eget, mattis eleifend dui.\
+          \ In ullamcorper, enim id posuere mattis, urna ex tempus ipsum, ac bibendum\
+          \ neque arcu at mi. Pellentesque ultricies rutrum nibh a accumsan. Morbi\
+          \ non fermentum eros. Sed at nisl et purus suscipit congue. Vestibulum auctor\
+          \ vehicula maximus. In semper felis neque, eu condimentum lacus pharetra\
+          \ ut. Curabitur nibh metus, dapibus sed tellus ac, commodo porta orci.'"
+    - keyword: AS
+    - select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            numeric_literal: '1'
+            alias_expression:
+              alias_operator:
+                keyword: AS
+              naked_identifier: col
 - statement_terminator: ;
 - statement:
     create_view_statement:
@@ -441,16 +472,19 @@ file:
       - start_bracket: (
       - column_reference:
           naked_identifier: id
-      - keyword: COMMENT
-      - quoted_literal: "'Primary key'"
+      - comment_clause:
+          keyword: COMMENT
+          quoted_literal: "'Primary key'"
       - comma: ','
       - column_reference:
           naked_identifier: value
-      - keyword: COMMENT
-      - quoted_literal: "'Metric value'"
+      - comment_clause:
+          keyword: COMMENT
+          quoted_literal: "'Metric value'"
       - end_bracket: )
-    - keyword: COMMENT
-    - quoted_literal: "'A comprehensive view example'"
+    - comment_clause:
+        keyword: COMMENT
+        quoted_literal: "'A comprehensive view example'"
     - keyword: DEFAULT
     - keyword: COLLATION
     - object_reference:
@@ -493,8 +527,9 @@ file:
     - keyword: VIEW
     - table_reference:
         naked_identifier: temp_summary
-    - keyword: COMMENT
-    - quoted_literal: "'Temporary summary for session'"
+    - comment_clause:
+        keyword: COMMENT
+        quoted_literal: "'Temporary summary for session'"
     - keyword: AS
     - select_statement:
         select_clause:

--- a/test/fixtures/rules/std_rule_cases/LT05.yml
+++ b/test/fixtures/rules/std_rule_cases/LT05.yml
@@ -360,6 +360,19 @@ test_pass_ignore_comment_clauses_postgres:
       layout.long_lines:
         ignore_comment_clauses: true
 
+test_pass_ignore_comment_clauses_databricks_create_view:
+  pass_str: |
+    CREATE VIEW my_schema.my_view
+    COMMENT 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer nec dignissim diam, eu consectetur dolor. Aliquam vestibulum hendrerit massa ac dapibus. Duis luctus ut nunc quis mollis. Pellentesque at ultricies justo. Mauris nulla metus, posuere in lorem eget, mattis eleifend dui. In ullamcorper, enim id posuere mattis, urna ex tempus ipsum, ac bibendum neque arcu at mi. Pellentesque ultricies rutrum nibh a accumsan. Morbi non fermentum eros. Sed at nisl et purus suscipit congue. Vestibulum auctor vehicula maximus. In semper felis neque, eu condimentum lacus pharetra ut. Curabitur nibh metus, dapibus sed tellus ac, commodo porta orci.'
+    AS
+    SELECT 1 AS col
+  configs:
+    core:
+      dialect: databricks
+    rules:
+      layout.long_lines:
+        ignore_comment_clauses: true
+
 test_fail_templated_comment_line:
   fail_str: |
     SELECT *


### PR DESCRIPTION
Fixes #7992.

This change makes Databricks `CREATE VIEW ... COMMENT` clauses parse as `comment_clause`, matching existing Databricks `CREATE FUNCTION ... COMMENT` behavior. This allows LT05 with `ignore_comment_clauses = True` to ignore long view comments correctly.

Changes:
- use `CommentClauseSegment` for Databricks view-level and column-level `COMMENT` clauses
- add a focused Databricks `CREATE VIEW ... COMMENT` fixture
- regenerate the Databricks `create_view.yml` parse fixture
- add LT05 regression coverage for `ignore_comment_clauses = True`

Validation:
- `python test/generate_parse_fixture_yml.py -d databricks`
- `python -m pytest test/dialects/dialects_test.py -k 'databricks and create_view'`
- `python -m pytest test/rules/yaml_test_cases_test.py -k LT05`
- `python -m pytest test/dialects/dialects_test.py -k databricks`
- `ruff check src/sqlfluff/dialects/dialect_databricks.py`
- `ruff format --check src/sqlfluff/dialects/dialect_databricks.py`
- `git diff --check -- <touched files>`

Notes:
- Repo-wide `git status`/`git diff --check` intermittently hung in this local checkout during working-tree refresh, but explicit pathspec checks confirmed only the intended 4 files are modified and clean.
- No LT05 implementation changes were needed.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Parse Databricks `CREATE VIEW` view-level and column-level `COMMENT` clauses as comment clauses. This lets `LT05` ignore long view comments when `ignore_comment_clauses = true` and aligns with `CREATE FUNCTION`.

- **Bug Fixes**
  - Use `CommentClauseSegment` for view- and column-level `COMMENT` in Databricks.
  - Update/regen parse fixtures and add an `LT05` regression for `ignore_comment_clauses = true`.

<sup>Written for commit f23a6762c268394ebaaf01e7cadb7dbb873a61a5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/7993?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

