### PR TITLE
Don't strip newlines that sit directly before a comment

### DIFF
--- a/src/sqlfluff/utils/reflow/respace.py
+++ b/src/sqlfluff/utils/reflow/respace.py
@@ -186,8 +186,12 @@ def determine_constraints(
             within_spacing, strip_newlines = _unpack_constraint(
                 within_constraint, strip_newlines
             )
-        # Prohibit stripping newlines after comment segments
-        if any(seg.is_type("comment") for seg in prev_block.segments):
+        # Prohibit stripping newlines adjacent to comment segments (either
+        # immediately before or immediately after this point), since doing
+        # so could glue code to a comment marker and change meaning.
+        if any(seg.is_type("comment") for seg in prev_block.segments) or any(
+            seg.is_type("comment") for seg in next_block.segments
+        ):
             strip_newlines = False
 
     # If segments are expected to be touch within. Then modify

--- a/test/utils/reflow/respace_test.py
+++ b/test/utils/reflow/respace_test.py
@@ -7,7 +7,7 @@ import logging
 
 import pytest
 
-from sqlfluff.core import Linter
+from sqlfluff.core import FluffConfig, Linter
 from sqlfluff.utils.reflow.elements import ReflowPoint
 from sqlfluff.utils.reflow.helpers import fixes_from_results
 from sqlfluff.utils.reflow.sequence import ReflowSequence
@@ -17,6 +17,29 @@ def parse_ansi_string(sql, config):
     """Parse an ansi sql string for testing."""
     linter = Linter(config=config)
     return linter.parse_string(sql).tree
+
+
+def test_reflow__respace_does_not_strip_newline_before_comment():
+    """A newline directly before a comment must survive strip_newlines=True.
+
+    Regression test: when a parent constraint (e.g. `spacing_within =
+    single:inline` on `expression`) requests stripped newlines between a
+    binary operator like `AND` and the following token, and that following
+    token is a comment, the newline separating them must NOT be removed.
+    Removing it would glue the operator to the `--` comment marker and
+    change the meaning/formatting of the statement.
+    """
+    config = FluffConfig(
+        overrides={"dialect": "ansi"},
+        configs={
+            "layout": {"type": {"expression": {"spacing_within": "single:inline"}}}
+        },
+    )
+    sql = "SELECT * FROM t WHERE a AND\n-- comment\nb\n"
+    root = parse_ansi_string(sql, config)
+    seq = ReflowSequence.from_root(root, config=config)
+    new_seq = seq.respace()
+    assert new_seq.get_raw() == sql
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes #6801

### What was happening

When a layout constraint asks for newlines to be stripped between two tokens (for example `spacing_within = single:inline` on an `expression`), the reflow code could delete a newline that sat right in front of a comment. The result was that the token before the comment got glued straight onto the `--` marker:

```sql
SELECT * FROM t WHERE a AND
-- comment
b
```

came back as

```sql
SELECT * FROM t WHERE a AND-- comment
b
```

which quietly changes what the statement means, since everything after `--` is now commented out on that line.

### Root cause

In `determine_constraints` (`src/sqlfluff/utils/reflow/respace.py`), the guard that keeps newlines around comments only looked at the *previous* block. If the previous block was a comment it kept the newline, but if the *next* block was the comment it did nothing, so an inherited `strip_newlines=True` went ahead and removed the newline in front of it.

### The fix

Check the next block for comment segments as well as the previous one. If either side of the point is a comment, we leave the newline alone. A newline that sits immediately before a comment now survives the respace.

### Before / after

- Before: `a AND\n-- comment\nb` -> `a AND-- comment\nb` (meaning changed)
- After: `a AND\n-- comment\nb` -> unchanged

### Tests

Added `test_reflow__respace_does_not_strip_newline_before_comment` in `test/utils/reflow/respace_test.py`, which sets the `single:inline` expression constraint and asserts the newline before the comment is preserved. The existing reflow suite (`test/utils/reflow/`) still passes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop stripping a newline that sits directly before a comment during respace. Prevents code being glued to the `--` marker and changing SQL meaning. Fixes #6801.

- **Bug Fixes**
  - In `determine_constraints`, also check the next block for comment segments; if previous or next is a comment, do not strip newlines.
  - Added regression test `test_reflow__respace_does_not_strip_newline_before_comment`; existing reflow tests still pass.

<sup>Written for commit 56e06b5378f0640c4c72fa162fdead8c0da854d1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8057?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

