### PR TITLE
fix: preserve Oracle execute file at-sign spacing

### DIFF
--- a/src/sqlfluff/core/default_config.cfg
+++ b/src/sqlfluff/core/default_config.cfg
@@ -185,6 +185,10 @@ line_position = leading
 spacing_within = touch
 line_position = leading
 
+[sqlfluff:layout:type:at_sign]
+spacing_before = touch
+spacing_after = touch
+
 [sqlfluff:layout:type:object_reference]
 spacing_within = touch:inline
 

--- a/test/fixtures/rules/std_rule_cases/LT01-operators.yml
+++ b/test/fixtures/rules/std_rule_cases/LT01-operators.yml
@@ -85,6 +85,15 @@ pass_tsql_assignment_operator:
     core:
       dialect: tsql
 
+pass_oracle_execute_file_double_at_sign:
+  # Oracle SQL*Plus @@ execute-file prefixes should not be separated by LT01.
+  pass_str: |
+    @@ACS_DBLOGIN_FK.SQL
+    @@ACS_DPS_STRUKTURKLASSE_FK.SQL
+  configs:
+    core:
+      dialect: oracle
+
 pass_concat_string:
   pass_str: SELECT 'barry' || 'pollard'
 


### PR DESCRIPTION
Fixes #8010

## Summary

This changes the default layout spacing for `at_sign` segments to `touch` on both sides. That keeps Oracle SQL*Plus execute-file statements such as `@@ACS_DBLOGIN_FK.SQL` intact instead of letting LT01 rewrite them to `@ @ ACS_DBLOGIN_FK.SQL`.

I also added an LT01 YAML regression case for the Oracle `@@` execute-file form.

## Validation

```text
sqlfluff lint --dialect oracle --rules LT01 /tmp/oracle_at.sql
sqlfluff fix --dialect oracle --rules LT01 /tmp/oracle_at_fix.sql
pytest test/rules/yaml_test_cases_test.py -k oracle_execute_file_double_at_sign
pytest test/dialects/oracle_test.py
pytest test/rules/yaml_test_cases_test.py -k LT01
sqlfluff lint --dialect oracle --rules LT01 test/fixtures/dialects/oracle/at_signs.sql
sqlfluff fix --dialect oracle --rules LT01 /tmp/oracle_at_signs_fixture.sql
git diff --check
```

## Notes

AI assistance was used to prepare this patch. I reproduced the issue locally and ran the validation commands above.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves Oracle SQL*Plus execute-file at-sign spacing so `LT01` no longer rewrites `@@file.sql` to `@ @ file.sql`. Sets the default at-sign layout to touch on both sides.

- **Bug Fixes**
  - Set `[sqlfluff:layout:type:at_sign]` with `spacing_before = touch` and `spacing_after = touch` to keep `@@ACS_DBLOGIN_FK.SQL` intact for the `oracle` dialect.
  - Added a YAML regression case for the Oracle `@@` execute-file form.

<sup>Written for commit 2dc68aae9a9a6cec615aa781fe0b9683e9efbd2c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8015?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

