### PR TITLE
fix(rust): correct subquery/SELECT parse via GREEDY-family cache skip

### DIFF
--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/cache.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/cache.rs
@@ -45,10 +45,10 @@ use crate::vdebug;
 /// - grammar_id: The GrammarId being matched (simple u32)
 /// - max_idx: Maximum index to parse up to (encodes terminator effects)
 ///
-/// PYTHON PARITY: Python's cache key is (raw, loc, type, max_idx).
-/// Terminators are NOT in the cache key! Instead, terminators affect max_idx
-/// calculation via trim_to_terminator(), so their effect is already captured.
-/// This dramatically improves cache hit rates.
+/// PYTHON PARITY: key is (pos, grammar_id, max_idx); terminators are not in the
+/// key (their effect rides in via max_idx). GREEDY-family frames, which trim on
+/// *inherited* terminators internally, are simply not cached (see
+/// `frame_cache_key`), so the key is always sufficient.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct TableCacheKey {
     pub pos: usize,
@@ -58,10 +58,6 @@ pub struct TableCacheKey {
 
 impl TableCacheKey {
     /// Create a new cache key.
-    ///
-    /// PYTHON PARITY: terminators and terminator_hash_cache parameters are now
-    /// ignored - we only use (pos, grammar_id, max_idx) just like Python uses
-    /// (raw, loc, type, max_idx). The max_idx already encodes terminator effects.
     pub fn new(pos: usize, grammar_id: GrammarId, max_idx: usize) -> Self {
         TableCacheKey {
             pos,

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/helpers.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/helpers.rs
@@ -304,6 +304,11 @@ impl<'a> Parser<'a> {
         let tables = Some(self.grammar_ctx.tables());
 
         for &opt_id in options {
+            // Skip the NONCODE sentinel (not a real grammar id; handled by
+            // `is_terminated`). Indexing the grammar tables with it would panic.
+            if opt_id == GrammarId::NONCODE {
+                continue;
+            }
             // Try to get simple hint for this grammar from tables
             if let Some(tables) = tables {
                 if let Some(hint) = tables.get_simple_hint_for_grammar(opt_id) {

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/delimited.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/delimited.rs
@@ -360,6 +360,28 @@ impl Parser<'_> {
         *working_idx = self.skip_to_code_if_gaps(*working_idx, *max_idx, allow_gaps);
         self.pos = *working_idx;
 
+        // PYTHON PARITY: respect the hard `max_idx` boundary before matching a
+        // delimiter (Python matches against `segments[:max_idx]`). Once the next
+        // code position reaches `max_idx`, the list is complete; otherwise a
+        // delimiter landing exactly on a parent's trimmed boundary would be
+        // consumed and the list would expand past it.
+        if *working_idx >= *max_idx {
+            vdebug!(
+                "Delimited[table]: reached max_idx ({}) after element, finalizing without delimiter",
+                *max_idx
+            );
+            let final_pos = *matched_idx;
+            self.pos = final_pos;
+            if *delimiter_count < min_delimiters {
+                frame.end_pos = Some(frame.pos);
+            } else {
+                frame.end_pos = Some(final_pos);
+            }
+            frame.state = FrameState::Combining;
+            stack.push(frame);
+            return Ok(TableFrameResult::Done);
+        }
+
         // Transition to MatchingDelimiter
         *delim_state = DelimitedPhase::MatchingDelimiter;
 

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/iterative.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/iterative.rs
@@ -1,6 +1,7 @@
 #[cfg(feature = "verbose-debug")]
 use crate::vdebug;
 use sqlfluffrs_types::GrammarId;
+use sqlfluffrs_types::ParseMode;
 // Only the verbose-debug tracing blocks in this module reference GrammarVariant directly;
 // the default build's uses live behind function-local imports. cfg-gating avoids an
 // unused-import warning in non-verbose builds.
@@ -743,26 +744,85 @@ impl Parser<'_> {
         if !parity::is_frame_cacheable(self.grammar_ctx.variant(frame.grammar_id)) {
             return Ok(None);
         }
+        // PYTHON PARITY: skip caching GREEDY-family frames. They trim on their
+        // *inherited* terminators internally, so the same (pos, grammar_id,
+        // max_idx) key can map to different results by context; Python never
+        // caches them either. A STRICT `Ref` forwarding a GREEDY-family target
+        // (e.g. `Ref("SelectClauseSegment")`) inherits the same dependence.
+        let parse_mode =
+            parity::effective_parse_mode(frame, self.grammar_ctx.inst(frame.grammar_id));
+        if self.is_greedy_family_for_cache(frame, parse_mode) {
+            return Ok(None);
+        }
         // Prefer the handler-calculated max_idx; fall back to computing it the same way the
         // handler would (CRITICAL: honour parse_mode_override for Bracketed inheritance).
         let max_idx = match frame.calculated_max_idx {
             Some(calc_max) => calc_max,
-            None => {
-                let parse_mode =
-                    parity::effective_parse_mode(frame, self.grammar_ctx.inst(frame.grammar_id));
-                self.calculate_max_idx(
-                    frame.pos,
-                    &frame.table_terminators,
-                    parse_mode,
-                    frame.parent_max_idx,
-                )?
-            }
+            None => self.calculate_max_idx(
+                frame.pos,
+                &frame.table_terminators,
+                parse_mode,
+                frame.parent_max_idx,
+            )?,
         };
         Ok(Some(TableCacheKey::new(
             frame.pos,
             frame.grammar_id,
             max_idx,
         )))
+    }
+
+    /// Whether `frame` is (or, for a `Ref`, forwards) a GREEDY-family frame and
+    /// so must not be cached. A `Ref` is itself STRICT but forwards its target's
+    /// match, so we resolve and inspect the target's parse mode.
+    #[inline]
+    fn is_greedy_family_for_cache(
+        &mut self,
+        frame: &TableParseFrame,
+        parse_mode: ParseMode,
+    ) -> bool {
+        // Own mode (already accounts for parse_mode_override) is cheap; check it.
+        if matches!(parse_mode, ParseMode::Greedy | ParseMode::GreedyOnceStarted) {
+            return true;
+        }
+        // Else: a STRICT `Ref` forwarding a GREEDY target. Inspect the resolved
+        // target's parse mode; resolution is memoized in `ref_child_cache`, so this
+        // is O(1) on the hot path after the first hit per Ref.
+        if self.grammar_ctx.variant(frame.grammar_id) != sqlfluffrs_types::GrammarVariant::Ref {
+            return false;
+        }
+        match self.resolve_ref_target(frame.grammar_id) {
+            Some(child_id) => matches!(
+                self.grammar_ctx.inst(child_id).parse_mode,
+                ParseMode::Greedy | ParseMode::GreedyOnceStarted
+            ),
+            None => false,
+        }
+    }
+
+    /// Resolve a `Ref` grammar to the grammar it matches against, mirroring the
+    /// resolution in `handle_ref_initial`: an explicit element child if present,
+    /// otherwise the segment grammar looked up by the ref's name in the dialect.
+    /// Backed by `ref_child_cache` (shared with `handle_ref_initial`) so the
+    /// by-name dialect lookup runs at most once per Ref.
+    #[inline]
+    fn resolve_ref_target(&mut self, grammar_id: GrammarId) -> Option<GrammarId> {
+        if let Some(&cached) = self.ref_child_cache.get(&grammar_id.0) {
+            return cached.map(GrammarId);
+        }
+        let resolved = self
+            .grammar_ctx
+            .element_children(grammar_id)
+            .next()
+            .or_else(|| {
+                let rule_name = self.grammar_ctx.ref_name(grammar_id);
+                self.dialect
+                    .get_segment_grammar(rule_name)
+                    .map(|root| root.grammar_id)
+            });
+        self.ref_child_cache
+            .insert(grammar_id.0, resolved.map(|g| g.0));
+        resolved
     }
 
     /// Checks the cache for a frame and handles cache hits. Returns FrameResult indicating what to do next.

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/match_algorithms.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/match_algorithms.rs
@@ -155,6 +155,11 @@ impl Parser<'_> {
         // If a terminator matches immediately (at start_idx), return as-is.
         // Python allows keyword terminators at the very start ("first element" edge case).
         for &term_id in terminators {
+            // Skip the NONCODE sentinel (not a real grammar id; handled by
+            // `is_terminated`). Indexing the grammar tables with it would panic.
+            if term_id == GrammarId::NONCODE {
+                continue;
+            }
             vdebug!(
                 "[GREEDY_MATCH_TABLE] greedy_match: checking immediate terminator match for {:?} at {}",
                 term_id, start_idx
@@ -200,6 +205,10 @@ impl Parser<'_> {
             }
 
             for &term_id in terminators {
+                // Skip the NONCODE sentinel (see the immediate-match loop above).
+                if term_id == GrammarId::NONCODE {
+                    continue;
+                }
                 vdebug!(
                     "[GREEDY_MATCH_TABLE] greedy_match: checking terminator {:?} at {}",
                     term_id,


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Three parser-parity fixes that together fix mis-parsed subquery SELECT clauses:

- Do not cache GREEDY-family frames (and STRICT Refs forwarding a GREEDY target such as Ref("SelectClauseSegment")): they trim on inherited terminators, so the same (pos, grammar_id, max_idx) key can map to different results by context. Mirrors Python, which never caches them.
- Delimited: respect the hard max_idx boundary before matching a delimiter so a delimiter on a parent's trimmed boundary does not expand the list.
- Skip the NONCODE sentinel in simple-hint and greedy-match terminator loops; it is not a real grammar id and indexing the tables with it panics.

### Are there any other side effects of this change that we should be aware of?
None

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes incorrect parsing of subquery SELECT clauses. Skips caching for GREEDY-family frames, enforces max_idx before delimiter matches, and ignores the NONCODE sentinel to prevent panics.

- **Bug Fixes**
  - Do not cache GREEDY-family frames, including STRICT `Ref` that forward GREEDY targets (mirrors Python behavior).
  - Delimited lists now respect `max_idx` before matching a delimiter to avoid expanding past a trimmed boundary.
  - Skip the `NONCODE` sentinel in simple-hint and greedy-match terminator loops to avoid table indexing panics.

<sup>Written for commit 5ee08fb7d0602015379a9b6eaf4b33338826e80f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8026?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

