### PR TITLE
fix(mysql): parse JSON_TABLE COLUMNS as identifiers not references

### DIFF
--- a/src/sqlfluff/dialects/dialect_mysql.py
+++ b/src/sqlfluff/dialects/dialect_mysql.py
@@ -36,6 +36,7 @@ from sqlfluff.core.parser import (
     StringParser,
     SymbolSegment,
     TypedParser,
+    WordSegment,
 )
 from sqlfluff.dialects import dialect_ansi as ansi
 from sqlfluff.dialects.dialect_mysql_keywords import (
@@ -437,6 +438,116 @@ class CurrentTimestampLikeFunctionSegment(BaseSegment):
     match_grammar = Sequence(
         Ref("CurrentTimestampLikeFunctionNameSegment"),
         Ref("CurrentTimestampLikeFunctionContentsSegment"),
+    )
+
+
+class JsonTableColumnDefinitionSegment(BaseSegment):
+    """A column definition in a JSON_TABLE COLUMNS clause.
+
+    The column names here define the shape of the table produced by
+    JSON_TABLE; they are not references to columns of an outer table, so
+    they are modelled as identifiers rather than column references.
+
+    https://dev.mysql.com/doc/refman/8.0/en/json-table-functions.html
+    """
+
+    type = "json_table_column_definition"
+    match_grammar: Matchable = OneOf(
+        # name FOR ORDINALITY
+        Sequence(
+            Ref("SingleIdentifierGrammar"),
+            "FOR",
+            "ORDINALITY",
+        ),
+        # NESTED [PATH] path COLUMNS (...)
+        Sequence(
+            "NESTED",
+            Ref.keyword("PATH", optional=True),
+            Ref("QuotedLiteralSegment"),
+            Ref("JsonTableColumnsClauseSegment"),
+        ),
+        # name type [EXISTS] PATH path [on_empty] [on_error]
+        Sequence(
+            Ref("SingleIdentifierGrammar"),
+            Ref("DatatypeSegment"),
+            OneOf(
+                Sequence("EXISTS", "PATH", Ref("QuotedLiteralSegment")),
+                Sequence(
+                    "PATH",
+                    Ref("QuotedLiteralSegment"),
+                    # on_empty / on_error handlers, in either order
+                    AnyNumberOf(
+                        Sequence(
+                            OneOf(
+                                "NULL",
+                                "ERROR",
+                                Sequence("DEFAULT", Ref("QuotedLiteralSegment")),
+                            ),
+                            "ON",
+                            OneOf("EMPTY", "ERROR"),
+                        ),
+                    ),
+                ),
+            ),
+        ),
+    )
+
+
+class JsonTableColumnsClauseSegment(BaseSegment):
+    """The COLUMNS clause in a JSON_TABLE function.
+
+    https://dev.mysql.com/doc/refman/8.0/en/json-table-functions.html
+    """
+
+    type = "json_table_columns_clause"
+    match_grammar: Matchable = Sequence(
+        "COLUMNS",
+        Bracketed(
+            Delimited(
+                Ref("JsonTableColumnDefinitionSegment"),
+            ),
+        ),
+    )
+
+
+class JsonTableFunctionContentsSegment(BaseSegment):
+    """JSON_TABLE function contents.
+
+    https://dev.mysql.com/doc/refman/8.0/en/json-table-functions.html
+    """
+
+    type = "function_contents"
+    match_grammar: Matchable = Bracketed(
+        Ref("ExpressionSegment"),
+        Ref("CommaSegment"),
+        Ref("QuotedLiteralSegment"),
+        Ref("JsonTableColumnsClauseSegment"),
+    )
+
+
+class JsonTableFunctionNameSegment(BaseSegment):
+    """JSON_TABLE function name segment.
+
+    Specified as type function_name so that linting rules identify it properly.
+    """
+
+    type = "function_name"
+    match_grammar: Matchable = StringParser(
+        "JSON_TABLE", WordSegment, type="function_name_identifier"
+    )
+
+
+class FunctionSegment(ansi.FunctionSegment):
+    """A scalar or aggregate function, with JSON_TABLE support."""
+
+    match_grammar = ansi.FunctionSegment.match_grammar.copy(
+        insert=[
+            Sequence(
+                Ref("JsonTableFunctionNameSegment"),
+                Ref("JsonTableFunctionContentsSegment"),
+            ),
+        ],
+        at=0,
     )
 
 

--- a/src/sqlfluff/dialects/dialect_mysql.py
+++ b/src/sqlfluff/dialects/dialect_mysql.py
@@ -441,18 +441,21 @@ class CurrentTimestampLikeFunctionSegment(BaseSegment):
     )
 
 
