### PR TITLE
Add regression tests for Lexer and Parser divergences

### DIFF
--- a/test/core/parser/rust_parser_test.py
+++ b/test/core/parser/rust_parser_test.py
@@ -851,6 +851,156 @@ def test__rust_parser__vs_python_stray_bracket_swallows_union_arm():
     assert rust_result == python_result
 
 
+# ---------------------------------------------------------------------------
+# RustParser vs. pure-Python Parser divergences on well-formed, already-shipped
+# dialect fixtures.
+#
+# Unlike the malformed-SQL cases above, these reproduce on VALID SQL that's
+# already checked into the repo as a dialect fixture with a Python-generated
+# .yml ground truth - i.e. RustParser disagrees with the fixture's own
+# checked-in expected output, on input nobody had to invent. Found by running
+# Parser vs RustParser over every fixture in every dialect (not just ansi);
+# unlike ansi (0 mismatches across 208 fixtures), other dialects' fixtures
+# turned up 7 mismatches across 4 dialects.
+# ---------------------------------------------------------------------------
+
+
+def _read_fixture(dialect: str, filename: str) -> str:
+    return (_FIXTURE_DIR / dialect / filename).read_text(encoding="utf-8")
+
+
+@pytest.mark.skipif(not _HAS_RUST_PARSER, reason="Rust parser not available")
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "Regression: for a PIVOT clause whose aggregate expression is a "
+        "function call (e.g. SUM(sales)), RustParser inserts a spurious "
+        "extra Indent leaf inside PivotClauseSegment's Bracketed content "
+        "that Python's Parser doesn't produce, shifting every subsequent "
+        "leaf in the tree by one position for the rest of the file. "
+        "PivotClauseSegment.match_grammar (dialect_sparksql.py:2485-2495) "
+        "is `Sequence(Indent, 'PIVOT', Bracketed(Indent, Delimited(Sequence("
+        "BaseExpressionElementGrammar, AliasExpressionSegment(optional))), "
+        "...))` - the nested Bracketed's own leading Indent appears to be "
+        "emitted twice on the Rust side for this shape. Reproduces "
+        "identically in both databricks/pivot.sql and "
+        "sparksql/pivot_clause.sql (databricks inherits sparksql's grammar)."
+    ),
+)
+def test__rust_parser__vs_python_pivot_clause_indent_duplication():
+    """RustParser duplicates an Indent inside PIVOT's bracketed content.
+
+    Uses the real, already-shipped databricks/pivot.sql fixture - this is
+    valid SQL with a correct Python-generated .yml, not invented malformed
+    input.
+    """
+    sql = _read_fixture("databricks", "pivot.sql")
+    rust_result, python_result = _compare_parser_vs_rust(sql, dialect="databricks")
+    assert rust_result == python_result
+
+
+@pytest.mark.skipif(not _HAS_RUST_PARSER, reason="Rust parser not available")
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "Regression: the same class of spurious extra Indent as the PIVOT "
+        "clause bug above, but inside UnpivotClauseSegment's bracketed "
+        "column-alias content instead of PivotClauseSegment's function-call "
+        "content - a second, distinct grammar site hitting the same "
+        "underlying Rust Bracketed/Indent duplication issue. Reproduces "
+        "identically in both databricks/unpivot.sql and "
+        "sparksql/unpivot_clause.sql."
+    ),
+)
+def test__rust_parser__vs_python_unpivot_clause_indent_duplication():
+    """RustParser duplicates an Indent inside UNPIVOT's bracketed content.
+
+    Uses the real, already-shipped databricks/unpivot.sql fixture.
+    """
+    sql = _read_fixture("databricks", "unpivot.sql")
+    rust_result, python_result = _compare_parser_vs_rust(sql, dialect="databricks")
+    assert rust_result == python_result
+
+
+@pytest.mark.skipif(not _HAS_RUST_PARSER, reason="Rust parser not available")
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "Regression: a numeric literal argument inside Snowflake's CREATE "
+        "CATALOG INTEGRATION statement is typed as 'numeric_literal' by "
+        "Python's Parser but as a generic, less-specific 'literal' by "
+        "RustParser - the two trees are otherwise byte-identical (same "
+        "leaf count, same positions), only the segment class assigned to "
+        "this one value differs, at 5 separate occurrences in the file. "
+        "This is a segment-class-assignment mismatch between the Rust "
+        "grammar table's codegen'd class for this grammar element and the "
+        "actual Python class Snowflake's grammar uses here."
+    ),
+)
+def test__rust_parser__vs_python_snowflake_numeric_literal_mistyped():
+    """RustParser types a numeric literal generically instead of as numeric_literal.
+
+    Uses the real, already-shipped snowflake/create_catalog_integration.sql
+    fixture.
+    """
+    sql = _read_fixture("snowflake", "create_catalog_integration.sql")
+    rust_result, python_result = _compare_parser_vs_rust(sql, dialect="snowflake")
+    assert rust_result == python_result
+
+
+@pytest.mark.skipif(not _HAS_RUST_PARSER, reason="Rust parser not available")
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "Regression: T-SQL's 'SomeSchema.Value(...)' (a datatype-method "
+        "call, e.g. an XML column's .value() method) is a genuine grammar "
+        "ambiguity - it can fully match either as a plain dotted function "
+        "call (FunctionSegment, function_name='SomeSchema.Value') or as a "
+        "column_reference with a DatatypeMethodSegment suffix "
+        "(ObjectReferenceSegment's AnyNumberOf(OneOf(Ref('DatatypeMethod"
+        "Segment'), ...)) in dialect_tsql.py:3565-3574). Both candidates "
+        "match the exact same span (a real longest-match TIE, not one "
+        "candidate being longer), so whichever wins depends purely on "
+        "alternative-evaluation order. Python's Parser picks the function "
+        "interpretation; RustParser picks the column_reference+datatype_"
+        "method interpretation - a structurally different tree for the "
+        "same SQL, not just a differently-typed leaf."
+    ),
+)
+def test__rust_parser__vs_python_tsql_datatype_method_oneof_ambiguity():
+    """RustParser resolves a genuine OneOf tie differently than Python.
+
+    Uses the real, already-shipped tsql/datatype_methods.sql fixture.
+    """
+    sql = _read_fixture("tsql", "datatype_methods.sql")
+    rust_result, python_result = _compare_parser_vs_rust(sql, dialect="tsql")
+    assert rust_result == python_result
+
+
+@pytest.mark.skipif(not _HAS_RUST_PARSER, reason="Rust parser not available")
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "Regression: inside T-SQL's sqlcmd_command_segment (:setvar-style "
+        "sqlcmd commands), RustParser loses the original lexer-assigned "
+        "token type for its content - a bare word and a double-quoted "
+        "string both come out as a generic 'raw' segment instead of "
+        "'word'/'double_quote' respectively, as Python's Parser preserves. "
+        "sqlcmd_command_segment's content is matched via a catch-all "
+        "grammar (Anything()-style), and the Rust side isn't threading the "
+        "original token class through in that path."
+    ),
+)
+def test__rust_parser__vs_python_tsql_sqlcmd_command_loses_token_type():
+    """RustParser loses word/double_quote token typing inside sqlcmd_command_segment.
+
+    Uses the real, already-shipped tsql/sqlcmd_command.sql fixture.
+    """
+    sql = _read_fixture("tsql", "sqlcmd_command.sql")
+    rust_result, python_result = _compare_parser_vs_rust(sql, dialect="tsql")
+    assert rust_result == python_result
+
+
 @pytest.mark.skipif(not _HAS_RUST_PARSER, reason="Rust parser not available")
 def test__rust_parser__native_ast_profile_has_no_convert_stage():
     """With the native builder, profiling records no separate convert stage.

--- a/test/core/parser/rust_parser_test.py
+++ b/test/core/parser/rust_parser_test.py
@@ -1001,6 +1001,56 @@ def test__rust_parser__vs_python_tsql_sqlcmd_command_loses_token_type():
     assert rust_result == python_result
 
 
+# ---------------------------------------------------------------------------
+# PyLexer vs. PyRsLexer (the Rust-backed lexer) divergences.
+#
+# A separate investigation from the parser-layer bugs above: this compares
+# tokenization itself, not grammar matching. The lexer port turned out to be
+# extremely faithful (zero token-stream divergences across ~900 combined
+# adversarial cases: position markers, dialect-specific quoting, unlexable/
+# error boundaries). The one confirmed, deterministic divergence is in
+# SQLLexError's message text, not the tokens themselves.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not _HAS_RUST_PARSER, reason="Rust parser not available")
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "Regression: for an unlexable character run, PyLexer's "
+        "violations_from_segments (src/sqlfluff/core/parser/lexer.py:"
+        "838-847) builds the SQLLexError description via "
+        "'Unable to lex characters: {!r}'.format(...) - repr()-quoting and "
+        "escaping the raw text, and truncating to 9 characters plus a "
+        "literal '...' marker when longer. The Rust lexer's equivalent "
+        "(sqlfluffrs_lexer/src/lexer.rs:420-439, violations_from_tokens) "
+        "instead does format!(\"Unable to lex characters: {}\", "
+        "token.raw().chars().take(10).collect::<String>()) - embedding the "
+        "raw characters directly with no quoting/escaping, no truncation "
+        "marker, and a 10- vs 9-character cutoff. SQLLexError.from_rs_error "
+        "(src/sqlfluff/core/errors.py:190-200) passes the Rust description "
+        "through verbatim, so real lint/parse output can contain literal "
+        "unescaped control bytes or unicode where the Python lexer would "
+        "have produced a safely quoted repr()-style string."
+    ),
+)
+def test__rust_parser__vs_python_lexer_unlexable_error_message():
+    """PyRsLexer's SQLLexError text differs from PyLexer's for unlexable input.
+
+    Uses a non-ASCII character that neither lexer can tokenize, forcing the
+    <unlexable> fallback path on both sides.
+    """
+    from sqlfluff.core import FluffConfig
+    from sqlfluff.core.parser.lexer import PyLexer, PyRsLexer
+
+    sql = "SELECT \xa1 FROM t"
+    config = FluffConfig(overrides={"dialect": "ansi"})
+    _, py_errs = PyLexer(config=config).lex(sql)
+    _, rs_errs = PyRsLexer(config=config).lex(sql)
+
+    assert [str(e) for e in py_errs] == [str(e) for e in rs_errs]
+
+
 @pytest.mark.skipif(not _HAS_RUST_PARSER, reason="Rust parser not available")
 def test__rust_parser__native_ast_profile_has_no_convert_stage():
     """With the native builder, profiling records no separate convert stage.

