### PR TITLE
ClickHouse: parse multi-column LIMIT n BY a, b (#8030)

### DIFF
--- a/src/sqlfluff/dialects/dialect_clickhouse.py
+++ b/src/sqlfluff/dialects/dialect_clickhouse.py
@@ -2759,7 +2759,8 @@ class LimitClauseSegment(ansi.LimitClauseSegment):
                 "BY",
                 OneOf(
                     Ref("BracketedColumnReferenceListGrammar"),
-                    Ref("ColumnReferenceSegment"),
+                    # Unbracketed ``LIMIT n BY a, b`` accepts a list of columns.
+                    Delimited(Ref("ColumnReferenceSegment")),
                 ),
                 optional=True,
             ),

--- a/test/fixtures/dialects/clickhouse/limit_by.sql
+++ b/test/fixtures/dialects/clickhouse/limit_by.sql
@@ -5,3 +5,7 @@ with toto as (SELECT 1 as id, 'test' as name) SELECT * FROM toto LIMIT 1 by id;
 with toto as (SELECT 1 as id, 'test' as name) SELECT * FROM toto LIMIT 2 OFFSET 1 by id;
 
 with toto as (SELECT 1 as id, 'test' as name) SELECT * FROM toto LIMIT 2, 1 by (id, name);
+
+with toto as (SELECT 1 as id, 'test' as name) SELECT * FROM toto LIMIT 1 by id, name;
+
+with toto as (SELECT 1 as id, 'test' as name) SELECT * FROM toto LIMIT 2 OFFSET 1 by id, name;

--- a/test/fixtures/dialects/clickhouse/limit_by.yml
+++ b/test/fixtures/dialects/clickhouse/limit_by.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: bfb1a1991e553e932bdb4d70cc5871ef1bec789eb542a3da37739661335c4c54
+_hash: b5bb0d989dcc7437d8698dc1aef56b0dd600db28da3397967a40aa8c6bbdf55e
 file:
 - statement:
     with_compound_statement:
@@ -207,4 +207,107 @@ file:
           - column_reference:
               naked_identifier: name
           - end_bracket: )
+- statement_terminator: ;
+- statement:
+    with_compound_statement:
+      keyword: with
+      common_table_expression:
+        naked_identifier: toto
+        keyword: as
+        bracketed:
+          start_bracket: (
+          select_statement:
+            select_clause:
+            - keyword: SELECT
+            - select_clause_element:
+                numeric_literal: '1'
+                alias_expression:
+                  alias_operator:
+                    keyword: as
+                  naked_identifier: id
+            - comma: ','
+            - select_clause_element:
+                quoted_literal: "'test'"
+                alias_expression:
+                  alias_operator:
+                    keyword: as
+                  naked_identifier: name
+          end_bracket: )
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: toto
+        limit_clause:
+        - keyword: LIMIT
+        - limit_clause_component:
+            numeric_literal: '1'
+        - keyword: by
+        - column_reference:
+            naked_identifier: id
+        - comma: ','
+        - column_reference:
+            naked_identifier: name
+- statement_terminator: ;
+- statement:
+    with_compound_statement:
+      keyword: with
+      common_table_expression:
+        naked_identifier: toto
+        keyword: as
+        bracketed:
+          start_bracket: (
+          select_statement:
+            select_clause:
+            - keyword: SELECT
+            - select_clause_element:
+                numeric_literal: '1'
+                alias_expression:
+                  alias_operator:
+                    keyword: as
+                  naked_identifier: id
+            - comma: ','
+            - select_clause_element:
+                quoted_literal: "'test'"
+                alias_expression:
+                  alias_operator:
+                    keyword: as
+                  naked_identifier: name
+          end_bracket: )
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: toto
+        limit_clause:
+        - keyword: LIMIT
+        - limit_clause_component:
+            numeric_literal: '2'
+        - keyword: OFFSET
+        - limit_clause_component:
+            numeric_literal: '1'
+        - keyword: by
+        - column_reference:
+            naked_identifier: id
+        - comma: ','
+        - column_reference:
+            naked_identifier: name
 - statement_terminator: ;


### PR DESCRIPTION
### Brief summary of the change made

Fixes #8030. The unbracketed ClickHouse `LIMIT ... BY` clause only accepted a single column, so a comma-separated list left the trailing column(s) unparsable (a follow-up to the single-column `LIMIT BY` fixed in #5494):

```sql
SELECT * FROM t LIMIT 1 BY a, b   -- was: PRS 'Found unparsable section: , b'
SELECT * FROM t LIMIT 1 BY a      -- already parsed
```

### How

The `BY` clause matched `OneOf(BracketedColumnReferenceListGrammar, ColumnReferenceSegment)`. Replaced the single `ColumnReferenceSegment` with `Delimited(ColumnReferenceSegment)`, so an unbracketed list `a, b` parses (the bracketed `(a, b)` form was already supported, and `Delimited` still matches the single-column case).

### Are there any other side effects of this change that we should be aware of?

No. Verified:

- Extended the existing `clickhouse/limit_by` fixture with `LIMIT 1 BY id, name` and `LIMIT 2 OFFSET 1 BY id, name`; the new cases fail on `main` and pass here.
- Full ClickHouse dialect suite passes (147 tests). Single-column, bracketed, and `OFFSET` forms all still parse.
- `ruff check` clean.

(Supersedes the stale #8049, which was closed for inactivity.)

### Pull request checklist

- [x] Added fixture coverage and regenerated the YAML.
- [x] Reproduces/resolves the issue; new cases fail on `main`.
- [x] Lint clean; no regressions.

---

*Disclosure: prepared with AI assistance; reviewed and verified locally against the dialect test suite.*


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable parsing of multi-column unbracketed ClickHouse LIMIT ... BY lists (e.g., LIMIT 1 BY a, b). Fixes #8030.

- **Bug Fixes**
  - In `LimitClauseSegment`, replace `ColumnReferenceSegment` with `Delimited(ColumnReferenceSegment)` in the `BY` clause grammar.
  - Add fixtures for `LIMIT 1 BY id, name` and `LIMIT 2 OFFSET 1 BY id, name`.

<sup>Written for commit 6989b54956d1ca5777951432f9255b19cdb8415b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8105?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

