### PR TITLE
fix(rust): match Python's bracket-nesting depth in Anything grammars

### DIFF
--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/core.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/core.rs
@@ -1535,7 +1535,7 @@ impl<'a> Parser<'a> {
                 // Handle bracket openers - match entire bracketed section with nested brackets
                 if tok_raw == "(" || tok_raw == "[" || tok_raw == "{" {
                     let bracket_match =
-                        self.match_bracket_recursively(tok_raw.as_str(), tok_raw == "(");
+                        self.match_bracket_recursively(tok_raw.as_str(), tok_raw == "(", true);
                     child_matches.push(bracket_match);
                 } else {
                     // Regular token - just bump, it'll be part of the raw content
@@ -1587,10 +1587,16 @@ impl<'a> Parser<'a> {
         }
     }
 
-    /// Recursively match brackets, handling nested brackets properly.
-    /// This ensures that nested brackets inside Anything grammars produce
-    /// proper BracketedSegment child_matches.
-    fn match_bracket_recursively(&mut self, open_bracket: &str, persists: bool) -> MatchResult {
+    /// Recursively match brackets. `nested_match` mirrors Python's
+    /// `resolve_bracket`: when true, directly-nested brackets are attached as
+    /// structured children; the recursive call passes false, so deeper brackets
+    /// are consumed but flattened to raw siblings (pure-Python parity).
+    fn match_bracket_recursively(
+        &mut self,
+        open_bracket: &str,
+        persists: bool,
+        nested_match: bool,
+    ) -> MatchResult {
         // Python parity: bracket leaf type depends on the bracket char
         // (`[`→square, `{`→curly); only `(` uses the plain bracket type.
         let (close_bracket, start_bracket_type, end_bracket_type) = match open_bracket {
@@ -1631,9 +1637,12 @@ impl<'a> Parser<'a> {
                 } else if inner_raw == "(" || inner_raw == "[" || inner_raw == "{" {
                     // Found a nested bracket - recursively match it
                     let nested_persists = inner_raw == "(";
-                    let nested_match =
-                        self.match_bracket_recursively(inner_raw.as_str(), nested_persists);
-                    inner_child_matches.push(Arc::new(nested_match));
+                    let nested_bracket =
+                        self.match_bracket_recursively(inner_raw.as_str(), nested_persists, false);
+                    // Only attach directly-nested brackets; deeper ones flatten.
+                    if nested_match {
+                        inner_child_matches.push(Arc::new(nested_bracket));
+                    }
                 } else {
                     // Regular token - just bump
                     self.bump();


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
`match_bracket_recursively` attached nested brackets as structured children at every depth; Python's `resolve_bracket` only does so one level deep. Thread a `nested_match` flag so deeper brackets are still consumed but flatten to raw siblings, restoring pure-Python parse-tree parity (surfaced in Greenplum).


### Are there any other side effects of this change that we should be aware of?
None

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns Rust parser with Python’s bracket handling in Anything grammars by only attaching one level of nested brackets and flattening deeper ones. This restores pure-Python parse tree parity and fixes Greenplum parsing differences.

- **Bug Fixes**
  - Added a `nested_match` flag to `match_bracket_recursively` and updated the call site to control depth.
  - Directly nested brackets become structured children; deeper nests are consumed but emitted as raw siblings.

<sup>Written for commit 2edff74d57c1392d6b94ce8c4c142d8d6c9ee9e5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8013?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

