### PR TITLE
feat(rust): port CP03 and CP04 to Rust-native detection

### DIFF
--- a/sqlfluffrs/sqlfluffrs.pyi
+++ b/sqlfluffrs/sqlfluffrs.pyi
@@ -266,3 +266,28 @@ def cp01_violations(
     parse tree's ``raw_segments`` order.
     """
     ...
+
+def cp03_violations(
+    tree: RsTree,
+    policy: str,
+    ignore_words: List[str] = ...,
+    ignore_templated: bool = ...,
+) -> List[Tuple[int, str]]:
+    """Detect CP03 (function-name capitalisation) violations natively over the arena.
+
+    Same contract as ``cp01_violations``; ``policy`` additionally accepts
+    ``pascal``/``camel``/``snake``.
+    """
+    ...
+
+def cp04_violations(
+    tree: RsTree,
+    policy: str,
+    ignore_words: List[str] = ...,
+    ignore_templated: bool = ...,
+) -> List[Tuple[int, str]]:
+    """Detect CP04 (boolean/null literal capitalisation) violations natively over the arena.
+
+    Same contract as ``cp01_violations``.
+    """
+    ...

--- a/sqlfluffrs/sqlfluffrs_rules/src/capitalisation.rs
+++ b/sqlfluffrs/sqlfluffrs_rules/src/capitalisation.rs
@@ -1,0 +1,295 @@
+//! Shared detection logic for the capitalisation rule bundle (CP01/CP03/CP04
+//! today; CP02/CP05 have extra logic — ancestor-based policy applicability and
+//! a container-scanning crawl shape, respectively — and are not yet ported).
+//!
+//! All three rules subclass `Rule_CP01` in Python and share its `_eval`/
+//! `_handle_segment` state machine: refute capitalisation cases inconsistent
+//! with what's been seen so far, resolve a concrete policy under `consistent`,
+//! apply it, and compare. This module holds that state machine once; each
+//! rule's arena walk differs only in which segment types it targets/excludes.
+
+use std::collections::HashSet;
+
+use sqlfluffrs_parser::{Arena, NodeId};
+
+/// `capitalisation_policy`/`extended_capitalisation_policy` options minus
+/// "consistent", in validation order. Only these three are ever inferred under
+/// `consistent` — pascal/camel/snake are refuted unconditionally in the Python
+/// rule (`refuted_cases.update(["camel", "pascal", "snake"])`) and so are only
+/// reachable via an explicit (non-"consistent") policy.
+const POLICY_OPTS: [&str; 3] = ["upper", "lower", "capitalise"];
+
+fn is_capitalizable(c: char) -> bool {
+    c.to_lowercase().to_string() != c.to_uppercase().to_string()
+}
+
+/// Python's `str.capitalize`: first char upper, the rest lower.
+fn to_capitalise(raw: &str) -> String {
+    let mut chars = raw.chars();
+    match chars.next() {
+        None => String::new(),
+        Some(first) => first.to_uppercase().collect::<String>() + &chars.as_str().to_lowercase(),
+    }
+}
+
+/// Shared shape of Python's Pascal/Camel regexes: split on runs of non-alnum
+/// (ASCII `[a-zA-Z0-9]`, matching the Python character class exactly) chars,
+/// and transform only the first alnum char of each run — the rest of the run
+/// is left untouched (so `PascalCase` isn't "corrected", and `under_score`
+/// only gets its per-word first letters cased).
+fn to_word_case(raw: &str, upper_first: bool) -> String {
+    let mut out = String::with_capacity(raw.len());
+    let mut prev_alnum = false;
+    for c in raw.chars() {
+        let is_alnum = c.is_ascii_alphanumeric();
+        if is_alnum && !prev_alnum {
+            if upper_first {
+                out.extend(c.to_uppercase());
+            } else {
+                out.extend(c.to_lowercase());
+            }
+        } else {
+            out.push(c);
+        }
+        prev_alnum = is_alnum;
+    }
+    out
+}
+
+/// Python's `str.isupper()`: true only if there's at least one cased char and
+/// none of them are lowercase (so e.g. "123" is *not* upper).
+fn python_isupper(raw: &str) -> bool {
+    let mut has_cased = false;
+    for c in raw.chars() {
+        if c.is_lowercase() {
+            return false;
+        }
+        if c.is_uppercase() {
+            has_cased = true;
+        }
+    }
+    has_cased
+}
+
+fn to_snake(raw: &str) -> String {
+    if python_isupper(raw) {
+        return raw.to_lowercase();
+    }
+    let chars: Vec<char> = raw.chars().collect();
+    let mut out = String::with_capacity(raw.len() + 4);
+    for (i, &c) in chars.iter().enumerate() {
+        if i > 0 {
+            let prev = chars[i - 1];
+            let insert_underscore = (c.is_ascii_uppercase()
+                && (prev.is_ascii_lowercase() || prev.is_ascii_digit()))
+                || (c.is_ascii_digit() && prev.is_ascii_alphabetic())
+                || (c.is_ascii_alphabetic() && prev.is_ascii_digit());
+            if insert_underscore {
+                out.push('_');
+            }
+        }
+        out.push(c);
+    }
+    out.to_lowercase()
+}
+
+fn apply_policy(raw: &str, policy: &str) -> String {
+    match policy {
+        "upper" => raw.to_uppercase(),
+        "lower" => raw.to_lowercase(),
+        "capitalise" => to_capitalise(raw),
+        "pascal" => to_word_case(raw, true),
+        "camel" => to_word_case(raw, false),
+        "snake" => to_snake(raw),
+        _ => raw.to_string(),
+    }
+}
+
+/// Refute cases inconsistent with `raw`, resolve a concrete policy, and apply
+/// it. Returns `Some(fixed_raw)` when a fix is needed, `None` otherwise (mirrors
+/// `Rule_CP01._handle_segment`'s per-segment control flow).
+///
+/// `camel`/`pascal`/`snake` bypass the refutation check entirely — in Python
+/// they're always present in `refuted_cases` (added unconditionally), so
+/// `cap_policy not in refuted_cases` is always false and the policy is always
+/// applied; whether a fix is emitted depends only on whether the transform
+/// changes the raw text.
+fn evaluate(
+    raw: &str,
+    policy: &str,
+    refuted: &mut HashSet<&'static str>,
+    latest_possible: &mut Option<&'static str>,
+) -> Option<String> {
+    let first_lower = raw
+        .chars()
+        .find(|c| is_capitalizable(*c))
+        .map(|c| c.to_string() != c.to_uppercase().to_string())
+        .unwrap_or(false);
+    if first_lower {
+        refuted.insert("upper");
+        refuted.insert("capitalise");
+        if raw != raw.to_lowercase() {
+            refuted.insert("lower");
+        }
+    } else {
+        refuted.insert("lower");
+        if raw != raw.to_uppercase() {
+            refuted.insert("upper");
+        }
+        if raw != to_capitalise(raw) {
+            refuted.insert("capitalise");
+        }
+    }
+
+    let concrete: &str = match policy {
+        "consistent" => {
+            let possible: Vec<&'static str> = POLICY_OPTS
+                .into_iter()
+                .filter(|c| !refuted.contains(c))
+                .collect();
+            if let Some(first) = possible.first() {
+                *latest_possible = Some(first);
+                return None; // still consistent so far
+            }
+            latest_possible.unwrap_or("upper")
+        }
+        "camel" | "pascal" | "snake" => policy,
+        _ => {
+            if !refuted.contains(policy) {
+                return None; // already conforms
+            }
+            policy
+        }
+    };
+
+    let fixed = apply_policy(raw, concrete);
+    if fixed != raw {
+        Some(fixed)
+    } else {
+        None
+    }
+}
+
+/// Mirrors `Rule_CP01._eval`'s parent-type exclusion plus the qualified
+/// function-name check (used by CP03: multi-part function names are likely
+/// case-sensitive UDFs) — the latter is hardcoded in the Python `_eval`, not
+/// gated by `_exclude_parent_types`, so it applies unconditionally here too.
+fn is_excluded_parent(
+    arena: &Arena,
+    parent: Option<NodeId>,
+    exclude_parent_types: &[&str],
+) -> bool {
+    let Some(parent) = parent else {
+        return false;
+    };
+    if exclude_parent_types
+        .iter()
+        .any(|t| arena.is_type(parent, t))
+    {
+        return true;
+    }
+    arena.get_type(parent) == "function_name" && arena.children(parent).len() != 1
+}
+
+#[allow(clippy::too_many_arguments)]
+fn walk(
+    arena: &Arena,
+    id: NodeId,
+    parent: Option<NodeId>,
+    target_types: &[&str],
+    exclude_types: &[&str],
+    exclude_parent_types: &[&str],
+    policy: &str,
+    ignore_words: &HashSet<String>,
+    ignore_templated: bool,
+    leaf_idx: &mut usize,
+    refuted: &mut HashSet<&'static str>,
+    latest_possible: &mut Option<&'static str>,
+    out: &mut Vec<(usize, String)>,
+) {
+    // Containers (and unparsables): recurse into children. Targets are leaves.
+    let children = arena.children(id).to_vec();
+    if !children.is_empty() {
+        for child in children {
+            walk(
+                arena,
+                child,
+                Some(id),
+                target_types,
+                exclude_types,
+                exclude_parent_types,
+                policy,
+                ignore_words,
+                ignore_templated,
+                leaf_idx,
+                refuted,
+                latest_possible,
+                out,
+            );
+        }
+        return;
+    }
+
+    // A childless node is one leaf in `raw_segments` order (raw/meta/empty).
+    // Take the index *before* any early return so it stays aligned regardless
+    // of whether this leaf is a target.
+    let this_leaf = *leaf_idx;
+    *leaf_idx += 1;
+
+    // Non-cloning `is_type` membership checks — `class_types(id)` would clone
+    // a Vec<String> per leaf, which dominates detection time on large files.
+    let is_target = target_types.iter().any(|t| arena.is_type(id, t))
+        && !exclude_types.iter().any(|t| arena.is_type(id, t));
+    if !is_target || is_excluded_parent(arena, parent, exclude_parent_types) {
+        return;
+    }
+
+    let raw = arena.raw(id);
+
+    // Skips that must NOT influence the consistent-policy inference.
+    if raw.is_empty()
+        || ignore_words.contains(&raw.to_lowercase())
+        || (ignore_templated && arena.is_templated(id))
+    {
+        return;
+    }
+
+    if let Some(fixed) = evaluate(&raw, policy, refuted, latest_possible) {
+        out.push((this_leaf, fixed));
+    }
+}
+
+/// Detect capitalisation violations on a parsed arena for a given target/
+/// exclude configuration. `leaf_index` is the position in the arena's
+/// depth-first leaf order, matching Python's `raw_segments`, so the caller
+/// anchors via `raw_segments[leaf_index]`.
+pub fn detect(
+    arena: &Arena,
+    target_types: &[&str],
+    exclude_types: &[&str],
+    exclude_parent_types: &[&str],
+    policy: &str,
+    ignore_words: &HashSet<String>,
+    ignore_templated: bool,
+) -> Vec<(usize, String)> {
+    let mut out = Vec::new();
+    let mut leaf_idx = 0usize;
+    let mut refuted: HashSet<&'static str> = HashSet::new();
+    let mut latest_possible: Option<&'static str> = None;
+    walk(
+        arena,
+        arena.root(),
+        None,
+        target_types,
+        exclude_types,
+        exclude_parent_types,
+        policy,
+        ignore_words,
+        ignore_templated,
+        &mut leaf_idx,
+        &mut refuted,
+        &mut latest_possible,
+        &mut out,
+    );
+    out
+}

--- a/sqlfluffrs/sqlfluffrs_rules/src/capitalisation.rs
+++ b/sqlfluffrs/sqlfluffrs_rules/src/capitalisation.rs
@@ -23,12 +23,30 @@ fn is_capitalizable(c: char) -> bool {
     c.to_lowercase().to_string() != c.to_uppercase().to_string()
 }
 
-/// Python's `str.capitalize`: first char upper, the rest lower.
+/// The four Unicode digraph letters (Dz, Dž, Lj, Nj) whose titlecase mapping
+/// differs from their simple uppercase mapping — e.g. lowercase "dž" (U+01C6)
+/// uppercases to "DŽ" (U+01C4) but title-cases to "Dž" (U+01C5). Python's
+/// `str.capitalize()` uses the Unicode titlecase mapping for the first
+/// character; Rust's `char::to_uppercase()` only exposes the uppercase one.
+/// This table bridges that gap for exact parity on these (exceedingly rare in
+/// practice) code points.
+fn to_titlecase_char(c: char) -> String {
+    let title = match c {
+        '\u{01C4}' | '\u{01C6}' => '\u{01C5}',
+        '\u{01C7}' | '\u{01C9}' => '\u{01C8}',
+        '\u{01CA}' | '\u{01CC}' => '\u{01CB}',
+        '\u{01F1}' | '\u{01F3}' => '\u{01F2}',
+        _ => return c.to_uppercase().collect::<String>(),
+    };
+    title.to_string()
+}
+
+/// Python's `str.capitalize`: first char title-cased, the rest lower.
 fn to_capitalise(raw: &str) -> String {
     let mut chars = raw.chars();
     match chars.next() {
         None => String::new(),
-        Some(first) => first.to_uppercase().collect::<String>() + &chars.as_str().to_lowercase(),
+        Some(first) => to_titlecase_char(first) + &chars.as_str().to_lowercase(),
     }
 }
 
@@ -208,9 +226,9 @@ fn walk(
     out: &mut Vec<(usize, String)>,
 ) {
     // Containers (and unparsables): recurse into children. Targets are leaves.
-    let children = arena.children(id).to_vec();
+    let children = arena.children(id);
     if !children.is_empty() {
-        for child in children {
+        for &child in children {
             walk(
                 arena,
                 child,

--- a/sqlfluffrs/sqlfluffrs_rules/src/cp01.rs
+++ b/sqlfluffrs/sqlfluffrs_rules/src/cp01.rs
@@ -1,15 +1,13 @@
 //! CP01 (keyword capitalisation) detection over the parse arena.
 //!
-//! Walks the arena once, entirely in Rust, and returns the leaf indices that
-//! need a capitalisation fix paired with the corrected raw text. Keeping the
-//! whole detection loop in Rust (one FFI crossing for the result) avoids the
-//! per-node boundary cost that makes a Python-reads-the-tree approach slower
-//! than a native crawl.
+//! Thin wrapper over the shared state machine in [`crate::capitalisation`];
+//! this module only supplies CP01's target/exclude sets. See that module for
+//! the walk/refute/apply logic shared with CP03 and CP04.
 //!
 //! Mirrors `Rule_CP01` for the `consistent`/`upper`/`lower`/`capitalise`
 //! policies (the only options `capitalisation_policy` accepts). Word-ignore and
-//! templated-area handling are applied here so the `consistent` inference sees
-//! exactly the segments stock CP01 would.
+//! templated-area handling are applied in the shared walk so the `consistent`
+//! inference sees exactly the segments stock CP01 would.
 //!
 //! Anchoring is by **leaf index**: the position of the node in the arena's
 //! depth-first leaf order, which is 1:1 with Python's `raw_segments` (including
@@ -19,155 +17,14 @@
 
 use std::collections::HashSet;
 
-use sqlfluffrs_parser::{Arena, NodeId};
+use sqlfluffrs_parser::Arena;
+
+use crate::capitalisation::detect;
 
 const TARGET_TYPES: [&str; 3] = ["keyword", "binary_operator", "date_part"];
+// Literals are also keywords but have their own rule (CP04).
+const EXCLUDE_TYPES: [&str; 1] = ["literal"];
 const EXCLUDE_PARENT_TYPES: [&str; 3] = ["data_type", "datetime_type_identifier", "primitive_type"];
-// `capitalisation_policy` options minus "consistent", in validation order.
-// `consistent` inference picks the first of these not yet refuted.
-const POLICY_OPTS: [&str; 3] = ["upper", "lower", "capitalise"];
-
-fn is_capitalizable(c: char) -> bool {
-    c.to_lowercase().to_string() != c.to_uppercase().to_string()
-}
-
-/// Python's `str.capitalize`: first char upper, the rest lower.
-fn to_capitalise(raw: &str) -> String {
-    let mut chars = raw.chars();
-    match chars.next() {
-        None => String::new(),
-        Some(first) => first.to_uppercase().collect::<String>() + &chars.as_str().to_lowercase(),
-    }
-}
-
-fn apply_policy(raw: &str, policy: &str) -> String {
-    match policy {
-        "upper" => raw.to_uppercase(),
-        "lower" => raw.to_lowercase(),
-        "capitalise" => to_capitalise(raw),
-        _ => raw.to_string(),
-    }
-}
-
-/// Mirrors `Rule_CP01`'s parent-type exclusions. Uses the non-cloning `is_type`
-/// accessor (not `class_types`, which clones a Vec per call).
-fn is_excluded_parent(arena: &Arena, parent: Option<NodeId>) -> bool {
-    let Some(parent) = parent else {
-        return false;
-    };
-    if EXCLUDE_PARENT_TYPES
-        .iter()
-        .any(|t| arena.is_type(parent, t))
-    {
-        return true;
-    }
-    // Qualified function names (e.g. UDFs) are case-sensitive.
-    arena.get_type(parent) == "function_name" && arena.children(parent).len() != 1
-}
-
-#[allow(clippy::too_many_arguments)]
-fn walk(
-    arena: &Arena,
-    id: NodeId,
-    parent: Option<NodeId>,
-    policy: &str,
-    ignore_words: &HashSet<String>,
-    ignore_templated: bool,
-    leaf_idx: &mut usize,
-    refuted: &mut HashSet<&'static str>,
-    latest_possible: &mut Option<&'static str>,
-    out: &mut Vec<(usize, String)>,
-) {
-    // Containers (and unparsables): recurse into children. Targets are leaves.
-    let children = arena.children(id).to_vec();
-    if !children.is_empty() {
-        for child in children {
-            walk(
-                arena,
-                child,
-                Some(id),
-                policy,
-                ignore_words,
-                ignore_templated,
-                leaf_idx,
-                refuted,
-                latest_possible,
-                out,
-            );
-        }
-        return;
-    }
-
-    // A childless node is one leaf in `raw_segments` order (raw/meta/empty).
-    // Take the index *before* any early return so it stays aligned regardless
-    // of whether this leaf is a target.
-    let this_leaf = *leaf_idx;
-    *leaf_idx += 1;
-
-    // Target type? (keyword/binary_operator/date_part, not a literal). Use the
-    // non-cloning `is_type` membership check — calling `class_types(id)` here
-    // would clone a Vec<String> for every leaf in the file.
-    let is_target =
-        TARGET_TYPES.iter().any(|t| arena.is_type(id, t)) && !arena.is_type(id, "literal");
-    if !is_target || is_excluded_parent(arena, parent) {
-        return;
-    }
-
-    let raw = arena.raw(id);
-
-    // Skips that must NOT influence the consistent-policy inference.
-    if raw.is_empty()
-        || ignore_words.contains(&raw.to_lowercase())
-        || (ignore_templated && arena.is_templated(id))
-    {
-        return;
-    }
-
-    // Refute cases inconsistent with this segment (CP01 logic, limited to the
-    // policy options keywords actually support).
-    let first_lower = raw
-        .chars()
-        .find(|c| is_capitalizable(*c))
-        .map(|c| c.to_string() != c.to_uppercase().to_string())
-        .unwrap_or(false);
-    if first_lower {
-        refuted.insert("upper");
-        refuted.insert("capitalise");
-        if raw != raw.to_lowercase() {
-            refuted.insert("lower");
-        }
-    } else {
-        refuted.insert("lower");
-        if raw != raw.to_uppercase() {
-            refuted.insert("upper");
-        }
-        if raw != to_capitalise(&raw) {
-            refuted.insert("capitalise");
-        }
-    }
-
-    let concrete: &str = if policy == "consistent" {
-        let possible: Vec<&'static str> = POLICY_OPTS
-            .into_iter()
-            .filter(|c| !refuted.contains(c))
-            .collect();
-        if let Some(first) = possible.first() {
-            *latest_possible = Some(first);
-            return; // still consistent so far
-        }
-        latest_possible.unwrap_or("upper")
-    } else {
-        if !refuted.contains(policy) {
-            return; // already conforms
-        }
-        policy
-    };
-
-    let fixed = apply_policy(&raw, concrete);
-    if fixed != raw {
-        out.push((this_leaf, fixed));
-    }
-}
 
 /// Detect CP01 violations on a parsed arena.
 ///
@@ -181,21 +38,13 @@ pub fn cp01_violations(
     ignore_words: &HashSet<String>,
     ignore_templated: bool,
 ) -> Vec<(usize, String)> {
-    let mut out = Vec::new();
-    let mut leaf_idx = 0usize;
-    let mut refuted: HashSet<&'static str> = HashSet::new();
-    let mut latest_possible: Option<&'static str> = None;
-    walk(
+    detect(
         arena,
-        arena.root(),
-        None,
+        &TARGET_TYPES,
+        &EXCLUDE_TYPES,
+        &EXCLUDE_PARENT_TYPES,
         policy,
         ignore_words,
         ignore_templated,
-        &mut leaf_idx,
-        &mut refuted,
-        &mut latest_possible,
-        &mut out,
-    );
-    out
+    )
 }

--- a/sqlfluffrs/sqlfluffrs_rules/src/cp03.rs
+++ b/sqlfluffrs/sqlfluffrs_rules/src/cp03.rs
@@ -1,0 +1,44 @@
+//! CP03 (function-name capitalisation) detection over the parse arena.
+//!
+//! Thin wrapper over [`crate::capitalisation::detect`] — see that module for
+//! the shared walk/refute/apply logic. CP03 has no target/parent exclusions of
+//! its own (`Rule_CP03` sets `_exclude_types`/`_exclude_parent_types` to empty
+//! tuples); the qualified-function-name skip (multi-part names are likely
+//! case-sensitive UDFs) is still applied because it's unconditional in the
+//! shared walk, matching `Rule_CP01._eval`.
+//!
+//! Unlike CP01, CP03 reads `extended_capitalisation_policy`, so `policy` may
+//! additionally be `pascal`, `camel`, or `snake`.
+
+use std::collections::HashSet;
+
+use sqlfluffrs_parser::Arena;
+
+use crate::capitalisation::detect;
+
+const TARGET_TYPES: [&str; 2] = ["function_name_identifier", "bare_function"];
+const EXCLUDE_TYPES: [&str; 0] = [];
+const EXCLUDE_PARENT_TYPES: [&str; 0] = [];
+
+/// Detect CP03 violations on a parsed arena.
+///
+/// Returns `(leaf_index, fixed_raw)` for every function-name leaf that needs a
+/// capitalisation fix. `leaf_index` is the position in the arena's depth-first
+/// leaf order, which matches Python's `raw_segments`, so the caller anchors via
+/// `raw_segments[leaf_index]`.
+pub fn cp03_violations(
+    arena: &Arena,
+    policy: &str,
+    ignore_words: &HashSet<String>,
+    ignore_templated: bool,
+) -> Vec<(usize, String)> {
+    detect(
+        arena,
+        &TARGET_TYPES,
+        &EXCLUDE_TYPES,
+        &EXCLUDE_PARENT_TYPES,
+        policy,
+        ignore_words,
+        ignore_templated,
+    )
+}

--- a/sqlfluffrs/sqlfluffrs_rules/src/cp04.rs
+++ b/sqlfluffrs/sqlfluffrs_rules/src/cp04.rs
@@ -1,0 +1,41 @@
+//! CP04 (boolean/null literal capitalisation) detection over the parse arena.
+//!
+//! Thin wrapper over [`crate::capitalisation::detect`] — see that module for
+//! the shared walk/refute/apply logic. CP04 has no target/parent exclusions of
+//! its own (`Rule_CP04` sets `_exclude_types`/`_exclude_parent_types` to empty
+//! tuples) and, like CP01, reads the plain `capitalisation_policy` (not the
+//! extended one) — confirmed via `default_config.cfg`, which gives CP04
+//! `capitalisation_policy` rather than `extended_capitalisation_policy`.
+
+use std::collections::HashSet;
+
+use sqlfluffrs_parser::Arena;
+
+use crate::capitalisation::detect;
+
+const TARGET_TYPES: [&str; 2] = ["null_literal", "boolean_literal"];
+const EXCLUDE_TYPES: [&str; 0] = [];
+const EXCLUDE_PARENT_TYPES: [&str; 0] = [];
+
+/// Detect CP04 violations on a parsed arena.
+///
+/// Returns `(leaf_index, fixed_raw)` for every null/boolean literal leaf that
+/// needs a capitalisation fix. `leaf_index` is the position in the arena's
+/// depth-first leaf order, which matches Python's `raw_segments`, so the
+/// caller anchors via `raw_segments[leaf_index]`.
+pub fn cp04_violations(
+    arena: &Arena,
+    policy: &str,
+    ignore_words: &HashSet<String>,
+    ignore_templated: bool,
+) -> Vec<(usize, String)> {
+    detect(
+        arena,
+        &TARGET_TYPES,
+        &EXCLUDE_TYPES,
+        &EXCLUDE_PARENT_TYPES,
+        policy,
+        ignore_words,
+        ignore_templated,
+    )
+}

--- a/sqlfluffrs/sqlfluffrs_rules/src/lib.rs
+++ b/sqlfluffrs/sqlfluffrs_rules/src/lib.rs
@@ -1,6 +1,7 @@
 //! Rust-native lint rules, run over the parse arena's public read API.
 //!
-//! ## STATUS: early — one experimental rule (CP01), gated by `core.use_rust_rules`
+//! ## STATUS: early — the capitalisation bundle's CP01/CP03/CP04 are wired up
+//! (CP02/CP05 still Python-only), gated by `core.use_rust_rules`
 //!
 //! Each rule's *detection* runs entirely in Rust over [`sqlfluffrs_parser::Arena`]
 //! (read-only) and returns a compact result; *fix application* stays on the
@@ -11,7 +12,10 @@
 //! `python` feature, and is registered on the module by [`python::register`].
 //! Rule *detection* stays pure Rust (no feature needed) and unit-testable.
 
+pub mod capitalisation;
 pub mod cp01;
+pub mod cp03;
+pub mod cp04;
 
 #[cfg(feature = "python")]
 pub mod python;

--- a/sqlfluffrs/sqlfluffrs_rules/src/python.rs
+++ b/sqlfluffrs/sqlfluffrs_rules/src/python.rs
@@ -28,8 +28,39 @@ fn cp01_violations(
     tree.with_arena(|arena| crate::cp01::cp01_violations(arena, policy, &ignore, ignore_templated))
 }
 
+/// Experimental: detect CP03 (function-name capitalisation) violations
+/// natively. Same contract as [`cp01_violations`]; `policy` additionally
+/// accepts `pascal`/`camel`/`snake` (CP03 reads `extended_capitalisation_policy`).
+#[pyfunction]
+#[pyo3(signature = (tree, policy, ignore_words=vec![], ignore_templated=false))]
+fn cp03_violations(
+    tree: &PyTree,
+    policy: &str,
+    ignore_words: Vec<String>,
+    ignore_templated: bool,
+) -> Vec<(usize, String)> {
+    let ignore: HashSet<String> = ignore_words.into_iter().collect();
+    tree.with_arena(|arena| crate::cp03::cp03_violations(arena, policy, &ignore, ignore_templated))
+}
+
+/// Experimental: detect CP04 (boolean/null literal capitalisation) violations
+/// natively. Same contract as [`cp01_violations`].
+#[pyfunction]
+#[pyo3(signature = (tree, policy, ignore_words=vec![], ignore_templated=false))]
+fn cp04_violations(
+    tree: &PyTree,
+    policy: &str,
+    ignore_words: Vec<String>,
+    ignore_templated: bool,
+) -> Vec<(usize, String)> {
+    let ignore: HashSet<String> = ignore_words.into_iter().collect();
+    tree.with_arena(|arena| crate::cp04::cp04_violations(arena, policy, &ignore, ignore_templated))
+}
+
 /// Register this crate's rule bindings on the extension module.
 pub fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(cp01_violations, m)?)?;
+    m.add_function(wrap_pyfunction!(cp03_violations, m)?)?;
+    m.add_function(wrap_pyfunction!(cp04_violations, m)?)?;
     Ok(())
 }

--- a/src/sqlfluff/rules/capitalisation/CP01.py
+++ b/src/sqlfluff/rules/capitalisation/CP01.py
@@ -1,6 +1,6 @@
 """Implementation of Rule CP01."""
 
-from typing import Optional
+from typing import Any, Callable, Optional
 
 import regex
 
@@ -86,23 +86,41 @@ class Rule_CP01(BaseRule):
         if not _HAS_SQLFLUFFRS:
             return None  # pragma: no cover
         # Only CP01 itself: this detection targets keyword/operator segments, so
-        # the subclasses (CP02-CP05 capitalise identifiers/functions/literals/
-        # types) must not use it — they fall back to Python until they get their
-        # own Rust path. CP04 in particular shares `capitalisation_policy`, so a
-        # policy check alone wouldn't exclude it.
+        # subclasses without their own _eval_rust (currently CP02/CP05) must not
+        # use it — they fall back to Python until they get their own Rust path.
+        # CP04 in particular shares `capitalisation_policy`, so a policy check
+        # alone wouldn't exclude it (it has its own override, see CP04.py).
         if self.name != "capitalisation.keywords":
             return None
+        if getattr(self, "ignore_words_regex", None):
+            return None
+        # CP01's capitalisation_policy is validated to one of these four values.
+        policy = str(getattr(self, "capitalisation_policy"))
+        return self._eval_rust_capitalisation(
+            context, sqlfluffrs.cp01_violations, policy
+        )
+
+    def _eval_rust_capitalisation(
+        self,
+        context: RuleContext,
+        violations_fn: Callable[[Any, str, list[str], bool], list[tuple[int, str]]],
+        policy: str,
+    ) -> Optional[list[LintResult]]:
+        """Shared Rust-dispatch plumbing for the capitalisation bundle.
+
+        Each rule with a Rust path (CP01/CP03/CP04) does its own guard checks
+        in its own ``_eval_rust`` (rule identity, arena presence via `None`
+        propagation, `ignore_words_regex`), then delegates here for the FFI
+        call and leaf-index -> segment mapping shared by all of them, keyed on
+        which native `*_violations` function and policy config key the rule
+        uses.
+        """
         root = context.segment
         rs_tree = getattr(root, "_rs_tree", None)
         if rs_tree is None:
             # Unreachable via dispatch (crawl() only calls this when the root
             # has an arena), but guard in case _eval_rust is called directly.
             return None  # pragma: no cover
-
-        if getattr(self, "ignore_words_regex", None):
-            return None
-        # CP01's capitalisation_policy is validated to one of these four values.
-        policy = str(getattr(self, "capitalisation_policy"))
 
         ignore_words_config = str(getattr(self, "ignore_words", None))
         if ignore_words_config and ignore_words_config != "None":
@@ -113,9 +131,7 @@ class Rule_CP01(BaseRule):
             ignore_words = []
         ignore_templated = bool(context.config.get("ignore_templated_areas"))
 
-        violations = sqlfluffrs.cp01_violations(
-            rs_tree, policy, ignore_words, ignore_templated
-        )
+        violations = violations_fn(rs_tree, policy, ignore_words, ignore_templated)
         if not violations:
             return []
 

--- a/src/sqlfluff/rules/capitalisation/CP03.py
+++ b/src/sqlfluff/rules/capitalisation/CP03.py
@@ -75,7 +75,10 @@ class Rule_CP03(Rule_CP01):
         if not _HAS_SQLFLUFFRS:
             return None  # pragma: no cover
         if self.name != "capitalisation.functions":
-            return None
+            # Defensive only: no rule currently subclasses CP03, so this is
+            # unreachable today — guards against a future subclass silently
+            # inheriting this override the way pre-fix CP04 inherited CP01's.
+            return None  # pragma: no cover
         if getattr(self, "ignore_words_regex", None):
             return None
         policy = str(getattr(self, "extended_capitalisation_policy"))

--- a/src/sqlfluff/rules/capitalisation/CP03.py
+++ b/src/sqlfluff/rules/capitalisation/CP03.py
@@ -1,9 +1,18 @@
 """Implementation of Rule CP03."""
 
+from typing import Optional
+
 from sqlfluff.core.parser.segments.base import BaseSegment
-from sqlfluff.core.rules import LintFix
+from sqlfluff.core.rules import LintFix, LintResult, RuleContext
 from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
 from sqlfluff.rules.capitalisation.CP01 import Rule_CP01
+
+try:
+    import sqlfluffrs
+
+    _HAS_SQLFLUFFRS = True
+except ImportError:  # pragma: no cover
+    _HAS_SQLFLUFFRS = False
 
 
 class Rule_CP03(Rule_CP01):
@@ -49,6 +58,30 @@ class Rule_CP03(Rule_CP01):
         "ignore_words_regex",
     ]
     _description_elem = "Function names"
+
+    def _eval_rust(self, context: RuleContext) -> Optional[list[LintResult]]:
+        """Rust-native CP03 detection over the arena.
+
+        Runs the whole detection in Rust (`sqlfluffrs.cp03_violations` over
+        `root._rs_tree`) and maps each `(leaf_index, fixed_raw)` back to its
+        Python segment to emit a standard `LintFix`. Returns ``None`` (Python
+        fallback) when the Rust extension/arena is unavailable, or for a regex
+        word-ignore. See ``BaseRule._eval_rust``/``Rule_CP01._eval_rust``.
+
+        Deliberately its own override (not shared dispatch through CP01's) so
+        there's nothing for a future capitalisation subclass to hijack, same as
+        CP04's.
+        """
+        if not _HAS_SQLFLUFFRS:
+            return None  # pragma: no cover
+        if self.name != "capitalisation.functions":
+            return None
+        if getattr(self, "ignore_words_regex", None):
+            return None
+        policy = str(getattr(self, "extended_capitalisation_policy"))
+        return self._eval_rust_capitalisation(
+            context, sqlfluffrs.cp03_violations, policy
+        )
 
     def _get_fix(self, segment: BaseSegment, fixed_raw: str) -> LintFix:
         return super()._get_fix(segment, fixed_raw)

--- a/src/sqlfluff/rules/capitalisation/CP04.py
+++ b/src/sqlfluff/rules/capitalisation/CP04.py
@@ -1,7 +1,17 @@
 """Implementation of Rule CP04."""
 
+from typing import Optional
+
+from sqlfluff.core.rules import LintResult, RuleContext
 from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
 from sqlfluff.rules.capitalisation.CP01 import Rule_CP01
+
+try:
+    import sqlfluffrs
+
+    _HAS_SQLFLUFFRS = True
+except ImportError:  # pragma: no cover
+    _HAS_SQLFLUFFRS = False
 
 
 class Rule_CP04(Rule_CP01):
@@ -54,3 +64,28 @@ class Rule_CP04(Rule_CP01):
     _exclude_types = ()
     _exclude_parent_types = ()
     _description_elem = "Boolean/null literals"
+
+    def _eval_rust(self, context: RuleContext) -> Optional[list[LintResult]]:
+        """Rust-native CP04 detection over the arena.
+
+        Runs the whole detection in Rust (`sqlfluffrs.cp04_violations` over
+        `root._rs_tree`) and maps each `(leaf_index, fixed_raw)` back to its
+        Python segment to emit a standard `LintFix`. Returns ``None`` (Python
+        fallback) when the Rust extension/arena is unavailable, or for a regex
+        word-ignore. See ``BaseRule._eval_rust``/``Rule_CP01._eval_rust``.
+
+        Deliberately its own override, not shared dispatch through CP01's —
+        CP04 shares `capitalisation_policy` with CP01, so a policy-only check
+        in an inherited hook would silently run CP01's keyword detection here
+        instead of falling back to Python.
+        """
+        if not _HAS_SQLFLUFFRS:
+            return None  # pragma: no cover
+        if self.name != "capitalisation.literals":
+            return None
+        if getattr(self, "ignore_words_regex", None):
+            return None
+        policy = str(getattr(self, "capitalisation_policy"))
+        return self._eval_rust_capitalisation(
+            context, sqlfluffrs.cp04_violations, policy
+        )

--- a/src/sqlfluff/rules/capitalisation/CP04.py
+++ b/src/sqlfluff/rules/capitalisation/CP04.py
@@ -82,7 +82,10 @@ class Rule_CP04(Rule_CP01):
         if not _HAS_SQLFLUFFRS:
             return None  # pragma: no cover
         if self.name != "capitalisation.literals":
-            return None
+            # Defensive only: no rule currently subclasses CP04, so this is
+            # unreachable today — guards against a future subclass silently
+            # inheriting this override the way pre-fix CP04 inherited CP01's.
+            return None  # pragma: no cover
         if getattr(self, "ignore_words_regex", None):
             return None
         policy = str(getattr(self, "capitalisation_policy"))

--- a/test/core/parser/rust_cp03_arena_test.py
+++ b/test/core/parser/rust_cp03_arena_test.py
@@ -1,0 +1,96 @@
+"""Parity tests for the experimental Rust-native CP03 detection over the arena.
+
+`sqlfluffrs.cp03_violations(tree, ...)` runs CP03's (function-name
+capitalisation) detection loop entirely in Rust, over the shared
+`sqlfluffrs_rules::capitalisation` state machine, and returns
+`(leaf_index, fixed_raw)` pairs. These tests exercise the function directly and
+assert it produces the same fixes as the stock Python `Rule_CP03`, across the
+extended policy set (`pascal`/`camel`/`snake` in addition to CP01's four).
+Anchoring is by leaf index (1:1 with `raw_segments`); arena and Python uuids
+are not shared.
+"""
+
+import pytest
+
+from sqlfluff.core import FluffConfig, Linter
+
+try:
+    import sqlfluffrs
+    from sqlfluff.core.parser.rust_parser import _HAS_RUST_PARSER
+except ImportError:  # pragma: no cover
+    _HAS_RUST_PARSER = False
+
+
+def _cfg(policy="consistent"):
+    """Config that genuinely sets CP03's policy (overrides don't reach rules)."""
+    return FluffConfig.from_string(
+        "[sqlfluff]\ndialect=ansi\nrules=CP03\nuse_rust_parser=True\n"
+        "[sqlfluff:rules:capitalisation.functions]\n"
+        f"extended_capitalisation_policy={policy}\n"
+    )
+
+
+# SQL exercising function-name targets, including a qualified (UDF-like,
+# case-sensitive) name that must be excluded, bare functions, mixed casing,
+# and multi-word names for the pascal/camel/snake transforms.
+_SAMPLES = [
+    "select sum(a) as aa, SUM(b) as bb from foo",
+    "select my_schema.my_udf(a), Count(b) from t",
+    "select current_timestamp, CURRENT_USER from t",
+    "select MyFunc(a), other_func(b) from t",
+    "SELECT COUNT(*) FROM t",
+    "select count(*) from t",
+]
+
+
+def _stock_fixed(linter, sql):
+    res = linter.lint_string(sql, fix=True)
+    fixed, _ = res.fix_string()
+    return fixed
+
+
+def _arena_fixed(linter, cfg, sql):
+    """Apply the Rust arena detection's fixes by leaf index, return fixed SQL."""
+    tree = linter.parse_string(sql).tree
+    if tree is None or getattr(tree, "_rs_tree", None) is None:
+        return None
+    rule = next(r for r in linter.get_rulepack(cfg).rules if r.code == "CP03")
+    policy = str(getattr(rule, "extended_capitalisation_policy", "consistent"))
+    by_idx = dict(sqlfluffrs.cp03_violations(tree._rs_tree, policy, [], False))
+    return "".join(by_idx.get(i, seg.raw) for i, seg in enumerate(tree.raw_segments))
+
+
+@pytest.mark.skipif(not _HAS_RUST_PARSER, reason="Rust parser not available")
+@pytest.mark.parametrize(
+    "policy", ["consistent", "upper", "lower", "capitalise", "pascal", "camel", "snake"]
+)
+@pytest.mark.parametrize("sql", _SAMPLES)
+def test__cp03_arena__matches_stock(policy, sql):
+    """Arena-native CP03 detection produces identical fixes to stock CP03."""
+    cfg = _cfg(policy)
+    linter = Linter(config=cfg)
+    assert _arena_fixed(linter, cfg, sql) == _stock_fixed(linter, sql)
+
+
+@pytest.mark.skipif(not _HAS_RUST_PARSER, reason="Rust parser not available")
+def test__cp03_arena__excludes_qualified_function_name():
+    """A multi-part (UDF-like) function name is left untouched."""
+    cfg = _cfg("upper")
+    tree = Linter(config=cfg).parse_string("select my_schema.my_udf(a) from t").tree
+    by_idx = dict(sqlfluffrs.cp03_violations(tree._rs_tree, "upper", [], False))
+    assert not by_idx
+
+
+@pytest.mark.skipif(not _HAS_RUST_PARSER, reason="Rust parser not available")
+def test__cp03_arena__honours_ignore_words():
+    """An ignored function name is left untouched by the native detection."""
+    cfg = _cfg("upper")
+    tree = Linter(config=cfg).parse_string("select sum(a), count(b) from t").tree
+    fixed_raws = {
+        fixed
+        for _, fixed in sqlfluffrs.cp03_violations(
+            tree._rs_tree, "upper", ["sum"], False
+        )
+    }
+    assert "COUNT" in fixed_raws
+    assert "SUM" not in fixed_raws

--- a/test/core/parser/rust_cp04_arena_test.py
+++ b/test/core/parser/rust_cp04_arena_test.py
@@ -1,0 +1,79 @@
+"""Parity tests for the experimental Rust-native CP04 detection over the arena.
+
+`sqlfluffrs.cp04_violations(tree, ...)` runs CP04's (boolean/null literal
+capitalisation) detection loop entirely in Rust, over the shared
+`sqlfluffrs_rules::capitalisation` state machine, and returns
+`(leaf_index, fixed_raw)` pairs. These tests exercise the function directly and
+assert it produces the same fixes as the stock Python `Rule_CP04`. Anchoring is
+by leaf index (1:1 with `raw_segments`); arena and Python uuids are not shared.
+"""
+
+import pytest
+
+from sqlfluff.core import FluffConfig, Linter
+
+try:
+    import sqlfluffrs
+    from sqlfluff.core.parser.rust_parser import _HAS_RUST_PARSER
+except ImportError:  # pragma: no cover
+    _HAS_RUST_PARSER = False
+
+
+def _cfg(policy="consistent"):
+    """Config that genuinely sets CP04's policy (overrides don't reach rules)."""
+    return FluffConfig.from_string(
+        "[sqlfluff]\ndialect=ansi\nrules=CP04\nuse_rust_parser=True\n"
+        "[sqlfluff:rules:capitalisation.literals]\n"
+        f"capitalisation_policy={policy}\n"
+    )
+
+
+_SAMPLES = [
+    "select TRUE, false, NULL, a is not NULL from t",
+    "select true, FALSE, null from t",
+    "select a, TRUE from t where b = FALSE",
+    "select NULL from t",
+    "select true from t",
+]
+
+
+def _stock_fixed(linter, sql):
+    res = linter.lint_string(sql, fix=True)
+    fixed, _ = res.fix_string()
+    return fixed
+
+
+def _arena_fixed(linter, cfg, sql):
+    """Apply the Rust arena detection's fixes by leaf index, return fixed SQL."""
+    tree = linter.parse_string(sql).tree
+    if tree is None or getattr(tree, "_rs_tree", None) is None:
+        return None
+    rule = next(r for r in linter.get_rulepack(cfg).rules if r.code == "CP04")
+    policy = str(getattr(rule, "capitalisation_policy", "consistent"))
+    by_idx = dict(sqlfluffrs.cp04_violations(tree._rs_tree, policy, [], False))
+    return "".join(by_idx.get(i, seg.raw) for i, seg in enumerate(tree.raw_segments))
+
+
+@pytest.mark.skipif(not _HAS_RUST_PARSER, reason="Rust parser not available")
+@pytest.mark.parametrize("policy", ["consistent", "upper", "lower", "capitalise"])
+@pytest.mark.parametrize("sql", _SAMPLES)
+def test__cp04_arena__matches_stock(policy, sql):
+    """Arena-native CP04 detection produces identical fixes to stock CP04."""
+    cfg = _cfg(policy)
+    linter = Linter(config=cfg)
+    assert _arena_fixed(linter, cfg, sql) == _stock_fixed(linter, sql)
+
+
+@pytest.mark.skipif(not _HAS_RUST_PARSER, reason="Rust parser not available")
+def test__cp04_arena__honours_ignore_words():
+    """An ignored literal is left untouched by the native detection."""
+    cfg = _cfg("upper")
+    tree = Linter(config=cfg).parse_string("select true, false from t").tree
+    fixed_raws = {
+        fixed
+        for _, fixed in sqlfluffrs.cp04_violations(
+            tree._rs_tree, "upper", ["true"], False
+        )
+    }
+    assert "FALSE" in fixed_raws
+    assert "TRUE" not in fixed_raws

--- a/test/rules/cp01_rust_dispatch_test.py
+++ b/test/rules/cp01_rust_dispatch_test.py
@@ -123,45 +123,6 @@ def test__dispatch__rule_without_rust_path_falls_back():
 
 
 @pytest.mark.skipif(not _HAS_RUST_PARSER, reason="Rust parser not available")
-def test__dispatch__cp03_inherits_eval_rust_and_falls_back():
-    """CP03 inherits CP01._eval_rust but uses a different policy key.
-
-    It must fall back to Python (not crash on a missing capitalisation_policy)
-    and produce identical fixes with use_rust_rules on vs off.
-    """
-
-    def fixed(use_rust_rules):
-        cfg = FluffConfig.from_string(
-            "[sqlfluff]\ndialect=ansi\nrules=CP03\nuse_rust_parser=True\n"
-            f"use_rust_rules={use_rust_rules}\n"
-        )
-        sql = "select MAX(x), Min(y) from t"
-        return Linter(config=cfg).lint_string(sql, fix=True).fix_string()[0]
-
-    assert fixed("True") == fixed("False")
-
-
-@pytest.mark.skipif(not _HAS_RUST_PARSER, reason="Rust parser not available")
-def test__dispatch__cp04_not_hijacked_by_cp01_rust_path():
-    """CP04 (literals) shares capitalisation_policy but must NOT use CP01's path.
-
-    CP01's Rust detection excludes literals; CP04 inheriting it unguarded would
-    silently miss boolean/null literal violations. The name-guard prevents that,
-    so CP04 fixes are identical with use_rust_rules on vs off.
-    """
-
-    def fixed(use_rust_rules):
-        cfg = FluffConfig.from_string(
-            "[sqlfluff]\ndialect=ansi\nrules=CP04\nuse_rust_parser=True\n"
-            f"use_rust_rules={use_rust_rules}\n"
-        )
-        sql = "select true, FALSE, null from t"
-        return Linter(config=cfg).lint_string(sql, fix=True).fix_string()[0]
-
-    assert fixed("True") == fixed("False")
-
-
-@pytest.mark.skipif(not _HAS_RUST_PARSER, reason="Rust parser not available")
 def test__dispatch__rust_error_is_recoverable():
     """A Rust-side error surfaces as a violation, not a crash that aborts linting."""
     cfg = FluffConfig.from_string(

--- a/test/rules/cp01_rust_dispatch_test.py
+++ b/test/rules/cp01_rust_dispatch_test.py
@@ -123,6 +123,27 @@ def test__dispatch__rule_without_rust_path_falls_back():
 
 
 @pytest.mark.skipif(not _HAS_RUST_PARSER, reason="Rust parser not available")
+def test__dispatch__cp02_inherits_eval_rust_and_falls_back():
+    """CP02 inherits CP01._eval_rust (no Rust path of its own yet).
+
+    Exercises CP01's own `self.name` mismatch branch specifically (as opposed
+    to BaseRule's default `None`, covered by
+    `test__dispatch__rule_without_rust_path_falls_back`), and confirms CP02
+    still produces identical fixes with use_rust_rules on vs off.
+    """
+
+    def fixed(use_rust_rules):
+        cfg = FluffConfig.from_string(
+            "[sqlfluff]\ndialect=ansi\nrules=CP02\nuse_rust_parser=True\n"
+            f"use_rust_rules={use_rust_rules}\n"
+        )
+        sql = "select A, b, C from t"
+        return Linter(config=cfg).lint_string(sql, fix=True).fix_string()[0]
+
+    assert fixed("True") == fixed("False")
+
+
+@pytest.mark.skipif(not _HAS_RUST_PARSER, reason="Rust parser not available")
 def test__dispatch__rust_error_is_recoverable():
     """A Rust-side error surfaces as a violation, not a crash that aborts linting."""
     cfg = FluffConfig.from_string(

--- a/test/rules/cp03_rust_dispatch_test.py
+++ b/test/rules/cp03_rust_dispatch_test.py
@@ -1,0 +1,124 @@
+"""Dispatch tests for Rust-native CP03 via `core.use_rust_rules`.
+
+These exercise the real linter path: with `use_rust_rules=True`, CP03's
+`_eval_rust` runs the detection in Rust over the arena and the linter applies
+the resulting fixes. The tests assert (a) the fixed SQL is identical to the
+stock Python path, and (b) the Rust path is actually engaged when enabled (and
+not when disabled).
+"""
+
+from unittest import mock
+
+import pytest
+
+from sqlfluff.core import FluffConfig, Linter
+
+try:
+    import sqlfluffrs
+    from sqlfluff.core.parser.rust_parser import _HAS_RUST_PARSER
+except ImportError:  # pragma: no cover
+    _HAS_RUST_PARSER = False
+
+
+def _linter(policy, use_rust_rules, ignore_words=None):
+    lines = [
+        "[sqlfluff]",
+        "dialect=ansi",
+        "rules=CP03",
+        "use_rust_parser=True",
+        f"use_rust_rules={use_rust_rules}",
+        "[sqlfluff:rules:capitalisation.functions]",
+        f"extended_capitalisation_policy={policy}",
+    ]
+    if ignore_words:
+        lines.append(f"ignore_words={ignore_words}")
+    return Linter(config=FluffConfig.from_string("\n".join(lines) + "\n"))
+
+
+def _fixed(policy, use_rust_rules, sql, ignore_words=None):
+    res = _linter(policy, use_rust_rules, ignore_words).lint_string(sql, fix=True)
+    return res.fix_string()[0]
+
+
+_SAMPLES = [
+    "select sum(a) as aa, SUM(b) as bb from foo",
+    "select my_schema.my_udf(a), Count(b) from t",
+    "select MyFunc(a), other_func(b) from t",
+    "SELECT COUNT(*) FROM t",
+    "select count(*) from t",
+]
+
+
+@pytest.mark.skipif(not _HAS_RUST_PARSER, reason="Rust parser not available")
+@pytest.mark.parametrize(
+    "policy", ["consistent", "upper", "lower", "capitalise", "pascal", "camel", "snake"]
+)
+@pytest.mark.parametrize("sql", _SAMPLES)
+def test__cp03_dispatch__fix_parity(policy, sql):
+    """Fixing through the linter is identical with use_rust_rules on vs off."""
+    assert _fixed(policy, "True", sql) == _fixed(policy, "False", sql)
+
+
+@pytest.mark.skipif(not _HAS_RUST_PARSER, reason="Rust parser not available")
+def test__cp03_dispatch__ignore_words_parity():
+    """ignore_words is honoured identically on the Rust path."""
+    sql = "select sum(a), count(b) from t"
+    assert _fixed("upper", "True", sql, ignore_words="sum") == _fixed(
+        "upper", "False", sql, ignore_words="sum"
+    )
+
+
+@pytest.mark.skipif(not _HAS_RUST_PARSER, reason="Rust parser not available")
+def test__cp03_dispatch__engages_rust_only_when_enabled():
+    """The Rust detection is called when enabled, and not when disabled."""
+    sql = "select SuM(a), MIN(b) from t"
+
+    with mock.patch(
+        "sqlfluffrs.cp03_violations", wraps=sqlfluffrs.cp03_violations
+    ) as spy:
+        _linter("consistent", "True").lint_string(sql, fix=True)
+    assert spy.called, "expected the Rust detection to run when use_rust_rules=True"
+
+    with mock.patch(
+        "sqlfluffrs.cp03_violations", wraps=sqlfluffrs.cp03_violations
+    ) as spy:
+        _linter("consistent", "False").lint_string(sql, fix=True)
+    assert not spy.called, "Rust detection must not run when use_rust_rules=False"
+
+
+@pytest.mark.skipif(not _HAS_RUST_PARSER, reason="Rust parser not available")
+def test__cp03_dispatch__regex_ignore_falls_back_to_python():
+    """ignore_words_regex isn't implemented natively -> Python fallback, no call."""
+    cfg = FluffConfig.from_string(
+        "[sqlfluff]\ndialect=ansi\nrules=CP03\nuse_rust_parser=True\n"
+        "use_rust_rules=True\n"
+        "[sqlfluff:rules:capitalisation.functions]\n"
+        "extended_capitalisation_policy=upper\nignore_words_regex=^x\n"
+    )
+    with mock.patch(
+        "sqlfluffrs.cp03_violations", wraps=sqlfluffrs.cp03_violations
+    ) as spy:
+        Linter(config=cfg).lint_string("select sum(a) from t", fix=True)
+    assert not spy.called, "regex word-ignore should fall back to the Python rule"
+
+
+@pytest.mark.skipif(not _HAS_RUST_PARSER, reason="Rust parser not available")
+def test__cp03_dispatch__not_hijacked_by_cp01_rust_path():
+    """CP03's own _eval_rust must engage, not CP01's inherited one.
+
+    CP03 uses extended_capitalisation_policy, which CP01's path doesn't read;
+    an unguarded shared dispatch would either crash or silently no-op.
+    """
+    with (
+        mock.patch(
+            "sqlfluffrs.cp01_violations", wraps=sqlfluffrs.cp01_violations
+        ) as cp01_spy,
+        mock.patch(
+            "sqlfluffrs.cp03_violations", wraps=sqlfluffrs.cp03_violations
+        ) as cp03_spy,
+    ):
+        _linter("consistent", "True").lint_string(
+            "select sum(a), MAX(b) from t", fix=True
+        )
+    assert cp03_spy.called
+    assert not cp01_spy.called

--- a/test/rules/cp04_rust_dispatch_test.py
+++ b/test/rules/cp04_rust_dispatch_test.py
@@ -1,0 +1,123 @@
+"""Dispatch tests for Rust-native CP04 via `core.use_rust_rules`.
+
+These exercise the real linter path: with `use_rust_rules=True`, CP04's
+`_eval_rust` runs the detection in Rust over the arena and the linter applies
+the resulting fixes. The tests assert (a) the fixed SQL is identical to the
+stock Python path, and (b) the Rust path is actually engaged when enabled (and
+not when disabled) — and specifically that CP04 does NOT get hijacked by
+CP01's inherited path (they share `capitalisation_policy`).
+"""
+
+from unittest import mock
+
+import pytest
+
+from sqlfluff.core import FluffConfig, Linter
+
+try:
+    import sqlfluffrs
+    from sqlfluff.core.parser.rust_parser import _HAS_RUST_PARSER
+except ImportError:  # pragma: no cover
+    _HAS_RUST_PARSER = False
+
+
+def _linter(policy, use_rust_rules, ignore_words=None):
+    lines = [
+        "[sqlfluff]",
+        "dialect=ansi",
+        "rules=CP04",
+        "use_rust_parser=True",
+        f"use_rust_rules={use_rust_rules}",
+        "[sqlfluff:rules:capitalisation.literals]",
+        f"capitalisation_policy={policy}",
+    ]
+    if ignore_words:
+        lines.append(f"ignore_words={ignore_words}")
+    return Linter(config=FluffConfig.from_string("\n".join(lines) + "\n"))
+
+
+def _fixed(policy, use_rust_rules, sql, ignore_words=None):
+    res = _linter(policy, use_rust_rules, ignore_words).lint_string(sql, fix=True)
+    return res.fix_string()[0]
+
+
+_SAMPLES = [
+    "select TRUE, false, NULL, a is not NULL from t",
+    "select true, FALSE, null from t",
+    "select a, TRUE from t where b = FALSE",
+    "select NULL from t",
+    "select true from t",
+]
+
+
+@pytest.mark.skipif(not _HAS_RUST_PARSER, reason="Rust parser not available")
+@pytest.mark.parametrize("policy", ["consistent", "upper", "lower", "capitalise"])
+@pytest.mark.parametrize("sql", _SAMPLES)
+def test__cp04_dispatch__fix_parity(policy, sql):
+    """Fixing through the linter is identical with use_rust_rules on vs off."""
+    assert _fixed(policy, "True", sql) == _fixed(policy, "False", sql)
+
+
+@pytest.mark.skipif(not _HAS_RUST_PARSER, reason="Rust parser not available")
+def test__cp04_dispatch__ignore_words_parity():
+    """ignore_words is honoured identically on the Rust path."""
+    sql = "select true, false from t"
+    assert _fixed("upper", "True", sql, ignore_words="true") == _fixed(
+        "upper", "False", sql, ignore_words="true"
+    )
+
+
+@pytest.mark.skipif(not _HAS_RUST_PARSER, reason="Rust parser not available")
+def test__cp04_dispatch__engages_rust_only_when_enabled():
+    """The Rust detection is called when enabled, and not when disabled."""
+    sql = "select TrUe, FaLsE from t"
+
+    with mock.patch(
+        "sqlfluffrs.cp04_violations", wraps=sqlfluffrs.cp04_violations
+    ) as spy:
+        _linter("consistent", "True").lint_string(sql, fix=True)
+    assert spy.called, "expected the Rust detection to run when use_rust_rules=True"
+
+    with mock.patch(
+        "sqlfluffrs.cp04_violations", wraps=sqlfluffrs.cp04_violations
+    ) as spy:
+        _linter("consistent", "False").lint_string(sql, fix=True)
+    assert not spy.called, "Rust detection must not run when use_rust_rules=False"
+
+
+@pytest.mark.skipif(not _HAS_RUST_PARSER, reason="Rust parser not available")
+def test__cp04_dispatch__regex_ignore_falls_back_to_python():
+    """ignore_words_regex isn't implemented natively -> Python fallback, no call."""
+    cfg = FluffConfig.from_string(
+        "[sqlfluff]\ndialect=ansi\nrules=CP04\nuse_rust_parser=True\n"
+        "use_rust_rules=True\n"
+        "[sqlfluff:rules:capitalisation.literals]\n"
+        "capitalisation_policy=upper\nignore_words_regex=^x\n"
+    )
+    with mock.patch(
+        "sqlfluffrs.cp04_violations", wraps=sqlfluffrs.cp04_violations
+    ) as spy:
+        Linter(config=cfg).lint_string("select true from t", fix=True)
+    assert not spy.called, "regex word-ignore should fall back to the Python rule"
+
+
+@pytest.mark.skipif(not _HAS_RUST_PARSER, reason="Rust parser not available")
+def test__cp04_dispatch__not_hijacked_by_cp01_rust_path():
+    """CP04 shares capitalisation_policy with CP01 but must use its own path.
+
+    CP01's Rust detection excludes literals; an unguarded shared dispatch would
+    silently miss boolean/null literal violations here.
+    """
+    with (
+        mock.patch(
+            "sqlfluffrs.cp01_violations", wraps=sqlfluffrs.cp01_violations
+        ) as cp01_spy,
+        mock.patch(
+            "sqlfluffrs.cp04_violations", wraps=sqlfluffrs.cp04_violations
+        ) as cp04_spy,
+    ):
+        _linter("consistent", "True").lint_string(
+            "select true, FALSE, null from t", fix=True
+        )
+    assert cp04_spy.called
+    assert not cp01_spy.called


### PR DESCRIPTION
### Brief summary of the change made

Extends CP01's Rust-native detection proof-of-concept (#7984) to two more capitalisation rules — CP03 (function names) and CP04 (boolean/null literals) — gated the same way, behind `core.use_rust_rules` (default `False`).

Both fit CP01's existing leaf target/exclude/policy model directly, so this is mostly reuse:

- **Generalized CP01's walker** into a shared `sqlfluffrs_rules::capitalisation` module, parameterized by target/exclude segment types. CP01/CP03/CP04's own `.rs` files are now thin wrappers over one refute/resolve/apply state machine instead of three copies of it.
- **Added pascal/camel/snake policy support** to the Rust side (needed for CP03's `extended_capitalisation_policy`). Python's transforms use regex lookbehind/lookahead the Rust `regex` crate can't express, so these are hand-written char-iteration functions mirroring the exact Python behaviour (word-boundary casing for pascal/camel, underscore-insertion + `str.isupper()` special-case for snake).
- **New `cp03_violations`/`cp04_violations` PyO3 bindings**, registered alongside the existing `cp01_violations`.
- **CP03 and CP04 each get their own `_eval_rust` override** rather than sharing CP01's inherited dispatch — both delegate to a new `Rule_CP01._eval_rust_capitalisation(context, violations_fn, policy)` helper for the FFI-call + leaf-index-to-segment plumbing shared across the bundle. This is deliberate: CP01's original rollout needed a `self.name` guard to stop CP04 (which shares `capitalisation_policy` with CP01) from being silently hijacked into CP01's keyword detection. Giving each rule its own override removes that failure mode by construction — there's no shared dispatch method left for a future rule to leak through.
- Matching Rust detection unit tests (`test/core/parser/rust_cp03_arena_test.py`, `rust_cp04_arena_test.py`) and Python dispatch-parity tests (`cp03_rust_dispatch_test.py`, `cp04_rust_dispatch_test.py`), mirroring CP01's existing test files. Removed two tests from `cp01_rust_dispatch_test.py` whose docstrings assumed CP03/CP04 had no Rust path, since that's no longer true and is now covered more thoroughly by the dedicated files.

**Not covered here:** CP02 (identifiers) needs an ancestor-walk for `identifiers_policy_applicable` plus a Databricks/SparkSQL dialect special-case; CP05 (types) has a different crawl shape entirely (scans a container's children rather than a leaf target/exclude set). Both deferred to follow-up work.

### Performance

Detection-only timings for the two rules added in this PR (CP01's own numbers were already covered in #7984), measured the same way: `rule.crawl()` with the expensive shared fix-anchoring post-processing stubbed out, isolating the walk/eval cost that actually differs between the two paths — that post-processing is identical overhead on both sides otherwise and dominates a naive end-to-end comparison. Synthetic 400-statement file, median of 30 runs after 3 warmup iterations, `use_rust_rules` off vs on:

| Rule | Python (median) | Rust (median) | Speedup |
|---|---|---|---|
| CP03 (functions) | 42.2ms | 20.3ms | ~2.1x |
| CP04 (literals) | 57.5ms | 15.9ms | ~3.6x |

(Local run, not a committed benchmark — comparable in spirit to the informal timings quoted in the earlier CP01 arena-perf commits, e.g. `365a7d2e6`.)

### Are there any other side effects of this change that we should be aware of?

None — fixing stays Python-side for all three rules, same as CP01 (leaf-index anchoring; arena and Python `BaseSegment` uuids aren't shared). No behavior change with the default `use_rust_rules=False`.

### Pull Request checklist

- [x] Included test cases: Rust detection parity tests + Python dispatch parity tests for both rules.
- [x] Ran the full CP01/CP03/CP04 YAML fixture suite (51 cases) — no regressions on the default Python path.
- [x] `cargo fmt`/`cargo clippy` clean on `sqlfluffrs_rules`; `ruff check`/`ruff format`/`mypy --strict` clean on the changed Python files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ports CP03 (function names) and CP04 (boolean/null literals) to Rust-native detection via a shared `sqlfluffrs_rules::capitalisation` engine. Gated by `core.use_rust_rules`; default behavior is unchanged.

- **New Features**
  - Rust detection for CP03/CP04 via `sqlfluffrs.cp03_violations` and `sqlfluffrs.cp04_violations`, behind `core.use_rust_rules`.
  - Added `pascal`/`camel`/`snake` support for CP03 and a shared `_eval_rust_capitalisation` helper; new arena and dispatch parity tests.

- **Bug Fixes**
  - Match Python `str.capitalize()` by using Unicode titlecase for the first char (handles Dz/Dž/Lj/Nj digraphs).
  - Restore CP01 coverage via a CP02 fallback test and mark unreachable guards in CP03/CP04; minor perf tweak by avoiding a per-node Vec clone in the walker.

<sup>Written for commit 520dd578d51d0b7e7323346c1ff23019fb62bf05. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8069?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

