### PR TITLE
Support WITH TAG clause in Snowflake CREATE TASK

### DIFF
--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -5406,6 +5406,8 @@ class CreateTaskSegment(BaseSegment):
         ),
         Ref("ObjectReferenceSegment"),
         Indent,
+        # https://docs.snowflake.com/en/sql-reference/sql/create-task#optional-parameters
+        Ref("TagBracketedEqualsSegment", optional=True),
         AnyNumberOf(
             OneOf(
                 Sequence(

--- a/test/fixtures/dialects/snowflake/create_task.sql
+++ b/test/fixtures/dialects/snowflake/create_task.sql
@@ -116,3 +116,16 @@ AS
 CREATE TASK mytask
 AS
     ALTER DYNAMIC TABLE foo REFRESH;
+
+-- WITH TAG clause (https://github.com/sqlfluff/sqlfluff/issues/8060)
+CREATE OR REPLACE TASK GLOBAL_SANDBOX.SHARED_PLAYGROUND.SELECT_ONE_TASK
+    WITH TAG (GLOBAL_SANDBOX.SHARED_PLAYGROUND.data_owner = 'data_team')
+    SCHEDULE = 'USING CRON 0 0 1 1 * UTC'
+AS
+    SELECT 1;
+
+CREATE TASK mytask
+    TAG (cost_center = 'finance', env = 'prod')
+    SCHEDULE = '5 MINUTE'
+AS
+    SELECT 1;

--- a/test/fixtures/dialects/snowflake/create_task.yml
+++ b/test/fixtures/dialects/snowflake/create_task.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: defb2195730c814314f9764c6316f8abe378ed43c4539485a4d7d4ddfc2f13a6
+_hash: c18ac771488b0e0f07705544697da2498251c1298ef601737f4cfe42f92c3359
 file:
 - statement:
     create_task_statement:
@@ -659,4 +659,77 @@ file:
         - table_reference:
             naked_identifier: foo
         - keyword: REFRESH
+- statement_terminator: ;
+- statement:
+    create_task_statement:
+    - keyword: CREATE
+    - keyword: OR
+    - keyword: REPLACE
+    - keyword: TASK
+    - object_reference:
+      - naked_identifier: GLOBAL_SANDBOX
+      - dot: .
+      - naked_identifier: SHARED_PLAYGROUND
+      - dot: .
+      - naked_identifier: SELECT_ONE_TASK
+    - tag_bracketed_equals:
+      - keyword: WITH
+      - keyword: TAG
+      - bracketed:
+          start_bracket: (
+          tag_reference:
+          - naked_identifier: GLOBAL_SANDBOX
+          - dot: .
+          - naked_identifier: SHARED_PLAYGROUND
+          - dot: .
+          - naked_identifier: data_owner
+          comparison_operator:
+            raw_comparison_operator: '='
+          quoted_literal: "'data_team'"
+          end_bracket: )
+    - keyword: SCHEDULE
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - quoted_literal: "'USING CRON 0 0 1 1 * UTC'"
+    - keyword: AS
+    - statement:
+        select_statement:
+          select_clause:
+            keyword: SELECT
+            select_clause_element:
+              numeric_literal: '1'
+- statement_terminator: ;
+- statement:
+    create_task_statement:
+    - keyword: CREATE
+    - keyword: TASK
+    - object_reference:
+        naked_identifier: mytask
+    - tag_bracketed_equals:
+        keyword: TAG
+        bracketed:
+        - start_bracket: (
+        - tag_reference:
+            naked_identifier: cost_center
+        - comparison_operator:
+            raw_comparison_operator: '='
+        - quoted_literal: "'finance'"
+        - comma: ','
+        - tag_reference:
+            naked_identifier: env
+        - comparison_operator:
+            raw_comparison_operator: '='
+        - quoted_literal: "'prod'"
+        - end_bracket: )
+    - keyword: SCHEDULE
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - quoted_literal: "'5 MINUTE'"
+    - keyword: AS
+    - statement:
+        select_statement:
+          select_clause:
+            keyword: SELECT
+            select_clause_element:
+              numeric_literal: '1'
 - statement_terminator: ;


### PR DESCRIPTION
### Brief summary of the change made

Fixes #8060.

Snowflake allows an optional `WITH TAG ( <tag> = '<value>' [, ...] )` clause on `CREATE TASK` ([docs](https://docs.snowflake.com/en/sql-reference/sql/create-task#optional-parameters)), but `CreateTaskSegment` did not accept it, so a valid statement like:

```sql
CREATE OR REPLACE TASK GLOBAL_SANDBOX.SHARED_PLAYGROUND.SELECT_ONE_TASK
    WITH TAG (GLOBAL_SANDBOX.SHARED_PLAYGROUND.data_owner = 'data_team')
    SCHEDULE = 'USING CRON 0 0 1 1 * UTC'
AS
    SELECT 1;
```

was reported as an unparsable section.

The dialect already has a `TagBracketedEqualsSegment` (`[WITH] TAG (name = 'value', ...)`, used by other Snowflake `CREATE`/`ALTER` statements), so the fix just references it, as an optional clause after the task name in `CreateTaskSegment`.

### Are there any other side effects of this change that we should be aware of?

No. The clause is optional, so existing `CREATE TASK` statements are unaffected (the full snowflake dialect fixture suite — 627 tests — still passes). Because `TagBracketedEqualsSegment` already makes the leading `WITH` optional, both `WITH TAG (...)` and a bare `TAG (...)` are accepted, matching its use elsewhere in the dialect; both forms are covered by the new fixtures.

### Pull Request checklist

- [x] `.sql`/`.yml` parser test cases added in `test/fixtures/dialects/snowflake/create_task.sql` (+ regenerated `create_task.yml`). The new statements fail as an unparsable section on `main` and parse correctly with this change.
- [x] Reused existing documented grammar; no new public behavior needing separate docs.

---

*AI disclosure: this change was prepared with the assistance of an AI tool (Claude Code). I reproduced the issue, reviewed and verified the grammar change and regenerated fixtures, and take responsibility for the contribution.*


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for the optional WITH TAG clause in Snowflake CREATE TASK, fixing parse errors on valid statements (Fixes #8060). Reuses existing grammar so current statements keep working.

- **Bug Fixes**
  - Parser now accepts `WITH TAG (...)` or `TAG (...)` after the task name in `CREATE TASK` via `TagBracketedEqualsSegment`.
  - Added parse fixtures for both forms to ensure coverage.

<sup>Written for commit 7ff32c1bd6a132ec94cd0e35f0d53d0306128c36. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8061?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

