### PR TITLE
docs(parser): correct min_delimiters type and default in Delimited docstring

### DIFF
--- a/src/sqlfluff/core/parser/grammar/delimited.py
+++ b/src/sqlfluff/core/parser/grammar/delimited.py
@@ -61,8 +61,8 @@ class Delimited(OneOf):
                 Defaults to ().
             reset_terminators (bool, optional): Flag indicating whether terminators
                 should be reset. Defaults to False.
-            min_delimiters (Optional[int], optional): Minimum number of delimiters to
-                match. Defaults to None.
+            min_delimiters (int, optional): Minimum number of delimiters to
+                match. Defaults to 0.
             bracket_pairs_set (str, optional): Name of the bracket pairs set. Defaults
                 to "bracket_pairs".
             allow_gaps (bool, optional): Flag indicating whether gaps between segments


### PR DESCRIPTION

### Brief summary of the change made

The `Delimited.__init__` Args docstring documented `min_delimiters` as
`(Optional[int], optional): ... Defaults to None.`, but the parameter's
signature is `min_delimiters: int = 0`. The value is stored as-is and then used
directly in a numeric comparison (`if delimiters < self.min_delimiters:`), so a
`None` value would raise `TypeError` and was never a valid input. This updates
the docstring to `(int, optional): ... Defaults to 0.` so the documented
contract matches the code.

Docs-only change to a single Args entry in
`src/sqlfluff/core/parser/grammar/delimited.py`; no behavior change. This is a
correctness fix with no tracked issue.

### Are there any other side effects of this change that we should be aware of?

None. The change touches two lines of a docstring only. The signature, stored
attribute, and comparison logic are unchanged, and every caller already passes
an `int` (dialects pass `min_delimiters=0` / `min_delimiters=1`). The `Optional`
import in the module stays in use (`delimiter_match: Optional[MatchResult]`), so
no imports are added or removed.


- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other: not applicable. This is a docstring-only correctness fix with no code-behavior change, so no test case demonstrates it. The existing `test/core/parser/grammar/grammar_other_test.py` (32 passing) already covers `min_delimiters` behavior, and `ruff check` (which includes pydocstyle) stays green.
- [x] Added appropriate documentation for the change (the change *is* the documentation fix).
- Created GitHub issues for any relevant followup/future enhancements if appropriate: none needed.

---

## The diff

```diff
diff --git a/src/sqlfluff/core/parser/grammar/delimited.py b/src/sqlfluff/core/parser/grammar/delimited.py
index 9f1ff952..8756edf3 100644
--- a/src/sqlfluff/core/parser/grammar/delimited.py
+++ b/src/sqlfluff/core/parser/grammar/delimited.py
@@ -61,8 +61,8 @@ class Delimited(OneOf):
                 Defaults to ().
             reset_terminators (bool, optional): Flag indicating whether terminators
                 should be reset. Defaults to False.
-            min_delimiters (Optional[int], optional): Minimum number of delimiters to
-                match. Defaults to None.
+            min_delimiters (int, optional): Minimum number of delimiters to
+                match. Defaults to 0.
             bracket_pairs_set (str, optional): Name of the bracket pairs set. Defaults
                 to "bracket_pairs".
             allow_gaps (bool, optional): Flag indicating whether gaps between segments
```


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrects the `Delimited.__init__` Args docstring to document `min_delimiters` as `int` with default `0`, matching the signature and usage. Docs-only change; no behavior impact.

<sup>Written for commit 49359f76162e085fe351b5c1171c82f1c592b99b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8082?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

