### PR TITLE
Fix ST06 reordering SELECT columns in CREATE VIEW with an explicit column list

### DIFF
--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -3421,6 +3421,25 @@ class AlterTableStatementSegment(BaseSegment):
     )
 
 
+class CreateViewSelectableSegment(BaseSegment):
+    """The SELECT body of a `CREATE VIEW` statement, optionally bracketed.
+
+    Kept as its own segment type (rather than inlining
+    ``OptionallyBracketed(Ref("SelectableGrammar"))`` directly into
+    ``CreateViewStatementSegment``) so that a parenthesised SELECT body,
+    e.g. ``CREATE VIEW v AS (SELECT col1, col2 FROM t)``, is never a bare
+    ``bracketed`` segment at the direct-child level of
+    ``create_view_statement``. Without this wrapper, that parenthesised
+    SELECT is structurally indistinguishable from an explicit bracketed
+    column list (``CREATE VIEW v (col1, col2) AS ...``) to any code that
+    checks direct children for a "bracketed" segment containing
+    column references.
+    """
+
+    type = "create_view_selectable"
+    match_grammar: Matchable = OptionallyBracketed(Ref("SelectableGrammar"))
+
+
 class CreateViewStatementSegment(BaseSegment):
     """A `CREATE VIEW` statement."""
 
@@ -3437,7 +3456,7 @@ class CreateViewStatementSegment(BaseSegment):
         # Optional list of column names
         Ref("BracketedColumnReferenceListGrammar", optional=True),
         "AS",
-        OptionallyBracketed(Ref("SelectableGrammar")),
+        Ref("CreateViewSelectableSegment"),
         Ref("WithNoSchemaBindingClauseSegment", optional=True),
     )
 

--- a/src/sqlfluff/rules/structure/ST06.py
+++ b/src/sqlfluff/rules/structure/ST06.py
@@ -66,6 +66,13 @@ class Rule_ST06(BaseRule):
                 # Look for a bracketed segment containing column references
                 for child in parent.segments:
                     if child.is_type("bracketed"):
+                        # A bracketed SELECT body (e.g. `AS (SELECT ...)`) is
+                        # not an explicit column list, even though it may
+                        # itself contain identifiers/column references.
+                        if any(
+                            child.recursive_crawl("select_statement")
+                        ) or any(child.recursive_crawl("with_compound_statement")):
+                            continue
                         # Check if this bracketed segment contains column references
                         # ANSI-based dialects (Snowflake, PostgreSQL, etc.)
                         # use column_reference
@@ -78,6 +85,18 @@ class Rule_ST06(BaseRule):
                         if any(
                             seg.is_type("index_column_definition")
                             for seg in child.recursive_crawl("index_column_definition")
+                        ):
+                            return True
+                        # BigQuery dialect uses column_definition instead
+                        if any(
+                            seg.is_type("column_definition")
+                            for seg in child.recursive_crawl("column_definition")
+                        ):
+                            return True
+                        # ClickHouse dialect uses a plain identifier instead
+                        if any(
+                            seg.is_type("identifier")
+                            for seg in child.recursive_crawl("identifier")
                         ):
                             return True
                 # Found a CREATE VIEW but no explicit column list

--- a/test/dialects/ansi_test.py
+++ b/test/dialects/ansi_test.py
@@ -226,3 +226,52 @@ def test__dialect__ansi_parse_indented_joins(sql_string, indented_joins, meta_lo
         idx for idx, raw_seg in enumerate(tree.get_raw_segments()) if raw_seg.is_meta
     )
     assert res_meta_locs == meta_loc
