### PR TITLE
Don't auto-fix ST07 for BigQuery hyphenated table names

### DIFF
--- a/src/sqlfluff/rules/structure/ST07.py
+++ b/src/sqlfluff/rules/structure/ST07.py
@@ -1,6 +1,5 @@
 """Implementation of Rule ST07."""
 
-import re
 from typing import Optional
 
 from sqlfluff.core.parser import (
@@ -122,14 +121,19 @@ class Rule_ST07(BaseRule):
         to_delete, insert_after_anchor = _extract_deletion_sequence_and_anchor(segment)
 
         table_a, table_b = table_aliases[:2]
-        # ref_str is only the last part of a multi-part reference. For BigQuery
-        # hyphenated names it is e.g. "table-c", which is not a valid naked
-        # identifier, so splicing it into a generated ON clause yields broken SQL.
-        if not (
-            _NAKED_IDENTIFIER.match(table_a.ref_str)
-            and _NAKED_IDENTIFIER.match(table_b.ref_str)
-        ):
-            return unfixable_result
+        # Only splice ref_str into the ON clause if it is the raw of a single
+        # parsed identifier segment (BigQuery hyphenated names are not).
+        for table in (table_a, table_b):
+            if not table.segment or table.segment.raw != table.ref_str:
+                return unfixable_result
+
+        using_cols = _extract_cols_from_using(segment, using_anchor)
+        # An ON rewrite makes unqualified references to USING columns
+        # ambiguous (issue #7230), so decline to fix.
+        using_cols_upper = {col.upper() for col in using_cols}
+        for ref in select_info.reference_buffer if select_info else []:
+            if ref.raw_upper in using_cols_upper:
+                return unfixable_result
 
         edit_segments = [
             KeywordSegment(raw="ON"),
@@ -137,7 +141,7 @@ class Rule_ST07(BaseRule):
         ] + _generate_join_conditions(
             table_a.ref_str,
             table_b.ref_str,
-            _extract_cols_from_using(segment, using_anchor),
+            using_cols,
         )
 
         assert table_a.segment
@@ -155,9 +159,6 @@ class Rule_ST07(BaseRule):
             description=description,
             fixes=fixes,
         )
-
-
-_NAKED_IDENTIFIER = re.compile(r"^[A-Za-z_][A-Za-z0-9_$]*$")
 
 
 def _extract_cols_from_using(join_clause: Segments, using_segs: Segments) -> list[str]:

--- a/src/sqlfluff/rules/structure/ST07.py
+++ b/src/sqlfluff/rules/structure/ST07.py
@@ -1,5 +1,6 @@
 """Implementation of Rule ST07."""
 
