### PR TITLE
perf(rust): memoize Ref child-grammar resolution (~22% faster parsing)

### DIFF
--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/cache.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/cache.rs
@@ -95,6 +95,16 @@ impl TableParseCache {
         }
     }
 
+    /// Pre-size the cache. The frame cache grows to several times the token
+    /// count during a parse; reserving up front avoids repeated rehashing.
+    pub fn with_capacity(cap: usize) -> Self {
+        TableParseCache {
+            cache: HashMap::with_capacity(cap),
+            hits: 0,
+            misses: 0,
+        }
+    }
+
     /// Check cache for a result
     pub fn get(&mut self, key: &TableCacheKey) -> Option<&TableCacheValue> {
         match self.cache.get(key) {

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/core.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/core.rs
@@ -156,6 +156,12 @@ pub struct Parser<'a> {
     pub(crate) indent_config: hashbrown::HashMap<&'static str, bool>,
     // Regex cache for table-driven RegexParser (pattern_string -> compiled RegexMode)
     regex_cache: hashbrown::HashMap<String, std::sync::Arc<RegexMode>>,
+    /// Memoizes a Ref's resolved child grammar (ref grammar_id -> child grammar_id).
+    /// The resolution (element children / by-name dialect lookup) depends only on
+    /// the Ref's grammar_id, but the same Ref is hit thousands of times per parse,
+    /// so caching it avoids repeating the by-name `get_*_segment_grammar` match.
+    /// `None` value = no child (the Ref resolves to Empty).
+    pub(crate) ref_child_cache: hashbrown::HashMap<u32, Option<u32>>,
     /// Maximum number of main-loop iterations before aborting.
     /// Configurable via `rust_parser_max_iterations` in `.sqlfluff`.
     pub(crate) max_parser_iterations: usize,
@@ -208,6 +214,7 @@ impl<'a> Parser<'a> {
             grammar_ctx,
             indent_config,
             regex_cache: hashbrown::HashMap::new(),
+            ref_child_cache: hashbrown::HashMap::new(),
             max_parser_iterations: 3_000_000,
             parser_warn_threshold: 2_000_000,
             max_parse_depth,

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/core.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/core.rs
@@ -207,7 +207,9 @@ impl<'a> Parser<'a> {
             tokens,
             pos: 0,
             dialect,
-            table_cache: TableParseCache::new(),
+            // The frame cache grows to several times the token count; pre-size it
+            // to avoid repeated rehashing of a map that reaches thousands of entries.
+            table_cache: TableParseCache::with_capacity(tokens.len().saturating_mul(8)),
             metrics: ParserMetrics::default(),
             terminator_match_cache: hashbrown::HashMap::new(),
             cache_enabled: true,

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/ref_grammar.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/ref_grammar.rs
@@ -72,25 +72,37 @@ impl Parser<'_> {
 
         self.pos = start_pos;
 
-        // Get element children (excludes the exclude grammar if present).
-        // For a Ref with only an exclude (no explicit match_grammar child), this will be empty.
-        let element_children: Vec<GrammarId> =
-            self.grammar_ctx.element_children(grammar_id).collect();
-
-        // Use first element child if present, otherwise resolve by name via dialect mapping.
-        // CRITICAL: For Ref grammars with an exclude, the `children` list contains ONLY the
-        // exclude grammar. The actual referenced segment must be resolved by name.
-        let child_grammar_id = if !element_children.is_empty() {
-            element_children[0]
-        } else {
-            match self.dialect.get_segment_grammar(&rule_name) {
-                Some(root) => root.grammar_id,
-                None => {
-                    vdebug!(
-                        "Ref[table]: No element children and no dialect mapping for '{}', returning Empty",
-                        rule_name
-                    );
-                    return Ok(stack.complete_frame_empty(&frame));
+        // Resolve the Ref's child grammar. This depends only on `grammar_id`
+        // (first element child if present, else a by-name dialect lookup), but the
+        // same Ref is hit thousands of times per parse, so memoize it — the by-name
+        // `get_*_segment_grammar` match is otherwise ~20% of parse self-time.
+        let child_grammar_id = match self.ref_child_cache.get(&grammar_id.0) {
+            Some(&Some(id)) => GrammarId(id),
+            Some(&None) => return Ok(stack.complete_frame_empty(&frame)),
+            None => {
+                // First element child if present, otherwise resolve by name.
+                // CRITICAL: For Ref grammars with an exclude, `children` contains ONLY
+                // the exclude grammar, so the referenced segment is resolved by name.
+                let resolved = self
+                    .grammar_ctx
+                    .element_children(grammar_id)
+                    .next()
+                    .or_else(|| {
+                        self.dialect
+                            .get_segment_grammar(&rule_name)
+                            .map(|root| root.grammar_id)
+                    });
+                self.ref_child_cache
+                    .insert(grammar_id.0, resolved.map(|g| g.0));
+                match resolved {
+                    Some(id) => id,
+                    None => {
+                        vdebug!(
+                            "Ref[table]: No element children and no dialect mapping for '{}', returning Empty",
+                            rule_name
+                        );
+                        return Ok(stack.complete_frame_empty(&frame));
+                    }
                 }
             }
         };


### PR DESCRIPTION
### Brief summary of the change made

A symbolicated profile of the table-driven parser showed the single biggest hot spot was the generated `get_*_segment_grammar` lookup — a ~1,200-arm `match name { ... }` hit on every `Ref` to resolve its name to a grammar — at **~20% of parse self-time**.

Resolving a `Ref` to its child grammar (first element child if present, else the by-name dialect lookup) depends only on the `Ref`'s `grammar_id`, but the same `Ref` is hit thousands of times per parse. This memoizes `grammar_id -> child grammar_id` in a per-`Parser` `HashMap`, so the by-name match runs at most once per distinct `Ref`; subsequent hits are an integer lookup. The per-call `element_children` `Vec` allocation is removed too (`.collect()[0]` → `.next()`).

A second small commit pre-sizes the frame parse cache (`TableParseCache`) to `tokens.len() * 8` in `Parser::new` — it grows to several times the token count during a parse, and reserving up front avoids repeated rehashing.

### Performance

Criterion, parsing the TPC-H/TPC-DS suites:

| Benchmark | base | this PR | change |
|---|---|---|---|
| `parse_tpch_22` | 97.4 ms | 75.8 ms | **−22.2%** |
| `parse_tpcds_99` | 979.6 ms | 771.4 ms | **−21.3%** |

(Memo ≈ −22%, cache pre-sizing ≈ −1% more.) Both `p = 0.00`. A re-profile with the memo in place confirms `get_*_segment_grammar` drops from 19.5% → 0.8% self-time.

### Are there any other side effects of this change that we should be aware of?

None — behavior is unchanged. The memoized value is a pure function of the `Ref`'s `grammar_id` (both `element_children` and the by-name `ref_name → get_segment_grammar` resolution are deterministic from it), and the cache is per-`Parser` (single dialect). All dialect fixture tests pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Memoized Ref child-grammar resolution and pre-sized the frame parse cache to cut rehashing, resulting in ~22% faster parsing on TPC‑H/TPC‑DS. Behavior is unchanged.

- **Refactors**
  - Cache `grammar_id -> child grammar_id` per `Parser` to avoid the large by-name match; use `.next()` instead of allocating a `Vec`.
  - Add `TableParseCache::with_capacity` and pre-size to `tokens.len() * 8` in `Parser::new`.

<sup>Written for commit 6079b0c2900a742b8655fc3a7c305ee1131ac4b7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8024?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

