### PR TITLE
Stop LT01 spacing Oracle %type/%rowtype like modulo

### DIFF
--- a/src/sqlfluff/core/default_config.cfg
+++ b/src/sqlfluff/core/default_config.cfg
@@ -194,6 +194,10 @@ line_position = leading
 spacing_before = touch
 spacing_after = touch
 
+[sqlfluff:layout:type:attribute_indicator]
+spacing_before = touch
+spacing_after = touch
+
 [sqlfluff:layout:type:object_reference]
 spacing_within = touch:inline
 

--- a/src/sqlfluff/dialects/dialect_oracle.py
+++ b/src/sqlfluff/dialects/dialect_oracle.py
@@ -178,6 +178,12 @@ oracle_dialect.add(
         ),
     ),
     AtSignSegment=StringParser("@", SymbolSegment, type="at_sign"),
+    # `%` as an attribute indicator (%TYPE, %ROWTYPE, %FOUND, ...). Distinct
+    # from ModuloSegment so the global `spacing_within = touch` on
+    # "binary_operator" doesn't force spaces around it as if it were arithmetic.
+    AttributeIndicatorSegment=StringParser(
+        "%", SymbolSegment, type="attribute_indicator"
+    ),
     RightArrowSegment=StringParser("=>", SymbolSegment, type="right_arrow"),
     # Colon prefix for bind variables (:var) and trigger pseudorecords
     # (:NEW, :OLD). Distinct from ColonSegment so the global
