### PR TITLE
perf(rust): replace HashMap results store with single Option slot in parse frame stack

### DIFF
--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/frame.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/frame.rs
@@ -18,19 +18,16 @@ pub enum TableFrameResult {
 /// Stack structure for managing ParseFrames and related state
 pub struct TableParseFrameStack {
     stack: Vec<TableParseFrame>,
-    /// Completed-child results, keyed by `frame_id`.
+    /// Single pending result slot: `(frame_id, result, end_pos, element_key)`.
     ///
-    /// This is the hand-off channel between a child and its parent: when a child
-    /// frame reaches `Complete`, the loop writes its
-    /// `(Arc<MatchResult>, end_pos, element_key)` here; the parent — parked in
-    /// `WaitingForChild` — reclaims it by looking up its own
-    /// `last_child_frame_id`. `Arc` keeps the hand-off clone-free.
+    /// At most one child result is in-flight at any time because the stack
+    /// processes frames sequentially and each parent consumes its child's result
+    /// before any new result is written. Replacing the HashMap with an Option
+    /// eliminates all hash-map overhead on the hot child-to-parent hand-off path.
     ///
-    /// - `end_pos`: token position just past the child's match (the parent's new
-    ///   `working_idx`/`matched_idx`).
-    /// - `element_key`: optional per-element identity (set by OneOf, consumed by
-    ///   AnyNumberOf for `max_times_per_element` accounting); `None` otherwise.
-    pub results: hashbrown::HashMap<usize, (Arc<MatchResult>, usize, Option<u64>)>,
+    /// - `end_pos`: token position just past the child's match.
+    /// - `element_key`: optional per-element identity for AnyNumberOf accounting.
+    pub results: Option<(usize, Arc<MatchResult>, usize, Option<u64>)>,
     pub frame_id_counter: usize,
     // Add any additional state fields here as needed
 }
@@ -45,9 +42,21 @@ impl TableParseFrameStack {
     pub fn new() -> Self {
         TableParseFrameStack {
             stack: Vec::new(),
-            results: hashbrown::HashMap::new(),
+            results: None,
             frame_id_counter: 0,
         }
+    }
+
+    /// Take a pending result for `frame_id`. Returns `None` if no result is
+    /// pending or the stored frame id does not match.
+    #[inline]
+    pub fn take_pending(
+        &mut self,
+        frame_id: usize,
+    ) -> Option<(Arc<MatchResult>, usize, Option<u64>)> {
+        self.results
+            .take_if(|(stored_id, ..)| *stored_id == frame_id)
+            .map(|(_, result, end_pos, element_key)| (result, end_pos, element_key))
     }
 
     pub fn push(&mut self, frame: TableParseFrame) {
@@ -80,8 +89,7 @@ impl TableParseFrameStack {
 
     #[inline]
     pub(crate) fn insert_empty_result(&mut self, frame_id: usize, pos: usize) {
-        self.results
-            .insert(frame_id, (Arc::new(MatchResult::empty_at(pos)), pos, None));
+        self.results = Some((frame_id, Arc::new(MatchResult::empty_at(pos)), pos, None));
     }
 
     #[inline]
@@ -91,8 +99,7 @@ impl TableParseFrameStack {
         match_result: MatchResult,
         end_pos: usize,
     ) {
-        self.results
-            .insert(frame_id, (Arc::new(match_result), end_pos, None));
+        self.results = Some((frame_id, Arc::new(match_result), end_pos, None));
     }
 
     #[inline]
@@ -102,7 +109,7 @@ impl TableParseFrameStack {
         match_result: Arc<MatchResult>,
         end_pos: usize,
     ) {
-        self.results.insert(frame_id, (match_result, end_pos, None));
+        self.results = Some((frame_id, match_result, end_pos, None));
     }
 
     #[inline]
@@ -113,8 +120,7 @@ impl TableParseFrameStack {
         end_pos: usize,
         element_key: Option<u64>,
     ) {
-        self.results
-            .insert(frame_id, (match_result, end_pos, element_key));
+        self.results = Some((frame_id, match_result, end_pos, element_key));
     }
 
     /// Push child frame and update parent to wait for it

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/iterative.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/iterative.rs
@@ -250,9 +250,9 @@ impl Parser<'_> {
                 iteration_count
             );
         }
-        vdebug!("DEBUG: Main loop ended. Stack has {} frames left. Results has {} entries. Looking for frame_id={}",
+        vdebug!("DEBUG: Main loop ended. Stack has {} frames left. Result pending: {}. Looking for frame_id={}",
             stack.len(),
-            stack.results.len(),
+            stack.results.is_some(),
             initial_frame_id
         );
 
@@ -306,12 +306,11 @@ impl Parser<'_> {
         }
 
         vdebug!(
-            "Main loop ended. Stack empty. Results has {} entries. Looking for frame_id={}",
-            stack.results.len(),
+            "Main loop ended. Stack empty. Result pending: {}. Looking for frame_id={}",
+            stack.results.is_some(),
             initial_frame_id
         );
-        if let Some((match_result, end_pos, _element_key)) = stack.results.remove(&initial_frame_id)
-        {
+        if let Some((match_result, end_pos, _element_key)) = stack.take_pending(initial_frame_id) {
             vdebug!(
                 "DEBUG: Found result for frame_id={}, end_pos={}",
                 initial_frame_id,
@@ -354,9 +353,9 @@ impl Parser<'_> {
         } else {
             // Parse error - don't cache errors for now (to keep it simple)
             let error = ParseError::new(format!(
-                "Iterative parse produced no result (initial_frame_id={}, stack.results has {} entries)",
+                "Iterative parse produced no result (initial_frame_id={}, result_pending={})",
                 initial_frame_id,
-                stack.results.len()
+                stack.results.is_some()
             ));
             Err(error)
         }
@@ -479,7 +478,7 @@ impl Parser<'_> {
             }
         };
 
-        let child = stack.results.remove(&child_frame_id);
+        let child = stack.take_pending(child_frame_id);
         vdebug!(
             "[RESULT GET] parent_frame_id={}, child_frame_id={}, child_found={}",
             frame.frame_id,
@@ -812,7 +811,7 @@ impl Parser<'_> {
         vdebug!("ERROR: Exceeded max iterations ({})", max_iterations);
         vdebug!("Last frame: {:?}", _frame.grammar_id);
         vdebug!("Stack depth: {}", _stack.len());
-        vdebug!("Results count: {}", _stack.results.len());
+        vdebug!("Result pending: {}", _stack.results.is_some());
 
         // Print last 20 frames on stack for diagnosis
         vdebug!("\n=== Last 20 frames on stack ===");


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
At most one child result is in-flight at a time because frames are processed sequentially and each parent consumes its child result before any new result is written. Replacing the HashMap with Option eliminates hashing, allocation, and lookup overhead on the hot child-to-parent hand-off path. Adds take_pending() for ergonomic, id-checked retrieval.

### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [ ] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the per-frame results HashMap with a single pending-result slot and added `take_pending(frame_id)` for id-checked hand-off. This removes map overhead on the hot path and keeps parse results unchanged.

- **Refactors**
  - Use a single `Option` pending slot `(frame_id, Arc<MatchResult>, end_pos, element_key)` with `take_pending(frame_id)`; iterative parser now uses it and logs `result_pending` instead of map size.
  - Update result writers in `frame.rs` to set the slot via helpers; remove all map `.remove()` call sites.

<sup>Written for commit b3b0ac842825d31519d760dd110809fe7466c3ea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8003?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

