### PR TITLE
fix(mysql): parse JSON_VALUE RETURNING type with CHARACTER SET

### DIFF
--- a/src/sqlfluff/dialects/dialect_mysql.py
+++ b/src/sqlfluff/dialects/dialect_mysql.py
@@ -533,13 +533,17 @@ class JsonTableFunctionNameSegment(BaseSegment):
 
 
 class FunctionSegment(ansi.FunctionSegment):
-    """A scalar or aggregate function, with JSON_TABLE support."""
+    """A scalar or aggregate function, with JSON_TABLE and JSON_VALUE support."""
 
     match_grammar = ansi.FunctionSegment.match_grammar.copy(
         insert=[
             Sequence(
                 Ref("JsonTableFunctionNameSegment"),
                 Ref("JsonTableFunctionContentsSegment"),
+            ),
+            Sequence(
+                Ref("JsonValueFunctionNameSegment"),
+                Ref("JsonValueFunctionContentsSegment"),
             ),
         ],
         at=0,
@@ -2939,6 +2943,49 @@ class DropIndexStatementSegment(ansi.DropIndexStatementSegment):
                 OneOf("DEFAULT", "NONE", "SHARED", "EXCLUSIVE"),
             ),
             optional=True,
+        ),
+    )
+
+
+class JsonValueFunctionNameSegment(BaseSegment):
+    """JSON_VALUE function name segment.
+
+    Need to specify as type function_name so that linting rules identify it properly.
+    """
+
+    type = "function_name"
+    match_grammar: Matchable = StringParser(
+        "JSON_VALUE", KeywordSegment, type="function_name_identifier"
+    )
+
+
+class JsonValueFunctionContentsSegment(BaseSegment):
+    """JSON_VALUE function contents.
+
+    JSON_VALUE(json_doc, path [RETURNING type] [on_empty] [on_error])
+
+    https://dev.mysql.com/doc/refman/8.4/en/json-search-functions.html#function_json-value
+    """
+
+    type = "function_contents"
+    match_grammar: Matchable = Bracketed(
+        Ref("ExpressionSegment"),
+        Ref("CommaSegment"),
+        Ref("ExpressionSegment"),
+        Sequence(
+            "RETURNING",
+            Ref("DatatypeSegment"),
+            Sequence("CHARACTER", "SET", Ref("NakedIdentifierSegment"), optional=True),
+            optional=True,
+        ),
+        # [on_empty] [on_error]: {NULL | ERROR | DEFAULT value} ON {EMPTY | ERROR}
+        AnyNumberOf(
+            Sequence(
+                OneOf("NULL", "ERROR", Sequence("DEFAULT", Ref("ExpressionSegment"))),
+                "ON",
+                OneOf("EMPTY", "ERROR"),
+            ),
+            max_times=2,
         ),
     )
 

--- a/test/fixtures/dialects/mysql/json_value_returning.sql
+++ b/test/fixtures/dialects/mysql/json_value_returning.sql
@@ -1,0 +1,11 @@
+SELECT JSON_VALUE('{"a":"b"}', '$.a') AS basic_example;
+SELECT JSON_VALUE('{"a":"b"}', '$.a' RETURNING CHAR) AS returning_char;
+SELECT JSON_VALUE('{"a":"b"}', '$.a' RETURNING CHAR(255) CHARACTER SET utf8mb4) AS returning_charset;
+SELECT JSON_VALUE('{"a":"1"}', '$.a' RETURNING UNSIGNED) AS returning_unsigned;
+SELECT JSON_VALUE('{"a":"1"}', '$.a' RETURNING SIGNED) AS returning_signed;
+SELECT JSON_VALUE('{"a":"1"}', '$.a' RETURNING DECIMAL(4, 2)) AS returning_decimal;
+SELECT JSON_VALUE('{"a":"b"}', '$.a' RETURNING CHAR(10) DEFAULT 'x' ON EMPTY ERROR ON ERROR) AS on_empty_on_error;
+SELECT
+    JSON_VALUE('{"a":"1"}', '$.a' RETURNING UNSIGNED)
+UNION ALL
+SELECT JSON_VALUE('{"a":"b"}', '$.a' RETURNING CHAR(255) CHARACTER SET utf8mb4);

