### PR TITLE
Teradata: make OVERLAPS an infix comparison operator

### DIFF
--- a/src/sqlfluff/dialects/dialect_teradata.py
+++ b/src/sqlfluff/dialects/dialect_teradata.py
@@ -169,6 +169,10 @@ teradata_dialect.add(
     NotEqualToSegment_a=StringParser("NE", ComparisonOperatorSegment),
     NotEqualToSegment_b=StringParser("NOT=", ComparisonOperatorSegment),
     NotEqualToSegment_c=StringParser("^=", ComparisonOperatorSegment),
+    # Unlike the ANSI `overlaps_clause`, this binds two operands, so it also
+    # works where a boolean is expected (e.g. inside CASE WHEN).
+    # https://docs.teradata.com/r/kmuOwjp1zEYg98JsB8fu_A/3VIgdwHNVU~tsnNiIR1aEw
+    OverlapsOperatorSegment=StringParser("OVERLAPS", ComparisonOperatorSegment),
 )
 
 
@@ -1068,15 +1072,3 @@ class NotEqualToSegment_c(CompositeComparisonOperatorSegment):
     match_grammar = Sequence(
         Ref("BitwiseXorSegment"), Ref("RawEqualsSegment"), allow_gaps=False
     )
-
-
-class OverlapsOperatorSegment(CompositeComparisonOperatorSegment):
-    """The OVERLAPS period comparison operator.
-
-    Unlike the ANSI `overlaps_clause`, this binds two operands, so it also works
-    where a boolean is expected (e.g. inside CASE WHEN).
-
-    https://docs.teradata.com/r/kmuOwjp1zEYg98JsB8fu_A/3VIgdwHNVU~tsnNiIR1aEw
-    """
-
-    match_grammar = Sequence("OVERLAPS")

--- a/src/sqlfluff/dialects/dialect_teradata.py
+++ b/src/sqlfluff/dialects/dialect_teradata.py
@@ -149,6 +149,7 @@ teradata_dialect.replace(
         Ref("NotEqualToSegment_b"),
         Ref("NotEqualToSegment_c"),
         Ref("LikeOperatorSegment"),
+        Ref("OverlapsOperatorSegment"),
         Sequence("IS", "DISTINCT", "FROM"),
         Sequence("IS", "NOT", "DISTINCT", "FROM"),
     ),
@@ -1067,3 +1068,15 @@ class NotEqualToSegment_c(CompositeComparisonOperatorSegment):
     match_grammar = Sequence(
         Ref("BitwiseXorSegment"), Ref("RawEqualsSegment"), allow_gaps=False
     )
+
+
+class OverlapsOperatorSegment(CompositeComparisonOperatorSegment):
+    """The OVERLAPS period comparison operator.
+
+    Unlike the ANSI `overlaps_clause`, this binds two operands, so it also works
+    where a boolean is expected (e.g. inside CASE WHEN).
+
+    https://docs.teradata.com/r/kmuOwjp1zEYg98JsB8fu_A/3VIgdwHNVU~tsnNiIR1aEw
+    """
+
+    match_grammar = Sequence("OVERLAPS")

--- a/test/fixtures/dialects/teradata/select_overlaps.sql
+++ b/test/fixtures/dialects/teradata/select_overlaps.sql
@@ -1,0 +1,16 @@
+-- OVERLAPS binds two operands, so it also works where a boolean is expected.
+-- https://github.com/sqlfluff/sqlfluff/issues/2492
+SELECT
+    CASE
+        WHEN (current_date, current_date + 7) OVERLAPS (DATE '2021-01-01', DATE '2021-01-07') THEN 1
+        ELSE 0
+    END AS strt_yr
+FROM tbl;
+
+SELECT col1
+FROM tbl
+WHERE (start_date, end_date) OVERLAPS (DATE '2021-01-01', DATE '2021-01-07');
+
+SELECT col1
+FROM tbl
+WHERE period1 OVERLAPS period2;

--- a/test/fixtures/dialects/teradata/select_overlaps.yml
+++ b/test/fixtures/dialects/teradata/select_overlaps.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 89bf0b7ec8c679c0b7910cdd8087d5aace4467aa4c5d927f34b74af4d5e7d807
+_hash: f5ad13f50e18d226122fc138a9d13a1e089ff50828a31e23e93257e565a79ecd
 file:
 - statement:
     select_statement:
@@ -26,8 +26,7 @@ file:
                       binary_operator: +
                       numeric_literal: '7'
                     end_bracket: )
