### PR TITLE
perf(rust): borrow static segment type/class strings into the Node + arena tree

### DIFF
--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/arena.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/arena.rs
@@ -17,6 +17,7 @@
 //! uuid through `apply_as_root` is deferred to the fixing milestone where
 //! cross-reingest identity matters for `LintFix` anchoring.
 
+use std::borrow::Cow;
 use std::cell::RefCell;
 use std::sync::Arc;
 
@@ -43,16 +44,16 @@ impl NodeId {
 #[derive(Debug, Clone, PartialEq)]
 enum ArenaKind {
     Raw {
-        segment_class: String,
-        segment_type: String,
+        segment_class: Cow<'static, str>,
+        segment_type: Cow<'static, str>,
         raw: String,
         instance_types: Vec<String>,
         class_types: Vec<String>,
         kwargs: RawSegmentKwargs,
     },
     Segment {
-        segment_class: String,
-        segment_type: Option<String>,
+        segment_class: Cow<'static, str>,
+        segment_type: Option<Cow<'static, str>>,
         class_types: Vec<String>,
     },
     Meta {
@@ -303,8 +304,10 @@ impl Arena {
     /// Semantic type string (mirrors [`Node::get_type`]).
     pub(crate) fn get_type(&self, id: NodeId) -> String {
         match &self.node(id).kind {
-            ArenaKind::Raw { segment_type, .. } => segment_type.clone(),
-            ArenaKind::Segment { segment_type, .. } => segment_type.clone().unwrap_or_default(),
+            ArenaKind::Raw { segment_type, .. } => segment_type.to_string(),
+            ArenaKind::Segment { segment_type, .. } => {
+                segment_type.as_deref().unwrap_or_default().to_string()
+            }
             ArenaKind::Meta { meta_type } => meta_type_str(meta_type).to_string(),
             ArenaKind::Unparsable { .. } => "unparsable".to_string(),
             ArenaKind::Empty => "empty".to_string(),
@@ -344,7 +347,7 @@ impl Arena {
                 segment_type,
                 class_types,
                 ..
-            } => segment_type == target || class_types.iter().any(|t| t == target),
+            } => segment_type.as_ref() == target || class_types.iter().any(|t| t == target),
             ArenaKind::Segment {
                 segment_type,
                 class_types,
@@ -392,7 +395,7 @@ impl Arena {
     pub(crate) fn segment_class(&self, id: NodeId) -> Option<String> {
         match &self.node(id).kind {
             ArenaKind::Raw { segment_class, .. } | ArenaKind::Segment { segment_class, .. } => {
-                Some(segment_class.clone())
+                Some(segment_class.to_string())
             }
             _ => None,
         }
@@ -464,7 +467,7 @@ impl Arena {
                     )
                 });
                 let non_code_by_type = segment_type.contains("comment")
-                    || matches!(segment_type.as_str(), "whitespace" | "newline");
+                    || matches!(segment_type.as_ref(), "whitespace" | "newline");
                 let non_code_by_class = class_types.iter().any(|t| t == "comment");
                 !(non_code_by_instance || non_code_by_type || non_code_by_class)
             }
@@ -724,22 +727,22 @@ mod tests {
             &["identifier"],
         );
         let col = Node::Segment {
-            segment_class: "ColumnReferenceSegment".to_string(),
-            segment_type: Some("column_reference".to_string()),
+            segment_class: "ColumnReferenceSegment".into(),
+            segment_type: Some("column_reference".into()),
             pos_marker: None,
             class_types: vec!["column_reference".to_string()],
             children: vec![ident],
         };
         let select = Node::Segment {
-            segment_class: "SelectStatementSegment".to_string(),
-            segment_type: Some("select_statement".to_string()),
+            segment_class: "SelectStatementSegment".into(),
+            segment_type: Some("select_statement".into()),
             pos_marker: None,
             class_types: vec!["select_statement".to_string(), "statement".to_string()],
             children: vec![kw, ws, col],
         };
         Node::Segment {
-            segment_class: "StatementSegment".to_string(),
-            segment_type: Some("statement".to_string()),
+            segment_class: "StatementSegment".into(),
+            segment_type: Some("statement".into()),
             pos_marker: None,
             class_types: vec!["statement".to_string()],
             children: vec![select],
@@ -834,8 +837,8 @@ mod tests {
         // Mirror `BaseSegment.get_child`/`get_children`, which consider *all*
         // children including metas: a query for `indent` must return the meta.
         let tree = Node::Segment {
-            segment_class: "SelectStatementSegment".to_string(),
-            segment_type: Some("select_statement".to_string()),
+            segment_class: "SelectStatementSegment".into(),
+            segment_type: Some("select_statement".into()),
             pos_marker: None,
             class_types: vec!["select_statement".to_string()],
             children: vec![

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/core.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/core.rs
@@ -6,6 +6,7 @@
 use crate::parser::match_result::{self, MatchedClass, SegmentKwargs};
 #[cfg(feature = "verbose-debug")]
 use crate::vdebug;
+use std::borrow::Cow;
 use std::sync::Arc;
 
 use crate::parser::table_driven::frame::{TableFrameResult, TableParseFrame};
@@ -525,8 +526,8 @@ impl<'a> Parser<'a> {
                 let result = MatchResult {
                     matched_slice: token_pos..token_pos + 1,
                     matched_class: Some(MatchedClass {
-                        class_name: raw_class.to_string(),
-                        segment_type: Some(token_type.to_string()),
+                        class_name: Cow::Borrowed(raw_class),
+                        segment_type: Some(Cow::Borrowed(token_type)),
                         segment_kwargs,
                     }),
                     ..Default::default()
@@ -749,8 +750,8 @@ impl<'a> Parser<'a> {
                 let match_result = MatchResult {
                     matched_slice: token_pos..token_pos + 1,
                     matched_class: Some(MatchedClass {
-                        class_name: raw_class.to_string(),
-                        segment_type: Some(effective_segment_type.clone()),
+                        class_name: Cow::Borrowed(raw_class),
+                        segment_type: Some(Cow::Owned(effective_segment_type.clone())),
                         segment_kwargs,
                     }),
                     ..Default::default()
@@ -912,8 +913,8 @@ impl<'a> Parser<'a> {
                 let result = MatchResult {
                     matched_slice: token_pos..token_pos + 1,
                     matched_class: Some(MatchedClass {
-                        class_name: raw_class.to_string(),
-                        segment_type: Some(token_type.to_string()),
+                        class_name: Cow::Borrowed(raw_class),
+                        segment_type: Some(Cow::Borrowed(token_type)),
                         segment_kwargs,
                     }),
                     ..Default::default()
@@ -1211,8 +1212,8 @@ impl<'a> Parser<'a> {
                     let result = MatchResult {
                         matched_slice: token_pos..token_pos + 1,
                         matched_class: Some(MatchedClass {
-                            class_name: raw_class.clone(),
-                            segment_type: Some(token_type.clone()),
+                            class_name: Cow::Owned(raw_class.clone()),
+                            segment_type: Some(Cow::Owned(token_type.clone())),
                             segment_kwargs,
                         }),
                         ..Default::default()
@@ -1604,8 +1605,8 @@ impl<'a> Parser<'a> {
         let open_bracket_match = MatchResult {
             matched_slice: self.pos..self.pos + 1,
             matched_class: Some(MatchedClass {
-                class_name: "SymbolSegment".to_string(),
-                segment_type: Some(start_bracket_type.to_string()),
+                class_name: Cow::Borrowed("SymbolSegment"),
+                segment_type: Some(Cow::Borrowed(start_bracket_type)),
                 segment_kwargs: SegmentKwargs {
                     instance_types: Some(vec![start_bracket_type.to_string()]),
                     ..Default::default()
@@ -1652,8 +1653,8 @@ impl<'a> Parser<'a> {
         let close_bracket_match = MatchResult {
             matched_slice: bracket_end - 1..bracket_end,
             matched_class: Some(MatchedClass {
-                class_name: "SymbolSegment".to_string(),
-                segment_type: Some(end_bracket_type.to_string()),
+                class_name: Cow::Borrowed("SymbolSegment"),
+                segment_type: Some(Cow::Borrowed(end_bracket_type)),
                 segment_kwargs: SegmentKwargs {
                     instance_types: Some(vec![end_bracket_type.to_string()]),
                     ..Default::default()

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/match_result.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/match_result.rs
@@ -9,6 +9,7 @@
 
 #[cfg(feature = "verbose-debug")]
 use crate::vdebug;
+use std::borrow::Cow;
 use std::fmt::Display;
 use std::ops::Range;
 use std::sync::Arc;
@@ -57,16 +58,16 @@ impl Default for SegmentKwargs {
 
 #[derive(Debug, Clone, Default)]
 pub struct MatchedClass {
-    pub class_name: String,
-    pub segment_type: Option<String>,
+    pub class_name: Cow<'static, str>,
+    pub segment_type: Option<Cow<'static, str>>,
     pub segment_kwargs: SegmentKwargs,
 }
 
 impl MatchedClass {
     pub fn root() -> Self {
         MatchedClass {
-            class_name: "Root".to_string(),
-            segment_type: Some("file".to_string()),
+            class_name: Cow::Borrowed("Root"),
+            segment_type: Some(Cow::Borrowed("file")),
             segment_kwargs: SegmentKwargs {
                 class_types: Some(vec!["base".to_string(), "file".to_string()]),
                 ..Default::default()
@@ -76,8 +77,8 @@ impl MatchedClass {
 
     pub fn unparsable(message: &str, error_pos: usize) -> Self {
         MatchedClass {
-            class_name: "UnparsableSegment".to_string(),
-            segment_type: Some("unparsable".to_string()),
+            class_name: Cow::Borrowed("UnparsableSegment"),
+            segment_type: Some(Cow::Borrowed("unparsable")),
             segment_kwargs: SegmentKwargs {
                 parse_error: Some((message.to_string(), error_pos)),
                 class_types: Some(vec!["base".to_string(), "unparsable".to_string()]),
@@ -238,8 +239,8 @@ impl MatchResult {
         // When bracket_persists is true (parentheses), wrap in BracketedSegment.
         let matched_class = if bracket_persists {
             Some(MatchedClass {
-                class_name: "BracketedSegment".to_string(),
-                segment_type: Some("bracketed".to_string()),
+                class_name: Cow::Borrowed("BracketedSegment"),
+                segment_type: Some(Cow::Borrowed("bracketed")),
                 segment_kwargs: SegmentKwargs {
                     class_types: Some(vec!["base".to_string(), "bracketed".to_string()]),
                     ..Default::default()
@@ -581,15 +582,15 @@ impl MatchResult {
                         .unwrap_or_default();
                     if instance_types.is_empty() {
                         if let Some(seg_type) = &match_class.segment_type {
-                            instance_types.push(seg_type.clone());
+                            instance_types.push(seg_type.to_string());
                         }
                     }
 
-                    let effective_segment_type = match_class
+                    let effective_segment_type: Cow<'static, str> = match_class
                         .segment_type
                         .clone()
-                        .or_else(|| instance_types.first().cloned())
-                        .unwrap_or_else(|| "raw".to_string());
+                        .or_else(|| instance_types.first().map(|s| Cow::Owned(s.clone())))
+                        .unwrap_or(Cow::Borrowed("raw"));
 
                     let raw_class_ct = match_class.segment_kwargs.class_types.unwrap_or_default();
 
@@ -816,13 +817,13 @@ fn token_to_node(tok: &Token) -> Node {
         // In Rust, tok.token_type holds the class-level type (e.g. "raw") while
         // tok.instance_types holds the per-instance override (e.g. ["double_quote"]).
         // Use instance_types[0] as the segment_type to match Python's behavior.
-        let segment_type = tok
+        let segment_type: Cow<'static, str> = tok
             .instance_types
             .first()
-            .cloned()
-            .unwrap_or_else(|| tok.token_type.clone());
+            .map(|s| Cow::Owned(s.clone()))
+            .unwrap_or_else(|| Cow::Owned(tok.token_type.clone()));
         Node::new_raw_with_class_types(
-            tok.class_name.clone(),
+            Cow::Owned(tok.class_name.clone()),
             segment_type,
             tok.raw.to_string(),
             tok.pos_marker.clone(),

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/python.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/python.rs
@@ -66,7 +66,7 @@ impl PyNode {
     fn segment_class(&self) -> Option<String> {
         match &self.0 {
             Node::Raw { segment_class, .. } | Node::Segment { segment_class, .. } => {
-                Some(segment_class.clone())
+                Some(segment_class.to_string())
             }
             _ => None,
         }
@@ -270,7 +270,10 @@ impl PyMatchResult {
     /// Get the matched class type as a string (or None)
     #[getter]
     fn matched_class(&self) -> Option<String> {
-        self.0.matched_class.as_ref().map(|s| s.class_name.clone())
+        self.0
+            .matched_class
+            .as_ref()
+            .map(|s| s.class_name.to_string())
     }
 
     /// Get child matches as a list of PyMatchResult objects

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/ref_grammar.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/ref_grammar.rs
@@ -1,4 +1,5 @@
 use sqlfluffrs_types::GrammarId;
+use std::borrow::Cow;
 use std::sync::Arc;
 
 use crate::parser::{
@@ -244,7 +245,13 @@ impl Parser<'_> {
             //   2. The child match is a bare token match (no matched_class, exactly 1 token)
             //
             // In that case, use the actual token's effective type (instance_types[0] or token_type).
-            let effective_segment_type = if let Some(seg_type) = state.segment_type.as_deref() {
+            // `state.segment_type` is `Option<&'static str>` (Copy), so binding by
+            // value keeps the `'static` lifetime — the common case borrows the
+            // grammar-table string into the node with no allocation. Only the
+            // isinstance override (a runtime token type) takes the owned branch.
+            let effective_segment_type: Cow<'static, str> = if let Some(seg_type) =
+                state.segment_type
+            {
                 // Check if the child match is a bare single-token match (no matched_class)
                 // by looking at the match_result's matched_class and slice length
                 let is_bare_token_match = ref_match_result.matched_class.is_none()
@@ -270,18 +277,18 @@ impl Parser<'_> {
                                 seg_type,
                                 tok.raw()
                             );
-                            effective.to_string()
+                            Cow::Owned(effective.to_string())
                         } else {
-                            seg_type.to_string()
+                            Cow::Borrowed(seg_type)
                         }
                     } else {
-                        seg_type.to_string()
+                        Cow::Borrowed(seg_type)
                     }
                 } else {
-                    seg_type.to_string()
+                    Cow::Borrowed(seg_type)
                 }
             } else {
-                state.segment_type.unwrap_or_default().to_string()
+                Cow::Borrowed(state.segment_type.unwrap_or_default())
             };
 
             vdebug!(
@@ -289,27 +296,26 @@ impl Parser<'_> {
                 state.name,
                 effective_segment_type
             );
-            let matched_class =
-                if !effective_segment_type.is_empty() || state.segment_class_name.is_some() {
-                    // Look up the Python _class_types hierarchy for this grammar from codegen tables.
-                    let class_types = self.grammar_ctx.segment_class_types(state.grammar_id);
-                    Some(MatchedClass {
-                        // take() instead of clone() + unwrap — frame context is not read
-                        // again after this point (state transitions to Complete).
-                        class_name: state
-                            .segment_class_name
-                            .take()
-                            .unwrap_or_default()
-                            .to_string(),
-                        segment_type: Some(effective_segment_type),
-                        segment_kwargs: SegmentKwargs {
-                            class_types,
-                            ..Default::default()
-                        },
-                    })
-                } else {
-                    None
-                };
+            let matched_class = if !effective_segment_type.is_empty()
+                || state.segment_class_name.is_some()
+            {
+                // Look up the Python _class_types hierarchy for this grammar from codegen tables.
+                let class_types = self.grammar_ctx.segment_class_types(state.grammar_id);
+                Some(MatchedClass {
+                    // take() instead of clone() + unwrap — frame context is not read
+                    // again after this point (state transitions to Complete).
+                    // segment_class_name is Option<&'static str> (PR #8002), so
+                    // borrow the grammar-table class name straight into the node.
+                    class_name: Cow::Borrowed(state.segment_class_name.take().unwrap_or_default()),
+                    segment_type: Some(effective_segment_type),
+                    segment_kwargs: SegmentKwargs {
+                        class_types,
+                        ..Default::default()
+                    },
+                })
+            } else {
+                None
+            };
 
             // let start_idx = self.skip_start_index_forward_to_code(*saved_pos, final_pos);
 

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/types.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/types.rs
@@ -3,6 +3,7 @@
 use hashbrown::HashSet;
 use serde_yaml_ng::{Mapping, Value};
 use sqlfluffrs_types::{GrammarId, PositionMarker};
+use std::borrow::Cow;
 
 /// Helper enum for tuple serialization, similar to Python's TupleSerialisedSegment.
 #[derive(Debug, Clone, PartialEq)]
@@ -41,9 +42,9 @@ pub struct RawSegmentKwargs {
 pub enum Node {
     /// Leaf: Raw token/segment from lexer (RawSegment, KeywordSegment, etc.)
     Raw {
-        segment_class: String, // "KeywordSegment", "LiteralSegment"
-        segment_type: String,  // "keyword", "literal", "whitespace"
-        raw: String,           // Actual text
+        segment_class: Cow<'static, str>, // "KeywordSegment", "LiteralSegment"
+        segment_type: Cow<'static, str>,  // "keyword", "literal", "whitespace"
+        raw: String,                      // Actual text
         pos_marker: Option<PositionMarker>,
         instance_types: Vec<String>, // ["keyword"], ["numeric_literal", "literal"]
         /// Full class type hierarchy (mirrors Python's ``class_types`` property).
@@ -56,8 +57,8 @@ pub enum Node {
 
     /// Container: Parsed segment with children (BaseSegment subclasses)
     Segment {
-        segment_class: String,        // "SelectStatementSegment"
-        segment_type: Option<String>, // "select_statement"
+        segment_class: Cow<'static, str>,        // "SelectStatementSegment"
+        segment_type: Option<Cow<'static, str>>, // "select_statement"
         pos_marker: Option<PositionMarker>,
         /// Python parity: mirrors ``BaseSegment._class_types`` (static, computed
         /// from the class inheritance chain).  Populated from codegen aux_data
@@ -95,13 +96,15 @@ impl Node {
     /// class_types`` are available, call ``new_raw_with_class_types``
     /// instead.
     pub fn new_raw(
-        segment_class: String,
-        segment_type: String,
+        segment_class: impl Into<Cow<'static, str>>,
+        segment_type: impl Into<Cow<'static, str>>,
         raw: String,
         pos_marker: Option<PositionMarker>,
         instance_types: Vec<String>,
         segment_kwargs: RawSegmentKwargs,
     ) -> Self {
+        let segment_class = segment_class.into();
+        let segment_type = segment_type.into();
         let class_types = Self::build_class_types(&segment_type, &instance_types, &[]);
         Node::Raw {
             segment_class,
@@ -120,14 +123,16 @@ impl Node {
     /// ``class_types`` is computed as
     /// ``instance_types ∪ {segment_type} ∪ raw_class_class_types``.
     pub fn new_raw_with_class_types(
-        segment_class: String,
-        segment_type: String,
+        segment_class: impl Into<Cow<'static, str>>,
+        segment_type: impl Into<Cow<'static, str>>,
         raw: String,
         pos_marker: Option<PositionMarker>,
         instance_types: Vec<String>,
         raw_class_class_types: &[String],
         segment_kwargs: RawSegmentKwargs,
     ) -> Self {
+        let segment_class = segment_class.into();
+        let segment_type = segment_type.into();
         let class_types =
             Self::build_class_types(&segment_type, &instance_types, raw_class_class_types);
         Node::Raw {
@@ -207,13 +212,13 @@ impl Node {
 
                 // Filter in code_only mode (except comments which stay)
                 if code_only && !is_code {
-                    return NodeTupleValue::Tuple(segment_type.clone(), vec![]);
+                    return NodeTupleValue::Tuple(segment_type.to_string(), vec![]);
                 }
 
                 if show_raw {
-                    NodeTupleValue::Raw(segment_type.clone(), raw.clone())
+                    NodeTupleValue::Raw(segment_type.to_string(), raw.clone())
                 } else {
-                    NodeTupleValue::Tuple(segment_type.clone(), vec![])
+                    NodeTupleValue::Tuple(segment_type.to_string(), vec![])
                 }
             }
             Node::Meta { meta_type, .. } => {
@@ -395,7 +400,7 @@ impl Node {
                     )
                 });
                 let non_code_by_type = segment_type.contains("comment")
-                    || matches!(segment_type.as_str(), "whitespace" | "newline");
+                    || matches!(segment_type.as_ref(), "whitespace" | "newline");
                 // Also check class_types for "comment" — this covers non-standard
                 // comment types like obevo_annotation, prompt_command, notebook_start
                 // whose segment_type doesn't literally contain "comment" but whose
@@ -432,8 +437,10 @@ impl Node {
     /// Get the type of this node based on its variant
     pub fn get_type(&self) -> String {
         match self {
-            Node::Raw { segment_type, .. } => segment_type.clone(),
-            Node::Segment { segment_type, .. } => segment_type.clone().unwrap_or_default(),
+            Node::Raw { segment_type, .. } => segment_type.to_string(),
+            Node::Segment { segment_type, .. } => {
+                segment_type.as_deref().unwrap_or_default().to_string()
+            }
             Node::Meta { meta_type, .. } => match meta_type {
                 MetaType::Indent { .. } => "indent".to_string(),
                 MetaType::Dedent { .. } => "dedent".to_string(),
@@ -537,8 +544,8 @@ mod tests {
     #[test]
     fn test_segment_node_as_record_empty() {
         let node = Node::Segment {
-            segment_class: "StatementSegment".to_string(),
-            segment_type: Some("statement".to_string()),
+            segment_class: "StatementSegment".into(),
+            segment_type: Some("statement".into()),
             pos_marker: None,
             class_types: vec![],
             children: vec![],
@@ -555,8 +562,8 @@ mod tests {
     #[test]
     fn test_segment_node_as_record_merge() {
         let node = Node::Segment {
-            segment_class: "StatementSegment".to_string(),
-            segment_type: Some("statement".to_string()),
+            segment_class: "StatementSegment".into(),
+            segment_type: Some("statement".into()),
             pos_marker: None,
             class_types: vec![],
             children: vec![
@@ -709,8 +716,8 @@ mod tests {
             RawSegmentKwargs::default(),
         );
         let node = Node::Segment {
-            segment_class: "StatementSegment".to_string(),
-            segment_type: Some("statement".to_string()),
+            segment_class: "StatementSegment".into(),
+            segment_type: Some("statement".into()),
             pos_marker: None,
             class_types: vec![],
             children: vec![child1, child2],


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Use Cow for a number of static str cases so we aren't reallocating and cloning all over the place.

### Are there any other side effects of this change that we should be aware of?
None

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Borrowed static segment class/type strings across the Rust parser using Cow to avoid cloning, cutting allocations when building the parse/arena tree. No behavior changes.

- **Refactors**
  - Replaced owned `String` with `Cow<'static, str>` for `segment_class` and `segment_type` in `Node`, arena, and `MatchedClass`, and updated parser paths to pass borrowed values.
  - Borrow grammar-table names and token types into nodes; only allocate for runtime overrides (e.g., `instance_types`).
  - Updated getters and Python bindings to return owned strings at API boundaries (`get_type`, `segment_class`, `PyMatchResult.matched_class`).

<sup>Written for commit b5ee6c5f9d8be44ce991b6ec90d19b596f96ed53. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8020?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

