### PR TITLE
Clarify fix confirmation in getting started docs

### DIFF
--- a/docs/source/gettingstarted.rst
+++ b/docs/source/gettingstarted.rst
@@ -184,6 +184,10 @@ For now, we only want to fix the following rules: *LT02*, *LT12*, *CP01*
     == [test.sql] FIXED
     4 fixable linting violations found
 
+By default, :code:`sqlfluff fix` applies fixes immediately. To review
+the proposed fixes and confirm them before they are applied, use
+:code:`sqlfluff fix --check`.
+
 If we now open up :code:`test.sql`, we'll see the content is
 now different.
 


### PR DESCRIPTION
## Summary
- clarify that `sqlfluff fix` applies fixes immediately by default
- point users to `sqlfluff fix --check` when they want to review and confirm fixes first

Addresses one concrete docs gap from #6968.

## Tests
- `git diff --check`
- `../sqlfluff/.venv-codex/bin/python -m compileall -q docs/source/gettingstarted.rst`
- Docutils parse of `docs/source/gettingstarted.rst` using an existing Sphinx/Docutils environment; only existing Sphinx-specific `:ref:` role diagnostics were reported by plain Docutils

Note: a full Sphinx build could not start in this lightweight worktree because `docs/source/conf.py` requires generated `_partials/rule_list.json`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarify the getting started docs: `sqlfluff fix` applies fixes immediately. Add a note to use `sqlfluff fix --check` when you want to review and confirm fixes before applying.

<sup>Written for commit 77d22f0626c22ff1c21cbd4573e15ed6d04d60c0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8044?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