--- a/test/core/parser/rust_parser_test.py
+++ b/test/core/parser/rust_parser_test.py
@@ -535,44 +535,94 @@ def test__rust_parser__profiling_accumulates_and_resets():
 _FIXTURE_DIR = Path(__file__).resolve().parents[3] / "test" / "fixtures" / "dialects"
 _FIXTURE_SQL = sorted(_FIXTURE_DIR.glob("*/*.sql"))
 
+# Fixtures with a *known*, already-documented Python-vs-RustParser divergence
+# (see the dedicated xfail regressions above/below in this file). Three-way
+# parity below is expected to fail on exactly these until those bugs are
+# fixed; everywhere else in the corpus, all three tree-building paths must
+# agree.
+_KNOWN_PYTHON_RUST_DIVERGENCES = {
+    ("databricks", "pivot.sql"),
+    ("databricks", "unpivot.sql"),
+    ("sparksql", "pivot_clause.sql"),
+    ("sparksql", "unpivot_clause.sql"),
+    ("snowflake", "create_catalog_integration.sql"),
+    ("tsql", "datatype_methods.sql"),
+    ("tsql", "sqlcmd_command.sql"),
+}
+
+
+def _fixture_param(sqlfile: Path):
+    key = (sqlfile.parent.name, sqlfile.name)
+    if key in _KNOWN_PYTHON_RUST_DIVERGENCES:
+        return pytest.param(
+            sqlfile,
+            marks=pytest.mark.xfail(
+                strict=True,
+                reason=(
+                    "Known Python-vs-RustParser divergence on this fixture; "
+                    "see the dedicated test__rust_parser__vs_python_* "
+                    "regression for this file elsewhere in this module."
+                ),
+            ),
+        )
+    return pytest.param(sqlfile)
+
 
 @pytest.mark.skipif(not _HAS_RUST_PARSER, reason="Rust parser not available")
 @pytest.mark.parametrize(
     "sqlfile",
-    _FIXTURE_SQL,
+    [_fixture_param(p) for p in _FIXTURE_SQL],
     ids=[str(p.relative_to(_FIXTURE_DIR)) for p in _FIXTURE_SQL],
 )
 def test__rust_parser__native_ast_parity(sqlfile):