+
+
+def test__dialect__ansi_create_view_bracketed_select_is_not_bracketed_column_list():
+    """A parenthesised SELECT body in CREATE VIEW must not look like a column list.
+
+    ``CREATE VIEW v AS (SELECT ...)`` wraps the SELECT in optional brackets.
+    Code that inspects the direct children of ``create_view_statement`` to
+    detect an *explicit column list* (a bracketed segment containing
+    ``column_reference`` children, as produced by an actual
+    ``CREATE VIEW v (col1, col2) AS ...``) must not be fooled by this
+    parenthesised SELECT, even though its select targets are themselves
+    simple column references. The direct children of the statement must
+    therefore not include a bare ``bracketed`` segment for the SELECT body.
+    """
+    lnt = Linter(dialect="ansi")
+    parsed = lnt.parse_string(
+        "CREATE VIEW v AS (SELECT col1, col2 FROM my_table);"
+    )
+    create_view = next(parsed.tree.recursive_crawl("create_view_statement"))
+
+    def is_ambiguous_bracketed_column_list(segment):
+        return segment.is_type("bracketed") and any(
+            seg.is_type("column_reference")
+            for seg in segment.recursive_crawl("column_reference")
+        )
+
+    # None of the *direct* children of the create_view_statement should be a
+    # bare "bracketed" segment containing column references -- that shape is
+    # reserved for an explicit column list, e.g. CREATE VIEW v (col1, col2).
+    offending = [
+        child for child in create_view.segments if is_ambiguous_bracketed_column_list(child)
+    ]
+    assert offending == [], (
+        "The bracketed SELECT body was mistakable for an explicit column list: "
+        f"{[seg.raw for seg in offending]}"
+    )
+
+    # And an explicit column list is still detected correctly.
+    lnt2 = Linter(dialect="ansi")
+    parsed2 = lnt2.parse_string(
+        "CREATE VIEW v (col1, col2) AS SELECT col1, col2 FROM my_table;"
+    )
+    create_view2 = next(parsed2.tree.recursive_crawl("create_view_statement"))
+    explicit = [
+        child
+        for child in create_view2.segments
+        if is_ambiguous_bracketed_column_list(child)
+    ]
+    assert len(explicit) == 1

--- a/test/fixtures/dialects/ansi/create_view_a.yml
+++ b/test/fixtures/dialects/ansi/create_view_a.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 828d3386d75173425688561ed663eaed5b254a2b06a3288cafd28f329128f049
+_hash: f7865f927c152e445ee48e98be8a9cadcf2a3c1e7deefd1f1e9a9c4f79069c38
 file:
 - statement:
     create_view_statement:
@@ -12,42 +12,43 @@ file:
     - table_reference:
         naked_identifier: a
     - keyword: AS
-    - select_statement:
-        select_clause:
-          keyword: SELECT
-          select_clause_element:
-            column_reference:
-              naked_identifier: c
-        from_clause:
-          keyword: FROM
-          from_expression:
-            from_expression_element:
-              table_expression:
-                table_reference:
-                  naked_identifier: table1
-            join_clause:
-            - keyword: INNER
-            - keyword: JOIN
-            - from_expression_element:
+    - create_view_selectable:
+        select_statement:
+          select_clause:
+            keyword: SELECT
+            select_clause_element:
+              column_reference:
+                naked_identifier: c
+          from_clause:
+            keyword: FROM
+            from_expression:
+              from_expression_element:
                 table_expression:
                   table_reference:
-                    naked_identifier: table2
-            - join_on_condition:
-                keyword: 'ON'
-                bracketed:
-                  start_bracket: (
-                  expression:
-                  - column_reference:
-                    - naked_identifier: table1
-                    - dot: .
-                    - naked_identifier: id
-                  - comparison_operator:
-                      raw_comparison_operator: '='
-                  - column_reference:
-                    - naked_identifier: table2
-                    - dot: .
-                    - naked_identifier: id
-                  end_bracket: )
+                    naked_identifier: table1
+              join_clause:
+              - keyword: INNER
+              - keyword: JOIN
+              - from_expression_element:
+                  table_expression:
+                    table_reference:
+                      naked_identifier: table2
+              - join_on_condition:
+                  keyword: 'ON'
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                    - column_reference:
+                      - naked_identifier: table1
+                      - dot: .
+                      - naked_identifier: id
+                    - comparison_operator:
+                        raw_comparison_operator: '='
+                    - column_reference:
+                      - naked_identifier: table2
+                      - dot: .
+                      - naked_identifier: id
+                    end_bracket: )
 - statement_terminator: ;
 - statement:
     create_view_statement:
@@ -58,56 +59,57 @@ file:
     - table_reference:
         naked_identifier: vw_appt_latest
     - keyword: AS
