### PR TITLE
Fix unclosed GREEDY-mode bracket recovering instead of raising

### DIFF
--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/bracketed.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/bracketed.rs
@@ -421,23 +421,20 @@ impl Parser<'_> {
                 stack.push(frame);
                 Ok(TableFrameResult::Done)
             } else {
-                // GREEDY mode: Create parse error result for unclosed bracket
-                // Python parity: raises SQLParseError which gets caught and converted to violation
+                // GREEDY mode should hard-raise here, matching Python's
+                // Bracketed.match() (resolve_bracket in match_algorithms.py) and
+                // this module's own greedy_match. The error propagates through
+                // root_parse to RsParseError, which rust_parser.py converts back
+                // into the same SQLParseError Python raises.
                 vdebug!(
-                        "Bracketed[table] GREEDY mode: No closing bracket found at EOF, creating parse error result"
+                        "Bracketed[table] GREEDY mode: No closing bracket found at EOF, raising parse error"
                     );
 
-                // Create error result with position at opening bracket
-                // PYTHON PARITY: Message must match Python's SQLParseError message exactly
-                let error_match = MatchResult::with_error(
-                    frame.pos,
-                    self.pos,
+                Err(ParseError::with_context(
                     "Couldn't find closing bracket for opening bracket.".to_string(),
-                    frame.pos, // Error at opening bracket position
-                );
-
-                stack.insert_result(frame.frame_id, error_match, self.pos);
-                Ok(TableFrameResult::Done)
+                    Some(frame.pos), // Error at opening bracket position
+                    None,
+                ))
             }
         } else {
             // STRICT mode check: All content elements must end at the closing bracket position
@@ -540,25 +537,20 @@ impl Parser<'_> {
                 stack.push(frame);
                 return Ok(TableFrameResult::Done);
             } else {
-                // GREEDY mode: Closing bracket not found - raise parse error
-                // PYTHON PARITY: This matches Python's behavior where Bracketed.match()
-                // raises SQLParseError("Couldn't find closing bracket for opening bracket.")
+                // GREEDY mode should hard-raise here too, for the same reason as
+                // the sibling GREEDY-EOF branch in
+                // handle_bracketed_content_result above.
                 vdebug!(
                         "Bracketed[table] GREEDY mode: Couldn't find closing bracket for opening bracket at pos {}, frame_id={}",
                         frame.pos,
                         frame.frame_id
                     );
 
-                // Create error result with position at opening bracket
-                let error_match = MatchResult::with_error(
-                    frame.pos,
-                    self.pos,
+                return Err(ParseError::with_context(
                     "Couldn't find closing bracket for opening bracket.".to_string(),
-                    frame.pos, // Error at opening bracket position
-                );
-
-                stack.insert_result(frame.frame_id, error_match, self.pos);
-                return Ok(TableFrameResult::Done);
+                    Some(frame.pos), // Error at opening bracket position
+                    None,
+                ));
             }
         } else {
             child_matches.push(Arc::clone(child_match));

--- a/test/core/parser/rust_parser_test.py
+++ b/test/core/parser/rust_parser_test.py
@@ -845,21 +845,30 @@ def test__rust_parser__vs_python_mismatched_bracket_type_error_message():
 
 
 @pytest.mark.skipif(not _HAS_RUST_PARSER, reason="Rust parser not available")
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "Regression: a nested nested-bracket-type mismatch (e.g. an "
-        "unclosed '(' inside '[...]' that gets 'closed' by the outer ']') "
-        "makes Python raise the same 'Found unexpected end bracket!' "
-        "SQLParseError as the flat mismatched-bracket-type case. RustParser "
-        "instead silently recovers a tree, demoting the malformed nested "
-        "bracket content to an unparsable expression rather than raising. "
-        "This is bug class 3 (Python raises, Rust recovers) triggered by a "
-        "nested mismatch rather than an unclosed-to-EOF bracket."
-    ),
-)
 def test__rust_parser__vs_python_nested_bracket_mismatch_raises():