-    """The fused builder must produce the same tree as convert+apply.
+    """All three tree-building paths must agree: Python, RustParser, fused.
 
-    For every dialect fixture, parse the same lexer output twice - once via the
-    legacy convert+apply path and once via the fused native builder - and assert
-    the resulting BaseSegment trees (or raised exceptions) are identical. Both
-    paths use the same config, so this isolates the tree-building difference.
+    For every dialect fixture, parse the same lexer output three ways - the
+    pure-Python Parser, RustParser's legacy convert+apply path, and
+    RustParser's fused native-AST builder - and assert the resulting
+    BaseSegment trees (or raised exceptions) are all identical. Fixtures with
+    an already-documented Python-vs-RustParser divergence are marked xfail
+    (see _KNOWN_PYTHON_RUST_DIVERGENCES); every other fixture must agree
+    across all three paths.
     """
     from sqlfluff.core import FluffConfig
-    from sqlfluff.core.parser import Lexer
+    from sqlfluff.core.parser import Lexer, Parser
     from sqlfluff.core.parser.rust_parser import set_native_ast
 
     config = FluffConfig(overrides={"dialect": sqlfile.parent.name})
     segments, _ = Lexer(config=config).lex(sqlfile.read_text(encoding="utf-8"))
 
-    def build(native: bool):
+    def result_for(tree):
+        return (
+            "tree",
+            tree.to_tuple(code_only=False, show_raw=True, include_meta=True)
+            if tree
+            else None,
+        )
+
+    def build_rust(native: bool):
         set_native_ast(native)
         try:
             tree = RustParser(config=config).parse(segments, fname=str(sqlfile))
-            return (
-                "tree",
-                tree.to_tuple(code_only=False, show_raw=True, include_meta=True)
-                if tree
-                else None,
-            )
+            return result_for(tree)
         except BaseException as err:  # PanicException is a BaseException
             return ("exc", type(err).__name__)
         finally:
             set_native_ast(False)
 
-    assert build(native=True) == build(native=False)
+    def build_python():
+        try:
+            tree = Parser(config=config).parse(segments, fname=str(sqlfile))
+            return result_for(tree)
+        except BaseException as err:
+            return ("exc", type(err).__name__)
+
+    python_result = build_python()
+    rust_default = build_rust(native=False)
+    rust_native = build_rust(native=True)
+
+    assert rust_native == rust_default, "native-AST path diverges from convert+apply"
+    assert python_result == rust_default, "RustParser diverges from Python Parser"
 
 
 @pytest.mark.skipif(not _HAS_RUST_PARSER, reason="Rust parser not available")
@@ -1024,7 +1074,7 @@ def test__rust_parser__vs_python_tsql_sqlcmd_command_loses_token_type():
         "escaping the raw text, and truncating to 9 characters plus a "
         "literal '...' marker when longer. The Rust lexer's equivalent "
         "(sqlfluffrs_lexer/src/lexer.rs:420-439, violations_from_tokens) "
-        "instead does format!(\"Unable to lex characters: {}\", "
+        'instead does format!("Unable to lex characters: {}", '
         "token.raw().chars().take(10).collect::<String>()) - embedding the "
         "raw characters directly with no quoting/escaping, no truncation "
         "marker, and a 10- vs 9-character cutoff. SQLLexError.from_rs_error "

--- a/test/core/parser/rust_parser_test.py
+++ b/test/core/parser/rust_parser_test.py
@@ -620,6 +620,125 @@ def test__rust_parser__native_ast_recursion_depth_asymmetry():
     assert build(native=True) == build(native=False)
 
 
+# ---------------------------------------------------------------------------
+# RustParser vs. pure-Python Parser parity on malformed/error-recovery SQL
+#
+# Unlike the native_ast checks above (which compare RustParser against
+# itself), these compare RustParser's Rust grammar-matching engine against
+# the ground-truth pure-Python Parser, on malformed ANSI SQL that exercises
+# GREEDY/GREEDY_ONCE_STARTED error-recovery paths. All 208 well-formed ANSI
+# fixtures already parse identically between the two; these regressions only
+# surface on malformed input, which is why they were previously undetected.
+# ---------------------------------------------------------------------------
+
+
+def _compare_parser_vs_rust(sql: str, dialect: str = "ansi"):
+    """Parse the same SQL with the pure-Python Parser and RustParser."""
+    from sqlfluff.core import FluffConfig
+    from sqlfluff.core.parser import Lexer, Parser
+
+    config = FluffConfig(overrides={"dialect": dialect})
+    segments, _ = Lexer(config=config).lex(sql)
+
+    def build(use_rust: bool):
+        try:
+            parser = RustParser(config=config) if use_rust else Parser(config=config)
+            tree = parser.parse(segments, fname="t.sql")
+            return (
+                "tree",
+                tree.to_tuple(code_only=False, show_raw=True, include_meta=True)
+                if tree
+                else None,
+            )
+        except BaseException as err:
+            return ("exc", type(err).__name__)
+
+    return build(True), build(False)
+
+
+@pytest.mark.skipif(not _HAS_RUST_PARSER, reason="Rust parser not available")
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "Regression: when a GREEDY_ONCE_STARTED Sequence (e.g. "
+        "SelectClauseSegment) fails partway through, the Rust engine's "
+        "'failed after partial match' branch "
+        "(sqlfluffrs_parser/src/parser/table_driven/sequence.rs, the branch "
+        "building `unparsable_match` with `..Default::default()`) drops the "
+        "already-matched children's MatchResult (child_matches/"
+        "insert_segments) instead of preserving them as siblings the way "
+        "Python's Sequence.match does. The already-matched SELECT keyword "
+        "then falls back to a raw, untyped `word` segment instead of a "
+        "`keyword` segment. This is not just cosmetic: it makes rule ST05 "
+        "raise an unhandled AssertionError('Keyword not found.') on input "
+        "like 'SELECT CASE' when use_rust_parser=True, where the "
+        "pure-Python path just reports a normal parse violation."
+    ),
+)
+def test__rust_parser__vs_python_partial_match_failure_drops_children():
+    """RustParser loses keyword typing when a GREEDY_ONCE_STARTED match fails.
+
+    Minimal repro for a real correctness regression found by comparing
+    RustParser against the ground-truth Python Parser on malformed SQL.
+    """
+    rust_result, python_result = _compare_parser_vs_rust("SELECT CASE")
+    assert rust_result == python_result
+
+
+@pytest.mark.skipif(not _HAS_RUST_PARSER, reason="Rust parser not available")
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "Regression: Python's greedy_match/next_ex_bracket_match "
+        "(src/sqlfluff/core/parser/match_algorithms.py:469-529) aborts the "
+        "terminator search entirely on an unexpected closing bracket, "
+        "claiming everything up to EOF as unparsable. Rust's greedy_match "
+        "(sqlfluffrs_parser/src/parser/table_driven/match_algorithms.rs:"
+        "142-266) only special-cases *opening* brackets and has no "
+        "equivalent handling for a stray closing bracket, so it keeps "
+        "scanning and finds the next real terminator (e.g. FROM) instead. "
+        "Rust's behaviour is arguably more useful here, but it is a real, "
+        "deterministic structural divergence from the Python parser for "
+        "SQL containing an unbalanced closing bracket."
+    ),
+)
+def test__rust_parser__vs_python_stray_closing_bracket_terminator():
+    """RustParser recovers more of the tree than Python after a stray ')'.
+
+    Python swallows everything up to EOF as unparsable once it hits an
+    unexpected closing bracket; RustParser instead keeps parsing and
+    recovers a proper from_clause sibling.
+    """
+    rust_result, python_result = _compare_parser_vs_rust("SELECT 1) FROM t")
+    assert rust_result == python_result
+
+
+@pytest.mark.skipif(not _HAS_RUST_PARSER, reason="Rust parser not available")
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "Regression: Bracketed.match (src/sqlfluff/core/parser/grammar/"
+        "sequence.py:541-562) only suppresses the hard "
+        "'Couldn't find closing bracket' SQLParseError for "
+        "ParseMode.STRICT; for ParseMode.GREEDY (used by "
+        "CTEDefinitionSegment at dialect_ansi.py:2869 and the VALUES tuple "
+        "in ValuesClauseSegment at dialect_ansi.py:2748) Python always "
+        "raises when no closing bracket is found before EOF. RustParser's "
+        "codegen'd engine does not replicate this hard-raise, and instead "
+        "returns a tree with the remainder wrapped as unparsable."
+    ),
+)
+def test__rust_parser__vs_python_unclosed_greedy_bracket_raises():
+    """Python raises SQLParseError for an unclosed GREEDY-mode bracket.
+
+    RustParser instead recovers a tree, for the specific GREEDY-mode
+    Bracketed sites (CTE definitions, VALUES tuples) that Python treats as
+    a hard parse error rather than an unparsable section.
+    """
+    rust_result, python_result = _compare_parser_vs_rust("WITH a AS (SELECT 1")
+    assert rust_result == python_result
+
+
 @pytest.mark.skipif(not _HAS_RUST_PARSER, reason="Rust parser not available")
 def test__rust_parser__native_ast_profile_has_no_convert_stage():
     """With the native builder, profiling records no separate convert stage.