+import re
 from typing import Optional
 
 from sqlfluff.core.parser import (
@@ -121,6 +122,15 @@ class Rule_ST07(BaseRule):
         to_delete, insert_after_anchor = _extract_deletion_sequence_and_anchor(segment)
 
         table_a, table_b = table_aliases[:2]
+        # ref_str is only the last part of a multi-part reference. For BigQuery
+        # hyphenated names it is e.g. "table-c", which is not a valid naked
+        # identifier, so splicing it into a generated ON clause yields broken SQL.
+        if not (
+            _NAKED_IDENTIFIER.match(table_a.ref_str)
+            and _NAKED_IDENTIFIER.match(table_b.ref_str)
+        ):
+            return unfixable_result
+
         edit_segments = [
             KeywordSegment(raw="ON"),
             WhitespaceSegment(raw=" "),
@@ -145,6 +155,9 @@ class Rule_ST07(BaseRule):
             description=description,
             fixes=fixes,
         )
+
+
+_NAKED_IDENTIFIER = re.compile(r"^[A-Za-z_][A-Za-z0-9_$]*$")
 
 
 def _extract_cols_from_using(join_clause: Segments, using_segs: Segments) -> list[str]:

--- a/test/rules/std_ST07_test.py
+++ b/test/rules/std_ST07_test.py
@@ -1,0 +1,21 @@
+"""Tests the python routines within ST07."""
+
+import sqlfluff
+
+
+def test__rules__std_ST07_bigquery_hyphenated_table_no_fix():
+    """ST07 must not propose a fix for BigQuery joins on hyphenated table names.
+
+    The last dot-delimited part of a BigQuery table reference (e.g. "table-c"
+    in "project-a.dataset-b.table-c") is not a valid naked identifier because
+    it contains a hyphen. Splicing it directly into a generated ``ON`` clause
+    (e.g. ``ON table-c.a = table-d.a``) produces invalid SQL, so the rule
+    should still flag the ``USING`` clause but decline to offer an unsafe fix.
+    """
+    sql = (
+        "SELECT * FROM project-a.dataset-b.table-c "
+        "JOIN dataset-c.table-d USING (a);"
+    )
+    result = sqlfluff.lint(sql, rules=["ST07"], dialect="bigquery")
+    assert len(result) == 1
+    assert result[0]["fixes"] == []

--- a/test/rules/std_ST07_test.py
+++ b/test/rules/std_ST07_test.py
@@ -4,14 +4,7 @@ import sqlfluff
 
 
 def test__rules__std_ST07_bigquery_hyphenated_table_no_fix():
-    """ST07 must not propose a fix for BigQuery joins on hyphenated table names.
-
-    The last dot-delimited part of a BigQuery table reference (e.g. "table-c"
-    in "project-a.dataset-b.table-c") is not a valid naked identifier because
-    it contains a hyphen. Splicing it directly into a generated ``ON`` clause
-    (e.g. ``ON table-c.a = table-d.a``) produces invalid SQL, so the rule
-    should still flag the ``USING`` clause but decline to offer an unsafe fix.
-    """
+    """No fix for hyphenated names: ref_str spans several parse segments."""
     sql = (
         "SELECT * FROM project-a.dataset-b.table-c "
         "JOIN dataset-c.table-d USING (a);"
@@ -19,3 +12,27 @@ def test__rules__std_ST07_bigquery_hyphenated_table_no_fix():
     result = sqlfluff.lint(sql, rules=["ST07"], dialect="bigquery")
     assert len(result) == 1
     assert result[0]["fixes"] == []
+
+
+def test__rules__std_ST07_unqualified_using_column_no_fix():
+    """No fix when a USING column is referenced unqualified (issue #7230)."""
+    sql = (
+        "SELECT field_1, field_2, field_3 FROM table_a "
+        "INNER JOIN table_b USING (field_1)"
+    )
+    result = sqlfluff.lint(sql, rules=["ST07"], dialect="bigquery")
+    assert len(result) == 1
+    assert result[0]["fixes"] == []
+
+    fixed = sqlfluff.fix(sql, rules=["ST07"], dialect="bigquery")
+    assert fixed == sql
+
+
+def test__rules__std_ST07_qualified_references_still_fixed():
+    """Fix still offered when all USING column references are qualified."""
+    sql = (
+        "SELECT table_a.field_1, table_b.field_2 FROM table_a "
+        "INNER JOIN table_b USING (field_1)"
+    )
+    fixed = sqlfluff.fix(sql, rules=["ST07"], dialect="bigquery")
+    assert "ON table_a.field_1 = table_b.field_1" in fixed


### PR DESCRIPTION
Fixes #7230

When ST07 rewrites a `USING (...)` join into an explicit `ON` clause, it builds each side of the condition from the table's `ref_str`. For a multi-part BigQuery reference like `project-a.dataset-b.table-c`, `ref_str` is only the final component — `table-c`. That component contains a hyphen, so it isn't a valid naked identifier, and splicing it into the generated clause produced invalid SQL.

Before:

```sql
SELECT * FROM project-a.dataset-b.table-c JOIN dataset-c.table-d USING (a);
```

got "fixed" to `... ON table-c.a = table-d.a`, which no longer parses.

After: the rule still flags the `USING` clause, but if either side's `ref_str` isn't a valid naked identifier it returns the unfixable result instead of offering a broken fix — matching how ST07 already declines other cases it can't safely rewrite.

I added a regression test in `test/rules/std_ST07_test.py` that lints the hyphenated-name example under the BigQuery dialect and asserts the violation is reported with no fixes. The full ST07 suite passes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent ST07 from proposing invalid ON rewrites for BigQuery joins with hyphenated table names, and avoid ambiguous rewrites when USING columns are referenced unqualified.

- **Bug Fixes**
  - Replace the regex guard with a parsed-segment check; only fix when the alias is a single identifier segment and segment.raw == ref_str. Blocks BigQuery hyphenated refs while keeping valid cases.
  - Decline autofix if any USING column is referenced unqualified. Added tests for hyphenated names (no fix), unqualified references (no fix), and qualified references (still fixed).

<sup>Written for commit 1d29df5cd3a7cc8656c14f956cb8bbd76b5061b7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8055?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

