### PR TITLE
Fix/greedy match stray closing bracket

### DIFF
--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/match_algorithms.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/match_algorithms.rs
@@ -204,6 +204,22 @@ impl Parser<'_> {
                 }
             }
 
+            // PYTHON PARITY: a closing bracket reached here is stray, not
+            // nested inside anything we're currently scanning past (an
+            // opening bracket's matching_bracket_idx skip would have
+            // consumed it otherwise). Mirror Python's next_ex_bracket_match
+            // (match_algorithms.py), which treats this as "unexpected end
+            // bracket! Return no match": abort the terminator search and
+            // claim everything through max_idx, rather than scan past the
+            // stray bracket to a later terminator like `FROM` or `UNION`.
+            if raw == ")" || raw == "]" || raw == "}" {
+                vdebug!(
+                    "[GREEDY_MATCH_TABLE] greedy_match: unexpected closing bracket at {} — aborting terminator search, claiming through {}",
+                    i, max_idx
+                );
+                return Ok((start_idx, max_idx));
+            }
+
             for &term_id in terminators {
                 // Skip the NONCODE sentinel (see the immediate-match loop above).
                 if term_id == GrammarId::NONCODE {

--- a/test/core/parser/rust_parser_test.py
+++ b/test/core/parser/rust_parser_test.py
@@ -736,28 +736,17 @@ def test__rust_parser__vs_python_partial_match_failure_drops_children():
 
 
 @pytest.mark.skipif(not _HAS_RUST_PARSER, reason="Rust parser not available")
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "Regression: Python's greedy_match/next_ex_bracket_match "
-        "(src/sqlfluff/core/parser/match_algorithms.py:469-529) aborts the "
-        "terminator search entirely on an unexpected closing bracket, "
-        "claiming everything up to EOF as unparsable. Rust's greedy_match "
-        "(sqlfluffrs_parser/src/parser/table_driven/match_algorithms.rs:"
-        "142-266) only special-cases *opening* brackets and has no "
-        "equivalent handling for a stray closing bracket, so it keeps "
-        "scanning and finds the next real terminator (e.g. FROM) instead. "
-        "Rust's behaviour is arguably more useful here, but it is a real, "
-        "deterministic structural divergence from the Python parser for "
-        "SQL containing an unbalanced closing bracket."
-    ),
-)
 def test__rust_parser__vs_python_stray_closing_bracket_terminator():
-    """RustParser recovers more of the tree than Python after a stray ')'.
+    """RustParser aborts its terminator search on a stray ')', matching Python.
 
-    Python swallows everything up to EOF as unparsable once it hits an
-    unexpected closing bracket; RustParser instead keeps parsing and
-    recovers a proper from_clause sibling.
+    Regression test: Python's greedy_match/next_ex_bracket_match
+    (src/sqlfluff/core/parser/match_algorithms.py:469-529) aborts the
+    terminator search entirely on an unexpected closing bracket, claiming
+    everything up to EOF as unparsable. RustParser's greedy_match
+    (sqlfluffrs_parser/src/parser/table_driven/match_algorithms.rs) now
+    replicates this: an unmatched ')'/']'/'}' encountered while scanning for
+    a terminator immediately aborts the search, rather than continuing on
+    to find a later terminator (e.g. FROM) as it previously did.
     """
     rust_result, python_result = _compare_parser_vs_rust("SELECT 1) FROM t")
     assert rust_result == python_result
@@ -877,24 +866,18 @@ def test__rust_parser__vs_python_nested_bracket_mismatch_raises():
 
 
 @pytest.mark.skipif(not _HAS_RUST_PARSER, reason="Rust parser not available")
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "Regression: a second instance of the 'stray closing bracket' bug "
-        "(sqlfluffrs_parser/src/parser/table_driven/match_algorithms.rs:"
-        "142-266 has no equivalent of Python's abort-to-EOF-on-unexpected-"
-        "closing-bracket rule in match_algorithms.py:469-529), this time at "
-        "UnorderedSelectStatementSegment's own terminator scan "
-        "(dialect_ansi.py:2755-2781) rather than SelectClauseSegment's. "
-        "This one is high-impact: with a stray ')' before a UNION, Python "
-        "discards the ENTIRE second arm of the set operation as unparsable "
-        "(') UNION SELECT c' all swallowed), while RustParser correctly "
-        "recovers a proper set_expression with both select_statement arms "
-        "intact and only the stray ')' marked unparsable."
-    ),
-)
 def test__rust_parser__vs_python_stray_bracket_swallows_union_arm():
-    """A stray ')' before UNION: Python discards the whole second arm, Rust doesn't."""
+    """A stray ')' before UNION: Rust now discards the second arm too, matching Python.
+
+    Regression test: a second instance of the stray-closing-bracket bug
+    (see test__rust_parser__vs_python_stray_closing_bracket_terminator),
+    this time at UnorderedSelectStatementSegment's own terminator scan
+    (dialect_ansi.py) rather than SelectClauseSegment's. Before the fix,
+    with a stray ')' before a UNION, Python discarded the ENTIRE second arm
+    of the set operation as unparsable while RustParser incorrectly
+    recovered a proper set_expression with both arms intact - now both
+    engines discard the second arm identically.
+    """
     rust_result, python_result = _compare_parser_vs_rust(
         "SELECT a FROM t) UNION SELECT c"
     )