-                - comparison_operator:
-                    keyword: OVERLAPS
+                - comparison_operator: OVERLAPS
                 - bracketed:
                   - start_bracket: (
                   - keyword: DATE
@@ -81,8 +80,7 @@ file:
           - column_reference:
               naked_identifier: end_date
           - end_bracket: )
-        - comparison_operator:
-            keyword: OVERLAPS
+        - comparison_operator: OVERLAPS
         - bracketed:
           - start_bracket: (
           - keyword: DATE
@@ -111,8 +109,7 @@ file:
         expression:
         - column_reference:
             naked_identifier: period1
-        - comparison_operator:
-            keyword: OVERLAPS
+        - comparison_operator: OVERLAPS
         - column_reference:
             naked_identifier: period2
 - statement_terminator: ;

--- a/test/fixtures/dialects/teradata/select_overlaps.yml
+++ b/test/fixtures/dialects/teradata/select_overlaps.yml
@@ -1,0 +1,118 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 89bf0b7ec8c679c0b7910cdd8087d5aace4467aa4c5d927f34b74af4d5e7d807
+file:
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+            case_expression:
+            - keyword: CASE
+            - when_clause:
+              - keyword: WHEN
+              - expression:
+                - bracketed:
+                    start_bracket: (
+                    column_reference:
+                      naked_identifier: current_date
+                    comma: ','
+                    expression:
+                      bare_function: current_date
+                      binary_operator: +
+                      numeric_literal: '7'
+                    end_bracket: )
+                - comparison_operator:
+                    keyword: OVERLAPS
+                - bracketed:
+                  - start_bracket: (
+                  - keyword: DATE
+                  - date_constructor_literal: "'2021-01-01'"
+                  - comma: ','
+                  - keyword: DATE
+                  - date_constructor_literal: "'2021-01-07'"
+                  - end_bracket: )
+              - keyword: THEN
+              - expression:
+                  numeric_literal: '1'
+            - else_clause:
+                keyword: ELSE
+                expression:
+                  numeric_literal: '0'
+            - keyword: END
+          alias_expression:
+            alias_operator:
+              keyword: AS
+            naked_identifier: strt_yr
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: tbl
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          column_reference:
+            naked_identifier: col1
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: tbl
+      where_clause:
+        keyword: WHERE
+        expression:
+        - bracketed:
+          - start_bracket: (
+          - column_reference:
+              naked_identifier: start_date
+          - comma: ','
+          - column_reference:
+              naked_identifier: end_date
+          - end_bracket: )
+        - comparison_operator:
+            keyword: OVERLAPS
+        - bracketed:
+          - start_bracket: (
+          - keyword: DATE
+          - date_constructor_literal: "'2021-01-01'"
+          - comma: ','
+          - keyword: DATE
+          - date_constructor_literal: "'2021-01-07'"
+          - end_bracket: )
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          column_reference:
+            naked_identifier: col1
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: tbl
+      where_clause:
+        keyword: WHERE
+        expression:
+        - column_reference:
+            naked_identifier: period1
+        - comparison_operator:
+            keyword: OVERLAPS
+        - column_reference:
+            naked_identifier: period2
+- statement_terminator: ;


### PR DESCRIPTION
### Brief summary of the change made

`(a, b) OVERLAPS (c, d)` didn't parse in teradata. The ANSI `overlaps_clause` only matches the right-hand side, so `OVERLAPS` never binds two operands and falls over anywhere a boolean is expected, like the `CASE WHEN` in the issue.

Added `OVERLAPS` to teradata's comparison operators so it works as the infix predicate it is. `NORMALIZE ON ... OVERLAPS` still parses.

Same bug exists in ansi and postgres, so this arguably belongs in ANSI. Kept it to teradata since that's what the issue is about, happy to move it up if you'd rather.

Fixes #2492.

### Are there any other side effects of this change that we should be aware of?

No, teradata only. No other dialect ymls moved.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases:
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects/teradata`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Treats `OVERLAPS` as an infix comparison operator in Teradata so `(a, b) OVERLAPS (c, d)` parses and works in WHERE and CASE expressions. Keeps `NORMALIZE ON ... OVERLAPS` behavior unchanged.

- **Bug Fixes**
  - Added `OverlapsOperatorSegment` to Teradata comparison operators to bind both operands; implemented with `StringParser` for consistency.
  - Added parser tests for CASE, WHERE, and period comparisons. Fixes #2492.

<sup>Written for commit 36f2bfc2300318d70fa93ba9ea23989b03b034c0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8123?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