@@ -406,7 +412,7 @@ oracle_dialect.add(
     ),
     ImplicitCursorAttributesGrammar=Sequence(
         Ref("SingleIdentifierGrammar"),
-        Ref("ModuloSegment"),
+        Ref("AttributeIndicatorSegment"),
         OneOf(
             "ISOPEN",
             "FOUND",
@@ -2607,7 +2613,7 @@ class ColumnTypeReferenceSegment(BaseSegment):
     type = "column_type_reference"
 
     match_grammar = Sequence(
-        Ref("ColumnReferenceSegment"), Ref("ModuloSegment"), "TYPE"
+        Ref("ColumnReferenceSegment"), Ref("AttributeIndicatorSegment"), "TYPE"
     )
 
 
@@ -2620,7 +2626,7 @@ class RowTypeReferenceSegment(BaseSegment):
     type = "row_type_reference"
 
     match_grammar = Sequence(
-        Ref("TableReferenceSegment"), Ref("ModuloSegment"), "ROWTYPE"
+        Ref("TableReferenceSegment"), Ref("AttributeIndicatorSegment"), "ROWTYPE"
     )
 
 

--- a/test/fixtures/dialects/oracle/assignment.yml
+++ b/test/fixtures/dialects/oracle/assignment.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 02638b4bd8ef4d40723402128c1093b73f9341156fd016fd57838dc2f18258aa
+_hash: 160a219d6cb18938e80aa6311529aa02adfe21b098dc4632eec99c95a3231b8c
 file:
 - batch:
     statement:
@@ -63,14 +63,14 @@ file:
         - row_type_reference:
             table_reference:
               naked_identifier: employees
-            binary_operator: '%'
+            attribute_indicator: '%'
             keyword: ROWTYPE
         - statement_terminator: ;
         - naked_identifier: emp_rec2
         - row_type_reference:
             table_reference:
               naked_identifier: employees
-            binary_operator: '%'
+            attribute_indicator: '%'
             keyword: ROWTYPE
         - statement_terminator: ;
         - collection_type:

--- a/test/fixtures/dialects/oracle/column_type.yml
+++ b/test/fixtures/dialects/oracle/column_type.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 88b0bfd64d491300a9003165885d6cb553ae251e14d10662a4ca44be6fee8bdb
+_hash: 53886bce69579bc8f5bb7404b9d4bad95f7327dba9edfb6fabb35a0533b763f1
 file:
 - batch:
     statement:
@@ -16,7 +16,7 @@ file:
             - naked_identifier: employees
             - dot: .
             - naked_identifier: last_name
-            binary_operator: '%'
+            attribute_indicator: '%'
             keyword: TYPE
           statement_terminator: ;
       - keyword: BEGIN
@@ -65,7 +65,7 @@ file:
         - column_type_reference:
             column_reference:
               naked_identifier: name
-            binary_operator: '%'
+            attribute_indicator: '%'
             keyword: TYPE
         - assignment_operator: :=
         - expression:

--- a/test/fixtures/dialects/oracle/create_trigger.yml
+++ b/test/fixtures/dialects/oracle/create_trigger.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 025c8c0c73784ba02bb8f842d4dc97e3d18559669916ca1a6241767d81023e49
+_hash: f4ae9f6bbb34e4cae76e4bc6f58042b9cb9d00e8ebb29a32732373b2de629ce5
 file:
 - batch:
     statement:
@@ -437,7 +437,7 @@ file:
             - row_type_reference:
                 table_reference:
                   naked_identifier: employee_salaries
-                binary_operator: '%'
+                attribute_indicator: '%'
                 keyword: ROWTYPE
             - keyword: INDEX
             - keyword: BY

--- a/test/fixtures/dialects/oracle/cursor.yml
+++ b/test/fixtures/dialects/oracle/cursor.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: c6b985cbfc099cd17a56c27ccc1ff799ffbc5aede6fc832da3c204b59dd2c790
+_hash: 5fff04d594be9b0316ed4fbf1d242ec0a6e9ec6d23aa44e97efec09672d5f02c
 file:
 - batch:
     statement:
@@ -20,7 +20,7 @@ file:
           - row_type_reference:
               table_reference:
                 naked_identifier: employees
-              binary_operator: '%'
+              attribute_indicator: '%'
               keyword: ROWTYPE
         - statement_terminator: ;
         - ref_cursor_type:
@@ -52,7 +52,7 @@ file:
           - row_type_reference:
               table_reference:
                 naked_identifier: departments
-              binary_operator: '%'
+              attribute_indicator: '%'
               keyword: ROWTYPE
         - statement_terminator: ;
         - naked_identifier: dept_cv
@@ -139,7 +139,7 @@ file:
             - naked_identifier: employees
             - dot: .
             - naked_identifier: salary
-            binary_operator: '%'
+            attribute_indicator: '%'
             keyword: TYPE
         - statement_terminator: ;
         - naked_identifier: sal_multiple
@@ -148,7 +148,7 @@ file:
             - naked_identifier: employees
             - dot: .
             - naked_identifier: salary
-            binary_operator: '%'
+            attribute_indicator: '%'
             keyword: TYPE
         - statement_terminator: ;
         - naked_identifier: factor
@@ -216,7 +216,7 @@ file:
               - keyword: WHEN
               - expression:
                   naked_identifier: cv
-                  binary_operator: '%'
+                  attribute_indicator: '%'
                   keyword: NOTFOUND
           - statement_terminator: ;
           - statement:
@@ -307,7 +307,7 @@ file:
             - naked_identifier: employees
             - dot: .
             - naked_identifier: salary
-            binary_operator: '%'
+            attribute_indicator: '%'
             keyword: TYPE
         - statement_terminator: ;
         - naked_identifier: sal_multiple
@@ -316,7 +316,7 @@ file:
             - naked_identifier: employees
             - dot: .
             - naked_identifier: salary
-            binary_operator: '%'
+            attribute_indicator: '%'
             keyword: TYPE
         - statement_terminator: ;
         - naked_identifier: factor
@@ -402,7 +402,7 @@ file:
               - keyword: WHEN
               - expression:
                   naked_identifier: cv
-                  binary_operator: '%'
+                  attribute_indicator: '%'
                   keyword: NOTFOUND
           - statement_terminator: ;
           - statement:
@@ -526,7 +526,7 @@ file:
               - keyword: WHEN
               - expression:
                   naked_identifier: cv
-                  binary_operator: '%'
+                  attribute_indicator: '%'
                   keyword: NOTFOUND
           - statement_terminator: ;
           - statement:
@@ -717,7 +717,7 @@ file:
           - row_type_reference:
               table_reference:
                 naked_identifier: departments
-              binary_operator: '%'
+              attribute_indicator: '%'
               keyword: ROWTYPE
           - statement_terminator: ;
         - cursor_variable:
@@ -761,7 +761,7 @@ file:
           - row_type_reference:
               table_reference:
                 naked_identifier: departments
-              binary_operator: '%'
+              attribute_indicator: '%'
               keyword: ROWTYPE
           - keyword: IS
           - select_statement:
@@ -794,7 +794,7 @@ file:
           - row_type_reference:
               table_reference:
                 naked_identifier: locations
-              binary_operator: '%'
+              attribute_indicator: '%'
               keyword: ROWTYPE
           - statement_terminator: ;
         - cursor_variable:
@@ -844,7 +844,7 @@ file:
             - naked_identifier: employees
             - dot: .
             - naked_identifier: salary
-            binary_operator: '%'
+            attribute_indicator: '%'
             keyword: TYPE
         - statement_terminator: ;
         - naked_identifier: sal_multiple
@@ -853,7 +853,7 @@ file:
             - naked_identifier: employees
             - dot: .
             - naked_identifier: salary
-            binary_operator: '%'
+            attribute_indicator: '%'
             keyword: TYPE
         - statement_terminator: ;
         - naked_identifier: factor
@@ -921,7 +921,7 @@ file:
               - keyword: WHEN
               - expression:
                   naked_identifier: c1
-                  binary_operator: '%'
+                  attribute_indicator: '%'
                   keyword: NOTFOUND
           - statement_terminator: ;
           - statement:
@@ -1012,7 +1012,7 @@ file:
             - naked_identifier: employees
             - dot: .
             - naked_identifier: salary
-            binary_operator: '%'
+            attribute_indicator: '%'
             keyword: TYPE
         - statement_terminator: ;
         - naked_identifier: sal_multiple
@@ -1021,7 +1021,7 @@ file:
             - naked_identifier: employees
             - dot: .
             - naked_identifier: salary
-            binary_operator: '%'
+            attribute_indicator: '%'
             keyword: TYPE
         - statement_terminator: ;
         - naked_identifier: factor
@@ -1107,7 +1107,7 @@ file:
               - keyword: WHEN
               - expression:
                   naked_identifier: c1
-                  binary_operator: '%'
+                  attribute_indicator: '%'
                   keyword: NOTFOUND
           - statement_terminator: ;
           - statement:
@@ -1207,7 +1207,7 @@ file:
               - keyword: WHEN
               - expression:
                   naked_identifier: c1
-                  binary_operator: '%'
+                  attribute_indicator: '%'
                   keyword: NOTFOUND
           - statement_terminator: ;
           - statement:
@@ -1310,7 +1310,7 @@ file:
           row_type_reference:
             table_reference:
               naked_identifier: c1
-            binary_operator: '%'
+            attribute_indicator: '%'
             keyword: ROWTYPE
           statement_terminator: ;
       - keyword: BEGIN
@@ -1336,7 +1336,7 @@ file:
               - keyword: WHEN
               - expression:
                   naked_identifier: c1
-                  binary_operator: '%'
+                  attribute_indicator: '%'
                   keyword: NOTFOUND
           - statement_terminator: ;
           - statement:
@@ -1467,7 +1467,7 @@ file:
                 - naked_identifier: employees
                 - dot: .
                 - naked_identifier: last_name
-                binary_operator: '%'
+                attribute_indicator: '%'
                 keyword: TYPE
             - statement_terminator: ;
             - naked_identifier: first_name_
@@ -1476,7 +1476,7 @@ file:
                 - naked_identifier: employees
                 - dot: .
                 - naked_identifier: first_name
-                binary_operator: '%'
+                attribute_indicator: '%'
                 keyword: TYPE
             - statement_terminator: ;
             - naked_identifier: overpayment_
@@ -1485,7 +1485,7 @@ file:
                 - naked_identifier: employees
                 - dot: .
                 - naked_identifier: salary
-                binary_operator: '%'
+                attribute_indicator: '%'
                 keyword: TYPE
             - statement_terminator: ;
           - begin_end_block:
@@ -1511,7 +1511,7 @@ file:
                     - keyword: WHEN
                     - expression:
                         naked_identifier: c
-                        binary_operator: '%'
+                        attribute_indicator: '%'
                         keyword: NOTFOUND
                 - statement_terminator: ;
                 - statement:
@@ -1815,7 +1815,7 @@ file:
                 - naked_identifier: departments
                 - dot: .
                 - naked_identifier: department_name
-                binary_operator: '%'
+                attribute_indicator: '%'
                 keyword: TYPE
             - statement_terminator: ;
             - naked_identifier: mgr_name
@@ -1824,7 +1824,7 @@ file:
                 - naked_identifier: employees
                 - dot: .
                 - naked_identifier: last_name
-                binary_operator: '%'
+                attribute_indicator: '%'
                 keyword: TYPE
             - statement_terminator: ;
             - naked_identifier: city_name
@@ -1833,7 +1833,7 @@ file:
                 - naked_identifier: locations
                 - dot: .
                 - naked_identifier: city
-                binary_operator: '%'
+                attribute_indicator: '%'
                 keyword: TYPE
             - statement_terminator: ;
           - begin_end_block:
@@ -1859,7 +1859,7 @@ file:
                     - keyword: WHEN
                     - expression:
                         naked_identifier: c
-                        binary_operator: '%'
+                        attribute_indicator: '%'
                         keyword: NOTFOUND
                 - statement_terminator: ;
                 - statement:
@@ -2145,7 +2145,7 @@ file:
                 - naked_identifier: employees
                 - dot: .
                 - naked_identifier: last_name
-                binary_operator: '%'
+                attribute_indicator: '%'
                 keyword: TYPE
             - statement_terminator: ;
             - naked_identifier: first_name_
@@ -2154,7 +2154,7 @@ file:
                 - naked_identifier: employees
                 - dot: .
                 - naked_identifier: first_name
-                binary_operator: '%'
+                attribute_indicator: '%'
                 keyword: TYPE
             - statement_terminator: ;
             - naked_identifier: overpayment_
@@ -2163,7 +2163,7 @@ file:
                 - naked_identifier: employees
                 - dot: .
                 - naked_identifier: salary
-                binary_operator: '%'
+                attribute_indicator: '%'
                 keyword: TYPE
             - statement_terminator: ;
           - begin_end_block:
@@ -2189,7 +2189,7 @@ file:
                     - keyword: WHEN
                     - expression:
                         naked_identifier: c
-                        binary_operator: '%'
+                        attribute_indicator: '%'
                         keyword: NOTFOUND
                 - statement_terminator: ;
                 - statement:
@@ -2686,7 +2686,7 @@ file:
             - naked_identifier: departments
             - dot: .
             - naked_identifier: department_name
-            binary_operator: '%'
+            attribute_indicator: '%'
             keyword: TYPE
         - statement_terminator: ;
         - naked_identifier: emp_name
@@ -2695,7 +2695,7 @@ file:
             - naked_identifier: employees
             - dot: .
             - naked_identifier: last_name
-            binary_operator: '%'
+            attribute_indicator: '%'
             keyword: TYPE
         - statement_terminator: ;
         - cursor_variable:
@@ -2804,7 +2804,7 @@ file:
               - keyword: WHEN
               - expression:
                   naked_identifier: c1
-                  binary_operator: '%'
+                  attribute_indicator: '%'
                   keyword: NOTFOUND
           - statement_terminator: ;
           - statement:
@@ -2842,7 +2842,7 @@ file:
                   - keyword: WHEN
                   - expression:
                       naked_identifier: emp_cur
-                      binary_operator: '%'
+                      attribute_indicator: '%'
                       keyword: NOTFOUND
               - statement_terminator: ;
               - statement:
@@ -2916,7 +2916,7 @@ file:
           row_type_reference:
             table_reference:
               naked_identifier: emp
-            binary_operator: '%'
+            attribute_indicator: '%'
             keyword: ROWTYPE
           statement_terminator: ;
       - keyword: BEGIN
@@ -2942,7 +2942,7 @@ file:
               - keyword: WHEN
               - expression:
                   naked_identifier: c1
-                  binary_operator: '%'
+                  attribute_indicator: '%'
                   keyword: NOTFOUND
           - statement_terminator: ;
           - statement:

--- a/test/fixtures/dialects/oracle/fetch.yml
+++ b/test/fixtures/dialects/oracle/fetch.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: a5f4b230145663d66043d7982c252a1965109e6f2e9e8667ce2c0a21cba8a595
+_hash: 6288c34f8fe941b43daa1c2fad7e3792a8683e7b770743e8180618e67b97b591
 file:
 - batch:
     statement:
@@ -23,7 +23,7 @@ file:
                 - naked_identifier: employees
                 - dot: .
                 - naked_identifier: employee_id
-                binary_operator: '%'
+                attribute_indicator: '%'
                 keyword: TYPE
             - comma: ','
             - naked_identifier: salary
@@ -32,7 +32,7 @@ file:
                 - naked_identifier: employees
                 - dot: .
                 - naked_identifier: salary
-                binary_operator: '%'
+                attribute_indicator: '%'
                 keyword: TYPE
             - end_bracket: )
         - statement_terminator: ;
@@ -293,7 +293,7 @@ file:
             - naked_identifier: employees
             - dot: .
             - naked_identifier: last_name
-            binary_operator: '%'
+            attribute_indicator: '%'
             keyword: TYPE
         - statement_terminator: ;
         - naked_identifier: v_jobid
@@ -302,7 +302,7 @@ file:
             - naked_identifier: employees
             - dot: .
             - naked_identifier: job_id
-            binary_operator: '%'
+            attribute_indicator: '%'
             keyword: TYPE
         - statement_terminator: ;
         - cursor_variable:
@@ -349,7 +349,7 @@ file:
         - row_type_reference:
             table_reference:
               naked_identifier: employees
-            binary_operator: '%'
+            attribute_indicator: '%'
             keyword: ROWTYPE
         - statement_terminator: ;
       - keyword: BEGIN
@@ -377,7 +377,7 @@ file:
               - keyword: WHEN
               - expression:
                   naked_identifier: c1
-                  binary_operator: '%'
+                  attribute_indicator: '%'
                   keyword: NOTFOUND
           - statement_terminator: ;
           - statement:
@@ -456,7 +456,7 @@ file:
               - keyword: WHEN
               - expression:
                   naked_identifier: c2
-                  binary_operator: '%'
+                  attribute_indicator: '%'
                   keyword: NOTFOUND
           - statement_terminator: ;
           - statement:
@@ -579,35 +579,35 @@ file:
         - row_type_reference:
             table_reference:
               naked_identifier: c
-            binary_operator: '%'
+            attribute_indicator: '%'
             keyword: ROWTYPE
         - statement_terminator: ;
         - naked_identifier: job2
         - row_type_reference:
             table_reference:
               naked_identifier: c
-            binary_operator: '%'
+            attribute_indicator: '%'
             keyword: ROWTYPE
         - statement_terminator: ;
         - naked_identifier: job3
         - row_type_reference:
             table_reference:
               naked_identifier: c
-            binary_operator: '%'
+            attribute_indicator: '%'
             keyword: ROWTYPE
         - statement_terminator: ;
         - naked_identifier: job4
         - row_type_reference:
             table_reference:
               naked_identifier: c
-            binary_operator: '%'
+            attribute_indicator: '%'
             keyword: ROWTYPE
         - statement_terminator: ;
         - naked_identifier: job5
         - row_type_reference:
             table_reference:
               naked_identifier: c
-            binary_operator: '%'
+            attribute_indicator: '%'
             keyword: ROWTYPE
         - statement_terminator: ;
       - keyword: BEGIN
@@ -835,7 +835,7 @@ file:
             - naked_identifier: employees
             - dot: .
             - naked_identifier: last_name
-            binary_operator: '%'
+            attribute_indicator: '%'
             keyword: TYPE
         - statement_terminator: ;
         - naked_identifier: v_jobid
@@ -844,7 +844,7 @@ file:
             - naked_identifier: employees
             - dot: .
             - naked_identifier: job_id
-            binary_operator: '%'
+            attribute_indicator: '%'
             keyword: TYPE
         - statement_terminator: ;
         - naked_identifier: query_2
@@ -864,7 +864,7 @@ file:
         - row_type_reference:
             table_reference:
               naked_identifier: employees
-            binary_operator: '%'
+            attribute_indicator: '%'
             keyword: ROWTYPE
         - statement_terminator: ;
       - keyword: BEGIN
@@ -931,7 +931,7 @@ file:
               - keyword: WHEN
               - expression:
                   naked_identifier: cv
-                  binary_operator: '%'
+                  attribute_indicator: '%'
                   keyword: NOTFOUND
           - statement_terminator: ;
           - statement:
@@ -1007,7 +1007,7 @@ file:
               - keyword: WHEN
               - expression:
                   naked_identifier: cv
-                  binary_operator: '%'
+                  attribute_indicator: '%'
                   keyword: NOTFOUND
           - statement_terminator: ;
           - statement:
@@ -1082,7 +1082,7 @@ file:
               - naked_identifier: employees
               - dot: .
               - naked_identifier: last_name
-              binary_operator: '%'
+              attribute_indicator: '%'
               keyword: TYPE
         - statement_terminator: ;
         - collection_type:
@@ -1096,7 +1096,7 @@ file:
               - naked_identifier: employees
               - dot: .
               - naked_identifier: salary
-              binary_operator: '%'
+              attribute_indicator: '%'
               keyword: TYPE
         - statement_terminator: ;
         - naked_identifier: emp_cv
@@ -1269,7 +1269,7 @@ file:
           row_type_reference:
             table_reference:
               naked_identifier: emp
-            binary_operator: '%'
+            attribute_indicator: '%'
             keyword: ROWTYPE
           statement_terminator: ;
       - keyword: BEGIN
@@ -1295,7 +1295,7 @@ file:
               - keyword: WHEN
               - expression:
                   naked_identifier: c1
-                  binary_operator: '%'
+                  attribute_indicator: '%'
                   keyword: NOTFOUND
           - statement_terminator: ;
           - statement:
@@ -1383,7 +1383,7 @@ file:
         - row_type_reference:
             table_reference:
               naked_identifier: employees
-            binary_operator: '%'
+            attribute_indicator: '%'
             keyword: ROWTYPE
         - statement_terminator: ;
         - naked_identifier: v_stmt_str
@@ -1401,7 +1401,7 @@ file:
             - naked_identifier: employees
             - dot: .
             - naked_identifier: job_id
-            binary_operator: '%'
+            attribute_indicator: '%'
             keyword: TYPE
         - statement_terminator: ;
       - keyword: BEGIN
@@ -1439,7 +1439,7 @@ file:
               - keyword: WHEN
               - expression:
                   naked_identifier: v_emp_cursor
-                  binary_operator: '%'
+                  attribute_indicator: '%'
                   keyword: NOTFOUND
           - statement_terminator: ;
           - keyword: END
@@ -1470,7 +1470,7 @@ file:
               - naked_identifier: employees
               - dot: .
               - naked_identifier: last_name
-              binary_operator: '%'
+              attribute_indicator: '%'
               keyword: TYPE
         - statement_terminator: ;
         - collection_type:
@@ -1484,7 +1484,7 @@ file:
               - naked_identifier: employees
               - dot: .
               - naked_identifier: salary
-              binary_operator: '%'
+              attribute_indicator: '%'
               keyword: TYPE
         - statement_terminator: ;
         - cursor_variable:
@@ -1539,7 +1539,7 @@ file:
           - row_type_reference:
               table_reference:
                 naked_identifier: c1
-              binary_operator: '%'
+              attribute_indicator: '%'
               keyword: ROWTYPE
         - statement_terminator: ;
         - naked_identifier: recs
@@ -1893,7 +1893,7 @@ file:
           - row_type_reference:
               table_reference:
                 naked_identifier: c1
-              binary_operator: '%'
+              attribute_indicator: '%'
               keyword: ROWTYPE
         - statement_terminator: ;
         - naked_identifier: stock_managers
@@ -2137,7 +2137,7 @@ file:
               - keyword: WHEN
               - expression:
                   naked_identifier: c1
-                  binary_operator: '%'
+                  attribute_indicator: '%'
                   keyword: NOTFOUND
           - statement_terminator: ;
           - keyword: END

--- a/test/fixtures/dialects/oracle/for_loop.yml
+++ b/test/fixtures/dialects/oracle/for_loop.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: fdc358d6501f37180a02a066de0c437a2a01d1699f2e5e24cc39e8a71941cc17
+_hash: ed43d43abd19acebf123927b3433b5e73a8e519936dd532cd4a8a69f6ef26297
 file:
 - batch:
     statement:
@@ -539,7 +539,7 @@ file:
           row_type_reference:
             table_reference:
               naked_identifier: employees
-            binary_operator: '%'
+            attribute_indicator: '%'
             keyword: ROWTYPE
           statement_terminator: ;
           cursor_variable:
@@ -592,7 +592,7 @@ file:
                 - keyword: WHEN
                 - expression:
                     naked_identifier: c1
-                    binary_operator: '%'
+                    attribute_indicator: '%'
                     keyword: NOTFOUND
             - statement_terminator: ;
             - keyword: END
@@ -616,7 +616,7 @@ file:
           row_type_reference:
             table_reference:
               naked_identifier: employees
-            binary_operator: '%'
+            attribute_indicator: '%'
             keyword: ROWTYPE
           statement_terminator: ;
           cursor_variable:
@@ -681,7 +681,7 @@ file:
                       - keyword: WHEN
                       - expression:
                           naked_identifier: c1
-                          binary_operator: '%'
+                          attribute_indicator: '%'
                           keyword: NOTFOUND
                   - statement_terminator: ;
                   - keyword: END
@@ -709,7 +709,7 @@ file:
           row_type_reference:
             table_reference:
               naked_identifier: employees
-            binary_operator: '%'
+            attribute_indicator: '%'
             keyword: ROWTYPE
           statement_terminator: ;
           cursor_variable:
@@ -774,7 +774,7 @@ file:
                       - keyword: WHEN
                       - expression:
                           naked_identifier: c1
-                          binary_operator: '%'
+                          attribute_indicator: '%'
                           keyword: NOTFOUND
                   - statement_terminator: ;
                   - keyword: END

--- a/test/fixtures/dialects/oracle/forall.yml
+++ b/test/fixtures/dialects/oracle/forall.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 08ce0a98c0dcb1f5ca298d80a52b719a354d99d59c5333452cbb5f8b882fc12c
+_hash: 46b83d97598b4ccfc27088feaf6be1f1e2e29baa7ad1e1d15133badbfd0b04c6
 file:
 - batch:
     statement:
@@ -107,7 +107,7 @@ file:
               - naked_identifier: parts1
               - dot: .
               - naked_identifier: pnum
-              binary_operator: '%'
+              attribute_indicator: '%'
               keyword: TYPE
           - keyword: INDEX
           - keyword: BY
@@ -125,7 +125,7 @@ file:
               - naked_identifier: parts1
               - dot: .
               - naked_identifier: pname
-              binary_operator: '%'
+              attribute_indicator: '%'
               keyword: TYPE
           - keyword: INDEX
           - keyword: BY

--- a/test/fixtures/dialects/oracle/open_for.yml
+++ b/test/fixtures/dialects/oracle/open_for.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 1923d4143d82b238d9a9640c783855710552440dc24016aa5c5fd2726044fd81
+_hash: a0959e6f5dadb7733c9e7a718b62ac8302c204c7960f1857c6af822142c2c688
 file:
 - batch:
     statement:
@@ -20,7 +20,7 @@ file:
             - naked_identifier: employees
             - dot: .
             - naked_identifier: last_name
-            binary_operator: '%'
+            attribute_indicator: '%'
             keyword: TYPE
         - statement_terminator: ;
         - naked_identifier: v_jobid
@@ -29,7 +29,7 @@ file:
             - naked_identifier: employees
             - dot: .
             - naked_identifier: job_id
-            binary_operator: '%'
+            attribute_indicator: '%'
             keyword: TYPE
         - statement_terminator: ;
         - naked_identifier: query_2
@@ -49,7 +49,7 @@ file:
         - row_type_reference:
             table_reference:
               naked_identifier: employees
-            binary_operator: '%'
+            attribute_indicator: '%'
             keyword: ROWTYPE
         - statement_terminator: ;
       - keyword: BEGIN
@@ -116,7 +116,7 @@ file:
               - keyword: WHEN
               - expression:
                   naked_identifier: cv
-                  binary_operator: '%'
+                  attribute_indicator: '%'
                   keyword: NOTFOUND
           - statement_terminator: ;
           - statement:
@@ -192,7 +192,7 @@ file:
               - keyword: WHEN
               - expression:
                   naked_identifier: cv
-                  binary_operator: '%'
+                  attribute_indicator: '%'
                   keyword: NOTFOUND
           - statement_terminator: ;
           - statement:
@@ -392,7 +392,7 @@ file:
         - row_type_reference:
             table_reference:
               naked_identifier: employees
-            binary_operator: '%'
+            attribute_indicator: '%'
             keyword: ROWTYPE
         - statement_terminator: ;
         - naked_identifier: v_stmt_str
@@ -410,7 +410,7 @@ file:
             - naked_identifier: employees
             - dot: .
             - naked_identifier: job_id
-            binary_operator: '%'
+            attribute_indicator: '%'
             keyword: TYPE
         - statement_terminator: ;
       - keyword: BEGIN
@@ -448,7 +448,7 @@ file:
               - keyword: WHEN
               - expression:
                   naked_identifier: v_emp_cursor
-                  binary_operator: '%'
+                  attribute_indicator: '%'
                   keyword: NOTFOUND
           - statement_terminator: ;
           - keyword: END

--- a/test/fixtures/dialects/oracle/record_type.yml
+++ b/test/fixtures/dialects/oracle/record_type.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: d1b8a38170f9796a60169e55d24db976a846bd274bc0b31250a47bf523733b6e
+_hash: df8eed5761739e44aa5233d6dbcd299c488f66c371c1bafac196128cf6ca8179
 file:
 - batch:
     statement:
@@ -177,7 +177,7 @@ file:
                 - naked_identifier: employees
                 - dot: .
                 - naked_identifier: first_name
-                binary_operator: '%'
+                attribute_indicator: '%'
                 keyword: TYPE
             - comma: ','
             - naked_identifier: last
@@ -186,7 +186,7 @@ file:
                 - naked_identifier: employees
                 - dot: .
                 - naked_identifier: last_name
-                binary_operator: '%'
+                attribute_indicator: '%'
                 keyword: TYPE
             - end_bracket: )
         - statement_terminator: ;
