### PR TITLE
Fix Databricks spaced table property names

### DIFF
--- a/src/sqlfluff/dialects/dialect_databricks.py
+++ b/src/sqlfluff/dialects/dialect_databricks.py
@@ -1029,7 +1029,6 @@ class PropertyNameSegment(sparksql.PropertyNameSegment):
                     Ref("PropertiesBackTickedIdentifierSegment"),
                 ),
                 delimiter=Ref("DotSegment"),
-                allow_gaps=False,
             ),
             Ref("SingleIdentifierGrammar"),
         ),

--- a/test/fixtures/dialects/databricks/create_table.sql
+++ b/test/fixtures/dialects/databricks/create_table.sql
@@ -122,3 +122,9 @@ CREATE TABLE catalog.silver.child2 (
     REFERENCES catalog.silver.parent (parent_key)
     ON UPDATE NO ACTION ON DELETE NO ACTION
 ) USING DELTA;
+
+CREATE TABLE delta_change_feed_table (
+    id BIGINT
+)
+USING DELTA
+TBLPROPERTIES (delta . enableChangeDataFeed = TRUE);

--- a/test/fixtures/dialects/databricks/create_table.yml
+++ b/test/fixtures/dialects/databricks/create_table.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 3901f10cb7b46483f262fb84994c722d7b9673457ccacccaed6789649dcd4440
+_hash: 75f3f9984805399168f7982b363fc9394f23242bb8476de8695ace7768626b90
 file:
 - statement:
     create_table_statement:
@@ -974,4 +974,35 @@ file:
         keyword: USING
         data_source_format:
           keyword: DELTA
+- statement_terminator: ;
+- statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: delta_change_feed_table
+    - bracketed:
+        start_bracket: (
+        column_definition:
+          column_reference:
+            naked_identifier: id
+          data_type:
+            primitive_type:
+              keyword: BIGINT
+        end_bracket: )
+    - using_clause:
+        keyword: USING
+        data_source_format:
+          keyword: DELTA
+    - keyword: TBLPROPERTIES
+    - bracketed:
+        start_bracket: (
+        property_name_identifier:
+        - properties_naked_identifier: delta
+        - dot: .
+        - properties_naked_identifier: enableChangeDataFeed
+        comparison_operator:
+          raw_comparison_operator: '='
+        boolean_literal: 'TRUE'
+        end_bracket: )
 - statement_terminator: ;


### PR DESCRIPTION
## Summary

- Allow Databricks table property names to contain normal whitespace around dots.
- Add a regression fixture for `CREATE TABLE ... USING DELTA TBLPROPERTIES (delta . enableChangeDataFeed = TRUE)`.

Fixes #4927.

## Tests

- `python -m pytest test/dialects/dialects_test.py -k "databricks and create_table" -q`
- `python -m pytest test/dialects/dialects_test.py -k databricks -q`
- `python -m ruff check src/sqlfluff/dialects/dialect_databricks.py`
- `git diff --check`

AI assistance was used to help prepare this change.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix parsing of Databricks table property names that include whitespace around dots in CREATE TABLE TBLPROPERTIES, and add a regression test for "delta . enableChangeDataFeed" (fixes #4927).

- **Bug Fixes**
  - Removed gap restriction in `PropertyNameSegment` to allow whitespace around dot separators.
  - Added SQL/YAML fixtures covering `TBLPROPERTIES (delta . enableChangeDataFeed = TRUE)`.

<sup>Written for commit 0102683b28d4a2eb87b67b6c41a1046d9d05e5ab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8042?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

