### PR TITLE
Allow ClickHouse LIMIT BY expression lists

### DIFF
--- a/src/sqlfluff/dialects/dialect_clickhouse.py
+++ b/src/sqlfluff/dialects/dialect_clickhouse.py
@@ -2681,8 +2681,14 @@ class LimitClauseSegment(ansi.LimitClauseSegment):
             Sequence(
                 "BY",
                 OneOf(
-                    Ref("BracketedColumnReferenceListGrammar"),
-                    Ref("ColumnReferenceSegment"),
+                    "ALL",
+                    Delimited(
+                        OneOf(
+                            Ref("ColumnReferenceSegment"),
+                            Ref("ExpressionSegment"),
+                        ),
+                        terminators=[Ref("SelectClauseTerminatorGrammar")],
+                    ),
                 ),
                 optional=True,
             ),

--- a/test/fixtures/dialects/clickhouse/limit_by.sql
+++ b/test/fixtures/dialects/clickhouse/limit_by.sql
@@ -5,3 +5,6 @@ with toto as (SELECT 1 as id, 'test' as name) SELECT * FROM toto LIMIT 1 by id;
 with toto as (SELECT 1 as id, 'test' as name) SELECT * FROM toto LIMIT 2 OFFSET 1 by id;
 
 with toto as (SELECT 1 as id, 'test' as name) SELECT * FROM toto LIMIT 2, 1 by (id, name);
+
+SELECT * FROM t LIMIT 1 BY a, b;
+SELECT * FROM t LIMIT 2 BY ALL;

--- a/test/fixtures/dialects/clickhouse/limit_by.yml
+++ b/test/fixtures/dialects/clickhouse/limit_by.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: bfb1a1991e553e932bdb4d70cc5871ef1bec789eb542a3da37739661335c4c54
+_hash: 1099af78820bb9906539cac91527e72c463a0c9eb22e50fb08971e73a7b8f0f5
 file:
 - statement:
     with_compound_statement:
@@ -199,12 +199,61 @@ file:
         - limit_clause_component:
             numeric_literal: '1'
         - keyword: by
-        - bracketed:
-          - start_bracket: (
-          - column_reference:
-              naked_identifier: id
-          - comma: ','
-          - column_reference:
-              naked_identifier: name
-          - end_bracket: )
+        - expression:
+            bracketed:
+            - start_bracket: (
+            - column_reference:
+                naked_identifier: id
+            - comma: ','
+            - column_reference:
+                naked_identifier: name
+            - end_bracket: )
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: t
+      limit_clause:
+      - keyword: LIMIT
+      - limit_clause_component:
+          numeric_literal: '1'
+      - keyword: BY
+      - column_reference:
+          naked_identifier: a
+      - comma: ','
+      - column_reference:
+          naked_identifier: b
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: t
+      limit_clause:
+      - keyword: LIMIT
+      - limit_clause_component:
+          numeric_literal: '2'
+      - keyword: BY
+      - keyword: ALL
 - statement_terminator: ;


### PR DESCRIPTION
## Summary

- allow ClickHouse `LIMIT ... BY` to accept a comma-separated expression list
- keep `LIMIT ... BY ALL` explicit
- add generated fixture coverage for `LIMIT 1 BY a, b` and `LIMIT 2 BY ALL`

## Verification

- `./.venv-py313/bin/sqlfluff parse --dialect clickhouse test/fixtures/dialects/clickhouse/limit_by.sql`
- `./.venv-py313/bin/python -m pytest test/dialects/dialects_test.py -k 'clickhouse and limit_by'`
- `./.venv-py313/bin/python -m pytest test/dialects/dialects_test.py -k 'clickhouse'`
- `./.venv-py313/bin/python -m ruff check src/sqlfluff/dialects/dialect_clickhouse.py`
- `git diff --check`

Closes #8030.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extend ClickHouse LIMIT BY to accept comma-separated expression lists and support the ALL keyword. This brings the parser in line with ClickHouse syntax and adds tests.

- **New Features**
  - Accepts comma-separated expressions in LIMIT ... BY (e.g., LIMIT 1 BY a, b).
  - Supports explicit ALL (e.g., LIMIT 2 BY ALL) with fixture coverage.

<sup>Written for commit 821fe4cc7022f9429f548bf480543aef10d7aa4d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8049?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

