### PR TITLE
Fix Redshift EXCLUDE after select list items

### DIFF
--- a/src/sqlfluff/dialects/dialect_redshift.py
+++ b/src/sqlfluff/dialects/dialect_redshift.py
@@ -2931,6 +2931,19 @@ class WildcardExpressionSegment(ansi.WildcardExpressionSegment):
     )
 
 
+class SelectClauseElementSegment(ansi.SelectClauseElementSegment):
+    """An element in a Redshift SELECT clause."""
+
+    match_grammar = OneOf(
+        Ref("WildcardExpressionSegment"),
+        Sequence(
+            Ref("BaseExpressionElementGrammar"),
+            Ref("AliasExpressionSegment", optional=True),
+            Ref("ExcludeClauseSegment", optional=True),
+        ),
+    )
+
+
 class ExcludeClauseSegment(BaseSegment):
     """A Redshift SELECT EXCLUDE clause.
 

--- a/test/fixtures/dialects/redshift/select_exclude.sql
+++ b/test/fixtures/dialects/redshift/select_exclude.sql
@@ -5,3 +5,5 @@ SELECT * EXCLUDE col1, col2 FROM table1;
 SELECT * EXCLUDE (col1) FROM table1;
 
 SELECT * EXCLUDE (col1, col2) FROM table1;
+
+SELECT *, NULL AS example EXCLUDE (col1, col2) FROM table1;

--- a/test/fixtures/dialects/redshift/select_exclude.yml
+++ b/test/fixtures/dialects/redshift/select_exclude.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: ccfe5628326043e2977dbfdf0721ccb5be8f8449f571dcb4fbb46d8e92aa9eb8
+_hash: 5468a4fc71e9daf5fcd1cee677b0771c131e1c95e78b85056c4ce5cefd771847
 file:
 - statement:
     select_statement:
@@ -85,6 +85,37 @@ file:
               - comma: ','
               - naked_identifier: col2
               - end_bracket: )
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: table1
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      - comma: ','
+      - select_clause_element:
+          null_literal: 'NULL'
+          alias_expression:
+            alias_operator:
+              keyword: AS
+            naked_identifier: example
+          select_exclude_clause:
+            keyword: EXCLUDE
+            bracketed:
+            - start_bracket: (
+            - naked_identifier: col1
+            - comma: ','
+            - naked_identifier: col2
+            - end_bracket: )
       from_clause:
         keyword: FROM
         from_expression:


### PR DESCRIPTION
## Summary
- allow Redshift `EXCLUDE` clauses after non-wildcard select list items
- add fixture coverage for `SELECT *, NULL AS example EXCLUDE (...)`

Fixes #7899.

## Tests
- `.venv-codex314/bin/python -m pytest test/dialects/dialects_test.py::test__dialect__base_parse_struct -k 'redshift and select_exclude' -q`
- `.venv-codex314/bin/python -m pytest test/dialects/dialects_test.py::test__dialect__base_parse_struct -k redshift -q`
- `.venv-codex314/bin/python -m ruff check src/sqlfluff/dialects/dialect_redshift.py`
- `.venv-codex314/bin/python -m ruff format --check src/sqlfluff/dialects/dialect_redshift.py`
- `git diff --check`
- `.venv-codex314/bin/sqlfluff parse --dialect redshift test/fixtures/dialects/redshift/select_exclude.sql`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Redshift SELECT parsing to allow EXCLUDE after non-wildcard items (not just '*'), matching Redshift syntax. Fixes #7899.

- **Bug Fixes**
  - Updated `SelectClauseElementSegment` to allow `ExcludeClauseSegment` after expressions and optional alias.
  - Added fixture for: SELECT *, NULL AS example EXCLUDE (col1, col2) FROM table1.

<sup>Written for commit 23712530cb2376ec1dea84e7bf215966db9d7bd9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8043?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