-    - bracketed:
-        start_bracket: (
-        with_compound_statement:
-          keyword: WITH
-          common_table_expression:
-            naked_identifier: most_current
-            keyword: as
-            bracketed:
-              start_bracket: (
-              select_statement:
-                select_clause:
-                  keyword: SELECT
-                  select_clause_element:
-                    wildcard_expression:
-                      wildcard_identifier:
-                        naked_identifier: da
-                        dot: .
-                        star: '*'
-                from_clause:
-                  keyword: FROM
-                  from_expression:
-                    from_expression_element:
-                      table_expression:
-                        table_reference:
-                          naked_identifier: dim_appt
-                      alias_expression:
-                        naked_identifier: da
-                where_clause:
-                  keyword: WHERE
-                  expression:
-                    column_reference:
-                    - naked_identifier: da
-                    - dot: .
-                    - naked_identifier: current_appt_id
-                    keyword: IS
-                    null_literal: 'NULL'
-              end_bracket: )
-          select_statement:
-            select_clause:
-              keyword: SELECT
-              select_clause_element:
-                wildcard_expression:
-                  wildcard_identifier:
-                    star: '*'
-            from_clause:
-              keyword: from
-              from_expression:
-                from_expression_element:
-                  table_expression:
-                    table_reference:
-                      naked_identifier: most_current
-        end_bracket: )
+    - create_view_selectable:
+        bracketed:
+          start_bracket: (
+          with_compound_statement:
+            keyword: WITH
+            common_table_expression:
+              naked_identifier: most_current
+              keyword: as
+              bracketed:
+                start_bracket: (
+                select_statement:
+                  select_clause:
+                    keyword: SELECT
+                    select_clause_element:
+                      wildcard_expression:
+                        wildcard_identifier:
+                          naked_identifier: da
+                          dot: .
+                          star: '*'
+                  from_clause:
+                    keyword: FROM
+                    from_expression:
+                      from_expression_element:
+                        table_expression:
+                          table_reference:
+                            naked_identifier: dim_appt
+                        alias_expression:
+                          naked_identifier: da
+                  where_clause:
+                    keyword: WHERE
+                    expression:
+                      column_reference:
+                      - naked_identifier: da
+                      - dot: .
+                      - naked_identifier: current_appt_id
+                      keyword: IS
+                      null_literal: 'NULL'
+                end_bracket: )
+            select_statement:
+              select_clause:
+                keyword: SELECT
+                select_clause_element:
+                  wildcard_expression:
+                    wildcard_identifier:
+                      star: '*'
+              from_clause:
+                keyword: from
+                from_expression:
+                  from_expression_element:
+                    table_expression:
+                      table_reference:
+                        naked_identifier: most_current
+          end_bracket: )
 - statement_terminator: ;

--- a/test/fixtures/dialects/ansi/create_view_if_not_exists.yml
+++ b/test/fixtures/dialects/ansi/create_view_if_not_exists.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 6932759b92f812b45c0a8c035862e8dfaf8b3055b433de9b17e2e20604d7d93c
+_hash: 34ad4a6ded1496837b43e6184796f990f615b8c56c095793bf158e8df2fcf121
 file:
   statement:
     create_view_statement:
@@ -15,39 +15,40 @@ file:
     - table_reference:
         naked_identifier: a
     - keyword: AS
-    - select_statement:
-        select_clause:
-          keyword: SELECT
-          select_clause_element:
-            column_reference:
-              naked_identifier: c
-        from_clause:
-          keyword: FROM
-          from_expression:
-            from_expression_element:
-              table_expression:
-                table_reference:
-                  naked_identifier: table1
-            join_clause:
-            - keyword: INNER
-            - keyword: JOIN
-            - from_expression_element:
+    - create_view_selectable:
+        select_statement:
+          select_clause:
+            keyword: SELECT
+            select_clause_element:
+              column_reference:
+                naked_identifier: c
+          from_clause:
+            keyword: FROM
+            from_expression:
+              from_expression_element:
                 table_expression:
                   table_reference:
-                    naked_identifier: table2
-            - join_on_condition:
-                keyword: 'ON'
-                bracketed:
-                  start_bracket: (
-                  expression:
-                  - column_reference:
-                    - naked_identifier: table1
-                    - dot: .
-                    - naked_identifier: id
-                  - comparison_operator:
-                      raw_comparison_operator: '='
-                  - column_reference:
-                    - naked_identifier: table2
-                    - dot: .
-                    - naked_identifier: id
-                  end_bracket: )
+                    naked_identifier: table1
+              join_clause:
+              - keyword: INNER
+              - keyword: JOIN
+              - from_expression_element:
+                  table_expression:
+                    table_reference:
+                      naked_identifier: table2
+              - join_on_condition:
+                  keyword: 'ON'
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                    - column_reference:
+                      - naked_identifier: table1
+                      - dot: .
+                      - naked_identifier: id
+                    - comparison_operator:
+                        raw_comparison_operator: '='
+                    - column_reference:
+                      - naked_identifier: table2
+                      - dot: .
+                      - naked_identifier: id
+                    end_bracket: )

