### PR TITLE
[databricks]: support bare Databricks notebook magic cells

### DIFF
--- a/src/sqlfluff/dialects/dialect_databricks.py
+++ b/src/sqlfluff/dialects/dialect_databricks.py
@@ -118,11 +118,6 @@ databricks_dialect.insert_lexer_matchers(
         ),
         RegexLexer("magic_line", r"(-- MAGIC)( [^%]{1})([^\n]*)", CodeSegment),
         RegexLexer("magic_start", r"(-- MAGIC %)([^\n]{2,})(\r?\n)", CodeSegment),
-        RegexLexer(
-            "bare_magic_cell",
-            r"(?s)%[^\r\n]*(?:(?!(?:\r?\n){2}-- COMMAND ----------(?:\r?\n)).)*(?=(?:\r?\n){2}-- COMMAND ----------(?:\r?\n)|\Z)",
-            CodeSegment,
-        ),
     ],
     before="inline_comment",
 )
@@ -306,9 +301,6 @@ databricks_dialect.add(
     ),
     MagicLineGrammar=TypedParser("magic_line", CodeSegment, type="magic_line"),
     MagicStartGrammar=TypedParser("magic_start", CodeSegment, type="magic_start"),
-    BareMagicCellGrammar=TypedParser(
-        "bare_magic_cell", CodeSegment, type="bare_magic_cell"
-    ),
     VariableNameIdentifierSegment=OneOf(
         Ref("NakedIdentifierSegment"),
         Ref("BackQuotedIdentifierSegment"),
@@ -2050,10 +2042,21 @@ class MagicCellStatementSegment(BaseSegment):
                 AnyNumberOf(Ref("MagicLineGrammar"), optional=True),
             ),
             Ref("MagicSingleLineGrammar", optional=True),
-            Ref("BareMagicCellGrammar"),
+            Ref("BareMagicCellSegment"),
         ),
         terminators=[Ref("CommandCellSegment", optional=True)],
         reset_terminators=True,
+    )
+
+
+class BareMagicCellSegment(BaseSegment):
+    """A bare Databricks notebook magic cell starting with %."""
+
+    type = "bare_magic_cell"
+    match_grammar = Sequence(
+        Ref("ModuloSegment"),
+        Anything(terminators=[Ref("CommandCellSegment")], optional=True),
+        allow_gaps=False,
     )
 
 

--- a/src/sqlfluff/dialects/dialect_databricks.py
+++ b/src/sqlfluff/dialects/dialect_databricks.py
@@ -118,6 +118,11 @@ databricks_dialect.insert_lexer_matchers(
         ),
         RegexLexer("magic_line", r"(-- MAGIC)( [^%]{1})([^\n]*)", CodeSegment),
         RegexLexer("magic_start", r"(-- MAGIC %)([^\n]{2,})(\r?\n)", CodeSegment),
+        RegexLexer(
+            "bare_magic_cell",
+            r"(?s)%[^\r\n]*(?:(?!(?:\r?\n){2}-- COMMAND ----------(?:\r?\n)).)*(?=(?:\r?\n){2}-- COMMAND ----------(?:\r?\n)|\Z)",
+            CodeSegment,
+        ),
     ],
     before="inline_comment",
 )
@@ -301,6 +306,9 @@ databricks_dialect.add(
     ),
     MagicLineGrammar=TypedParser("magic_line", CodeSegment, type="magic_line"),
     MagicStartGrammar=TypedParser("magic_start", CodeSegment, type="magic_start"),
+    BareMagicCellGrammar=TypedParser(
+        "bare_magic_cell", CodeSegment, type="bare_magic_cell"
+    ),
     VariableNameIdentifierSegment=OneOf(
         Ref("NakedIdentifierSegment"),
         Ref("BackQuotedIdentifierSegment"),
@@ -2042,6 +2050,7 @@ class MagicCellStatementSegment(BaseSegment):
                 AnyNumberOf(Ref("MagicLineGrammar"), optional=True),
             ),
             Ref("MagicSingleLineGrammar", optional=True),
+            Ref("BareMagicCellGrammar"),
         ),
         terminators=[Ref("CommandCellSegment", optional=True)],
         reset_terminators=True,