--- a/test/fixtures/dialects/mysql/json_value_returning.yml
+++ b/test/fixtures/dialects/mysql/json_value_returning.yml
@@ -1,0 +1,259 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: cc374437c17b589a211fd18664159c64ef7803c2bbbc544ab3142941fa520ae9
+file:
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: JSON_VALUE
+            function_contents:
+              bracketed:
+              - start_bracket: (
+              - expression:
+                  quoted_literal: "'{\"a\":\"b\"}'"
+              - comma: ','
+              - expression:
+                  quoted_literal: "'$.a'"
+              - end_bracket: )
+          alias_expression:
+            alias_operator:
+              keyword: AS
+            naked_identifier: basic_example
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: JSON_VALUE
+            function_contents:
+              bracketed:
+              - start_bracket: (
+              - expression:
+                  quoted_literal: "'{\"a\":\"b\"}'"
+              - comma: ','
+              - expression:
+                  quoted_literal: "'$.a'"
+              - keyword: RETURNING
+              - data_type:
+                  data_type_identifier: CHAR
+              - end_bracket: )
+          alias_expression:
+            alias_operator:
+              keyword: AS
+            naked_identifier: returning_char
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: JSON_VALUE
+            function_contents:
+              bracketed:
+              - start_bracket: (
+              - expression:
+                  quoted_literal: "'{\"a\":\"b\"}'"
+              - comma: ','
+              - expression:
+                  quoted_literal: "'$.a'"
+              - keyword: RETURNING
+              - data_type:
+                  data_type_identifier: CHAR
+                  bracketed_arguments:
+                    bracketed:
+                      start_bracket: (
+                      numeric_literal: '255'
+                      end_bracket: )
+              - keyword: CHARACTER
+              - keyword: SET
+              - naked_identifier: utf8mb4
+              - end_bracket: )
+          alias_expression:
+            alias_operator:
+              keyword: AS
+            naked_identifier: returning_charset
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: JSON_VALUE
+            function_contents:
+              bracketed:
+              - start_bracket: (
+              - expression:
+                  quoted_literal: "'{\"a\":\"1\"}'"
+              - comma: ','
+              - expression:
+                  quoted_literal: "'$.a'"
+              - keyword: RETURNING
+              - data_type:
+                  keyword: UNSIGNED
+              - end_bracket: )
+          alias_expression:
+            alias_operator:
+              keyword: AS
+            naked_identifier: returning_unsigned
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: JSON_VALUE
+            function_contents:
+              bracketed:
+              - start_bracket: (
+              - expression:
+                  quoted_literal: "'{\"a\":\"1\"}'"
+              - comma: ','
+              - expression:
+                  quoted_literal: "'$.a'"
+              - keyword: RETURNING
+              - data_type:
+                  keyword: SIGNED
+              - end_bracket: )
+          alias_expression:
+            alias_operator:
+              keyword: AS
+            naked_identifier: returning_signed
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: JSON_VALUE
+            function_contents:
+              bracketed:
+              - start_bracket: (
+              - expression:
+                  quoted_literal: "'{\"a\":\"1\"}'"
+              - comma: ','
+              - expression:
+                  quoted_literal: "'$.a'"
+              - keyword: RETURNING
+              - data_type:
+                  data_type_identifier: DECIMAL
+                  bracketed_arguments:
+                    bracketed:
+                    - start_bracket: (
+                    - numeric_literal: '4'
+                    - comma: ','
+                    - numeric_literal: '2'
+                    - end_bracket: )
+              - end_bracket: )
+          alias_expression:
+            alias_operator:
+              keyword: AS
+            naked_identifier: returning_decimal
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: JSON_VALUE
+            function_contents:
+              bracketed:
+              - start_bracket: (
+              - expression:
+                  quoted_literal: "'{\"a\":\"b\"}'"
+              - comma: ','
+              - expression:
+                  quoted_literal: "'$.a'"
+              - keyword: RETURNING
+              - data_type:
+                  data_type_identifier: CHAR
+                  bracketed_arguments:
+                    bracketed:
+                      start_bracket: (
+                      numeric_literal: '10'
+                      end_bracket: )
+              - keyword: DEFAULT
+              - expression:
+                  quoted_literal: "'x'"
+              - keyword: 'ON'
+              - keyword: EMPTY
+              - keyword: ERROR
+              - keyword: 'ON'
+              - keyword: ERROR
+              - end_bracket: )
+          alias_expression:
+            alias_operator:
+              keyword: AS
+            naked_identifier: on_empty_on_error
+- statement_terminator: ;
+- statement:
+    set_expression:
+    - select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            function:
+              function_name:
+                function_name_identifier: JSON_VALUE
+              function_contents:
+                bracketed:
+                - start_bracket: (
+                - expression:
+                    quoted_literal: "'{\"a\":\"1\"}'"
+                - comma: ','
+                - expression:
+                    quoted_literal: "'$.a'"
+                - keyword: RETURNING
+                - data_type:
+                    keyword: UNSIGNED
+                - end_bracket: )
+    - set_operator:
+      - keyword: UNION
+      - keyword: ALL
+    - select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            function:
+              function_name:
+                function_name_identifier: JSON_VALUE
+              function_contents:
+                bracketed:
+                - start_bracket: (
+                - expression:
+                    quoted_literal: "'{\"a\":\"b\"}'"
+                - comma: ','
+                - expression:
+                    quoted_literal: "'$.a'"
+                - keyword: RETURNING
+                - data_type:
+                    data_type_identifier: CHAR
+                    bracketed_arguments:
+                      bracketed:
+                        start_bracket: (
+                        numeric_literal: '255'
+                        end_bracket: )
+                - keyword: CHARACTER
+                - keyword: SET
+                - naked_identifier: utf8mb4
+                - end_bracket: )
+- statement_terminator: ;


