### PR TITLE
perf(rust): compare Arc<TemplatedFile> by pointer instead of by value in PositionMarker merge

### DIFF
--- a/sqlfluffrs/sqlfluffrs_python/src/marker.rs
+++ b/sqlfluffrs/sqlfluffrs_python/src/marker.rs
@@ -105,6 +105,15 @@ impl PyPositionMarker {
         self.0.to_source_dict()
     }
 
+    // `from_child_markers`, `from_point`, and `from_points` below all end up
+    // in `RsPositionMarker`'s counterparts, which check that combined markers
+    // share one `Arc<TemplatedFile>` first by pointer, then fall back to a
+    // value comparison (see sqlfluffrs_types/src/marker.rs). Across the
+    // Python/Rust boundary, pointer identity is only guaranteed because
+    // `PySqlFluffTemplatedFile` extraction is normalized through
+    // `PY_TEMPLATED_FILE_CACHE`; the value-comparison fallback is what keeps
+    // markers built from a `TemplatedFile` that bypassed that cache from
+    // panicking, as long as its content still matches.
     #[classmethod]
     #[pyo3(signature = (markers))]
     pub fn from_child_markers(

--- a/sqlfluffrs/sqlfluffrs_types/src/marker.rs
+++ b/sqlfluffrs/sqlfluffrs_types/src/marker.rs
@@ -177,7 +177,15 @@ impl PositionMarker {
 
     #[must_use]
     pub fn from_points(start_marker: &PositionMarker, end_marker: &PositionMarker) -> Self {
-        if start_marker.templated_file != end_marker.templated_file {
+        // Markers within one parse almost always share the same underlying
+        // `Arc` allocation, so check that cheaply first. Only fall back to
+        // `TemplatedFile`'s derived `PartialEq` (an O(file size) comparison)
+        // when the pointers differ, so two markers backed by distinct but
+        // content-identical `Arc<TemplatedFile>` allocations still compare
+        // equal, matching the pre-pointer-comparison behavior.
+        if !Arc::ptr_eq(&start_marker.templated_file, &end_marker.templated_file)
+            && start_marker.templated_file != end_marker.templated_file
+        {
             panic!("Markers must refer to the same templated file.");
         }
 
@@ -205,11 +213,17 @@ impl PositionMarker {
             templated_start = templated_start.min(marker.templated_slice.start);
             templated_stop = templated_stop.max(marker.templated_slice.stop);
 
-            if templated_file.is_none() {
-                templated_file = Some(marker.templated_file.clone());
-            }
-            if templated_file.as_ref() != Some(&marker.templated_file) {
-                panic!("Markers must refer to the same templated file.");
+            match &templated_file {
+                None => templated_file = Some(marker.templated_file.clone()),
+                // Pointer-eq fast path with value-eq fallback: see the
+                // comment in `from_points` above.
+                Some(tf)
+                    if !Arc::ptr_eq(tf, &marker.templated_file)
+                        && *tf != marker.templated_file =>
+                {
+                    panic!("Markers must refer to the same templated file.");
+                }
+                Some(_) => {}
             }
         }
 

--- a/sqlfluffrs/sqlfluffrs_types/src/marker.rs
+++ b/sqlfluffrs/sqlfluffrs_types/src/marker.rs
@@ -218,8 +218,7 @@ impl PositionMarker {
                 // Pointer-eq fast path with value-eq fallback: see the
                 // comment in `from_points` above.
                 Some(tf)
-                    if !Arc::ptr_eq(tf, &marker.templated_file)
-                        && *tf != marker.templated_file =>
+                    if !Arc::ptr_eq(tf, &marker.templated_file) && *tf != marker.templated_file =>
                 {
                     panic!("Markers must refer to the same templated file.");
                 }

--- a/sqlfluffrs/sqlfluffrs_types/src/templater/templatefile.rs
+++ b/sqlfluffrs/sqlfluffrs_types/src/templater/templatefile.rs
@@ -5,6 +5,11 @@ use crate::slice::Slice;
 
 use super::fileslice::{RawFileSlice, TemplatedFileSlice};
 
+// `PartialEq` here is a full structural comparison across every field,
+// including `source_str` and `templated_str`. Callers holding an
+// `Arc<TemplatedFile>` should compare with `Arc::ptr_eq` instead of `==`
+// wherever the two markers are expected to originate from the same parse;
+// see `PositionMarker::from_points` in sqlfluffrs_types/src/marker.rs.
 #[derive(Debug, PartialEq, Clone, Hash)]
 pub struct TemplatedFile {
     pub source_str: String,


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
* `PositionMarker::from_points` and `PositionMarker::from_child_markers` compared two `Arc<TemplatedFile>` values with `!=`, which recurses into `TemplatedFile`'s derived `PartialEq` and deep compares every field (`source_str`, `templated_str`, slices) on each call.
* `from_child_markers` runs once per non leaf tree node, so on a large file this touched the whole underlying byte buffer on every node built, showing up as the majority of `apply_as_tree`'s cost.
* Both call sites now check `Arc::ptr_eq` first (the fast path taken on every real parse, since markers within one parse always share the same allocation) and only fall back to the full value comparison when the pointers differ, so the  perf win is essentially free while still accepting content identical markers backed by separate allocations, exactly as before.                                                                                                                                                                                                                                                                                                                                                           

## Performance
| Benchmark | Before | After | Improvement |
|---|---|---|---|
| Athena (991,723B, `mean`) | 28,536.4ms | 8,374.1ms | 70.6% reduction (3.4x faster) |
| TPC-H suite (22 queries, `mean`) | 564.9ms | 465.9ms | 17.5% reduction |
| TPC-DS suite (99 queries, `mean`) | 3,671.7ms | 3,339.0ms | 9.1% reduction |

On Athena, `apply_as_tree` alone drops from 20,703.8ms (78.4% of stages) to 482.7ms (7.4% of stages), about 43x faster. The effect scales with file size, which is why the smaller TPC queries show smaller but still real gains. 

### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [ ] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speed up marker merging by comparing `Arc<TemplatedFile>` by pointer in `PositionMarker` constructors, avoiding deep value comparisons and cutting parse time on large files.

- **Performance**
  - `PositionMarker::from_points` and `from_child_markers` now use `Arc::ptr_eq` with a value-equality fallback, eliminating O(file-size) comparisons on each merge.
  - Athena (991,723B, parse mean): 28,536.4ms → 8,374.1ms (−70.6%, ~3.4x). `apply_as_tree`: 20,703.8ms → 482.7ms (~43x).
  - TPC-H suite mean: 564.9ms → 465.9ms (−17.5%). TPC-DS suite mean: 3,671.7ms → 3,339.0ms (−9.1%).
  - Behavior unchanged: identical-content files backed by distinct allocations still compare equal. Python layer: pointer identity flows via `PY_TEMPLATED_FILE_CACHE`; fallback handles uncached cases.

<sup>Written for commit 864632aaab8120c76f46788b38cafce20063557f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8078?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



