### PR TITLE
Read Jinja macro files with the configured encoding (#6633)

### DIFF
--- a/src/sqlfluff/core/templaters/jinja.py
+++ b/src/sqlfluff/core/templaters/jinja.py
@@ -33,6 +33,7 @@ from jinja2.sandbox import SandboxedEnvironment
 from sqlfluff.core.config import FluffConfig
 from sqlfluff.core.errors import SQLFluffUserError, SQLTemplaterError
 from sqlfluff.core.formatter import FormatterInterface
+from sqlfluff.core.helpers.file import get_encoding
 from sqlfluff.core.helpers.slice import is_zero_slice, slice_length
 from sqlfluff.core.templaters.base import (
     RawFileSlice,
@@ -167,6 +168,7 @@ class JinjaTemplater(PythonTemplater):
         env: Environment,
         ctx: dict[str, Any],
         exclude_paths: Optional[list[str]] = None,
+        config_encoding: str = "autodetect",
     ) -> dict[str, DbtMacroWrapper]:
         """Take a path and extract macros from it.
 
@@ -175,6 +177,7 @@ class JinjaTemplater(PythonTemplater):
             env (Environment): The environment object.
             ctx (Dict): The context dictionary.
             exclude_paths (Optional[[List][str]]): A list of paths to exclude
+            config_encoding: The configured encoding or autodetect.
 
         Returns:
             dict: A dictionary containing the extracted macros.
@@ -196,10 +199,10 @@ class JinjaTemplater(PythonTemplater):
                     ):
                         continue
                 # It's a file. Extract macros from it.
-                # Read as UTF-8 rather than relying on the platform default
-                # encoding, which crashes on non-ASCII macros on e.g. Windows
-                # (cp1252). See #6633.
-                with open(path_entry, encoding="utf-8") as opened_file:
+                encoding = get_encoding(
+                    fname=path_entry, config_encoding=config_encoding
+                )
+                with open(path_entry, encoding=encoding) as opened_file:
                     template = opened_file.read()
                 # Update the context with macros from the file.
                 try:
@@ -224,6 +227,7 @@ class JinjaTemplater(PythonTemplater):
                                     env=env,
                                     ctx=ctx,
                                     exclude_paths=exclude_paths,
+                                    config_encoding=config_encoding,
                                 )
                             )
         return macro_ctx
@@ -279,12 +283,14 @@ class JinjaTemplater(PythonTemplater):
         macros_path = self._get_macros_path(config, "load_macros_from_path")
         exclude_macros_path = self._get_macros_path(config, "exclude_macros_from_path")
         if macros_path:
+            config_encoding: str = config.get("encoding", default="autodetect")
             macro_ctx.update(
                 self._extract_macros_from_path(
                     macros_path,
                     env=env,
                     ctx=ctx,
                     exclude_paths=exclude_macros_path,
+                    config_encoding=config_encoding,
                 )
             )
 

--- a/src/sqlfluff/core/templaters/jinja.py
+++ b/src/sqlfluff/core/templaters/jinja.py
@@ -196,7 +196,10 @@ class JinjaTemplater(PythonTemplater):
                     ):
                         continue
                 # It's a file. Extract macros from it.
-                with open(path_entry) as opened_file:
+                # Read as UTF-8 rather than relying on the platform default
+                # encoding, which crashes on non-ASCII macros on e.g. Windows
+                # (cp1252). See #6633.
+                with open(path_entry, encoding="utf-8") as opened_file:
                     template = opened_file.read()
                 # Update the context with macros from the file.
                 try:

--- a/test/core/templaters/jinja_test.py
+++ b/test/core/templaters/jinja_test.py
@@ -584,17 +584,27 @@ def test__templater_jinja_error_variable():
     assert any(v.rule_code() == "TMP" and v.line_no == 1 for v in vs)
 
 
-def test__templater_jinja_macro_path_utf8(tmp_path, monkeypatch):
-    """Macro files are read as UTF-8 regardless of the platform default encoding.
+@pytest.mark.parametrize(
+    ("file_encoding", "config_encoding"),
+    [
+        ("utf-8", "utf-8"),
+        ("utf-16", "utf-16"),
+        ("utf-8", "autodetect"),
+    ],
+)
+def test__templater_jinja_macro_path_configured_encoding(
+    tmp_path, monkeypatch, file_encoding, config_encoding
+):
+    """Macro files are read with the encoding from the configuration.
 
     See #6633: on platforms whose default text encoding is not UTF-8 (e.g.
     Windows cp1252), a macro containing a non-ASCII character used to raise a
     ``UnicodeDecodeError`` when loaded from ``load_macros_from_path``.
     """
     macro_file = tmp_path / "macros.sql"
-    # "Á" (U+00C1) is UTF-8 bytes C3 81; byte 0x81 is undefined in cp1252.
     macro_file.write_text(
-        "{% macro square(n) %}-- Á\n{{ n * n }}{% endmacro %}", encoding="utf-8"
+        "{% macro square(n) %}-- Á\n{{ n * n }}{% endmacro %}",
+        encoding=file_encoding,
     )
 
     real_open = open
@@ -607,9 +617,19 @@ def test__templater_jinja_macro_path_utf8(tmp_path, monkeypatch):
 
     monkeypatch.setattr("builtins.open", cp1252_default_open)
 
-    macros = JinjaTemplater._extract_macros_from_path(
-        [str(macro_file)], env=Environment(), ctx={}
+    config = FluffConfig(
+        configs={
+            "core": {
+                "dialect": "ansi",
+                "encoding": config_encoding,
+                "templater": "jinja",
+            },
+            "templater": {
+                "jinja": {"load_macros_from_path": str(macro_file)},
+            },
+        }
     )
+    macros = JinjaTemplater()._extract_macros(config, env=Environment(), ctx={})
     assert "square" in macros
 
 

--- a/test/core/templaters/jinja_test.py
+++ b/test/core/templaters/jinja_test.py
@@ -584,6 +584,35 @@ def test__templater_jinja_error_variable():
     assert any(v.rule_code() == "TMP" and v.line_no == 1 for v in vs)
 
 
+def test__templater_jinja_macro_path_utf8(tmp_path, monkeypatch):
+    """Macro files are read as UTF-8 regardless of the platform default encoding.
+
+    See #6633: on platforms whose default text encoding is not UTF-8 (e.g.
+    Windows cp1252), a macro containing a non-ASCII character used to raise a
+    ``UnicodeDecodeError`` when loaded from ``load_macros_from_path``.
+    """
+    macro_file = tmp_path / "macros.sql"
+    # "Á" (U+00C1) is UTF-8 bytes C3 81; byte 0x81 is undefined in cp1252.
+    macro_file.write_text(
+        "{% macro square(n) %}-- Á\n{{ n * n }}{% endmacro %}", encoding="utf-8"
+    )
+
+    real_open = open
+
+    def cp1252_default_open(file, mode="r", *args, encoding=None, **kwargs):
+        # Emulate a platform whose default text encoding is cp1252.
+        if encoding is None and "b" not in mode:
+            encoding = "cp1252"
+        return real_open(file, mode, *args, encoding=encoding, **kwargs)
+
+    monkeypatch.setattr("builtins.open", cp1252_default_open)
+
+    macros = JinjaTemplater._extract_macros_from_path(
+        [str(macro_file)], env=Environment(), ctx={}
+    )
+    assert "square" in macros
+
+
 def test__templater_jinja_dynamic_variable_no_violations():
     """Test no templater violation for variable defined within template."""
     t = JinjaTemplater(override_context=dict(blah="foo"))


### PR DESCRIPTION
### Brief summary of the change made

Fixes #6633. Jinja macro files loaded through `load_macros_from_path` were opened with the platform default encoding. On systems where that default differs from the configured SQLFluff encoding, non-ASCII macro files could raise `UnicodeDecodeError` and abort linting.

### How

Pass the configured `encoding` value into `_extract_macros_from_path()` and resolve each macro file with the existing `get_encoding()` helper before opening it. This honors explicit encodings such as UTF-8 or UTF-16 and preserves SQLFluff's default `autodetect` behavior. Recursive macro-directory loading carries the same configured value.

### Are there any other side effects of this change that we should be aware of?

No. Macro files now follow the same configured encoding policy as target SQL files.

Verified:

- The regression test emulates a `cp1252` platform default and covers explicit UTF-8, explicit UTF-16, and autodetected UTF-8 macro files.
- Full Jinja templater suite passes: **124 tests**.
- Ruff, mypy, doc8, yamllint, codespell, and all repository pre-commit hooks pass.

### Pull request checklist

- [x] Added a regression test.
- [x] Uses SQLFluff's configured encoding and existing autodetection helper.
- [x] Lint and type checks are clean.

---

*Disclosure: prepared with AI assistance; reviewed and verified locally against the test suite.*
