### PR TITLE
fix(rust): Make Parser metrics accessible again

### DIFF
--- a/sqlfluffrs/sqlfluffrs_benchmarks/examples/time_tpc.rs
+++ b/sqlfluffrs/sqlfluffrs_benchmarks/examples/time_tpc.rs
@@ -40,20 +40,21 @@ struct RunStats {
 
 impl RunStats {
     fn capture(duration: Duration, parser: &Parser) -> Self {
-        let (hits, misses, _) = parser.table_cache.stats();
+        let (hits, misses, _) = parser.cache_stats();
+        let m = parser.metrics();
         RunStats {
             duration_secs: duration.as_secs_f64(),
             cache_hits: hits,
             cache_misses: misses,
-            cache_entries: parser.table_cache.len(),
-            pruning_calls: parser.pruning_calls.get(),
-            pruning_total: parser.pruning_total.get(),
-            pruning_kept: parser.pruning_kept.get(),
-            match_attempts: parser.match_attempts.get(),
-            match_successes: parser.match_successes.get(),
-            complete_match_early_exits: parser.complete_match_early_exits.get(),
-            terminator_checks: parser.terminator_checks.get(),
-            terminator_hits: parser.terminator_hits.get(),
+            cache_entries: parser.cache_entries(),
+            pruning_calls: m.pruning_calls.get(),
+            pruning_total: m.pruning_total.get(),
+            pruning_kept: m.pruning_kept.get(),
+            match_attempts: m.match_attempts.get(),
+            match_successes: m.match_successes.get(),
+            complete_match_early_exits: m.complete_match_early_exits.get(),
+            terminator_checks: m.terminator_checks.get(),
+            terminator_hits: m.terminator_hits.get(),
         }
     }
 }
@@ -196,18 +197,19 @@ fn timed_suite_runs(all_tokens: &[Vec<Token>]) -> Vec<RunStats> {
             for tokens in all_tokens {
                 let mut p = Parser::new(tokens, Dialect::Ansi, hashbrown::HashMap::new());
                 p.call_rule_as_root().expect("Parse failed");
-                let (h, m, _) = p.table_cache.stats();
+                let (h, miss, _) = p.cache_stats();
                 cache_hits += h;
-                cache_misses += m;
-                cache_entries += p.table_cache.len();
-                pruning_calls += p.pruning_calls.get();
-                pruning_total += p.pruning_total.get();
-                pruning_kept += p.pruning_kept.get();
-                match_attempts += p.match_attempts.get();
-                match_successes += p.match_successes.get();
-                early_exits += p.complete_match_early_exits.get();
-                term_checks += p.terminator_checks.get();
-                term_hits += p.terminator_hits.get();
+                cache_misses += miss;
+                cache_entries += p.cache_entries();
+                let m = p.metrics();
+                pruning_calls += m.pruning_calls.get();
+                pruning_total += m.pruning_total.get();
+                pruning_kept += m.pruning_kept.get();
+                match_attempts += m.match_attempts.get();
+                match_successes += m.match_successes.get();
+                early_exits += m.complete_match_early_exits.get();
+                term_checks += m.terminator_checks.get();
+                term_hits += m.terminator_hits.get();
             }
             RunStats {
                 duration_secs: t0.elapsed().as_secs_f64(),

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/core.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/core.rs
@@ -51,7 +51,7 @@ fn read_string_ids_from_aux(
 /// `Parser` struct focused on parsing state and to expose the counters as a unit
 /// via [`Parser::diagnostics`] rather than field-by-field across the FFI boundary.
 #[derive(Debug, Default)]
-pub(crate) struct ParserMetrics {
+pub struct ParserMetrics {
     /// Number of `prune_options` calls.
     pub pruning_calls: std::cell::Cell<usize>,
     /// Total options considered across all prune calls.
@@ -260,6 +260,24 @@ impl<'a> Parser<'a> {
     /// Python bindings and perf debugging instead of reaching into individual counters.
     pub fn diagnostics(&self) -> std::collections::HashMap<String, usize> {
         self.metrics.as_map()
+    }
+
+    /// Borrow the raw diagnostic counters.
+    ///
+    /// Cheaper than [`Parser::diagnostics`] (no map allocation), so benchmarks can read
+    /// individual counters inside timed regions without distorting measurements.
+    pub fn metrics(&self) -> &ParserMetrics {
+        &self.metrics
+    }
+
+    /// Parse-cache stats as `(hits, misses, hit_rate)`.
+    pub fn cache_stats(&self) -> (usize, usize, f64) {
+        self.table_cache.stats()
+    }
+
+    /// Number of entries currently held in the parse cache.
+    pub fn cache_entries(&self) -> usize {
+        self.table_cache.len()
     }
 
     /// Parse and return MatchResult


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
This fixes access to the metrics for the benchmarks introduced in #7981.

### Are there any other side effects of this change that we should be aware of?
None

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores access to parser metrics for benchmarks by exposing a small public API on `Parser`. Benchmarks now read metrics cheaply without touching internals, fixing broken metrics collection and reducing overhead.

- **Bug Fixes**
  - Made `ParserMetrics` public and added `Parser::metrics()`, `Parser::cache_stats()`, and `Parser::cache_entries()`.
  - Updated `time_tpc.rs` to use these methods instead of internal fields.
  - Avoids map allocation in timed sections so metric reads don’t skew results.

<sup>Written for commit 015c802ca28bdb51b0636cd07d131af9aa7545bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8006?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

