### PR TITLE
perf(rust): fix O(n²) validation in map_template_slices

### DIFF
--- a/sqlfluffrs/sqlfluffrs_lexer/src/lexer.rs
+++ b/sqlfluffrs/sqlfluffrs_lexer/src/lexer.rs
@@ -283,30 +283,25 @@ impl Lexer {
     ) -> Vec<TemplateElement> {
         let mut idx = 0;
         let mut templated_buff = Vec::new();
+        // Advance once per element rather than restarting from 0 each time,
+        // keeping the validation O(n) in total file size.
+        let mut template_chars = template.templated_str.chars();
 
         for element in elements {
             let element_len = element.raw.chars().count();
             let template_slice = Slice::from(idx..idx + element_len);
             idx += element_len;
 
-            // Create a TemplateElement from the LexedElement and the template slice
-            let templated_element = TemplateElement::from_element(element, template_slice);
-            templated_buff.push(templated_element);
-
-            // // Validate that the slice matches the element's raw content
-            let templated_substr: String = template
-                .templated_str
-                .chars()
-                .skip(template_slice.start)
-                .take(template_slice.len())
-                .collect();
-
+            let templated_substr: String = template_chars.by_ref().take(element_len).collect();
             if *templated_substr != *element.raw {
                 panic!(
                     "Template and lexed elements do not match. This should never happen  {:?} != {:?}",
                     &element.raw, &templated_substr
                 )
             }
+
+            let templated_element = TemplateElement::from_element(element, template_slice);
+            templated_buff.push(templated_element);
         }
 
         templated_buff


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
`map_template_slices` contained a validation loop confirming each lexed token matched the corresponding template substring. The loop used `chars().skip(n).take(k)`, which restarts from position 0 on every call, making total cost O(n²) in file size.

The fix creates a single `Chars` iterator before the loop and advances it by `element_len` on each iteration using `by_ref().take()`, reducing total cost to O(n). Because the check is now cheap, it runs in all build profiles, preserving the correctness invariant in production.

| Suite | Baseline | This branch | vs Baseline |
|---|---|---|---|
| athena/lex_athena | 3393.5 ms | 584.6 ms | -83% |
| tpch/lex_tpch_22 | 22.1 ms | 20.1 ms | -9.3% |
| tpcds/lex_tpcds_99 | 188.0 ms | 168.0 ms | -10.6% |

The athena fixture is a large file where the O(n²) validation loop dominated lex time. Fixing the algorithm drops lex cost from 3.4 s to 585 ms, an 83% reduction. For TPC-H and TPC-DS (shorter queries) the loop was proportionally cheaper, so lex savings are 9-11%.

### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [ ] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes an O(n²) validation loop in the Rust lexer’s map_template_slices by streaming over a single char iterator, making the check O(n). This cuts lex time significantly on large files.

- **Bug Fixes**
  - Iterate with a single `Chars` and advance via `by_ref().take(element_len)` instead of per-element `skip().take()`, and keep the check on in all build profiles.
  - Benchmarks: -83% on `athena/lex_athena` (3.4s → 0.58s); 9–11% speedups on TPC-H/DS.

<sup>Written for commit 6ddbfe77429f7c4e3eb0bacc7ed7698b0ba16efa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/7995?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