@@ -207,7 +207,7 @@ file:
                 - naked_identifier: employees
                 - dot: .
                 - naked_identifier: phone_number
-                binary_operator: '%'
+                attribute_indicator: '%'
                 keyword: TYPE
             - end_bracket: )
         - statement_terminator: ;
@@ -352,7 +352,7 @@ file:
                 - naked_identifier: employees
                 - dot: .
                 - naked_identifier: phone_number
-                binary_operator: '%'
+                attribute_indicator: '%'
                 keyword: TYPE
             - end_bracket: )
         - statement_terminator: ;

--- a/test/fixtures/dialects/oracle/returning_into.yml
+++ b/test/fixtures/dialects/oracle/returning_into.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: ed4960348e96325dd5a4e302dd3016d53d6fc215645738473703a23ef88c18a7
+_hash: b69491eeb30a90ecd2d4ddeeb37ba2eea0e9d237e36fe309b6f3fc4c13b93a35
 file:
 - batch:
     statement:
@@ -23,7 +23,7 @@ file:
                 - naked_identifier: employees
                 - dot: .
                 - naked_identifier: last_name
-                binary_operator: '%'
+                attribute_indicator: '%'
                 keyword: TYPE
             - comma: ','
             - naked_identifier: salary
@@ -32,7 +32,7 @@ file:
                 - naked_identifier: employees
                 - dot: .
                 - naked_identifier: salary
