### PR TITLE
perf(rust): gate map_template_slices validation behind debug_assertions

### DIFF
--- a/sqlfluffrs/sqlfluffrs_lexer/src/lexer.rs
+++ b/sqlfluffrs/sqlfluffrs_lexer/src/lexer.rs
@@ -281,6 +281,10 @@ impl Lexer {
         elements: &[LexedElement],
         template: &TemplatedFile,
     ) -> Vec<TemplateElement> {
+        // Silence "unused variable" in release builds where the debug_assertions
+        // validation block below is compiled out.
+        #[cfg(not(debug_assertions))]
+        let _ = template;
         let mut idx = 0;
         let mut templated_buff = Vec::new();
 
@@ -293,19 +297,24 @@ impl Lexer {
             let templated_element = TemplateElement::from_element(element, template_slice);
             templated_buff.push(templated_element);
 
-            // // Validate that the slice matches the element's raw content
-            let templated_substr: String = template
-                .templated_str
-                .chars()
-                .skip(template_slice.start)
-                .take(template_slice.len())
-                .collect();
+            // Validate that the slice matches the element's raw content.
+            // Gated to debug builds: chars().skip(start) restarts from 0 each call,
+            // making this O(n²) in file size for release runs.
+            #[cfg(debug_assertions)]
+            {
+                let templated_substr: String = template
+                    .templated_str
+                    .chars()
+                    .skip(template_slice.start)
+                    .take(template_slice.len())
+                    .collect();
 
-            if *templated_substr != *element.raw {
-                panic!(
-                    "Template and lexed elements do not match. This should never happen  {:?} != {:?}",
-                    &element.raw, &templated_substr
-                )
+                if *templated_substr != *element.raw {
+                    panic!(
+                        "Template and lexed elements do not match. This should never happen  {:?} != {:?}",
+                        &element.raw, &templated_substr
+                    )
+                }
             }
         }
 


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
`map_template_slices` contained a loop validating each lexed token whether it matches the corresponding template substring. The loop used `chars().skip(n).take(k)`, which restarts from position 0 on every call, making total cost O(n^2) in file size. The check asserts a mathematical invariant the lexer's byte-offset arithmetic already guarantees (if my math skills didn't betray me). 
I didn't want to drop the `panic` message for future regressions but wrap in `#[cfg(debug_assertions)]` making it explicit and eliminating the O(n^2) cost in release builds. 
The saving scales with file size; for shorter TPC-H/TPC-DS queries it is small relative to total lex time.

## Benchmark results
| Suite | Baseline | This branch | vs Baseline |
|---|---|---|---|
| athena/lex_athena | 3393.5 ms | 576.4 ms | -83% |
| tpch/lex_tpch_22 | 22.1 ms | 19.5 ms | -11.6% |
| tpcds/lex_tpcds_99 | 188.0 ms | 176.8 ms | -5.9% |


The athena fixture is a large file where the O(n^2) validation loop dominates lex time. Removing it drops lex cost from 3.4 s to 576 ms, an 83% reduction. For TPC-H and TPC-DS (shorter queries) the loop was proportionally cheaper, so the lex savings are 6-12%.

### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [ ] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gate the `map_template_slices` validation behind `debug_assertions` to remove its O(n^2) cost in release builds. This cuts lexer time on large files by up to 83% while keeping the invariant check in debug builds.

- **Refactors**
  - Wrapped the substring comparison block with `#[cfg(debug_assertions)]` and kept the panic message for regressions.
  - Added `#[cfg(not(debug_assertions))] let _ = template;` to silence the unused variable in release builds.

<sup>Written for commit d21371aece7327cf089c51c1fbd42a8751093dbf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/7994?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

