### PR TITLE
fix(rust): flatten only raw-segment wrappers in `Node::to_tuple`

### DIFF
--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/types.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/types.rs
@@ -231,7 +231,11 @@ impl Node {
                     NodeTupleValue::Tuple(type_str.to_string(), vec![])
                 }
             }
-            Node::Segment { children, .. } => {
+            Node::Segment {
+                children,
+                class_types,
+                ..
+            } => {
                 // Collect relevant children (respecting code_only and include_meta).
                 let relevant_children: Vec<&Node> = children
                     .iter()
@@ -246,23 +250,17 @@ impl Node {
                     })
                     .collect();
 
-                // Special case: if the segment has exactly one child that is a Raw node
-                // with the SAME segment_type as this Segment, treat this segment as a leaf.
-                // This handles cases where a Segment wrapper still exists around a single
-                // token of matching type (e.g. WordSegment wrapping word Raw node).
-                //
-                // We do NOT apply this when types differ (e.g. select_clause_element
-                // wrapping numeric_literal) — that must remain nested to match Python output.
-                if show_raw && relevant_children.len() == 1 {
-                    if let Node::Raw {
-                        raw,
-                        segment_type: child_type,
-                        ..
-                    } = relevant_children[0]
-                    {
-                        if self.get_type() == *child_type {
-                            return NodeTupleValue::Raw(self.get_type(), raw.clone());
-                        }
+                // Collapse a single-Raw-child Segment to a leaf `(type, raw)`,
+                // mirroring Python's bare `RawSegment`. Only raw-segment classes
+                // (LiteralSegment/WordSegment/...) are spurious wrappers here; they
+                // carry `"raw"` in `class_types`, while genuine containers
+                // (e.g. ColumnIndexSegment, FileLiteralSegment) lack it and stay nested.
+                if show_raw
+                    && relevant_children.len() == 1
+                    && class_types.iter().any(|t| t == "raw")
+                {
+                    if let Node::Raw { raw, .. } = relevant_children[0] {
+                        return NodeTupleValue::Raw(self.get_type(), raw.clone());
                     }
                 }
 


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
`Node::to_tuple` collapsed any single-Raw-child Segment whose type matched its child's type into a leaf. That over-flattened genuine container segments that Python keeps nested (e.g. duckdb `ColumnIndexSegment`, sparksql `FileLiteralSegment`), and missed spurious wrappers whose child type differs (e.g. `binary_operator` wrapping the DIV keyword).

### Are there any other side effects of this change that we should be aware of?
Note: sparksql `add_jar`'s `file_literal` nesting is also corrected by this change, but a separate residual leaf-type mismatch there (`file_literal` vs `literal`, from a `TypedParser` defined without an explicit `type=`) is out of scope and left for a follow-up.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Limit flattening in `Node::to_tuple` to raw-segment wrappers so the Rust tuple output matches Python and avoids collapsing real container segments.

- **Bug Fixes**
  - Flatten only when `class_types` contains "raw" and there is a single `Raw` child; return `(type, raw)`.
  - Keep container segments nested (e.g., duckdb `ColumnIndexSegment`, sparksql `FileLiteralSegment`). Fixes over-flattening and corrects `add_jar` `file_literal` nesting; a separate `file_literal` vs `literal` mismatch is left for follow-up.

<sup>Written for commit 94e193d274072e1ef0367771762eb73b52cbdc3d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8000?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