-                binary_operator: '%'
+                attribute_indicator: '%'
                 keyword: TYPE
             - end_bracket: )
         - statement_terminator: ;
@@ -46,7 +46,7 @@ file:
             - naked_identifier: employees
             - dot: .
             - naked_identifier: salary
-            binary_operator: '%'
+            attribute_indicator: '%'
             keyword: TYPE
         - statement_terminator: ;
       - keyword: BEGIN
@@ -165,7 +165,7 @@ file:
             - naked_identifier: employees_temp
             - dot: .
             - naked_identifier: employee_id
-            binary_operator: '%'
+            attribute_indicator: '%'
             keyword: TYPE
         - assignment_operator: :=
         - expression:
@@ -177,7 +177,7 @@ file:
             - naked_identifier: employees_temp
             - dot: .
             - naked_identifier: first_name
-            binary_operator: '%'
+            attribute_indicator: '%'
             keyword: TYPE
         - assignment_operator: :=
         - expression:
@@ -189,7 +189,7 @@ file:
             - naked_identifier: employees_temp
             - dot: .
             - naked_identifier: last_name
-            binary_operator: '%'
+            attribute_indicator: '%'
             keyword: TYPE
         - assignment_operator: :=
         - expression:
@@ -330,7 +330,7 @@ file:
               - naked_identifier: employees
               - dot: .
               - naked_identifier: employee_id
