### PR TITLE
perf(rust): compute raw_normalized lazily with cached regex compilation

### DIFF
--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/match_result.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/match_result.rs
@@ -740,7 +740,7 @@ pub fn segment_kwargs_from_token(
 ) -> SegmentKwargs {
     SegmentKwargs {
         instance_types: instance_types.or_else(|| Some(vec![token_type.to_string()])),
-        casefold: casefold.unwrap_or_else(|| tok.casefold.clone()),
+        casefold: casefold.unwrap_or_else(|| tok.casefold()),
         trim_chars: tok.trim_chars.clone(),
         escape_replacement: tok.escape_replacement().cloned(),
         quoted_value: tok.quoted_value().cloned(),

--- a/sqlfluffrs/sqlfluffrs_types/src/regex.rs
+++ b/sqlfluffrs/sqlfluffrs_types/src/regex.rs
@@ -1,7 +1,21 @@
 use std::fmt::Display;
+use std::sync::RwLock;
 
 use fancy_regex::{Regex as FancyRegex, RegexBuilder as FancyRegexBuilder};
+use hashbrown::HashMap;
+use once_cell::sync::Lazy;
 use regex::{Regex, RegexBuilder};
+
+/// Process-global cache of compiled `RegexMode`s, keyed by `(pattern, case_insensitive)`.
+///
+/// Compiling a regex is orders of magnitude more expensive than matching one, and
+/// the same handful of dialect patterns (quoted-value / escape-replacement) are
+/// reused across thousands of tokens. Cache the compiled form so each distinct
+/// pattern is built at most once.
+///
+/// Note: the parser keeps its own instance-scoped cache for grammar patterns.
+static REGEX_CACHE: Lazy<RwLock<HashMap<(String, bool), RegexMode>>> =
+    Lazy::new(|| RwLock::new(HashMap::new()));
 
 #[derive(Debug, Clone)]
 pub enum RegexModeGroup {
@@ -36,6 +50,34 @@ pub enum RegexMode {
 impl RegexMode {
     pub fn new(pattern: &str) -> Self {
         Self::new_with_flags(pattern, true)
+    }
+
+    /// Like [`RegexMode::new`], but returns a cached compiled regex, only
+    /// compiling on the first request for a given pattern.
+    pub fn cached(pattern: &str) -> Self {
+        Self::cached_with_flags(pattern, true)
+    }
+
+    /// Like [`RegexMode::new_with_flags`], but returns a cached compiled regex,
+    /// only compiling on the first request for a given `(pattern, flags)`.
+    pub fn cached_with_flags(pattern: &str, case_insensitive: bool) -> Self {
+        let key = (pattern.to_string(), case_insensitive);
+        // Fast path: shared read lock for the common (already-cached) case.
+        if let Some(re) = REGEX_CACHE
+            .read()
+            .unwrap_or_else(|p| p.into_inner())
+            .get(&key)
+        {
+            return re.clone();
+        }
+        // Slow path: compile under the write lock so each pattern is built at
+        // most once even under concurrent first use.
+        REGEX_CACHE
+            .write()
+            .unwrap_or_else(|p| p.into_inner())
+            .entry(key)
+            .or_insert_with(|| Self::new_with_flags(pattern, case_insensitive))
+            .clone()
     }
 
     pub fn new_with_flags(pattern: &str, case_insensitive: bool) -> Self {

--- a/sqlfluffrs/sqlfluffrs_types/src/token/construction.rs
+++ b/sqlfluffrs/sqlfluffrs_types/src/token/construction.rs
@@ -24,7 +24,6 @@ impl Token {
         } = config;
 
         let (token_types, class_types) = iter_base_types("base", class_types.clone());
-        let raw_value = Token::normalize(&raw, quoted_value.clone(), escape_replacement.clone());
         Self {
             token_type: token_types,
             class_name: "BaseSegment".to_string(),
@@ -34,7 +33,7 @@ impl Token {
             is_meta: false,
             allow_empty: false,
             pos_marker: Some(pos_marker),
-            raw: crate::token::RawString::new(raw),
+            raw: crate::token::RawString::new(raw, quoted_value, escape_replacement),
             is_whitespace: false,
             is_code: true,
             is_comment: false,
@@ -53,10 +52,7 @@ impl Token {
             source_fixes: None,
             trim_start,
             trim_chars,
-            quoted_value,
-            escape_replacement,
             casefold,
-            raw_value,
             matching_bracket_idx: None, // Will be computed after all tokens are created
         }
     }

--- a/sqlfluffrs/sqlfluffrs_types/src/token/construction.rs
+++ b/sqlfluffrs/sqlfluffrs_types/src/token/construction.rs
@@ -33,7 +33,7 @@ impl Token {
             is_meta: false,
             allow_empty: false,
             pos_marker: Some(pos_marker),
-            raw: crate::token::RawString::new(raw, quoted_value, escape_replacement),
+            raw: crate::token::RawString::new(raw, quoted_value, escape_replacement, casefold),
             is_whitespace: false,
             is_code: true,
             is_comment: false,
@@ -52,7 +52,6 @@ impl Token {
             source_fixes: None,
             trim_start,
             trim_chars,
-            casefold,
             matching_bracket_idx: None, // Will be computed after all tokens are created
         }
     }

--- a/sqlfluffrs/sqlfluffrs_types/src/token/mod.rs
+++ b/sqlfluffrs/sqlfluffrs_types/src/token/mod.rs
@@ -66,7 +66,6 @@ pub struct Token {
     pub source_fixes: Option<Vec<SourceFix>>,
     pub trim_start: Option<Vec<String>>,
     pub trim_chars: Option<Vec<String>>,
-    pub casefold: CaseFold,
     /// Pre-computed index of matching bracket for O(1) lookup during parsing.
     /// For opening brackets like '(', '[', '{', this points to the matching closing bracket.
     /// For closing brackets like ')', ']', '}', this points back to the matching opening bracket.
@@ -138,6 +137,11 @@ impl Token {
     /// Get the escape_replacement pattern for this token (if any)
     pub fn escape_replacement(&self) -> Option<&(String, String)> {
         self.raw.escape_replacement()
+    }
+
+    /// Get the casefold mode for this token (`CaseFold::None` if unset)
+    pub fn casefold(&self) -> CaseFold {
+        self.raw.casefold()
     }
 
     pub fn normalize(
@@ -339,6 +343,7 @@ impl Token {
                 new_raw,
                 self.raw.quoted_value().cloned(),
                 self.raw.escape_replacement().cloned(),
+                self.raw.casefold(),
             ),
             source_fixes: Some(source_fixes.unwrap_or(self.source_fixes())),
             uuid: crate::identity::next_id(),

--- a/sqlfluffrs/sqlfluffrs_types/src/token/mod.rs
+++ b/sqlfluffrs/sqlfluffrs_types/src/token/mod.rs
@@ -66,11 +66,7 @@ pub struct Token {
     pub source_fixes: Option<Vec<SourceFix>>,
     pub trim_start: Option<Vec<String>>,
     pub trim_chars: Option<Vec<String>>,
-    quoted_value: Option<(String, RegexModeGroup)>,
-    escape_replacement: Option<(String, String)>,
     pub casefold: CaseFold,
-    #[allow(dead_code)]
-    raw_value: String,
     /// Pre-computed index of matching bracket for O(1) lookup during parsing.
     /// For opening brackets like '(', '[', '{', this points to the matching closing bracket.
     /// For closing brackets like ')', ']', '}', this points back to the matching opening bracket.
@@ -136,29 +132,30 @@ impl Token {
 
     /// Get the quoted_value pattern for this token (if any)
     pub fn quoted_value(&self) -> Option<&(String, RegexModeGroup)> {
-        self.quoted_value.as_ref()
+        self.raw.quoted_value()
     }
 
     /// Get the escape_replacement pattern for this token (if any)
     pub fn escape_replacement(&self) -> Option<&(String, String)> {
-        self.escape_replacement.as_ref()
+        self.raw.escape_replacement()
     }
 
     pub fn normalize(
         value: &str,
-        quoted_value: Option<(String, RegexModeGroup)>,
-        escape_replacement: Option<(String, String)>,
+        quoted_value: Option<&(String, RegexModeGroup)>,
+        escape_replacement: Option<&(String, String)>,
     ) -> String {
         let mut str_buffer = value.to_string();
 
-        if let Some((ref regex_str, idx)) = quoted_value {
-            if let Some(captured) = RegexMode::new(regex_str).capture(idx, value) {
+        if let Some((regex_str, idx)) = quoted_value {
+            if let Some(captured) = RegexMode::cached(regex_str).capture(idx.clone(), value) {
                 str_buffer = captured
             }
         }
 
-        if let Some((ref regex_str, ref replacement)) = escape_replacement {
-            str_buffer = RegexMode::new(regex_str).replace_all(&str_buffer, replacement.as_str());
+        if let Some((regex_str, replacement)) = escape_replacement {
+            str_buffer =
+                RegexMode::cached(regex_str).replace_all(&str_buffer, replacement.as_str());
         }
 
         str_buffer
@@ -292,12 +289,13 @@ impl Token {
         raw_buff
     }
 
-    fn _raw_normalized(&self) -> String {
-        todo!()
-    }
-
+    /// The normalized form of this token's raw value: the quoted value extracted
+    /// and escape sequences replaced, per this token's dialect config.
+    ///
+    /// Computed lazily and cached, so tokens never inspected by a rule pay
+    /// nothing, and the common case (no transform spec) avoids all regex work.
     pub fn raw_normalized(&self) -> String {
-        todo!()
+        self.raw.normalized().to_owned()
     }
 
     pub fn stringify(&self, ident: usize, tabsize: usize, code_only: bool) -> String {
@@ -336,7 +334,12 @@ impl Token {
     pub fn edit(&self, raw: Option<String>, source_fixes: Option<Vec<SourceFix>>) -> Self {
         let new_raw = raw.unwrap_or_else(|| self.raw.as_str().to_owned());
         Self {
-            raw: RawString::new(new_raw),
+            // Carry over the transform spec so the edited raw normalizes the same way.
+            raw: RawString::new(
+                new_raw,
+                self.raw.quoted_value().cloned(),
+                self.raw.escape_replacement().cloned(),
+            ),
             source_fixes: Some(source_fixes.unwrap_or(self.source_fixes())),
             uuid: crate::identity::next_id(),
             ..self.clone()

--- a/sqlfluffrs/sqlfluffrs_types/src/token/raw_string.rs
+++ b/sqlfluffrs/sqlfluffrs_types/src/token/raw_string.rs
@@ -1,13 +1,40 @@
+use std::sync::OnceLock;
+
+use crate::regex::RegexModeGroup;
+
+use super::Token;
+
+/// A raw token string together with the forms derived from it: its uppercase
+/// version (always), and its normalized version (lazily, per the transform
+/// spec). Co-locating them keeps the derived forms in sync with `raw` and keeps
+/// the eager work out of the hot path.
 #[derive(Debug, Clone)]
 pub struct RawString {
     raw: String,
     raw_upper: String,
+    /// Spec for normalizing `raw`: extract the quoted value / replace escapes.
+    quoted_value: Option<(String, RegexModeGroup)>,
+    escape_replacement: Option<(String, String)>,
+    /// Lazily computed, config-dependent normalized form. Empty until the first
+    /// `normalized()` call (typically only during linting), so construction and
+    /// parsing pay nothing.
+    normalized: OnceLock<String>,
 }
 
 impl RawString {
-    pub fn new(raw: String) -> Self {
+    pub fn new(
+        raw: String,
+        quoted_value: Option<(String, RegexModeGroup)>,
+        escape_replacement: Option<(String, String)>,
+    ) -> Self {
         let raw_upper = raw.to_uppercase();
-        Self { raw, raw_upper }
+        Self {
+            raw,
+            raw_upper,
+            quoted_value,
+            escape_replacement,
+            normalized: OnceLock::new(),
+        }
     }
 
     pub fn as_str(&self) -> &str {
@@ -16,5 +43,31 @@ impl RawString {
 
     pub fn upper(&self) -> &str {
         &self.raw_upper
+    }
+
+    /// Get the quoted_value transform spec (if any).
+    pub fn quoted_value(&self) -> Option<&(String, RegexModeGroup)> {
+        self.quoted_value.as_ref()
+    }
+
+    /// Get the escape_replacement transform spec (if any).
+    pub fn escape_replacement(&self) -> Option<&(String, String)> {
+        self.escape_replacement.as_ref()
+    }
+
+    /// The normalized form of `raw`, computed at most once. When there is no
+    /// transform spec the result is `raw` itself, so no regex work is done.
+    pub fn normalized(&self) -> &str {
+        self.normalized.get_or_init(|| {
+            if self.quoted_value.is_none() && self.escape_replacement.is_none() {
+                self.raw.clone()
+            } else {
+                Token::normalize(
+                    &self.raw,
+                    self.quoted_value.as_ref(),
+                    self.escape_replacement.as_ref(),
+                )
+            }
+        })
     }
 }

--- a/sqlfluffrs/sqlfluffrs_types/src/token/raw_string.rs
+++ b/sqlfluffrs/sqlfluffrs_types/src/token/raw_string.rs
@@ -2,16 +2,18 @@ use std::sync::OnceLock;
 
 use crate::regex::RegexModeGroup;
 
-use super::Token;
+use super::{CaseFold, Token};
 
-/// Spec for normalizing `raw` (extract the quoted value / replace escapes),
-/// plus the lazily-computed result. Boxed and only present for the minority of
-/// tokens that actually carry a transform (string literals, quoted identifiers),
-/// so the common token pays a single pointer instead of ~128 bytes.
+/// Spec for normalizing `raw` (extract the quoted value, replace escapes,
+/// casefold), plus the lazily-computed result. Boxed and only present for the
+/// minority of tokens that actually carry a transform (string literals, quoted
+/// identifiers, the rare casefolded grammar), so the common token pays a single
+/// pointer instead of carrying these fields inline.
 #[derive(Debug, Clone)]
 struct NormalizeSpec {
     quoted_value: Option<(String, RegexModeGroup)>,
     escape_replacement: Option<(String, String)>,
+    casefold: CaseFold,
     /// Config-dependent normalized form, computed at most once. Empty until the
     /// first `normalized()` call (typically only during linting).
     normalized: OnceLock<String>,
@@ -35,6 +37,7 @@ impl RawString {
         raw: String,
         quoted_value: Option<(String, RegexModeGroup)>,
         escape_replacement: Option<(String, String)>,
+        casefold: CaseFold,
     ) -> Self {
         // Only allocate an uppercase copy when it actually differs from `raw`.
         let raw_upper = if raw.is_ascii() && !raw.bytes().any(|b| b.is_ascii_lowercase()) {
@@ -42,10 +45,14 @@ impl RawString {
         } else {
             Some(raw.to_uppercase())
         };
-        let spec = if quoted_value.is_some() || escape_replacement.is_some() {
+        let spec = if quoted_value.is_some()
+            || escape_replacement.is_some()
+            || casefold != CaseFold::None
+        {
             Some(Box::new(NormalizeSpec {
                 quoted_value,
                 escape_replacement,
+                casefold,
                 normalized: OnceLock::new(),
             }))
         } else {
@@ -74,6 +81,11 @@ impl RawString {
     /// Get the escape_replacement transform spec (if any).
     pub fn escape_replacement(&self) -> Option<&(String, String)> {
         self.spec.as_ref().and_then(|s| s.escape_replacement.as_ref())
+    }
+
+    /// Get the casefold mode (`CaseFold::None` when there is no spec).
+    pub fn casefold(&self) -> CaseFold {
+        self.spec.as_ref().map_or(CaseFold::None, |s| s.casefold)
     }
 
     /// The normalized form of `raw`, computed at most once. With no transform

--- a/sqlfluffrs/sqlfluffrs_types/src/token/raw_string.rs
+++ b/sqlfluffrs/sqlfluffrs_types/src/token/raw_string.rs
@@ -4,21 +4,30 @@ use crate::regex::RegexModeGroup;
 
 use super::Token;
 
+/// Spec for normalizing `raw` (extract the quoted value / replace escapes),
+/// plus the lazily-computed result. Boxed and only present for the minority of
+/// tokens that actually carry a transform (string literals, quoted identifiers),
+/// so the common token pays a single pointer instead of ~128 bytes.
+#[derive(Debug, Clone)]
+struct NormalizeSpec {
+    quoted_value: Option<(String, RegexModeGroup)>,
+    escape_replacement: Option<(String, String)>,
+    /// Config-dependent normalized form, computed at most once. Empty until the
+    /// first `normalized()` call (typically only during linting).
+    normalized: OnceLock<String>,
+}
+
 /// A raw token string together with the forms derived from it: its uppercase
-/// version (always), and its normalized version (lazily, per the transform
-/// spec). Co-locating them keeps the derived forms in sync with `raw` and keeps
-/// the eager work out of the hot path.
+/// version, and its normalized version. Co-locating them keeps the derived
+/// forms in sync with `raw` and keeps the eager work out of the hot path.
 #[derive(Debug, Clone)]
 pub struct RawString {
     raw: String,
-    raw_upper: String,
-    /// Spec for normalizing `raw`: extract the quoted value / replace escapes.
-    quoted_value: Option<(String, RegexModeGroup)>,
-    escape_replacement: Option<(String, String)>,
-    /// Lazily computed, config-dependent normalized form. Empty until the first
-    /// `normalized()` call (typically only during linting), so construction and
-    /// parsing pay nothing.
-    normalized: OnceLock<String>,
+    /// Uppercase form. `None` when it is identical to `raw` (whitespace,
+    /// punctuation, numbers, already-uppercase text), avoiding a duplicate
+    /// allocation for the many tokens with no lowercase letters.
+    raw_upper: Option<String>,
+    spec: Option<Box<NormalizeSpec>>,
 }
 
 impl RawString {
@@ -27,13 +36,25 @@ impl RawString {
         quoted_value: Option<(String, RegexModeGroup)>,
         escape_replacement: Option<(String, String)>,
     ) -> Self {
-        let raw_upper = raw.to_uppercase();
+        // Only allocate an uppercase copy when it actually differs from `raw`.
+        let raw_upper = if raw.is_ascii() && !raw.bytes().any(|b| b.is_ascii_lowercase()) {
+            None
+        } else {
+            Some(raw.to_uppercase())
+        };
+        let spec = if quoted_value.is_some() || escape_replacement.is_some() {
+            Some(Box::new(NormalizeSpec {
+                quoted_value,
+                escape_replacement,
+                normalized: OnceLock::new(),
+            }))
+        } else {
+            None
+        };
         Self {
             raw,
             raw_upper,
-            quoted_value,
-            escape_replacement,
-            normalized: OnceLock::new(),
+            spec,
         }
     }
 
@@ -42,32 +63,31 @@ impl RawString {
     }
 
     pub fn upper(&self) -> &str {
-        &self.raw_upper
+        self.raw_upper.as_deref().unwrap_or(&self.raw)
     }
 
     /// Get the quoted_value transform spec (if any).
     pub fn quoted_value(&self) -> Option<&(String, RegexModeGroup)> {
-        self.quoted_value.as_ref()
+        self.spec.as_ref().and_then(|s| s.quoted_value.as_ref())
     }
 
     /// Get the escape_replacement transform spec (if any).
     pub fn escape_replacement(&self) -> Option<&(String, String)> {
-        self.escape_replacement.as_ref()
+        self.spec.as_ref().and_then(|s| s.escape_replacement.as_ref())
     }
 
-    /// The normalized form of `raw`, computed at most once. When there is no
-    /// transform spec the result is `raw` itself, so no regex work is done.
+    /// The normalized form of `raw`, computed at most once. With no transform
+    /// spec the result is `raw` itself, so no work or storage is needed.
     pub fn normalized(&self) -> &str {
-        self.normalized.get_or_init(|| {
-            if self.quoted_value.is_none() && self.escape_replacement.is_none() {
-                self.raw.clone()
-            } else {
+        match &self.spec {
+            None => &self.raw,
+            Some(spec) => spec.normalized.get_or_init(|| {
                 Token::normalize(
                     &self.raw,
-                    self.quoted_value.as_ref(),
-                    self.escape_replacement.as_ref(),
+                    spec.quoted_value.as_ref(),
+                    spec.escape_replacement.as_ref(),
                 )
-            }
-        })
+            }),
+        }
     }
 }

--- a/sqlfluffrs/sqlfluffrs_types/src/token/raw_string.rs
+++ b/sqlfluffrs/sqlfluffrs_types/src/token/raw_string.rs
@@ -45,19 +45,18 @@ impl RawString {
         } else {
             Some(raw.to_uppercase())
         };
-        let spec = if quoted_value.is_some()
-            || escape_replacement.is_some()
-            || casefold != CaseFold::None
-        {
-            Some(Box::new(NormalizeSpec {
-                quoted_value,
-                escape_replacement,
-                casefold,
-                normalized: OnceLock::new(),
-            }))
-        } else {
-            None
-        };
+        let spec =
+            if quoted_value.is_some() || escape_replacement.is_some() || casefold != CaseFold::None
+            {
+                Some(Box::new(NormalizeSpec {
+                    quoted_value,
+                    escape_replacement,
+                    casefold,
+                    normalized: OnceLock::new(),
+                }))
+            } else {
+                None
+            };
         Self {
             raw,
             raw_upper,
@@ -80,7 +79,9 @@ impl RawString {
 
     /// Get the escape_replacement transform spec (if any).
     pub fn escape_replacement(&self) -> Option<&(String, String)> {
-        self.spec.as_ref().and_then(|s| s.escape_replacement.as_ref())
+        self.spec
+            .as_ref()
+            .and_then(|s| s.escape_replacement.as_ref())
     }
 
     /// Get the casefold mode (`CaseFold::None` when there is no spec).


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
`Token::base_token` called `Token::normalize()` for every lexed token to populate a `raw_value` field that had no readers (`raw_normalized()` was `todo!()`). For most tokens that was a wasted string clone; for quoted/escaped tokens it recompiled a regex per token, which dominated lexing cost.

Rather than dropping the work (it's needed once `raw_normalized()` is implemented for linting), this makes it lazy and cached:
- Remove the eagerly-computed `raw_value` field; nothing read it.
- Implement `raw_normalized()` to compute on demand from fields already on the token, with a fast path that skips all regex work when there's no `quoted_value`/`escape_replacement`.
- Add a process-global `RegexMode` cache so each distinct dialect pattern compiles at most once instead of once per token.

Performance
Criterion, lexing the TPC-H (22) and TPC-DS (99) query suites, vs. main:

| Suite | Stage | main | branch | change |
|---|---|---|---|---|
| TPC-H | lex | 16.13 ms | 7.61 ms | **−52.9%** |
| | lex+parse | 114.3 ms | 106.4 ms | −7.0% |
| TPC-DS | lex | 147.72 ms | 65.25 ms | **−55.8%** |
| | lex+parse | 1158.3 ms | 1072.5 ms | −7.4% |
Lexing ~2.2× faster; parse unchanged (within noise), confirming the change is isolated to token construction.

**Now with Tokens 20% smaller!**

Supersedes #8005 

### Are there any other side effects of this change that we should be aware of?
None

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make token normalization lazy inside `RawString` with a process‑global regex cache, and shrink token memory. Removes the unused eager `raw_value`; boxes the transform spec (including `casefold`) and skips duplicate uppercase strings; lexing ~2× faster, parse unchanged.

- **Refactors**
  - Moved `quoted_value`/`escape_replacement` and `casefold` into `RawString`; added `normalized()` with `OnceLock`; `Token::raw_normalized()` and `casefold()` now delegate; `edit()` preserves the spec.
  - Added a process‑global cached `RegexMode` keyed by `(pattern, case_insensitive)` and switched `Token::normalize()` to borrow specs and use `RegexMode::cached()`; `RawString` only stores `upper` when it differs to avoid extra allocations.

<sup>Written for commit 5748037769646c197aeb0d0cf4c3668b22beb575. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8019?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