-    """Python raises on nested bracket-type mismatch; RustParser recovers a tree."""
+    """Python and RustParser now agree on a nested bracket-type mismatch.
+
+    Regression test: a nested bracket-type mismatch (e.g. an unclosed '('
+    inside '[...]' that gets "closed" by the outer ']') makes Python raise
+    'Found unexpected end bracket!' (SQLParseError). RustParser used to
+    silently recover a tree instead, because its lexer-level bracket-pairer
+    (`compute_bracket_pairs`) resolved a closing bracket against the first
+    same-type opener found anywhere on the open-bracket stack, rather than
+    requiring it to match the innermost (top-of-stack) opener. That let an
+    outer bracket "steal" a closer meant for a more-recently-opened,
+    different-type inner bracket, instead of leaving both unresolved as a
+    genuine syntax error - violating LIFO nesting discipline and diverging
+    from Python's recursive `resolve_bracket`, which only ever resolves the
+    innermost open bracket next.
+
+    Fixed by requiring the top of the bracket stack to match the closer's
+    expected type in both `compute_bracket_pairs` implementations:
+    `sqlfluffrs_lexer/src/lexer.rs` (used when sqlfluffrs does its own
+    lexing) and the duplicate in `sqlfluffrs_parser/src/parser/python.rs`
+    (used when RustParser re-derives bracket pairs from Python-lexed
+    tokens, e.g. via `Linter(use_rust_parser=True)` - the only publicly
+    observable path, and the one the initial lexer.rs-only fix missed).
+    """
     rust_result, python_result = _compare_parser_vs_rust("SELECT a[(1]")
     assert rust_result == python_result
 

--- a/test/core/parser/rust_parser_test.py
+++ b/test/core/parser/rust_parser_test.py
@@ -845,32 +845,48 @@ def test__rust_parser__vs_python_mismatched_bracket_type_error_message():
 
 
 @pytest.mark.skipif(not _HAS_RUST_PARSER, reason="Rust parser not available")
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "Regression: a nested bracket-type mismatch (an unclosed '(' inside "
+        "'[...]' that gets 'closed' by the outer ']') makes Python's "
+        "resolve_bracket detect the mismatch directly and raise a specific "
+        "'Found unexpected end bracket!, was expecting ..., but got ...' "
+        "SQLParseError. RustParser's lexer-level bracket-pairer "
+        "(`compute_bracket_pairs` in sqlfluffrs_lexer/src/lexer.rs and its "
+        "duplicate in sqlfluffrs_parser/src/parser/python.rs) resolves a "
+        "closing bracket against the first same-type opener found anywhere "
+        "on the open-bracket stack, rather than requiring it to match the "
+        "innermost (top-of-stack) opener, violating LIFO nesting "
+        "discipline. That leaves the inner '(' permanently unmatched, "
+        "which a separate, unrelated check in greedy_match "
+        "(sqlfluffrs_parser/src/parser/table_driven/match_algorithms.rs) "
+        "then reports with the generic 'Couldn't find closing bracket for "
+        "opening bracket.' message instead. Both engines raise "
+        "SQLParseError, but with different text, so this test (which "
+        "compares full exception message, not just type) fails. Fixed by "
+        "requiring the top of the bracket stack to match the closer's "
+        "expected type in both `compute_bracket_pairs` implementations."
+    ),
+)
 def test__rust_parser__vs_python_nested_bracket_mismatch_raises():
-    """Python and RustParser now agree on a nested bracket-type mismatch.
+    """Python raises a specific message on a nested bracket-type mismatch; RustParser's differs."""
+    from sqlfluff.core import FluffConfig
+    from sqlfluff.core.parser import Lexer, Parser
 
-    Regression test: a nested bracket-type mismatch (e.g. an unclosed '('
-    inside '[...]' that gets "closed" by the outer ']') makes Python raise
-    'Found unexpected end bracket!' (SQLParseError). RustParser used to
-    silently recover a tree instead, because its lexer-level bracket-pairer
-    (`compute_bracket_pairs`) resolved a closing bracket against the first
-    same-type opener found anywhere on the open-bracket stack, rather than
-    requiring it to match the innermost (top-of-stack) opener. That let an
-    outer bracket "steal" a closer meant for a more-recently-opened,
-    different-type inner bracket, instead of leaving both unresolved as a
-    genuine syntax error - violating LIFO nesting discipline and diverging
-    from Python's recursive `resolve_bracket`, which only ever resolves the
-    innermost open bracket next.
+    sql = "SELECT a[(1]"
+    config = FluffConfig(overrides={"dialect": "ansi"})
+    segments, _ = Lexer(config=config).lex(sql)
 