--- a/test/fixtures/dialects/athena/create_view.yml
+++ b/test/fixtures/dialects/athena/create_view.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 4b9f327cd36317b0514ab31fba38d44f4416e2578e095ee9952aac4f2289f9b0
+_hash: f212baf073a744014c714a8e9c1a160799cd47a08d7d451b8c3b9d9b597eceb1
 file:
 - statement:
     create_view_statement:
@@ -12,34 +12,35 @@ file:
     - table_reference:
         naked_identifier: test
     - keyword: AS
-    - select_statement:
-        select_clause:
-        - keyword: SELECT
-        - select_clause_element:
-            column_reference:
-              naked_identifier: orderkey
-        - comma: ','
-        - select_clause_element:
-            column_reference:
-              naked_identifier: orderstatus
-        - comma: ','
-        - select_clause_element:
-            expression:
+    - create_view_selectable:
+        select_statement:
+          select_clause:
+          - keyword: SELECT
+          - select_clause_element:
               column_reference:
-                naked_identifier: totalprice
-              binary_operator: /
-              numeric_literal: '2'
-            alias_expression:
-              alias_operator:
-                keyword: AS
-              naked_identifier: half
-        from_clause:
-          keyword: FROM
-          from_expression:
-            from_expression_element:
-              table_expression:
-                table_reference:
-                  naked_identifier: orders
+                naked_identifier: orderkey
+          - comma: ','
+          - select_clause_element:
+              column_reference:
+                naked_identifier: orderstatus
+          - comma: ','
+          - select_clause_element:
+              expression:
+                column_reference:
+                  naked_identifier: totalprice
+                binary_operator: /
+                numeric_literal: '2'
+              alias_expression:
+                alias_operator:
+                  keyword: AS
+                naked_identifier: half
+          from_clause:
+            keyword: FROM
+            from_expression:
+              from_expression_element:
+                table_expression:
+                  table_reference:
+                    naked_identifier: orders
 - statement_terminator: ;
 - statement:
     create_view_statement:
@@ -50,32 +51,33 @@ file:
     - table_reference:
         naked_identifier: test
     - keyword: AS
-    - select_statement:
-        select_clause:
-        - keyword: SELECT
-        - select_clause_element:
-            column_reference:
-              naked_identifier: orderkey
-        - comma: ','
-        - select_clause_element:
-            column_reference:
-              naked_identifier: orderstatus
-        - comma: ','
-        - select_clause_element:
-            expression:
+    - create_view_selectable:
+        select_statement:
+          select_clause:
+          - keyword: SELECT
+          - select_clause_element:
               column_reference:
-                naked_identifier: totalprice
-              binary_operator: /
-              numeric_literal: '4'
-            alias_expression:
-              alias_operator:
-                keyword: AS
-              naked_identifier: quarter
-        from_clause:
-          keyword: FROM
-          from_expression:
-            from_expression_element:
-              table_expression:
-                table_reference:
-                  naked_identifier: orders
+                naked_identifier: orderkey
+          - comma: ','
+          - select_clause_element:
+              column_reference:
+                naked_identifier: orderstatus
+          - comma: ','
+          - select_clause_element:
+              expression:
+                column_reference:
+                  naked_identifier: totalprice
+                binary_operator: /
+                numeric_literal: '4'
+              alias_expression:
+                alias_operator:
+                  keyword: AS
+                naked_identifier: quarter
+          from_clause:
+            keyword: FROM
+            from_expression:
+              from_expression_element:
+                table_expression:
+                  table_reference:
+                    naked_identifier: orders
 - statement_terminator: ;

--- a/test/fixtures/dialects/vertica/create_view.yml
+++ b/test/fixtures/dialects/vertica/create_view.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 0db732adecf3da212c3020a4b911199734dd9d5bf21b382703ffa5db22285781
+_hash: 1d1db9ad3de9397c2a9fe3717340ce4d6cef92dd53ebded741a6f6c53864c540
 file:
   statement:
     create_view_statement:
@@ -12,87 +12,88 @@ file:
     - table_reference:
         naked_identifier: temp_t0
     - keyword: AS
