### PR TITLE
Fix Bracketed GREEDY mode absorbing trailing trivia into unparsable segment

### DIFF
--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/helpers.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/helpers.rs
@@ -153,6 +153,30 @@ impl<'a> Parser<'a> {
         min_idx
     }
 
+    /// Move an index backward through tokens until tokens[index - 1] is code,
+    /// trimming trailing comments too. Matches Python's canonical
+    /// `skip_stop_index_backward_to_code` (src/sqlfluff/core/parser/
+    /// match_algorithms.py), which checks only `segments[_idx - 1].is_code`.
+    /// Use this (rather than `skip_stop_index_backward_to_code` above, which
+    /// keeps comments for `calculate_max_idx`) when trimming a GREEDY-mode
+    /// "leftover content" span before wrapping it as UnparsableSegment (e.g.
+    /// Bracketed.match's gap/leftover handling): a trailing comment there
+    /// should stay outside the unparsable span as its own sibling, the same
+    /// as trailing whitespace.
+    /// Returns the index after the last code token, or `min_idx` if none found.
+    pub(crate) fn skip_stop_index_backward_to_code_excluding_comments(
+        &self,
+        stop_idx: usize,
+        min_idx: usize,
+    ) -> usize {
+        for _idx in (min_idx..stop_idx).rev() {
+            if self.tokens[_idx].is_code() {
+                return _idx + 1;
+            }
+        }
+        min_idx
+    }
+
     /// Get the pre-computed matching bracket index for a token.
     /// This is a public wrapper for accessing pre-computed bracket pairs.
     /// Returns None if not a bracket, if matching bracket wasn't found during lexing,

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/bracketed.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/bracketed.rs
@@ -455,23 +455,47 @@ impl Parser<'_> {
                         return Ok(TableFrameResult::Done);
                     } else {
                         // GREEDY mode: Create unparsable section for tokens between content end and closing bracket
-                        vdebug!(
-                                "Bracketed[table] GREEDY mode: Creating unparsable section for tokens {}..{} (content ended at {}, closing bracket at {})",
-                                check_pos, expected_close_pos, check_pos, expected_close_pos
+                        //
+                        // PYTHON PARITY: trim trailing non-code and comments off
+                        // the unparsable span (via the `_excluding_comments`
+                        // variant below), matching Python's Bracketed.match. Any
+                        // trimmed gap stays as untouched, raw sibling content
+                        // between here and the closing bracket.
+                        let unparsable_stop = self
+                            .skip_stop_index_backward_to_code_excluding_comments(
+                                expected_close_pos,
+                                check_pos,
                             );
 
-                        // Create an UnparsableSegment for the tokens we couldn't parse
-                        let unparsable_match = MatchResult {
-                            matched_slice: check_pos..expected_close_pos,
-                            matched_class: Some(MatchedClass::unparsable(
-                                "Nothing here.",
-                                expected_close_pos,
-                            )),
-                            ..Default::default()
-                        };
-                        child_matches.push(Arc::new(unparsable_match));
+                        // Guard against a zero-length span (mirrors sequence.rs's
+                        // analogous GREEDY-leftover handling in
+                        // handle_sequence_combining, `if _stop_idx > _idx`):
+                        // MatchResult::apply panics on a zero-length matched_slice
+                        // with matched_class set, so only create the unparsable
+                        // child when there's actually code left to wrap.
+                        if unparsable_stop > check_pos {
+                            vdebug!(
+                                    "Bracketed[table] GREEDY mode: Creating unparsable section for tokens {}..{} (content ended at {}, closing bracket at {})",
+                                    check_pos, unparsable_stop, check_pos, expected_close_pos
+                                );
 
-                        // Move position to the closing bracket
+                            // Create an UnparsableSegment for the tokens we couldn't parse
+                            let unparsable_match = MatchResult {
+                                matched_slice: check_pos..unparsable_stop,
+                                matched_class: Some(MatchedClass::unparsable(
+                                    "Nothing here.",
+                                    unparsable_stop,
+                                )),
+                                ..Default::default()
+                            };
+                            child_matches.push(Arc::new(unparsable_match));
+                        }
+
+                        // Move position to the closing bracket. Any gap between
+                        // unparsable_stop and expected_close_pos (the trimmed
+                        // trailing non-code) is left uncovered by any child here
+                        // and is filled in as raw, untouched content when the
+                        // tree is materialized.
                         self.pos = expected_close_pos;
                     }
                 } else {

--- a/test/core/parser/rust_parser_test.py
+++ b/test/core/parser/rust_parser_test.py
@@ -790,29 +790,20 @@ def test__rust_parser__vs_python_unclosed_greedy_bracket_raises():
 
 
 @pytest.mark.skipif(not _HAS_RUST_PARSER, reason="Rust parser not available")
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "Regression: for a GREEDY-mode Bracketed's Delimited content, "
-        "trailing trivia (whitespace/comments) between a dangling trailing "
-        "comma and the closing bracket is merged into the unparsable "
-        "segment on the Rust side (sqlfluffrs_parser/src/parser/"
-        "table_driven/bracketed.rs:456-476, which builds the unparsable "
-        "span straight through to the closing bracket with no skip-back "
-        "for trailing trivia), whereas Python's Bracketed.match "
-        "(src/sqlfluff/core/parser/grammar/sequence.py:503-533) keeps that "
-        "trivia as a separate, untyped sibling gap outside the unparsable "
-        "class. Reproduces at any GREEDY Bracketed+Delimited site (IN-list, "
-        "USING-list, ...), not just the one used here."
-    ),
-)
 def test__rust_parser__vs_python_trailing_trivia_in_unparsable():
