### PR TITLE
fix(postgres): parse COPY ... FROM STDIN inline data blocks

### DIFF
--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -219,13 +219,14 @@ postgres_dialect.insert_lexer_matchers(
             # so it stays context-free; a `COPY ... FROM STDIN` without a trailing
             # `\.` data block does not match and parses as a normal statement.
             # The header may span multiple lines (e.g. a column list or `WITH`
-            # options on their own lines). `[^;]` rather than `[^\r\n]` allows the
-            # newlines while still stopping at the statement terminator, so the
-            # match cannot absorb a preceding statement to reach a later
-            # `FROM STDIN`.
+            # options on their own lines). The scan toward the terminating `;`
+            # must also skip over quoted string literals so option values like
+            # `DELIMITER ';'` do not prematurely end the match. This still keeps
+            # the match bounded to one statement, so it cannot absorb a preceding
+            # statement to reach a later `FROM STDIN`.
             # Approach originally proposed in #7759 by @RedZapdos123.
             "postgres_copy_stdin_data_block",
-            r"(?i)COPY\b[^;]*?\bFROM\b\s+STDIN\b[^;]*?;[ \t]*\r?\n"
+            r"(?i)COPY\b(?:[^;']|'(?:[^']|'')*')*?\bFROM\b\s+STDIN\b(?:[^;']|'(?:[^']|'')*')*?;[ \t]*\r?\n"
             r"(?:[^\r\n]*\r?\n)*?\\\.[ \t]*(?=\r?\n|$)",
             CodeSegment,
         ),