-class JsonTableColumnDefinitionSegment(BaseSegment):
-    """A column definition in a JSON_TABLE COLUMNS clause.
+class JsonTableColumnsClauseSegment(BaseSegment):
+    """The COLUMNS clause in a JSON_TABLE function.
 
-    The column names here define the shape of the table produced by
-    JSON_TABLE; they are not references to columns of an outer table, so
-    they are modelled as identifiers rather than column references.
+    The column names defined here describe the shape of the table produced by
+    JSON_TABLE; they are not references to columns of an outer table, so they
+    are modelled as identifiers rather than column references.
 
     https://dev.mysql.com/doc/refman/8.0/en/json-table-functions.html
     """
 
-    type = "json_table_column_definition"
-    match_grammar: Matchable = OneOf(
+    type = "json_table_columns_clause"
+
+    # A single column definition. Defined locally because it is only used
+    # inside this clause; the NESTED branch recurses through the clause itself.
+    _column_definition: Matchable = OneOf(
         # name FOR ORDINALITY
         Sequence(
             Ref("SingleIdentifierGrammar"),
@@ -492,19 +495,11 @@ class JsonTableColumnDefinitionSegment(BaseSegment):
         ),
     )
 
-
-class JsonTableColumnsClauseSegment(BaseSegment):
-    """The COLUMNS clause in a JSON_TABLE function.
-
-    https://dev.mysql.com/doc/refman/8.0/en/json-table-functions.html
-    """
-
-    type = "json_table_columns_clause"
     match_grammar: Matchable = Sequence(
         "COLUMNS",
         Bracketed(
             Delimited(
-                Ref("JsonTableColumnDefinitionSegment"),
+                _column_definition,
             ),
         ),
     )

--- a/test/fixtures/dialects/mariadb/json_table.sql
+++ b/test/fixtures/dialects/mariadb/json_table.sql
@@ -1,0 +1,13 @@
+-- JSON_TABLE COLUMNS definitions must not be read as column references
+-- (https://github.com/sqlfluff/sqlfluff/issues/6945).
+SELECT
+    `jt`.`name`,
+    `jt`.`price`
+FROM JSON_TABLE(
+    @json,
+    '$[*]'
+    COLUMNS(
+        `name` VARCHAR(10) PATH '$.name',
+        `price` DECIMAL(8, 2) PATH '$.price'
+    )
+) AS `jt`;

--- a/test/fixtures/dialects/mariadb/json_table.yml
+++ b/test/fixtures/dialects/mariadb/json_table.yml
@@ -1,0 +1,73 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: dbae3652e2d89bfa40bf0df381ecd15ec6f6637851306716182091ac624802ba
+file:
+  statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+          - quoted_identifier: '`jt`'
+          - dot: .
+          - quoted_identifier: '`name`'
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+          - quoted_identifier: '`jt`'
+          - dot: .
+          - quoted_identifier: '`price`'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              function:
+                function_name:
+                  function_name_identifier: JSON_TABLE
+                function_contents:
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                      variable: '@json'
+                    comma: ','
+                    quoted_literal: "'$[*]'"
+                    json_table_columns_clause:
+                      keyword: COLUMNS
+                      bracketed:
+                      - start_bracket: (
+                      - json_table_column_definition:
+                          quoted_identifier: '`name`'
+                          data_type:
+                            data_type_identifier: VARCHAR
+                            bracketed_arguments:
+                              bracketed:
+                                start_bracket: (
+                                numeric_literal: '10'
+                                end_bracket: )
+                          keyword: PATH
+                          quoted_literal: "'$.name'"
+                      - comma: ','
+                      - json_table_column_definition:
+                          quoted_identifier: '`price`'
+                          data_type:
+                            data_type_identifier: DECIMAL
+                            bracketed_arguments:
+                              bracketed:
+                              - start_bracket: (
+                              - numeric_literal: '8'
+                              - comma: ','
+                              - numeric_literal: '2'
+                              - end_bracket: )
+                          keyword: PATH
+                          quoted_literal: "'$.price'"
+                      - end_bracket: )
+                    end_bracket: )
+            alias_expression:
+              alias_operator:
+                keyword: AS
+              quoted_identifier: '`jt`'
+  statement_terminator: ;

--- a/test/fixtures/dialects/mariadb/json_table.yml
+++ b/test/fixtures/dialects/mariadb/json_table.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: dbae3652e2d89bfa40bf0df381ecd15ec6f6637851306716182091ac624802ba
+_hash: b19efd592daa82ca68b136a631b5d249b6b5143e9839d8d0f157067096c6826b
 file:
   statement:
     select_statement:
@@ -39,31 +39,29 @@ file:
                       keyword: COLUMNS
                       bracketed:
                       - start_bracket: (
-                      - json_table_column_definition:
-                          quoted_identifier: '`name`'
-                          data_type:
-                            data_type_identifier: VARCHAR
-                            bracketed_arguments:
-                              bracketed:
-                                start_bracket: (
-                                numeric_literal: '10'
-                                end_bracket: )
-                          keyword: PATH
-                          quoted_literal: "'$.name'"
+                      - quoted_identifier: '`name`'
+                      - data_type:
+                          data_type_identifier: VARCHAR
+                          bracketed_arguments:
+                            bracketed:
+                              start_bracket: (
+                              numeric_literal: '10'
+                              end_bracket: )
+                      - keyword: PATH
+                      - quoted_literal: "'$.name'"
                       - comma: ','
-                      - json_table_column_definition:
-                          quoted_identifier: '`price`'
-                          data_type:
-                            data_type_identifier: DECIMAL
-                            bracketed_arguments:
-                              bracketed:
-                              - start_bracket: (
-                              - numeric_literal: '8'
-                              - comma: ','
-                              - numeric_literal: '2'
-                              - end_bracket: )
-                          keyword: PATH
-                          quoted_literal: "'$.price'"
+                      - quoted_identifier: '`price`'
+                      - data_type:
+                          data_type_identifier: DECIMAL
+                          bracketed_arguments:
+                            bracketed:
+                            - start_bracket: (
+                            - numeric_literal: '8'
+                            - comma: ','
+                            - numeric_literal: '2'
+                            - end_bracket: )
+                      - keyword: PATH
+                      - quoted_literal: "'$.price'"
                       - end_bracket: )
                     end_bracket: )
             alias_expression:

--- a/test/fixtures/dialects/mysql/json_table.sql
+++ b/test/fixtures/dialects/mysql/json_table.sql
@@ -1,0 +1,48 @@
+-- Single-table select: COLUMNS definitions must not be read as column
+-- references (https://github.com/sqlfluff/sqlfluff/issues/6945).
+SELECT
+    `jt`.`name`,
+    `jt`.`color`,
+    `jt`.`price`
+FROM JSON_TABLE(
+    @json,
+    '$[*]'
+    COLUMNS(
+        `name` VARCHAR(10) PATH '$.name',
+        `color` VARCHAR(10) PATH '$.color',
+        `price` DECIMAL(8, 2) PATH '$.price'
+    )
+) AS `jt`;
+
+-- Joined select: the COLUMNS definitions must not trigger qualification rules.
+SELECT
+    `jt`.`name`,
+    `sub`.`size`
+FROM (
+    SELECT `items`.`size`
+    FROM `items`
+) AS `sub`
+CROSS JOIN JSON_TABLE(
+    @json,
+    '$[*]'
+    COLUMNS(`name` VARCHAR(50) PATH '$.name')
+) AS `jt`;
+
+-- FOR ORDINALITY, EXISTS PATH, ON EMPTY / ON ERROR, and NESTED PATH.
+SELECT
+    `jt`.`id`,
+    `jt`.`name`,
+    `jt`.`has_price`,
+    `jt`.`tag`
+FROM JSON_TABLE(
+    @json,
+    '$[*]'
+    COLUMNS(
+        `id` FOR ORDINALITY,
+        `name` VARCHAR(40) PATH '$.name' DEFAULT '0' ON EMPTY NULL ON ERROR,
+        `has_price` VARCHAR(10) EXISTS PATH '$.price',
+        NESTED PATH '$.tags[*]' COLUMNS(
+            `tag` VARCHAR(40) PATH '$.tag'
+        )
+    )
+) AS `jt`;

--- a/test/fixtures/dialects/mysql/json_table.yml
+++ b/test/fixtures/dialects/mysql/json_table.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: dfc8e3d9226812673731110a480b2fc476bd6fac130d86e444d7a808f46cf61b
+_hash: 74e77c723a0f03823e5c0b6a553903ea9aef17a27f1812e57b45d9e2a74cdfda
 file:
 - statement:
     select_statement:
@@ -45,43 +45,40 @@ file:
                       keyword: COLUMNS
                       bracketed:
                       - start_bracket: (
-                      - json_table_column_definition:
-                          quoted_identifier: '`name`'
-                          data_type:
-                            data_type_identifier: VARCHAR
-                            bracketed_arguments:
-                              bracketed:
-                                start_bracket: (
-                                numeric_literal: '10'
-                                end_bracket: )
-                          keyword: PATH
-                          quoted_literal: "'$.name'"
+                      - quoted_identifier: '`name`'
+                      - data_type:
+                          data_type_identifier: VARCHAR
+                          bracketed_arguments:
+                            bracketed:
+                              start_bracket: (
+                              numeric_literal: '10'
+                              end_bracket: )
+                      - keyword: PATH
+                      - quoted_literal: "'$.name'"
                       - comma: ','
-                      - json_table_column_definition:
-                          quoted_identifier: '`color`'
-                          data_type:
-                            data_type_identifier: VARCHAR
-                            bracketed_arguments:
-                              bracketed:
-                                start_bracket: (
-                                numeric_literal: '10'
-                                end_bracket: )
-                          keyword: PATH
-                          quoted_literal: "'$.color'"
+                      - quoted_identifier: '`color`'
+                      - data_type:
+                          data_type_identifier: VARCHAR
+                          bracketed_arguments:
+                            bracketed:
+                              start_bracket: (
+                              numeric_literal: '10'
+                              end_bracket: )
+                      - keyword: PATH
+                      - quoted_literal: "'$.color'"
                       - comma: ','
-                      - json_table_column_definition:
-                          quoted_identifier: '`price`'
-                          data_type:
-                            data_type_identifier: DECIMAL
-                            bracketed_arguments:
-                              bracketed:
-                              - start_bracket: (
-                              - numeric_literal: '8'
-                              - comma: ','
-                              - numeric_literal: '2'
-                              - end_bracket: )
-                          keyword: PATH
-                          quoted_literal: "'$.price'"
+                      - quoted_identifier: '`price`'
+                      - data_type:
+                          data_type_identifier: DECIMAL
+                          bracketed_arguments:
+                            bracketed:
+                            - start_bracket: (
+                            - numeric_literal: '8'
+                            - comma: ','
+                            - numeric_literal: '2'
+                            - end_bracket: )
+                      - keyword: PATH
+                      - quoted_literal: "'$.price'"
                       - end_bracket: )
                     end_bracket: )
             alias_expression:
@@ -150,17 +147,16 @@ file:
                         keyword: COLUMNS
                         bracketed:
                           start_bracket: (
-                          json_table_column_definition:
-                            quoted_identifier: '`name`'
-                            data_type:
-                              data_type_identifier: VARCHAR
-                              bracketed_arguments:
-                                bracketed:
-                                  start_bracket: (
-                                  numeric_literal: '50'
-                                  end_bracket: )
-                            keyword: PATH
-                            quoted_literal: "'$.name'"
+                          quoted_identifier: '`name`'
+                          data_type:
+                            data_type_identifier: VARCHAR
+                            bracketed_arguments:
+                              bracketed:
+                                start_bracket: (
+                                numeric_literal: '50'
+                                end_bracket: )
+                          keyword: PATH
+                          quoted_literal: "'$.name'"
                           end_bracket: )
                       end_bracket: )
               alias_expression:
@@ -214,63 +210,58 @@ file:
                       keyword: COLUMNS
                       bracketed:
                       - start_bracket: (
-                      - json_table_column_definition:
-                        - quoted_identifier: '`id`'
-                        - keyword: FOR
-                        - keyword: ORDINALITY
+                      - quoted_identifier: '`id`'
+                      - keyword: FOR
+                      - keyword: ORDINALITY
                       - comma: ','
-                      - json_table_column_definition:
-                        - quoted_identifier: '`name`'
-                        - data_type:
-                            data_type_identifier: VARCHAR
-                            bracketed_arguments:
-                              bracketed:
-                                start_bracket: (
-                                numeric_literal: '40'
-                                end_bracket: )
-                        - keyword: PATH
-                        - quoted_literal: "'$.name'"
-                        - keyword: DEFAULT
-                        - quoted_literal: "'0'"
-                        - keyword: 'ON'
-                        - keyword: EMPTY
-                        - keyword: 'NULL'
-                        - keyword: 'ON'
-                        - keyword: ERROR
-                      - comma: ','
-                      - json_table_column_definition:
-                        - quoted_identifier: '`has_price`'
-                        - data_type:
-                            data_type_identifier: VARCHAR
-                            bracketed_arguments:
-                              bracketed:
-                                start_bracket: (
-                                numeric_literal: '10'
-                                end_bracket: )
-                        - keyword: EXISTS
-                        - keyword: PATH
-                        - quoted_literal: "'$.price'"
-                      - comma: ','
-                      - json_table_column_definition:
-                        - keyword: NESTED
-                        - keyword: PATH
-                        - quoted_literal: "'$.tags[*]'"
-                        - json_table_columns_clause:
-                            keyword: COLUMNS
+                      - quoted_identifier: '`name`'
+                      - data_type:
+                          data_type_identifier: VARCHAR
+                          bracketed_arguments:
                             bracketed:
                               start_bracket: (
-                              json_table_column_definition:
-                                quoted_identifier: '`tag`'
-                                data_type:
-                                  data_type_identifier: VARCHAR
-                                  bracketed_arguments:
-                                    bracketed:
-                                      start_bracket: (
-                                      numeric_literal: '40'
-                                      end_bracket: )
-                                keyword: PATH
-                                quoted_literal: "'$.tag'"
+                              numeric_literal: '40'
                               end_bracket: )
+                      - keyword: PATH
+                      - quoted_literal: "'$.name'"
+                      - keyword: DEFAULT
+                      - quoted_literal: "'0'"
+                      - keyword: 'ON'
+                      - keyword: EMPTY
+                      - keyword: 'NULL'
+                      - keyword: 'ON'
+                      - keyword: ERROR
+                      - comma: ','
+                      - quoted_identifier: '`has_price`'
+                      - data_type:
+                          data_type_identifier: VARCHAR
+                          bracketed_arguments:
+                            bracketed:
+                              start_bracket: (
+                              numeric_literal: '10'
+                              end_bracket: )
+                      - keyword: EXISTS
+                      - keyword: PATH
+                      - quoted_literal: "'$.price'"
+                      - comma: ','
+                      - keyword: NESTED
+                      - keyword: PATH
+                      - quoted_literal: "'$.tags[*]'"
+                      - json_table_columns_clause:
+                          keyword: COLUMNS
+                          bracketed:
+                            start_bracket: (
+                            quoted_identifier: '`tag`'
+                            data_type:
+                              data_type_identifier: VARCHAR
+                              bracketed_arguments:
+                                bracketed:
+                                  start_bracket: (
+                                  numeric_literal: '40'
+                                  end_bracket: )
+                            keyword: PATH
+                            quoted_literal: "'$.tag'"
+                            end_bracket: )
                       - end_bracket: )
                     end_bracket: )
             alias_expression:

--- a/test/fixtures/dialects/mysql/json_table.yml
+++ b/test/fixtures/dialects/mysql/json_table.yml
@@ -1,0 +1,280 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: dfc8e3d9226812673731110a480b2fc476bd6fac130d86e444d7a808f46cf61b
+file:
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+          - quoted_identifier: '`jt`'
+          - dot: .
+          - quoted_identifier: '`name`'
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+          - quoted_identifier: '`jt`'
+          - dot: .
+          - quoted_identifier: '`color`'
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+          - quoted_identifier: '`jt`'
+          - dot: .
+          - quoted_identifier: '`price`'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              function:
+                function_name:
+                  function_name_identifier: JSON_TABLE
+                function_contents:
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                      variable: '@json'
+                    comma: ','
+                    quoted_literal: "'$[*]'"
+                    json_table_columns_clause:
+                      keyword: COLUMNS
+                      bracketed:
+                      - start_bracket: (
+                      - json_table_column_definition:
+                          quoted_identifier: '`name`'
+                          data_type:
+                            data_type_identifier: VARCHAR
+                            bracketed_arguments:
+                              bracketed:
+                                start_bracket: (
+                                numeric_literal: '10'
+                                end_bracket: )
+                          keyword: PATH
+                          quoted_literal: "'$.name'"
+                      - comma: ','
+                      - json_table_column_definition:
+                          quoted_identifier: '`color`'
+                          data_type:
+                            data_type_identifier: VARCHAR
+                            bracketed_arguments:
+                              bracketed:
+                                start_bracket: (
+                                numeric_literal: '10'
+                                end_bracket: )
+                          keyword: PATH
+                          quoted_literal: "'$.color'"
+                      - comma: ','
+                      - json_table_column_definition:
+                          quoted_identifier: '`price`'
+                          data_type:
+                            data_type_identifier: DECIMAL
+                            bracketed_arguments:
+                              bracketed:
+                              - start_bracket: (
+                              - numeric_literal: '8'
+                              - comma: ','
+                              - numeric_literal: '2'
+                              - end_bracket: )
+                          keyword: PATH
+                          quoted_literal: "'$.price'"
+                      - end_bracket: )
+                    end_bracket: )
+            alias_expression:
+              alias_operator:
+                keyword: AS
+              quoted_identifier: '`jt`'
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+          - quoted_identifier: '`jt`'
+          - dot: .
+          - quoted_identifier: '`name`'
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+          - quoted_identifier: '`sub`'
+          - dot: .
+          - quoted_identifier: '`size`'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              bracketed:
+                start_bracket: (
+                select_statement:
+                  select_clause:
+                    keyword: SELECT
+                    select_clause_element:
+                      column_reference:
+                      - quoted_identifier: '`items`'
+                      - dot: .
+                      - quoted_identifier: '`size`'
+                  from_clause:
+                    keyword: FROM
+                    from_expression:
+                      from_expression_element:
+                        table_expression:
+                          table_reference:
+                            quoted_identifier: '`items`'
+                end_bracket: )
+            alias_expression:
+              alias_operator:
+                keyword: AS
+              quoted_identifier: '`sub`'
+          join_clause:
+          - keyword: CROSS
+          - keyword: JOIN
+          - from_expression_element:
+              table_expression:
+                function:
+                  function_name:
+                    function_name_identifier: JSON_TABLE
+                  function_contents:
+                    bracketed:
+                      start_bracket: (
+                      expression:
+                        variable: '@json'
+                      comma: ','
+                      quoted_literal: "'$[*]'"
+                      json_table_columns_clause:
+                        keyword: COLUMNS
+                        bracketed:
+                          start_bracket: (
+                          json_table_column_definition:
+                            quoted_identifier: '`name`'
+                            data_type:
+                              data_type_identifier: VARCHAR
+                              bracketed_arguments:
+                                bracketed:
+                                  start_bracket: (
+                                  numeric_literal: '50'
+                                  end_bracket: )
+                            keyword: PATH
+                            quoted_literal: "'$.name'"
+                          end_bracket: )
+                      end_bracket: )
+              alias_expression:
+                alias_operator:
+                  keyword: AS
+                quoted_identifier: '`jt`'
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+          - quoted_identifier: '`jt`'
+          - dot: .
+          - quoted_identifier: '`id`'
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+          - quoted_identifier: '`jt`'
+          - dot: .
+          - quoted_identifier: '`name`'
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+          - quoted_identifier: '`jt`'
+          - dot: .
+          - quoted_identifier: '`has_price`'
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+          - quoted_identifier: '`jt`'
+          - dot: .
+          - quoted_identifier: '`tag`'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              function:
+                function_name:
+                  function_name_identifier: JSON_TABLE
+                function_contents:
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                      variable: '@json'
+                    comma: ','
+                    quoted_literal: "'$[*]'"
+                    json_table_columns_clause:
+                      keyword: COLUMNS
+                      bracketed:
+                      - start_bracket: (
+                      - json_table_column_definition:
+                        - quoted_identifier: '`id`'
+                        - keyword: FOR
+                        - keyword: ORDINALITY
+                      - comma: ','
+                      - json_table_column_definition:
+                        - quoted_identifier: '`name`'
+                        - data_type:
+                            data_type_identifier: VARCHAR
+                            bracketed_arguments:
+                              bracketed:
+                                start_bracket: (
+                                numeric_literal: '40'
+                                end_bracket: )
+                        - keyword: PATH
+                        - quoted_literal: "'$.name'"
+                        - keyword: DEFAULT
+                        - quoted_literal: "'0'"
+                        - keyword: 'ON'
+                        - keyword: EMPTY
+                        - keyword: 'NULL'
+                        - keyword: 'ON'
+                        - keyword: ERROR
+                      - comma: ','
+                      - json_table_column_definition:
+                        - quoted_identifier: '`has_price`'
+                        - data_type:
+                            data_type_identifier: VARCHAR
+                            bracketed_arguments:
+                              bracketed:
+                                start_bracket: (
+                                numeric_literal: '10'
+                                end_bracket: )
+                        - keyword: EXISTS
+                        - keyword: PATH
+                        - quoted_literal: "'$.price'"
+                      - comma: ','
+                      - json_table_column_definition:
+                        - keyword: NESTED
+                        - keyword: PATH
+                        - quoted_literal: "'$.tags[*]'"
+                        - json_table_columns_clause:
+                            keyword: COLUMNS
+                            bracketed:
+                              start_bracket: (
+                              json_table_column_definition:
+                                quoted_identifier: '`tag`'
+                                data_type:
+                                  data_type_identifier: VARCHAR
+                                  bracketed_arguments:
+                                    bracketed:
+                                      start_bracket: (
+                                      numeric_literal: '40'
+                                      end_bracket: )
+                                keyword: PATH
+                                quoted_literal: "'$.tag'"
+                              end_bracket: )
+                      - end_bracket: )
+                    end_bracket: )
+            alias_expression:
+              alias_operator:
+                keyword: AS
+              quoted_identifier: '`jt`'
+- statement_terminator: ;


### PR DESCRIPTION
### Brief summary of the change made

Fixes #6945.

MySQL/MariaDB `JSON_TABLE(... COLUMNS(...))` builds a table from a JSON document, so the names inside `COLUMNS(...)` are *column definitions*, not column uses. The MySQL dialect had no dedicated `JSON_TABLE` grammar, so those definitions parsed as generic `column_reference`s and the References rule family (RF03/RF02) collected them as unqualified references, producing false positives.

The fix ports the existing in-codebase Oracle `JSON_TABLE` pattern to MySQL: five segments (`JsonTableColumnDefinitionSegment`, `JsonTableColumnsClauseSegment`, `JsonTableFunctionContentsSegment`, `JsonTableFunctionNameSegment`, and a `FunctionSegment` override) that model the column names inside `COLUMNS(...)` as identifiers. MariaDB inherits the behavior through `mysql_dialect.copy_as`.

Before (on `main`), the issue's repro reports four RF03 false positives:

```
L:   9 | P:   9 | RF03 | Unqualified reference '`name`' found in single table select.
L:   9 | P:   9 | RF03 | Unqualified reference '`name`' ... inconsistent with previous references.
L:  10 | P:   9 | RF03 | Unqualified reference '`color`' found in single table select.
L:  11 | P:   9 | RF03 | Unqualified reference '`price`' found in single table select.
```

After the change the same input lints clean.

### Are there any other side effects of this change that we should be aware of?

No. The new grammar is scoped to the `JSON_TABLE` function in the MySQL/MariaDB dialects; it does not touch the shared analysis layer or any other dialect. There is zero drift in existing dialect fixtures (the full MySQL + MariaDB suite is unchanged apart from the two new files).

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate the code change:
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects/mysql/json_table.{sql,yml}` and `test/fixtures/dialects/mariadb/json_table.{sql,yml}` (covering single-table select, multiple tables, and qualified/unqualified column access).

Validation:
- `python -m pytest test/dialects/dialects_test.py -k "mysql or mariadb"` is green (1256 passed)
- `python -m pytest test/rules/std_test.py -k "RF03 or RF02"` is green
- re-ran the issue's repro: the RF03 false positives are present on `main` and gone with this change (before/after above)
- `ruff check` clean on the changed dialect source

I used AI assistance while working on this, but I wrote and reviewed the change and the tests myself and verified the behavior locally.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Treat MySQL/MariaDB `JSON_TABLE` COLUMNS as column definitions (identifiers) instead of references, removing RF02/RF03 false positives. Adds a dedicated `JSON_TABLE` function grammar, mirroring Oracle, so names inside `COLUMNS(...)` no longer trigger qualification rules.

- **Bug Fixes**
  - Add dedicated `JSON_TABLE` grammar that treats `COLUMNS(...)` names as identifiers.
  - Remove RF02/RF03 false positives in selects using `JSON_TABLE` (MySQL and MariaDB); add parser fixtures for ORDINALITY, EXISTS/NESTED PATH, and on-empty/on-error.

- **Refactors**
  - Inline the single-use column-definition grammar into the `COLUMNS` clause to simplify the parser; NESTED recursion unchanged.

<sup>Written for commit df53817a8e329898b76a33bb0746b93cf586cf3c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8025?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

