### PR TITLE
perf(linter): dedupe source patches with a set, not a list

### DIFF
--- a/src/sqlfluff/core/linter/patch.py
+++ b/src/sqlfluff/core/linter/patch.py
@@ -282,7 +282,7 @@ def generate_source_patches(
     # Iterate patches, filtering and translating as we go:
     linter_logger.debug("### Beginning Patch Iteration.")
     filtered_source_patches = []
-    dedupe_buffer = []
+    dedupe_buffer: set[tuple[tuple[int, int], str]] = set()
     # We use enumerate so that we get an index for each patch. This is entirely
     # so when debugging logs we can find a given patch again!
     for idx, patch in enumerate(
@@ -292,10 +292,11 @@ def generate_source_patches(
         _log_hints(patch, templated_file)
 
         # Check for duplicates
-        if patch.dedupe_tuple() in dedupe_buffer:
+        dedupe_tuple = patch.dedupe_tuple()
+        if dedupe_tuple in dedupe_buffer:
             linter_logger.info(
                 "      - Skipping. Source space Duplicate: %s",
-                patch.dedupe_tuple(),
+                dedupe_tuple,
             )
             continue
 
@@ -315,14 +316,14 @@ def generate_source_patches(
                 "      * Keeping patch on new or literal-only section.",
             )
             filtered_source_patches.append(patch)
-            dedupe_buffer.append(patch.dedupe_tuple())
+            dedupe_buffer.add(dedupe_tuple)
         # Handle the easy case of an explicit source fix
         elif patch.patch_category == "source":
             linter_logger.info(
                 "      * Keeping explicit source fix patch.",
             )
             filtered_source_patches.append(patch)
-            dedupe_buffer.append(patch.dedupe_tuple())
+            dedupe_buffer.add(dedupe_tuple)
         # Is it a zero length patch.
         elif (
             patch.source_slice.start == patch.source_slice.stop
@@ -332,7 +333,7 @@ def generate_source_patches(
                 "      * Keeping insertion patch on slice boundary.",
             )
             filtered_source_patches.append(patch)
-            dedupe_buffer.append(patch.dedupe_tuple())
+            dedupe_buffer.add(dedupe_tuple)
         else:  # pragma: no cover
             # We've got a situation where the ends of our patch need to be
             # more carefully mapped. This used to happen with greedy template


### PR DESCRIPTION

### Brief summary of the change made

`generate_source_patches` (in `src/sqlfluff/core/linter/patch.py`) deduplicates the
`FixPatch` objects yielded during `sqlfluff fix` by keeping seen keys in a Python
**list** and testing membership with `if patch.dedupe_tuple() in dedupe_buffer`.
List membership is a linear scan, so the dedupe is O(n^2) in the number of patches,
and `dedupe_tuple()` was recomputed several times per kept patch.

This switches the dedupe buffer to a **set** (O(1) membership) and computes
`dedupe_tuple()` once per patch, reusing it for the skip log and the three keep
branches.

The sibling function in the same module, `merge_source_patches`, already performs
the identical source-space dedupe with a set
(`dedupe_buffer: set[tuple[tuple[int, int], str]] = set()`), so this also makes the
two functions consistent. `FixPatch.dedupe_tuple()` returns a hashable
`(tuple[int, int], str)`, so this is a drop-in change: the same patches are kept,
skipped, and returned in the same sorted order.

### Are there any other side effects of this change that we should be aware of?

None. This is behavior-preserving. List `in` and set `in` both test value equality,
`dedupe_tuple()` is pure, and the keep/skip branches and the final
`sorted(..., key=lambda x: x.source_slice.start)` are unchanged. The only difference
is the data structure used for deduplication and not recomputing `dedupe_tuple()`.
The affected lines are already exercised by the existing fix/auto-fix suites
(`test/core/linter/` and `test/rules/std_fix_auto_test.py`).


- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - No new test cases. This is a behavior-preserving performance/consistency change
    with no observable output difference, so there is nothing new to assert. The
    changed lines are covered by the existing `test/core/linter/` and
    `test/rules/std_fix_auto_test.py` suites (patch.py stays at 98% coverage, all
    changed lines covered). The set-based sibling `merge_source_patches` (#7808)
    shipped with no timing test; a micro-benchmark here would be flaky and
    non-idiomatic.
- [x] Added appropriate documentation for the change. (N/A - internal helper, no
  user-facing docs affected.)
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
  (None needed.)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch `generate_source_patches` to use a `set` for deduping and cache `dedupe_tuple()` per patch to remove the O(n^2) overhead. Behavior is unchanged and output order stays the same, matching `merge_source_patches`.

- **Refactors**
  - Replaced list buffer with `set[tuple[tuple[int, int], str]]` for O(1) membership checks.
  - Compute `dedupe_tuple()` once per patch and reuse in logs and adds.
  - Keeps the same kept/skipped patches and final sorted order; consistent with `merge_source_patches`.

<sup>Written for commit 94c6be626d437bc196fcd2243ad35203b8393435. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8084?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

