### PR TITLE
Fix RF02 false positive on SELECT * EXCEPT (...) columns

### DIFF
--- a/src/sqlfluff/utils/analysis/select.py
+++ b/src/sqlfluff/utils/analysis/select.py
@@ -70,6 +70,26 @@ def _get_struct_alias_refs(segment: BaseSegment) -> set[int]:
     return struct_alias_ids
 
 
+def _get_select_except_refs(segment: BaseSegment) -> set[int]:
+    """Get the ids of object references inside a SELECT * EXCEPT clause.
+
+    Dialects like Databricks, SparkSQL, and ClickHouse support
+    ``SELECT t.* EXCEPT (col1, col2)`` where the excluded columns are listed
+    inside an ``EXCEPT (...)`` clause. Those columns name what to drop from the
+    star expansion, so they don't need to be qualified and shouldn't be treated
+    as ordinary column references by rules like RF02.
+    See: https://github.com/sqlfluff/sqlfluff/issues/5764
+    """
+    except_ref_ids: set[int] = set()
+    for except_clause in segment.recursive_crawl(
+        "select_except_clause",
+        no_recursive_seg_type=["select_statement", "merge_statement"],
+    ):
+        for ref in except_clause.recursive_crawl("object_reference"):
+            except_ref_ids.add(id(ref))
+    return except_ref_ids
+
+
 def _get_object_references(
     segment: BaseSegment,
     exclude_ids: Optional[set[int]] = None,
@@ -110,8 +130,11 @@ def get_select_statement_info(
     # Identify references that are aliases inside STRUCT() functions so we can
     # exclude them. These are alias definitions, not real column references.
     # See: https://github.com/sqlfluff/sqlfluff/issues/6919
-    struct_alias_ids = _get_struct_alias_refs(sc)
-    reference_buffer = _get_object_references(sc, exclude_ids=struct_alias_ids)
+    # Also identify columns listed in a SELECT * EXCEPT (...) clause; those name
+    # columns to drop from the star expansion and don't need qualification.
+    # See: https://github.com/sqlfluff/sqlfluff/issues/5764
+    exclude_ref_ids = _get_struct_alias_refs(sc) | _get_select_except_refs(sc)
+    reference_buffer = _get_object_references(sc, exclude_ids=exclude_ref_ids)
     table_reference_buffer = []
     for potential_clause in (
         "where_clause",

--- a/test/fixtures/rules/std_rule_cases/RF02.yml
+++ b/test/fixtures/rules/std_rule_cases/RF02.yml
@@ -694,3 +694,48 @@ test_pass_redshift_array_unnest:
   configs:
     core:
       dialect: redshift
+
+test_pass_databricks_star_except:
+  # Columns inside a SELECT * EXCEPT (...) clause name what to drop from the
+  # star expansion, so they don't need qualification.
+  # https://github.com/sqlfluff/sqlfluff/issues/5764
+  pass_str: |
+    SELECT
+        test.* EXCEPT (test_column),
+        test_2.*
+    FROM test
+    LEFT JOIN test_2 ON test.test_column = test_2.test_column
+  configs:
+    core:
+      dialect: databricks
+
+test_pass_sparksql_star_except:
+  pass_str: |
+    SELECT a.* EXCEPT (col_one, col_two)
+    FROM table_a AS a
+    JOIN table_b AS b ON a.id = b.id
+  configs:
+    core:
+      dialect: sparksql
+
+test_pass_clickhouse_star_except:
+  pass_str: |
+    SELECT a.* EXCEPT (col_one, col_two)
+    FROM table_a AS a
+    JOIN table_b AS b ON a.id = b.id
+  configs:
+    core:
+      dialect: clickhouse
+
+test_fail_unqualified_reference_with_star_except:
+  # The EXCEPT exclusion is scoped to the EXCEPT clause; a genuinely
+  # unqualified reference elsewhere in the select should still fail.
+  fail_str: |
+    SELECT
+        a.* EXCEPT (col_one),
+        col_two
+    FROM table_a AS a
+    JOIN table_b AS b ON a.id = b.id
+  configs:
+    core:
+      dialect: databricks


### PR DESCRIPTION
Fixes #5764.

RF02 was wrongly flagging the columns inside a `SELECT * EXCEPT (col1, col2)` clause as unqualified references. Those columns just name what to drop from the star expansion, so they don't need to be qualified and shouldn't be treated like ordinary column references.

The fix excludes object references that descend from a `select_except_clause` when building the select clause reference buffer, mirroring the existing STRUCT-alias exclusion (`exclude_ids`) that was added for #6919. Because it's a single change in the shared analysis layer, it covers every dialect that has an EXCEPT clause: Databricks, SparkSQL, ClickHouse, and BigQuery.

I kept the scope to the EXCEPT false positive only. The separate semi/anti-join request from the issue comments is left out.

Validation:
- added pass cases for databricks/sparksql/clickhouse plus a fail case proving a genuinely unqualified reference elsewhere in the same select still gets flagged
- `python -m pytest test/rules/yaml_test_cases_test.py -k "RF01 or RF02 or RF03 or AL05"` is green (337 passed)
- re-ran the issue's repro and the false positive is gone

I used AI assistance while working on this, but I wrote and reviewed the change and the tests myself and verified the behavior locally.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes RF02 falsely flagging columns listed in SELECT * EXCEPT (...) as unqualified. We now ignore those names during select analysis, removing the false positive across Databricks, SparkSQL, ClickHouse, and BigQuery.

- **Bug Fixes**
  - Exclude `object_reference` nodes under `select_except_clause` when building the select reference buffer, mirroring the STRUCT alias exclusion.
  - Added tests for Databricks, SparkSQL, and ClickHouse, plus a counterexample to ensure genuine unqualified references still fail.

<sup>Written for commit dd0212d63ae566fe5d7622127695ebfcb86d776d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/7999?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