-              binary_operator: '%'
+              attribute_indicator: '%'
               keyword: TYPE
         - statement_terminator: ;
         - naked_identifier: enums
@@ -348,7 +348,7 @@ file:
               - naked_identifier: employees
               - dot: .
               - naked_identifier: last_name
-              binary_operator: '%'
+              attribute_indicator: '%'
               keyword: TYPE
         - statement_terminator: ;
         - naked_identifier: names
@@ -402,7 +402,7 @@ file:
                   - pipe: '|'
                   - pipe: '|'
                 - naked_identifier: SQL
-                - binary_operator: '%'
+                - attribute_indicator: '%'
                 - keyword: ROWCOUNT
                 - binary_operator:
                   - pipe: '|'
@@ -491,7 +491,7 @@ file:
               - naked_identifier: employees
               - dot: .
               - naked_identifier: salary
-              binary_operator: '%'
+              attribute_indicator: '%'
               keyword: TYPE
         - statement_terminator: ;
         - naked_identifier: old_sals
@@ -513,7 +513,7 @@ file:
               - naked_identifier: employees
               - dot: .
               - naked_identifier: last_name
-              binary_operator: '%'
+              attribute_indicator: '%'
               keyword: TYPE
         - statement_terminator: ;
         - naked_identifier: names