--- a/test/core/parser/rust_parser_test.py
+++ b/test/core/parser/rust_parser_test.py
@@ -740,6 +740,118 @@ def test__rust_parser__vs_python_unclosed_greedy_bracket_raises():
 
 
 @pytest.mark.skipif(not _HAS_RUST_PARSER, reason="Rust parser not available")
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "Regression: for a GREEDY-mode Bracketed's Delimited content, "
+        "trailing trivia (whitespace/comments) between a dangling trailing "
+        "comma and the closing bracket is merged into the unparsable "
+        "segment on the Rust side (sqlfluffrs_parser/src/parser/"
+        "table_driven/bracketed.rs:456-476, which builds the unparsable "
+        "span straight through to the closing bracket with no skip-back "
+        "for trailing trivia), whereas Python's Bracketed.match "
+        "(src/sqlfluff/core/parser/grammar/sequence.py:503-533) keeps that "
+        "trivia as a separate, untyped sibling gap outside the unparsable "
+        "class. Reproduces at any GREEDY Bracketed+Delimited site (IN-list, "
+        "USING-list, ...), not just the one used here."
+    ),
+)
+def test__rust_parser__vs_python_trailing_trivia_in_unparsable():
+    """RustParser merges trailing trivia into an unparsable span; Python doesn't.
+
+    A dangling trailing comma inside a GREEDY-mode Delimited bracket (e.g.
+    an IN-list) is wrapped as unparsable by both engines, but they disagree
+    on whether the whitespace between the comma and the closing bracket is
+    part of that unparsable span or a sibling of it.
+    """
+    rust_result, python_result = _compare_parser_vs_rust(
+        "SELECT a FROM t WHERE a IN (1, )"
+    )
+    assert rust_result == python_result
+
+
+@pytest.mark.skipif(not _HAS_RUST_PARSER, reason="Rust parser not available")
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "Regression: on a mismatched bracket type (e.g. '[' closed by ')'), "
+        "Python's bracket-matching immediately detects the mismatch and "
+        "raises a specific 'Found unexpected end bracket!, was expecting "
+        "..., but got ...' SQLParseError. RustParser's engine doesn't "
+        "replicate this specific check and instead falls through to the "
+        "generic 'Couldn't find closing bracket for opening bracket.' "
+        "error, as if the bracket were simply never closed. Same error "
+        "message content differs even though both raise SQLParseError, so "
+        "callers matching on the message (or anything depending on exact "
+        "error text) will see different behaviour."
+    ),
+)
+def test__rust_parser__vs_python_mismatched_bracket_type_error_message():
+    """RustParser's error message differs from Python's for a wrong-bracket-type close."""
+    from sqlfluff.core import FluffConfig
+    from sqlfluff.core.parser import Lexer, Parser
+
+    sql = "SELECT a[)"
+    config = FluffConfig(overrides={"dialect": "ansi"})
+    segments, _ = Lexer(config=config).lex(sql)
+
+    def build(use_rust: bool):
+        parser = RustParser(config=config) if use_rust else Parser(config=config)
+        try:
+            parser.parse(segments, fname="t.sql")
+            return None
+        except BaseException as err:
+            return (type(err).__name__, str(err))
+
+    assert build(True) == build(False)
+
+
+@pytest.mark.skipif(not _HAS_RUST_PARSER, reason="Rust parser not available")
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "Regression: a nested nested-bracket-type mismatch (e.g. an "
+        "unclosed '(' inside '[...]' that gets 'closed' by the outer ']') "
+        "makes Python raise the same 'Found unexpected end bracket!' "
+        "SQLParseError as the flat mismatched-bracket-type case. RustParser "
+        "instead silently recovers a tree, demoting the malformed nested "
+        "bracket content to an unparsable expression rather than raising. "
+        "This is bug class 3 (Python raises, Rust recovers) triggered by a "
+        "nested mismatch rather than an unclosed-to-EOF bracket."
+    ),
+)
+def test__rust_parser__vs_python_nested_bracket_mismatch_raises():
+    """Python raises on nested bracket-type mismatch; RustParser recovers a tree."""
+    rust_result, python_result = _compare_parser_vs_rust("SELECT a[(1]")
+    assert rust_result == python_result
+
+
+@pytest.mark.skipif(not _HAS_RUST_PARSER, reason="Rust parser not available")
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "Regression: a second instance of the 'stray closing bracket' bug "
+        "(sqlfluffrs_parser/src/parser/table_driven/match_algorithms.rs:"
+        "142-266 has no equivalent of Python's abort-to-EOF-on-unexpected-"
+        "closing-bracket rule in match_algorithms.py:469-529), this time at "
+        "UnorderedSelectStatementSegment's own terminator scan "
+        "(dialect_ansi.py:2755-2781) rather than SelectClauseSegment's. "
+        "This one is high-impact: with a stray ')' before a UNION, Python "
+        "discards the ENTIRE second arm of the set operation as unparsable "
+        "(') UNION SELECT c' all swallowed), while RustParser correctly "
+        "recovers a proper set_expression with both select_statement arms "
+        "intact and only the stray ')' marked unparsable."
+    ),
+)
+def test__rust_parser__vs_python_stray_bracket_swallows_union_arm():
+    """A stray ')' before UNION: Python discards the whole second arm, Rust doesn't."""
+    rust_result, python_result = _compare_parser_vs_rust(
+        "SELECT a FROM t) UNION SELECT c"
+    )
+    assert rust_result == python_result
+
+
+@pytest.mark.skipif(not _HAS_RUST_PARSER, reason="Rust parser not available")
 def test__rust_parser__native_ast_profile_has_no_convert_stage():
     """With the native builder, profiling records no separate convert stage.
 

--- a/test/core/parser/rust_parser_test.py
+++ b/test/core/parser/rust_parser_test.py
@@ -576,6 +576,51 @@ def test__rust_parser__native_ast_parity(sqlfile):
 
 
 @pytest.mark.skipif(not _HAS_RUST_PARSER, reason="Rust parser not available")
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "Regression: _convert_rs_match_result (the native_ast=False tree "
+        "builder) recurses through an extra generator-expression stack frame "
+        "per nesting level that _apply_rs_match_result (the fused "
+        "native_ast=True builder) doesn't have, so the legacy path blows the "
+        "Python call stack roughly twice as early as the fused path for the "
+        "same deeply-nested input. Only reachable when max_parse_depth is "
+        "raised above its default (600): at the default, the depth guard "
+        "fires first on both paths identically, masking the divergence."
+    ),
+)
+def test__rust_parser__native_ast_recursion_depth_asymmetry():
+    """native_ast=True tolerates deeper bracket nesting than native_ast=False.
+
+    Minimal repro for a real (if narrow) correctness divergence: with the
+    depth guard raised out of the way, the two AST-building paths do not
+    fail at the same input size for identical SQL and identical config.
+    """
+    from sqlfluff.core import FluffConfig
+    from sqlfluff.core.parser import Lexer
+    from sqlfluff.core.parser.rust_parser import set_native_ast
+
+    sql = "SELECT " + "(" * 70 + "1" + ")" * 70
+    config = FluffConfig(overrides={"dialect": "ansi", "max_parse_depth": 2000})
+    segments, _ = Lexer(config=config).lex(sql)
+
+    def build(native):
+        set_native_ast(native)
+        try:
+            tree = RustParser(config=config).parse(segments, fname="t.sql")
+            return (
+                "tree",
+                tree.to_tuple(code_only=False, show_raw=True, include_meta=True),
+            )
+        except BaseException as err:  # PanicException/RecursionError, etc.
+            return ("exc", type(err).__name__)
+        finally:
+            set_native_ast(False)
+
+    assert build(native=True) == build(native=False)
+
+
+@pytest.mark.skipif(not _HAS_RUST_PARSER, reason="Rust parser not available")
 def test__rust_parser__native_ast_profile_has_no_convert_stage():
     """With the native builder, profiling records no separate convert stage.
 


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
I'd like to make the RustLexer and fused native-AST RustParser path the default parser given the superior performance. That switch is only safe once we have confidence that RustParser's output matches Python's across all dialects. This PR starts building the required confidence by making existing divergences visible and enforces parity going forward, so we can track progress toward the default switch.

