### PR TITLE
perf(rust): borrow static Token strings as Cow<'static, str>

### DIFF
--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/match_result.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/match_result.rs
@@ -793,7 +793,7 @@ fn node_pos_marker(node: &Node) -> Option<PositionMarker> {
 /// determine the variant.  All other tokens become `Node::Raw`.
 fn token_to_node(tok: &Token) -> Node {
     if tok.is_meta {
-        let meta_type = match tok.token_type.as_str() {
+        let meta_type = match tok.token_type.as_ref() {
             "end_of_file" => MetaType::EndOfFile,
             "indent" => MetaType::Indent { is_implicit: false },
             "dedent" => MetaType::Dedent { is_implicit: false },
@@ -821,9 +821,9 @@ fn token_to_node(tok: &Token) -> Node {
             .instance_types
             .first()
             .map(|s| Cow::Owned(s.clone()))
-            .unwrap_or_else(|| Cow::Owned(tok.token_type.clone()));
+            .unwrap_or_else(|| tok.token_type.clone());
         Node::new_raw_with_class_types(
-            Cow::Owned(tok.class_name.clone()),
+            tok.class_name.clone(),
             segment_type,
             tok.raw().to_owned(),
             tok.pos_marker.clone(),

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/ref_grammar.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/ref_grammar.rs
@@ -268,7 +268,7 @@ impl Parser<'_> {
                             .instance_types
                             .first()
                             .map(String::as_str)
-                            .unwrap_or(tok.token_type.as_str());
+                            .unwrap_or(tok.token_type.as_ref());
 
                         if effective != seg_type {
                             vdebug!(

--- a/sqlfluffrs/sqlfluffrs_types/src/token/construction.rs
+++ b/sqlfluffrs/sqlfluffrs_types/src/token/construction.rs
@@ -38,7 +38,7 @@ impl Token {
             is_whitespace: false,
             is_code: true,
             is_comment: false,
-            _default_raw: "".to_string(),
+            _default_raw: Cow::Borrowed(""),
             indent_value: 0,
             is_templated: false,
             block_uuid: None,
@@ -47,8 +47,8 @@ impl Token {
             parent: None,
             parent_idx: None,
             segments,
-            preface_modifier: "".to_string(),
-            suffix: "".to_string(),
+            preface_modifier: Cow::Borrowed(""),
+            suffix: Cow::Borrowed(""),
             uuid: crate::identity::next_id(),
             source_fixes: None,
             trim_start,
@@ -71,7 +71,7 @@ impl Token {
             vec![],
         );
         token.class_name = Cow::Borrowed("RawSegment");
-        token.suffix = suffix;
+        token.suffix = Cow::Owned(suffix);
         token.token_type = token_type;
         token
     }
@@ -210,7 +210,7 @@ impl Token {
         token.is_whitespace = true;
         token.is_code = false;
         token.is_comment = false;
-        token._default_raw = " ".to_string();
+        token._default_raw = Cow::Borrowed(" ");
         token
     }
 
@@ -229,7 +229,7 @@ impl Token {
         token.is_whitespace = true;
         token.is_code = false;
         token.is_comment = false;
-        token._default_raw = "\n".to_string();
+        token._default_raw = Cow::Borrowed("\n");
         token
     }
 
@@ -272,8 +272,8 @@ impl Token {
         token.is_meta = true;
         token.is_templated = is_templated;
         token.block_uuid = block_uuid;
-        token.preface_modifier = "[META] ".to_string();
-        token.suffix = String::new();
+        token.preface_modifier = Cow::Borrowed("[META] ");
+        token.suffix = Cow::Borrowed("");
         token
     }
 
@@ -302,8 +302,8 @@ impl Token {
         token.class_name = Cow::Borrowed("Indent");
         token.indent_value = 1;
         token.suffix = block_uuid
-            .map(|u| u.as_hyphenated().to_string())
-            .unwrap_or_default();
+            .map(|u| Cow::Owned(u.as_hyphenated().to_string()))
+            .unwrap_or(Cow::Borrowed(""));
         token
     }
 

--- a/sqlfluffrs/sqlfluffrs_types/src/token/construction.rs
+++ b/sqlfluffrs/sqlfluffrs_types/src/token/construction.rs
@@ -1,6 +1,7 @@
 use super::{config::TokenConfig, Token};
 use crate::{marker::PositionMarker, slice::Slice, templater::templatefile::TemplatedFile};
 
+use std::borrow::Cow;
 use std::sync::Arc;
 
 use hashbrown::HashSet;
@@ -26,7 +27,7 @@ impl Token {
         let (token_types, class_types) = iter_base_types("base", class_types.clone());
         Self {
             token_type: token_types,
-            class_name: "BaseSegment".to_string(),
+            class_name: Cow::Borrowed("BaseSegment"),
             instance_types,
             class_types,
             comment_separate: false,
@@ -69,7 +70,7 @@ impl Token {
             },
             vec![],
         );
-        token.class_name = "RawSegment".to_string();
+        token.class_name = Cow::Borrowed("RawSegment");
         token.suffix = suffix;
         token.token_type = token_type;
         token
@@ -90,7 +91,7 @@ impl Token {
             },
         );
         token.token_type = token_type;
-        token.class_name = "SymbolSegment".to_string();
+        token.class_name = Cow::Borrowed("SymbolSegment");
         token
     }
 
@@ -105,7 +106,7 @@ impl Token {
             },
         );
         token.token_type = token_type;
-        token.class_name = "IdentifierSegment".to_string();
+        token.class_name = Cow::Borrowed("IdentifierSegment");
         token
     }
 
@@ -120,7 +121,7 @@ impl Token {
             },
         );
         token.token_type = token_type;
-        token.class_name = "LiteralSegment".to_string();
+        token.class_name = Cow::Borrowed("LiteralSegment");
         token
     }
 
@@ -140,7 +141,7 @@ impl Token {
             },
         );
         token.token_type = token_type;
-        token.class_name = "BinaryOperatorSegment".to_string();
+        token.class_name = Cow::Borrowed("BinaryOperatorSegment");
         token
     }
 
@@ -160,7 +161,7 @@ impl Token {
             },
         );
         token.token_type = token_type;
-        token.class_name = "ComparisonOperatorSegment".to_string();
+        token.class_name = Cow::Borrowed("ComparisonOperatorSegment");
         token
     }
 
@@ -175,7 +176,7 @@ impl Token {
             },
         );
         token.token_type = token_type;
