### PR TITLE
Parse Oracle SQL*Plus ACCEPT and REMARK commands

### DIFF
--- a/src/sqlfluff/dialects/dialect_oracle.py
+++ b/src/sqlfluff/dialects/dialect_oracle.py
@@ -120,6 +120,22 @@ oracle_dialect.insert_lexer_matchers(
             r"PROMPT([^(\r\n)])*((?=\n)|(?=\r\n))?",
             CommentSegment,
         ),
+        RegexLexer(
+            "accept_command",
+            (
+                r"[aA][cC][cC](?:[eE][pP][tT])?"
+                r"(?:[^\S\r\n]+[^(\r\n)]*)?((?=\n)|(?=\r\n)|$)"
+            ),
+            CommentSegment,
+        ),
+        RegexLexer(
+            "remark_command",
+            (
+                r"[rR][eE][mM](?:[aA][rR][kK])?"
+                r"(?:[^\S\r\n]+[^(\r\n)]*)?((?=\n)|(?=\r\n)|$)"
+            ),
+            CommentSegment,
+        ),
         StringLexer("at_sign", "@", CodeSegment),
     ],
     before="word",

--- a/src/sqlfluff/dialects/dialect_oracle.py
+++ b/src/sqlfluff/dialects/dialect_oracle.py
@@ -124,7 +124,8 @@ oracle_dialect.insert_lexer_matchers(
             "accept_command",
             (
                 r"[aA][cC][cC](?:[eE][pP][tT])?"
-                r"[^\S\r\n]+[^;(\r\n)]*((?=\n)|(?=\r\n)|$)"
+                r"[^\S\r\n]+(?![^(\r\n)]*;[^\S\r\n]*((?=\n)|(?=\r\n)|$))"
+                r"[^(\r\n)]*((?=\n)|(?=\r\n)|$)"
             ),
             CommentSegment,
         ),
@@ -132,7 +133,9 @@ oracle_dialect.insert_lexer_matchers(
             "remark_command",
             (
                 r"[rR][eE][mM](?:[aA][rR][kK])?"
-                r"[^\S\r\n]+[^;(\r\n)]*((?=\n)|(?=\r\n)|$)"
+                r"(?:[^\S\r\n]+"
+                r"(?![^(\r\n)]*;[^\S\r\n]*((?=\n)|(?=\r\n)|$))"
+                r"[^(\r\n)]*)?((?=\n)|(?=\r\n)|$)"
             ),
             CommentSegment,
         ),

--- a/src/sqlfluff/dialects/dialect_oracle.py
+++ b/src/sqlfluff/dialects/dialect_oracle.py
@@ -124,7 +124,7 @@ oracle_dialect.insert_lexer_matchers(
             "accept_command",
             (
                 r"[aA][cC][cC](?:[eE][pP][tT])?"
-                r"(?:[^\S\r\n]+[^(\r\n)]*)?((?=\n)|(?=\r\n)|$)"
+                r"[^\S\r\n]+[^;(\r\n)]*((?=\n)|(?=\r\n)|$)"
             ),
             CommentSegment,
         ),
@@ -132,7 +132,7 @@ oracle_dialect.insert_lexer_matchers(
             "remark_command",
             (
                 r"[rR][eE][mM](?:[aA][rR][kK])?"
-                r"(?:[^\S\r\n]+[^(\r\n)]*)?((?=\n)|(?=\r\n)|$)"
+                r"[^\S\r\n]+[^;(\r\n)]*((?=\n)|(?=\r\n)|$)"
             ),
             CommentSegment,
         ),

--- a/src/sqlfluff/dialects/dialect_oracle.py
+++ b/src/sqlfluff/dialects/dialect_oracle.py
@@ -124,8 +124,7 @@ oracle_dialect.insert_lexer_matchers(
             "accept_command",
             (
                 r"[aA][cC][cC](?:[eE][pP][tT])?"
-                r"[^\S\r\n]+(?![^(\r\n)]*;[^\S\r\n]*((?=\n)|(?=\r\n)|$))"
-                r"[^(\r\n)]*((?=\n)|(?=\r\n)|$)"
+                r"[^\S\r\n]+(?:'(?:[^']|'')*'|[^;(\r\n)])*((?=\n)|(?=\r\n)|$)"
             ),
             CommentSegment,
         ),
