### PR TITLE
Allow ClickHouse digit-leading identifiers

### DIFF
--- a/src/sqlfluff/dialects/dialect_clickhouse.py
+++ b/src/sqlfluff/dialects/dialect_clickhouse.py
@@ -228,7 +228,7 @@ clickhouse_dialect.replace(
     NakedIdentifierSegment=SegmentGenerator(
         # Generate the anti template from the set of reserved keywords
         lambda dialect: RegexParser(
-            r"[a-zA-Z_][0-9a-zA-Z_]*",
+            r"[0-9a-zA-Z_]*[a-zA-Z_][0-9a-zA-Z_]*",
             IdentifierSegment,
             type="naked_identifier",
             anti_template=r"^("

--- a/test/fixtures/dialects/clickhouse/identifier.sql
+++ b/test/fixtures/dialects/clickhouse/identifier.sql
@@ -7,3 +7,7 @@ SELECT bar AS _1 FROM foo;
 SELECT * FROM foo.bar _1;
 
 SELECT * FROM foo.bar AS _1;
+
+SELECT 3s_video_views FROM t;
+
+SELECT 1 AS 30_day_cm3;

--- a/test/fixtures/dialects/clickhouse/identifier.yml
+++ b/test/fixtures/dialects/clickhouse/identifier.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: c1c72774e91ec7601e3c5a5048914612722000c172032d7d15e5da84dc1c4ddf
+_hash: a8f848d7e258a225d794a6ef8fcbf2fb4e75b6da50328c4a6c8988d0c9e5bb73
 file:
 - statement:
     select_statement:
@@ -101,4 +101,30 @@ file:
               alias_operator:
                 keyword: AS
               naked_identifier: _1
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          column_reference:
+            naked_identifier: 3s_video_views
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: t
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          numeric_literal: '1'
+          alias_expression:
+            alias_operator:
+              keyword: AS
+            naked_identifier: 30_day_cm3
 - statement_terminator: ;


### PR DESCRIPTION
## Summary

- relax ClickHouse naked identifiers so unquoted names like `3s_video_views` and `30_day_cm3` parse as identifiers
- keep pure numeric values parsing as numeric literals
- add identifier fixture coverage for a digit-leading column reference and alias

Fixes #8035.

## Checks

- `PYTHONPATH=src .venv-codex314/bin/python -m pytest 'test/dialects/dialects_test.py::test__dialect__base_file_parse[clickhouse-identifier.sql]' -q` failed before the grammar change with parse errors for `3s_video_views` and `AS 30_day_cm3`
- `PYTHONPATH=src .venv-codex314/bin/python -m pytest 'test/dialects/dialects_test.py::test__dialect__base_file_parse[clickhouse-identifier.sql]' -q`
- `printf 'SELECT 3s_video_views FROM t;\nSELECT 1 AS 30_day_cm3;\nSELECT 123 FROM t;\nSELECT 1.25 FROM t;\n' | PYTHONPATH=src .venv-codex314/bin/python -m sqlfluff parse --dialect clickhouse -`
- `PYTHONPATH=src .venv-codex314/bin/python test/generate_parse_fixture_yml.py -d clickhouse -f '*identifier*'`
- `PYTHONPATH=src .venv-codex314/bin/python -m pytest test/dialects/dialects_test.py -q -k 'clickhouse and identifier'`
- `PYTHONPATH=src .venv-codex314/bin/python -m pytest test/dialects/dialects_test.py -q -k 'clickhouse and base_file_parse'`
- `PYTHONPATH=src .venv-codex314/bin/python -m ruff check src/sqlfluff/dialects/dialect_clickhouse.py`
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow digit-leading identifiers in the ClickHouse dialect (e.g., 3s_video_views, 30_day_cm3) so they parse as identifiers. Pure numeric tokens still parse as numeric literals.

- **Bug Fixes**
  - Relaxed `NakedIdentifierSegment` to `[0-9a-zA-Z_]*[a-zA-Z_][0-9a-zA-Z_]*` to permit digit-leading names with at least one letter/underscore.
  - Added fixtures for digit-leading column references and aliases.

<sup>Written for commit ea1586d728807f1e27f1d00abc311f43e0acfbc8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8047?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

