### PR TITLE
perf: convert PositionMarker from a frozen dataclass to a plain __slots__ class

### DIFF
--- a/src/sqlfluff/core/parser/markers.py
+++ b/src/sqlfluff/core/parser/markers.py
@@ -4,7 +4,6 @@ This class is a construct to keep track of positions within a file.
 """
 
 from collections.abc import Sequence
-from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Optional
 
 from sqlfluff.core.helpers.slice import zero_slice
@@ -14,7 +13,6 @@ if TYPE_CHECKING:  # pragma: no cover
     from sqlfluffrs import RsPositionMarker
 
 
-@dataclass(frozen=True)
 class PositionMarker:
     """A reference to a position in a file.
 
@@ -29,28 +27,57 @@ class PositionMarker:
         - Positions within the fixed file are identified with a line number and line
           position, which identify a point.
         - Arithmetic comparisons are on the location in the fixed file.
+
+    NOTE: This used to be a frozen dataclass. One is constructed per lexed
+    token, so it's on a hot path: frozen dataclasses generate an __init__
+    that calls object.__setattr__() once per field (required because normal
+    assignment is blocked on a frozen instance), which is considerably
+    slower than plain attribute assignment on an ordinary class. Nothing
+    in the codebase relies on instances being hashable, immutable-by-
+    enforcement, or constructed via dataclass-specific machinery (e.g.
+    dataclasses.replace), so a hand-written __init__ with plain assignment
+    is safe and meaningfully cheaper to construct.
     """
 
-    source_slice: slice
-    templated_slice: slice
-    templated_file: "TemplatedFile"
-    # If not set, these will be initialised in the post init.
-    working_line_no: int = -1
-    working_line_pos: int = -1
+    __slots__ = (
+        "source_slice",
+        "templated_slice",
+        "templated_file",
+        "working_line_no",
+        "working_line_pos",
+    )
 
-    def __post_init__(self) -> None:
-        # If the working position has not been explicitly set
-        # then infer it from the position in the templated file.
-        # This is accurate up until the point that any fixes have
-        # been applied.
-        if self.working_line_no == -1 or self.working_line_pos == -1:
-            line_no, line_pos = self.templated_position()
-            # Use the base method because we're working with a frozen class
-            object.__setattr__(self, "working_line_no", line_no)
-            object.__setattr__(self, "working_line_pos", line_pos)
+    def __init__(
+        self,
+        source_slice: slice,
+        templated_slice: slice,
+        templated_file: "TemplatedFile",
+        # If not set, these will be inferred below.
+        working_line_no: int = -1,
+        working_line_pos: int = -1,
+    ) -> None:
+        self.source_slice = source_slice
+        self.templated_slice = templated_slice
+        self.templated_file = templated_file
+        # If the working position has not been explicitly set then infer it
+        # from the position in the templated file. This is accurate up until
+        # the point that any fixes have been applied.
+        if working_line_no == -1 or working_line_pos == -1:
+            working_line_no, working_line_pos = self.templated_position()
+        self.working_line_no = working_line_no
+        self.working_line_pos = working_line_pos
 
     def __str__(self) -> str:
         return self.to_source_string()
+
+    def __repr__(self) -> str:
+        return (
+            f"PositionMarker(source_slice={self.source_slice!r}, "
+            f"templated_slice={self.templated_slice!r}, "
+            f"templated_file={self.templated_file!r}, "
+            f"working_line_no={self.working_line_no!r}, "
+            f"working_line_pos={self.working_line_pos!r})"
+        )
 
     def __gt__(self, other: "PositionMarker") -> bool:
         return self.working_loc > other.working_loc

--- a/src/sqlfluff/core/parser/markers.py
+++ b/src/sqlfluff/core/parser/markers.py
@@ -70,15 +70,6 @@ class PositionMarker:
     def __str__(self) -> str:
         return self.to_source_string()
 
-    def __repr__(self) -> str:
-        return (
-            f"PositionMarker(source_slice={self.source_slice!r}, "
-            f"templated_slice={self.templated_slice!r}, "
-            f"templated_file={self.templated_file!r}, "
-            f"working_line_no={self.working_line_no!r}, "
-            f"working_line_pos={self.working_line_pos!r})"
-        )
-
     def __gt__(self, other: "PositionMarker") -> bool:
         return self.working_loc > other.working_loc
 


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
`PositionMarker` is constructed once per lexed token, so it sits on the lexer's hot path. This converts it from `@dataclass(frozen=True)` to a plain class using `__slots__` with a hand written `__init__`.

Frozen dataclasses enforce immutability by routing every field assignment in the generated `__init__` through `object.__setattr__()`, which is considerably slower to construct than direct attribute assignment on an ordinary class. All comparison operators, properties, and classmethods are unchanged.

Profiled with `cProfile`, isolating just the lex stage (`Lexer.lex` through `RsLexer._tokens_to_segments`) over a 991KB Athena SQL fixture. There were 710,095 `PositionMarker` constructions per run.

| Metric | Change |
| --- | --- |
| `PositionMarker.__init__` cumulative time | ↓ ~32% |
| `PositionMarker.__init__` self (tottime) | ↓ ~29% |


### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [ ] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Convert `PositionMarker` from a frozen dataclass to a lightweight `__slots__` class to speed up token lexing. Adds a manual `__init__` that infers working positions when unset; behavior is unchanged.

- **Refactors**
  - Replaced `@dataclass(frozen=True)` with a plain class using `__slots__` and a hand-written `__init__` that infers `working_line_no` and `working_line_pos` when unset.
  - Removed unused `__repr__`; comparisons and public behavior are unchanged.

- **Performance**
  - On a 991KB Athena SQL fixture (710,095 constructions): `__init__` cumulative time ↓ ~32%, self time ↓ ~29%.

<sup>Written for commit f9ddca9ba6f6255ae317d2e835c5f8ca717eecb8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8092?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



