### PR TITLE
Fix mismatched bracket type giving generic error only

### DIFF
--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/match_algorithms.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/match_algorithms.rs
@@ -70,6 +70,40 @@ fn try_match_grammar(
     }
 }
 
+/// Scan forward from `from_idx` for the first bracket-like token not already
+/// resolved by lexing (i.e. one whose `matching_bracket_idx` is `None`),
+/// skipping over any properly nested, already-resolved bracket pairs along
+/// the way (same technique as `greedy_match`'s own bracket-skip).
+///
+/// An unresolved token found this way must be a *closing* bracket of the
+/// wrong type: if it were the correct type for whatever opener is looking
+/// for it, lexing would already have paired them (see
+/// `sqlfluffrs_lexer::compute_bracket_pairs`). Returns `(index, raw_char)`
+/// for that mismatched closer, or `None` if genuinely nothing is found
+/// before `tokens.len()` (a real "unclosed to EOF" case) or another
+/// unresolved *opening* bracket is hit first (ambiguous - fall back to the
+/// generic message rather than guess).
+///
+/// Used to distinguish Python's two distinct bracket-resolution failures
+/// (`resolve_bracket`, match_algorithms.py): "Couldn't find closing bracket
+/// for opening bracket" (genuinely unclosed) vs. "Found unexpected end
+/// bracket!, was expecting X, but got Y" (closed by the wrong type).
+fn find_mismatched_closing_bracket(tokens: &[Token], from_idx: usize) -> Option<(usize, String)> {
+    let mut idx = from_idx;
+    while idx < tokens.len() {
+        let raw = tokens[idx].raw();
+        match raw {
+            "(" | "[" | "{" => match tokens[idx].matching_bracket_idx {
+                Some(matching_idx) => idx = matching_idx + 1,
+                None => return None,
+            },
+            ")" | "]" | "}" => return Some((idx, raw.to_string())),
+            _ => idx += 1,
+        }
+    }
+    None
+}
+
 pub(crate) fn skip_stop_index_backward_to_code(
     tokens: &[Token],
     start_idx: usize,
@@ -192,6 +226,32 @@ impl Parser<'_> {
                     i = matching_idx + 1;
                     continue;
                 } else {
+                    // PYTHON PARITY: mirror Python's resolve_bracket by raising
+                    // its specific "wrong bracket type" error when the closer
+                    // ahead is mismatched, keeping the generic "never closed"
+                    // message for the true unclosed-to-EOF case.
+                    if let Some((mismatch_idx, actual_close)) =
+                        find_mismatched_closing_bracket(tokens, i + 1)
+                    {
+                        let expected_close = match raw {
+                            "(" => ")",
+                            "[" => "]",
+                            "{" => "}",
+                            _ => unreachable!("raw already matched an opening bracket above"),
+                        };
+                        vdebug!(
+                            "[GREEDY_MATCH_TABLE] greedy_match: mismatched closing bracket '{}' at {} for opening bracket at {} (expected '{}')",
+                            actual_close, mismatch_idx, i, expected_close
+                        );
+                        return Err(ParseError::with_context(
+                            format!(
+                                "Found unexpected end bracket!, was expecting <StringParser: '{}'>, but got <StringParser: '{}'>",
+                                expected_close, actual_close
+                            ),
+                            Some(mismatch_idx),
+                            None,
+                        ));
+                    }
                     vdebug!(
                         "[GREEDY_MATCH_TABLE] greedy_match: no matching closing bracket for opening bracket at {}",
                         i

--- a/test/core/parser/rust_parser_test.py
+++ b/test/core/parser/rust_parser_test.py
@@ -821,23 +821,18 @@ def test__rust_parser__vs_python_trailing_trivia_in_unparsable():
 
 
 @pytest.mark.skipif(not _HAS_RUST_PARSER, reason="Rust parser not available")
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "Regression: on a mismatched bracket type (e.g. '[' closed by ')'), "
-        "Python's bracket-matching immediately detects the mismatch and "
-        "raises a specific 'Found unexpected end bracket!, was expecting "
-        "..., but got ...' SQLParseError. RustParser's engine doesn't "
-        "replicate this specific check and instead falls through to the "
-        "generic 'Couldn't find closing bracket for opening bracket.' "
-        "error, as if the bracket were simply never closed. Same error "
-        "message content differs even though both raise SQLParseError, so "
-        "callers matching on the message (or anything depending on exact "
-        "error text) will see different behaviour."
-    ),
-)
 def test__rust_parser__vs_python_mismatched_bracket_type_error_message():
-    """RustParser's error message differs from Python's for a wrong-bracket-type close."""
+    """RustParser now raises the same specific error as Python for a wrong-bracket-type close.
+
+    Regression test: on a mismatched bracket type (e.g. '[' closed by ')'),
+    Python's bracket-matching immediately detects the mismatch and raises a
+    specific 'Found unexpected end bracket!, was expecting ..., but got
+    ...' SQLParseError. RustParser's greedy_match used to fall through to
+    the generic 'Couldn't find closing bracket for opening bracket.' error
+    instead, as if the bracket were simply never closed - it now scans
+    forward to distinguish a genuinely-unclosed bracket from one closed by
+    the wrong type, matching Python's specific message.
+    """
     from sqlfluff.core import FluffConfig
     from sqlfluff.core.parser import Lexer, Parser
 


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
When SQL has a bracket closed with the wrong type (e.g. `(foo]`), the Python parser raises an error naming the specific expected and actual bracket characters. `RustParser` raised a generic "mismatched brackets" error without naming which bracket types were involved.

Error messages from `RustParser` for this class of malformed SQL were less useful than the Python parser's, making it harder to diagnose the exact problem from the error message alone.

```sql
SELECT a[)
```

Added a `find_mismatched_closing_bracket` helper in `sqlfluffrs_parser/src/parser/table_driven/match_algorithms.rs` that
identifies the specific expected and actual bracket characters and includes them in the raised error message, matching Python's wording.

### Are there any other side effects of this change that we should be aware of?
Not really. Again, like in https://github.com/sqlfluff/sqlfluff/pull/8117, the brackets are hard coded so far.

### Pull Request checklist
- [ ] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rust parser now reports the exact expected and actual bracket when a bracket is closed by the wrong type, matching Python's error message. This makes parse errors easier to diagnose.

- **Bug Fixes**
  - Added `find_mismatched_closing_bracket` to detect wrong-type closers and include expected/actual chars in the error.
  - Retains the generic "Couldn't find closing bracket..." only for true unclosed cases; updated tests to assert the new message.

<sup>Written for commit 9db21039ff4f790eab2161e7dcae770abc903440. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8119?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