--- a/test/core/parser/rust_parser_test.py
+++ b/test/core/parser/rust_parser_test.py
@@ -756,6 +756,40 @@ def test__rust_parser__vs_python_stray_closing_bracket_terminator():
 @pytest.mark.xfail(
     strict=True,
     reason=(
+        "Known gap: greedy_match's stray-closing-bracket check "
+        "(sqlfluffrs_parser/src/parser/table_driven/match_algorithms.rs) "
+        "recognises brackets by a hardcoded raw-text match on '(', '[', "
+        "'{' and ')', ']', '}'. Python's equivalent, next_ex_bracket_match "
+        "(src/sqlfluff/core/parser/match_algorithms.py:469-529), instead "
+        "looks up the active dialect's bracket_pairs set, so it also "
+        "recognises dialect-specific bracket tokens such as Snowflake's "
+        "MATCH_RECOGNIZE exclude brackets '{-'/'-}' "
+        "(dialect_snowflake.py:128-130). On a stray '-}', Python aborts the "
+        "terminator search and claims the rest as unparsable, while Rust's "
+        "hardcoded check doesn't recognise '-}' as a bracket at all and "
+        "keeps scanning, finding the following FROM as a normal terminator. "
+        "Fixing it means threading the dialect's bracket set through "
+        "greedy_match instead of hardcoding ASCII brackets."
+    ),
+)
+def test__rust_parser__vs_python_stray_closing_bracket_hardcoded_set():
+    """RustParser's greedy_match only recognises a hardcoded ASCII bracket set.
+
+    Snowflake's MATCH_RECOGNIZE exclude brackets ('{-'/'-}') are part of the
+    dialect's bracket_pairs set, so Python treats a stray '-}' the same way
+    as a stray ')'. RustParser's hardcoded check doesn't recognise '-}' as a
+    bracket, so it keeps scanning past it instead of aborting.
+    """
+    rust_result, python_result = _compare_parser_vs_rust(
+        "SELECT 1 -} FROM t", dialect="snowflake"
+    )
+    assert rust_result == python_result
+
+
+@pytest.mark.skipif(not _HAS_RUST_PARSER, reason="Rust parser not available")
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
         "Regression: Bracketed.match (src/sqlfluff/core/parser/grammar/"
         "sequence.py:541-562) only suppresses the hard "
         "'Couldn't find closing bracket' SQLParseError for "


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
`greedy_match` in `RustParser` had no handling for encountering a closing bracket that doesn't correspond to any open bracket in the current context. It would either continue scanning past it or behave inconsistently, instead of stopping the greedy match the way the Python parser does.

SQL containing a stray/unexpected closing bracket could be parsed differently by `RustParser` than by the Python parser, leading to different segment boundaries or missed unparsable-section detection.

```sql
SELECT 1) FROM t
```

```sql
SELECT a FROM t) UNION SELECT c
```

In `sqlfluffrs_parser/src/parser/table_driven/match_algorithms.rs`, `greedy_match` was updated to detect a stray closing bracket and abort the greedy match at that point, matching Python's behavior.

### Are there any other side effects of this change that we should be aware of?
Not really. I noticed the opening brackets were hard coded, so I hard coded the closing brackets as well. However, we should actually use the dialect specific brackets. Out of scope for here, I've added a new regression test for it to resolve later.

### Pull Request checklist
- [ ] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `RustParser` greedy matching when it hits a stray closing bracket. The parser now stops at the unexpected bracket, matching Python behavior and preventing divergent segment boundaries or missed unparsable detection.

- **Bug Fixes**
  - Updated `sqlfluffrs_parser` `greedy_match` to abort on unmatched `)`, `]`, or `}`, mirroring Python.
  - Added regression tests for "SELECT 1) FROM t" and "SELECT a FROM t) UNION SELECT c".
  - Added xfail test documenting a known gap: the bracket set is hardcoded (ASCII only). Dialect-specific brackets (e.g., Snowflake `{-`/`-}`) are not yet recognized.

<sup>Written for commit 42b6cc457e03622fa2ec2a93a5a1b63f7bf03737. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8117?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