@@ -580,7 +580,7 @@ file:
                   - pipe: '|'
                   - pipe: '|'
                 - naked_identifier: SQL
-                - binary_operator: '%'
+                - attribute_indicator: '%'
                 - keyword: ROWCOUNT
                 - binary_operator:
                   - pipe: '|'
@@ -712,7 +712,7 @@ file:
               - naked_identifier: employees
               - dot: .
               - naked_identifier: employee_id
-              binary_operator: '%'
+              attribute_indicator: '%'
               keyword: TYPE
         - statement_terminator: ;
         - naked_identifier: e_ids
@@ -730,7 +730,7 @@ file:
               - naked_identifier: employees
               - dot: .
               - naked_identifier: department_id
-              binary_operator: '%'
+              attribute_indicator: '%'
               keyword: TYPE
         - statement_terminator: ;
         - naked_identifier: d_ids
@@ -805,7 +805,7 @@ file:
                   - pipe: '|'
                   - pipe: '|'
                 - naked_identifier: SQL
-                - binary_operator: '%'
+                - attribute_indicator: '%'
                 - keyword: ROWCOUNT
                 - binary_operator:
                   - pipe: '|'
@@ -894,7 +894,7 @@ file:
               - naked_identifier: t1
               - dot: .
               - naked_identifier: description
