### PR TITLE
docs: fix BaseGrammar.copy terminators arg reference

### DIFF
--- a/src/sqlfluff/core/parser/grammar/base.py
+++ b/src/sqlfluff/core/parser/grammar/base.py
@@ -255,7 +255,7 @@ class BaseGrammar(Matchable):
                 Elements are searched for individually.
             terminators (:obj:`list` of :obj:`str` or Matchable): New
                 terminators to add to the existing ones. Whether they
-                replace or append is controlled by `append_terminators`.
+                replace or append is controlled by `replace_terminators`.
                 :obj:`str` objects will be interpreted as keywords and
                 passed to `Ref.keyword()`.
             replace_terminators (:obj:`bool`, default False): When `True`


### PR DESCRIPTION

### Brief summary of the change made

The `terminators` argument in `BaseGrammar.copy` is documented as:

> New terminators to add to the existing ones. Whether they replace or append
> is controlled by `append_terminators`.

There is no `append_terminators` parameter on the method. The flag that actually
controls replace-vs-append is `replace_terminators`, which is documented
correctly two lines further down in the same docstring and is what the method
body branches on (`if replace_terminators:`). This corrects the cross-reference
so it names the real parameter.

No behaviour change: this is a one-word docstring fix.

### Are there any other side effects of this change that we should be aware of?

None. This is documentation only (a single word in one docstring); there is no
runtime, API, or parsing change. `ruff check` and `ruff format` stay clean and
the parser grammar test suite is unaffected.


- [x] Included test cases to demonstrate any code changes, which may be one or
      more of the following:
  - [ ] `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - [ ] `.sql`/`.yml` parser test cases in `test/fixtures/dialects`.
  - [ ] Full autofix test cases in `test/fixtures/linter/autofix`.
  - [x] Other: not applicable. This is a documentation-only correction of an
        internal docstring with no code-path change, so there is nothing to
        assert with a fixture. `ruff check`/`ruff format` (which enforce
        docstring style) and `test/core/parser/grammar/` (95 passed) confirm
        nothing regressed.
- [x] Added appropriate documentation for the change (the change *is* the
      documentation fix).
- [ ] Created GitHub issues for any relevant followup/future enhancements if
      appropriate. Not needed.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed the `BaseGrammar.copy` docstring to reference `replace_terminators` (not the non-existent `append_terminators`) as the flag controlling replace vs append; documentation-only, no behavior change.

<sup>Written for commit 9aa4b5b7463c3004fe7f5e8ce1831461052cebc3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8094?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