-    - set_expression:
-      - select_statement:
-          select_clause:
-            keyword: SELECT
-            select_clause_element:
-              wildcard_expression:
-                wildcard_identifier:
-                  star: '*'
-          from_clause:
-            keyword: from
-            from_expression:
-              from_expression_element:
-                table_expression:
-                  table_reference:
-                    naked_identifier: t0_p1
-      - set_operator:
-        - keyword: UNION
-        - keyword: ALL
-      - select_statement:
-          select_clause:
-            keyword: SELECT
-            select_clause_element:
-              wildcard_expression:
-                wildcard_identifier:
-                  star: '*'
-          from_clause:
-            keyword: from
-            from_expression:
-              from_expression_element:
-                table_expression:
-                  table_reference:
-                    naked_identifier: t0_p2
-      - set_operator:
-        - keyword: UNION
-        - keyword: ALL
-      - select_statement:
-          select_clause:
-            keyword: SELECT
-            select_clause_element:
-              wildcard_expression:
-                wildcard_identifier:
-                  star: '*'
-          from_clause:
-            keyword: from
-            from_expression:
-              from_expression_element:
-                table_expression:
-                  table_reference:
-                    naked_identifier: t0_p3
-      - set_operator:
-        - keyword: UNION
-        - keyword: ALL
-      - select_statement:
-          select_clause:
-            keyword: SELECT
-            select_clause_element:
-              wildcard_expression:
-                wildcard_identifier:
-                  star: '*'
-          from_clause:
-            keyword: from
-            from_expression:
-              from_expression_element:
-                table_expression:
-                  table_reference:
-                    naked_identifier: t0_p4
-      - set_operator:
-        - keyword: UNION
-        - keyword: ALL
-      - select_statement:
-          select_clause:
-            keyword: SELECT
-            select_clause_element:
-              wildcard_expression:
-                wildcard_identifier:
-                  star: '*'
-          from_clause:
-            keyword: from
-            from_expression:
-              from_expression_element:
-                table_expression:
-                  table_reference:
-                    naked_identifier: t0_p5
+    - create_view_selectable:
+        set_expression:
+        - select_statement:
+            select_clause:
+              keyword: SELECT
+              select_clause_element:
+                wildcard_expression:
+                  wildcard_identifier:
+                    star: '*'
+            from_clause:
+              keyword: from
+              from_expression:
+                from_expression_element:
+                  table_expression:
+                    table_reference:
+                      naked_identifier: t0_p1
+        - set_operator:
+          - keyword: UNION
+          - keyword: ALL
+        - select_statement:
+            select_clause:
+              keyword: SELECT
+              select_clause_element:
+                wildcard_expression:
+                  wildcard_identifier:
+                    star: '*'
+            from_clause:
+              keyword: from
+              from_expression:
+                from_expression_element:
+                  table_expression:
+                    table_reference:
+                      naked_identifier: t0_p2
+        - set_operator:
+          - keyword: UNION
+          - keyword: ALL
+        - select_statement:
+            select_clause:
+              keyword: SELECT
+              select_clause_element:
+                wildcard_expression:
+                  wildcard_identifier:
+                    star: '*'
+            from_clause:
+              keyword: from
+              from_expression:
+                from_expression_element:
+                  table_expression:
+                    table_reference:
+                      naked_identifier: t0_p3
+        - set_operator:
+          - keyword: UNION
+          - keyword: ALL
+        - select_statement:
+            select_clause:
+              keyword: SELECT
+              select_clause_element:
+                wildcard_expression:
+                  wildcard_identifier:
+                    star: '*'
+            from_clause:
+              keyword: from
+              from_expression:
+                from_expression_element:
+                  table_expression:
+                    table_reference:
+                      naked_identifier: t0_p4
+        - set_operator:
+          - keyword: UNION
+          - keyword: ALL
+        - select_statement:
+            select_clause:
+              keyword: SELECT
+              select_clause_element:
+                wildcard_expression:
+                  wildcard_identifier:
+                    star: '*'
+            from_clause:
+              keyword: from
+              from_expression:
+                from_expression_element:
+                  table_expression:
+                    table_reference:
+                      naked_identifier: t0_p5
   statement_terminator: ;

--- a/test/fixtures/rules/std_rule_cases/ST06.yml
+++ b/test/fixtures/rules/std_rule_cases/ST06.yml
@@ -359,6 +359,61 @@ test_pass_create_view_with_explicit_columns_tsql:
       e.department
     FROM employees e
 