-              binary_operator: '%'
+              attribute_indicator: '%'
               keyword: TYPE
         - statement_terminator: ;
         - collection_type:
@@ -908,7 +908,7 @@ file:
               - naked_identifier: t1
               - dot: .
               - naked_identifier: id
-              binary_operator: '%'
+              attribute_indicator: '%'
               keyword: TYPE
         - statement_terminator: ;
         - collection_type:
@@ -922,7 +922,7 @@ file:
               - naked_identifier: t1
               - dot: .
               - naked_identifier: description
-              binary_operator: '%'
+              attribute_indicator: '%'
               keyword: TYPE
         - statement_terminator: ;
         - naked_identifier: l_desc_tab
@@ -1093,7 +1093,7 @@ file:
               - naked_identifier: emp
               - dot: .
               - naked_identifier: sal
-              binary_operator: '%'
+              attribute_indicator: '%'
               keyword: TYPE
         - statement_terminator: ;
         - collection_type:
@@ -1107,7 +1107,7 @@ file:
               - naked_identifier: emp
               - dot: .
               - naked_identifier: empno
-              binary_operator: '%'
+              attribute_indicator: '%'
               keyword: TYPE
         - statement_terminator: ;
         - naked_identifier: l_empno

--- a/test/fixtures/dialects/oracle/rowtype.yml
+++ b/test/fixtures/dialects/oracle/rowtype.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: f5cf15fd073e80281505313679e4477ab849088e162756fe1ab070697638aa55
+_hash: 13e90d685982137f6dce3fd3075b5db9f306245d3ee5af17f28e1f749812bb2f
 file:
 - batch:
     statement:
