### PR TITLE
fix(clickhouse): parse tuple element access on any expression

### DIFF
--- a/src/sqlfluff/dialects/dialect_clickhouse.py
+++ b/src/sqlfluff/dialects/dialect_clickhouse.py
@@ -318,6 +318,14 @@ clickhouse_dialect.replace(
         Ref("TupleElementAccessSegment"),
         ansi_dialect.get_grammar("Expression_D_Grammar"),
     ),
+    # Allow tuple element access (`.N`) as a postfix accessor alongside array
+    # subscripting, so it can follow any Expression_D base -- e.g. a function
+    # call `f(x).2`, a subscript `arr[1].2`, or a tuple literal `(a, b).1` --
+    # not just a bare/bracketed column reference.
+    AccessorGrammar=AnyNumberOf(
+        Ref("ArrayAccessorSegment"),
+        Ref("TupleElementAccessorSegment"),
+    ),
     # ClickHouse C-style ternary `cond ? then : else`; the lowest-precedence
     # operator, so the optional tail wraps the whole Expression_A condition.
     # https://clickhouse.com/docs/en/sql-reference/functions/conditional-functions#ternary-operator
@@ -2866,5 +2874,23 @@ class TupleElementAccessSegment(BaseSegment):
             min_times=1,
             allow_gaps=False,
         ),
+        allow_gaps=False,
+    )
+
+
+class TupleElementAccessorSegment(BaseSegment):
+    """A tuple element access postfix like the `.2` in `f(x).2`.
+
+    Used as an accessor (via ``AccessorGrammar``) so tuple element access can
+    follow any ``Expression_D`` base -- a function call, an array subscript, a
+    tuple literal, etc. The lexer tokenizes ``.2`` as a numeric literal rather
+    than a dot followed by an integer, so the postfix is a run of numeric
+    literals that must abut the preceding expression (``allow_gaps=False``).
+    """
+
+    type = "tuple_element_access"
+    match_grammar: Matchable = AnyNumberOf(
+        Ref("NumericLiteralSegment"),
+        min_times=1,
         allow_gaps=False,
     )

--- a/test/fixtures/dialects/clickhouse/tuple_element_access.sql
+++ b/test/fixtures/dialects/clickhouse/tuple_element_access.sql
@@ -7,3 +7,14 @@ SELECT
     test.1.1.2,
     (test.1).2,
     test.2;
+
+-- Tuple element access on expressions that are not a bare or bracketed
+-- column reference: a function call, an array subscript and a tuple literal
+-- (https://github.com/sqlfluff/sqlfluff/issues/8032).
+SELECT
+    f(x).2,
+    arr[1].2,
+    (a, b).1,
+    f(x).1.2
+FROM t;
+

--- a/test/fixtures/dialects/clickhouse/tuple_element_access.sql
+++ b/test/fixtures/dialects/clickhouse/tuple_element_access.sql
@@ -17,4 +17,3 @@ SELECT
     (a, b).1,
     f(x).1.2
 FROM t;
-

--- a/test/fixtures/dialects/clickhouse/tuple_element_access.yml
+++ b/test/fixtures/dialects/clickhouse/tuple_element_access.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 996cc66cb89609078d320152e41a281472f77721bbab2355cbdf058d3ac78932
+_hash: c5cf43bf9323d2252754bc305d9d5395d6de84ffef28e48f85aa6fefec997019
 file:
 - statement:
     select_statement:
@@ -89,4 +89,70 @@ file:
             column_reference:
               naked_identifier: test
               numeric_literal: '.2'
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          expression:
+            function:
+              function_name:
+                function_name_identifier: f
+              function_contents:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    column_reference:
+                      naked_identifier: x
+                  end_bracket: )
+            tuple_element_access:
+              numeric_literal: '.2'
+      - comma: ','
+      - select_clause_element:
+          expression:
+            column_reference:
+              naked_identifier: arr
+            array_accessor:
+              start_square_bracket: '['
+              numeric_literal: '1'
+              end_square_bracket: ']'
+            tuple_element_access:
+              numeric_literal: '.2'
+      - comma: ','
+      - select_clause_element:
+          expression:
+            bracketed:
+            - start_bracket: (
+            - column_reference:
+                naked_identifier: a
+            - comma: ','
+            - column_reference:
+                naked_identifier: b
+            - end_bracket: )
+            tuple_element_access:
+              numeric_literal: '.1'
+      - comma: ','
+      - select_clause_element:
+          expression:
+            function:
+              function_name:
+                function_name_identifier: f
+              function_contents:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    column_reference:
+                      naked_identifier: x
+                  end_bracket: )
+            tuple_element_access:
+            - numeric_literal: '.1'
+            - numeric_literal: '.2'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: t
 - statement_terminator: ;


