### PR TITLE
perf(rust): eliminate dummy `Arc<MatchResult>` sentinel in `RefState`

### DIFF
--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/frame.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/frame.rs
@@ -227,7 +227,7 @@ pub struct RefState {
     pub last_child_frame_id: Option<usize>,
     /// The actual grammar this Ref resolves to (for casefold lookup).
     pub child_grammar_id: GrammarId,
-    pub match_result: Arc<MatchResult>,
+    pub match_result: Option<Arc<MatchResult>>,
 }
 
 /// Sub-state for Bracketed parsing. The `WaitingForChild` handler in

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/ref_grammar.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/ref_grammar.rs
@@ -127,7 +127,7 @@ impl Parser<'_> {
             saved_pos: child_start_pos,
             last_child_frame_id: Some(stack.frame_id_counter),
             child_grammar_id,
-            match_result: Arc::new(MatchResult::empty_at(start_pos)),
+            match_result: None,
         });
 
         // CRITICAL: Set parent frame state to WaitingForChild so it will
@@ -188,7 +188,7 @@ impl Parser<'_> {
                 frame.frame_id,
                 child_end_pos
             );
-            state.match_result = Arc::clone(child_match);
+            state.match_result = Some(Arc::clone(child_match));
             self.pos = *child_end_pos;
             frame.end_pos = Some(*child_end_pos);
         } else {
@@ -227,19 +227,14 @@ impl Parser<'_> {
 
         vdebug!("Ref[table] Combining: frame_id={}", frame.frame_id,);
 
-        // Debug: print accumulated children to inspect whether typed tokens are present
-        if !state.match_result.is_empty() {
-            vdebug!(
-                "Ref[table] Combining DEBUG: accumulated nodes={:?}",
-                state.match_result
-            );
-        }
-
         // Build final result
         let final_pos = frame.end_pos.unwrap_or(frame.pos);
-        let result_match = if state.match_result.is_empty() {
-            MatchResult::empty_at(frame.pos)
-        } else {
+        let result_match = if let Some(ref_match_result) = &state.match_result {
+            // Debug: print accumulated children to inspect whether typed tokens are present
+            vdebug!(
+                "Ref[table] Combining DEBUG: accumulated nodes={:?}",
+                ref_match_result
+            );
             // TODO: make this cleaner
             // Python parity for leaf token grammars (CodeSegment, WordSegment etc.):
             // When `Ref("CodeSegment")` resolves to Token("raw") and matches a token,
@@ -255,12 +250,12 @@ impl Parser<'_> {
             let effective_segment_type = if let Some(seg_type) = state.segment_type.as_deref() {
                 // Check if the child match is a bare single-token match (no matched_class)
                 // by looking at the match_result's matched_class and slice length
-                let is_bare_token_match = state.match_result.matched_class.is_none()
-                    && state.match_result.matched_slice.len() == 1
-                    && state.match_result.child_matches.is_empty();
+                let is_bare_token_match = ref_match_result.matched_class.is_none()
+                    && ref_match_result.matched_slice.len() == 1
+                    && ref_match_result.child_matches.is_empty();
 
                 if is_bare_token_match {
-                    let token_idx = state.match_result.matched_slice.start;
+                    let token_idx = ref_match_result.matched_slice.start;
                     if let Some(tok) = self.tokens.get(token_idx) {
                         // Get effective type as &str WITHOUT cloning first so the common
                         // case (types already match) pays no allocation cost.
@@ -324,8 +319,10 @@ impl Parser<'_> {
                 // start_idx,
                 state.saved_pos,
                 final_pos,
-                vec![state.match_result.clone()],
+                vec![Arc::clone(ref_match_result)],
             )
+        } else {
+            MatchResult::empty_at(frame.pos)
         };
 
         self.pos = final_pos;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
Replace the empty `Arc<MatchResult>` used to initialise `RefState.match_result` with `Option<Arc<MatchResult>>`. The old sentinel required allocating a heap-resident `MatchResult` for every `Ref` frame pushed onto the parse stack, even when the child ultimately returned empty. Switching to `None` eliminates that allocation on the failure path and removes a spurious `Arc::clone` on the success path.

### Benchmarks
| Benchmark | Before | After | Delta |
|---|---|---|---|
| `athena / parse` | 4.456 s | 4.085 s | -8.3% |
| `tpch / parse` | 148.9 ms | 139.2 ms | -6.5% |
| `tpcds / parse` | 1.536 s | 1.454 s | -5.3% |

### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [ ] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switched `RefState.match_result` from a dummy `Arc<MatchResult>` sentinel to `Option<Arc<MatchResult>>` to cut allocations and speed up parsing. This removes a per-frame heap allocation on failures and one clone on success.

- **Refactors**
  - Changed `RefState.match_result` to `Option<Arc<MatchResult>>`; start at `None`, set `Some` only on child match; default to `MatchResult::empty_at` when absent.
  - Benchmarks: athena/parse −8.3% (4.456s → 4.085s); tpch/parse −6.5% (148.9ms → 139.2ms); tpcds/parse −5.3% (1.536s → 1.454s).

<sup>Written for commit e8cc2cbb4bb6a2c2e470d3fe8477be59cd484d0a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/7996?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