--- a/src/sqlfluff/dialects/dialect_databricks.py
+++ b/src/sqlfluff/dialects/dialect_databricks.py
@@ -19,6 +19,7 @@ from sqlfluff.core.parser import (
     IdentifierSegment,
     Indent,
     Matchable,
+    NewlineSegment,
     OneOf,
     OptionallyBracketed,
     Ref,
@@ -118,6 +119,33 @@ databricks_dialect.insert_lexer_matchers(
         ),
         RegexLexer("magic_line", r"(-- MAGIC)( [^%]{1})([^\n]*)", CodeSegment),
         RegexLexer("magic_start", r"(-- MAGIC %)([^\n]{2,})(\r?\n)", CodeSegment),
+        RegexLexer(
+            "bare_magic_sql",
+            r"(\r?\n)+-- COMMAND ----------(\r?\n)+%sql\b[^\r\n]*",
+            CommentSegment,
+            subdivider=RegexLexer("newline", r"\r\n|\n", NewlineSegment),
+            trim_post_subdivide=RegexLexer(
+                "command", r"-- COMMAND ----------", CodeSegment
+            ),
+        ),
+        RegexLexer(
+            "bare_magic_cell",
+            r"(?s)(\r?\n)+-- COMMAND ----------(\r?\n)+"
+            r"%(?:python|scala|r|sh|md|run|fs|pip|conda)\b[^\r\n]*"
+            r"(?:(?!(?:\r?\n){2}-- COMMAND ----------(?:\r?\n)).)*"
+            r"(?=(?:\r?\n){2}-- COMMAND ----------(?:\r?\n)|\Z)",
+            CodeSegment,
+            subdivider=RegexLexer("newline", r"\r\n|\n", NewlineSegment),
+            trim_post_subdivide=RegexLexer(
+                "command", r"-- COMMAND ----------", CodeSegment
+            ),
+        ),
+        RegexLexer(
+            "command",
+            r"(\r?\n){2}-- COMMAND ----------(\r?\n)",
+            CodeSegment,
+            subdivider=RegexLexer("newline", r"\r\n|\n", NewlineSegment),
+        ),
     ],
     before="inline_comment",
 )
@@ -301,6 +329,9 @@ databricks_dialect.add(
     ),
     MagicLineGrammar=TypedParser("magic_line", CodeSegment, type="magic_line"),
     MagicStartGrammar=TypedParser("magic_start", CodeSegment, type="magic_start"),
+    BareMagicCellGrammar=TypedParser(
+        "bare_magic_cell", CodeSegment, type="bare_magic_cell"
+    ),
     VariableNameIdentifierSegment=OneOf(
         Ref("NakedIdentifierSegment"),
         Ref("BackQuotedIdentifierSegment"),
@@ -2042,21 +2073,11 @@ class MagicCellStatementSegment(BaseSegment):
                 AnyNumberOf(Ref("MagicLineGrammar"), optional=True),
             ),
             Ref("MagicSingleLineGrammar", optional=True),
-            Ref("BareMagicCellSegment"),
+            # One `bare_magic_cell` token per line (see the lexer subdivider).
+            AnyNumberOf(Ref("BareMagicCellGrammar")),
         ),
         terminators=[Ref("CommandCellSegment", optional=True)],
         reset_terminators=True,
-    )
-
-
-class BareMagicCellSegment(BaseSegment):
-    """A bare Databricks notebook magic cell starting with %."""
-
-    type = "bare_magic_cell"
-    match_grammar = Sequence(
-        Ref("ModuloSegment"),
-        Anything(terminators=[Ref("CommandCellSegment")], optional=True),
-        allow_gaps=False,
     )
 
 