`RustParser` should produce the same parse trees and errors as the pure-Python `Parser`, but no existing test parsed the same SQL with both and compared the results:
- `test__rust_parser__native_ast_parity` compared RustParser's two internal tree-building modes against each other, not against the Python parser.
- `test__dialect__base_file_parse` only checks round-trip raw-text fidelity, not tree structure or segment types.
- `test__dialect__base_parse_struct` compares against a checked-in YAML ground truth, but always parses with `Parser`, never `RustParser`.

Additionally, I've pointed Claude at the three parsers to find differences not already captured with the existing fixtures and create tests for it.

- Added `xfail(strict=True)` regressions to `test/core/parser/rust_parser_test.py` that run the same SQL through `Parser` and `RustParser` and compare parse tree tuples, or exception type/message for invalid SQL. Each documents one known divergence. Fixes are left to separate follow-up PRs, which also remove the corresponding `xfail`.
- Extended `test__rust_parser__native_ast_parity` to a three-way comparison (`Parser`, RustParser convert+apply, RustParser fused native-AST) across the full dialect fixture corpus, instead of just the two RustParser modes. Fixtures with an already-documented divergence are excluded via `_KNOWN_PYTHON_RUST_DIVERGENCES`; everything else must agree across all three paths.

I'd suggest keeping the `xfail` tests after they've been resolved to prevent regression, but we can also drop them/rework them into other fixtures.