@@ -134,8 +133,7 @@ oracle_dialect.insert_lexer_matchers(
             (
                 r"[rR][eE][mM](?:[aA][rR][kK])?"
                 r"(?:[^\S\r\n]+"
-                r"(?![^(\r\n)]*;[^\S\r\n]*((?=\n)|(?=\r\n)|$))"
-                r"[^(\r\n)]*)?((?=\n)|(?=\r\n)|$)"
+                r"(?:'(?:[^']|'')*'|[^;(\r\n)])*)?((?=\n)|(?=\r\n)|$)"
             ),
             CommentSegment,
         ),

--- a/test/fixtures/dialects/oracle/sqlplus_commands.sql
+++ b/test/fixtures/dialects/oracle/sqlplus_commands.sql
@@ -4,3 +4,17 @@ ACC short_var
 REMARK this is a SQL*Plus remark
 REM this is a SQL*Plus remark abbreviation
 SELECT job_id FROM employees;
+
+DECLARE
+acc NUMBER;
+BEGIN
+NULL;
+END;
+/
+
+DECLARE
+rem NUMBER;
+BEGIN
+NULL;
+END;
+/

--- a/test/fixtures/dialects/oracle/sqlplus_commands.sql
+++ b/test/fixtures/dialects/oracle/sqlplus_commands.sql
@@ -1,0 +1,6 @@
+PROMPT this is an Oracle SQL newline delimited prompt statement
+ACCEPT var
+ACC short_var
+REMARK this is a SQL*Plus remark
+REM this is a SQL*Plus remark abbreviation
+SELECT job_id FROM employees;

--- a/test/fixtures/dialects/oracle/sqlplus_commands.sql
+++ b/test/fixtures/dialects/oracle/sqlplus_commands.sql
@@ -1,7 +1,10 @@
 PROMPT this is an Oracle SQL newline delimited prompt statement
 ACCEPT var
 ACC short_var
+ACCEPT myvar PROMPT 'Enter value; then press Enter'
+REMARK
 REMARK this is a SQL*Plus remark
+REM
 REM this is a SQL*Plus remark abbreviation
 SELECT job_id FROM employees;
 

--- a/test/fixtures/dialects/oracle/sqlplus_commands.sql
+++ b/test/fixtures/dialects/oracle/sqlplus_commands.sql
@@ -21,3 +21,17 @@ BEGIN
 NULL;
 END;
 /
+
+DECLARE
+    acc := 1; -- comment
+BEGIN
+    NULL;
+END;
+/
+
+DECLARE
+    rem := 1; -- comment
+BEGIN
+    NULL;
+END;
+/

--- a/test/fixtures/dialects/oracle/sqlplus_commands.yml
+++ b/test/fixtures/dialects/oracle/sqlplus_commands.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 4f84cd6039f2116d460e2717812de0b713d2586d280316d943b0cb6622005f3a
+_hash: 361f354f6d9b4a8d3e9551a4b8ffc3652cf9762ed4cca607a3a43e9cdd563386
 file:
 - batch:
   - statement:
@@ -55,4 +55,48 @@ file:
       - keyword: END
     statement_terminator: ;
     slash_buffer_executor:
+      slash: /
+- batch:
+  - statement:
+      assignment_segment_statement:
+      - object_reference:
+          naked_identifier: DECLARE
+      - object_reference:
+          naked_identifier: acc
+      - assignment_operator: :=
+      - expression:
+          numeric_literal: '1'
+  - statement_terminator: ;
+  - statement:
+      begin_end_block:
+      - keyword: BEGIN
+      - statement:
+          null_statement:
+            keyword: 'NULL'
+      - statement_terminator: ;
+      - keyword: END
+  - statement_terminator: ;
+  - slash_buffer_executor:
+      slash: /
+- batch:
+  - statement:
+      assignment_segment_statement:
+      - object_reference:
+          naked_identifier: DECLARE
+      - object_reference:
+          naked_identifier: rem
+      - assignment_operator: :=
+      - expression:
+          numeric_literal: '1'
+  - statement_terminator: ;
+  - statement:
+      begin_end_block:
+      - keyword: BEGIN
+      - statement:
+          null_statement:
+            keyword: 'NULL'
+      - statement_terminator: ;
+      - keyword: END
+  - statement_terminator: ;
+  - slash_buffer_executor:
       slash: /