-        token.class_name = "WordSegment".to_string();
+        token.class_name = Cow::Borrowed("WordSegment");
         token
     }
 
@@ -190,7 +191,7 @@ impl Token {
             },
         );
         token.token_type = token_type;
-        token.class_name = "UnlexableSegment".to_string();
+        token.class_name = Cow::Borrowed("UnlexableSegment");
         token
     }
 
@@ -205,7 +206,7 @@ impl Token {
             },
         );
         token.token_type = token_type;
-        token.class_name = "WhitespaceSegment".to_string();
+        token.class_name = Cow::Borrowed("WhitespaceSegment");
         token.is_whitespace = true;
         token.is_code = false;
         token.is_comment = false;
@@ -224,7 +225,7 @@ impl Token {
             },
         );
         token.token_type = token_type;
-        token.class_name = "NewlineSegment".to_string();
+        token.class_name = Cow::Borrowed("NewlineSegment");
         token.is_whitespace = true;
         token.is_code = false;
         token.is_comment = false;
@@ -243,7 +244,7 @@ impl Token {
             },
         );
         token.token_type = token_type;
-        token.class_name = "CommentSegment".to_string();
+        token.class_name = Cow::Borrowed("CommentSegment");
         token.is_code = false;
         token.is_comment = true;
         token
@@ -266,7 +267,7 @@ impl Token {
             },
         );
         token.token_type = token_type;
-        token.class_name = "MetaSegment".to_string();
+        token.class_name = Cow::Borrowed("MetaSegment");
         token.is_code = false;
         token.is_meta = true;
         token.is_templated = is_templated;
