### PR TITLE
Fix ClickHouse unparenthesized EXCEPT wildcards

### DIFF
--- a/src/sqlfluff/dialects/dialect_clickhouse.py
+++ b/src/sqlfluff/dialects/dialect_clickhouse.py
@@ -690,7 +690,7 @@ class SetExpressionSegment(ansi.SetExpressionSegment):
 class SetOperatorSegment(ansi.SetOperatorSegment):
     """A set operator such as Union, Minus, Except or Intersect.
 
-    Excludes ClickHouse `SELECT * EXCEPT (...)` wildcard exclusions from being
+    Excludes ClickHouse `SELECT * EXCEPT ...` wildcard exclusions from being
     consumed as set operators.
     """
 
@@ -704,7 +704,13 @@ class SetOperatorSegment(ansi.SetOperatorSegment):
             Ref.keyword("ALL", optional=True),
         ),
         "MINUS",
-        exclude=Sequence("EXCEPT", Bracketed(Anything())),
+        exclude=Sequence(
+            "EXCEPT",
+            OneOf(
+                Bracketed(Anything()),
+                Ref("SingleIdentifierGrammar"),
+            ),
+        ),
     )
 
 

--- a/test/fixtures/dialects/clickhouse/select_except.sql
+++ b/test/fixtures/dialects/clickhouse/select_except.sql
@@ -1,2 +1,4 @@
 SELECT * EXCEPT (c1) from t1;
 SELECT * EXCEPT (c1, c2) from t1;
+SELECT * EXCEPT c1 from t1;
+SELECT t1.* EXCEPT c1 from t1;

--- a/test/fixtures/dialects/clickhouse/select_except.yml
+++ b/test/fixtures/dialects/clickhouse/select_except.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: ac4e56119ee233d9046cfd776655e3f259a469303a6d656776f6c3c03b47bb84
+_hash: 9b02b713b3c78cbe2938a546632aef2549599c63d98aa4ecd01bde74c61b8340
 file:
 - statement:
     select_statement:
@@ -43,6 +43,46 @@ file:
               - comma: ','
               - naked_identifier: c2
               - end_bracket: )
+      from_clause:
+        keyword: from
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: t1
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+            select_except_clause:
+              keyword: EXCEPT
+              naked_identifier: c1
+      from_clause:
+        keyword: from
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: t1
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              naked_identifier: t1
+              dot: .
+              star: '*'
+            select_except_clause:
+              keyword: EXCEPT
+              naked_identifier: c1
       from_clause:
         keyword: from
         from_expression:


### PR DESCRIPTION
## Summary

- keep ClickHouse `EXCEPT` wildcard exclusions from being parsed as set operators when the excluded column is unparenthesized
- add fixture coverage for both `SELECT * EXCEPT c1` and `SELECT t1.* EXCEPT c1`

Fixes #8034.

## Checks

- `printf 'SELECT * EXCEPT c FROM t;\nSELECT t.* EXCEPT c FROM t;\n' | PYTHONPATH=src .venv-codex314/bin/python -m sqlfluff parse --dialect clickhouse -`
- `PYTHONPATH=src .venv-codex314/bin/python test/generate_parse_fixture_yml.py -d clickhouse -f '*select_except*'`
- `PYTHONPATH=src .venv-codex314/bin/python -m pytest test/dialects/dialects_test.py -q -k 'clickhouse and select_except and parse_struct'`
- `PYTHONPATH=src .venv-codex314/bin/python -m pytest test/dialects/dialects_test.py -q -k 'clickhouse and base_file_parse'`
- `PYTHONPATH=src .venv-codex314/bin/python -m ruff check src/sqlfluff/dialects/dialect_clickhouse.py test/generate_parse_fixture_yml.py`
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes ClickHouse EXCEPT wildcard parsing where unparenthesized exclusions were misread as set operators. Queries like `SELECT * EXCEPT c1` and `SELECT t1.* EXCEPT c1` now parse correctly (fixes #8034).

- **Bug Fixes**
  - Updated `SetOperatorSegment` to exclude `EXCEPT` followed by a bracketed list or a single identifier from set-operator parsing.
  - Added parse fixtures for unparenthesized EXCEPT cases to prevent regressions.

<sup>Written for commit 3f5e9ffe4896ec8aae64098cd2ad0c915b274888. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8046?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