### Are there any other side effects of this change that we should be aware of?
CI will run a tick slower given more work is done, but negligible in my opinion.

### Pull Request checklist
- [ ] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds strict regression tests and expands parity checks to ensure `RustParser` matches the Python `Parser` across all dialect fixtures and key error-recovery paths, making current divergences visible and preventing regressions. This builds confidence to switch the default to the `RustLexer` + fused native-AST `RustParser` path.

- New Features
  - Extended three-way parity across `Parser`, `RustParser` convert+apply, and `RustParser` native-AST for all dialect fixtures; known mismatches are excluded via `_KNOWN_PYTHON_RUST_DIVERGENCES`.
  - Added strict `xfail` regressions comparing trees/exceptions between `Parser` and `RustParser` for:
    - GREEDY/Sequence partial matches, stray/mismatched/unclosed brackets, and trailing-trivia handling in unparsable spans.
    - Real fixture divergences in `databricks`/`sparksql` PIVOT/UNPIVOT, Snowflake numeric literals, and T-SQL datatype methods and `sqlcmd` commands.
  - Added recursion-depth asymmetry test between `native_ast=True` and `False`.
  - Added lexer-layer regression for `PyLexer` vs `PyRsLexer` `SQLLexError` message formatting.
  - All regressions are `xfail(strict=True)` to document known gaps and enforce future parity; fixes will remove the corresponding `xfail`.

<sup>Written for commit 7ef3cacda9329a2f2a0f31d2aa6e56f27550b4eb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8106?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

