### PR TITLE
Oracle: parse the SQL*Plus SHOW command (#8102)

### DIFF
--- a/src/sqlfluff/dialects/dialect_oracle.py
+++ b/src/sqlfluff/dialects/dialect_oracle.py
@@ -1202,6 +1202,50 @@ class IndexTypeReferenceSegment(BaseSegment):
     match_grammar = ansi.ObjectReferenceSegment.match_grammar.copy()
 
 
+class ShowStatementSegment(BaseSegment):
+    """A SQL*Plus ``SHOW`` command.
+
+    https://docs.oracle.com/en/database/oracle/oracle-database/latest/sqpug/SHOW.html
+    """
+
+    type = "show_statement"
+
+    match_grammar = Sequence(
+        "SHOW",
+        OneOf(
+            # SHOW ERRORS [object_type [schema.]name]
+            Sequence(
+                "ERRORS",
+                Sequence(
+                    OneOf(
+                        "FUNCTION",
+                        "PROCEDURE",
+                        "TRIGGER",
+                        "VIEW",
+                        "DIMENSION",
+                        Sequence("PACKAGE", Ref.keyword("BODY", optional=True)),
+                        Sequence("TYPE", Ref.keyword("BODY", optional=True)),
+                        Sequence("JAVA", OneOf("SOURCE", "CLASS")),
+                    ),
+                    Ref("ObjectReferenceSegment"),
+                    optional=True,
+                ),
+            ),
+            # SHOW PARAMETER[S] [name]
+            Sequence(
+                OneOf("PARAMETERS", "PARAMETER"),
+                Ref("ParameterNameSegment", optional=True),
+            ),
+            # Reserved keywords that cannot be matched as a bare identifier.
+            "ALL",
+            "USER",
+            # Any other single-word option, or a SET system variable, e.g.
+            # SGA, PDBS, RELEASE, RECYCLEBIN, SPOOL, LINESIZE, PAGESIZE.
+            Ref("NakedIdentifierSegment"),
+        ),
+    )
+
+
 # Adding Oracle specific statements.
 class StatementSegment(ansi.StatementSegment):
     """A generic segment, to any of its child subsegments.
@@ -1255,6 +1299,7 @@ class StatementSegment(ansi.StatementSegment):
             Ref("AlterSynonymStatementSegment"),
             Ref("DropProfileStatementSegment"),
             Ref("DropClusterStatementSegment"),
+            Ref("ShowStatementSegment"),
         ],
     )
 

--- a/src/sqlfluff/dialects/dialect_oracle.py
+++ b/src/sqlfluff/dialects/dialect_oracle.py
@@ -189,6 +189,7 @@ oracle_dialect.add(
     ),
     PowerOperatorSegment=StringParser("**", SymbolSegment, type="binary_operator"),
     ModOperatorSegment=StringParser("MOD", WordSegment, type="binary_operator"),
+    ShowOptionSegment=TypedParser("word", CodeSegment, type="show_option"),
     OnCommitGrammar=Sequence(
         "ON",
         "COMMIT",
@@ -1234,14 +1235,19 @@ class ShowStatementSegment(BaseSegment):
             # SHOW PARAMETER[S] [name]
             Sequence(
                 OneOf("PARAMETERS", "PARAMETER"),
-                Ref("ParameterNameSegment", optional=True),
+                Ref(
+                    "ParameterNameSegment",
+                    optional=True,
+                    exclude=OneOf("SHOW", "SET", "PROMPT"),
+                ),
             ),
-            # Reserved keywords that cannot be matched as a bare identifier.
             "ALL",
             "USER",
-            # Any other single-word option, or a SET system variable, e.g.
-            # SGA, PDBS, RELEASE, RECYCLEBIN, SPOOL, LINESIZE, PAGESIZE.
-            Ref("NakedIdentifierSegment"),
+            # Any other single-word option, including a SET system variable.
+            Ref(
+                "ShowOptionSegment",
+                exclude=OneOf("SHOW", "SET", "PROMPT"),
+            ),
         ),
     )
 

--- a/src/sqlfluff/dialects/dialect_oracle.py
+++ b/src/sqlfluff/dialects/dialect_oracle.py
@@ -1206,7 +1206,7 @@ class IndexTypeReferenceSegment(BaseSegment):
 class ShowStatementSegment(BaseSegment):
     """A SQL*Plus ``SHOW`` command.
 
-    https://docs.oracle.com/en/database/oracle/oracle-database/latest/sqpug/SHOW.html
+    https://docs.oracle.com/en/database/oracle/oracle-database/26/sqpug/SHOW.html
     """
 
     type = "show_statement"
@@ -1238,7 +1238,7 @@ class ShowStatementSegment(BaseSegment):
                 Ref(
                     "ParameterNameSegment",
                     optional=True,
-                    exclude=OneOf("SHOW", "SET", "PROMPT"),
+                    exclude=OneOf("SHOW", "SET", "PROMPT", "SELECT"),
                 ),
             ),
             "ALL",
@@ -1246,7 +1246,7 @@ class ShowStatementSegment(BaseSegment):
             # Any other single-word option, including a SET system variable.
             Ref(
                 "ShowOptionSegment",
-                exclude=OneOf("SHOW", "SET", "PROMPT"),
+                exclude=OneOf("SHOW", "SET", "PROMPT", "SELECT"),
             ),
         ),
     )

--- a/test/fixtures/dialects/oracle/show.sql
+++ b/test/fixtures/dialects/oracle/show.sql
@@ -1,0 +1,28 @@
+-- SQL*Plus SHOW command.
+-- https://docs.oracle.com/en/database/oracle/oracle-database/latest/sqpug/SHOW.html
+
+SHOW ERRORS;
+
+SHOW ERRORS FUNCTION my_func;
+
+SHOW ERRORS PACKAGE BODY my_pkg;
+
+SHOW PARAMETER;
+
+SHOW PARAMETERS sga_target;
+
+SHOW RECYCLEBIN;
+
+SHOW ALL;
+
+SHOW USER;
+
+SHOW SGA;
+
+SHOW RELEASE;
+
+SHOW PDBS;
+
+SHOW CON_NAME;
+
+SHOW LINESIZE;

--- a/test/fixtures/dialects/oracle/show.sql
+++ b/test/fixtures/dialects/oracle/show.sql
@@ -26,3 +26,14 @@ SHOW PDBS;
 SHOW CON_NAME;
 
 SHOW LINESIZE;
+
+-- SHOW accepts SET system variables that are Oracle reserved words.
+SHOW LONG;
+
+SHOW NULL;
+
+-- SQL*Plus terminates commands at newlines without requiring semicolons.
+SHOW PARAMETERS
+SHOW USER
+SHOW PARAMETERS
+SET SCAN ON

--- a/test/fixtures/dialects/oracle/show.sql
+++ b/test/fixtures/dialects/oracle/show.sql
@@ -1,5 +1,5 @@
 -- SQL*Plus SHOW command.
--- https://docs.oracle.com/en/database/oracle/oracle-database/latest/sqpug/SHOW.html
+-- https://docs.oracle.com/en/database/oracle/oracle-database/26/sqpug/SHOW.html
 
 SHOW ERRORS;
 
@@ -37,3 +37,5 @@ SHOW PARAMETERS
 SHOW USER
 SHOW PARAMETERS
 SET SCAN ON
+SHOW PARAMETERS
+SELECT 1 FROM DUAL;

--- a/test/fixtures/dialects/oracle/show.yml
+++ b/test/fixtures/dialects/oracle/show.yml
@@ -1,0 +1,81 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 58b4458ec62b00cf00925045321d60cffb350d26688128c1d92d67891fb36da7
+file:
+  batch:
+  - statement:
+      show_statement:
+      - keyword: SHOW
+      - keyword: ERRORS
+  - statement_terminator: ;
+  - statement:
+      show_statement:
+      - keyword: SHOW
+      - keyword: ERRORS
+      - keyword: FUNCTION
+      - object_reference:
+          naked_identifier: my_func
+  - statement_terminator: ;
+  - statement:
+      show_statement:
+      - keyword: SHOW
+      - keyword: ERRORS
+      - keyword: PACKAGE
+      - keyword: BODY
+      - object_reference:
+          naked_identifier: my_pkg
+  - statement_terminator: ;
+  - statement:
+      show_statement:
+      - keyword: SHOW
+      - keyword: PARAMETER
+  - statement_terminator: ;
+  - statement:
+      show_statement:
+      - keyword: SHOW
+      - keyword: PARAMETERS
+      - parameter: sga_target
+  - statement_terminator: ;
+  - statement:
+      show_statement:
+        keyword: SHOW
+        naked_identifier: RECYCLEBIN
+  - statement_terminator: ;
+  - statement:
+      show_statement:
+      - keyword: SHOW
+      - keyword: ALL
+  - statement_terminator: ;
+  - statement:
+      show_statement:
+      - keyword: SHOW
+      - keyword: USER
+  - statement_terminator: ;
+  - statement:
+      show_statement:
+        keyword: SHOW
+        naked_identifier: SGA
+  - statement_terminator: ;
+  - statement:
+      show_statement:
+        keyword: SHOW
+        naked_identifier: RELEASE
+  - statement_terminator: ;
+  - statement:
+      show_statement:
+        keyword: SHOW
+        naked_identifier: PDBS
+  - statement_terminator: ;
+  - statement:
+      show_statement:
+        keyword: SHOW
+        naked_identifier: CON_NAME
+  - statement_terminator: ;
+  - statement:
+      show_statement:
+        keyword: SHOW
+        naked_identifier: LINESIZE
+  - statement_terminator: ;

--- a/test/fixtures/dialects/oracle/show.yml
+++ b/test/fixtures/dialects/oracle/show.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: f410098ea526b66e1b418f1117c5f42b2b189cb6db856c5f9a73024b7c4048fb
+_hash: f6e64e5298a1647f79cf21e3f5c45015d419e35b7ad5f431ef5ac70058813428
 file:
 - batch:
   - statement:
@@ -108,3 +108,23 @@ file:
     - keyword: SET
     - keyword: SCAN
     - keyword: 'ON'
+- batch:
+    statement:
+      show_statement:
+      - keyword: SHOW
+      - keyword: PARAMETERS
+- batch:
+    statement:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            numeric_literal: '1'
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: DUAL
+    statement_terminator: ;

--- a/test/fixtures/dialects/oracle/show.yml
+++ b/test/fixtures/dialects/oracle/show.yml
@@ -3,9 +3,9 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 58b4458ec62b00cf00925045321d60cffb350d26688128c1d92d67891fb36da7
+_hash: f410098ea526b66e1b418f1117c5f42b2b189cb6db856c5f9a73024b7c4048fb
 file:
-  batch:
+- batch:
   - statement:
       show_statement:
       - keyword: SHOW
@@ -42,7 +42,7 @@ file:
   - statement:
       show_statement:
         keyword: SHOW
-        naked_identifier: RECYCLEBIN
+        show_option: RECYCLEBIN
   - statement_terminator: ;
   - statement:
       show_statement:
@@ -57,25 +57,54 @@ file:
   - statement:
       show_statement:
         keyword: SHOW
-        naked_identifier: SGA
+        show_option: SGA
   - statement_terminator: ;
   - statement:
       show_statement:
         keyword: SHOW
-        naked_identifier: RELEASE
+        show_option: RELEASE
   - statement_terminator: ;
   - statement:
       show_statement:
         keyword: SHOW
-        naked_identifier: PDBS
+        show_option: PDBS
   - statement_terminator: ;
   - statement:
       show_statement:
         keyword: SHOW
-        naked_identifier: CON_NAME
+        show_option: CON_NAME
   - statement_terminator: ;
   - statement:
       show_statement:
         keyword: SHOW
-        naked_identifier: LINESIZE
+        show_option: LINESIZE
   - statement_terminator: ;
+  - statement:
+      show_statement:
+        keyword: SHOW
+        show_option: LONG
+  - statement_terminator: ;
+  - statement:
+      show_statement:
+        keyword: SHOW
+        show_option: 'NULL'
+  - statement_terminator: ;
+  - statement:
+      show_statement:
+      - keyword: SHOW
+      - keyword: PARAMETERS
+- batch:
+    statement:
+      show_statement:
+      - keyword: SHOW
+      - keyword: USER
+- batch:
+    statement:
+      show_statement:
+      - keyword: SHOW
+      - keyword: PARAMETERS
+- batch:
+    sqlplus_set_statement:
+    - keyword: SET
+    - keyword: SCAN
+    - keyword: 'ON'


### PR DESCRIPTION
### Brief summary of the change made

Fixes #8102. The Oracle dialect didn't support the SQL*Plus `SHOW` command at all, so `show errors` (and every other `SHOW` option) produced a `Found unparsable section` error.

```sql
show errors;   -- was: PRS 'show errors'
```

### How

Add a `ShowStatementSegment` (registered in the Oracle `StatementSegment`) covering the documented [`SHOW`](https://docs.oracle.com/en/database/oracle/oracle-database/26/sqpug/SHOW.html) options:

- `SHOW ERRORS [ {FUNCTION | PROCEDURE | PACKAGE [BODY] | TRIGGER | VIEW | TYPE [BODY] | DIMENSION | JAVA SOURCE | JAVA CLASS} [schema.]name ]`
- `SHOW PARAMETER[S] [name]`
- the reserved-keyword options `ALL` and `USER`
- any other single-word option or SET system variable (`SGA`, `PDBS`, `RELEASE`, `RECYCLEBIN`, `SPOOL`, `LINESIZE`, `PAGESIZE`, …), matched via a naked identifier so **no new keywords are required**.

### Are there any other side effects of this change that we should be aware of?

No. `SHOW` is a new statement; nothing else is affected. Verified:

- New fixture `oracle/show` (14 forms incl. `ERRORS`, `ERRORS FUNCTION ...`, `ERRORS PACKAGE BODY ...`, `PARAMETER[S]`, `RECYCLEBIN`, `ALL`, `USER`, `SGA`, `RELEASE`, `PDBS`, `CON_NAME`, `LINESIZE`); cases fail on `main` and pass here.
- Full Oracle dialect suite passes (291 tests).
- `ruff check` / `ruff format --check` clean; no keyword-set changes.

### Pull request checklist

- [x] Added a fixture and regenerated the YAML.
- [x] Reproduces/resolves the issue; new cases fail on `main`.
- [x] Lint clean; no regressions.

---

*Disclosure: prepared with AI assistance; reviewed and verified locally against the dialect test suite.*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds parsing support for the Oracle SQL*Plus `SHOW` command and newline-terminated commands, removing “Found unparsable section” errors (e.g., `SHOW ERRORS`). Fixes #8102.

- Added `ShowStatementSegment` and registered it in the Oracle `StatementSegment`.
- Supports `SHOW ERRORS` with optional object type and `[schema.]name`, and `SHOW PARAMETER[S] [name]`.
- Accepts reserved options `ALL` and `USER`, plus any single-word option or SET variable (e.g., `SGA`, `PDBS`, `RELEASE`, `RECYCLEBIN`, `SPOOL`, `LINESIZE`, `LONG`, `NULL`).
- Excludes `SHOW`, `SET`, `PROMPT`, and `SELECT` from option names so newline-terminated `SHOW` statements don't consume a following `SELECT`.

<sup>Written for commit cfd786287b55c604a4066b6718bc5689e8dee975. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8104?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

