### PR TITLE
fix GREEDY sequence partial-match failure dropping matched children

### DIFF
--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/sequence.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/sequence.rs
@@ -411,13 +411,18 @@ impl Parser<'_> {
         }
 
         // GREEDY modes with partial match - create UnparsableSegment
+        //
+        // NOTE: pass current_element_grammar_id here, the element that just
+        // failed to match, not the next element. Python's equivalent
+        // (skip_start_index_forward_to_code in grammar/sequence.py) always
+        // skips forward over any gap before the failed element, regardless of
+        // what comes after it, so mirroring that keeps trailing whitespace as
+        // a sibling gap even when the next element happens to be a Meta
+        // (e.g. Dedent).
         let child_start_pos = self.calculate_sequence_child_start_position(
             matched_idx,
             allow_gaps,
-            elements
-                .get(next_element_idx)
-                .copied()
-                .unwrap_or(current_element_grammar_id),
+            current_element_grammar_id,
             max_idx,
         );
 
@@ -458,9 +463,32 @@ impl Parser<'_> {
             element_desc, last_matched_token, error_token
         );
 
-        let unparsable_match = MatchResult {
+        // Keep the children/inserts already matched before this element
+        // failed as typed siblings (mirrors Python's Sequence.match "handle
+        // the case of a partial match"); only the unmatched tail becomes its
+        // own UnparsableSegment child appended alongside them.
+        //
+        // Deliberately not flushing `ctx.meta_buffer` here, unlike the
+        // sibling "ran out of tokens" branch above: Python's equivalent
+        // branch (grammar/sequence.py) has no such flush either, so a meta
+        // queued right before the failed element is dropped the same way.
+        let (insert_segments, mut child_matches) = {
+            let ctx = frame.context.as_sequence_mut().unwrap();
+            (
+                std::mem::take(&mut ctx.insert_segments),
+                std::mem::take(&mut ctx.child_matches),
+            )
+        };
+        child_matches.push(Arc::new(MatchResult {
             matched_slice: child_start_pos..max_idx,
             matched_class: Some(MatchedClass::unparsable(&error_message, child_start_pos)),
+            ..Default::default()
+        }));
+
+        let unparsable_match = MatchResult {
+            matched_slice: start_idx..max_idx,
+            insert_segments,
+            child_matches,
             ..Default::default()
         };
         let end_pos = unparsable_match.end();

--- a/test/core/parser/rust_parser_test.py
+++ b/test/core/parser/rust_parser_test.py
@@ -707,29 +707,24 @@ def _compare_parser_vs_rust(sql: str, dialect: str = "ansi"):
 
 
 @pytest.mark.skipif(not _HAS_RUST_PARSER, reason="Rust parser not available")
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "Regression: when a GREEDY_ONCE_STARTED Sequence (e.g. "
-        "SelectClauseSegment) fails partway through, the Rust engine's "
-        "'failed after partial match' branch "
-        "(sqlfluffrs_parser/src/parser/table_driven/sequence.rs, the branch "
-        "building `unparsable_match` with `..Default::default()`) drops the "
-        "already-matched children's MatchResult (child_matches/"
-        "insert_segments) instead of preserving them as siblings the way "
-        "Python's Sequence.match does. The already-matched SELECT keyword "
-        "then falls back to a raw, untyped `word` segment instead of a "
-        "`keyword` segment. This is not just cosmetic: it makes rule ST05 "
-        "raise an unhandled AssertionError('Keyword not found.') on input "
-        "like 'SELECT CASE' when use_rust_parser=True, where the "
-        "pure-Python path just reports a normal parse violation."
-    ),
-)
 def test__rust_parser__vs_python_partial_match_failure_drops_children():
-    """RustParser loses keyword typing when a GREEDY_ONCE_STARTED match fails.
+    """RustParser preserves keyword typing when a GREEDY_ONCE_STARTED match fails.
 
-    Minimal repro for a real correctness regression found by comparing
-    RustParser against the ground-truth Python Parser on malformed SQL.
+    Regression test: when a GREEDY_ONCE_STARTED Sequence (e.g.
+    SelectClauseSegment) fails partway through, the already-matched
+    children (e.g. the SELECT keyword) must stay typed siblings, with only
+    the unmatched tail wrapped as UnparsableSegment - matching Python's
+    Sequence.match "handle the case of a partial match" behaviour.
+
+    Previously, RustParser's "failed after partial match" branch in
+    sqlfluffrs_parser/src/parser/table_driven/sequence.rs built its error
+    MatchResult with `..Default::default()`, which silently dropped
+    child_matches/insert_segments accumulated before the failure, so the
+    already-matched SELECT keyword fell back to a raw, untyped `word`
+    segment. This wasn't just cosmetic: it made rule ST05 raise an
+    unhandled AssertionError('Keyword not found.') on input like
+    'SELECT CASE' under use_rust_parser=True, where the pure-Python path
+    just reported a normal parse violation.
     """
     rust_result, python_result = _compare_parser_vs_rust("SELECT CASE")
     assert rust_result == python_result


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
When a `Sequence` grammar in GREEDY mode fails partway through matching (after some elements already matched successfully), `RustParser` discarded all the already-matched children and returned an empty/default match result instead of keeping what had matched so far.

For SQL that partially matches a sequence grammar before failing, `RustParser` produced a different (and less informative) parse tree than the Python parser, which preserves the matched prefix. This affects error recovery and unparsable-segment reporting for malformed SQL.

```sql
SELECT CASE
```

In `sqlfluffrs_parser/src/parser/table_driven/sequence.rs`, the partial-match failure path was changed to keep the children matched so far instead of resetting to `..Default::default()`.

### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [ ] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes GREEDY sequence partial-match handling in `RustParser` to preserve already-matched children, aligning with the Python parser and improving error recovery on malformed SQL (e.g. `SELECT CASE`).

- **Bug Fixes**
  - Keep matched children and inserts when a GREEDY sequence fails; only wrap the unmatched tail as an `UnparsableSegment`.
  - Pass `current_element_grammar_id` to `calculate_sequence_child_start_position` to mirror Python gap-skipping and keep trailing whitespace as a sibling.
  - Added a regression test to ensure Rust vs Python parity on `SELECT CASE` and removed the previous xfail.

<sup>Written for commit adda5533adc9084cf8a6851116f4f8f7de9afe5e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8116?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

