### PR TITLE
refactor(rust): encapsulate raw/raw_upper in RawString to enforce invariant

### DIFF
--- a/sqlfluffrs/sqlfluffrs_lexer/src/lexer.rs
+++ b/sqlfluffrs/sqlfluffrs_lexer/src/lexer.rs
@@ -389,7 +389,7 @@ impl Lexer {
             let raw = tokens[idx].raw();
 
             // Check if this is an opening bracket
-            if let Some(open_char) = match raw.as_str() {
+            if let Some(open_char) = match raw {
                 "(" => Some('('),
                 "[" => Some('['),
                 "{" => Some('{'),
@@ -398,7 +398,7 @@ impl Lexer {
                 bracket_stack.push((idx, open_char));
             }
             // Check if this is a closing bracket
-            else if let Some(expected_open) = match raw.as_str() {
+            else if let Some(expected_open) = match raw {
                 ")" => Some('('),
                 "]" => Some('['),
                 "}" => Some('{'),

--- a/sqlfluffrs/sqlfluffrs_lexer/src/lexer.rs
+++ b/sqlfluffrs/sqlfluffrs_lexer/src/lexer.rs
@@ -425,7 +425,7 @@ impl Lexer {
                 SQLLexError::new(
                     Some(format!(
                         "Unable to lex characters: {}",
-                        token.raw.chars().take(10).collect::<String>()
+                        token.raw().chars().take(10).collect::<String>()
                     )),
                     token.pos_marker.clone(),
                     None,

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/core.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/core.rs
@@ -552,7 +552,7 @@ impl<'a> Parser<'a> {
 
                 #[cfg(feature = "verbose-debug")]
                 {
-                    let raw = tok.raw().to_string();
+                    let raw = tok.raw().to_owned();
 
                     vdebug!(
                         "StringParser[table] MATCHED: token='{}' as {} (type={}) at pos={}",
@@ -647,7 +647,7 @@ impl<'a> Parser<'a> {
                 let token_pos = self.pos;
                 #[cfg(feature = "verbose-debug")]
                 {
-                    let raw = tok.raw().to_string();
+                    let raw = tok.raw().to_owned();
                     let token_type_val = tok.token_type.clone();
                     let inst_types = tok.instance_types.clone();
                     let class_types = tok.class_types();
@@ -896,7 +896,7 @@ impl<'a> Parser<'a> {
                 let token_pos = self.pos;
                 #[cfg(feature = "verbose-debug")]
                 {
-                    let raw = tok.raw().to_string();
+                    let raw = tok.raw().to_owned();
 
                     vdebug!(
                         "MultiStringParser[table] MATCHED: token='{}' as {} (type={}) at pos={}",
@@ -1363,7 +1363,7 @@ impl<'a> Parser<'a> {
             Some(tok) if tok.is_type(&[&token_type]) => {
                 let token_pos = self.pos;
                 #[cfg(feature = "verbose-debug")]
-                let raw = tok.raw().to_string();
+                let raw = tok.raw().to_owned();
                 self.bump();
 
                 vdebug!(
@@ -1546,7 +1546,7 @@ impl<'a> Parser<'a> {
             }
 
             if let Some(tok) = self.peek() {
-                let tok_raw = tok.raw();
+                let tok_raw = tok.raw().to_owned();
 
                 // Handle bracket openers - match entire bracketed section with nested brackets
                 if tok_raw == "(" || tok_raw == "[" || tok_raw == "{" {
@@ -1639,7 +1639,7 @@ impl<'a> Parser<'a> {
         // Match everything until matching close bracket, recursively handling nested brackets
         while !self.is_at_end() {
             if let Some(inner_tok) = self.peek() {
-                let inner_raw = inner_tok.raw();
+                let inner_raw = inner_tok.raw().to_owned();
 
                 if inner_raw == close_bracket {
                     // Found our closing bracket

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/helpers.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/helpers.rs
@@ -178,7 +178,7 @@ impl<'a> Parser<'a> {
         // Validate the token at matching_idx is actually the expected closing bracket
         let close_tok = self.tokens.get(matching_idx)?;
         let open_raw = open_tok.raw();
-        let expected_close = match open_raw.as_str() {
+        let expected_close = match open_raw {
             "(" => ")",
             "[" => "]",
             "{" => "}",

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/match_result.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/match_result.rs
@@ -798,7 +798,7 @@ fn token_to_node(tok: &Token) -> Node {
             "dedent" => MetaType::Dedent { is_implicit: false },
             "template_loop" => MetaType::TemplateLoop,
             _ => MetaType::Template {
-                source_str: tok.raw(),
+                source_str: tok.raw().to_owned(),
                 block_type: tok.block_type().expect("block_type for template"),
             },
         };
@@ -824,7 +824,7 @@ fn token_to_node(tok: &Token) -> Node {
         Node::new_raw_with_class_types(
             tok.class_name.clone(),
             segment_type,
-            tok.raw(),
+            tok.raw().to_owned(),
             tok.pos_marker.clone(),
             tok.instance_types.clone(),
             &raw_class_ct,

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/match_result.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/match_result.rs
@@ -824,7 +824,7 @@ fn token_to_node(tok: &Token) -> Node {
         Node::new_raw_with_class_types(
             tok.class_name.clone(),
             segment_type,
-            tok.raw.to_string(),
+            tok.raw(),
             tok.pos_marker.clone(),
             tok.instance_types.clone(),
             &raw_class_ct,

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/python.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/python.rs
@@ -75,7 +75,7 @@ impl PyNode {
     /// Get raw text of this node (recursively joins children for containers)
     #[getter]
     fn raw(&self) -> String {
-        self.0.raw()
+        self.0.raw().to_owned()
     }
 
     /// Check if node is empty
@@ -659,7 +659,7 @@ fn compute_bracket_pairs(tokens: &mut [Token]) {
         let raw = tokens[idx].raw();
 
         // Check if this is an opening bracket
-        if let Some(open_char) = match raw.as_str() {
+        if let Some(open_char) = match raw {
             "(" => Some('('),
             "[" => Some('['),
             "{" => Some('{'),
@@ -668,7 +668,7 @@ fn compute_bracket_pairs(tokens: &mut [Token]) {
             bracket_stack.push((idx, open_char));
         }
         // Check if this is a closing bracket
-        else if let Some(expected_open) = match raw.as_str() {
+        else if let Some(expected_open) = match raw {
             ")" => Some('('),
             "]" => Some('['),
             "}" => Some('{'),

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/anynumberof.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/anynumberof.rs
@@ -46,7 +46,7 @@ impl Parser<'_> {
                 vdebug!(
                 "AnyNumberOf[table] Initial: grammar='{}' start_token='{}' token_type='{}' start_pos={}",
                 grammar_name,
-                tok.raw,
+                tok.raw(),
                 tok.get_type(),
                 start_pos
             );

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/oneof.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/oneof.rs
@@ -238,7 +238,7 @@ impl Parser<'_> {
                 let end_idx = child_end_pos_val.min(self.tokens.len());
                 if start_idx < end_idx {
                     for tok in &self.tokens[start_idx..end_idx] {
-                        candidate_tokens.push(tok.raw().to_string());
+                        candidate_tokens.push(tok.raw().to_owned());
                     }
                 }
             }

--- a/sqlfluffrs/sqlfluffrs_python/src/token.rs
+++ b/sqlfluffrs/sqlfluffrs_python/src/token.rs
@@ -161,7 +161,7 @@ pub struct PyToken(pub Token);
 impl PyToken {
     #[getter]
     pub fn raw(&self) -> String {
-        self.0.raw()
+        self.0.raw().to_owned()
     }
 
     pub fn raw_trimmed(&self) -> String {

--- a/sqlfluffrs/sqlfluffrs_python/src/token.rs
+++ b/sqlfluffrs/sqlfluffrs_python/src/token.rs
@@ -161,7 +161,7 @@ pub struct PyToken(pub Token);
 impl PyToken {
     #[getter]
     pub fn raw(&self) -> String {
-        self.0.raw.to_string()
+        self.0.raw()
     }
 
     pub fn raw_trimmed(&self) -> String {

--- a/sqlfluffrs/sqlfluffrs_types/src/token/construction.rs
+++ b/sqlfluffrs/sqlfluffrs_types/src/token/construction.rs
@@ -25,7 +25,6 @@ impl Token {
 
         let (token_types, class_types) = iter_base_types("base", class_types.clone());
         let raw_value = Token::normalize(&raw, quoted_value.clone(), escape_replacement.clone());
-        let raw_upper = raw.to_uppercase();
         Self {
             token_type: token_types,
             class_name: "BaseSegment".to_string(),
@@ -35,8 +34,7 @@ impl Token {
             is_meta: false,
             allow_empty: false,
             pos_marker: Some(pos_marker),
-            raw,
-            raw_upper,
+            raw: crate::token::RawString::new(raw),
             is_whitespace: false,
             is_code: true,
             is_comment: false,

--- a/sqlfluffrs/sqlfluffrs_types/src/token/eq.rs
+++ b/sqlfluffrs/sqlfluffrs_types/src/token/eq.rs
@@ -6,7 +6,7 @@ impl PartialEq for Token {
     fn eq(&self, other: &Self) -> bool {
         self.uuid == other.uuid
             || (self.token_type == other.token_type
-                && self.raw == other.raw
+                && self.raw.as_str() == other.raw.as_str()
                 && self.pos_marker.is_some()
                 && other.pos_marker.is_some()
                 && self.pos_marker == other.pos_marker)
@@ -16,7 +16,7 @@ impl PartialEq for Token {
 impl Hash for Token {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         self.token_type.hash(state);
-        self.raw.hash(state);
+        self.raw.as_str().hash(state);
         if let Some(p) = self.pos_marker.as_ref() {
             p.working_loc().hash(state);
         }

--- a/sqlfluffrs/sqlfluffrs_types/src/token/fmt.rs
+++ b/sqlfluffrs/sqlfluffrs_types/src/token/fmt.rs
@@ -8,7 +8,7 @@ impl Display for Token {
             "<{}: ({}) '{}'>",
             self.class_name.clone(),
             self.pos_marker.clone().expect("PositionMarker unset"),
-            self.raw.escape_debug(),
+            self.raw.as_str().escape_debug(),
         )
     }
 }

--- a/sqlfluffrs/sqlfluffrs_types/src/token/mod.rs
+++ b/sqlfluffrs/sqlfluffrs_types/src/token/mod.rs
@@ -5,6 +5,8 @@ mod eq;
 pub mod fix;
 mod fmt;
 pub mod path;
+mod raw_string;
+pub use raw_string::RawString;
 
 use std::{
     fmt::Write,
@@ -45,8 +47,7 @@ pub struct Token {
     pub is_meta: bool,
     pub allow_empty: bool,
     pub pos_marker: Option<PositionMarker>,
-    pub raw: String,
-    pub raw_upper: String,
+    raw: RawString,
     is_whitespace: bool,
     is_code: bool,
     is_comment: bool,
@@ -126,11 +127,11 @@ impl Token {
     }
 
     pub fn raw(&self) -> String {
-        self.raw.clone()
+        self.raw.as_str().to_owned()
     }
 
     pub fn raw_upper(&self) -> &str {
-        &self.raw_upper
+        self.raw.upper()
     }
 
     /// Get the quoted_value pattern for this token (if any)
@@ -265,7 +266,7 @@ impl Token {
     }
 
     pub fn raw_trimmed(&self) -> String {
-        let mut raw_buff = self.raw.clone();
+        let mut raw_buff = self.raw.as_str().to_owned();
 
         // Trim start sequences
         if let Some(trim_start) = &self.trim_start {
@@ -276,7 +277,7 @@ impl Token {
 
         // Trim specified characters from both ends
         if let Some(trim_chars) = &self.trim_chars {
-            raw_buff = self.raw.clone(); // Reset raw_buff before trimming chars
+            raw_buff = self.raw.as_str().to_owned(); // Reset raw_buff before trimming chars
 
             for seq in trim_chars {
                 while raw_buff.starts_with(seq) {
@@ -333,10 +334,9 @@ impl Token {
     }
 
     pub fn edit(&self, raw: Option<String>, source_fixes: Option<Vec<SourceFix>>) -> Self {
-        let new_raw = raw.unwrap_or(self.raw.clone());
+        let new_raw = raw.unwrap_or_else(|| self.raw.as_str().to_owned());
         Self {
-            raw_upper: new_raw.to_uppercase(),
-            raw: new_raw,
+            raw: RawString::new(new_raw),
             source_fixes: Some(source_fixes.unwrap_or(self.source_fixes())),
             uuid: crate::identity::next_id(),
             ..self.clone()
@@ -534,7 +534,7 @@ impl Token {
         self.pos_marker
             .clone()
             .expect("PositionMarker unset")
-            .working_loc_after(&self.raw)
+            .working_loc_after(self.raw.as_str())
     }
 
     pub fn recursive_crawl_all(&self, reverse: bool) -> Box<dyn Iterator<Item = &Token> + '_> {
@@ -587,7 +587,7 @@ impl Token {
         let include_meta = include_meta.unwrap_or_default();
         // If `show_raw` is true and there are no child segments, return (type, raw)
         if show_raw && self.segments.is_empty() {
-            return TupleSerialisedSegment::Str(self.get_type(), self.raw.clone());
+            return TupleSerialisedSegment::Str(self.get_type(), self.raw.as_str().to_owned());
         }
 
         // Determine filtering criteria for child segments
@@ -679,7 +679,7 @@ impl Token {
             let new_position = new_position.expect("Position should be assigned");
             let new_position = new_position.with_working_position(line_no, line_pos);
             let (new_line_no, new_line_pos) =
-                new_position.infer_next_position(&segment.raw, line_no, line_pos);
+                new_position.infer_next_position(segment.raw.as_str(), line_no, line_pos);
             line_no = new_line_no;
             line_pos = new_line_pos;
 

--- a/sqlfluffrs/sqlfluffrs_types/src/token/mod.rs
+++ b/sqlfluffrs/sqlfluffrs_types/src/token/mod.rs
@@ -6,7 +6,7 @@ pub mod fix;
 mod fmt;
 pub mod path;
 mod raw_string;
-pub use raw_string::RawString;
+pub(crate) use raw_string::RawString;
 
 use std::{
     fmt::Write,
@@ -126,8 +126,8 @@ impl Token {
         }
     }
 
-    pub fn raw(&self) -> String {
-        self.raw.as_str().to_owned()
+    pub fn raw(&self) -> &str {
+        self.raw.as_str()
     }
 
     pub fn raw_upper(&self) -> &str {

--- a/sqlfluffrs/sqlfluffrs_types/src/token/raw_string.rs
+++ b/sqlfluffrs/sqlfluffrs_types/src/token/raw_string.rs
@@ -1,0 +1,20 @@
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct RawString {
+    raw: String,
+    raw_upper: String,
+}
+
+impl RawString {
+    pub fn new(raw: String) -> Self {
+        let raw_upper = raw.to_uppercase();
+        Self { raw, raw_upper }
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.raw
+    }
+
+    pub fn upper(&self) -> &str {
+        &self.raw_upper
+    }
+}

--- a/sqlfluffrs/sqlfluffrs_types/src/token/raw_string.rs
+++ b/sqlfluffrs/sqlfluffrs_types/src/token/raw_string.rs
@@ -1,4 +1,4 @@
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone)]
 pub struct RawString {
     raw: String,
     raw_upper: String,

--- a/sqlfluffrs/tests/test_bracketed_sequence.rs
+++ b/sqlfluffrs/tests/test_bracketed_sequence.rs
@@ -18,7 +18,7 @@ fn test_bracketed_implicit_sequence() {
 
     println!("\n=== TOKENS ===");
     for (i, tok) in tokens.iter().enumerate() {
-        println!("{:3}: {:20} {:?}", i, tok.token_type, tok.raw);
+        println!("{:3}: {:20} {:?}", i, tok.token_type, tok.raw());
     }
 
     assert!(lex_errors.is_empty(), "Lexer errors: {:?}", lex_errors);


### PR DESCRIPTION

<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made

`Token` previously exposed `raw: String` and `raw_upper: String` as two separate `pub` fields, with the invariant `raw_upper == raw.to_uppercase()` maintained by hand in two places (`base_token` and `edit`). Nothing prevented a caller from writing to either field directly and leaving them out of sync.

This PR introduces `RawString`, a small wrapper type that co-locates the two strings and enforces the invariant at construction. `Token.raw` is now a private `RawString` field. The existing `.raw()` and `.raw_upper()` accessors are unchanged from the caller's perspective, so no API breakage. `RawString` is scoped to `pub(crate)` since no external crate needs to name the type directly, and it derives only `Debug` and `Clone`.
              
### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [ ] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Encapsulated token raw text and its uppercase cache in `RawString` to keep them synced and reduce allocations. `Token::raw()` and `raw_upper()` now return `&str`; updated call sites across crates; runtime behavior is unchanged.

- **Refactors**
  - Added `sqlfluffrs_types::token::RawString`; `Token` stores it privately.
  - Changed `Token::raw()` to return `&str`; `raw_upper()` returns `&str`.
  - Updated equality, hashing, `Display`, serialization, and position math to use borrowed `&str`.
  - Updated lexer, parser (incl. bracket matching), Python bindings, and tests to borrow and only allocate with `.to_owned()` when needed.

- **Migration**
  - Replace `token.raw` with `token.raw()` and `token.raw_upper` with `token.raw_upper()`.
  - If you need an owned `String`, call `token.raw().to_owned()`.
  - Update matches like `match tok.raw().as_str()` to `match tok.raw()`.

<sup>Written for commit 187985415a0fb77887871eeb1a7f13aefda15b90. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8009?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



