### PR TITLE
ClickHouse: parse ORDER BY / LIMIT / SETTINGS on non-final union members (#8031)

### DIFF
--- a/src/sqlfluff/dialects/dialect_clickhouse.py
+++ b/src/sqlfluff/dialects/dialect_clickhouse.py
@@ -701,11 +701,46 @@ class UnorderedSelectStatementSegment(ansi.UnorderedSelectStatementSegment):
     )
 
 
-class SetExpressionSegment(ansi.SetExpressionSegment):
-    """Enhance set expression to include ClickHouse-specific clauses."""
+class UnorderedSetExpressionSegment(ansi.UnorderedSetExpressionSegment):
+    """Allow ``ORDER BY`` / ``LIMIT`` / ``SETTINGS`` on non-final union members.
 
-    match_grammar = ansi.SetExpressionSegment.match_grammar.copy(
+    Unlike ANSI - where a trailing ``ORDER BY`` / ``LIMIT`` binds to the whole
+    set - ClickHouse permits each member preceding a set operator to carry its
+    own ``ORDER BY``, ``LIMIT`` and ``SETTINGS`` clauses without being
+    parenthesised. Matching those clauses in the position between a member and
+    the following set operator keeps them attached to the (non-final) member,
+    while the clauses trailing the final member continue to bind to the whole
+    set expression.
+    """
+
+    match_grammar = Sequence(
+        Ref("NonSetSelectableGrammar"),
+        AnyNumberOf(
+            Sequence(
+                Ref("OrderByClauseSegment", optional=True),
+                Ref("LimitClauseSegment", optional=True),
+                Ref("SettingsClauseSegment", optional=True),
+                Ref("SetOperatorSegment"),
+                Ref("NonSetSelectableGrammar"),
+            ),
+            min_times=1,
+        ),
+    )
+
+
+class SetExpressionSegment(ansi.SetExpressionSegment):
+    """Enhance set expression to include ClickHouse-specific clauses.
+
+    Built from the ClickHouse ``UnorderedSetExpressionSegment`` so that
+    per-member ``ORDER BY`` / ``LIMIT`` / ``SETTINGS`` are recognised, while the
+    clauses trailing the final member bind to the whole set expression.
+    """
+
+    match_grammar = UnorderedSetExpressionSegment.match_grammar.copy(
         insert=[
+            Ref("OrderByClauseSegment", optional=True),
+            Ref("LimitClauseSegment", optional=True),
+            Ref("NamedWindowSegment", optional=True),
             Ref("FormatClauseSegment", optional=True),
             Ref("SettingsClauseSegment", optional=True),
             Ref("IntoOutfileClauseSegment", optional=True),

--- a/test/fixtures/dialects/clickhouse/select_union_member_clauses.sql
+++ b/test/fixtures/dialects/clickhouse/select_union_member_clauses.sql
@@ -1,0 +1,16 @@
+-- ClickHouse allows ORDER BY / LIMIT / SETTINGS on a non-final member of an
+-- unparenthesised UNION (https://clickhouse.com/docs/en/sql-reference/statements/select/union).
+
+SELECT a FROM t ORDER BY a UNION ALL SELECT b FROM u;
+
+SELECT a FROM t LIMIT 10 UNION ALL SELECT b FROM u;
+
+SELECT a FROM t ORDER BY a LIMIT 10 UNION ALL SELECT b FROM u;
+
+SELECT a FROM t SETTINGS max_threads = 1 UNION ALL SELECT b FROM u;
+
+SELECT a FROM t ORDER BY a
+UNION ALL
+SELECT b FROM u ORDER BY b
+UNION ALL
+SELECT c FROM v;

--- a/test/fixtures/dialects/clickhouse/select_union_member_clauses.yml
+++ b/test/fixtures/dialects/clickhouse/select_union_member_clauses.yml
@@ -1,0 +1,217 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 9a43353ae203a0b8d5d24b4cd75a56af94ba236ddc1898b3adb05fd5ad9d4c0f
+file:
+- statement:
+    set_expression:
+    - select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            column_reference:
+              naked_identifier: a
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: t
+    - orderby_clause:
+      - keyword: ORDER
+      - keyword: BY
+      - column_reference:
+          naked_identifier: a
+    - set_operator:
+      - keyword: UNION
+      - keyword: ALL
+    - select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            column_reference:
+              naked_identifier: b
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: u
+- statement_terminator: ;
+- statement:
+    set_expression:
+    - select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            column_reference:
+              naked_identifier: a
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: t
+    - limit_clause:
+        keyword: LIMIT
+        limit_clause_component:
+          numeric_literal: '10'
+    - set_operator:
+      - keyword: UNION
+      - keyword: ALL
+    - select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            column_reference:
+              naked_identifier: b
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: u
+- statement_terminator: ;
+- statement:
+    set_expression:
+    - select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            column_reference:
+              naked_identifier: a
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: t
+    - orderby_clause:
+      - keyword: ORDER
+      - keyword: BY
+      - column_reference:
+          naked_identifier: a
+    - limit_clause:
+        keyword: LIMIT
+        limit_clause_component:
+          numeric_literal: '10'
+    - set_operator:
+      - keyword: UNION
+      - keyword: ALL
+    - select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            column_reference:
+              naked_identifier: b
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: u
+- statement_terminator: ;
+- statement:
+    set_expression:
+    - select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            column_reference:
+              naked_identifier: a
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: t
+    - settings_clause:
+        keyword: SETTINGS
+        naked_identifier: max_threads
+        comparison_operator:
+          raw_comparison_operator: '='
+        numeric_literal: '1'
+    - set_operator:
+      - keyword: UNION
+      - keyword: ALL
+    - select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            column_reference:
+              naked_identifier: b
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: u
+- statement_terminator: ;
+- statement:
+    set_expression:
+    - select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            column_reference:
+              naked_identifier: a
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: t
+    - orderby_clause:
+      - keyword: ORDER
+      - keyword: BY
+      - column_reference:
+          naked_identifier: a
+    - set_operator:
+      - keyword: UNION
+      - keyword: ALL
+    - select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            column_reference:
+              naked_identifier: b
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: u
+    - orderby_clause:
+      - keyword: ORDER
+      - keyword: BY
+      - column_reference:
+          naked_identifier: b
+    - set_operator:
+      - keyword: UNION
+      - keyword: ALL
+    - select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            column_reference:
+              naked_identifier: c
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: v
+- statement_terminator: ;


### PR DESCRIPTION
### Brief summary of the change made

Fixes #8031. ClickHouse permits `ORDER BY`, `LIMIT` and `SETTINGS` on an individual, non-final member of an unparenthesised `UNION`, but sqlfluff treated everything from the set operator onward as unparsable once a left-hand member carried one of those clauses:

```sql
SELECT a FROM t ORDER BY a UNION ALL SELECT b FROM u;              -- was: PRS 'UNION ALL ...'
SELECT a FROM t LIMIT 10 UNION ALL SELECT b FROM u;                -- was: PRS 'UNION ALL ...'
SELECT a FROM t ORDER BY a LIMIT 10 UNION ALL SELECT b FROM u;     -- was: PRS 'UNION ALL ...'
SELECT a FROM t SETTINGS max_threads = 1 UNION ALL SELECT b FROM u;-- was: PRS 'UNION ALL ...'
```

### How

The ClickHouse `UnorderedSetExpressionSegment` is overridden to match `ORDER BY` / `LIMIT` / `SETTINGS` **in the position between a member and the following set operator**, so those clauses attach to the (non-final) member. The clauses trailing the *final* member continue to be matched by `SetExpressionSegment` and bind to the whole set expression, so the existing set-level `SETTINGS` / `FORMAT` / `INTO OUTFILE` behaviour (`select_union_with_settings`) is unchanged.

This intentionally avoids the ambiguity noted in #8031: a clause after the last member is still set-level, a clause before a `UNION` is member-level — matching ClickHouse's own semantics.

### Are there any other side effects of this change that we should be aware of?

No. Verified:

- The existing `clickhouse/select_union_with_settings` fixture parses identically (set-level `SETTINGS`/`FORMAT`/`INTO OUTFILE` unaffected).
- Full ClickHouse dialect fixture suite passes (147 tests).
- New fixture `clickhouse/select_union_member_clauses` added; its cases fail on `main` and pass here (the `ORDER BY` nests inside the member, before the `set_operator`).
- `ruff check` / `ruff format --check` clean.

### Pull request checklist

- [x] Added a fixture and regenerated the YAML.
- [x] Reproduces/resolves the issue; new cases fail on `main`.
- [x] Lint clean; no regressions in the ClickHouse dialect suite.

---

*Disclosure: prepared with AI assistance; reviewed and verified locally against the dialect test suite.*


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Parse ORDER BY/LIMIT/SETTINGS on non-final UNION members in ClickHouse and attach them to that member, fixing #8031. Trailing clauses after the final member remain set-level.

- **Bug Fixes**
  - Override `UnorderedSetExpressionSegment` to match member-level clauses before a set operator.
  - Build `SetExpressionSegment` on top to preserve set-level `SETTINGS`/`FORMAT`/`INTO OUTFILE` after the final member.
  - Add `select_union_member_clauses` fixture; ClickHouse dialect tests pass.

<sup>Written for commit 60b0a257dec99cf52e9b4423067d1ce9b381e153. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8100?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

