### PR TITLE
perf: replace per-token uuid4 with a tagged monotonic counter (Python + Rust)

### DIFF
--- a/sqlfluffrs/sqlfluffrs_types/src/identity.rs
+++ b/sqlfluffrs/sqlfluffrs_types/src/identity.rs
@@ -1,0 +1,55 @@
+//! Process-global unique identifiers for tokens.
+//!
+//! Replaces per-token `Uuid::new_v4()`. A token's `uuid` is only ever used as
+//! an opaque identity key (compared by equality and used as a map key in the
+//! fix engine); it is never parsed back as an RFC-4122 UUID, so a monotonic
+//! counter is sufficient -- and far cheaper than drawing 16 bytes of CSPRNG
+//! entropy per token.
+//!
+//! The high bits carry a source tag so these ids stay disjoint from ids minted
+//! on the Python side (which uses `PYTHON_TAG = 1 << 120`). `PyToken.uuid`
+//! surfaces this `u128` to Python verbatim, where Python-created segments and
+//! Rust-origin tokens share one id space inside the fix engine. Without the
+//! tag, both counters would start at 1 and a Rust token would collide with an
+//! unrelated Python segment.
+//!
+//! NOTE: this is the token *identity* uuid only. Templated `block_uuid`s remain
+//! genuine `Uuid`s -- they are round-tripped through `Uuid::parse_str` at the
+//! Python boundary and must keep RFC-4122 structure.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// Source tag OR'd into the high bits of every Rust-minted id. Must stay
+/// distinct from the Python tag (`1 << 120`). `2 << 120` sets bit 121, leaving
+/// the low 120 bits for the counter; both fit within a `u128`.
+const RUST_TAG: u128 = 2u128 << 120;
+
+static COUNTER: AtomicU64 = AtomicU64::new(1);
+
+/// Return a process-unique, source-tagged token identifier.
+///
+/// `fetch_add` with `Relaxed` ordering is correct here: we need atomic
+/// uniqueness, not any happens-before relationship with other memory, so the
+/// cheapest ordering suffices.
+pub fn next_id() -> u128 {
+    RUST_TAG | (COUNTER.fetch_add(1, Ordering::Relaxed) as u128)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Tag must match Python's convention and never overlap its space.
+    const PYTHON_TAG: u128 = 1u128 << 120;
+
+    #[test]
+    fn ids_are_tagged_unique_and_disjoint_from_python() {
+        let a = next_id();
+        let b = next_id();
+        assert_ne!(a, b, "ids must be unique");
+        assert_eq!(a >> 120, 0b10, "rust tag (bit 121) must be set");
+        // A Rust id can never equal a Python id: their tag bits differ.
+        assert_ne!(a & !(RUST_TAG | PYTHON_TAG), a, "counter occupies low bits");
+        assert_eq!(RUST_TAG & PYTHON_TAG, 0, "tag spaces must not overlap");
+    }
+}

--- a/sqlfluffrs/sqlfluffrs_types/src/lib.rs
+++ b/sqlfluffrs/sqlfluffrs_types/src/lib.rs
@@ -2,6 +2,7 @@ pub mod config;
 pub mod grammar_api;
 pub mod grammar_inst;
 pub mod grammar_tables;
+pub mod identity;
 pub mod marker;
 pub mod matcher;
 pub mod parser;

