### PR TITLE
fix(teradata): parse BTEQ FILE= command arguments

### DIFF
--- a/src/sqlfluff/dialects/dialect_teradata.py
+++ b/src/sqlfluff/dialects/dialect_teradata.py
@@ -212,6 +212,24 @@ class BteqKeyWordSegment(BaseSegment):
     )
 
 
+class BteqFilePathSegment(BaseSegment):
+    """An unquoted file path used by BTEQ commands such as ``.RUN FILE=``.
+
+    BTEQ accepts bare file paths (e.g. ``POSTING``, ``reports/out.sql``,
+    ``../posting.sql``) as well as quoted ones. Model the unquoted form from
+    existing tokens rather than lexing paths as a single token.
+    """
+
+    type = "bteq_file_path"
+    match_grammar = AnyNumberOf(
+        Ref("SingleIdentifierGrammar"),
+        Ref("DotSegment"),
+        Ref("SlashSegment"),
+        min_times=1,
+        allow_gaps=False,
+    )
+
+
 class BteqStatementSegment(BaseSegment):
     """Bteq statements start with a dot, followed by a Keyword.
 
@@ -220,6 +238,7 @@ class BteqStatementSegment(BaseSegment):
     # BTEQ commands
     .if errorcode > 0 then .quit 2
     .IF ACTIVITYCOUNT = 0 THEN .QUIT
+    .RUN FILE=POSTING
     """
 
     type = "bteq_statement"
@@ -228,6 +247,12 @@ class BteqStatementSegment(BaseSegment):
         Ref("BteqKeyWordSegment"),
         AnyNumberOf(
             Ref("BteqKeyWordSegment"),
+            # FILE=<path> argument, e.g. `.RUN FILE=POSTING`.
+            Sequence(
+                "FILE",
+                Ref("EqualsSegment"),
+                OneOf(Ref("QuotedLiteralSegment"), Ref("BteqFilePathSegment")),
+            ),
             # if ... then: the ...
             Sequence(
                 Ref("ComparisonOperatorGrammar"), Ref("LiteralGrammar"), optional=True

--- a/test/fixtures/dialects/teradata/bteq.sql
+++ b/test/fixtures/dialects/teradata/bteq.sql
@@ -1,1 +1,2 @@
 .if errorcode > 0 then .quit 4;
+.RUN FILE=POSTING

--- a/test/fixtures/dialects/teradata/bteq.yml
+++ b/test/fixtures/dialects/teradata/bteq.yml
@@ -3,9 +3,9 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 5c9454897c6fb0804ca61cd756db50740fc13aabf09a5232ea602068cc2fa713
+_hash: b0619d78ca5ce85c3130a4f928668e9810e012db400fa9533d494a5d850b7571
 file:
-  statement:
+- statement:
     bteq_statement:
     - dot: .
     - bteq_key_word_segment:
@@ -21,4 +21,14 @@ file:
         dot: .
         keyword: quit
         numeric_literal: '4'
-  statement_terminator: ;
+- statement_terminator: ;
+- statement:
+    bteq_statement:
+      dot: .
+      bteq_key_word_segment:
+        keyword: RUN
+      keyword: FILE
+      comparison_operator:
+        raw_comparison_operator: '='
+      bteq_file_path:
+        naked_identifier: POSTING


### PR DESCRIPTION
### Brief summary of the change made

BTEQ meta-commands such as `.RUN FILE=POSTING` failed to parse in the Teradata dialect: the command keyword (`.RUN`) matched, but the `FILE=<path>` argument was left as an unparsable section.

This adds a command-specific `FILE=<path>` option to `BteqStatementSegment`, plus a dedicated `BteqFilePathSegment` that models unquoted file paths from existing tokens (`SingleIdentifierGrammar`, `DotSegment`, `SlashSegment`) rather than introducing a new lexer token. Both unquoted paths (`.RUN FILE=POSTING`, `.RUN FILE=reports/out.sql`) and quoted paths (`.RUN FILE='posting.sql'`) now parse.

This deliberately uses a narrow, command-specific tail rather than a broad "consume everything until newline" matcher, so invalid trailing tokens are still rejected (e.g. `.QUIT 4 unexpected` and `.RUN garbage` remain unparsable).

makes progress on #1673

### Are there any other side effects of this change that we should be aware of?

This change is narrowly scoped to the `.RUN FILE=<path>` syntax only. It does **not** add general BTEQ coverage: other BTEQ meta-commands (`.SET`, `.IMPORT`, `.EXPORT`, `.LOGON`, etc.) are still not parsed and remain out of scope here. They continue to parse via their existing grammar (where one exists) or remain unparsable (where one does not). This is intentional, so the PR does not imply broader BTEQ support than it delivers.

Beyond that:
- No changes to the lexer.
- No changes to grammar outside the Teradata dialect.
- No other dialects are affected.
- All existing Teradata fixtures continue to pass.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - [x] `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (`test/fixtures/dialects/teradata/bteq.sql` + `bteq.yml`, YAML auto-generated with `python test/generate_parse_fixture_yml.py`).
- [x] Added appropriate documentation for the change. (No user-facing docs needed; this is an internal dialect grammar change. The new command is documented inline in the `BteqStatementSegment` docstring.)
- [x] Created GitHub issues for any relevant followup/future enhancements if appropriate. (No new issue created; broader BTEQ command support remains tracked by the existing #1673.)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds parsing support for BTEQ `.RUN FILE=<path>` in the Teradata dialect, covering both quoted and unquoted paths. Fixes previously unparsable `FILE=<path>` arguments while still rejecting invalid trailing tokens.

- **Bug Fixes**
  - Added a command-specific `FILE=<path>` option to `BteqStatementSegment`.
  - Introduced `BteqFilePathSegment` to model unquoted paths from existing tokens; supports `.RUN FILE=POSTING` and `.RUN FILE='posting.sql'`.
  - No lexer or cross-dialect changes; tests added for the new case.

<sup>Written for commit f48fc2186ec8b035530ca0577a73b47cb0c5276a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8023?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

