### PR TITLE
Parse Oracle ALTER TABLE ADD with bracketed constraints

### DIFF
--- a/src/sqlfluff/dialects/dialect_oracle.py
+++ b/src/sqlfluff/dialects/dialect_oracle.py
@@ -1129,7 +1129,10 @@ class AlterTableConstraintClauses(BaseSegment):
     match_grammar = OneOf(
         Sequence(
             "ADD",
-            Ref("TableConstraintSegment"),
+            OneOf(
+                Ref("TableConstraintSegment"),
+                Bracketed(Delimited(Ref("TableConstraintSegment"))),
+            ),
         ),
         # @TODO MODIFY
         # @TODO DROP

--- a/test/fixtures/dialects/oracle/alter_table.sql
+++ b/test/fixtures/dialects/oracle/alter_table.sql
@@ -21,6 +21,15 @@ ALTER TABLE table_name
 ADD CONSTRAINT constraint_name
 FOREIGN KEY (column_name) REFERENCES other_table_name (other_column_name);
 
+-- add_constraint_clause with bracketed constraints
+ALTER TABLE table_name ADD (
+    CONSTRAINT constraint_name
+    FOREIGN KEY (column_name) REFERENCES other_table_name (other_column_name));
+
+ALTER TABLE table_name ADD (
+    CONSTRAINT pk_name PRIMARY KEY (column_name),
+    CONSTRAINT fk_name FOREIGN KEY (column_name) REFERENCES other_table_name (other_column_name));
+
 -- rename_constraint_clause
 ALTER TABLE table_name RENAME CONSTRAINT source_constraint_name TO target_constraint_name;
 

--- a/test/fixtures/dialects/oracle/alter_table.yml
+++ b/test/fixtures/dialects/oracle/alter_table.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: fc66dcd892c616fe6d48a210ed8fb2b87c96c76ba40b6aeacdd74de1ba46f314
+_hash: c153c69f134fe0d1534d7504a1ec01a54793b92c32cffacff26a3965ff958ca4
 file:
   batch:
   - statement:
@@ -116,6 +116,80 @@ file:
               column_reference:
                 naked_identifier: other_column_name
               end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      alter_table_statement:
+      - keyword: ALTER
+      - keyword: TABLE
+      - table_reference:
+          naked_identifier: table_name
+      - alter_table_constraint_clauses:
+          keyword: ADD
+          bracketed:
+            start_bracket: (
+            table_constraint:
+            - keyword: CONSTRAINT
+            - object_reference:
+                naked_identifier: constraint_name
+            - keyword: FOREIGN
+            - keyword: KEY
+            - bracketed:
+                start_bracket: (
+                column_reference:
+                  naked_identifier: column_name
+                end_bracket: )
+            - keyword: REFERENCES
+            - table_reference:
+                naked_identifier: other_table_name
+            - bracketed:
+                start_bracket: (
+                column_reference:
+                  naked_identifier: other_column_name
+                end_bracket: )
+            end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      alter_table_statement:
+      - keyword: ALTER
+      - keyword: TABLE
+      - table_reference:
+          naked_identifier: table_name
+      - alter_table_constraint_clauses:
+          keyword: ADD
+          bracketed:
+          - start_bracket: (
+          - table_constraint:
+            - keyword: CONSTRAINT
+            - object_reference:
+                naked_identifier: pk_name
+            - keyword: PRIMARY
+            - keyword: KEY
+            - bracketed:
+                start_bracket: (
+                column_reference:
+                  naked_identifier: column_name
+                end_bracket: )
+          - comma: ','
+          - table_constraint:
+            - keyword: CONSTRAINT
+            - object_reference:
+                naked_identifier: fk_name
+            - keyword: FOREIGN
+            - keyword: KEY
+            - bracketed:
+                start_bracket: (
+                column_reference:
+                  naked_identifier: column_name
+                end_bracket: )
+            - keyword: REFERENCES
+            - table_reference:
+                naked_identifier: other_table_name
+            - bracketed:
+                start_bracket: (
+                column_reference:
+                  naked_identifier: other_column_name
+                end_bracket: )
+          - end_bracket: )
   - statement_terminator: ;
   - statement:
       alter_table_statement:


### PR DESCRIPTION
### Brief summary of the change made

Linting Oracle SQL blows up on the bracketed form of ADD constraint:

    ALTER TABLE t ADD (
        CONSTRAINT c FOREIGN KEY (a) REFERENCES o (a));

Drop the brackets and it parses fine. The `ADD` branch in `AlterTableConstraintClauses` only took a bare `TableConstraintSegment`, no brackets, even though the sibling column clause already handles `ADD (...)`. Gave it the same treatment, so a single constraint and a comma list in parens both parse. Added fixtures for both and regenerated the yml.

Fixes #8075.

### Are there any other side effects of this change that we should be aware of?

Don't think so. It's scoped to the Oracle `ADD` constraint branch and the bare form still parses like before.

One thing for you: I kept it contained and copied the existing column-clause idiom instead of reworking all of `ADD (...)` into one path. Mixed brackets (columns and constraints together) would want the broader version, but that's out of scope here.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases:
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (regenerated with `tox -e generate-fixture-yml`).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow Oracle ALTER TABLE ADD with bracketed constraints to parse, supporting a single constraint or a comma-separated list. This fixes failures when linting statements like ADD (CONSTRAINT ...), while keeping the bare form unchanged.

- **Bug Fixes**
  - Updated `AlterTableConstraintClauses` to accept `ADD` with either a single `TableConstraintSegment` or a bracketed, comma-delimited list.
  - Added fixtures for both cases and regenerated `.yml` expectations; no changes to non-bracketed `ADD` behavior.

<sup>Written for commit fdd12042b70f60de7b15cb792182e90decdaac97. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8076?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

