### PR TITLE
feat(mysql): support GROUP BY ... WITH ROLLUP modifier

### DIFF
--- a/src/sqlfluff/dialects/dialect_mysql.py
+++ b/src/sqlfluff/dialects/dialect_mysql.py
@@ -372,6 +372,36 @@ mysql_dialect.add(
 )
 
 
+class GroupByClauseSegment(ansi.GroupByClauseSegment):
+    """A MySQL `GROUP BY` clause, adding the `WITH ROLLUP` modifier.
+
+    https://dev.mysql.com/doc/refman/8.0/en/group-by-modifiers.html
+    """
+
+    match_grammar: Matchable = Sequence(
+        "GROUP",
+        "BY",
+        Indent,
+        OneOf(
+            "ALL",
+            Ref("GroupingSetsClauseSegment"),
+            Ref("CubeRollupClauseSegment"),
+            Sequence(
+                Delimited(
+                    OneOf(
+                        Ref("ColumnReferenceSegment"),
+                        Ref("NumericLiteralSegment"),
+                        Ref("ExpressionSegment"),
+                    ),
+                    terminators=[Ref("GroupByClauseTerminatorGrammar")],
+                ),
+            ),
+        ),
+        Dedent,
+        Sequence("WITH", "ROLLUP", optional=True),
+    )
+
+
 class TableReferenceSegment(ansi.TableReferenceSegment):
     """A reference to a table.
 

--- a/src/sqlfluff/dialects/dialect_mysql.py
+++ b/src/sqlfluff/dialects/dialect_mysql.py
@@ -378,27 +378,8 @@ class GroupByClauseSegment(ansi.GroupByClauseSegment):
     https://dev.mysql.com/doc/refman/8.0/en/group-by-modifiers.html
     """
 
-    match_grammar: Matchable = Sequence(
-        "GROUP",
-        "BY",
-        Indent,
-        OneOf(
-            "ALL",
-            Ref("GroupingSetsClauseSegment"),
-            Ref("CubeRollupClauseSegment"),
-            Sequence(
-                Delimited(
-                    OneOf(
-                        Ref("ColumnReferenceSegment"),
-                        Ref("NumericLiteralSegment"),
-                        Ref("ExpressionSegment"),
-                    ),
-                    terminators=[Ref("GroupByClauseTerminatorGrammar")],
-                ),
-            ),
-        ),
-        Dedent,
-        Sequence("WITH", "ROLLUP", optional=True),
+    match_grammar = ansi.GroupByClauseSegment.match_grammar.copy(
+        insert=[Sequence("WITH", "ROLLUP", optional=True)],
     )
 
 

--- a/test/fixtures/dialects/mysql/group_by_with_rollup.sql
+++ b/test/fixtures/dialects/mysql/group_by_with_rollup.sql
@@ -1,0 +1,10 @@
+-- MySQL GROUP BY ... WITH ROLLUP modifier
+-- https://dev.mysql.com/doc/refman/8.0/en/group-by-modifiers.html
+
+SELECT a, SUM(b) FROM t GROUP BY a WITH ROLLUP;
+
+SELECT a, b, SUM(c) FROM t GROUP BY a, b WITH ROLLUP;
+
+SELECT a, SUM(b) FROM t GROUP BY 1 WITH ROLLUP HAVING SUM(b) > 10;
+
+SELECT a, SUM(b) FROM t GROUP BY a WITH ROLLUP ORDER BY a;

--- a/test/fixtures/dialects/mysql/group_by_with_rollup.yml
+++ b/test/fixtures/dialects/mysql/group_by_with_rollup.yml
@@ -1,0 +1,170 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 0a52bf288644dbfa06f5c0d7fdfbf6a43b652f4260377e80449183f112f141bf
+file:
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            naked_identifier: a
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: SUM
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  column_reference:
+                    naked_identifier: b
+                end_bracket: )
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: t
+      groupby_clause:
+      - keyword: GROUP
+      - keyword: BY
+      - column_reference:
+          naked_identifier: a
+      - keyword: WITH
+      - keyword: ROLLUP
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            naked_identifier: a
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            naked_identifier: b
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: SUM
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  column_reference:
+                    naked_identifier: c
+                end_bracket: )
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: t
+      groupby_clause:
+      - keyword: GROUP
+      - keyword: BY
+      - column_reference:
+          naked_identifier: a
+      - comma: ','
+      - column_reference:
+          naked_identifier: b
+      - keyword: WITH
+      - keyword: ROLLUP
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            naked_identifier: a
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: SUM
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  column_reference:
+                    naked_identifier: b
+                end_bracket: )
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: t
+      groupby_clause:
+      - keyword: GROUP
+      - keyword: BY
+      - numeric_literal: '1'
+      - keyword: WITH
+      - keyword: ROLLUP
+      having_clause:
+        keyword: HAVING
+        expression:
+          function:
+            function_name:
+              function_name_identifier: SUM
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  column_reference:
+                    naked_identifier: b
+                end_bracket: )
+          comparison_operator:
+            raw_comparison_operator: '>'
+          numeric_literal: '10'
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            naked_identifier: a
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: SUM
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  column_reference:
+                    naked_identifier: b
+                end_bracket: )
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: t
+      groupby_clause:
+      - keyword: GROUP
+      - keyword: BY
+      - column_reference:
+          naked_identifier: a
+      - keyword: WITH
+      - keyword: ROLLUP
+      orderby_clause:
+      - keyword: ORDER
+      - keyword: BY
+      - column_reference:
+          naked_identifier: a
+- statement_terminator: ;


### PR DESCRIPTION
## Brief summary of the change made

MySQL's [`GROUP BY ... WITH ROLLUP`](https://dev.mysql.com/doc/refman/8.0/en/group-by-modifiers.html) was reported as an unparsable section:

```sql
SELECT a, SUM(b) FROM t GROUP BY a WITH ROLLUP;
--                                  ^^^^^^^^^^^ Found unparsable section: 'WITH ROLLUP'
```

The `mysql` dialect inherited ansi's `GroupByClauseSegment`, which only supports the `ROLLUP(...)` function form, not MySQL's postfix `WITH ROLLUP` modifier.

This overrides `GroupByClauseSegment` in the `mysql` dialect, mirroring the ansi grammar and appending an optional trailing `WITH ROLLUP`.

## Are there any other side effects?

No. The override is scoped to the `mysql` dialect and existing `GROUP BY` forms parse unchanged (all pre-existing mysql fixtures still pass).

## Which tests were run / added?

- New dialect fixture `test/fixtures/dialects/mysql/group_by_with_rollup.sql` (+ generated `.yml`) covering single-column, multi-column, `HAVING`, and `ORDER BY` variants.
- `pytest test/dialects/dialects_test.py -k mysql` → **632 passed, 0 failed**.
- `ruff check` / `ruff format --check` clean.

## AI-assisted contribution disclosure

Per the CONTRIBUTING guide's *AI-Assisted Contributions* policy: this change was prepared with AI assistance. It was reviewed, tested, and verified locally before submission.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for MySQL’s GROUP BY ... WITH ROLLUP so these queries parse correctly. Scoped to the `mysql` dialect.

- New Features
  - Overrode `GroupByClauseSegment` in `mysql`, extending `ansi.GroupByClauseSegment.match_grammar` via `.copy(insert=[...])` to allow optional trailing WITH ROLLUP.
  - Added fixtures covering single/multi column, HAVING, and ORDER BY variants.

<sup>Written for commit 9f2e711c9db6b1a90cb004c4f31f722320b85c07. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8066?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