--- a/sqlfluffrs/sqlfluffrs_types/src/token/construction.rs
+++ b/sqlfluffrs/sqlfluffrs_types/src/token/construction.rs
@@ -49,7 +49,7 @@ impl Token {
             segments,
             preface_modifier: "".to_string(),
             suffix: "".to_string(),
-            uuid: Uuid::new_v4().as_u128(),
+            uuid: crate::identity::next_id(),
             source_fixes: None,
             trim_start,
             trim_chars,

--- a/sqlfluffrs/sqlfluffrs_types/src/token/mod.rs
+++ b/sqlfluffrs/sqlfluffrs_types/src/token/mod.rs
@@ -334,7 +334,7 @@ impl Token {
         Self {
             raw: raw.unwrap_or(self.raw.clone()),
             source_fixes: Some(source_fixes.unwrap_or(self.source_fixes())),
-            uuid: Uuid::new_v4().as_u128(),
+            uuid: crate::identity::next_id(),
             ..self.clone()
         }
     }

--- a/src/sqlfluff/core/helpers/identity.py
+++ b/src/sqlfluff/core/helpers/identity.py
@@ -1,0 +1,39 @@
+"""Process-global unique identifiers for segments.
+
+Replaces per-instance ``uuid4()`` generation. A monotonic counter is
+sufficient because segment ``uuid`` values are only ever used as opaque,
+in-memory identity keys (dict keys and ``==`` in the fix engine). They never
+need cryptographic unpredictability or cross-process uniqueness, and are never
+parsed back as RFC-4122 UUIDs.
+
+The high bits carry a source tag so these ids stay disjoint from token ids
+minted on the Rust side (see the ``identity`` module in ``sqlfluffrs_types``,
+which uses ``RUST_TAG = 2 << 120``). Both runtimes count from 1, so without the
+tag a Python-created segment and a Rust-origin token would share low integer
+ids -- and the fix engine would then treat two unrelated segments as the same
+anchor. This is not hypothetical: ``PyToken.uuid`` surfaces the Rust ``u128``
+to Python verbatim, so the two id spaces genuinely meet inside one tree.
+"""
+
+from __future__ import annotations
+
+import itertools
+
+# Source tag OR'd into the high bits of every Python-minted id. Must stay
+# distinct from the Rust tag (``2 << 120``). Fits within 128 bits alongside any
+# realistic process-lifetime counter value (which is always < ``2 ** 120``).
+_PYTHON_TAG = 1 << 120
+
+_counter = itertools.count(1)
+
+
+def get_next_id() -> int:
+    """Return a process-unique, source-tagged identifier.
+
+    ``next()`` on an ``itertools.count`` is atomic under the CPython GIL -- its
+    C-level ``__next__`` never releases the GIL mid-increment -- so this is
+    thread-safe without an explicit lock. Avoiding the lock is the point: it
+    keeps the per-segment cost to a single counter increment rather than
+    re-introducing the lock acquire/release that motivated dropping ``uuid4``.
+    """
+    return _PYTHON_TAG | next(_counter)

--- a/src/sqlfluff/core/parser/segments/base.py
+++ b/src/sqlfluff/core/parser/segments/base.py
@@ -12,7 +12,6 @@ Here we define:
 from __future__ import annotations
 
 import logging
-import os
 import weakref
 from collections.abc import Iterator, Sequence
 from dataclasses import dataclass
@@ -29,6 +28,7 @@ from typing import (
     cast,
 )
 
+from sqlfluff.core.helpers.identity import get_next_id
 from sqlfluff.core.helpers.slice import is_zero_slice
 from sqlfluff.core.parser.context import ParseContext
 from sqlfluff.core.parser.helpers import trim_non_code_segments
@@ -139,10 +139,10 @@ class SegmentMetaclass(type, Matchable):
         here saves calculating it at runtime for each
         instance of the class.
         """
-        # Create a cache uuid on definition.
+        # Create a cache key on definition.
         # We do it here so every _definition_ of a segment
-        # gets a unique UUID regardless of dialect.
-        class_dict["_cache_key"] = os.urandom(16).hex()
+        # gets a unique key regardless of dialect.
+        class_dict["_cache_key"] = format(get_next_id(), "x")
 
         # Populate the `_class_types` property on creation.
         added_type = class_dict.get("type", None)
@@ -215,9 +215,8 @@ class BaseSegment(metaclass=SegmentMetaclass):
         self.pos_marker = pos_marker
         self.segments: tuple[BaseSegment, ...] = segments
         # Tracker for matching when things start moving.
-        # NOTE: We're storing the .int attribute so that it's swifter
-        # for comparisons.
-        self.uuid = uuid or int.from_bytes(os.urandom(16), "big")
+        # NOTE: We store a plain int so that it's swift for comparisons.
+        self.uuid = uuid or get_next_id()
 
         self.set_as_parent(recurse=False)
         self.validate_non_code_ends()

--- a/src/sqlfluff/core/parser/segments/raw.py
+++ b/src/sqlfluff/core/parser/segments/raw.py
@@ -5,11 +5,11 @@ any children, and the output of the lexer.
 """
 
 import functools
-import os
 from typing import TYPE_CHECKING, Any, Callable, Optional, Union, cast
 
 import regex as re
 
+from sqlfluff.core.helpers.identity import get_next_id
 from sqlfluff.core.parser.markers import PositionMarker
 from sqlfluff.core.parser.segments.base import BaseSegment, SourceFix
 
@@ -74,8 +74,8 @@ class RawSegment(BaseSegment):
         self.trim_chars = trim_chars
         # Keep track of any source fixes
         self._source_fixes = source_fixes
-        # UUID for matching (the int attribute of it)
-        self.uuid = uuid or int.from_bytes(os.urandom(16), "big")
+        # Identifier for matching (a plain int, swift for comparisons).
+        self.uuid = uuid or get_next_id()
         self.quoted_value = quoted_value
         self.escape_replacements = escape_replacements
         self.casefold = casefold


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Replace per-instance `uuid4()` / `Uuid::new_v4()` segment-id generation with a process-global monotonic counter on both the Python and Rust sides.

Because `PyToken.uuid` surfaces the Rust `u128` to Python verbatim, a fixed tree mixes Rust-origin tokens with Python-created segments in one id space. To keep the two counters from colliding (both start at 1), each id carries a source tag in its high bits — Python `1 << 120`, Rust `2 << 120` — so a Rust id can never equal a Python id.

### Benchmarks
Per-call cost of the id generator (called once per token/segment). Isolated microbenchmarks — an explicit end-to-end parse delta is omitted because the Rust match-application path currently falls back to Python on this branch, which would muddy attribution.

Python (`timeit`, 2M calls, 3.13):

| method | ns/call | vs uuid4 |
|---|---|---|
| `uuid4().int` (before) | 1201 | 1.00x |
| `os.urandom(16)` int (#7988) | 809 | 0.67x |
| `get_next_id()` (after) | 35.3 | 0.03x (~34x faster) |

Rust (`criterion`, release):

| method | ns/call | vs uuid4 |
|---|---|---|
| `Uuid::new_v4().as_u128()` (before) | ~740 | 1.00x |
| `next_id()` (after) | ~1.6 | ~466x faster |

### Are there any other side effects of this change that we should be aware of?
Segment/token `uuid`s are now small tagged sequential integers rather than random 128-bit values. They remain unique within a process (the only property the fix engine relies on) but are no longer globally/cross-process unique, and are no longer valid RFC-4122 UUIDs.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced per-token UUIDs with a fast, process-global monotonic counter in Python and Rust. IDs are source-tagged to keep Python (`1 << 120`) and Rust (`2 << 120`) spaces disjoint, cutting per-id cost by ~34x (Python) and ~466x (Rust).

- **Refactors**
  - Added `get_next_id()` in `sqlfluff.core.helpers.identity` and `identity::next_id()` in `sqlfluffrs_types`.
  - Replaced `uuid4()`/`os.urandom(16)` and `Uuid::new_v4()` for segment/token `uuid` fields with tagged counters; `block_uuid` remains an RFC-4122 UUID.
  - Updated segment class `_cache_key` to use `get_next_id()` (hex).

<sup>Written for commit a635170eaf11536fa0f336da2323ad7d647db592. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/7997?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