-    Fixed by requiring the top of the bracket stack to match the closer's
-    expected type in both `compute_bracket_pairs` implementations:
-    `sqlfluffrs_lexer/src/lexer.rs` (used when sqlfluffrs does its own
-    lexing) and the duplicate in `sqlfluffrs_parser/src/parser/python.rs`
-    (used when RustParser re-derives bracket pairs from Python-lexed
-    tokens, e.g. via `Linter(use_rust_parser=True)` - the only publicly
-    observable path, and the one the initial lexer.rs-only fix missed).
-    """
-    rust_result, python_result = _compare_parser_vs_rust("SELECT a[(1]")
-    assert rust_result == python_result
+    def build(use_rust: bool):
+        parser = RustParser(config=config) if use_rust else Parser(config=config)
+        try:
+            parser.parse(segments, fname="t.sql")
+            return None
+        except BaseException as err:
+            return (type(err).__name__, str(err))
+
+    assert build(True) == build(False)
 
 
 @pytest.mark.skipif(not _HAS_RUST_PARSER, reason="Rust parser not available")

--- a/test/core/parser/rust_parser_test.py
+++ b/test/core/parser/rust_parser_test.py
@@ -764,26 +764,14 @@ def test__rust_parser__vs_python_stray_closing_bracket_terminator():
 
 
 @pytest.mark.skipif(not _HAS_RUST_PARSER, reason="Rust parser not available")
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "Regression: Bracketed.match (src/sqlfluff/core/parser/grammar/"
-        "sequence.py:541-562) only suppresses the hard "
-        "'Couldn't find closing bracket' SQLParseError for "
-        "ParseMode.STRICT; for ParseMode.GREEDY (used by "
-        "CTEDefinitionSegment at dialect_ansi.py:2869 and the VALUES tuple "
-        "in ValuesClauseSegment at dialect_ansi.py:2748) Python always "
-        "raises when no closing bracket is found before EOF. RustParser's "
-        "codegen'd engine does not replicate this hard-raise, and instead "
-        "returns a tree with the remainder wrapped as unparsable."
-    ),
-)
 def test__rust_parser__vs_python_unclosed_greedy_bracket_raises():
-    """Python raises SQLParseError for an unclosed GREEDY-mode bracket.
+    """Python and RustParser now agree: an unclosed GREEDY-mode bracket raises.
 
-    RustParser instead recovers a tree, for the specific GREEDY-mode
-    Bracketed sites (CTE definitions, VALUES tuples) that Python treats as
-    a hard parse error rather than an unparsable section.
+    Regression test for bracketed.rs: for ParseMode.GREEDY (used by
+    CTEDefinitionSegment and the VALUES tuple in ValuesClauseSegment),
+    Python's Bracketed.match() always raises SQLParseError when no closing
+    bracket is found before EOF, so RustParser should raise too rather than
+    quietly recovering an unparsable tree.
     """
     rust_result, python_result = _compare_parser_vs_rust("WITH a AS (SELECT 1")
     assert rust_result == python_result


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
When a `Bracketed` grammar in GREEDY mode reaches end-of-file without finding its closing bracket, or ends up with an empty child match where one is required, `RustParser` returned a soft "with error" match result and kept going, instead of raising a hard parse error the way the Python parser does.

Unclosed brackets in SQL could be silently accepted (or produce a very different parse tree) by `RustParser` instead of surfacing a parse error, masking malformed input that the Python parser correctly flags.

```sql
WITH a AS (SELECT 1
```

In `sqlfluffrs_parser/src/parser/table_driven/bracketed.rs`, the two affected branches (`handle_bracketed_content_result`'s GREEDY-EOF case and `handle_bracketed_close_result`'s empty-child-match case) were changed to return `Err(ParseError::with_context(...))` instead of a soft `MatchResult::with_error`.

### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [ ] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `RustParser` raise a hard error for unclosed GREEDY-mode brackets to match Python. This surfaces malformed SQL instead of silently recovering a tree.

- **Bug Fixes**
  - In `sqlfluffrs_parser/src/parser/table_driven/bracketed.rs`, GREEDY EOF and empty-child-match paths now return `Err(ParseError::with_context(...))` instead of `MatchResult::with_error`.
  - Tests: unclosed GREEDY bracket now asserts both parsers raise (`WITH a AS (SELECT 1`); restored `xfail` for nested bracket-type mismatch with a more specific test comparing error text (`SELECT a[(1]`).

<sup>Written for commit 386b6489db88788812426320ebbefedf8263c1b9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8121?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

