### PR TITLE
perf: bypass __setattr__ in RawSegment.__init__ via direct __dict__ writes

### DIFF
--- a/src/sqlfluff/core/parser/segments/raw.py
+++ b/src/sqlfluff/core/parser/segments/raw.py
@@ -29,6 +29,22 @@ class RawSegment(BaseSegment):
     # to enable simple initialisation.
     _default_raw = ""
 
+    # NOTE: These are declared here (rather than solely via `self.x = value`
+    # in __init__) because __init__ writes most fields straight into
+    # self.__dict__ for performance (see the NOTE in __init__), which mypy
+    # can't use to infer instance attribute types the way it can a plain
+    # assignment.
+    _raw: str
+    _raw_upper: str
+    _raw_value: str
+    instance_types: tuple[str, ...]
+    trim_start: Optional[tuple[str, ...]]
+    trim_chars: Optional[tuple[str, ...]]
+    _source_fixes: Optional[list[SourceFix]]
+    quoted_value: Optional[tuple[str, Union[int, str]]]
+    escape_replacements: Optional[list[tuple[str, str]]]
+    casefold: Optional[Callable[[str], str]]
+
     def __init__(
         self,
         raw: Optional[str] = None,
@@ -51,35 +67,46 @@ class RawSegment(BaseSegment):
         If raw is not provided, we default to _default_raw if present.
         If pos_marker is not provided, it is assume that this will be
         inserted later as part of a reposition phase.
+
+        NOTE: This writes straight into ``self.__dict__`` rather than via
+        plain attribute assignment. RawSegment has no children, so none of
+        BaseSegment.__setattr__'s cache-invalidation machinery applies here,
+        but *any* class-level ``__setattr__`` override still forces every
+        ``self.x = y`` through a full Python-level call. This class is on
+        the lexer's hot path (one instantiation per raw token), so bypassing
+        the attribute protocol entirely is a meaningful win at that volume.
         """
-        if raw is not None:  # NB, raw *can* be an empty string and be valid
-            self._raw = raw
-        else:
-            self._raw = self._default_raw
-        self._raw_upper = self._raw.upper()
-        # pos marker is required here. We ignore the typing initially
-        # because it might *initially* be unset, but it will be reset
-        # later.
-        self.pos_marker: PositionMarker = pos_marker  # type: ignore
-        # Set the segments attribute to be an empty tuple.
-        self.segments = ()
-        self.instance_types: tuple[str, ...]
         if type:
             assert not instance_types, "Cannot set `type` and `instance_types`."
-            self.instance_types = (type,)
-        else:
-            self.instance_types = instance_types
+            instance_types = (type,)
+
+        _raw = raw if raw is not None else self._default_raw
+
+        # pos marker is required here. We ignore the typing initially
+        # because it might *initially* be unset, but it will be reset
+        # later. NOTE: Assigned normally (not via the __dict__ bypass below)
+        # because this annotated assignment is what tells mypy that, for a
+        # RawSegment specifically, pos_marker is non-Optional - several call
+        # sites downstream rely on that narrowing.
+        self.pos_marker: PositionMarker = pos_marker  # type: ignore
+
+        d = self.__dict__
+        d["_raw"] = _raw
+        d["_raw_upper"] = _raw.upper()
+        # Set the segments attribute to be an empty tuple.
+        d["segments"] = ()
+        d["instance_types"] = instance_types
         # What should we trim off the ends to get to content
-        self.trim_start = trim_start
-        self.trim_chars = trim_chars
+        d["trim_start"] = trim_start
+        d["trim_chars"] = trim_chars
         # Keep track of any source fixes
-        self._source_fixes = source_fixes
+        d["_source_fixes"] = source_fixes
         # Identifier for matching (a plain int, swift for comparisons).
-        self.uuid = uuid or get_next_id()
-        self.quoted_value = quoted_value
-        self.escape_replacements = escape_replacements
-        self.casefold = casefold
-        self._raw_value: str = self.normalize()
+        d["uuid"] = uuid or get_next_id()
+        d["quoted_value"] = quoted_value
+        d["escape_replacements"] = escape_replacements
+        d["casefold"] = casefold
+        d["_raw_value"] = self.normalize()
 
     @functools.cached_property
     def representation(self) -> str:


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
`RawSegment.__init__` is on the lexer's hot path, one instantiation per raw token. Its ~13 field assignments each went through a Python-level `__setattr__` override that exists only to skip `BaseSegment.__setattr__`'s "segments" cache-invalidation check, but still paid a full function call per attribute regardless. This PR writes those fields directly into `self.__dict__`, bypassing the attribute-set protocol during construction. The override itself is untouched and still applies to any post-construction mutation.

`pos_marker` is kept as a plain assignment since that specific annotated assignment is what narrows its type to non-`Optional` for `RawSegment`, which several call sites rely on. Fields mypy can no longer infer from a plain assignment get explicit class-level type annotations instead.

| Metric | Before | After | Delta |
| --- | --- | --- | --- |
| `RawSegment.__setattr__` calls | 9,941,340 | 710,105 | -93%
| `RawSegment.__setattr__` total time |2.47s | 0.28s | -89% |

### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [ ] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speed up tokenization by bypassing `__setattr__` in `RawSegment.__init__` using direct `self.__dict__` writes. This cuts per-token init overhead and reduces `__setattr__` time by ~89%.

- **Refactors**
  - Initialize most fields via `self.__dict__` to avoid Python-level attribute sets in `__init__`; keep `pos_marker` as a normal typed assignment to retain non-Optional narrowing.
  - Add class-level type annotations for attributes that are no longer inferred from plain assignments.
  - Preserve the existing `__setattr__` override for post-construction mutations; behavior unchanged.
  - Normalize `type`/`instance_types` (assert exclusivity; wrap `type` into a tuple).
  - Perf impact: `__setattr__` calls 9,941,340 → 710,105 (−93%); time 2.47s → 0.28s (−89%).

<sup>Written for commit b647de6eb581ea2e80cec84fb181666cbc826379. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8093?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

