### PR TITLE
perf(rust): remove RefCell wrappers from parser caches

### DIFF
--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/core.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/core.rs
@@ -147,14 +147,14 @@ pub struct Parser<'a> {
     /// Cache for terminator match results: (position, grammar_id) -> matches
     /// Key insight: the same terminator at the same position will always give the same result.
     /// This avoids redundant parse_table_iterative calls from nested Delimited grammars.
-    pub(crate) terminator_match_cache: std::cell::RefCell<hashbrown::HashMap<(usize, u32), bool>>,
+    pub(crate) terminator_match_cache: hashbrown::HashMap<(usize, u32), bool>,
     // Table-driven grammar support
     pub(crate) grammar_ctx: GrammarContext<'static>,
     /// Indentation configuration (key -> enabled)
     /// Used by conditional meta segments (e.g., indented_joins=true enables Indent/Dedent)
     pub(crate) indent_config: hashbrown::HashMap<&'static str, bool>,
     // Regex cache for table-driven RegexParser (pattern_string -> compiled RegexMode)
-    regex_cache: std::cell::RefCell<hashbrown::HashMap<String, std::sync::Arc<RegexMode>>>,
+    regex_cache: hashbrown::HashMap<String, std::sync::Arc<RegexMode>>,
     /// Maximum number of main-loop iterations before aborting.
     /// Configurable via `rust_parser_max_iterations` in `.sqlfluff`.
     pub(crate) max_parser_iterations: usize,
@@ -202,11 +202,11 @@ impl<'a> Parser<'a> {
             dialect,
             table_cache: TableParseCache::new(),
             metrics: ParserMetrics::default(),
-            terminator_match_cache: std::cell::RefCell::new(hashbrown::HashMap::new()),
+            terminator_match_cache: hashbrown::HashMap::new(),
             cache_enabled: true,
             grammar_ctx,
             indent_config,
-            regex_cache: std::cell::RefCell::new(hashbrown::HashMap::new()),
+            regex_cache: hashbrown::HashMap::new(),
             max_parser_iterations: 3_000_000,
             parser_warn_threshold: 2_000_000,
             max_parse_depth,
@@ -1136,19 +1136,17 @@ impl<'a> Parser<'a> {
         }
 
         let pattern = {
-            let mut cache = self.regex_cache.borrow_mut();
             let comp_key = normalize_for_compile(&pattern_str).to_string();
-            cache
+            self.regex_cache
                 .entry(comp_key.clone())
                 .or_insert_with(|| std::sync::Arc::new(RegexMode::new(&comp_key)))
                 .clone()
         };
 
         let anti_pattern = if let Some(anti_str) = anti_opt.as_ref() {
-            let mut cache = self.regex_cache.borrow_mut();
             let comp_key = normalize_for_compile(anti_str).to_string();
             Some(
-                cache
+                self.regex_cache
                     .entry(comp_key.clone())
                     .or_insert_with(|| std::sync::Arc::new(RegexMode::new(&comp_key)))
                     .clone(),

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/helpers.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/helpers.rs
@@ -521,7 +521,7 @@ impl<'a> Parser<'a> {
 
             // Check terminator match cache first - key is (position after skipping transparent, grammar_id)
             let cache_key = (saved_pos, term_id.0);
-            if let Some(&cached_result) = self.terminator_match_cache.borrow().get(&cache_key) {
+            if let Some(&cached_result) = self.terminator_match_cache.get(&cache_key) {
                 vdebug!(
                     "  TERMCACHE HIT at pos {} for {:?}: {}",
                     saved_pos,
@@ -549,9 +549,7 @@ impl<'a> Parser<'a> {
                 self.pos = check_pos;
 
                 // Cache the result
-                self.terminator_match_cache
-                    .borrow_mut()
-                    .insert(cache_key, !is_empty);
+                self.terminator_match_cache.insert(cache_key, !is_empty);
 
                 if !is_empty {
                     vdebug!("  TERMED Terminator matched (table-driven): {:?}", term_id);
@@ -564,9 +562,7 @@ impl<'a> Parser<'a> {
             } else {
                 self.pos = check_pos;
                 // Cache the failure
-                self.terminator_match_cache
-                    .borrow_mut()
-                    .insert(cache_key, false);
+                self.terminator_match_cache.insert(cache_key, false);
             }
             vdebug!("  Terminator did not match (table-driven): {:?}", term_id);
         }

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/iterative.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/iterative.rs
@@ -479,7 +479,7 @@ impl Parser<'_> {
             }
         };
 
-        let child = stack.results.get(&child_frame_id).cloned();
+        let child = stack.results.remove(&child_frame_id);
         vdebug!(
             "[RESULT GET] parent_frame_id={}, child_frame_id={}, child_found={}",
             frame.frame_id,

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/match_algorithms.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/match_algorithms.rs
@@ -206,11 +206,7 @@ impl Parser<'_> {
                     i
                 );
                 let cache_key = (i, term_id.0);
-                let cached = self
-                    .terminator_match_cache
-                    .borrow()
-                    .get(&cache_key)
-                    .copied();
+                let cached = self.terminator_match_cache.get(&cache_key).copied();
                 let matched = if let Some(hit) = cached {
                     hit
                 } else {
@@ -218,9 +214,7 @@ impl Parser<'_> {
                         .try_match_grammar(term_id, i, terminators)
                         .map(|end_pos| end_pos > i)
                         .unwrap_or(false);
-                    self.terminator_match_cache
-                        .borrow_mut()
-                        .insert(cache_key, result);
+                    self.terminator_match_cache.insert(cache_key, result);
                     result
                 };
                 if matched {


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
terminator_match_cache and regex_cache no longer use interior mutability. All call sites replace .borrow()/.borrow_mut() with direct field access, and the WaitingForChild result lookup switches from .get().cloned() to .remove() to drop the now-unnecessary extra retain.

### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [ ] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove `RefCell` from parser caches and streamline hot paths to cut parsing overhead. Behavior is unchanged; we avoid interior mutability and unnecessary clones/retains.

- **Refactors**
  - Replaced `RefCell<HashMap>` with `HashMap` for `terminator_match_cache` and `regex_cache`; updated call sites to use direct lookups/inserts.
  - Switched table-driven child result retrieval to `remove()` to avoid retaining child results.

<sup>Written for commit 66cb0ecb4e4c79cf0227ed1f052ab03e6f2a33c0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8004?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

