### PR TITLE
perf(rust): replace Vec/String frame fields with SmallVec and static str

### DIFF
--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/frame.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/frame.rs
@@ -26,6 +26,7 @@
 //! See the glossary in `ENGINE.md` for the full list.
 
 use hashbrown::HashMap;
+use smallvec::SmallVec;
 use std::sync::Arc;
 
 use crate::parser::MetaSegment;
@@ -82,7 +83,7 @@ pub enum FrameContext {
 #[derive(Debug, Clone)]
 pub struct AnyNumberOfState {
     pub grammar_id: GrammarId,
-    pub pruned_children: Vec<GrammarId>,
+    pub pruned_children: SmallVec<[GrammarId; 8]>,
     pub count: usize,
     pub matched_idx: usize,
     pub working_idx: usize,
@@ -192,7 +193,7 @@ pub struct SequenceState {
 pub struct OneOfState {
     pub grammar_id: GrammarId,
     /// Children after simple_hint pruning.
-    pub pruned_children: Vec<GrammarId>,
+    pub pruned_children: SmallVec<[GrammarId; 8]>,
     pub post_skip_pos: usize,
     /// Best candidate seen so far, as `(result, consumed, child_grammar_id)`
     /// where `consumed = child_end_pos - post_skip_pos` (token count, NOT an
@@ -218,9 +219,9 @@ pub struct OneOfState {
 #[derive(Debug, Clone)]
 pub struct RefState {
     pub grammar_id: GrammarId,
-    pub name: String,
-    pub segment_class_name: Option<String>,
-    pub segment_type: Option<String>,
+    pub name: &'static str,
+    pub segment_class_name: Option<&'static str>,
+    pub segment_type: Option<&'static str>,
     /// Position the child was started at (after any leading-transparent skip);
     /// the position restored when the child comes back empty.
     pub saved_pos: usize,

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/helpers.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/helpers.rs
@@ -269,7 +269,7 @@ impl<'a> Parser<'a> {
     /// Prune options for table-driven parsing based on simple hints.
     ///
     /// This is the table-driven equivalent of prune_options().
-    pub(crate) fn prune_options(&mut self, options: &[GrammarId]) -> Vec<GrammarId> {
+    pub(crate) fn prune_options(&mut self, options: &[GrammarId]) -> SmallVec<[GrammarId; 8]> {
         // Track stats
         self.metrics
             .pruning_calls
@@ -286,7 +286,7 @@ impl<'a> Parser<'a> {
             self.metrics
                 .pruning_kept
                 .set(self.metrics.pruning_kept.get() + options.len());
-            return options.to_vec();
+            return SmallVec::from_slice(options);
         };
 
         // Get token properties for matching
@@ -301,7 +301,7 @@ impl<'a> Parser<'a> {
             first_types
         );
 
-        let mut available_options = Vec::new();
+        let mut available_options = SmallVec::<[GrammarId; 8]>::new();
 
         // Get grammar tables if available
         let tables = Some(self.grammar_ctx.tables());
@@ -579,7 +579,7 @@ impl<'a> Parser<'a> {
     /// Prune terminators for table-driven parsing based on simple matchers.
     ///
     /// This is the table-driven equivalent of prune_terminators().
-    fn prune_terminators(&mut self, terminators: &[GrammarId]) -> Vec<GrammarId> {
+    fn prune_terminators(&mut self, terminators: &[GrammarId]) -> SmallVec<[GrammarId; 8]> {
         // Reuse the same pruning logic as prune_options
         self.prune_options(terminators)
     }

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/match_result.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/match_result.rs
@@ -151,7 +151,7 @@ impl MatchResult {
 
     /// Create a MatchResult for a Ref with child matches (lazy evaluation)
     pub fn ref_match(
-        _name: String,
+        _name: &'static str,
         matched_class: Option<MatchedClass>,
         start_idx: usize,
         end_idx: usize,

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/contexts.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/contexts.rs
@@ -1,3 +1,4 @@
+use smallvec::SmallVec;
 use std::sync::Arc;
 
 use sqlfluffrs_types::GrammarId;
@@ -125,7 +126,7 @@ impl crate::parser::AnyNumberOfState {
 
     #[inline]
     pub(crate) fn reset_for_next_repetition(&mut self, new_pruned_children: &[GrammarId]) {
-        self.pruned_children = new_pruned_children.to_vec();
+        self.pruned_children = SmallVec::from_slice(new_pruned_children);
         self.longest_match = (
             Arc::new(MatchResult::empty_at(self.longest_match.0.end())),
             None,

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/ref_grammar.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/ref_grammar.rs
@@ -26,7 +26,7 @@ impl Parser<'_> {
 
         // Get rule name via GrammarContext helper which knows how names are
         // stored in aux_data (generator packs ref names into aux_data).
-        let rule_name = self.grammar_ctx.ref_name(grammar_id).to_string();
+        let rule_name = self.grammar_ctx.ref_name(grammar_id);
 
         vdebug!(
             "Ref[table] Initial: frame_id={}, pos={}, grammar_id={}, rule={}",
@@ -97,7 +97,7 @@ impl Parser<'_> {
         // If the explicit child grammar allows gaps, collect leading transparent
         // tokens so child parsing starts at the next non-transparent token.
         let child_allows_gaps = self.grammar_ctx.inst(child_grammar_id).flags.allow_gaps();
-        let this_type = self.grammar_ctx.get_type(grammar_id);
+        let this_type = self.grammar_ctx.segment_type(grammar_id);
         let child_start_pos = if child_allows_gaps {
             self.skip_start_index_forward_to_code(start_pos, self.tokens.len())
         } else {
@@ -107,10 +107,7 @@ impl Parser<'_> {
         // Determine the segment_class (Python class name) from tables
         // This is what gets stored in matched_class for Python lookup
         // e.g., "ProcedureDefinitionGrammar", "SelectStatementSegment", etc.
-        let table_segment_class = self
-            .grammar_ctx
-            .segment_class(grammar_id)
-            .map(|s| s.to_string());
+        let table_segment_class = self.grammar_ctx.segment_class(grammar_id);
 
         vdebug!(
             "Ref[table]: rule_name='{}', table_segment_class={:?}",
@@ -284,7 +281,7 @@ impl Parser<'_> {
                     seg_type.to_string()
                 }
             } else {
-                state.segment_type.clone().unwrap_or_default()
+                state.segment_type.unwrap_or_default().to_string()
             };
 
             vdebug!(
@@ -299,7 +296,7 @@ impl Parser<'_> {
                     Some(MatchedClass {
                         // take() instead of clone() + unwrap — frame context is not read
                         // again after this point (state transitions to Complete).
-                        class_name: state.segment_class_name.take().unwrap_or_default(),
+                        class_name: state.segment_class_name.take().unwrap_or_default().to_string(),
                         segment_type: Some(effective_segment_type),
                         segment_kwargs: SegmentKwargs {
                             class_types,
@@ -313,8 +310,7 @@ impl Parser<'_> {
             // let start_idx = self.skip_start_index_forward_to_code(*saved_pos, final_pos);
 
             MatchResult::ref_match(
-                // std::mem::take avoids a clone since the context won't be accessed again.
-                std::mem::take(&mut state.name),
+                state.name,
                 matched_class,
                 // start_idx,
                 state.saved_pos,

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/ref_grammar.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/ref_grammar.rs
@@ -296,7 +296,11 @@ impl Parser<'_> {
                     Some(MatchedClass {
                         // take() instead of clone() + unwrap — frame context is not read
                         // again after this point (state transitions to Complete).
-                        class_name: state.segment_class_name.take().unwrap_or_default().to_string(),
+                        class_name: state
+                            .segment_class_name
+                            .take()
+                            .unwrap_or_default()
+                            .to_string(),
                         segment_type: Some(effective_segment_type),
                         segment_kwargs: SegmentKwargs {
                             class_types,


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
OneOfState.pruned_children and AnyNumberOfState.pruned_children switch from Vec to SmallVec<[GrammarId; 8]>, avoiding heap allocation for the common case of few options. RefState.name, segment_class_name, and segment_type switch from owned String/Option<String> to &''static str references, eliminating per-frame allocations in the hot Ref path. prune_options and prune_terminators return SmallVec to match.

### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [ ] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduce allocations in the Rust parser by switching pruning state to `SmallVec<[GrammarId; 8]>` and using `&'static str` in `RefState`. This cuts heap allocations on hot paths and speeds up table-driven Ref and pruning logic.

- **Refactors**
  - `OneOfState.pruned_children` and `AnyNumberOfState.pruned_children` use `SmallVec<[GrammarId; 8]>` instead of `Vec`.
  - `RefState.name`, `segment_class_name`, and `segment_type` use `&'static str`/`Option<&'static str>` instead of `String`/`Option<String>`.
  - `prune_options` and `prune_terminators` return `SmallVec<[GrammarId; 8]>`; callers updated in helpers and contexts.
  - `MatchResult::ref_match` now accepts a `&'static str` for the ref name.
  - Removed string cloning in table-driven `ref_grammar`; borrow rule name, segment class, and type directly from grammar tables.

<sup>Written for commit 2ab2b1bb066e9e53d5adfc53b371d228d65b5d20. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8002?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