--- a/test/fixtures/dialects/oracle/sqlplus_commands.yml
+++ b/test/fixtures/dialects/oracle/sqlplus_commands.yml
@@ -3,10 +3,10 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 54758f3b204edfeac40fce297c49a270f19760ba21ed011e205949a86c2f97dd
+_hash: 4f84cd6039f2116d460e2717812de0b713d2586d280316d943b0cb6622005f3a
 file:
-  batch:
-    statement:
+- batch:
+  - statement:
       select_statement:
         select_clause:
           keyword: SELECT
@@ -20,4 +20,39 @@ file:
               table_expression:
                 table_reference:
                   naked_identifier: employees
+  - statement_terminator: ;
+  - statement:
+      begin_end_block:
+      - declare_segment:
+          keyword: DECLARE
+          naked_identifier: acc
+          data_type:
+            data_type_identifier: NUMBER
+          statement_terminator: ;
+      - keyword: BEGIN
+      - statement:
+          null_statement:
+            keyword: 'NULL'
+      - statement_terminator: ;
+      - keyword: END
+  - statement_terminator: ;
+  - slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      begin_end_block:
+      - declare_segment:
+          keyword: DECLARE
+          naked_identifier: rem
+          data_type:
+            data_type_identifier: NUMBER
+          statement_terminator: ;
+      - keyword: BEGIN
+      - statement:
+          null_statement:
+            keyword: 'NULL'
+      - statement_terminator: ;
+      - keyword: END
     statement_terminator: ;
+    slash_buffer_executor:
+      slash: /

--- a/test/fixtures/dialects/oracle/sqlplus_commands.yml
+++ b/test/fixtures/dialects/oracle/sqlplus_commands.yml
@@ -1,0 +1,23 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 54758f3b204edfeac40fce297c49a270f19760ba21ed011e205949a86c2f97dd
+file:
+  batch:
+    statement:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            column_reference:
+              naked_identifier: job_id
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: employees
+    statement_terminator: ;


### PR DESCRIPTION
Fixes #8063.
Fixes #8064.

This change adds Oracle SQL*Plus-style line command support for `ACCEPT` / `ACC` and `REMARK` / `REM`, matching the existing lexer-level handling used for `PROMPT`.

Changes:
- add Oracle lexer matchers for `ACCEPT` / `ACC`
- add Oracle lexer matchers for `REMARK` / `REM`
- add a focused `sqlplus_commands` fixture covering `PROMPT`, `ACCEPT`, `ACC`, `REMARK`, and `REM`

Validation:
- targeted `sqlplus_commands` fixture: 3 passed
- all Oracle dialect tests: 288 passed
- `ruff check src/sqlfluff/dialects/dialect_oracle.py`
- `ruff format --check src/sqlfluff/dialects/dialect_oracle.py`
- `git diff --check`

Notes:
- The new commands are handled as `CommentSegment`, consistent with existing Oracle `PROMPT` handling.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds parsing for Oracle SQL*Plus line commands `ACCEPT`/`ACC` and `REMARK`/`REM`. They’re lexed as `CommentSegment` like `PROMPT`, with full command text preserved and restricted to full-line commands.

- **New Features**
  - Oracle lexer rules for `ACCEPT`/`ACC` and `REMARK`/`REM`, mapped to `CommentSegment` and limited to full-line commands.
  - Focused `sqlplus_commands` fixture verifies `PROMPT`, `ACCEPT`, `ACC`, `REMARK`, and `REM`.

- **Bug Fixes**
  - Prevent false positives by not matching `ACC`/`REM` when used in PL/SQL assignments (e.g., `acc := 1`, `rem := 1`).

<sup>Written for commit 21bea077c8e0c638d34f1b73f8591cefecb8264c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8067?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

