### PR TITLE
perf(rust): share class_types as a per-kind Arc instead of per-token HashSet

### DIFF
--- a/sqlfluffrs/sqlfluffrs_types/src/token/construction.rs
+++ b/sqlfluffrs/sqlfluffrs_types/src/token/construction.rs
@@ -5,6 +5,7 @@ use std::borrow::Cow;
 use std::sync::Arc;
 
 use hashbrown::HashSet;
+use once_cell::sync::Lazy;
 use uuid::Uuid;
 
 impl Token {
@@ -15,7 +16,9 @@ impl Token {
         segments: Vec<Token>,
     ) -> Self {
         let TokenConfig {
-            class_types,
+            // The lexer always supplies an empty class_types; the hierarchy is
+            // derived per-kind from a shared static instead (see *_CT below).
+            class_types: _,
             instance_types,
             trim_start,
             trim_chars,
@@ -24,12 +27,11 @@ impl Token {
             casefold,
         } = config;
 
-        let (token_types, class_types) = iter_base_types("base", class_types.clone());
         Self {
-            token_type: token_types,
+            token_type: Cow::Borrowed("base"),
             class_name: Cow::Borrowed("BaseSegment"),
             instance_types,
-            class_types,
+            class_types: BASE_CT.clone(),
             comment_separate: false,
             is_meta: false,
             allow_empty: false,
@@ -58,21 +60,13 @@ impl Token {
     }
 
     pub fn raw_token(raw: String, pos_marker: PositionMarker, config: TokenConfig) -> Self {
-        let (token_type, class_types) = iter_base_types("raw", config.class_types.clone());
         let suffix = format!("'{}'", raw.escape_debug().to_string().trim_matches('"'));
 
-        let mut token = Token::base_token(
-            raw,
-            pos_marker,
-            TokenConfig {
-                class_types,
-                ..config
-            },
-            vec![],
-        );
+        let mut token = Token::base_token(raw, pos_marker, config, vec![]);
         token.class_name = Cow::Borrowed("RawSegment");
         token.suffix = Cow::Owned(suffix);
-        token.token_type = token_type;
+        token.token_type = Cow::Borrowed("raw");
+        token.class_types = RAW_CT.clone();
         token
     }
 
@@ -81,47 +75,26 @@ impl Token {
     }
 
     pub fn symbol_token(raw: String, pos_marker: PositionMarker, config: TokenConfig) -> Self {
-        let (token_type, class_types) = iter_base_types("symbol", config.class_types.clone());
-        let mut token = Self::code_token(
-            raw,
-            pos_marker,
-            TokenConfig {
-                class_types,
-                ..config
-            },
-        );
-        token.token_type = token_type;
+        let mut token = Self::code_token(raw, pos_marker, config);
+        token.token_type = Cow::Borrowed("symbol");
         token.class_name = Cow::Borrowed("SymbolSegment");
+        token.class_types = SYMBOL_CT.clone();
         token
     }
 
     pub fn identifier_token(raw: String, pos_marker: PositionMarker, config: TokenConfig) -> Self {
-        let (token_type, class_types) = iter_base_types("identifier", config.class_types.clone());
-        let mut token = Self::code_token(
-            raw,
-            pos_marker,
-            TokenConfig {
-                class_types,
-                ..config
-            },
-        );
-        token.token_type = token_type;
+        let mut token = Self::code_token(raw, pos_marker, config);
+        token.token_type = Cow::Borrowed("identifier");
         token.class_name = Cow::Borrowed("IdentifierSegment");
+        token.class_types = IDENTIFIER_CT.clone();
         token
     }
 
     pub fn literal_token(raw: String, pos_marker: PositionMarker, config: TokenConfig) -> Self {
-        let (token_type, class_types) = iter_base_types("literal", config.class_types.clone());
-        let mut token = Self::code_token(
-            raw,
-            pos_marker,
-            TokenConfig {
-                class_types,
-                ..config
-            },
-        );
-        token.token_type = token_type;
+        let mut token = Self::code_token(raw, pos_marker, config);
+        token.token_type = Cow::Borrowed("literal");
         token.class_name = Cow::Borrowed("LiteralSegment");
+        token.class_types = LITERAL_CT.clone();
         token
     }
 
@@ -130,18 +103,10 @@ impl Token {
         pos_marker: PositionMarker,
         config: TokenConfig,
     ) -> Self {
-        let (token_type, class_types) =
-            iter_base_types("binary_operator", config.class_types.clone());
-        let mut token = Self::code_token(
-            raw,
-            pos_marker,
-            TokenConfig {
-                class_types,
-                ..config
-            },
-        );
-        token.token_type = token_type;
+        let mut token = Self::code_token(raw, pos_marker, config);
+        token.token_type = Cow::Borrowed("binary_operator");
         token.class_name = Cow::Borrowed("BinaryOperatorSegment");
+        token.class_types = BINARY_OPERATOR_CT.clone();
         token
     }
 
@@ -150,63 +115,34 @@ impl Token {
         pos_marker: PositionMarker,
         config: TokenConfig,
     ) -> Self {
-        let (token_type, class_types) =
-            iter_base_types("comparison_operator", config.class_types.clone());
-        let mut token = Self::code_token(
-            raw,
-            pos_marker,
-            TokenConfig {
-                class_types,
-                ..config
-            },
-        );
-        token.token_type = token_type;
+        let mut token = Self::code_token(raw, pos_marker, config);
+        token.token_type = Cow::Borrowed("comparison_operator");
         token.class_name = Cow::Borrowed("ComparisonOperatorSegment");
+        token.class_types = COMPARISON_OPERATOR_CT.clone();
         token
     }
 
     pub fn word_token(raw: String, pos_marker: PositionMarker, config: TokenConfig) -> Self {
-        let (token_type, class_types) = iter_base_types("word", config.class_types.clone());
-        let mut token = Self::code_token(
-            raw,
-            pos_marker,
-            TokenConfig {
-                class_types,
-                ..config
-            },
-        );
-        token.token_type = token_type;
+        let mut token = Self::code_token(raw, pos_marker, config);
+        token.token_type = Cow::Borrowed("word");
         token.class_name = Cow::Borrowed("WordSegment");
+        token.class_types = WORD_CT.clone();
         token
     }
 
     pub fn unlexable_token(raw: String, pos_marker: PositionMarker, config: TokenConfig) -> Self {
-        let (token_type, class_types) = iter_base_types("unlexable", config.class_types.clone());
-        let mut token = Self::code_token(
-            raw,
-            pos_marker,
-            TokenConfig {
-                class_types,
-                ..config
-            },
-        );
-        token.token_type = token_type;
+        let mut token = Self::code_token(raw, pos_marker, config);
+        token.token_type = Cow::Borrowed("unlexable");
         token.class_name = Cow::Borrowed("UnlexableSegment");
+        token.class_types = UNLEXABLE_CT.clone();
         token
     }
 
     pub fn whitespace_token(raw: String, pos_marker: PositionMarker, config: TokenConfig) -> Self {
-        let (token_type, class_types) = iter_base_types("whitespace", config.class_types.clone());
-        let mut token = Self::raw_token(
-            raw,
-            pos_marker,
-            TokenConfig {
-                class_types,
-                ..config
-            },
-        );
-        token.token_type = token_type;
+        let mut token = Self::raw_token(raw, pos_marker, config);
+        token.token_type = Cow::Borrowed("whitespace");
         token.class_name = Cow::Borrowed("WhitespaceSegment");
+        token.class_types = WHITESPACE_CT.clone();
         token.is_whitespace = true;
         token.is_code = false;
         token.is_comment = false;
@@ -215,17 +151,10 @@ impl Token {
     }
 
     pub fn newline_token(raw: String, pos_marker: PositionMarker, config: TokenConfig) -> Self {
-        let (token_type, class_types) = iter_base_types("newline", config.class_types.clone());
-        let mut token = Self::raw_token(
-            raw,
-            pos_marker,
-            TokenConfig {
-                class_types,
-                ..config
-            },
-        );
-        token.token_type = token_type;
+        let mut token = Self::raw_token(raw, pos_marker, config);
+        token.token_type = Cow::Borrowed("newline");
         token.class_name = Cow::Borrowed("NewlineSegment");
+        token.class_types = NEWLINE_CT.clone();
         token.is_whitespace = true;
         token.is_code = false;
         token.is_comment = false;
@@ -234,17 +163,10 @@ impl Token {
     }
 
     pub fn comment_token(raw: String, pos_marker: PositionMarker, config: TokenConfig) -> Self {
-        let (token_type, class_types) = iter_base_types("comment", config.class_types.clone());
-        let mut token = Self::raw_token(
-            raw,
-            pos_marker,
-            TokenConfig {
-                class_types,
-                ..config
-            },
-        );
-        token.token_type = token_type;
+        let mut token = Self::raw_token(raw, pos_marker, config);
+        token.token_type = Cow::Borrowed("comment");
         token.class_name = Cow::Borrowed("CommentSegment");
+        token.class_types = COMMENT_CT.clone();
         token.is_code = false;
         token.is_comment = true;
         token
@@ -254,20 +176,19 @@ impl Token {
         pos_marker: PositionMarker,
         is_templated: bool,
         block_uuid: Option<Uuid>,
-        class_types: HashSet<String>,
+        _class_types: HashSet<String>,
     ) -> Self {
-        let (token_type, class_types) = iter_base_types("meta", class_types.clone());
         let mut token = Self::raw_token(
             "".to_string(),
             pos_marker,
             TokenConfig {
-                class_types,
                 instance_types: vec![],
                 ..TokenConfig::default()
             },
         );
-        token.token_type = token_type;
+        token.token_type = Cow::Borrowed("meta");
         token.class_name = Cow::Borrowed("MetaSegment");
+        token.class_types = META_CT.clone();
         token.is_code = false;
         token.is_meta = true;
         token.is_templated = is_templated;
@@ -283,10 +204,10 @@ impl Token {
         block_uuid: Option<Uuid>,
         class_types: HashSet<String>,
     ) -> Self {
-        let (token_type, class_types) = iter_base_types("end_of_file", class_types);
         let mut token = Self::meta_token(pos_marker, is_templated, block_uuid, class_types);
-        token.token_type = token_type;
+        token.token_type = Cow::Borrowed("end_of_file");
         token.class_name = Cow::Borrowed("EndOfFile");
+        token.class_types = END_OF_FILE_CT.clone();
         token
     }
 
@@ -296,10 +217,10 @@ impl Token {
         block_uuid: Option<Uuid>,
         class_types: HashSet<String>,
     ) -> Self {
-        let (token_type, class_types) = iter_base_types("indent", class_types);
         let mut token = Self::meta_token(pos_marker, is_templated, block_uuid, class_types);
-        token.token_type = token_type;
+        token.token_type = Cow::Borrowed("indent");
         token.class_name = Cow::Borrowed("Indent");
+        token.class_types = INDENT_CT.clone();
         token.indent_value = 1;
         token.suffix = block_uuid
             .map(|u| Cow::Owned(u.as_hyphenated().to_string()))
@@ -313,10 +234,10 @@ impl Token {
         block_uuid: Option<Uuid>,
         class_types: HashSet<String>,
     ) -> Self {
-        let (token_type, class_types) = iter_base_types("dedent", class_types);
         let mut token = Self::indent_token(pos_marker, is_templated, block_uuid, class_types);
-        token.token_type = token_type;
+        token.token_type = Cow::Borrowed("dedent");
         token.class_name = Cow::Borrowed("Dedent");
+        token.class_types = DEDENT_CT.clone();
         token.indent_value = -1;
         token
     }
@@ -326,10 +247,10 @@ impl Token {
         block_uuid: Option<Uuid>,
         class_types: HashSet<String>,
     ) -> Self {
-        let (token_type, class_types) = iter_base_types("template_loop", class_types);
         let mut token = Self::meta_token(pos_marker, false, block_uuid, class_types);
-        token.token_type = token_type;
+        token.token_type = Cow::Borrowed("template_loop");
         token.class_name = Cow::Borrowed("TemplateLoop");
+        token.class_types = TEMPLATE_LOOP_CT.clone();
         token
     }
 
@@ -340,10 +261,10 @@ impl Token {
         block_uuid: Option<Uuid>,
         class_types: HashSet<String>,
     ) -> Self {
-        let (token_type, class_types) = iter_base_types("placeholder", class_types);
         let mut token = Self::meta_token(pos_marker, false, block_uuid, class_types);
-        token.token_type = token_type;
+        token.token_type = Cow::Borrowed("placeholder");
         token.class_name = Cow::Borrowed("TemplateSegment");
+        token.class_types = PLACEHOLDER_CT.clone();
         token.block_type = Some(block_type);
         token.source_str = Some(source_string);
         token
@@ -376,11 +297,35 @@ impl Token {
     }
 }
 
-fn iter_base_types(
-    token_type: &'static str,
-    class_types: HashSet<String>,
-) -> (Cow<'static, str>, HashSet<String>) {
-    let mut class_types = class_types;
-    class_types.insert(token_type.to_string());
-    (Cow::Borrowed(token_type), class_types)
+/// The class-type hierarchy is fully determined by a token's kind (the lexer
+/// always supplies an empty `class_types`), and is never mutated after
+/// construction. So each kind shares a single `Arc<HashSet<String>>` built once,
+/// instead of every token allocating an identical set.
+fn make_class_types(types: &[&str]) -> Arc<HashSet<String>> {
+    Arc::new(types.iter().map(|s| s.to_string()).collect())
 }
+
+macro_rules! class_types_static {
+    ($name:ident, $($ty:literal),+) => {
+        static $name: Lazy<Arc<HashSet<String>>> = Lazy::new(|| make_class_types(&[$($ty),+]));
+    };
+}
+
+class_types_static!(BASE_CT, "base");
+class_types_static!(RAW_CT, "base", "raw");
+class_types_static!(SYMBOL_CT, "base", "raw", "symbol");
+class_types_static!(IDENTIFIER_CT, "base", "raw", "identifier");
+class_types_static!(LITERAL_CT, "base", "raw", "literal");
+class_types_static!(BINARY_OPERATOR_CT, "base", "raw", "binary_operator");
+class_types_static!(COMPARISON_OPERATOR_CT, "base", "raw", "comparison_operator");
+class_types_static!(WORD_CT, "base", "raw", "word");
+class_types_static!(UNLEXABLE_CT, "base", "raw", "unlexable");
+class_types_static!(WHITESPACE_CT, "base", "raw", "whitespace");
+class_types_static!(NEWLINE_CT, "base", "raw", "newline");
+class_types_static!(COMMENT_CT, "base", "raw", "comment");
+class_types_static!(META_CT, "base", "raw", "meta");
+class_types_static!(END_OF_FILE_CT, "base", "raw", "meta", "end_of_file");
+class_types_static!(INDENT_CT, "base", "raw", "meta", "indent");
+class_types_static!(DEDENT_CT, "base", "raw", "meta", "indent", "dedent");
+class_types_static!(TEMPLATE_LOOP_CT, "base", "raw", "meta", "template_loop");
+class_types_static!(PLACEHOLDER_CT, "base", "raw", "meta", "placeholder");

--- a/sqlfluffrs/sqlfluffrs_types/src/token/mod.rs
+++ b/sqlfluffrs/sqlfluffrs_types/src/token/mod.rs
@@ -43,7 +43,7 @@ pub struct Token {
     pub token_type: Cow<'static, str>,
     pub class_name: Cow<'static, str>,
     pub instance_types: Vec<String>,
-    pub class_types: HashSet<String>,
+    pub class_types: Arc<HashSet<String>>,
     pub comment_separate: bool,
     pub is_meta: bool,
     pub allow_empty: bool,
@@ -181,7 +181,7 @@ impl Token {
     /// Adds the surrogate type for raw segments.
     pub fn class_types(&self) -> HashSet<String> {
         let mut full_types = self.instance_types.iter().cloned().collect::<HashSet<_>>();
-        full_types.extend(self.class_types.clone());
+        full_types.extend(self.class_types.iter().cloned());
         full_types
     }
 


### PR DESCRIPTION
### Brief summary of the change made

Every token built its own `class_types` `HashSet` at construction: the lexer always supplies an empty set and the constructor chain clones+inserts `{base, raw, kind}`, so each token paid ~6 allocations (growing `HashSet` clones + `String` type names) to build a set that is **identical for every token of that kind** and **never mutated** afterward.

Replace the per-token build with a shared `Arc<HashSet<String>>` per kind, built once via a `Lazy` static. `class_types` becomes `Arc<HashSet<String>>`; each constructor assigns its kind's static (an `Arc` clone, no allocation).

### Performance

Criterion, lexing the TPC-H/TPC-DS suites, vs. the stacked base:

| Benchmark | base | this PR | change |
|---|---|---|---|
| `lex_tpch_22` | 6.60 ms | 4.91 ms | **−25.5%** |
| `lex_tpcds_99` | 57.72 ms | 42.36 ms | **−26.6%** |

Both `p = 0.00`. `Token` also shrinks 528 → 496 bytes, and the whole token stream now shares ~15 sets instead of one `HashSet` per token. No behavior change.

### Stacking

> [!IMPORTANT]
> Stacked on **#8021** (which is itself stacked on #8019 and #8020). Merge those first; this will be rebased onto `main` as they land.

### Are there any other side effects of this change that we should be aware of?
None. `class_types` is read-only after construction (verified — all mutations are on `segment_kwargs`, never on a `Token`).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Share the class‑type hierarchy across tokens by switching `Token.class_types` to an `Arc<HashSet<String>>` and using per‑kind statics via `once_cell::sync::Lazy` instead of building a new set per token. This removes redundant allocations and speeds up lexing with no behavior change.

- **Performance**
  - TPC‑H 22: 6.60 ms → 4.91 ms (−25.5%); TPC‑DS 99: 57.72 ms → 42.36 ms (−26.6%).
  - `Token` size 528 → 496 bytes.

<sup>Written for commit 1dcc8fed5c4491cf8e303a6b2d727974e535f557. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8022?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

