### PR TITLE
TSQL: restore normalization kwargs on the patched single_quote lexer (RF05 false positive on quoted aliases)

### DIFF
--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -275,11 +275,21 @@ tsql_dialect.insert_lexer_matchers(
 
 tsql_dialect.patch_lexer_matchers(
     [
-        # Patching single_quote to allow for TSQL-style escaped quotes
+        # Patching single_quote to allow for TSQL-style escaped quotes.
+        # segment_kwargs mirror the ansi single_quote lexer so that
+        # raw_normalized() still strips the delimiters and unescapes, minus
+        # the backslash escapes which T-SQL does not have ('' is the only
+        # escape). Without them, rules comparing normalized identifiers
+        # (e.g. RF05 on a single-quoted alias) see the delimiters as part
+        # of the name.
         RegexLexer(
             "single_quote",
             r"'([^']|'')*'",
             CodeSegment,
+            segment_kwargs={
+                "quoted_value": (r"'((?:[^']|'')*)'", 1),
+                "escape_replacements": [(r"''", "'")],
+            },
         ),
         # Patching comments to remove hash comments
         RegexLexer(

--- a/test/fixtures/rules/std_rule_cases/RF05.yml
+++ b/test/fixtures/rules/std_rule_cases/RF05.yml
@@ -502,3 +502,25 @@ test_pass_pivot_snowflake_complex:
   configs:
     core:
       dialect: snowflake
+
+test_pass_tsql_single_quoted_alias:
+  # https://github.com/sqlfluff/sqlfluff/issues/6733
+  # The quote delimiters of a single-quoted alias are not special characters
+  # in the identifier itself.
+  pass_str: |
+    select
+        r.c.value('column[1]', 'varchar(10)') as 'Value'
+    from @xml.nodes('/rows/row') as r (c);
+  configs:
+    core:
+      dialect: tsql
+
+test_fail_tsql_single_quoted_alias_special_chars:
+  # A genuinely special character inside a single-quoted alias still fails.
+  fail_str: |
+    select
+        r.c.value('column[1]', 'varchar(10)') as 'Va lue'
+    from @xml.nodes('/rows/row') as r (c);
+  configs:
+    core:
+      dialect: tsql


### PR DESCRIPTION
### Brief summary of the change made

Makes progress on #6733 (the RF05 half; the LT01 spacing half will follow separately, as discussed on the issue).

RF05 fired on a legal single-quoted T-SQL alias:

```sql
select
    r.c.value('column[1]', 'varchar(10)') as 'Value'
from @xml.nodes('/rows/row') as r (c);
```

flagging the quote delimiters themselves as special characters. Root cause is one level below the rule: the tsql dialect patches the `single_quote` lexer (for `''` escapes) but the patch dropped the `segment_kwargs` the ansi lexer carries, so `quoted_value` was `None` and `raw_normalized()` returned the value with delimiters attached for every tsql single-quoted token:

```
ansi "Value"  ->  _raw_value 'Value'
tsql 'Value'  ->  _raw_value "'Value'"   (before this change)
```

The fix restores the kwargs on the patched lexer, with T-SQL escaping semantics: `''` is the only escape, no backslash escapes. After the change `'Value'` normalizes to `Value` and `'it''s'` to `it's`.

Two RF05 test cases added: the single-quoted alias from the issue now passes, and an alias with a genuinely special character (`'Va lue'`) still fails, so the rule keeps catching what it should.

### Are there any other side effects of this change that we should be aware of?

`_raw_value` / `raw_normalized()` now return stripped, unescaped values for all tsql single-quoted tokens (literals as well as identifiers), matching how every other dialect behaves. Parse trees and fixture YMLs are unchanged (`raw` is untouched). Full test evidence: the 545 tsql dialect fixtures pass unregenerated, and the whole rules suite passes (2413 passed, 39 skipped).

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes RF05 false positive on T-SQL single-quoted aliases by restoring normalization on the patched `single_quote` lexer. Normalization now strips quotes and unescapes `''`, matching other dialects.

- **Bug Fixes**
  - Re-added `segment_kwargs` to the T-SQL `single_quote` lexer; support only `''` escapes (no backslash).
  - `'Value'` → `Value`, `'it''s'` → `it's`; RF05 no longer treats quote delimiters as part of the name.
  - Added two RF05 tests: passing single-quoted alias; failing alias with a real special character.

<sup>Written for commit 71d1451bc1e62b1a96468aed7b1dd001117a4c0b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8088?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

