### PR TITLE
Fix T-SQL alias column list spacing

### DIFF
--- a/src/sqlfluff/core/default_config.cfg
+++ b/src/sqlfluff/core/default_config.cfg
@@ -225,6 +225,9 @@ spacing_within = touch:inline
 [sqlfluff:layout:type:bracketed_arguments]
 spacing_before = touch:inline
 
+[sqlfluff:layout:type:alias_column_list]
+spacing_before = touch:inline
+
 [sqlfluff:layout:type:match_condition]
 spacing_within = touch:inline
 

--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -2096,6 +2096,30 @@ class EqualAliasOperatorSegment(BaseSegment):
     match_grammar: Matchable = Sequence(Ref("RawEqualsSegment"))
 
 
+class AliasColumnListSegment(BaseSegment):
+    """An optional column list following a T-SQL alias."""
+
+    type = "alias_column_list"
+    match_grammar = Bracketed(Ref("SingleIdentifierListSegment"))
+
+
+class AliasExpressionSegment(ansi.AliasExpressionSegment):
+    """A reference to an object with an optional T-SQL alias column list."""
+
+    match_grammar: Matchable = Sequence(
+        Indent,
+        Ref("AsAliasOperatorSegment", optional=True),
+        OneOf(
+            Sequence(
+                Ref("SingleIdentifierGrammar"),
+                Ref("AliasColumnListSegment", optional=True),
+            ),
+            Ref("SingleQuotedIdentifierSegment"),
+        ),
+        Dedent,
+    )
+
+
 class SelectClauseModifierSegment(BaseSegment):
     """Things that come after SELECT but before the columns."""
 

--- a/test/fixtures/rules/std_rule_cases/LT01-brackets.yml
+++ b/test/fixtures/rules/std_rule_cases/LT01-brackets.yml
@@ -28,6 +28,14 @@ test_pass_parenthesis_function:
   pass_str: |
     SELECT foo(5) FROM T1;
 
+test_pass_tsql_xml_method_column_alias:
+  pass_str: |
+    DECLARE @Xml XML = '<a>1</a>';
+    SELECT 1 FROM @Xml.nodes('a') AS FN(A);
+  configs:
+    core:
+      dialect: tsql
+
 test_pass_snowflake_match_condition:
   pass_str: |
     select *


### PR DESCRIPTION
## Summary
- add a typed T-SQL alias column list segment so layout config can distinguish alias column lists from ordinary bracketed groups
- allow alias column lists to touch the alias name, matching valid T-SQL syntax like `AS FN(A)`
- add an LT01 regression case for XML method table aliases

## Verification
- `python -m pytest test/rules/yaml_test_cases_test.py::test__rule_test_case[LT01_test_pass_tsql_xml_method_column_alias]`
- `python -m pytest test/rules/yaml_test_cases_test.py -k "LT01_"`
- `python -m ruff check src/sqlfluff/dialects/dialect_tsql.py`
- `git diff --check`
- `sqlfluff lint --dialect tsql -` against `DECLARE @Xml XML = ... SELECT 1 FROM @Xml.nodes(...) AS FN(A);`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes LT01 false positives for T‑SQL alias column lists by recognizing and allowing no space between the alias and its column list (e.g., AS FN(A)). Adds a regression test for XML method table aliases.

- **Bug Fixes**
  - Added `alias_column_list` segment and layout config (`spacing_before = touch:inline`) to allow `AS FN(A)` in T‑SQL.
  - Updated T‑SQL `AliasExpressionSegment` to parse optional alias column lists after identifiers.
  - Added LT01 regression case for `@Xml.nodes(...) AS FN(A)` to ensure correct behavior.

<sup>Written for commit 4677f4ac7d241d7184333fc026d39e002977906f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8051?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