--- a/src/sqlfluff/dialects/dialect_databricks.py
+++ b/src/sqlfluff/dialects/dialect_databricks.py
@@ -104,6 +104,36 @@ databricks_dialect.insert_lexer_matchers(
 )
 
 databricks_dialect.insert_lexer_matchers(
+    # Bare notebook magic in the first cell must consume the notebook header,
+    # because the lexer only matches against the remaining string slice.
+    [
+        RegexLexer(
+            "notebook_start_bare_magic_sql",
+            r"-- Databricks notebook source(?:\r?\n)%sql\b[^\r\n]*",
+            CommentSegment,
+            subdivider=RegexLexer("newline", r"\r\n|\n", NewlineSegment),
+            trim_post_subdivide=RegexLexer(
+                "notebook_start", r"-- Databricks notebook source", CommentSegment
+            ),
+        ),
+        RegexLexer(
+            "notebook_start_bare_magic_cell",
+            r"(?s)-- Databricks notebook source(?:\r?\n)"
+            r"%(?:python|scala|r|sh|md|run|fs|pip|conda)\b[^\r\n]*"
+            r"(?:(?!(?:\r?\n){2}-- COMMAND ----------(?:\r?\n)).)*"
+            r"(?=(?:\r?\n){2}-- COMMAND ----------(?:\r?\n)|\Z)",
+            CodeSegment,
+            subdivider=RegexLexer("newline", r"\r\n|\n", NewlineSegment),
+            trim_post_subdivide=RegexLexer(
+                "notebook_start", r"-- Databricks notebook source", CommentSegment
+            ),
+        ),
+    ],
+    before="inline_comment",
+)
+
+
+databricks_dialect.insert_lexer_matchers(
     # Databricks Notebook Start:
     # needed to insert "so early" to avoid magic + notebook
     # start to be interpreted as inline comments
@@ -331,6 +361,9 @@ databricks_dialect.add(
     MagicStartGrammar=TypedParser("magic_start", CodeSegment, type="magic_start"),
     BareMagicCellGrammar=TypedParser(
         "bare_magic_cell", CodeSegment, type="bare_magic_cell"
+    ),
+    NotebookStartBareMagicCellGrammar=TypedParser(
+        "notebook_start_bare_magic_cell", CodeSegment, type="bare_magic_cell"
     ),
     VariableNameIdentifierSegment=OneOf(
         Ref("NakedIdentifierSegment"),
@@ -2074,7 +2107,12 @@ class MagicCellStatementSegment(BaseSegment):
             ),
             Ref("MagicSingleLineGrammar", optional=True),
             # One `bare_magic_cell` token per line (see the lexer subdivider).
-            AnyNumberOf(Ref("BareMagicCellGrammar")),
+            AnyNumberOf(
+                OneOf(
+                    Ref("BareMagicCellGrammar"),
+                    Ref("NotebookStartBareMagicCellGrammar"),
+                )
+            ),
         ),
         terminators=[Ref("CommandCellSegment", optional=True)],
         reset_terminators=True,

--- a/test/fixtures/dialects/databricks/bare_magic_first_line.sql
+++ b/test/fixtures/dialects/databricks/bare_magic_first_line.sql
@@ -1,0 +1,21 @@
+-- Databricks notebook source
+
+-- COMMAND ----------
+
+-- A bare magic marker is only a magic command on the first line of a cell.
+
+-- COMMAND ----------
+
+%python
+print("first line of the cell -> real magic cell")
+
+-- COMMAND ----------
+
+-- A `%keyword` that is NOT the first line of the cell is the modulo operator,
+-- even when it starts a line and its right operand shares a magic keyword name.
+SELECT
+    a
+    % r AS ratio,
+    a
+    %md AS still_modulo
+FROM t

--- a/test/fixtures/dialects/databricks/bare_magic_first_line.yml
+++ b/test/fixtures/dialects/databricks/bare_magic_first_line.yml
@@ -1,0 +1,47 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: edb9cd411da9044dec61e61a46101c245c0f89c46837a30689837ac18a16669b
+file:
+- statement_terminator: -- COMMAND ----------
+- statement:
+    magic_cell_segment:
+    - bare_magic_cell: '%python'
+    - bare_magic_cell: print("first line of the cell -> real magic cell")
+- statement_terminator: -- COMMAND ----------
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          expression:
+          - column_reference:
+              naked_identifier: a
+          - binary_operator: '%'
+          - column_reference:
+              naked_identifier: r
+          alias_expression:
+            alias_operator:
+              keyword: AS
+            naked_identifier: ratio
+      - comma: ','
+      - select_clause_element:
+          expression:
+          - column_reference:
+              naked_identifier: a
+          - binary_operator: '%'
+          - column_reference:
+              naked_identifier: md
+          alias_expression:
+            alias_operator:
+              keyword: AS
+            naked_identifier: still_modulo
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: t

--- a/test/fixtures/dialects/databricks/bare_magic_line.sql
+++ b/test/fixtures/dialects/databricks/bare_magic_line.sql
@@ -1,0 +1,13 @@
+-- Databricks notebook source
+
+-- COMMAND ----------
+%python
+print("Hello world")
+
+-- COMMAND ----------
+
+SELECT a FROM b;
+
+-- COMMAND ----------
+
+%run ./Notebook

--- a/test/fixtures/dialects/databricks/bare_magic_line.yml
+++ b/test/fixtures/dialects/databricks/bare_magic_line.yml
@@ -3,11 +3,18 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: eca5cbbdb465872c10860f003bbf7c8b0637aec6bf1ecd1d3a7d548dbf89d67f
+_hash: 94ed53ed5a14ec879482ebe7723c611b3e9bb8693411ca38929a6c47e4cebe34
 file:
 - statement:
     magic_cell_segment:
-      bare_magic_cell: "%python\nprint(\"Hello world\")"
+      bare_magic_cell:
+      - binary_operator: '%'
+      - word: python
+      - word: print
+      - bracketed:
+          start_bracket: (
+          double_quote: '"Hello world"'
+          end_bracket: )
 - statement_terminator: "\n\n-- COMMAND ----------\n"
 - statement:
     select_statement:
@@ -27,4 +34,9 @@ file:
 - statement_terminator: "\n\n-- COMMAND ----------\n"
 - statement:
     magic_cell_segment:
-      bare_magic_cell: "%run ./Notebook\n"
+      bare_magic_cell:
+      - binary_operator: '%'
+      - word: run
+      - dot: .
+      - divide: /
+      - word: Notebook

--- a/test/fixtures/dialects/databricks/bare_magic_line.yml
+++ b/test/fixtures/dialects/databricks/bare_magic_line.yml
@@ -1,0 +1,30 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 8c724eea91955b70a08b6b8900e421c061105ef350ad877eec2d4a82947fe8a0
+file:
+- statement:
+    magic_cell_segment:
+      bare_magic_cell: "%python\nprint(\"Hello world\")"
+- statement_terminator: "\n\n-- COMMAND ----------\n"
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          column_reference:
+            naked_identifier: a
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: b
+- statement_terminator: ;
+- statement_terminator: "\n\n-- COMMAND ----------\n"
+- statement:
+    magic_cell_segment:
+      bare_magic_cell: '%run ./Notebook'

--- a/test/fixtures/dialects/databricks/bare_magic_line.yml
+++ b/test/fixtures/dialects/databricks/bare_magic_line.yml
@@ -3,19 +3,14 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 94ed53ed5a14ec879482ebe7723c611b3e9bb8693411ca38929a6c47e4cebe34
+_hash: f845e8af9d124988fbe9f4ea1fd5f40670ab9d481b313c58e48a6832a527c80e
 file:
+- statement_terminator: -- COMMAND ----------
 - statement:
     magic_cell_segment:
-      bare_magic_cell:
-      - binary_operator: '%'
-      - word: python
-      - word: print
-      - bracketed:
-          start_bracket: (
-          double_quote: '"Hello world"'
-          end_bracket: )
-- statement_terminator: "\n\n-- COMMAND ----------\n"
+    - bare_magic_cell: '%python'
+    - bare_magic_cell: print("Hello world")
+- statement_terminator: -- COMMAND ----------
 - statement:
     select_statement:
       select_clause:
@@ -31,12 +26,7 @@ file:
               table_reference:
                 naked_identifier: b
 - statement_terminator: ;
-- statement_terminator: "\n\n-- COMMAND ----------\n"
+- statement_terminator: -- COMMAND ----------
 - statement:
     magic_cell_segment:
-      bare_magic_cell:
-      - binary_operator: '%'
-      - word: run
-      - dot: .
-      - divide: /
-      - word: Notebook
+      bare_magic_cell: '%run ./Notebook'

--- a/test/fixtures/dialects/databricks/bare_magic_line.yml
+++ b/test/fixtures/dialects/databricks/bare_magic_line.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 8c724eea91955b70a08b6b8900e421c061105ef350ad877eec2d4a82947fe8a0
+_hash: eca5cbbdb465872c10860f003bbf7c8b0637aec6bf1ecd1d3a7d548dbf89d67f
 file:
 - statement:
     magic_cell_segment:
@@ -27,4 +27,4 @@ file:
 - statement_terminator: "\n\n-- COMMAND ----------\n"
 - statement:
     magic_cell_segment:
-      bare_magic_cell: '%run ./Notebook'
+      bare_magic_cell: "%run ./Notebook\n"

--- a/test/fixtures/dialects/databricks/bare_magic_modulo.sql
+++ b/test/fixtures/dialects/databricks/bare_magic_modulo.sql
@@ -1,0 +1,17 @@
+-- Databricks notebook source
+
+-- COMMAND ----------
+
+%python
+print("magic cell, not modulo")
+
+-- COMMAND ----------
+
+-- The `%` modulo operator must survive next to bare magic cells, even when the
+-- right-hand operand shares a name with a magic keyword (r, md, sql, ...).
+SELECT
+    a % 2 AS m1,
+    a%b AS m2,
+    a%r AS m3,
+    a%md AS m4
+FROM t;

--- a/test/fixtures/dialects/databricks/bare_magic_modulo.yml
+++ b/test/fixtures/dialects/databricks/bare_magic_modulo.yml
@@ -1,0 +1,71 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 35c24239c4c6d346aa6155bc978b7a8d863a882b454cfd2b1790859482e6ffb9
+file:
+- statement_terminator: -- COMMAND ----------
+- statement:
+    magic_cell_segment:
+    - bare_magic_cell: '%python'
+    - bare_magic_cell: print("magic cell, not modulo")
+- statement_terminator: -- COMMAND ----------
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          expression:
+            column_reference:
+              naked_identifier: a
+            binary_operator: '%'
+            numeric_literal: '2'
+          alias_expression:
+            alias_operator:
+              keyword: AS
+            naked_identifier: m1
+      - comma: ','
+      - select_clause_element:
+          expression:
+          - column_reference:
+              naked_identifier: a
+          - binary_operator: '%'
+          - column_reference:
+              naked_identifier: b
+          alias_expression:
+            alias_operator:
+              keyword: AS
+            naked_identifier: m2
+      - comma: ','
+      - select_clause_element:
+          expression:
+          - column_reference:
+              naked_identifier: a
+          - binary_operator: '%'
+          - column_reference:
+              naked_identifier: r
+          alias_expression:
+            alias_operator:
+              keyword: AS
+            naked_identifier: m3
+      - comma: ','
+      - select_clause_element:
+          expression:
+          - column_reference:
+              naked_identifier: a
+          - binary_operator: '%'
+          - column_reference:
+              naked_identifier: md
+          alias_expression:
+            alias_operator:
+              keyword: AS
+            naked_identifier: m4
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: t
+- statement_terminator: ;

--- a/test/fixtures/dialects/databricks/bare_magic_notebook_start.sql
+++ b/test/fixtures/dialects/databricks/bare_magic_notebook_start.sql
@@ -1,0 +1,7 @@
+-- Databricks notebook source
+%python
+print("first line of the notebook -> real magic cell")
+
+-- COMMAND ----------
+
+SELECT 1

--- a/test/fixtures/dialects/databricks/bare_magic_notebook_start.yml
+++ b/test/fixtures/dialects/databricks/bare_magic_notebook_start.yml
@@ -1,0 +1,18 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: ed3b3f568e42b43a215f75e3475383255c35b34e5428213b40d348073194696b
+file:
+- statement:
+    magic_cell_segment:
+    - bare_magic_cell: '%python'
+    - bare_magic_cell: print("first line of the notebook -> real magic cell")
+- statement_terminator: -- COMMAND ----------
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          numeric_literal: '1'

--- a/test/fixtures/dialects/databricks/bare_magic_sql.sql
+++ b/test/fixtures/dialects/databricks/bare_magic_sql.sql
@@ -1,0 +1,16 @@
+-- Databricks notebook source
+
+-- COMMAND ----------
+
+%sql
+SELECT a % 2 AS m FROM t;
+
+-- COMMAND ----------
+
+%python
+print("opaque, not parsed as sql")
+
+-- COMMAND ----------
+
+%sql
+SELECT b FROM u

--- a/test/fixtures/dialects/databricks/bare_magic_sql.yml
+++ b/test/fixtures/dialects/databricks/bare_magic_sql.yml
@@ -3,51 +3,48 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 15d7e1b7c5ab28d1d712720d719b1cecc66c2a454972c78e3425d6edfcd144ba
+_hash: cc397b5063e3c575d8c81efc0a7edcb6e365cb1edca7257075885f7d86583178
 file:
-- statement:
-    magic_cell_segment:
-      magic_start: "-- MAGIC %md\n"
-      magic_line: '-- MAGIC # Dummy Notebook'
 - statement_terminator: -- COMMAND ----------
 - statement:
     select_statement:
       select_clause:
         keyword: SELECT
         select_clause_element:
-          column_reference:
-            naked_identifier: x
+          expression:
+            column_reference:
+              naked_identifier: a
+            binary_operator: '%'
+            numeric_literal: '2'
+          alias_expression:
+            alias_operator:
+              keyword: AS
+            naked_identifier: m
       from_clause:
         keyword: FROM
         from_expression:
           from_expression_element:
             table_expression:
               table_reference:
-                naked_identifier: y
-- statement_terminator: -- COMMAND ----------
-- statement:
-    magic_cell_segment:
-    - magic_start: "-- MAGIC %python\n"
-    - magic_line: "-- MAGIC foo = 'bar'"
-    - magic_line: -- MAGIC print(foo)
-- statement_terminator: -- COMMAND ----------
-- statement:
-    select_statement:
-      select_clause:
-        keyword: SELECT
-        select_clause_element:
-          column_reference:
-            naked_identifier: a
-      from_clause:
-        keyword: FROM
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: b
+                naked_identifier: t
 - statement_terminator: ;
 - statement_terminator: -- COMMAND ----------
 - statement:
     magic_cell_segment:
-      magic_start: "-- MAGIC %sh\n"
-      magic_line: -- MAGIC echo heloworld
+    - bare_magic_cell: '%python'
+    - bare_magic_cell: print("opaque, not parsed as sql")
+- statement_terminator: -- COMMAND ----------
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          column_reference:
+            naked_identifier: b
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: u

--- a/test/fixtures/dialects/databricks/bare_magic_sql_notebook_start.sql
+++ b/test/fixtures/dialects/databricks/bare_magic_sql_notebook_start.sql
@@ -1,0 +1,13 @@
+-- Databricks notebook source
+%sql
+SELECT a % 2 AS m FROM t;
+
+-- COMMAND ----------
+
+%python
+print("opaque, not parsed as sql")
+
+-- COMMAND ----------
+
+%sql
+SELECT b FROM u

--- a/test/fixtures/dialects/databricks/bare_magic_sql_notebook_start.yml
+++ b/test/fixtures/dialects/databricks/bare_magic_sql_notebook_start.yml
@@ -1,0 +1,49 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: cdb27c6061b7783249a57b511a12aa9a076db859a2034655bf2186a38e4d88e3
+file:
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+            column_reference:
+              naked_identifier: a
+            binary_operator: '%'
+            numeric_literal: '2'
+          alias_expression:
+            alias_operator:
+              keyword: AS
+            naked_identifier: m
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: t
+- statement_terminator: ;
+- statement_terminator: -- COMMAND ----------
+- statement:
+    magic_cell_segment:
+    - bare_magic_cell: '%python'
+    - bare_magic_cell: print("opaque, not parsed as sql")
+- statement_terminator: -- COMMAND ----------
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          column_reference:
+            naked_identifier: b
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: u

--- a/test/fixtures/dialects/databricks/command_terminator.yml
+++ b/test/fixtures/dialects/databricks/command_terminator.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 29da11329feadea30d92cf0f13e7fd80c65ef79c00a12c73c8e3e0c6514d5167
+_hash: a95e18bc8d12d2db9caab861fc60c5bd0412252345ab667c4d5ad049a32dc971
 file:
 - statement:
     select_statement:
@@ -19,7 +19,7 @@ file:
             table_expression:
               table_reference:
                 naked_identifier: TABLE1
-- statement_terminator: "\n\n-- COMMAND ----------\n"
+- statement_terminator: -- COMMAND ----------
 - statement:
     select_statement:
       select_clause:
@@ -34,7 +34,7 @@ file:
             table_expression:
               table_reference:
                 naked_identifier: TABLE2
-- statement_terminator: "\n\n-- COMMAND ----------\n"
+- statement_terminator: -- COMMAND ----------
 - statement:
     select_statement:
       select_clause:

--- a/test/fixtures/dialects/databricks/magic_single_line.yml
+++ b/test/fixtures/dialects/databricks/magic_single_line.yml
@@ -3,17 +3,17 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 7bd24732f4f263dec401f41cafbd4abf033c7c5bb082b2bbb171414bb1bf420a
+_hash: 9a7766255c90ab88dcc9d44928c5bf5ab43d8ae32ab648efc893f5ef1f8d7ba0
 file:
 - statement:
     magic_cell_segment:
       magic_start: "-- MAGIC %md\n"
       magic_line: '-- MAGIC # Dummy Notebook'
-- statement_terminator: "\n\n-- COMMAND ----------\n"
+- statement_terminator: -- COMMAND ----------
 - statement:
     magic_cell_segment:
       magic_single_line: -- MAGIC %run ./Notebook
-- statement_terminator: "\n\n-- COMMAND ----------\n"
+- statement_terminator: -- COMMAND ----------
 - statement:
     select_statement:
       select_clause:

--- a/test/fixtures/dialects/databricks/modulo_operator.sql
+++ b/test/fixtures/dialects/databricks/modulo_operator.sql
@@ -1,0 +1,4 @@
+SELECT 10 % 3 AS remainder;
+
+SELECT 10
+% 3 AS remainder;

--- a/test/fixtures/dialects/databricks/modulo_operator.yml
+++ b/test/fixtures/dialects/databricks/modulo_operator.yml
@@ -1,0 +1,35 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: d2fce82df7dbc598458d79401b4bac01053b3fd28fa4e3f420ea485c5de63152
+file:
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+          - numeric_literal: '10'
+          - binary_operator: '%'
+          - numeric_literal: '3'
+          alias_expression:
+            alias_operator:
+              keyword: AS
+            naked_identifier: remainder
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+          - numeric_literal: '10'
+          - binary_operator: '%'
+          - numeric_literal: '3'
+          alias_expression:
+            alias_operator:
+              keyword: AS
+            naked_identifier: remainder
+- statement_terminator: ;


### PR DESCRIPTION
### Brief summary of the change made

This change adds Databricks support for notebook cells that begin with a bare language marker like %python or %run, without requiring the `-- MAGIC`  prefix.

It introduces a lexer/parser path that treats these cells as opaque magic-cell content until the next `-- COMMAND ----------` delimiter, and adds parse fixtures covering both multi-line and single-line bare magic cells.

Fixes #7877 

### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support in the Databricks dialect for bare magic cells (`%python`, `%run`, etc.), including when they appear right after the notebook header; `%sql` headers are handled so the SQL body is parsed normally. Fixes #7877.

- **New Features**
  - Recognizes bare magic cells without `-- MAGIC` (including at notebook start), capturing content until the next command delimiter; `%sql` lines are treated as headers and the following SQL is parsed as normal SQL.
  - Only the first line of a cell can start a bare magic; preserves `%` as the SQL modulo operator even at line start or next to magic keywords.

- **Refactors**
  - Adopts regex-based lexer rules (`bare_magic_cell`, `bare_magic_sql`, `command`, and first-cell variants) with a typed grammar hook in `MagicCellStatementSegment`, replacing the earlier parser-only approach.

<sup>Written for commit 6d70ed516cddce4238930f5a7981d6700c9c0ba6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8011?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

