### PR TITLE
fix: raise SQLFluffUserError for invalid rule config option values

### DIFF
--- a/src/sqlfluff/core/rules/base.py
+++ b/src/sqlfluff/core/rules/base.py
@@ -1037,7 +1037,7 @@ class RuleSet:
                 and config_option not in valid_options
                 and config_option is not None
             ):
-                raise ValueError(
+                raise SQLFluffUserError(
                     (
                         "Invalid option '{}' for {} configuration. Must be one of {}"
                     ).format(

--- a/test/core/config/fluffconfig_test.py
+++ b/test/core/config/fluffconfig_test.py
@@ -257,7 +257,7 @@ def test__config__invalid_prefer_quoted_keyword_style():
         }
     )
 
-    with pytest.raises(ValueError) as exc_info:
+    with pytest.raises(SQLFluffUserError) as exc_info:
         Linter(config=config).get_rulepack()
 
     assert "prefer_quoted_keyword_style" in str(exc_info.value)


### PR DESCRIPTION

### Brief summary of the change made

An invalid value for a rule config option that carries a `validation` allow-list
(for example `capitalisation_policy = SHOUT`) was raising a bare Python
`ValueError`. The CLI wraps its work in `PathAndUserErrorHandler`, which only
catches `SQLFluffUserError` to render a clean `User Error: ...` message, so this
bare `ValueError` escaped and aborted `sqlfluff lint` with a full traceback
instead of a readable error.

This changes the single `raise` in `RuleSet._validate_config_options` to raise
`SQLFluffUserError` (which is a subclass of `ValueError`, already imported in
this module). The message and validation logic are unchanged; the error is now
presented to the user cleanly.

Before:
```
$ sqlfluff lint q.sql
Traceback (most recent call last):
  ...
ValueError: Invalid option 'SHOUT' for capitalisation_policy configuration. Must be one of ['consistent', 'upper', 'lower', 'capitalise']
```

After:
```
$ sqlfluff lint q.sql
User Error: Invalid option 'SHOUT' for capitalisation_policy configuration. Must be one of ['consistent', 'upper', 'lower', 'capitalise']
$ echo $?
2
```

The existing `test__config__invalid_prefer_quoted_keyword_style` already
exercised this exact path but asserted the too-loose `pytest.raises(ValueError)`
(which is why the wrong exception type went unnoticed). It has been tightened to
assert the specific `SQLFluffUserError`.

### Are there any other side effects of this change that we should be aware of?

None expected. `SQLFluffUserError` subclasses `ValueError`, so any caller that
catches `ValueError` still catches it; the only change is that the error is now
also caught by the CLI's user-error handler and rendered cleanly. The message
text is byte-for-byte identical.

Scope is deliberately limited to the user-facing allow-list rejection in
`_validate_config_options`. The other `raise ValueError` in the same class (the
rule-code collision in `register`, marked `# pragma: no cover`) is a
developer/plugin-registration error, not a user config error, and is left
untouched.

- [x] Included test cases to demonstrate the code change:
  - Tightened an existing unit test
    (`test/core/config/fluffconfig_test.py::test__config__invalid_prefer_quoted_keyword_style`)
    from `pytest.raises(ValueError)` to `pytest.raises(SQLFluffUserError)`.
    Proven red -> green: it fails on unmodified `base.py` and passes with the fix.
  - This is a pure error-type/CLI-behavior fix, so no `.yml` rule/parser fixtures
    apply.
- [x] No documentation change needed (no user-facing API/config surface changed;
    only the exception class of an already-documented validation error).
- [ ] Created GitHub issues for followup - n/a (no follow-up needed).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raise `SQLFluffUserError` for invalid rule config option values so the CLI shows a clean user error instead of a traceback. The error message is unchanged; only the exception type differs.

- **Bug Fixes**
  - In `RuleSet._validate_config_options`, raise `SQLFluffUserError` (a `ValueError` subclass) when a value is not in the allow-list; now caught by `PathAndUserErrorHandler` and exits with code 2.
  - Update `test__config__invalid_prefer_quoted_keyword_style` to expect `SQLFluffUserError`.

<sup>Written for commit 5e66428bc4a7cc85f7771c8920163bdfc8973e14. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8095?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

