### PR TITLE
docs(dbt): recommend explicit utf-8 encoding

### DIFF
--- a/docs/source/configuration/templating/dbt.rst
+++ b/docs/source/configuration/templating/dbt.rst
@@ -61,6 +61,17 @@ In *.sqlfluff*:
 
     [sqlfluff]
     templater = dbt
+    encoding = utf-8
+
+.. note::
+
+    Setting ``encoding = utf-8`` is recommended for dbt projects where
+    *SQLFluff* may write files, for example when running ``sqlfluff fix``.
+    The dbt templater uses dbt to read project files during compilation, while
+    *SQLFluff* writes fixed files using its configured encoding. Setting the
+    encoding explicitly avoids relying on autodetection and can prevent
+    ``UnicodeDecodeError`` failures when dbt reads files after they have been
+    fixed by *SQLFluff*.
 
 In *.sqlfluffignore*:
 

--- a/docsv/configuration/templating/dbt.md
+++ b/docsv/configuration/templating/dbt.md
@@ -66,7 +66,18 @@ In *.sqlfluff*:
 ```ini
 [sqlfluff]
 templater = dbt
+encoding = utf-8
 ```
+
+::: tip
+Setting `encoding = utf-8` is recommended for dbt projects where *SQLFluff*
+may write files, for example when running `sqlfluff fix`.
+The dbt templater uses dbt to read project files during compilation, while
+*SQLFluff* writes fixed files using its configured encoding. Setting the
+encoding explicitly avoids relying on autodetection and can prevent
+`UnicodeDecodeError` failures when dbt reads files after they have been
+fixed by *SQLFluff*.
+:::
 
 In *.sqlfluffignore*:
 


### PR DESCRIPTION
### Brief summary of the change made

Document `encoding = utf-8` in the dbt templater starter configuration and explain why setting it explicitly can help avoid `UnicodeDecodeError` failures after `sqlfluff fix` writes files that dbt later reads.

Fixes #3776.

### Are there any other side effects of this change that we should be aware of?

No runtime behavior changes. This is documentation only.

### Pull Request checklist

- [x] Added appropriate documentation for the change.
- [x] Checked for duplicate PRs before opening.

### Verification

- `git diff --check`
- `/Volumes/STOREJET/2/Dependencies/sqlfluff/venv/bin/python -m doc8 docs/source --file-encoding utf8` returned 0 accumulated errors.

I did not run a full Sphinx docs build because Sphinx is not installed in the local SQLFluff venv available in this workspace.

AI-assisted disclosure: I used AI assistance to inspect the issue, identify the existing dbt templater docs location, and draft this documentation update. I reviewed the final diff before submitting.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Recommend setting `encoding = utf-8` in the `dbt` templater config to prevent `UnicodeDecodeError` after `sqlfluff fix`. Updated both Sphinx and VitePress dbt templater docs with a short note and example.

<sup>Written for commit 2d8ba5c72925b8a2c950a95838032967e6806985. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8041?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

