### PR TITLE
Fix LT07 non-idempotent fix for CTE brackets that become multi-line

### DIFF
--- a/src/sqlfluff/rules/layout/LT07.py
+++ b/src/sqlfluff/rules/layout/LT07.py
@@ -62,18 +62,11 @@ class Rule_LT07(BaseRule):
             .segment.children(sp.is_type("common_table_expression"))
             .iterate_segments()
         ):
-            cte_start_bracket = (
-                cte.children()
-                .last(sp.is_type("bracketed"))
-                .children()
-                .first(sp.is_type("start_bracket"))
+            cte_bracketed = cte.children().last(sp.is_type("bracketed"))
+            cte_start_bracket = cte_bracketed.children().first(
+                sp.is_type("start_bracket")
             )
-            cte_end_bracket = (
-                cte.children()
-                .last(sp.is_type("bracketed"))
-                .children()
-                .last(sp.is_type("end_bracket"))
-            )
+            cte_end_bracket = cte_bracketed.children().last(sp.is_type("end_bracket"))
             if cte_start_bracket and cte_end_bracket:
                 self.logger.debug(
                     "Found CTE with brackets: %s & %s",
@@ -81,15 +74,25 @@ class Rule_LT07(BaseRule):
                     cte_end_bracket,
                 )
                 # Are they on the same line?
-                # NOTE: This assertion should be fairly safe because
-                # there aren't many reasons for an bracket to not yet
-                # be positioned.
-                assert cte_start_bracket[0].pos_marker
-                assert cte_end_bracket[0].pos_marker
-                if (
-                    cte_start_bracket[0].pos_marker.line_no
-                    == cte_end_bracket[0].pos_marker.line_no
-                ):
+                # NOTE: We deliberately inspect the tree structure for a
+                # newline between the brackets rather than comparing the
+                # position markers (`line_no`) of the brackets. During an
+                # in-progress fix pass another rule may have already inserted
+                # newlines into the CTE body without the position markers
+                # having been recomputed yet, so `line_no` can still report
+                # the brackets as being on the same line. Relying on it left
+                # `fix` non-idempotent: a CTE which *became* multi-line was
+                # not picked up until a second pass. A structural newline
+                # check reflects the current tree immediately.
+                spans_multiple_lines = any(
+                    elem.is_type("newline")
+                    or (
+                        elem.is_type("placeholder")
+                        and cast(TemplateSegment, elem).source_str == "\n"
+                    )
+                    for elem in cte_bracketed[0].raw_segments
+                )
+                if not spans_multiple_lines:
                     # Same line
                     self.logger.debug("Skipping because on same line.")
                     continue

--- a/test/fixtures/linter/autofix/ansi/032_LT07_cte_bracket_not_idempotent/after.sql
+++ b/test/fixtures/linter/autofix/ansi/032_LT07_cte_bracket_not_idempotent/after.sql
@@ -1,0 +1,8 @@
+WITH blah AS (
+    SELECT
+        x,
+        y
+    FROM foo
+)
+
+SELECT z FROM blah

--- a/test/fixtures/linter/autofix/ansi/032_LT07_cte_bracket_not_idempotent/before.sql
+++ b/test/fixtures/linter/autofix/ansi/032_LT07_cte_bracket_not_idempotent/before.sql
@@ -1,0 +1,3 @@
+WITH blah AS (SELECT x, y FROM foo)
+
+SELECT z FROM blah

--- a/test/fixtures/linter/autofix/ansi/032_LT07_cte_bracket_not_idempotent/test-config.yml
+++ b/test/fixtures/linter/autofix/ansi/032_LT07_cte_bracket_not_idempotent/test-config.yml
@@ -1,0 +1,3 @@
+test-config:
+  rules:
+    - ALL

--- a/test/fixtures/linter/autofix/ansi/033_LT07_cte_bracket_multi_cte_idempotent/after.sql
+++ b/test/fixtures/linter/autofix/ansi/033_LT07_cte_bracket_multi_cte_idempotent/after.sql
@@ -1,0 +1,18 @@
+WITH foo AS (
+    SELECT
+        a,
+        b
+    FROM t1
+),
+
+bar AS (
+    SELECT
+        c,
+        d
+    FROM t2
+)
+
+SELECT
+    foo.a,
+    bar.c
+FROM foo CROSS JOIN bar

--- a/test/fixtures/linter/autofix/ansi/033_LT07_cte_bracket_multi_cte_idempotent/before.sql
+++ b/test/fixtures/linter/autofix/ansi/033_LT07_cte_bracket_multi_cte_idempotent/before.sql
@@ -1,0 +1,3 @@
+WITH foo AS (SELECT a, b FROM t1), bar AS (SELECT c, d FROM t2)
+
+SELECT foo.a, bar.c FROM foo CROSS JOIN bar

--- a/test/fixtures/linter/autofix/ansi/033_LT07_cte_bracket_multi_cte_idempotent/test-config.yml
+++ b/test/fixtures/linter/autofix/ansi/033_LT07_cte_bracket_multi_cte_idempotent/test-config.yml
@@ -1,0 +1,3 @@
+test-config:
+  rules:
+    - ALL

--- a/test/fixtures/linter/autofix/ansi/034_LT07_cte_bracket_multiline_unchanged/after.sql
+++ b/test/fixtures/linter/autofix/ansi/034_LT07_cte_bracket_multiline_unchanged/after.sql
@@ -1,0 +1,11 @@
+WITH cte AS (
+    SELECT
+        a,
+        b
+    FROM foo
+)
+
+SELECT
+    a,
+    b
+FROM cte

--- a/test/fixtures/linter/autofix/ansi/034_LT07_cte_bracket_multiline_unchanged/before.sql
+++ b/test/fixtures/linter/autofix/ansi/034_LT07_cte_bracket_multiline_unchanged/before.sql
@@ -1,0 +1,11 @@
+WITH cte AS (
+    SELECT
+        a,
+        b
+    FROM foo
+)
+
+SELECT
+    a,
+    b
+FROM cte

--- a/test/fixtures/linter/autofix/ansi/034_LT07_cte_bracket_multiline_unchanged/test-config.yml
+++ b/test/fixtures/linter/autofix/ansi/034_LT07_cte_bracket_multiline_unchanged/test-config.yml
@@ -1,0 +1,3 @@
+test-config:
+  rules:
+    - ALL

--- a/test/fixtures/rules/std_rule_cases/LT07.yml
+++ b/test/fixtures/rules/std_rule_cases/LT07.yml
@@ -43,6 +43,12 @@ test_pass_with_clause_closing_oneline:
   # with statement oneline
   pass_str: with cte as (select 1) select * from cte
 
+test_pass_with_clause_closing_oneline_multiple_targets:
+  # A genuinely single-line CTE (even with multiple select targets) has no
+  # newline between its brackets, so the closing bracket rule must not fire.
+  # Guards against the same-line detection over-firing on single-line CTEs.
+  pass_str: with cte as (select a, b from t) select * from cte
+
 test_pass_with_clause_closing_misaligned_indentation:
   # Fix with statement indentation
   pass_str: |


### PR DESCRIPTION
### Description

`LT07` (CTE closing bracket should be on a new line) decided whether a CTE's brackets are already on the same line by comparing the position markers of the start and end bracket:

```python
if (
    cte_start_bracket[0].pos_marker.line_no
    == cte_end_bracket[0].pos_marker.line_no
):
    continue  # same line, nothing to do
```

During a single `fix` pass another layout rule can insert newlines into the CTE body before the position markers are recomputed, so `line_no` still reports the brackets as being on the same line even though the CTE has become multi-line. `LT07` then skipped a CTE that had just become multi-line, so its fix was **not idempotent**: the closing bracket was only moved to a new line on a second `fix` run.

This inspects the tree structure for a newline (or a templated newline placeholder) between the brackets instead of trusting `line_no`, which reflects the current tree immediately:

```python
spans_multiple_lines = any(
    elem.is_type("newline")
    or (elem.is_type("placeholder")
        and cast(TemplateSegment, elem).source_str == "\n")
    for elem in cte_bracketed[0].raw_segments
)
if not spans_multiple_lines:
    continue
```

The duplicated `.last("bracketed")` lookups are also collapsed into one local.

### Tests

Three autofix fixtures are added: `032` reproduces the non-idempotent case (a single `fix` now fully resolves it), `033` covers multiple CTEs, and `034` guards that an already-multi-line CTE is left unchanged. The full autofix suite (60) and the LT07 YAML cases pass, with no cross-rule regressions.

### AI disclosure

This change was prepared with the assistance of an AI coding agent (Anthropic's Claude Opus 4.8): it helped locate the stale-`line_no` root cause, draft the structural check, and write the fixtures. I reviewed the diff, verified the RED→GREEN behavior (the `032`/`033` fixtures fail without the change), and ran the autofix and rule suites locally.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes non-idempotent behavior in `LT07` where the CTE closing bracket only moved on a second fix pass. We now detect multi-line CTEs by scanning the bracketed segment for structural newlines (including templated placeholders) instead of comparing `pos_marker.line_no`, making the fix idempotent and preserving genuine single-line CTEs.

- **Bug Fixes**
  - Detect multi-line CTEs via structural newline check between brackets; stop relying on `line_no`.
  - Added autofix fixtures to cover the regression, multiple CTEs, and no-op on already multi-line cases.

<sup>Written for commit c95242a1296dbad7814a6374c4c1f4cc4654b33d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8068?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