--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -211,6 +211,20 @@ postgres_dialect.insert_lexer_matchers(
             LiteralSegment,
         ),
         RegexLexer(
+            # Matches a `COPY ... FROM STDIN;` command followed by an inline data
+            # block terminated by a line containing only `\.` (the format emitted
+            # by pg_dump / psql). The raw data rows are not SQL, so the whole
+            # construct is lexed as a single token to keep it out of the parser.
+            # The pattern is self-anchored on the `COPY ... FROM STDIN;` prefix,
+            # so it stays context-free; a `COPY ... FROM STDIN` without a trailing
+            # `\.` data block does not match and parses as a normal statement.
+            # Approach originally proposed in #7759 by @RedZapdos123.
+            "postgres_copy_stdin_data_block",
+            r"(?i)COPY\b[^\r\n]*?\bFROM\b\s+STDIN\b[^\r\n]*?;[ \t]*\r?\n"
+            r"(?:[^\r\n]*\r?\n)*?\\\.[ \t]*(?=\r?\n|$)",
+            CodeSegment,
+        ),
+        RegexLexer(
             # Matches the psql \copy meta-command, including the form with a
             # parenthesized query that can span multiple lines.
             # https://www.postgresql.org/docs/current/app-psql.html#APP-PSQL-META-COMMAND-COPY
@@ -504,6 +518,11 @@ postgres_dialect.add(
     ),
     PsqlCopyMetaCommandSegment=TypedParser(
         "psql_copy_command", CodeSegment, type="psql_copy_command"
+    ),
+    PostgresCopyStdinDataSegment=TypedParser(
+        "postgres_copy_stdin_data_block",
+        CodeSegment,
+        type="postgres_copy_stdin_data_statement",
     ),
     PsqlSetMetaCommandSegment=TypedParser(
         "psql_set_command", CodeSegment, type="psql_set_command"
@@ -7013,6 +7032,21 @@ class PsqlSetMetaCommandStatementSegment(BaseSegment):
     )
 
 
+class PostgresCopyStdinDataStatementSegment(BaseSegment):
+    r"""A `COPY ... FROM STDIN` command with an inline data block.
+
+    The command line and the raw data rows terminated by ``\.`` (as emitted by
+    ``pg_dump`` / ``psql``) are lexed as a single token, so the non-SQL data
+    does not surface as an unparsable section.
+    """
+
+    type = "postgres_copy_stdin_data_statement"
+
+    match_grammar = Sequence(
+        Ref("PostgresCopyStdinDataSegment"),
+    )
+
+
 class DropForeignTableStatement(BaseSegment):
     """A `DROP FOREIGN TABLE` Statement.
 
@@ -7299,6 +7333,7 @@ class FileSegment(BaseFileSegment):
     """
 
     match_grammar = AnyNumberOf(
+        Ref("PostgresCopyStdinDataStatementSegment"),
         Ref("PsqlCopyMetaCommandStatementSegment"),
         Ref("PsqlSetMetaCommandStatementSegment"),
         Delimited(

--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -218,9 +218,14 @@ postgres_dialect.insert_lexer_matchers(
             # The pattern is self-anchored on the `COPY ... FROM STDIN;` prefix,
             # so it stays context-free; a `COPY ... FROM STDIN` without a trailing
             # `\.` data block does not match and parses as a normal statement.
+            # The header may span multiple lines (e.g. a column list or `WITH`
+            # options on their own lines). `[^;]` rather than `[^\r\n]` allows the
+            # newlines while still stopping at the statement terminator, so the
+            # match cannot absorb a preceding statement to reach a later
+            # `FROM STDIN`.
             # Approach originally proposed in #7759 by @RedZapdos123.
             "postgres_copy_stdin_data_block",
-            r"(?i)COPY\b[^\r\n]*?\bFROM\b\s+STDIN\b[^\r\n]*?;[ \t]*\r?\n"
+            r"(?i)COPY\b[^;]*?\bFROM\b\s+STDIN\b[^;]*?;[ \t]*\r?\n"
             r"(?:[^\r\n]*\r?\n)*?\\\.[ \t]*(?=\r?\n|$)",
             CodeSegment,
         ),

--- a/test/fixtures/dialects/postgres/copy_from_stdin_data_block.sql
+++ b/test/fixtures/dialects/postgres/copy_from_stdin_data_block.sql
@@ -1,0 +1,11 @@
+COPY my_table (col1, col2) FROM stdin;
+1	foo
+2	bar
+\.
+
+COPY public.bookshelves_books (username, work_id, bookshelf_id) FROM stdin;
+openlibrary	15298516	1
+openlibrary	45310	3
+\.
+
+SELECT 1;

--- a/test/fixtures/dialects/postgres/copy_from_stdin_data_block.sql
+++ b/test/fixtures/dialects/postgres/copy_from_stdin_data_block.sql
@@ -18,4 +18,9 @@ WITH (FORMAT text);
 2	bar
 \.
 
+COPY my_table FROM STDIN WITH (DELIMITER ';');
+1	foo
+2	bar
+\.
+
 SELECT 1;

--- a/test/fixtures/dialects/postgres/copy_from_stdin_data_block.sql
+++ b/test/fixtures/dialects/postgres/copy_from_stdin_data_block.sql
@@ -8,4 +8,14 @@ openlibrary	15298516	1
 openlibrary	45310	3
 \.
 
+COPY my_table (
+    col1,
+    col2
+)
+FROM STDIN
+WITH (FORMAT text);
+1	foo
+2	bar
+\.
+
 SELECT 1;

--- a/test/fixtures/dialects/postgres/copy_from_stdin_data_block.yml
+++ b/test/fixtures/dialects/postgres/copy_from_stdin_data_block.yml
@@ -1,0 +1,21 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: cf145283ed38b8fc0e19a600c34ab68caeb5150c9181c8d01b044cb4602a1637
+file:
+- postgres_copy_stdin_data_statement:
+    postgres_copy_stdin_data_statement: "COPY my_table (col1, col2) FROM stdin;\n\
+      1\tfoo\n2\tbar\n\\."
+- postgres_copy_stdin_data_statement:
+    postgres_copy_stdin_data_statement: "COPY public.bookshelves_books (username,\
+      \ work_id, bookshelf_id) FROM stdin;\nopenlibrary\t15298516\t1\nopenlibrary\t\
+      45310\t3\n\\."
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          numeric_literal: '1'
+- statement_terminator: ;

--- a/test/fixtures/dialects/postgres/copy_from_stdin_data_block.yml
+++ b/test/fixtures/dialects/postgres/copy_from_stdin_data_block.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: cf145283ed38b8fc0e19a600c34ab68caeb5150c9181c8d01b044cb4602a1637
+_hash: 9c6d364d42b12d03c80b5e7ddadfcec6daabe105fb8b6737857b5be093363e3d
 file:
 - postgres_copy_stdin_data_statement:
     postgres_copy_stdin_data_statement: "COPY my_table (col1, col2) FROM stdin;\n\
@@ -12,6 +12,9 @@ file:
     postgres_copy_stdin_data_statement: "COPY public.bookshelves_books (username,\
       \ work_id, bookshelf_id) FROM stdin;\nopenlibrary\t15298516\t1\nopenlibrary\t\
       45310\t3\n\\."
+- postgres_copy_stdin_data_statement:
+    postgres_copy_stdin_data_statement: "COPY my_table (\n    col1,\n    col2\n)\n\
+      FROM STDIN\nWITH (FORMAT text);\n1\tfoo\n2\tbar\n\\."
 - statement:
     select_statement:
       select_clause:

--- a/test/fixtures/dialects/postgres/copy_from_stdin_data_block.yml
+++ b/test/fixtures/dialects/postgres/copy_from_stdin_data_block.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 9c6d364d42b12d03c80b5e7ddadfcec6daabe105fb8b6737857b5be093363e3d
+_hash: 506b3fa98eb678a444b699f3a11f97d35e3db9e1bc8bcd07137eec027502ac1b
 file:
 - postgres_copy_stdin_data_statement:
     postgres_copy_stdin_data_statement: "COPY my_table (col1, col2) FROM stdin;\n\
@@ -15,6 +15,9 @@ file:
 - postgres_copy_stdin_data_statement:
     postgres_copy_stdin_data_statement: "COPY my_table (\n    col1,\n    col2\n)\n\
       FROM STDIN\nWITH (FORMAT text);\n1\tfoo\n2\tbar\n\\."
+- postgres_copy_stdin_data_statement:
+    postgres_copy_stdin_data_statement: "COPY my_table FROM STDIN WITH (DELIMITER\
+      \ ';');\n1\tfoo\n2\tbar\n\\."
 - statement:
     select_statement:
       select_clause:


### PR DESCRIPTION
### Brief summary of the change made

`pg_dump` and `psql` emit `COPY ... FROM STDIN;` followed by the table data inlined as tab-separated rows, terminated by a line containing only `\.`. Those raw rows are not SQL, so sqlfluff surfaced the first data line as an unparsable section (`PRS`), as reported in #7697.

This lexes the whole construct as a single token and parses it as a dedicated file-level statement, so the raw data no longer reaches the parser. The lexer pattern is self-anchored on the `COPY ... FROM STDIN;` prefix and requires the trailing `\.` line, so it stays context-free: a `COPY ... FROM STDIN` without an inline data block still parses as a normal statement.

Fixture-based regression test added at `test/fixtures/dialects/postgres/copy_from_stdin_data_block.sql` (+ auto-generated `.yml`), covering two back-to-back data blocks followed by an ordinary `SELECT` to confirm parsing resumes after the terminator.

This re-opens the fix from #7759 by @RedZapdos123 in the fixture-based form the [dialect contribution guide](https://docs.sqlfluff.com/en/stable/guides/contributing/dialect.html) asks for, per @peterbud's note there. Original report by @Sanket17052006, MRE by @RedZapdos123.

Fixes #7697.

### Are there any other side effects of this change that we should be aware of?

No. The new lexer matcher only fires on the full `COPY ... FROM STDIN; ... \.` shape; existing `COPY` and `\copy` handling is untouched.

### Pull Request checklist

- [x] Please confirm you have completed any of the necessary steps below.

- [x] Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated by running `python test/generate_parse_fixture_yml.py`).
- [x] Added appropriate documentation for the change.
- [x] Created GitHub issues for any relevant followup/future enhancements if appropriate.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Parse Postgres COPY ... FROM STDIN inline data blocks, including multiline headers and quoted options with semicolons, so they no longer show as unparsable. Parsing resumes after the `\.` terminator. Fixes #7697.

- **Bug Fixes**
  - Added a lexer rule `postgres_copy_stdin_data_block` that captures `COPY ... FROM STDIN;` through the `\.` line and parses it as `postgres_copy_stdin_data_statement`.
  - Handles multiline headers and semicolons inside quoted literals; normal `COPY` and `\copy` remain unchanged.
  - Added fixtures for back-to-back data blocks, a multiline header, an option with `';'`, and a trailing `SELECT`.

<sup>Written for commit 8d37d938456fbb8aa102ef214dec7da7f8862071. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8059?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

