### PR TITLE
perf(python): avoid deep-copying dialect_obj/templater_obj in FluffConfig.copy

### DIFF
--- a/src/sqlfluff/core/config/fluffconfig.py
+++ b/src/sqlfluff/core/config/fluffconfig.py
@@ -260,16 +260,19 @@ class FluffConfig:
             :obj:`FluffConfig`: A shallow copy of this config object but with
             a deep copy of the internal ``_configs`` dict.
         """
-        configs_attribute_copy = deepcopy(self._configs)
+        core = self._configs["core"]
+        # `dialect_obj` and `templater_obj` are large, effectively immutable
+        # (never reassigned in place after construction) and safe to share
+        # across copies. `dialect_obj` in particular is a fully expanded
+        # grammar object graph, so deep-copying it on every `.copy()` call
+        # (i.e. on every parse) would dominate parse time. Seed deepcopy's
+        # memo so it reuses these references instead of duplicating them.
+        shared = (core.get("dialect_obj"), core.get("templater_obj"))
+        memo = {id(obj): obj for obj in shared if obj is not None}
+        configs_attribute_copy = deepcopy(self._configs, memo)
+
         config_copy = copy(self)
         config_copy._configs = configs_attribute_copy
-        # During the initial `.copy()`, we use the same `__reduce__()` method
-        # which is used during pickling. The `templater_obj` doesn't pickle
-        # well so is normally removed, but it's ok for us to just pass across
-        # the original object here as we're in the same process.
-        configs_attribute_copy["core"]["templater_obj"] = self._configs["core"][
-            "templater_obj"
-        ]
         return config_copy
 
     @classmethod


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
`FluffConfig.copy()` deep-copied the entire `_configs` dict on every call, including `core["dialect_obj"]`, i.e. a fully expanded `Dialect` grammar object graph that's never mutated after construction. Since `copy()` runs on every `Linter.parse_string()` call, duplicating that grammar was the dominant cost of every parse.

This shows up in two scenarios:
- **A single, long-lived `Linter` parsing many SQL strings**, e.g. linting a project's files in one process. `dialect_obj` never changes between calls, so every `parse_string()` call deep-copied the same grammar graph from scratch, then discarded the copy.
- **Many short-lived `Linter`/config instances, each parsing once**, e.g. a test suite building a fresh `FluffConfig` per case. There's no reuse to amortize: each case builds its own dialect object, then `lint_string()` → `parse_string()` → one `.copy()`, deep-copying the graph it just built, only to discard it moments later. Multiply that one wasted copy by thousands of cases and the waste adds up just as much as the shared-`Linter` scenario.
  
```powershell
test/rules/yaml_test_cases_test.py
Before: 2249 passed in 136.78s (0:02:16)
After:  2249 passed in 63.67s  (0:01:03)
```
~2.1x faster. Any code path that goes through `Linter.parse_string()` benefits equally, i.e. `lint_string`, `fix_string`, the public `sqlfluff` API, and the CLI. Paths that call `Linter.parse_rendered()` directly (e.g. the bulk dialect fixture tests) are unaffected, since they never hit `FluffConfig.copy()`.

### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [ ] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Avoid deep-copying `dialect_obj` and `templater_obj` in `FluffConfig.copy()` by reusing the same instances, significantly speeding up parsing (e.g., test suite ~2.1x faster). Improves all paths that call `Linter.parse_string()`; `parse_rendered()` is unchanged.

- **Refactors**
  - Seed `deepcopy` memo with `core["dialect_obj"]` and `core["templater_obj"]` so copies share these effectively immutable objects.
  - Removed the post-copy `templater_obj` reassignment; behavior is unchanged.

<sup>Written for commit 3b75cef5cec3c37fd651019b2966e0d86f08bece. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8079?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

