### PR TITLE
fix(core): re-parent provided children in `BaseSegment.copy`

### DIFF
--- a/src/sqlfluff/core/parser/segments/base.py
+++ b/src/sqlfluff/core/parser/segments/base.py
@@ -982,6 +982,8 @@ class BaseSegment(metaclass=SegmentMetaclass):
         # If segments were provided, use them.
         elif segments:
             new_segment.segments = segments
+            # Reset the parent references of the provided children.
+            new_segment.set_as_parent(recurse=False)
         # Otherwise we should handle recursive segment coping.
         # We use the native .copy() method (this method!) appropriately
         # so that the same logic is applied in recursion.

--- a/src/sqlfluff/core/rules/base.py
+++ b/src/sqlfluff/core/rules/base.py
@@ -896,10 +896,11 @@ class BaseRule(metaclass=RuleMetaclass):
             if root_segment
             else None
         )
-        # If no path found (e.g., segment is in unparsable section), return
-        # the original segment. This will be filtered out later in
-        # _process_lint_result if it's in an unparsable section.
-        if not path:
+        # If no path found, return the original segment. This shouldn't
+        # happen in practice given a correctly-parented tree (the anchor
+        # is always a descendant of root_segment), but is kept as a
+        # defensive fallback rather than raising.
+        if not path:  # pragma: no cover
             linter_logger.debug(
                 "No path found from %s to %s. Segment may be in unparsable section. "
                 "Returning original segment as anchor.",

--- a/test/core/parser/segments/segments_base_test.py
+++ b/test/core/parser/segments/segments_base_test.py
@@ -329,6 +329,22 @@ def test__parser__base_segments_parent_ref(DummySegment, raw_segments):
     assert seg.segments[0].get_parent()[0]
 
 
+def test__parser__base_segments_copy_segments_reparents_children(
+    DummySegment, raw_segments
+):
+    """Test that .copy(segments=...) reparents the provided children."""
+    old_seg = DummySegment(segments=raw_segments)
+    assert old_seg.segments[0].get_parent()[0] is old_seg
+
+    new_seg = old_seg.copy(segments=raw_segments)
+    assert new_seg is not old_seg
+    # The children should now report the *new* segment as their parent...
+    assert new_seg.segments[0].get_parent()[0] is new_seg
+    assert new_seg.segments[1].get_parent()[0] is new_seg
+    # ...rather than the old one.
+    assert old_seg.segments[0].get_parent()[0] is not old_seg
+
+
 def test__parser__raw_segment_raw_normalized():
     """Test comparison of raw segments."""
     template = TemplatedFile.from_string('"a"""."e"')


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
`copy(segments=...)` transplanted the provided children without resetting their parent references, so they kept pointing at the segment they were copied from, still a valid child of the old tree. After a mid-loop fix, `path_to()` could climb those stale refs out of the fixed tree, top out at the old `FileSegment`, and wrongly report "no path" — silently emptying reflow's `DepthMap`. With LT09+LT11 on postgres/greenplum set_operators.sql, LT11 missed 3 of 4 "INTERSECT (" violations after LT09's fix in the same pass, making `sqlfluff fix` non-idempotent (its own second run fixed them).

### Are there any other side effects of this change that we should be aware of?
None

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stale parent pointers when using `BaseSegment.copy(segments=...)`, preventing broken path resolution and missed fixes. Restores correct behavior for reflow and keeps `sqlfluff fix` idempotent.

- **Bug Fixes**
  - Re-parent provided children in `BaseSegment.copy(segments=...)` by calling `set_as_parent(recurse=False)`.
  - Added a unit test to ensure copied children reference the new parent.

- **Refactors**
  - Marked the unreachable no-path fallback in `_choose_anchor_segment()` as `# pragma: no cover` and clarified the comment.

<sup>Written for commit b771a5b8af9e1c1e9ec5d630feb7340e98c9548e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8109?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

