### PR TITLE
perf(rust): skip Token::normalize() in base_token hot path

### DIFF
--- a/sqlfluffrs/sqlfluffrs_types/src/token/construction.rs
+++ b/sqlfluffrs/sqlfluffrs_types/src/token/construction.rs
@@ -24,7 +24,9 @@ impl Token {
         } = config;
 
         let (token_types, class_types) = iter_base_types("base", class_types.clone());
-        let raw_value = Token::normalize(&raw, quoted_value.clone(), escape_replacement.clone());
+        // raw_normalized() is unimplemented (todo!) and raw_value has no readers,
+        // so normalize() is dead work. Skip it.
+        let raw_value = String::new();
         Self {
             token_type: token_types,
             class_name: "BaseSegment".to_string(),


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
raw_normalized() is unimplemented (todo!) so raw_value has no readers. Calling Token::normalize() on every lexed token is dead work: it runs regex replacements that produce a result nobody reads.

I left the todo! markers and functions, assuming they'll be needed later.

### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [ ] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip calling Token::normalize() in the base token construction hot path to avoid unused regex work. This reduces CPU time with no behavior change, since raw_value is unused and raw_normalized() is unimplemented.

<sup>Written for commit 684cf3cc57166f4b19037601717bda85b0cae918. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8005?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

