### PR TITLE
fix(rust): match Python leaf segment types for TypedParser and Anything brackets

### DIFF
--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/core.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/core.rs
@@ -656,55 +656,30 @@ impl<'a> Parser<'a> {
                 let (effective_segment_type, instance_types_vec) = if let Some(cls_type) =
                     class_type
                 {
-                    if token_type == cls_type {
-                        // No explicit type override: TypedParser was invoked like Python's
-                        // isinstance path. Preserve the token's own type and instance_types
-                        // so that e.g. a WordSegment token matching Ref("CodeSegment") outputs
-                        // `word: value` instead of `raw: value`, or a double_quote token outputs
-                        // `double_quote: "value"` instead of `raw: "value"`.
-                        //
-                        // This mirrors Python's RawSegment.get_type():
-                        //   if instance_types: return instance_types[0]
-                        //   return super().get_type()  (= class type attribute)
-                        let tok_effective_type = tok
-                            .instance_types
-                            .first()
-                            .cloned()
-                            .unwrap_or_else(|| tok.token_type.clone());
-                        let tok_inst = tok.instance_types.clone();
-                        vdebug!(
-                            "TypedParser[table] isinstance-path: token_type='{}' == cls_type='{}', preserving effective_type='{}', instance_types={:?}",
-                            token_type,
-                            cls_type,
-                            tok_effective_type,
-                            tok_inst
-                        );
-                        (tok_effective_type, tok_inst)
-                    } else {
-                        // Explicit type override: use configured instance_types from
-                        // codegen (Python parity), with old-schema fallback.
-                        let mut vec = configured_instance_types;
-                        if cls_type != token_type && !vec.iter().any(|t| t == cls_type) {
-                            vec.push(cls_type.to_string());
-                        }
-                        if template != token_type
-                            && template != cls_type
-                            && !vec.iter().any(|t| t == &template)
-                        {
-                            vec.push(template.to_string());
-                        }
-                        let effective_type = vec
-                            .first()
-                            .cloned()
-                            .unwrap_or_else(|| token_type.to_string());
-                        vdebug!(
-                            "TypedParser[table] explicit-override-path: token_type='{}' != cls_type='{}', instance_types={:?}",
-                            token_type,
-                            cls_type,
-                            vec
-                        );
-                        (effective_type, vec)
+                    // Python parity: TypedParser always overrides the token's
+                    // instance_types with its configured `_instance_types`
+                    // (= `configured_instance_types`), so the leaf type is
+                    // `_instance_types[0]` (e.g. `literal`, not the token's
+                    // lexer type `file_literal`).
+                    let mut vec = configured_instance_types;
+                    if !vec.iter().any(|t| t == cls_type) {
+                        vec.push(cls_type.to_string());
                     }
+                    if template != cls_type && !vec.iter().any(|t| t == &template) {
+                        vec.push(template.to_string());
+                    }
+                    let effective_type = vec
+                        .first()
+                        .cloned()
+                        .unwrap_or_else(|| token_type.to_string());
+                    vdebug!(
+                        "TypedParser[table] configured-path: token_type='{}' cls_type='{}' template='{}' instance_types={:?}",
+                        token_type,
+                        cls_type,
+                        template,
+                        vec
+                    );
+                    (effective_type, vec)
                 } else {
                     // Fallback: no class type info available, use TypedParser config as-is
                     log::warn!(
@@ -1602,10 +1577,12 @@ impl<'a> Parser<'a> {
     /// This ensures that nested brackets inside Anything grammars produce
     /// proper BracketedSegment child_matches.
     fn match_bracket_recursively(&mut self, open_bracket: &str, persists: bool) -> MatchResult {
-        let close_bracket = match open_bracket {
-            "(" => ")",
-            "[" => "]",
-            "{" => "}",
+        // Python parity: bracket leaf type depends on the bracket char
+        // (`[`→square, `{`→curly); only `(` uses the plain bracket type.
+        let (close_bracket, start_bracket_type, end_bracket_type) = match open_bracket {
+            "(" => (")", "start_bracket", "end_bracket"),
+            "[" => ("]", "start_square_bracket", "end_square_bracket"),
+            "{" => ("}", "start_curly_bracket", "end_curly_bracket"),
             _ => unreachable!(),
         };
 
@@ -1616,9 +1593,9 @@ impl<'a> Parser<'a> {
             matched_slice: self.pos..self.pos + 1,
             matched_class: Some(MatchedClass {
                 class_name: "SymbolSegment".to_string(),
-                segment_type: Some("start_bracket".to_string()),
+                segment_type: Some(start_bracket_type.to_string()),
                 segment_kwargs: SegmentKwargs {
-                    instance_types: Some(vec!["start_bracket".to_string()]),
+                    instance_types: Some(vec![start_bracket_type.to_string()]),
                     ..Default::default()
                 },
             }),
@@ -1664,9 +1641,9 @@ impl<'a> Parser<'a> {
             matched_slice: bracket_end - 1..bracket_end,
             matched_class: Some(MatchedClass {
                 class_name: "SymbolSegment".to_string(),
-                segment_type: Some("end_bracket".to_string()),
+                segment_type: Some(end_bracket_type.to_string()),
                 segment_kwargs: SegmentKwargs {
-                    instance_types: Some(vec!["end_bracket".to_string()]),
+                    instance_types: Some(vec![end_bracket_type.to_string()]),
                     ..Default::default()
                 },
             }),


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
This fixes two leave-type divergences:

- A TypedParser with no explicit `type=` (e.g. `TypedParser("file_literal", LiteralSegment)`) kept the matched token's own lexer type instead of the parser's configured `_instance_types`. Python's RawSegment.from_result_segments always overrides with the parser kwargs, so the primary type is [0]` (e.g. `literal`, not `file_literal`). Always use the configured instance types; drop the Rust-only "isinstance" heuristic.

- match_bracket_recursively (brackets inside Anything grammars) hardcoded start_bracket/end_bracket for every bracket kind. Type by character so `[`/`]` -> start/end_square_bracket and `{`/`}` -> start/end_curly_bracket, matching Python's dialect StringParsers; `(`/`)` stay start/end_bracket.

### Are there any other side effects of this change that we should be aware of?
None

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Align Rust parser leaf segment types with Python behavior for consistent outputs. Fixes `TypedParser` leaf typing and bracket token types inside `Anything` grammars.

- **Bug Fixes**
  - `TypedParser`: Always use configured `_instance_types`; leaf type is `_instance_types[0]`. Removed the Rust-only isinstance heuristic.
  - `Anything` brackets: Type by character — `(`/`)` → `start_bracket`/`end_bracket`, `[`/`]` → `start_square_bracket`/`end_square_bracket`, `{`/`}` → `start_curly_bracket`/`end_curly_bracket`.

<sup>Written for commit 9d65cc6550cd4f734cc792444a48765a9ba35724. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8001?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

