### PR TITLE
Parse Oracle FOR loop ranges with function-call bounds

### DIFF
--- a/src/sqlfluff/dialects/dialect_oracle.py
+++ b/src/sqlfluff/dialects/dialect_oracle.py
@@ -326,6 +326,7 @@ oracle_dialect.add(
     ),
     IterationBoundsGrammar=OneOf(
         Ref("NumericLiteralSegment"),
+        Ref("FunctionSegment"),
         Ref("SingleIdentifierGrammar"),
         Sequence(
             Ref("SingleIdentifierGrammar"),

--- a/test/fixtures/dialects/oracle/for_loop.sql
+++ b/test/fixtures/dialects/oracle/for_loop.sql
@@ -125,3 +125,17 @@ BEGIN
   CLOSE c1;
 END;
 /
+
+BEGIN
+  FOR i IN 1..LENGTH(v_str) LOOP
+    DBMS_OUTPUT.PUT_LINE(i);
+  END LOOP;
+END;
+/
+
+BEGIN
+  FOR i IN 1..v_arr.COUNT() LOOP
+    DBMS_OUTPUT.PUT_LINE(i);
+  END LOOP;
+END;
+/

--- a/test/fixtures/dialects/oracle/for_loop.yml
+++ b/test/fixtures/dialects/oracle/for_loop.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 513e2e564a872a290e6fafab4870235943739306ab7f6ce4477a04f989a3c6ae
+_hash: fdc358d6501f37180a02a066de0c437a2a01d1699f2e5e24cc39e8a71941cc17
 file:
 - batch:
     statement:
@@ -788,6 +788,95 @@ file:
           close_statement:
             keyword: CLOSE
             naked_identifier: c1
+      - statement_terminator: ;
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      begin_end_block:
+      - keyword: BEGIN
+      - statement:
+          for_loop_statement:
+          - keyword: FOR
+          - naked_identifier: i
+          - keyword: IN
+          - numeric_literal: '1'
+          - dot: .
+          - dot: .
+          - function:
+              function_name:
+                function_name_identifier: LENGTH
+              function_contents:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    column_reference:
+                      naked_identifier: v_str
+                  end_bracket: )
+          - loop_statement:
+            - keyword: LOOP
+            - statement:
+                function:
+                  function_name:
+                    naked_identifier: DBMS_OUTPUT
+                    dot: .
+                    function_name_identifier: PUT_LINE
+                  function_contents:
+                    bracketed:
+                      start_bracket: (
+                      expression:
+                        column_reference:
+                          naked_identifier: i
+                      end_bracket: )
+            - statement_terminator: ;
+            - keyword: END
+            - keyword: LOOP
+      - statement_terminator: ;
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      begin_end_block:
+      - keyword: BEGIN
+      - statement:
+          for_loop_statement:
+          - keyword: FOR
+          - naked_identifier: i
+          - keyword: IN
+          - numeric_literal: '1'
+          - dot: .
+          - dot: .
+          - function:
+              function_name:
+                naked_identifier: v_arr
+                dot: .
+                function_name_identifier: COUNT
+              function_contents:
+                bracketed:
+                  start_bracket: (
+                  end_bracket: )
+          - loop_statement:
+            - keyword: LOOP
+            - statement:
+                function:
+                  function_name:
+                    naked_identifier: DBMS_OUTPUT
+                    dot: .
+                    function_name_identifier: PUT_LINE
+                  function_contents:
+                    bracketed:
+                      start_bracket: (
+                      expression:
+                        column_reference:
+                          naked_identifier: i
+                      end_bracket: )
+            - statement_terminator: ;
+            - keyword: END
+            - keyword: LOOP
       - statement_terminator: ;
       - keyword: END
     statement_terminator: ;


### PR DESCRIPTION
### Brief summary of the change made

Oracle FOR loops blow up when a range bound is a function call:

    for i in 1..length(x) loop ...
    for i in 1..smth.count() loop ...

Both hit "Found unparsable section". `IterationBoundsGrammar` only allowed a number, a bare name, or `a.b`, so function calls fell through. Added `FunctionSegment`. Fixtures for both, yml regenerated.

Fixes #8072.

### Are there any other side effects of this change that we should be aware of?

No. Scoped to the range bounds, old forms parse the same.

One call for you: this covers function calls (both issue cases, plus `1..arr(1)`). Arithmetic like `1..n+1` still won't parse. Full fix is a real `ExpressionSegment` per bound, but the grammar's enumerated on purpose since `..` is two dots and a general expression gets ambiguous. Can broaden it if you'd rather.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (regenerated with `tox -e generate-fixture-yml`).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow Oracle FOR loop ranges to use function-call bounds (e.g., 1..LENGTH(x), 1..arr.COUNT()), fixing "Found unparsable section" errors. Fixes #8072.

- **Bug Fixes**
  - Updated `IterationBoundsGrammar` to accept `FunctionSegment`.
  - Added tests for `1..LENGTH(v_str)` and `1..v_arr.COUNT()`.
  - No change to other bounds; arithmetic like `1..n+1` still not supported.

<sup>Written for commit 9b9556a67e57f37ea003ea794fa0f4e27a455eff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8077?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