@@ -285,7 +286,7 @@ impl Token {
         let (token_type, class_types) = iter_base_types("end_of_file", class_types);
         let mut token = Self::meta_token(pos_marker, is_templated, block_uuid, class_types);
         token.token_type = token_type;
-        token.class_name = "EndOfFile".to_string();
+        token.class_name = Cow::Borrowed("EndOfFile");
         token
     }
 
@@ -298,7 +299,7 @@ impl Token {
         let (token_type, class_types) = iter_base_types("indent", class_types);
         let mut token = Self::meta_token(pos_marker, is_templated, block_uuid, class_types);
         token.token_type = token_type;
-        token.class_name = "Indent".to_string();
+        token.class_name = Cow::Borrowed("Indent");
         token.indent_value = 1;
         token.suffix = block_uuid
             .map(|u| u.as_hyphenated().to_string())
@@ -315,7 +316,7 @@ impl Token {
         let (token_type, class_types) = iter_base_types("dedent", class_types);
         let mut token = Self::indent_token(pos_marker, is_templated, block_uuid, class_types);
         token.token_type = token_type;
-        token.class_name = "Dedent".to_string();
+        token.class_name = Cow::Borrowed("Dedent");
         token.indent_value = -1;
         token
     }
@@ -328,7 +329,7 @@ impl Token {
         let (token_type, class_types) = iter_base_types("template_loop", class_types);
         let mut token = Self::meta_token(pos_marker, false, block_uuid, class_types);
         token.token_type = token_type;
-        token.class_name = "TemplateLoop".to_string();
+        token.class_name = Cow::Borrowed("TemplateLoop");
         token
     }
 
@@ -342,7 +343,7 @@ impl Token {
         let (token_type, class_types) = iter_base_types("placeholder", class_types);
         let mut token = Self::meta_token(pos_marker, false, block_uuid, class_types);
         token.token_type = token_type;
-        token.class_name = "TemplateSegment".to_string();
+        token.class_name = Cow::Borrowed("TemplateSegment");
         token.block_type = Some(block_type);
         token.source_str = Some(source_string);
         token
@@ -375,9 +376,11 @@ impl Token {
     }
 }
 
-fn iter_base_types(token_type: &str, class_types: HashSet<String>) -> (String, HashSet<String>) {
+fn iter_base_types(
+    token_type: &'static str,
+    class_types: HashSet<String>,
+) -> (Cow<'static, str>, HashSet<String>) {
     let mut class_types = class_types;
-    let token_type = token_type.to_string();
-    class_types.insert(token_type.clone());
-    (token_type, class_types)
+    class_types.insert(token_type.to_string());
+    (Cow::Borrowed(token_type), class_types)
 }

--- a/sqlfluffrs/sqlfluffrs_types/src/token/mod.rs
+++ b/sqlfluffrs/sqlfluffrs_types/src/token/mod.rs
@@ -9,6 +9,7 @@ mod raw_string;
 pub(crate) use raw_string::RawString;
 
 use std::{
+    borrow::Cow,
     fmt::Write,
     sync::{Arc, Weak},
 };
@@ -39,8 +40,8 @@ pub enum TupleSerialisedSegment {
 
 #[derive(Debug, Clone)]
 pub struct Token {
-    pub token_type: String,
-    pub class_name: String,
+    pub token_type: Cow<'static, str>,
+    pub class_name: Cow<'static, str>,
     pub instance_types: Vec<String>,
     pub class_types: HashSet<String>,
     pub comment_separate: bool,
@@ -235,7 +236,7 @@ impl Token {
     }
 
     pub fn get_type(&self) -> String {
-        self.token_type.clone()
+        self.token_type.to_string()
     }
 
     /// Get all types for this token (instance_types + class_types)
@@ -430,7 +431,7 @@ impl Token {
 
         // Recursively process child segments
         for seg in &self.segments {
-            if no_recursive_set.contains(seg.token_type.as_str()) {
+            if no_recursive_set.contains(seg.token_type.as_ref()) {
                 continue;
             }
             results.extend(seg.recursive_crawl(

--- a/sqlfluffrs/sqlfluffrs_types/src/token/mod.rs
+++ b/sqlfluffrs/sqlfluffrs_types/src/token/mod.rs
@@ -52,7 +52,7 @@ pub struct Token {
     is_whitespace: bool,
     is_code: bool,
     is_comment: bool,
-    _default_raw: String,
+    _default_raw: Cow<'static, str>,
     pub indent_value: i32,
     pub is_templated: bool,
     pub block_uuid: Option<Uuid>,
@@ -61,8 +61,8 @@ pub struct Token {
     parent: Option<Weak<Token>>,
     parent_idx: Option<usize>,
     pub segments: Vec<Token>,
-    preface_modifier: String,
-    suffix: String,
+    preface_modifier: Cow<'static, str>,
+    suffix: Cow<'static, str>,
     pub uuid: u128,
     pub source_fixes: Option<Vec<SourceFix>>,
     pub trim_start: Option<Vec<String>>,
@@ -249,7 +249,7 @@ impl Token {
     }
 
     pub fn preface_modifier(&self) -> String {
-        self.preface_modifier.clone()
+        self.preface_modifier.to_string()
     }
 
     pub fn is_type(&self, seg_types: &[&str]) -> bool {


### PR DESCRIPTION
### Brief summary of the change made

`Token` held several `String` fields that are always set from a tiny fixed vocabulary of static literals, so every lexed token was heap-allocating them. This borrows them as `Cow<'static, str>` so the literal cases are `Cow::Borrowed` (no allocation), and only genuinely dynamic values allocate via `Cow::Owned`:

- `token_type` / `class_name` — the segment type/class (e.g. `"whitespace"`, `"BaseSegment"`). Matches the `Node` / `MatchedClass` change in #8020, so the borrowed value threads straight through and `token_to_node` drops its `Cow::Owned(...clone())` at the boundary.
- `_default_raw` (`""` / `" "` / `"\n"`), `preface_modifier` (`""` / `"[META] "`), and the common `suffix` (`""`) — now `Cow::Borrowed`; only the dynamic `suffix` cases (a raw token's quoted form, an indent's block uuid) allocate.

### Performance

Pure speed win — `Token` size is unchanged (`Cow<str>` is the same size as `String`); the gain is allocation avoidance at construction, which compounds over the millions of tokens lexing builds. Criterion, lexing the TPC-H/TPC-DS suites, vs. the stacked base (#8019 + #8020):

| Benchmark | base | this PR | change |
|---|---|---|---|
| `lex_tpch_22` | 7.57 ms | 6.50 ms | **−13.2%** |
| `lex_tpcds_99` | 66.45 ms | 56.98 ms | **−14.3%** |

Both `p = 0.00`. No behavior change.

### Stacking

> [!IMPORTANT]
> Stacked on **#8019** and **#8020** — this branch includes their commits and should merge after both. Once they land, this will be rebased onto `main` so the diff reduces to just the Cow-on-Token commits.

### Are there any other side effects of this change that we should be aware of?
None. Public getters (`get_type`, `preface_modifier`, the Python bindings) still return owned `String` at the API boundary.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Borrowed static token strings as `Cow<'static, str>` and added lazy normalization/regex caching to cut allocations and speed up lexing by ~13–14%, with no behavior change.

- **Refactors**
  - `Token` now holds `token_type`, `class_name`, `_default_raw`, `preface_modifier`, and `suffix` as `Cow<'static, str>` (literals borrow; dynamic values allocate). Parser and node construction use `as_ref()` and pass through borrowed values; public getters still return `String`.
  - `RawString` computes normalization lazily and skips redundant uppercase copies; added a process-global regex cache in `sqlfluffrs_types::regex` via `RegexMode::cached{,_with_flags}`.

<sup>Written for commit af3e02a6cc75093e49a7245efb8bd5782dfbb48f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8021?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

