### PR TITLE
Fix Oracle SQLPlus SET SCAN parsing

### DIFF
--- a/src/sqlfluff/dialects/dialect_oracle.py
+++ b/src/sqlfluff/dialects/dialect_oracle.py
@@ -1214,6 +1214,7 @@ class StatementSegment(ansi.StatementSegment):
     match_grammar = ansi.StatementSegment.match_grammar.copy(
         insert=[
             Ref("CommentStatementSegment"),
+            Ref("SqlplusSetStatementSegment"),
             Ref("CreateProcedureStatementSegment"),
             Ref("DropProcedureStatementSegment"),
             Ref("AlterFunctionStatementSegment"),
@@ -1443,6 +1444,16 @@ class SlashBufferExecutorSegment(BaseSegment):
 
     type = "slash_buffer_executor"
     match_grammar = Ref("SlashSegment")
+
+
+class SqlplusSetStatementSegment(BaseSegment):
+    """A SQL*Plus `SET` command."""
+
+    type = "sqlplus_set_statement"
+
+    match_grammar = Sequence(
+        "SET", StringParser("SCAN", WordSegment, type="keyword"), OneOf("ON", "OFF")
+    )
 
 
 class CommentStatementSegment(BaseSegment):

--- a/src/sqlfluff/dialects/dialect_oracle.py
+++ b/src/sqlfluff/dialects/dialect_oracle.py
@@ -1214,7 +1214,6 @@ class StatementSegment(ansi.StatementSegment):
     match_grammar = ansi.StatementSegment.match_grammar.copy(
         insert=[
             Ref("CommentStatementSegment"),
-            Ref("SqlplusSetStatementSegment"),
             Ref("CreateProcedureStatementSegment"),
             Ref("DropProcedureStatementSegment"),
             Ref("AlterFunctionStatementSegment"),
@@ -1428,7 +1427,10 @@ class BatchSegment(BaseSegment):
     match_grammar = OneOf(
         Sequence(
             Delimited(
-                Ref("StatementSegment"),
+                OneOf(
+                    Ref("SqlplusSetStatementSegment"),
+                    Ref("StatementSegment"),
+                ),
                 delimiter=AnyNumberOf(Ref("DelimiterGrammar"), min_times=1),
                 allow_gaps=True,
                 allow_trailing=True,

--- a/test/fixtures/dialects/oracle/sqlplus_commands.sql
+++ b/test/fixtures/dialects/oracle/sqlplus_commands.sql
@@ -1,4 +1,5 @@
 PROMPT this is an Oracle SQL newline delimited prompt statement
+SET SCAN OFF
 ACCEPT var
 ACC short_var
 ACCEPT myvar PROMPT 'Enter value; then press Enter'

--- a/test/fixtures/dialects/oracle/sqlplus_commands.yml
+++ b/test/fixtures/dialects/oracle/sqlplus_commands.yml
@@ -3,8 +3,14 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 361f354f6d9b4a8d3e9551a4b8ffc3652cf9762ed4cca607a3a43e9cdd563386
+_hash: 93453499c9db02df938602747fa344839c3f03a052be2abf2fe0f7727e5261a9
 file:
+- batch:
+    statement:
+      sqlplus_set_statement:
+      - keyword: SET
+      - keyword: SCAN
+      - keyword: 'OFF'
 - batch:
   - statement:
       select_statement:

--- a/test/fixtures/dialects/oracle/sqlplus_commands.yml
+++ b/test/fixtures/dialects/oracle/sqlplus_commands.yml
@@ -3,14 +3,13 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 93453499c9db02df938602747fa344839c3f03a052be2abf2fe0f7727e5261a9
+_hash: f4622cac6ef80428f0380680fc769014144b40723d2be04a835c1deb1fe1991d
 file:
 - batch:
-    statement:
-      sqlplus_set_statement:
-      - keyword: SET
-      - keyword: SCAN
-      - keyword: 'OFF'
+    sqlplus_set_statement:
+    - keyword: SET
+    - keyword: SCAN
+    - keyword: 'OFF'
 - batch:
   - statement:
       select_statement:


### PR DESCRIPTION
Fixes #8073.

This change adds narrow Oracle SQL*Plus parsing support for `SET SCAN ON|OFF`, so `SET SCAN OFF` parses successfully in the Oracle dialect.

The fix is grammar-only and avoids adding broad lexer matching for `SET`, preserving normal SQL usage such as `UPDATE ... SET ...` and `ALTER SESSION SET ...`.

Validation:
- `python test/generate_parse_fixture_yml.py -d oracle`
- `python -m pytest test/dialects/dialects_test.py -k "oracle and sqlplus_commands"`
- `python -m pytest test/dialects/dialects_test.py -k oracle`
- `ruff check src/sqlfluff/dialects/dialect_oracle.py`
- `ruff format --check src/sqlfluff/dialects/dialect_oracle.py`
- `git diff --check -- src/sqlfluff/dialects/dialect_oracle.py test/fixtures/dialects/oracle/sqlplus_commands.sql test/fixtures/dialects/oracle/sqlplus_commands.yml`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #8073. Adds Oracle SQL*Plus parsing for SET SCAN ON|OFF and treats it as a top-level command so scripts with SET SCAN OFF parse correctly in the Oracle dialect.

- **Bug Fixes**
  - Introduces `SqlplusSetStatementSegment` and wires it into the batch grammar as a top-level segment.
  - Avoids broad lexer changes to keep normal `SET` usage (e.g., UPDATE ... SET ..., ALTER SESSION SET ...) unaffected.

<sup>Written for commit aadf56c04182cf6a7d320faa8b70234dededeb42. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8081?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