### PR DESCRIPTION
### Brief summary of the change made

MySQL's `JSON_VALUE` accepts an optional `RETURNING type` clause (with `CHARACTER SET`, or `SIGNED`/`UNSIGNED`) plus `ON EMPTY` / `ON ERROR` handlers, but the mysql dialect had no dedicated grammar for it. The call fell through to the generic function form and the tail was left unparsable, so these failed:

```sql
SELECT JSON_VALUE('{"a":"b"}', '$.a' RETURNING CHAR(255) CHARACTER SET utf8mb4);
SELECT JSON_VALUE('{"a":"1"}', '$.a' RETURNING UNSIGNED);
SELECT JSON_VALUE('{"a":"1"}', '$.a' RETURNING SIGNED);
```

This adds `JsonValueFunctionNameSegment` + `JsonValueFunctionContentsSegment` and routes `JSON_VALUE` to them by extending the mysql `FunctionSegment` (the same one #8025 just added for `JSON_TABLE`), so JSON_TABLE and JSON_VALUE now share a single overridden `FunctionSegment`. The contents model the documented grammar `JSON_VALUE(json_doc, path [RETURNING type] [on_empty] [on_error])`, so all three cases parse and mariadb (which inherits mysql) gets it too.

fixes #5832

This also completes the previously-abandoned PR #7830, which added the basic `RETURNING ... CHARACTER SET` form; it was closed only because the author went quiet, not for a technical reason. Thanks to @jonasboos for the original starting point. This version adds the `ON EMPTY` / `ON ERROR` handlers and integrates with the recently merged `JSON_TABLE` support instead of declaring a second `FunctionSegment`.

### Are there any other side effects of this change that we should be aware of?

Scope is limited to `JSON_VALUE`; nothing else changes:

- No lexer changes, no changes outside the mysql dialect, no other dialects affected. The existing `JSON_TABLE` support added in #8025 is preserved (it now lives in the same `FunctionSegment`).
- The `ON EMPTY` / `ON ERROR` order is not strictly enforced (an unordered `AnyNumberOf(..., max_times=2)`); this matches the oracle JSON_TABLE precedent. Strict-ordering enforcement is intentionally out of scope.
- The pre-existing loose behaviour of the generic ansi function form (lenient trailing tokens on other functions) is untouched; only `JSON_VALUE` gets a dedicated, validating form. Invalid `JSON_VALUE` tails (e.g. `RETURNING CHAR foo bar`, or 3+ `ON ...` clauses) still correctly fail to parse.
- Rust tables auto-regenerate from the Python grammar in CI; only the Python grammar was edited here.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes:
  - [x] `.sql`/`.yml` parser test cases in `test/fixtures/dialects/mysql/` (`json_value_returning.sql` + `.yml`, YAML auto-generated with `python test/generate_parse_fixture_yml.py -d mysql`).
- [x] Added appropriate documentation for the change. (No user-facing docs needed; internal dialect grammar, documented inline in the segment docstrings.)
- [x] Created GitHub issues for any relevant followup/future enhancements if appropriate. (None needed; this fully resolves #5832.)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds MySQL parsing for JSON_VALUE’s RETURNING clause (including CHARACTER SET and SIGNED/UNSIGNED) and ON EMPTY/ON ERROR handlers by routing the function through a dedicated grammar. Fixes previous parse failures and works for MariaDB too.

- **Bug Fixes**
  - Added `JsonValueFunctionNameSegment` and `JsonValueFunctionContentsSegment`, and updated mysql `FunctionSegment` to handle `JSON_VALUE` alongside `JSON_TABLE`.
  - Validates RETURNING <type> [CHARACTER SET ...] and up to two ON EMPTY/ON ERROR handlers; order not enforced; invalid tails still fail.
  - Added focused fixtures; no lexer or other dialect changes.

<sup>Written for commit d4929581865667b126d256f2948193d0b80502ad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8028?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

