### PR TITLE
perf: avoid quadratic tuple concatenation when applying match results

### DIFF
--- a/src/sqlfluff/core/parser/match_result.py
+++ b/src/sqlfluff/core/parser/match_result.py
@@ -208,7 +208,14 @@ class MatchResult:
         and any inserts. If there are overlaps, then we have a problem, and we
         should abort.
         """
-        result_segments: tuple["BaseSegment", ...] = ()
+        # NOTE: Accumulate into a list and build the tuple once at the end.
+        # `tuple += ...` looks equivalent but isn't: tuples are immutable, so
+        # each `+=` allocates a new tuple and copies everything accumulated
+        # so far, making a loop of N appends O(N^2). A list amortises
+        # appends/extends to O(N), which matters here since this runs at
+        # every level of a potentially large tree (e.g. long column/UNION/IN
+        # lists produce nodes with many trigger locations).
+        result_segments_list: list["BaseSegment"] = []
         if not slice_length(self.matched_slice):
             assert not self.matched_class, (
                 "Tried to apply zero length MatchResult with "
@@ -230,8 +237,8 @@ class MatchResult:
                     _pos = _get_point_pos_at_idx(segments, idx)
                     if parse_context:
                         parse_context.increment_parse_nodes()
-                    result_segments += (seg(pos_marker=_pos),)
-            return result_segments
+                    result_segments_list.append(seg(pos_marker=_pos))
+            return tuple(result_segments_list)
 
         assert len(segments) >= self.matched_slice.stop, (
             f"Matched slice ({self.matched_slice}) sits outside segment "
@@ -255,7 +262,7 @@ class MatchResult:
             # Have we passed any untouched segments?
             if idx > max_idx:
                 # If so, add them in unchanged.
-                result_segments += segments[max_idx:idx]
+                result_segments_list.extend(segments[max_idx:idx])
                 max_idx = idx
             elif idx < max_idx:  # pragma: no cover
                 raise ValueError(
@@ -267,8 +274,8 @@ class MatchResult:
             for trigger in trigger_locs[idx]:
                 # If it's a match, apply it.
                 if isinstance(trigger, MatchResult):
-                    result_segments += trigger.apply(
-                        segments=segments, parse_context=parse_context
+                    result_segments_list.extend(
+                        trigger.apply(segments=segments, parse_context=parse_context)
                     )
                     # Update the end slice.
                     max_idx = trigger.matched_slice.stop
@@ -277,12 +284,14 @@ class MatchResult:
                 # Otherwise it's a segment.
                 # Get the location from the next segment unless there isn't one.
                 _pos = _get_point_pos_at_idx(segments, idx)
-                result_segments += (trigger(pos_marker=_pos),)
+                result_segments_list.append(trigger(pos_marker=_pos))
 
         # If we finish working through the triggers and there's
         # still something left, then add that too.
         if max_idx < self.matched_slice.stop:
-            result_segments += segments[max_idx : self.matched_slice.stop]
+            result_segments_list.extend(segments[max_idx : self.matched_slice.stop])
+
+        result_segments = tuple(result_segments_list)
 
         if not self.matched_class:
             return result_segments

--- a/src/sqlfluff/core/parser/rust_parser.py
+++ b/src/sqlfluff/core/parser/rust_parser.py
@@ -561,7 +561,14 @@ try:
                 rs_match
             )
 
-            result_segments: tuple[BaseSegment, ...] = ()
+            # NOTE: Accumulate into a list and build the tuple once at the end.
+            # `tuple += ...` looks equivalent but isn't: tuples are immutable,
+            # so each `+=` allocates a new tuple and copies everything
+            # accumulated so far, making a loop of N appends O(N^2). A list
+            # amortises appends/extends to O(N), which matters here since this
+            # runs at every level of a potentially large tree (e.g. long
+            # column/UNION/IN lists produce nodes with many trigger locations).
+            result_segments_list: list[BaseSegment] = []
 
             # Zero-length match: only meta inserts are valid (mirrors apply()).
             if start == stop:
@@ -572,8 +579,8 @@ try:
                     )
                     _pos = _get_point_pos_at_idx(segments, idx)
                     parse_context.increment_parse_nodes()
-                    result_segments += (seg(pos_marker=_pos),)
-                return result_segments
+                    result_segments_list.append(seg(pos_marker=_pos))
+                return tuple(result_segments_list)
 
             # Merge inserts (added first) and child matches into trigger locations.
             trigger_locs: defaultdict[int, list[Union["RsMatchResult", type]]] = (
@@ -588,7 +595,7 @@ try:
             for idx in sorted(trigger_locs):
                 # Include any untouched segments before this trigger.
                 if idx > max_idx:
-                    result_segments += tuple(segments[max_idx:idx])
+                    result_segments_list.extend(segments[max_idx:idx])
                     max_idx = idx
                 elif idx < max_idx:  # pragma: no cover
                     # An outer match contains overlapping child matches: the
@@ -604,17 +611,21 @@ try:
                         # NOTE: apply() does not count meta inserts here (only in
                         # the zero-length branch above), so neither do we.
                         _pos = _get_point_pos_at_idx(segments, idx)
-                        result_segments += (trigger(pos_marker=_pos),)
+                        result_segments_list.append(trigger(pos_marker=_pos))
                     else:
                         # A child match - recurse and advance past it.
-                        result_segments += self._apply_rs_match_result(
-                            trigger, segments, parse_context
+                        result_segments_list.extend(
+                            self._apply_rs_match_result(
+                                trigger, segments, parse_context
+                            )
                         )
                         max_idx = trigger.matched_slice[1]
 
             # Anything left after the last trigger.
             if max_idx < stop:
-                result_segments += tuple(segments[max_idx:stop])
+                result_segments_list.extend(segments[max_idx:stop])
+
+            result_segments = tuple(result_segments_list)
 
             if not matched_class:
                 return result_segments


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
Both tree-building paths - MatchResult.apply() (the default) and RustParser._apply_rs_match_result (the experimental native-AST path) - built their result segment list via repeated `tuple_var += ...` inside a loop over trigger locations/children. Tuples are immutable, so each `+=` allocates a new tuple and copies everything accumulated so far: a loop of N appends is O(N^2), not O(N).

Fixed in both by accumulating into a plain list (O(1) amortised append/extend) and building the tuple once at the end. Purely mechanical, correctness-neutral - same algorithm, same output.

Parsing this pathological wide/flat SQL (20,000-column SELECT list + 20,000-value IN (...) list drops from 34s to 8s parsing time.
```sql
SELECT
    col_0,
    ...,
    col_19999
FROM wide_table
WHERE col_0 IN (0, ..., 19999);
```

### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [ ] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Avoided quadratic tuple concatenation when applying match results to speed up parse tree building. Parsing wide/flat SQL drops from 34s to 8s in a 20k-column/IN-list case.

- **Refactors**
  - Replaced repeated tuple concatenation with list accumulation and a final tuple build in `MatchResult.apply()` and `RustParser._apply_rs_match_result`.
  - Preserves behavior; reduces append complexity from O(N^2) to O(N), improving performance on large nodes.

<sup>Written for commit 33fd549598fb888662c5b8f283e2daef2157e748. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8089?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