+test_pass_create_view_with_explicit_columns_bigquery:
+  # ST06 must not reorder SELECT columns when a CREATE VIEW declares an
+  # explicit column list using BigQuery's column_definition segment type.
+  configs:
+    core:
+      dialect: bigquery
+  pass_str: |
+    CREATE VIEW MyView(simple_col, complex_col) AS
+    SELECT
+      CASE WHEN simple_col > 0 THEN 1 ELSE 0 END as complex_col,
+      simple_col
+    FROM table1
+
+test_pass_create_view_with_explicit_columns_clickhouse:
+  # ST06 must not reorder SELECT columns when a CREATE VIEW declares an
+  # explicit column list using ClickHouse's identifier segment type.
+  configs:
+    core:
+      dialect: clickhouse
+  pass_str: |
+    CREATE VIEW MyView(simple_col, complex_col) AS
+    SELECT
+      CASE WHEN simple_col > 0 THEN 1 ELSE 0 END as complex_col,
+      simple_col
+    FROM table1
+
+test_fail_create_view_bracketed_select_without_explicit_columns:
+  # A bracketed SELECT body in CREATE VIEW (e.g. `AS (SELECT ...)`) must not
+  # be mistaken for an explicit column list. ST06 must still flag SELECT
+  # targets that are out of order in this case.
+  fail_str: |
+    CREATE VIEW v AS (
+    SELECT
+      f.franchiseename,
+      TRY_TO_DOUBLE(f.franchiseename) AS franchiseid,
+      f.storestatus,
+      f.grandstoreopeningdate,
+      CASE WHEN f.grandstoreopeningdate < dateadd(month, -18, current_date) THEN 'Same Gym' ELSE NULL END as same_gym,
+      f.state
+    FROM franchisee f
+    )
+  line_numbers: [2]
+
+  fix_str: |
+    CREATE VIEW v AS (
+    SELECT
+      f.franchiseename,
+      f.storestatus,
+      f.grandstoreopeningdate,
+      f.state,
+      TRY_TO_DOUBLE(f.franchiseename) AS franchiseid,
+      CASE WHEN f.grandstoreopeningdate < dateadd(month, -18, current_date) THEN 'Same Gym' ELSE NULL END as same_gym
+    FROM franchisee f
+    )
+
 test_fail_create_view_without_explicit_columns_tsql:
   configs:
     core:


### PR DESCRIPTION
ST06 was reordering the SELECT columns of a CREATE VIEW that declares an explicit column list. For a view like

```sql
CREATE VIEW v (col1, col2, col3, col4)
AS SELECT col1, col2, CASE WHEN condition THEN col3 ELSE col5 END, col4 FROM t
```

the rule moves the CASE expression to the end, which silently misaligns the view's declared columns against the columns the SELECT actually returns — `col3` ends up exposing `col4`'s values. This is #6807.

The problem is in `_is_view_with_explicit_columns()`, which is supposed to make ST06 skip these views. Two things stopped it from working:

- A bracketed SELECT body (`AS (SELECT ...)`) is structurally the same as an explicit column list — both are bracketed segments containing column references — so the guard could be tripped by the parenthesised SELECT rather than a real column list. I split the view body out into its own segment type (`CreateViewSelectableSegment`) so a parenthesised SELECT is no longer a bare `bracketed` direct child of the create view statement, and the detection loop now skips any bracketed child that contains a select/with statement.
- Detection only looked for `column_reference` and `index_column_definition`. BigQuery represents an explicit column list with `column_definition` and ClickHouse with a plain `identifier`, so those dialects were never recognised. Both are handled now.

Existing YAML rule cases for CREATE VIEW with explicit columns continue to pass, and the parse fixtures for the affected dialects (ansi, athena, vertica) are updated to reflect the new view-body segment. Full test suite is green.

Fixes #6807

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes ST06 reordering SELECT columns in CREATE VIEW statements that declare an explicit column list. Correctly ignores parenthesized SELECT bodies to prevent view column misalignment. Fixes #6807.

- **Bug Fixes**
  - Added `CreateViewSelectableSegment` so `AS (SELECT ...)` is not treated as a bracketed column list.
  - Extended explicit column-list detection to BigQuery (`column_definition`) and ClickHouse (`identifier`).
  - Updated parse fixtures (ansi, athena, vertica) and added ST06 rule cases for the new scenarios.

<sup>Written for commit 0efb1cb57ce2da946724d6609d753b401f2fa183. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8056?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

