### PR TITLE
fix(postgres): parse psql variable placeholders as COPY targets

### DIFF
--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -5853,7 +5853,9 @@ class CopyStatementSegment(BaseSegment):
     type = "copy_statement"
 
     _target_subset = OneOf(
-        Ref("QuotedLiteralSegment"), Sequence("PROGRAM", Ref("QuotedLiteralSegment"))
+        Ref("QuotedLiteralSegment"),
+        Sequence("PROGRAM", Ref("QuotedLiteralSegment")),
+        Ref("PsqlVariableGrammar"),
     )
 
     _table_definition = Sequence(
@@ -5995,6 +5997,7 @@ class CopyStatementSegment(BaseSegment):
                 "FROM",
                 OneOf(
                     Ref("QuotedLiteralSegment"),
+                    Ref("PsqlVariableGrammar"),
                     Sequence("STDIN"),
                 ),
                 _postgres9_compatible_stdin_options,
@@ -6013,6 +6016,7 @@ class CopyStatementSegment(BaseSegment):
                 "TO",
                 OneOf(
                     Ref("QuotedLiteralSegment"),
+                    Ref("PsqlVariableGrammar"),
                     Sequence("STDOUT"),
                 ),
                 _postgres9_compatible_stdout_options,

--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -5854,7 +5854,10 @@ class CopyStatementSegment(BaseSegment):
 
     _target_subset = OneOf(
         Ref("QuotedLiteralSegment"),
-        Sequence("PROGRAM", Ref("QuotedLiteralSegment")),
+        Sequence(
+            "PROGRAM",
+            OneOf(Ref("QuotedLiteralSegment"), Ref("PsqlVariableGrammar")),
+        ),
         Ref("PsqlVariableGrammar"),
     )
 

--- a/test/fixtures/dialects/postgres/copy.sql
+++ b/test/fixtures/dialects/postgres/copy.sql
@@ -82,3 +82,5 @@ COPY my_table FROM :source WITH (FORMAT csv, DELIMITER E'\t');
 COPY my_table TO :dest WITH (FORMAT csv);
 COPY my_table FROM :'fname';
 COPY my_table TO :"out";
+COPY my_table FROM PROGRAM :'gen_cmd';
+COPY my_table TO PROGRAM :dest_cmd;

--- a/test/fixtures/dialects/postgres/copy.sql
+++ b/test/fixtures/dialects/postgres/copy.sql
@@ -75,3 +75,10 @@ COPY my_table TO STDOUT WITH CSV ESCAPE '\';
 COPY my_table(col1, col2) TO STDOUT WITH CSV ESCAPE AS '\';
 COPY my_table(col1, col2) TO STDOUT WITH CSV FORCE QUOTE *;
 COPY my_table(col1, col2) TO STDOUT WITH CSV FORCE QUOTE (col1, col2);
+
+-- Issue #7696: psql variable placeholders as COPY targets
+COPY tmp_table FROM :source;
+COPY my_table FROM :source WITH (FORMAT csv, DELIMITER E'\t');
+COPY my_table TO :dest WITH (FORMAT csv);
+COPY my_table FROM :'fname';
+COPY my_table TO :"out";

--- a/test/fixtures/dialects/postgres/copy.yml
+++ b/test/fixtures/dialects/postgres/copy.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 7183a7dc7491c71f71cee5e900729ff0c5f0d5eb9d01884c0b76be0b066ad37c
+_hash: 00dd772996ac92619ef17fcd709e1025260e2d03dedf682aeaa692f33293a6a7
 file:
 - statement:
     copy_statement:
@@ -1440,4 +1440,69 @@ file:
       - column_reference:
           naked_identifier: col2
       - end_bracket: )
