### PR TITLE
Fix RF02 false positive on table alias inside a query hint

### DIFF
--- a/src/sqlfluff/utils/analysis/select.py
+++ b/src/sqlfluff/utils/analysis/select.py
@@ -90,6 +90,25 @@ def _get_select_except_refs(segment: BaseSegment) -> set[int]:
     return except_ref_ids
 
 
+def _get_hint_refs(segment: BaseSegment) -> set[int]:
+    """Get the ids of object references inside a query hint.
+
+    Dialects like SparkSQL support optimizer hints such as
+    ``SELECT /*+ BROADCAST(t1) */ ...`` where the hint arguments name tables or
+    aliases for the planner. Those names are not column references in the select
+    and shouldn't be treated as ordinary references by rules like RF02.
+    See: https://github.com/sqlfluff/sqlfluff/issues/6771
+    """
+    hint_ref_ids: set[int] = set()
+    for hint in segment.recursive_crawl(
+        "select_hint",
+        no_recursive_seg_type=["select_statement", "merge_statement"],
+    ):
+        for ref in hint.recursive_crawl("object_reference"):
+            hint_ref_ids.add(id(ref))
+    return hint_ref_ids
+
+
 def _get_object_references(
     segment: BaseSegment,
     exclude_ids: Optional[set[int]] = None,
@@ -133,7 +152,12 @@ def get_select_statement_info(
     # Also identify columns listed in a SELECT * EXCEPT (...) clause; those name
     # columns to drop from the star expansion and don't need qualification.
     # See: https://github.com/sqlfluff/sqlfluff/issues/5764
-    exclude_ref_ids = _get_struct_alias_refs(sc) | _get_select_except_refs(sc)
+    # Also identify object references inside a query hint (e.g.
+    # ``/*+ BROADCAST(t1) */``); those name tables/aliases for the planner, not
+    # columns in the select. See: https://github.com/sqlfluff/sqlfluff/issues/6771
+    exclude_ref_ids = (
+        _get_struct_alias_refs(sc) | _get_select_except_refs(sc) | _get_hint_refs(sc)
+    )
     reference_buffer = _get_object_references(sc, exclude_ids=exclude_ref_ids)
     table_reference_buffer = []
     for potential_clause in (

--- a/test/fixtures/rules/std_rule_cases/RF02.yml
+++ b/test/fixtures/rules/std_rule_cases/RF02.yml
@@ -739,3 +739,41 @@ test_fail_unqualified_reference_with_star_except:
   configs:
     core:
       dialect: databricks
+
+test_pass_sparksql_broadcast_hint:
+  # The argument of a query hint names a table/alias for the planner, not a
+  # column in the select, so it doesn't need qualification.
+  # https://github.com/sqlfluff/sqlfluff/issues/6771
+  pass_str: |
+    SELECT /*+ BROADCAST(a) */
+        a.col_one,
+        b.col_two
+    FROM table_a AS a
+    JOIN table_b AS b ON a.id = b.id
+  configs:
+    core:
+      dialect: sparksql
+
+test_pass_sparksql_merge_hint_multiple_tables:
+  pass_str: |
+    SELECT /*+ MERGE(a, b) */
+        a.col_one,
+        b.col_two
+    FROM table_a AS a
+    JOIN table_b AS b ON a.id = b.id
+  configs:
+    core:
+      dialect: sparksql
+
+test_fail_unqualified_reference_with_hint:
+  # The hint exclusion is scoped to the hint; a genuinely unqualified
+  # reference elsewhere in the select should still fail.
+  fail_str: |
+    SELECT /*+ BROADCAST(a) */
+        col_one,
+        b.col_two
+    FROM table_a AS a
+    JOIN table_b AS b ON a.id = b.id
+  configs:
+    core:
+      dialect: sparksql


### PR DESCRIPTION
Fixes #6771.

RF02 was wrongly flagging the table-alias argument of a query hint, e.g. `SELECT /*+ BROADCAST(t1) */ ...`, as an unqualified reference. The argument names a table or alias for the planner, not a column in the select, so it doesn't need qualification.

The fix excludes object references that descend from a `select_hint` when building the select clause reference buffer, mirroring the existing STRUCT-alias (#6919) and `SELECT * EXCEPT` (#5764) exclusions. Because it's a single change in the shared analysis layer, it covers every dialect whose hints parse references this way.

I kept the scope to the hint false positive only.

Validation:
- added SparkSQL pass cases for `BROADCAST(a)` and `MERGE(a, b)`, plus a fail case proving a genuinely unqualified reference elsewhere in the same select still gets flagged
- `python -m pytest test/rules/yaml_test_cases_test.py -k "RF01 or RF02 or RF03 or AL05"` is green (343 passed)
- stashed the fix and re-ran the new pass cases to confirm they fail without it, then restored and confirmed green
- re-ran the issue's repro and the false positive is gone

I used AI assistance while working on this, but I wrote and reviewed the change and the tests myself and verified the behavior locally.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes RF02 falsely flagging table aliases inside query hints (e.g., SELECT /*+ BROADCAST(a) */ ...) as unqualified column references. Object references inside select hints are now excluded from qualification checks across dialects that parse hints this way.

- **Bug Fixes**
  - Ignore `object_reference` nodes under `select_hint` when building the select clause reference buffer, mirroring existing STRUCT-alias and SELECT * EXCEPT exclusions.
  - Add SparkSQL tests for `BROADCAST(a)` and `MERGE(a, b)`, plus a fail case ensuring real unqualified references still get flagged.

<sup>Written for commit de22e029850c6b4a2472bacaeba0662c2e587015. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8018?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