### PR DESCRIPTION
### Description

ClickHouse tuple element access by dot-index (`.N`) only parsed when the left-hand side was a bare or bracketed column reference (`x.1`, `x.1.2`, `(a.1).2`). Any expression that ends in `)` or `]` — a function call, an array subscript, or a tuple literal — left the trailing `.N` with nowhere to attach and produced an unparsable section:

```
SELECT f(x).2 FROM t     ->  L1:P12 PRS: Found unparsable section: '.2'
SELECT arr[1].2 FROM t   ->  L1:P14 PRS: Found unparsable section: '.2'
SELECT (a, b).1 FROM t   ->  L1:P14 PRS: Found unparsable section: '.1'
```

All three are valid ClickHouse (verified by the reporter on 26.4.2). Contrast: `SELECT x.1 FROM t` and `SELECT x.1.2 FROM t` already parse.

### Root cause

The lexer tokenizes `.2` as a single `numeric_literal` (not a dot + integer), so tuple element access is a run of numeric literals that must abut the preceding expression. The only grammar accepting that postfix, `TupleElementAccessSegment`, requires its LHS to be `Bracketed(ColumnReferenceSegment)`. So the postfix could only follow a bracketed column reference — a function call / subscript / tuple-literal LHS had no rule to consume the trailing `.N`.

### Fix

`Expression_D_Grammar` already has a postfix-accessor slot, `AccessorGrammar` (that is how array subscripting `arr[1]` attaches). Tuple element access is the same shape of postfix, so:

- add `TupleElementAccessorSegment` — `AnyNumberOf(NumericLiteralSegment, min_times=1, allow_gaps=False)`, mirroring the existing `TupleElementAccessSegment` body; and
- register it in the ClickHouse `AccessorGrammar` next to `ArrayAccessorSegment`.

Now `.N` attaches as a postfix accessor after any `Expression_D` base. The existing bare / bracketed forms are untouched, and because the accessor only matches with no preceding gap (`allow_gaps=False`), a normal float literal (`SELECT 1.5`, `SELECT a + 1.5`) is unaffected.

### Before / after

| SQL | before | after |
| --- | --- | --- |
| `SELECT f(x).2 FROM t` | unparsable `.2` | parses (`.2` -> `tuple_element_access`) |
| `SELECT arr[1].2 FROM t` | unparsable `.2` | parses |
| `SELECT (a, b).1 FROM t` | unparsable `.1` | parses |
| `SELECT f(x).1.2 FROM t` | unparsable `.1.2` | parses (chained) |
| `SELECT x.1`, `SELECT (a.1).2` | parses | parses (unchanged) |
| `SELECT 1.5`, `SELECT a + 1.5` | parses | parses (unchanged) |

### Tests

Extended the existing `test/fixtures/dialects/clickhouse/tuple_element_access.sql` fixture with the function-call, subscript, tuple-literal and chained (`f(x).1.2`) forms and regenerated the `.yml` via `test/generate_parse_fixture_yml.py`.

Proven to guard the bug (stash the source change → the fixture test fails, restore → passes):

```
# without the source fix
FAILED test/dialects/dialects_test.py::test__dialect__base_file_parse[clickhouse-tuple_element_access.sql]
FAILED test/dialects/dialects_test.py::test__dialect__base_broad_fix[clickhouse-tuple_element_access.sql]
FAILED test/dialects/dialects_test.py::test__dialect__base_parse_struct[clickhouse-tuple_element_access.sql-True-tuple_element_access.yml]
# with the fix
3 passed
```

Full dialect suite is green and there are no cross-dialect regressions (the change is ClickHouse-scoped):

```
test/dialects/dialects_test.py -k clickhouse   ->  144 passed
test/dialects/dialects_test.py (all dialects)  ->  6507 passed
```

`ruff check`, `ruff format --check` and `mypy` are clean on the changed source file.

Fixes #8032

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow tuple element access using `.N` after any ClickHouse expression (e.g., `f(x).2`, `arr[1].2`, `(a, b).1`) to fix parse errors and match ClickHouse behavior. Fixes #8032.

- **Bug Fixes**
  - Added `TupleElementAccessorSegment` to `AccessorGrammar` so `.N` attaches after any `Expression_D` (function calls, subscripts, tuple literals). Existing column-reference forms are unchanged. Floats (e.g., `1.5`) are unaffected (`allow_gaps=False`).
  - Extended ClickHouse fixtures for these cases (incl. `f(x).1.2`). Dialect and full suites pass.

- **Refactors**
  - Fixed linting in touched files; no functional changes.

<sup>Written for commit f3817ed0be94a84c087180009cdbb56475708815. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8062?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

