### PR TITLE
Fix ClickHouse double equals parsing

### DIFF
--- a/src/sqlfluff/dialects/dialect_clickhouse.py
+++ b/src/sqlfluff/dialects/dialect_clickhouse.py
@@ -11,6 +11,7 @@ from sqlfluff.core.parser import (
     BaseSegment,
     Bracketed,
     CodeSegment,
+    CompositeComparisonOperatorSegment,
     Conditional,
     Dedent,
     Delimited,
@@ -63,6 +64,11 @@ clickhouse_dialect.insert_lexer_matchers(
     before="newline",
 )
 
+clickhouse_dialect.insert_lexer_matchers(
+    [StringLexer("double_equals", "==", CodeSegment)],
+    before="equals",
+)
+
 clickhouse_dialect.patch_lexer_matchers(
     [
         RegexLexer(
@@ -94,6 +100,9 @@ clickhouse_dialect.add(
     ),
     LambdaFunctionSegment=TypedParser("lambda", SymbolSegment, type="lambda"),
     QuestionMarkSegment=StringParser("?", SymbolSegment, type="question"),
+    RawDoubleEqualsSegment=StringParser(
+        "==", SymbolSegment, type="raw_comparison_operator"
+    ),
 )
 
 clickhouse_dialect.replace(
@@ -108,6 +117,17 @@ clickhouse_dialect.replace(
         Ref("ComparisonOperatorGrammar"),
         # Add Lambda Function
         Ref("LambdaFunctionSegment"),
+    ),
+    ComparisonOperatorGrammar=OneOf(
+        Ref("EqualsSegment"),
+        Ref("DoubleEqualsSegment"),
+        Ref("GreaterThanSegment"),
+        Ref("LessThanSegment"),
+        Ref("GreaterThanOrEqualToSegment"),
+        Ref("LessThanOrEqualToSegment"),
+        Ref("NotEqualToSegment"),
+        Ref("LikeOperatorSegment"),
+        Ref("IsDistinctFromGrammar"),
     ),
     # https://clickhouse.com/docs/en/sql-reference/statements/select/join/#supported-types-of-join
     JoinTypeKeywordsGrammar=Sequence(
@@ -372,6 +392,12 @@ clickhouse_dialect.sets("datetime_units").update(
         "YY",
     ]
 )
+
+
+class DoubleEqualsSegment(CompositeComparisonOperatorSegment):
+    """Double equals operator."""
+
+    match_grammar: Matchable = Ref("RawDoubleEqualsSegment")
 
 
 class AccessPermissionSegment(ansi.AccessPermissionSegment):

--- a/test/fixtures/dialects/clickhouse/comparison_operators.sql
+++ b/test/fixtures/dialects/clickhouse/comparison_operators.sql
@@ -1,0 +1,1 @@
+SELECT a FROM t WHERE a == 1;

--- a/test/fixtures/dialects/clickhouse/comparison_operators.yml
+++ b/test/fixtures/dialects/clickhouse/comparison_operators.yml
@@ -1,0 +1,30 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 1154f45df2fea0f6ccc8fd71bda66f02cb34e648ad2850b083753958b5def7d4
+file:
+  statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          column_reference:
+            naked_identifier: a
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: t
+      where_clause:
+        keyword: WHERE
+        expression:
+          column_reference:
+            naked_identifier: a
+          comparison_operator:
+            raw_comparison_operator: ==
+          numeric_literal: '1'
+  statement_terminator: ;


### PR DESCRIPTION
## Summary
- Add ClickHouse lexer/parser support for the double-equals equality operator.
- Add a ClickHouse parse fixture covering SELECT a FROM t WHERE a == 1.

Fixes #8033.

## Testing
- Reproduced the original PRS failure with SQLFluff parse for SELECT a FROM t WHERE a == 1, then reran the same command after the fix and it parsed successfully.
- Generated ClickHouse parse fixtures successfully: 48 fixtures built.
- Ran focused fixture test: 3 passed, 6498 deselected.
- Ran ClickHouse dialect slice: 144 passed, 6357 deselected.
- Ran py_compile for src/sqlfluff/dialects/dialect_clickhouse.py.
- Ran git diff --check for the changed parser and fixture files.