@@ -14,7 +14,7 @@ file:
           row_type_reference:
             table_reference:
               naked_identifier: departments
-            binary_operator: '%'
+            attribute_indicator: '%'
             keyword: ROWTYPE
           statement_terminator: ;
       - keyword: BEGIN
@@ -151,7 +151,7 @@ file:
           row_type_reference:
             table_reference:
               naked_identifier: t1
-            binary_operator: '%'
+            attribute_indicator: '%'
             keyword: ROWTYPE
           statement_terminator: ;
       - keyword: BEGIN
@@ -304,7 +304,7 @@ file:
           row_type_reference:
             table_reference:
               naked_identifier: c
-            binary_operator: '%'
+            attribute_indicator: '%'
             keyword: ROWTYPE
           statement_terminator: ;
       - keyword: BEGIN
@@ -440,7 +440,7 @@ file:
           row_type_reference:
             table_reference:
               naked_identifier: c2
-            binary_operator: '%'
+            attribute_indicator: '%'
             keyword: ROWTYPE
           statement_terminator: ;
       - keyword: BEGIN
@@ -461,7 +461,7 @@ file:
           row_type_reference:
             table_reference:
               naked_identifier: t
-            binary_operator: '%'
+            attribute_indicator: '%'
             keyword: ROWTYPE
           statement_terminator: ;
       - keyword: BEGIN
@@ -533,7 +533,7 @@ file:
                 - naked_identifier: employees
                 - dot: .
                 - naked_identifier: first_name
-                binary_operator: '%'
+                attribute_indicator: '%'
                 keyword: TYPE
             - keyword: DEFAULT
             - expression:
@@ -545,7 +545,7 @@ file:
                 - naked_identifier: employees
                 - dot: .
                 - naked_identifier: last_name
-                binary_operator: '%'
+                attribute_indicator: '%'
                 keyword: TYPE
             - keyword: DEFAULT
             - expression:
@@ -582,7 +582,7 @@ file:
         - row_type_reference:
             table_reference:
               naked_identifier: c
-            binary_operator: '%'
+            attribute_indicator: '%'
             keyword: ROWTYPE
         - statement_terminator: ;
       - keyword: BEGIN
@@ -697,7 +697,7 @@ file:
             row_type_reference:
               table_reference:
                 naked_identifier: table_name
-              binary_operator: '%'
+              attribute_indicator: '%'
               keyword: rowtype
             end_bracket: )
       - keyword: is

--- a/test/fixtures/rules/std_rule_cases/LT01-operators.yml
+++ b/test/fixtures/rules/std_rule_cases/LT01-operators.yml
@@ -150,3 +150,34 @@ pass_sqlite_column_path_operator:
   configs:
     core:
       dialect: sqlite
+
+pass_oracle_attribute_indicator:
+  # %TYPE / %ROWTYPE / cursor attributes should not be spaced like the modulo
+  # operator. https://github.com/sqlfluff/sqlfluff/issues/8070
+  pass_str: |
+    DECLARE
+      v_a ex_tab.a%TYPE;
+      v_r ex_tab%ROWTYPE;
+      CURSOR c1 IS SELECT 1 FROM dual;
+    BEGIN
+      IF c1%NOTFOUND THEN
+        NULL;
+      END IF;
+    END;
+  configs:
+    core:
+      dialect: oracle
+
+fail_oracle_modulo_still_spaced:
+  # Real modulo must still get spacing enforced.
+  fail_str: |
+    BEGIN
+      x := a%b;
+    END;
+  fix_str: |
+    BEGIN
+      x := a % b;
+    END;
+  configs:
+    core:
+      dialect: oracle


### PR DESCRIPTION
### Brief summary of the change made

LT01 wants spaces around the `%` in `%type`/`%rowtype` because it's lexed as the modulo operator. Same for cursor attrs (`c1%notfound`) and var decls (`emp%rowtype`).

Gave the attribute `%` its own type (`attribute_indicator`) with a `touch` layout entry, like `::` and `@` already do. Real `a % b` still spaces fine. The oracle ymls changed since the `%` type changed.

Fixes #8070.

### Are there any other side effects of this change that we should be aware of?

No, just the `%` showing as `attribute_indicator` now instead of `binary_operator`.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (regenerated with `tox -e generate-fixture-yml`).