-    """RustParser merges trailing trivia into an unparsable span; Python doesn't.
+    """RustParser no longer merges trailing trivia into an unparsable span.
 
-    A dangling trailing comma inside a GREEDY-mode Delimited bracket (e.g.
-    an IN-list) is wrapped as unparsable by both engines, but they disagree
-    on whether the whitespace between the comma and the closing bracket is
-    part of that unparsable span or a sibling of it.
+    Regression test: for a GREEDY-mode Bracketed's Delimited content, the
+    trailing trivia (whitespace/comments) between a dangling trailing comma
+    and the closing bracket used to be merged into the unparsable segment
+    on the Rust side (Bracketed's own GREEDY-leftover detection built the
+    unparsable span straight through to the closing bracket with no
+    skip-back for trailing trivia), whereas Python's Bracketed.match keeps
+    that trivia as a separate, untyped sibling gap outside the unparsable
+    class. A dangling trailing comma inside a GREEDY-mode Delimited bracket
+    (e.g. an IN-list) is wrapped as unparsable by both engines; they now
+    agree on whether the whitespace between the comma and the closing
+    bracket is part of that unparsable span or a sibling of it.
     """
     rust_result, python_result = _compare_parser_vs_rust(
         "SELECT a FROM t WHERE a IN (1, )"


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
When a `Bracketed` grammar in GREEDY mode couldn't fully match its content, `RustParser` included trailing whitespace/comments (trivia) at the end of the unmatched region inside the resulting unparsable segment, instead of trimming
it off before the closing bracket.

Unparsable segments produced by `RustParser` for malformed bracketed content had different boundaries than the Python parser's, absorbing trailing trivia that Python leaves outside the unparsable region.

```sql
SELECT a FROM t WHERE a IN (1, )
```

In `sqlfluffrs_parser/src/parser/table_driven/bracketed.rs`, the GREEDY leftover-content handling was updated to trim trailing trivia back to the last code token, using a new helper `skip_stop_index_backward_to_code_excluding_comments` in `helpers.rs`.

### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [ ] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix GREEDY Bracketed parsing so trailing whitespace/comments are no longer absorbed into the unparsable segment. Aligns Rust parser span boundaries with the Python parser.

- **Bug Fixes**
  - Trim trailing trivia when creating GREEDY leftover spans using `skip_stop_index_backward_to_code_excluding_comments`.
  - Guard against zero-length unparsable matches; only create when there’s code.
  - Updated regression test to assert Rust/Python parity (removed xfail).

<sup>Written for commit 1bebaa75b3e6efe395695e17df33646f5cd4f87b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8118?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

