### PR TITLE
Fix isinstance-preserved token type dropped by RustParser.parse()

### DIFF
--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/ref_grammar.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/ref_grammar.rs
@@ -261,6 +261,12 @@ impl Parser<'_> {
             // value keeps the `'static` lifetime — the common case borrows the
             // grammar-table string into the node with no allocation. Only the
             // isinstance override (a runtime token type) takes the owned branch.
+            // Records the runtime type when the isinstance-preservation path
+            // below overrides the grammar-table segment_type, so it can also
+            // be carried through `segment_kwargs.instance_types` below - that
+            // field is what RustParser.parse()'s Python-side tree builder
+            // actually reads the type override from.
+            let mut isinstance_override: Option<String> = None;
             let effective_segment_type: Cow<'static, str> = if let Some(seg_type) =
                 state.segment_type
             {
@@ -289,6 +295,7 @@ impl Parser<'_> {
                                 seg_type,
                                 tok.raw()
                             );
+                            isinstance_override = Some(effective.to_string());
                             Cow::Owned(effective.to_string())
                         } else {
                             Cow::Borrowed(seg_type)
@@ -313,6 +320,13 @@ impl Parser<'_> {
             {
                 // Look up the Python _class_types hierarchy for this grammar from codegen tables.
                 let class_types = self.grammar_ctx.segment_class_types(state.grammar_id);
+                // RustParser.parse()'s Python-side tree builder (rust_parser.py's
+                // _rs_match_fields/_apply_rs_match_result) reads its type
+                // override from `segment_kwargs["instance_types"]`, not from
+                // this MatchedClass's own `segment_type` field (that one only
+                // feeds Rust's internal Node tree). Set it here too so the
+                // isinstance-preserved type above also reaches that path.
+                let instance_types = isinstance_override.map(|t| vec![t]);
                 Some(MatchedClass {
                     // take() instead of clone() + unwrap — frame context is not read
                     // again after this point (state transitions to Complete).
@@ -322,6 +336,7 @@ impl Parser<'_> {
                     segment_type: Some(effective_segment_type),
                     segment_kwargs: SegmentKwargs {
                         class_types,
+                        instance_types,
                         ..Default::default()
                     },
                 })

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/ref_grammar.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/ref_grammar.rs
@@ -261,12 +261,14 @@ impl Parser<'_> {
             // value keeps the `'static` lifetime — the common case borrows the
             // grammar-table string into the node with no allocation. Only the
             // isinstance override (a runtime token type) takes the owned branch.
-            // Records the runtime type when the isinstance-preservation path
-            // below overrides the grammar-table segment_type, so it can also
-            // be carried through `segment_kwargs.instance_types` below - that
-            // field is what RustParser.parse()'s Python-side tree builder
-            // actually reads the type override from.
-            let mut isinstance_override: Option<String> = None;
+            // Holds the token's full instance type list when the isinstance
+            // path below overrides the grammar-table segment_type, so
+            // `segment_kwargs.instance_types` (below) can carry every type the
+            // token is an instance of - not just the effective/leaf one -
+            // matching Python's `RawSegment.class_types` (instance_types ∪
+            // class_types), which RustParser.parse()'s Python-side tree
+            // builder reads its type override from.
+            let mut isinstance_override: Option<Vec<String>> = None;
             let effective_segment_type: Cow<'static, str> = if let Some(seg_type) =
                 state.segment_type
             {
@@ -295,7 +297,11 @@ impl Parser<'_> {
                                 seg_type,
                                 tok.raw()
                             );
-                            isinstance_override = Some(effective.to_string());
+                            isinstance_override = Some(if tok.instance_types.is_empty() {
+                                vec![effective.to_string()]
+                            } else {
+                                tok.instance_types.clone()
+                            });
                             Cow::Owned(effective.to_string())
                         } else {
                             Cow::Borrowed(seg_type)
@@ -320,13 +326,11 @@ impl Parser<'_> {
             {
                 // Look up the Python _class_types hierarchy for this grammar from codegen tables.
                 let class_types = self.grammar_ctx.segment_class_types(state.grammar_id);
-                // RustParser.parse()'s Python-side tree builder (rust_parser.py's
-                // _rs_match_fields/_apply_rs_match_result) reads its type
-                // override from `segment_kwargs["instance_types"]`, not from
-                // this MatchedClass's own `segment_type` field (that one only
-                // feeds Rust's internal Node tree). Set it here too so the
-                // isinstance-preserved type above also reaches that path.
-                let instance_types = isinstance_override.map(|t| vec![t]);
+                // rust_parser.py's tree builder (_rs_match_fields/
+                // _apply_rs_match_result) reads its type override from
+                // `segment_kwargs["instance_types"]`; `MatchedClass.segment_type`
+                // only feeds Rust's internal Node tree.
+                let instance_types = isinstance_override;
                 Some(MatchedClass {
                     // take() instead of clone() + unwrap — frame context is not read
                     // again after this point (state transitions to Complete).

--- a/test/core/parser/rust_parser_test.py
+++ b/test/core/parser/rust_parser_test.py
@@ -973,22 +973,22 @@ def test__rust_parser__vs_python_unpivot_clause_indent_duplication():
 
 
 @pytest.mark.skipif(not _HAS_RUST_PARSER, reason="Rust parser not available")
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "Regression: a numeric literal argument inside Snowflake's CREATE "
-        "CATALOG INTEGRATION statement is typed as 'numeric_literal' by "
-        "Python's Parser but as a generic, less-specific 'literal' by "
-        "RustParser - the two trees are otherwise byte-identical (same "
-        "leaf count, same positions), only the segment class assigned to "
-        "this one value differs, at 5 separate occurrences in the file. "
-        "This is a segment-class-assignment mismatch between the Rust "
-        "grammar table's codegen'd class for this grammar element and the "
-        "actual Python class Snowflake's grammar uses here."
-    ),
-)
 def test__rust_parser__vs_python_snowflake_numeric_literal_mistyped():
-    """RustParser types a numeric literal generically instead of as numeric_literal.
+    """RustParser now types this numeric literal as numeric_literal, matching Python.
+
+    Regression test: `Ref("LiteralSegment")` (dialect_snowflake.py) targets
+    a bare segment class with no dialect-specific match_grammar, so
+    Python's isinstance fast path returns the already-lexed "10" token
+    unwrapped, preserving its lex-time "numeric_literal" type.
+    RustParser's `handle_ref_combining` (ref_grammar.rs) computed that same
+    preserved type, but only fed it into `MatchedClass.segment_type` -
+    which feeds Rust's internal Node tree, not the Python-facing tree
+    RustParser.parse() actually builds. That builder reads the override
+    from `segment_kwargs["instance_types"]` instead, so the correct type
+    was silently dropped in favor of the generic "literal" default.
+
+    Fixed by also setting `segment_kwargs.instance_types` whenever the
+    isinstance-override applies.
 
     Uses the real, already-shipped snowflake/create_catalog_integration.sql
     fixture.
@@ -1028,21 +1028,21 @@ def test__rust_parser__vs_python_tsql_datatype_method_oneof_ambiguity():
 
 
 @pytest.mark.skipif(not _HAS_RUST_PARSER, reason="Rust parser not available")
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "Regression: inside T-SQL's sqlcmd_command_segment (:setvar-style "
-        "sqlcmd commands), RustParser loses the original lexer-assigned "
-        "token type for its content - a bare word and a double-quoted "
-        "string both come out as a generic 'raw' segment instead of "
-        "'word'/'double_quote' respectively, as Python's Parser preserves. "
-        "sqlcmd_command_segment's content is matched via a catch-all "
-        "grammar (Anything()-style), and the Rust side isn't threading the "
-        "original token class through in that path."
-    ),
-)
 def test__rust_parser__vs_python_tsql_sqlcmd_command_loses_token_type():
-    """RustParser loses word/double_quote token typing inside sqlcmd_command_segment.
+    """RustParser now preserves word/double_quote token typing inside sqlcmd_command_segment.
+
+    Regression test: inside T-SQL's sqlcmd_command_segment (:setvar-style
+    sqlcmd commands), RustParser used to lose the original lexer-assigned
+    token type for its content - a bare word and a double-quoted string
+    both came out as a generic 'raw' segment instead of
+    'word'/'double_quote' respectively, as Python's Parser preserves.
+
+    Same root cause and fix as
+    test__rust_parser__vs_python_snowflake_numeric_literal_mistyped: a
+    `Ref` to a bare segment class hits Python's isinstance fast path,
+    and the preserved type now gets threaded through
+    `segment_kwargs.instance_types` so RustParser.parse()'s Python-side
+    tree builder picks it up too.
 
     Uses the real, already-shipped tsql/sqlcmd_command.sql fixture.
     """

--- a/test/core/parser/rust_parser_test.py
+++ b/test/core/parser/rust_parser_test.py
@@ -545,9 +545,7 @@ _KNOWN_PYTHON_RUST_DIVERGENCES = {
     ("databricks", "unpivot.sql"),
     ("sparksql", "pivot_clause.sql"),
     ("sparksql", "unpivot_clause.sql"),
-    ("snowflake", "create_catalog_integration.sql"),
     ("tsql", "datatype_methods.sql"),
-    ("tsql", "sqlcmd_command.sql"),
 }
 
 


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
Some grammar references preserve a specific segment type override (an "isinstance override") so that matched tokens keep a more specific type than their grammar would otherwise assign. `RustParser`'s `handle_ref_combining` logic recorded this override on `MatchedClass.segment_type`, but the actual tree-building path used by `RustParser.parse()` (`_apply_rs_match_result`/`_rs_match_fields` in `rust_parser.py`) reads the type from `segment_kwargs.instance_types` instead, so the override was never applied to real output.

Segments that should keep a specific overridden type were instead typed more generically when parsed via `RustParser.parse()`, even though the same fix tested correctly against the other (legacy) tree-building path.

```sql
CREATE CATALOG INTEGRATION glue_int
  CATALOG_SOURCE = GLUE
  REFRESH_INTERVAL_SECONDS = 10;
```

(Snowflake dialect; `10` should be typed `numeric_literal`, but `RustParser` typed it as the more generic `literal`.)

```sql
:setvar variable_name "variable_value"
```

## How it was fixed

In `sqlfluffrs_parser/src/parser/table_driven/ref_grammar.rs`, `handle_ref_combining` now also threads the override into
`segment_kwargs.instance_types` (via a new `isinstance_override` field), not just `segment_type`, so it reaches `RustParser.parse()`'s actual output.

### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [ ] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `RustParser` dropping isinstance-preserved token types by passing the runtime instance type list into `segment_kwargs.instance_types` used by `RustParser.parse()`. Parsed trees now keep specific types (e.g., `numeric_literal`, `word`, `double_quote`) instead of generic defaults.

- **Bug Fixes**
  - In `handle_ref_combining` (Rust), capture the isinstance override as a full `instance_types` list and set `segment_kwargs.instance_types` (not only `segment_type`).
  - Matches Python parser output for Snowflake numeric literals in `CREATE CATALOG INTEGRATION` and T‑SQL `:setvar` command content.
  - Tests: removed xfails on the two parity tests and dropped the affected fixtures from the mismatch list.

<sup>Written for commit 81cce010392a72e03d5e32effa75a5ed41e13a9e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8122?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

