### PR TITLE
docs(cli): correct fix --quiet help note about --force

### DIFF
--- a/src/sqlfluff/cli/commands.py
+++ b/src/sqlfluff/cli/commands.py
@@ -1292,8 +1292,8 @@ def _paths_fix(
     is_flag=True,
     help=(
         "Reduces the amount of output to stdout to a minimal level. "
-        "This is effectively the opposite of -v. NOTE: It will only "
-        "take effect if -f/--force is also set."
+        "This is effectively the opposite of -v. NOTE: It cannot be "
+        "used together with -v/--verbose."
     ),
 )
 @click.option(


### PR DESCRIPTION
### Brief summary of the change made

The `-q/--quiet` help for the `fix` command currently ends with:

> NOTE: It will only take effect if -f/--force is also set.

That note is no longer accurate:

- `--quiet` takes effect based solely on `--verbose` not being set. In the `fix` command body it errors out and exits if both `--quiet` and `--verbose` are given, and otherwise forces verbosity to `-1`; there is no dependence on `--force`.
- `--force` has been a deprecated no-op since 3.0, so gating `--quiet` on it would make no sense even if the code still did.

You can see the mismatch directly: `sqlfluff fix -q --dialect ansi -` (no `--force`) already reduces output and applies fixes, which the old note says should not happen.

This updates the note to describe the actual guard: `--quiet` cannot be used together with `-v/--verbose`. Help-text only, no behavior change.

### Are there any other side effects of this change that we should be aware of?

None. This changes two lines inside a single Click `help=` string literal for the `fix` command's `--quiet` option. There is no code-path, behavior, or public API change, and no other command or option is touched.

- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - [x] Other: this is a help-string correction with no behavior change, so no new test is added. The described behavior is already covered by existing tests in `test/cli/commands_test.py`: `test__cli__fix_multiple_errors_quiet_force` and `test__cli__fix_multiple_errors_quiet_check` both invoke `fix --quiet` without `--force` and assert fixes are applied, and the `fix --quiet --verbose` case in `test__cli__command_lint_parse_with_retcode` asserts the exit code 2 guard that the corrected note describes.
- [x] Added appropriate documentation for the change. (The change is itself the documentation fix; no separate docs page references this note.)
- [x] Created GitHub issues for any relevant followup/future enhancements if appropriate. (Not applicable.)
