### PR TITLE
Fix nested bracket-type mismatch recovering instead of raising, matching Python's resolve_bracket

### DIFF
--- a/sqlfluffrs/sqlfluffrs_lexer/src/lexer.rs
+++ b/sqlfluffrs/sqlfluffrs_lexer/src/lexer.rs
@@ -408,19 +408,22 @@ impl Lexer {
                 // may be closed next, per LIFO nesting discipline. This matches
                 // Python's resolve_bracket (match_algorithms.py), which recurses
                 // into a freshly-opened bracket and only returns once that
-                // specific bracket is resolved. On a type mismatch here (e.g.
-                // `a[(1]`), both this closer and the innermost opener stay
-                // unresolved (matching_bracket_idx None for both); the outer `[`
-                // is left for its own closer rather than matched against `]`.
+                // specific bracket is resolved.
                 if let Some(&(open_idx, top_char)) = bracket_stack.last() {
                     if top_char == expected_open {
                         bracket_stack.pop();
                         // Set bidirectional pointers
                         tokens[open_idx].matching_bracket_idx = Some(idx);
                         tokens[idx].matching_bracket_idx = Some(open_idx);
+                    } else {
+                        // A type mismatch (e.g. `a[(1]`) is what Python's
+                        // resolve_bracket raises on, unwinding through every
+                        // enclosing bracket's own call. Clear the whole stack
+                        // to match that: every bracket still open at this
+                        // point stays unresolved, so none of them can later
+                        // pair with a closer that follows.
+                        bracket_stack.clear();
                     }
-                    // else: type mismatch - leave both this closer and the
-                    // top-of-stack opener unresolved.
                 }
                 // If the stack is empty, there's no open bracket at all -
                 // leave as None (syntax error).

--- a/sqlfluffrs/sqlfluffrs_lexer/src/lexer.rs
+++ b/sqlfluffrs/sqlfluffrs_lexer/src/lexer.rs
@@ -404,14 +404,26 @@ impl Lexer {
                 "}" => Some('{'),
                 _ => None,
             } {
-                // Try to match with the most recent opening bracket of the same type
-                if let Some(pos) = bracket_stack.iter().rposition(|(_, c)| *c == expected_open) {
-                    let (open_idx, _) = bracket_stack.remove(pos);
-                    // Set bidirectional pointers
-                    tokens[open_idx].matching_bracket_idx = Some(idx);
-                    tokens[idx].matching_bracket_idx = Some(open_idx);
+                // Only the most-recently-opened bracket (the top of the stack)
+                // may be closed next, per LIFO nesting discipline. This matches
+                // Python's resolve_bracket (match_algorithms.py), which recurses
+                // into a freshly-opened bracket and only returns once that
+                // specific bracket is resolved. On a type mismatch here (e.g.
+                // `a[(1]`), both this closer and the innermost opener stay
+                // unresolved (matching_bracket_idx None for both); the outer `[`
+                // is left for its own closer rather than matched against `]`.
+                if let Some(&(open_idx, top_char)) = bracket_stack.last() {
+                    if top_char == expected_open {
+                        bracket_stack.pop();
+                        // Set bidirectional pointers
+                        tokens[open_idx].matching_bracket_idx = Some(idx);
+                        tokens[idx].matching_bracket_idx = Some(open_idx);
+                    }
+                    // else: type mismatch - leave both this closer and the
+                    // top-of-stack opener unresolved.
                 }
-                // If no matching opening bracket, leave as None (syntax error)
+                // If the stack is empty, there's no open bracket at all -
+                // leave as None (syntax error).
             }
         }
         // Any remaining opening brackets on the stack are unmatched - leave as None

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/python.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/python.rs
@@ -681,18 +681,21 @@ fn compute_bracket_pairs(tokens: &mut [Token]) {
             // be closed next, per LIFO nesting discipline. See the sibling
             // implementation in sqlfluffrs_lexer/src/lexer.rs::compute_bracket_pairs
             // for the full rationale (Python parity with resolve_bracket in
-            // match_algorithms.py): on a type mismatch, both the closer and
-            // the innermost opener stay unresolved, for the outer opener's own
-            // closer to match against later.
+            // match_algorithms.py).
             if let Some(&(open_idx, top_char)) = bracket_stack.last() {
                 if top_char == expected_open {
                     bracket_stack.pop();
                     // Set bidirectional pointers
                     tokens[open_idx].matching_bracket_idx = Some(idx);
                     tokens[idx].matching_bracket_idx = Some(open_idx);
+                } else {
+                    // A type mismatch is what Python's resolve_bracket raises
+                    // on, unwinding through every enclosing bracket's own
+                    // call. Clear the whole stack to match that: every
+                    // bracket still open at this point stays unresolved, so
+                    // none of them can later pair with a closer that follows.
+                    bracket_stack.clear();
                 }
-                // else: type mismatch - leave both this closer and the
-                // top-of-stack opener unresolved.
             }
             // If the stack is empty, there's no open bracket at all - leave as None.
         }

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/python.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/python.rs
@@ -677,14 +677,24 @@ fn compute_bracket_pairs(tokens: &mut [Token]) {
             "}" => Some('{'),
             _ => None,
         } {
-            // Try to match with the most recent opening bracket of the same type
-            if let Some(pos) = bracket_stack.iter().rposition(|(_, c)| *c == expected_open) {
-                let (open_idx, _) = bracket_stack.remove(pos);
-                // Set bidirectional pointers
-                tokens[open_idx].matching_bracket_idx = Some(idx);
-                tokens[idx].matching_bracket_idx = Some(open_idx);
+            // Only the most-recently-opened bracket (the top of the stack) may
+            // be closed next, per LIFO nesting discipline. See the sibling
+            // implementation in sqlfluffrs_lexer/src/lexer.rs::compute_bracket_pairs
+            // for the full rationale (Python parity with resolve_bracket in
+            // match_algorithms.py): on a type mismatch, both the closer and
+            // the innermost opener stay unresolved, for the outer opener's own
+            // closer to match against later.
+            if let Some(&(open_idx, top_char)) = bracket_stack.last() {
+                if top_char == expected_open {
+                    bracket_stack.pop();
+                    // Set bidirectional pointers
+                    tokens[open_idx].matching_bracket_idx = Some(idx);
+                    tokens[idx].matching_bracket_idx = Some(open_idx);
+                }
+                // else: type mismatch - leave both this closer and the
+                // top-of-stack opener unresolved.
             }
-            // If no matching opening bracket, leave as None (syntax error)
+            // If the stack is empty, there's no open bracket at all - leave as None.
         }
     }
     // Any remaining opening brackets on the stack are unmatched - leave as None

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/match_algorithms.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/match_algorithms.rs
@@ -93,8 +93,8 @@ enum BracketScanResult {
 /// the way (same technique as `greedy_match`'s own bracket-skip).
 ///
 /// `open_idx` is the position of the opener already known to be unresolved
-/// (normally `from_idx - 1`), and `open_char` its type. Both track the
-/// innermost bracket currently "active", updating to each further
+/// (normally `from_idx - 1`). It, and the bracket type it opens with, track
+/// the innermost bracket currently "active", updating to each further
 /// unresolved opener found along the way, matching Python's
 /// `resolve_bracket` recursing one level deeper for every bracket it opens
 /// - so the position they end up at is always where Python's own
@@ -108,11 +108,14 @@ fn find_mismatched_closing_bracket(
     tokens: &[Token],
     from_idx: usize,
     open_idx: usize,
-    open_char: char,
 ) -> BracketScanResult {
     let mut idx = from_idx;
     let mut innermost_idx = open_idx;
-    let mut open_char = open_char;
+    let mut open_char = tokens[open_idx]
+        .raw()
+        .chars()
+        .next()
+        .expect("bracket raw is non-empty");
     while idx < tokens.len() {
         let raw = tokens[idx].raw();
         match raw {
@@ -265,8 +268,7 @@ impl Parser<'_> {
                     // message for the true unclosed-to-EOF case. Either way,
                     // blame the innermost still-open bracket, matching
                     // resolve_bracket's own recursive call.
-                    let open_char = raw.chars().next().expect("bracket raw is non-empty");
-                    match find_mismatched_closing_bracket(tokens, i + 1, i, open_char) {
+                    match find_mismatched_closing_bracket(tokens, i + 1, i) {
                         BracketScanResult::Mismatch {
                             idx: mismatch_idx,
                             actual_close,

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/match_algorithms.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/match_algorithms.rs
@@ -75,29 +75,38 @@ fn try_match_grammar(
 /// skipping over any properly nested, already-resolved bracket pairs along
 /// the way (same technique as `greedy_match`'s own bracket-skip).
 ///
-/// An unresolved token found this way must be a *closing* bracket of the
-/// wrong type: if it were the correct type for whatever opener is looking
-/// for it, lexing would already have paired them (see
-/// `sqlfluffrs_lexer::compute_bracket_pairs`). Returns `(index, raw_char)`
-/// for that mismatched closer, or `None` if genuinely nothing is found
-/// before `tokens.len()` (a real "unclosed to EOF" case) or another
-/// unresolved *opening* bracket is hit first (ambiguous - fall back to the
-/// generic message rather than guess).
+/// `open_char` tracks the innermost bracket type currently "active", to
+/// report the correct expected-closer type in the returned tuple. It
+/// starts as the opener at `from_idx - 1`, and updates to each further
+/// unresolved opener found along the way, matching Python's
+/// `resolve_bracket` recursing one level deeper for every bracket it opens.
+///
+/// Returns `(index, raw_char, expected_open)` for the mismatched closer,
+/// or `None` if genuinely nothing is found before `tokens.len()` (a real
+/// "unclosed to EOF" case).
 ///
 /// Used to distinguish Python's two distinct bracket-resolution failures
 /// (`resolve_bracket`, match_algorithms.py): "Couldn't find closing bracket
 /// for opening bracket" (genuinely unclosed) vs. "Found unexpected end
 /// bracket!, was expecting X, but got Y" (closed by the wrong type).
-fn find_mismatched_closing_bracket(tokens: &[Token], from_idx: usize) -> Option<(usize, String)> {
+fn find_mismatched_closing_bracket(
+    tokens: &[Token],
+    from_idx: usize,
+    open_char: char,
+) -> Option<(usize, String, char)> {
     let mut idx = from_idx;
+    let mut open_char = open_char;
     while idx < tokens.len() {
         let raw = tokens[idx].raw();
         match raw {
             "(" | "[" | "{" => match tokens[idx].matching_bracket_idx {
                 Some(matching_idx) => idx = matching_idx + 1,
-                None => return None,
+                None => {
+                    open_char = raw.chars().next().expect("bracket raw is non-empty");
+                    idx += 1;
+                }
             },
-            ")" | "]" | "}" => return Some((idx, raw.to_string())),
+            ")" | "]" | "}" => return Some((idx, raw.to_string(), open_char)),
             _ => idx += 1,
         }
     }
@@ -230,14 +239,15 @@ impl Parser<'_> {
                     // its specific "wrong bracket type" error when the closer
                     // ahead is mismatched, keeping the generic "never closed"
                     // message for the true unclosed-to-EOF case.
-                    if let Some((mismatch_idx, actual_close)) =
-                        find_mismatched_closing_bracket(tokens, i + 1)
+                    let open_char = raw.chars().next().expect("bracket raw is non-empty");
+                    if let Some((mismatch_idx, actual_close, innermost_open)) =
+                        find_mismatched_closing_bracket(tokens, i + 1, open_char)
                     {
-                        let expected_close = match raw {
-                            "(" => ")",
-                            "[" => "]",
-                            "{" => "}",
-                            _ => unreachable!("raw already matched an opening bracket above"),
+                        let expected_close = match innermost_open {
+                            '(' => ")",
+                            '[' => "]",
+                            '{' => "}",
+                            _ => unreachable!("open_char is always a bracket character"),
                         };
                         vdebug!(
                             "[GREEDY_MATCH_TABLE] greedy_match: mismatched closing bracket '{}' at {} for opening bracket at {} (expected '{}')",

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/match_algorithms.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/match_algorithms.rs
@@ -70,20 +70,35 @@ fn try_match_grammar(
     }
 }
 
+/// The result of scanning forward for how an unresolved opening bracket at
+/// `open_idx` is eventually accounted for.
+enum BracketScanResult {
+    /// A closer of the wrong type was found. `idx` is its position,
+    /// `actual_close` its raw text, and `expected_open` the type of the
+    /// innermost still-open bracket it should have closed instead.
+    Mismatch {
+        idx: usize,
+        actual_close: String,
+        expected_open: char,
+    },
+    /// Nothing closed it before `tokens.len()`. `idx` is the innermost
+    /// still-open bracket at that point, i.e. the one Python's recursive
+    /// `resolve_bracket` would have been sitting in when it hit EOF.
+    Unclosed { idx: usize },
+}
+
 /// Scan forward from `from_idx` for the first bracket-like token not already
 /// resolved by lexing (i.e. one whose `matching_bracket_idx` is `None`),
 /// skipping over any properly nested, already-resolved bracket pairs along
 /// the way (same technique as `greedy_match`'s own bracket-skip).
 ///
-/// `open_char` tracks the innermost bracket type currently "active", to
-/// report the correct expected-closer type in the returned tuple. It
-/// starts as the opener at `from_idx - 1`, and updates to each further
+/// `open_idx` is the position of the opener already known to be unresolved
+/// (normally `from_idx - 1`), and `open_char` its type. Both track the
+/// innermost bracket currently "active", updating to each further
 /// unresolved opener found along the way, matching Python's
-/// `resolve_bracket` recursing one level deeper for every bracket it opens.
-///
-/// Returns `(index, raw_char, expected_open)` for the mismatched closer,
-/// or `None` if genuinely nothing is found before `tokens.len()` (a real
-/// "unclosed to EOF" case).
+/// `resolve_bracket` recursing one level deeper for every bracket it opens
+/// - so the position they end up at is always where Python's own
+/// recursive call would raise from.
 ///
 /// Used to distinguish Python's two distinct bracket-resolution failures
 /// (`resolve_bracket`, match_algorithms.py): "Couldn't find closing bracket
@@ -92,9 +107,11 @@ fn try_match_grammar(
 fn find_mismatched_closing_bracket(
     tokens: &[Token],
     from_idx: usize,
+    open_idx: usize,
     open_char: char,
-) -> Option<(usize, String, char)> {
+) -> BracketScanResult {
     let mut idx = from_idx;
+    let mut innermost_idx = open_idx;
     let mut open_char = open_char;
     while idx < tokens.len() {
         let raw = tokens[idx].raw();
@@ -102,15 +119,22 @@ fn find_mismatched_closing_bracket(
             "(" | "[" | "{" => match tokens[idx].matching_bracket_idx {
                 Some(matching_idx) => idx = matching_idx + 1,
                 None => {
+                    innermost_idx = idx;
                     open_char = raw.chars().next().expect("bracket raw is non-empty");
                     idx += 1;
                 }
             },
-            ")" | "]" | "}" => return Some((idx, raw.to_string(), open_char)),
+            ")" | "]" | "}" => {
+                return BracketScanResult::Mismatch {
+                    idx,
+                    actual_close: raw.to_string(),
+                    expected_open: open_char,
+                };
+            }
             _ => idx += 1,
         }
     }
-    None
+    BracketScanResult::Unclosed { idx: innermost_idx }
 }
 
 pub(crate) fn skip_stop_index_backward_to_code(
@@ -238,39 +262,47 @@ impl Parser<'_> {
                     // PYTHON PARITY: mirror Python's resolve_bracket by raising
                     // its specific "wrong bracket type" error when the closer
                     // ahead is mismatched, keeping the generic "never closed"
-                    // message for the true unclosed-to-EOF case.
+                    // message for the true unclosed-to-EOF case. Either way,
+                    // blame the innermost still-open bracket, matching
+                    // resolve_bracket's own recursive call.
                     let open_char = raw.chars().next().expect("bracket raw is non-empty");
-                    if let Some((mismatch_idx, actual_close, innermost_open)) =
-                        find_mismatched_closing_bracket(tokens, i + 1, open_char)
-                    {
-                        let expected_close = match innermost_open {
-                            '(' => ")",
-                            '[' => "]",
-                            '{' => "}",
-                            _ => unreachable!("open_char is always a bracket character"),
-                        };
-                        vdebug!(
-                            "[GREEDY_MATCH_TABLE] greedy_match: mismatched closing bracket '{}' at {} for opening bracket at {} (expected '{}')",
-                            actual_close, mismatch_idx, i, expected_close
-                        );
-                        return Err(ParseError::with_context(
-                            format!(
-                                "Found unexpected end bracket!, was expecting <StringParser: '{}'>, but got <StringParser: '{}'>",
-                                expected_close, actual_close
-                            ),
-                            Some(mismatch_idx),
-                            None,
-                        ));
+                    match find_mismatched_closing_bracket(tokens, i + 1, i, open_char) {
+                        BracketScanResult::Mismatch {
+                            idx: mismatch_idx,
+                            actual_close,
+                            expected_open,
+                        } => {
+                            let expected_close = match expected_open {
+                                '(' => ")",
+                                '[' => "]",
+                                '{' => "}",
+                                _ => unreachable!("expected_open is always a bracket character"),
+                            };
+                            vdebug!(
+                                "[GREEDY_MATCH_TABLE] greedy_match: mismatched closing bracket '{}' at {} for opening bracket at {} (expected '{}')",
+                                actual_close, mismatch_idx, i, expected_close
+                            );
+                            return Err(ParseError::with_context(
+                                format!(
+                                    "Found unexpected end bracket!, was expecting <StringParser: '{}'>, but got <StringParser: '{}'>",
+                                    expected_close, actual_close
+                                ),
+                                Some(mismatch_idx),
+                                None,
+                            ));
+                        }
+                        BracketScanResult::Unclosed { idx: innermost_idx } => {
+                            vdebug!(
+                                "[GREEDY_MATCH_TABLE] greedy_match: no matching closing bracket for opening bracket at {}",
+                                innermost_idx
+                            );
+                            return Err(ParseError::with_context(
+                                "Couldn't find closing bracket for opening bracket.".to_string(),
+                                Some(innermost_idx),
+                                None,
+                            ));
+                        }
                     }
-                    vdebug!(
-                        "[GREEDY_MATCH_TABLE] greedy_match: no matching closing bracket for opening bracket at {}",
-                        i
-                    );
-                    return Err(ParseError::with_context(
-                        "Couldn't find closing bracket for opening bracket.".to_string(),
-                        Some(i),
-                        None,
-                    ));
                 }
             }
 

--- a/test/core/parser/rust_parser_test.py
+++ b/test/core/parser/rust_parser_test.py
@@ -689,12 +689,26 @@ def _compare_parser_vs_rust(sql: str, dialect: str = "ansi"):
             tree = parser.parse(segments, fname="t.sql")
             return (
                 "tree",
-                tree.to_tuple(code_only=False, show_raw=True, include_meta=True)
+                tree.to_tuple(
+                    code_only=False,
+                    show_raw=True,
+                    include_meta=True,
+                    include_position=True,
+                )
                 if tree
                 else None,
             )
         except BaseException as err:
-            return ("exc", type(err).__name__, str(err))
+            return (
+                "exc",
+                type(err).__name__,
+                str(err),
+                getattr(err, "line_no", None),
+                getattr(err, "line_pos", None),
+                getattr(err, "fatal", None),
+                getattr(err, "ignore", None),
+                getattr(err, "warning", None),
+            )
 
     return build(True), build(False)
 

--- a/test/core/parser/rust_parser_test.py
+++ b/test/core/parser/rust_parser_test.py
@@ -843,30 +843,47 @@ def test__rust_parser__vs_python_mismatched_bracket_type_error_message():
 
 @pytest.mark.skipif(not _HAS_RUST_PARSER, reason="Rust parser not available")
 def test__rust_parser__vs_python_nested_bracket_mismatch_raises():
-    """Python and RustParser now agree on a nested bracket-type mismatch.
+    """Python and RustParser agree on a nested bracket-type mismatch.
 
-    Regression test: a nested bracket-type mismatch (e.g. an unclosed '('
-    inside '[...]' that gets "closed" by the outer ']') makes Python raise
-    'Found unexpected end bracket!' (SQLParseError). RustParser used to
-    silently recover a tree instead, because its lexer-level bracket-pairer
-    (`compute_bracket_pairs`) resolved a closing bracket against the first
-    same-type opener found anywhere on the open-bracket stack, rather than
-    requiring it to match the innermost (top-of-stack) opener. That let an
-    outer bracket "steal" a closer meant for a more-recently-opened,
-    different-type inner bracket, instead of leaving both unresolved as a
-    genuine syntax error - violating LIFO nesting discipline and diverging
-    from Python's recursive `resolve_bracket`, which only ever resolves the
-    innermost open bracket next.
+    A nested bracket-type mismatch (e.g. an unclosed '(' inside '[...]'
+    that gets "closed" by the outer ']') should raise 'Found unexpected
+    end bracket!' (SQLParseError) in both engines: `compute_bracket_pairs`
+    requires a closer to match the innermost (top-of-stack) opener, per
+    LIFO nesting discipline, matching Python's recursive `resolve_bracket`,
+    which only ever resolves the innermost open bracket next.
 
-    Fixed by requiring the top of the bracket stack to match the closer's
-    expected type in both `compute_bracket_pairs` implementations:
+    Both `compute_bracket_pairs` implementations enforce this:
     `sqlfluffrs_lexer/src/lexer.rs` (used when sqlfluffrs does its own
     lexing) and the duplicate in `sqlfluffrs_parser/src/parser/python.rs`
     (used when RustParser re-derives bracket pairs from Python-lexed
     tokens, e.g. via `Linter(use_rust_parser=True)` - the only publicly
-    observable path, and the one the initial lexer.rs-only fix missed).
+    observable path).
     """
     rust_result, python_result = _compare_parser_vs_rust("SELECT a[(1]")
+    assert rust_result == python_result
+
+
+@pytest.mark.skipif(not _HAS_RUST_PARSER, reason="Rust parser not available")
+@pytest.mark.parametrize(
+    "sql",
+    [
+        "SELECT a[(1]) ]",
+        "SELECT a[[1)]]",
+    ],
+)
+def test__rust_parser__vs_python_crossed_bracket_after_mismatch_raises(sql):
+    """A later crossed bracket pair must not "recover" a mismatch, matching Python.
+
+    Once a bracket-type mismatch occurs, every bracket that was still open
+    at that point should stay unresolved, even if a later closer would
+    otherwise cross-match one of them. This mirrors Python's recursive
+    resolve_bracket: raising on the first mismatch unwinds through every
+    enclosing bracket's own call, so none of them can be validly resolved
+    afterwards. Both `compute_bracket_pairs` implementations enforce this
+    by clearing the entire bracket stack (not just the mismatched pair)
+    once a mismatch is found.
+    """
+    rust_result, python_result = _compare_parser_vs_rust(sql)
     assert rust_result == python_result
 
 

--- a/test/core/parser/rust_parser_test.py
+++ b/test/core/parser/rust_parser_test.py
@@ -694,7 +694,7 @@ def _compare_parser_vs_rust(sql: str, dialect: str = "ansi"):
                 else None,
             )
         except BaseException as err:
-            return ("exc", type(err).__name__)
+            return ("exc", type(err).__name__, str(err))
 
     return build(True), build(False)
 

--- a/test/core/parser/rust_parser_test.py
+++ b/test/core/parser/rust_parser_test.py
@@ -902,6 +902,20 @@ def test__rust_parser__vs_python_crossed_bracket_after_mismatch_raises(sql):
 
 
 @pytest.mark.skipif(not _HAS_RUST_PARSER, reason="Rust parser not available")
+def test__rust_parser__vs_python_unclosed_nested_bracket_error_position():
+    """An unclosed bracket nested inside another should be blamed, not its parent.
+
+    For brackets unclosed to EOF and nested two or more levels deep (e.g.
+    an unclosed '(' containing an unclosed '['), the "couldn't find closing
+    bracket" error should point at the innermost open bracket. This matches
+    Python's resolve_bracket, which recurses into each opening bracket and
+    raises from that recursive call once it reaches EOF.
+    """
+    rust_result, python_result = _compare_parser_vs_rust("SELECT a(b[1")
+    assert rust_result == python_result
+
+
+@pytest.mark.skipif(not _HAS_RUST_PARSER, reason="Rust parser not available")
 def test__rust_parser__vs_python_stray_bracket_swallows_union_arm():
     """A stray ')' before UNION: Rust now discards the second arm too, matching Python.
 

--- a/test/core/parser/rust_parser_test.py
+++ b/test/core/parser/rust_parser_test.py
@@ -857,21 +857,30 @@ def test__rust_parser__vs_python_mismatched_bracket_type_error_message():
 
 
 @pytest.mark.skipif(not _HAS_RUST_PARSER, reason="Rust parser not available")
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "Regression: a nested nested-bracket-type mismatch (e.g. an "
-        "unclosed '(' inside '[...]' that gets 'closed' by the outer ']') "
-        "makes Python raise the same 'Found unexpected end bracket!' "
-        "SQLParseError as the flat mismatched-bracket-type case. RustParser "
-        "instead silently recovers a tree, demoting the malformed nested "
-        "bracket content to an unparsable expression rather than raising. "
-        "This is bug class 3 (Python raises, Rust recovers) triggered by a "
-        "nested mismatch rather than an unclosed-to-EOF bracket."
-    ),
-)
 def test__rust_parser__vs_python_nested_bracket_mismatch_raises():
-    """Python raises on nested bracket-type mismatch; RustParser recovers a tree."""
+    """Python and RustParser now agree on a nested bracket-type mismatch.
+
+    Regression test: a nested bracket-type mismatch (e.g. an unclosed '('
+    inside '[...]' that gets "closed" by the outer ']') makes Python raise
+    'Found unexpected end bracket!' (SQLParseError). RustParser used to
+    silently recover a tree instead, because its lexer-level bracket-pairer
+    (`compute_bracket_pairs`) resolved a closing bracket against the first
+    same-type opener found anywhere on the open-bracket stack, rather than
+    requiring it to match the innermost (top-of-stack) opener. That let an
+    outer bracket "steal" a closer meant for a more-recently-opened,
+    different-type inner bracket, instead of leaving both unresolved as a
+    genuine syntax error - violating LIFO nesting discipline and diverging
+    from Python's recursive `resolve_bracket`, which only ever resolves the
+    innermost open bracket next.
+
+    Fixed by requiring the top of the bracket stack to match the closer's
+    expected type in both `compute_bracket_pairs` implementations:
+    `sqlfluffrs_lexer/src/lexer.rs` (used when sqlfluffrs does its own
+    lexing) and the duplicate in `sqlfluffrs_parser/src/parser/python.rs`
+    (used when RustParser re-derives bracket pairs from Python-lexed
+    tokens, e.g. via `Linter(use_rust_parser=True)` - the only publicly
+    observable path, and the one the initial lexer.rs-only fix missed).
+    """
     rust_result, python_result = _compare_parser_vs_rust("SELECT a[(1]")
     assert rust_result == python_result
 


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
`RustParser`'s bracket-matching (`compute_bracket_pairs`) did not follow the same last-in-first-out discipline as the Python parser when a closing bracket didn't match the innermost open bracket. Depending on the nesting, this could
cause `RustParser` to either silently recover from a bracket-type mismatch that Python treats as fatal, or leave brackets in an inconsistent state after one opener could not be resolved (a "stranded" opener). The error message raised also didn't always name the specific nested opener involved.

For SQL with nested brackets where an inner bracket is closed with the wrong type, `RustParser` could produce a different parse result or a different (or missing) error than the Python parser, instead of consistently raising with a message naming the mismatched bracket.

```sql
SELECT a[(1]
```

```sql
SELECT a[(1]) ]
```

`compute_bracket_pairs` (duplicated in `sqlfluffrs_lexer/src/lexer.rs` and `sqlfluffrs_parser/src/parser/python.rs`, since `RustParser`'s actual parse path uses the latter) now clears the entire bracket stack, not just the top entry, when a type mismatch is found, matching the Python parser's behavior where an exception at any nesting depth propagates through all enclosing brackets. `find_mismatched_closing_bracket` was also reworked to track nested unresolved openers via a local stack so the raised message names the correct expected/actual bracket types at any nesting depth.

### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [ ] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes nested bracket-type mismatches and unclosed-bracket reporting in the Rust parser to match Python’s `resolve_bracket`, preventing recovery and aligning error type, message, and position.

- **Bug Fixes**
  - Enforce strict LIFO in `compute_bracket_pairs` (in both `sqlfluffrs_lexer/src/lexer.rs` and `sqlfluffrs_parser/src/parser/python.rs`) and clear the entire stack on a mismatch so closers only match the top-of-stack opener.
  - Rework `match_algorithms.rs` to scan from the innermost unresolved opener and distinguish mismatch vs. unclosed cases, reporting the correct expected/actual types and blaming the innermost bracket; simplified the helper by removing a redundant parameter.
  - Expand tests to compare full error text, error position/flags, and tree segment positions; add cases for crossed-bracket sequences and for innermost-unclosed error positioning.

<sup>Written for commit 69a5c7f16bc1267614e6169ebc2739694f669a6a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8120?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

