### PR TITLE
[codex] Parse SparkSQL SET literal lists

### DIFF
--- a/src/sqlfluff/dialects/dialect_sparksql.py
+++ b/src/sqlfluff/dialects/dialect_sparksql.py
@@ -552,6 +552,7 @@ sparksql_dialect.add(
         Ref("EqualsSegment", optional=True),
         OneOf(
             Ref("LiteralGrammar"),
+            Bracketed(Delimited(Ref("LiteralGrammar"))),
             # when property value is Java Class Name
             Delimited(
                 Ref("PropertiesNakedIdentifierSegment"),

--- a/test/fixtures/dialects/sparksql/set.sql
+++ b/test/fixtures/dialects/sparksql/set.sql
@@ -7,3 +7,5 @@ SET;
 SET spark.sql.variable.substitute;
 
 SET spark.sql.cache.serializer=org.apache.spark.sql.execution.columnar.DefaultCachedBatchSerializer;
+
+SET foo=(1, 3);

--- a/test/fixtures/dialects/sparksql/set.yml
+++ b/test/fixtures/dialects/sparksql/set.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 1d054a4501b36dd0006dc6e682760051d612bf5ad29ee4f907259886819b57d5
+_hash: bc5f9d032b44ff9c8e91f87ef0ea115455942f04384a2d453b4ccfe3d363a196
 file:
 - statement:
     set_statement:
@@ -69,4 +69,18 @@ file:
     - properties_naked_identifier: columnar
     - dot: .
     - properties_naked_identifier: DefaultCachedBatchSerializer
+- statement_terminator: ;
+- statement:
+    set_statement:
+      keyword: SET
+      property_name_identifier:
+        properties_naked_identifier: foo
+      comparison_operator:
+        raw_comparison_operator: '='
+      bracketed:
+      - start_bracket: (
+      - numeric_literal: '1'
+      - comma: ','
+      - numeric_literal: '3'
+      - end_bracket: )
 - statement_terminator: ;


### PR DESCRIPTION
### Brief summary of the change made

Makes progress on #5357.

This updates the SparkSQL `SET` property grammar so parenthesized literal lists parse as property values, e.g. `SET foo=(1, 3);`. It also adds a SparkSQL dialect fixture covering that syntax and regenerates the expected parse tree.

The issue also mentions `${foo}` substitution under the raw templater. This PR intentionally does not change templater behavior; it only fixes the independent parser failure for the `SET` assignment itself.

### Are there any other side effects of this change that we should be aware of?

The existing single-literal property values and dotted Java-class-name property values continue to parse. The change is scoped to SparkSQL property values.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.

Validation performed:
- `.venv/bin/sqlfluff parse --dialect sparksql -` with `SET foo=(1, 3);`
- `.venv/bin/sqlfluff parse --dialect sparksql -` with existing dotted property assignment syntax
- `.venv/bin/python test/generate_parse_fixture_yml.py -d sparksql`
- `.venv/bin/python -m pytest test/dialects/dialects_test.py -k "sparksql and set"`
- `.venv/bin/python -m pytest test/dialects/dialects_test.py -k sparksql`
- `.venv/bin/ruff check src/sqlfluff/dialects/dialect_sparksql.py`
- `git diff --check`

AI-assisted contribution disclosure:
OpenAI Codex/ChatGPT was used to search for an issue, inspect SQLFluff grammar/tests, implement this small parser change, draft the PR description, and run validation. The generated code and fixture changes were manually reviewed and validated with the commands above.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow parsing of parenthesized literal lists as SparkSQL SET property values, e.g., SET foo=(1, 3);. Existing single-literal and dotted Java class values are unchanged.

- **Bug Fixes**
  - Updated SparkSQL SET property grammar to accept bracketed, comma-delimited literal lists.
  - Added/updated SparkSQL fixtures and expected parse tree to cover the new syntax; no templater behavior changes.

<sup>Written for commit 62701a01d7fa1cadfbf1e726a50e48e33a110d73. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8052?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