+- statement_terminator: ;
+- statement:
+    copy_statement:
+    - keyword: COPY
+    - table_reference:
+        naked_identifier: tmp_table
+    - keyword: FROM
+    - psql_variable:
+        colon: ':'
+        parameter: source
+- statement_terminator: ;
+- statement:
+    copy_statement:
+    - keyword: COPY
+    - table_reference:
+        naked_identifier: my_table
+    - keyword: FROM
+    - psql_variable:
+        colon: ':'
+        parameter: source
+    - keyword: WITH
+    - bracketed:
+      - start_bracket: (
+      - keyword: FORMAT
+      - naked_identifier: csv
+      - comma: ','
+      - keyword: DELIMITER
+      - quoted_literal: "E'\\t'"
+      - end_bracket: )
+- statement_terminator: ;
+- statement:
+    copy_statement:
+    - keyword: COPY
+    - table_reference:
+        naked_identifier: my_table
+    - keyword: TO
+    - psql_variable:
+        colon: ':'
+        parameter: dest
+    - keyword: WITH
+    - bracketed:
+        start_bracket: (
+        keyword: FORMAT
+        naked_identifier: csv
+        end_bracket: )
+- statement_terminator: ;
+- statement:
+    copy_statement:
+    - keyword: COPY
+    - table_reference:
+        naked_identifier: my_table
+    - keyword: FROM
+    - psql_variable:
+        colon: ':'
+        quoted_literal: "'fname'"
+- statement_terminator: ;
+- statement:
+    copy_statement:
+    - keyword: COPY
+    - table_reference:
+        naked_identifier: my_table
+    - keyword: TO
+    - psql_variable:
+        colon: ':'
+        parameter: '"out"'
 - statement_terminator: ;

--- a/test/fixtures/dialects/postgres/copy.yml
+++ b/test/fixtures/dialects/postgres/copy.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 00dd772996ac92619ef17fcd709e1025260e2d03dedf682aeaa692f33293a6a7
+_hash: e828edfa2f9b8f132796188d0568a6face270dee9bd9f5d86e8b2bd7c260a60a
 file:
 - statement:
     copy_statement:
@@ -1505,4 +1505,26 @@ file:
     - psql_variable:
         colon: ':'
         parameter: '"out"'
+- statement_terminator: ;
+- statement:
+    copy_statement:
+    - keyword: COPY
+    - table_reference:
+        naked_identifier: my_table
+    - keyword: FROM
+    - keyword: PROGRAM
+    - psql_variable:
+        colon: ':'
+        quoted_literal: "'gen_cmd'"
+- statement_terminator: ;
+- statement:
+    copy_statement:
+    - keyword: COPY
+    - table_reference:
+        naked_identifier: my_table
+    - keyword: TO
+    - keyword: PROGRAM
+    - psql_variable:
+        colon: ':'
+        parameter: dest_cmd
 - statement_terminator: ;


### PR DESCRIPTION
### Brief summary of the change made

`COPY ... FROM`/`COPY ... TO` now accept psql variable placeholders (`:source`, `:'name'`, `:"name"`) as the file target, alongside quoted literals and `PROGRAM`. Previously a placeholder target raised a `PRS` (unparsable section) error.

The placeholder is added in three spots so it works in both COPY forms: the shared `_target_subset` (parenthesized `WITH (...)` options) and the inline FROM/TO targets of the legacy non-parenthesized options. `PsqlVariableGrammar` already exists in this dialect and is reused as-is.

fixes #7696

### Are there any other side effects of this change that we should be aware of?

None. `::` cast parsing is unaffected (the placeholder grammar requires a single leading colon followed by an identifier or quoted literal). The full postgres dialect suite passes.

Note: the minimal example in the issue also uses the legacy `WITH delimiter ... quote ... csv` option ordering, which fails independently of the placeholder (it reproduces identically with a plain quoted literal target). That is a separate pre-existing limitation in the non-parenthesized option grammar and is out of scope here.

### Pull Request checklist

- [x] `.sql`/`.yml` parser test cases added in `test/fixtures/dialects/postgres/copy.{sql,yml}` covering `FROM`/`TO` with `:source`, `:'name'`, `:"name"` placeholders.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Postgres parser now accepts psql variable placeholders as `COPY` targets (`:source`, `:'name'`, `:"name"`) including `PROGRAM` arguments, matching psql behavior. This removes PRS errors in both parenthesized `WITH (...)` and legacy inline forms. Fixes #7696.

- **Bug Fixes**
  - Accept placeholders in `COPY ... FROM|TO` and `COPY ... FROM|TO PROGRAM` using `PsqlVariableGrammar`; `::` casts are unaffected.
  - Added tests in `test/fixtures/dialects/postgres/copy.{sql,yml}`.

<sup>Written for commit 656cb4b8dfae39ee01f5f9f6078f7cec4dbf7f6e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8027?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

