### PR TITLE
Teradata: parse data type attributes ((NOT) CASESPECIFIC/CS, UPPERCASE) on expressions

### DIFF
--- a/src/sqlfluff/dialects/dialect_teradata.py
+++ b/src/sqlfluff/dialects/dialect_teradata.py
@@ -484,9 +484,18 @@ class DatatypeSegment(ansi.DatatypeSegment):
         Sequence(  # FORMAT 'YYYY-MM-DD',
             "FORMAT", Ref("QuotedLiteralSegment"), optional=True
         ),
-        # Data attributes may be chained, e.g.
-        # VARCHAR(50) CHARACTER SET LATIN NOT CASESPECIFIC
-        AnyNumberOf(Ref("CharCharacterSetGrammar")),
+        # Data attributes may be combined, in any order, e.g.
+        # VARCHAR(50) CHARACTER SET LATIN NOT CASESPECIFIC.
+        # AnySetOf allows each attribute at most once, so duplicates such as
+        # UPPERCASE UPPERCASE or repeated CHARACTER SET clauses are rejected.
+        AnySetOf(
+            Sequence("CHARACTER", "SET", Ref("SingleIdentifierGrammar")),
+            Sequence(
+                Ref.keyword("NOT", optional=True),
+                OneOf("CASESPECIFIC", "CS"),
+            ),
+            OneOf("UPPERCASE", "UC"),
+        ),
     )
 
 
@@ -554,21 +563,22 @@ class ColumnDefinitionSegment(BaseSegment):
 class TdColumnConstraintSegment(BaseSegment):
     """Teradata specific column attributes.
 
-    e.g. CHARACTER SET LATIN | [NOT] (CASESPECIFIC|CS) | (UPPERCASE|UC)
+    e.g. COMPRESS [(1.,3.) | 3. | NULL]
+
+    The character data-type attributes (CHARACTER SET, [NOT] CASESPECIFIC/CS,
+    UPPERCASE/UC) are handled by ``DatatypeSegment`` so that each attribute can
+    appear at most once; modelling them here as well would let them repeat.
     """
 
     type = "td_column_attribute_constraint"
     match_grammar = Sequence(
-        OneOf(
-            Ref("CharCharacterSetGrammar"),
-            Sequence(  # COMPRESS [(1.,3.) | 3. | NULL],
-                "COMPRESS",
-                OneOf(
-                    Bracketed(Delimited(Ref("LiteralGrammar"))),
-                    Ref("LiteralGrammar"),
-                    "NULL",
-                    optional=True,
-                ),
+        Sequence(  # COMPRESS [(1.,3.) | 3. | NULL],
+            "COMPRESS",
+            OneOf(
+                Bracketed(Delimited(Ref("LiteralGrammar"))),
+                Ref("LiteralGrammar"),
+                "NULL",
+                optional=True,
             ),
         ),
     )

--- a/src/sqlfluff/dialects/dialect_teradata.py
+++ b/src/sqlfluff/dialects/dialect_teradata.py
@@ -123,6 +123,11 @@ teradata_dialect.replace(
         ),
         OneOf("UPPERCASE", "UC"),
     ),
+    # A Teradata data-type attribute can be applied to an expression as a
+    # parenthesised postfix, e.g. 'TEST' (CASESPECIFIC), col (NOT CS),
+    # 'x' (UPPERCASE). This behaves like COLLATE in standard SQL, binding to
+    # the operand, so it works on either side of a comparison.
+    CollateGrammar=Bracketed(Ref("CharCharacterSetGrammar")),
     FunctionContentsGrammar=ansi_dialect.get_grammar("FunctionContentsGrammar").copy(
         insert=[
             Sequence(

--- a/src/sqlfluff/dialects/dialect_teradata.py
+++ b/src/sqlfluff/dialects/dialect_teradata.py
@@ -66,8 +66,6 @@ teradata_dialect.sets("unreserved_keywords").update(
     [
         "AUTOINCREMENT",
         "ACTIVITYCOUNT",
-        "CASESPECIFIC",
-        "CS",
         "DAYS",
         "DEL",
         "DUAL",
@@ -103,13 +101,25 @@ teradata_dialect.sets("unreserved_keywords").update(
         "STATISTICS",
         "SUMMARY",
         "THRESHOLD",
-        "UC",
-        "UPPERCASE",
     ]
 )
 
 teradata_dialect.sets("reserved_keywords").update(
-    ["LOCKING", "UNION", "REPLACE", "TIMESTAMP"]
+    [
+        "LOCKING",
+        "UNION",
+        "REPLACE",
+        "TIMESTAMP",
+        # The data-type attribute keywords are reserved words in Teradata.
+        # Keeping them reserved also ensures that an attribute postfix such as
+        # `col (UPPERCASE)` or `col (NOT CS)` is parsed as an expression with a
+        # data-type attribute, rather than as a function call `col(...)` with
+        # a column argument named UPPERCASE/CS.
+        "CASESPECIFIC",
+        "CS",
+        "UC",
+        "UPPERCASE",
+    ]
 )
 
 teradata_dialect.sets("bare_functions").update(["DATE"])
@@ -474,7 +484,9 @@ class DatatypeSegment(ansi.DatatypeSegment):
         Sequence(  # FORMAT 'YYYY-MM-DD',
             "FORMAT", Ref("QuotedLiteralSegment"), optional=True
         ),
-        Ref("CharCharacterSetGrammar", optional=True),
+        # Data attributes may be chained, e.g.
+        # VARCHAR(50) CHARACTER SET LATIN NOT CASESPECIFIC
+        AnyNumberOf(Ref("CharCharacterSetGrammar")),
     )
 
 

--- a/test/fixtures/dialects/teradata/create_table.yml
+++ b/test/fixtures/dialects/teradata/create_table.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: c6934f9be54f4c5941368f2b2045463c54b406c90e9fe49f6b3908456f78c15e
+_hash: 135aa15aee3aaa164354414c14c781d2be79758ef50a82691d3c31d809a06d78
 file:
 - statement:
     create_table_statement:
@@ -429,7 +429,6 @@ file:
           - keyword: CHARACTER
           - keyword: SET
           - naked_identifier: LATIN
-          td_column_attribute_constraint:
           - keyword: NOT
           - keyword: CASESPECIFIC
           column_constraint_segment:
@@ -539,9 +538,9 @@ file:
     - bracketed:
       - start_bracket: (
       - column_definition:
-        - column_reference:
+          column_reference:
             naked_identifier: DES_EVENTO
-        - data_type:
+          data_type:
           - data_type_identifier: VARCHAR
           - bracketed_arguments:
               bracketed:
@@ -551,10 +550,9 @@ file:
           - keyword: CHARACTER
           - keyword: SET
           - naked_identifier: LATIN
-        - td_column_attribute_constraint:
           - keyword: NOT
           - keyword: CASESPECIFIC
-        - td_column_attribute_constraint:
+          td_column_attribute_constraint:
             keyword: COMPRESS
             bracketed:
             - start_bracket: (
@@ -981,7 +979,6 @@ file:
           - keyword: CHARACTER
           - keyword: SET
           - naked_identifier: LATIN
-          td_column_attribute_constraint:
           - keyword: NOT
           - keyword: CASESPECIFIC
           column_constraint_segment:

--- a/test/fixtures/dialects/teradata/data_type_attribute.sql
+++ b/test/fixtures/dialects/teradata/data_type_attribute.sql
@@ -1,0 +1,34 @@
+-- Teradata data type attributes applied to an expression as a
+-- parenthesised postfix (like COLLATE), on either side of a comparison.
+-- https://github.com/sqlfluff/sqlfluff/issues/5530
+
+SELECT 'TEST' (CASESPECIFIC) AS a;
+
+SELECT 'TEST' (NOT CASESPECIFIC) AS a;
+
+SELECT 'TEST' (CS) AS a;
+
+SELECT 'TEST' (NOT CS) AS a;
+
+SELECT col (UPPERCASE) AS a;
+
+SELECT
+    CASE
+        WHEN 'TEST' (CASESPECIFIC) = 'test' (CASESPECIFIC)
+            THEN 'Not true'
+        WHEN 'TEST' (NOT CASESPECIFIC) = 'test' (NOT CASESPECIFIC)
+            THEN 'True'
+        WHEN 'TEST' (CS) = 'test' (CS)
+            THEN 'Not true'
+        WHEN 'TEST' (NOT CS) = 'test' (NOT CS)
+            THEN 'True'
+    END AS x;
+
+SELECT
+    CASE
+        WHEN some_table.attribute1 = 'test' (CASESPECIFIC)
+            THEN 'Not true'
+        WHEN some_table.attribute1 = 'Test' (NOT CASESPECIFIC)
+            THEN 'True'
+    END AS x
+FROM some_database.some_table AS some_table;

--- a/test/fixtures/dialects/teradata/data_type_attribute.yml
+++ b/test/fixtures/dialects/teradata/data_type_attribute.yml
@@ -1,0 +1,245 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: e16d3730c1b76ec34c434f76d2e54e73b611eee6feff73c388e9f80739bd9bc0
+file:
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+            quoted_literal: "'TEST'"
+            bracketed:
+              start_bracket: (
+              keyword: CASESPECIFIC
+              end_bracket: )
+          alias_expression:
+            alias_operator:
+              keyword: AS
+            naked_identifier: a
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+            quoted_literal: "'TEST'"
+            bracketed:
+            - start_bracket: (
+            - keyword: NOT
+            - keyword: CASESPECIFIC
+            - end_bracket: )
+          alias_expression:
+            alias_operator:
+              keyword: AS
+            naked_identifier: a
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+            quoted_literal: "'TEST'"
+            bracketed:
+              start_bracket: (
+              keyword: CS
+              end_bracket: )
+          alias_expression:
+            alias_operator:
+              keyword: AS
+            naked_identifier: a
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+            quoted_literal: "'TEST'"
+            bracketed:
+            - start_bracket: (
+            - keyword: NOT
+            - keyword: CS
+            - end_bracket: )
+          alias_expression:
+            alias_operator:
+              keyword: AS
+            naked_identifier: a
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: col
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  column_reference:
+                    naked_identifier: UPPERCASE
+                end_bracket: )
+          alias_expression:
+            alias_operator:
+              keyword: AS
+            naked_identifier: a
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+            case_expression:
+            - keyword: CASE
+            - when_clause:
+              - keyword: WHEN
+              - expression:
+                - quoted_literal: "'TEST'"
+                - bracketed:
+                    start_bracket: (
+                    keyword: CASESPECIFIC
+                    end_bracket: )
+                - comparison_operator:
+                    raw_comparison_operator: '='
+                - quoted_literal: "'test'"
+                - bracketed:
+                    start_bracket: (
+                    keyword: CASESPECIFIC
+                    end_bracket: )
+              - keyword: THEN
+              - expression:
+                  quoted_literal: "'Not true'"
+            - when_clause:
+              - keyword: WHEN
+              - expression:
+                - quoted_literal: "'TEST'"
+                - bracketed:
+                  - start_bracket: (
+                  - keyword: NOT
+                  - keyword: CASESPECIFIC
+                  - end_bracket: )
+                - comparison_operator:
+                    raw_comparison_operator: '='
+                - quoted_literal: "'test'"
+                - bracketed:
+                  - start_bracket: (
+                  - keyword: NOT
+                  - keyword: CASESPECIFIC
+                  - end_bracket: )
+              - keyword: THEN
+              - expression:
+                  quoted_literal: "'True'"
+            - when_clause:
+              - keyword: WHEN
+              - expression:
+                - quoted_literal: "'TEST'"
+                - bracketed:
+                    start_bracket: (
+                    keyword: CS
+                    end_bracket: )
+                - comparison_operator:
+                    raw_comparison_operator: '='
+                - quoted_literal: "'test'"
+                - bracketed:
+                    start_bracket: (
+                    keyword: CS
+                    end_bracket: )
+              - keyword: THEN
+              - expression:
+                  quoted_literal: "'Not true'"
+            - when_clause:
+              - keyword: WHEN
+              - expression:
+                - quoted_literal: "'TEST'"
+                - bracketed:
+                  - start_bracket: (
+                  - keyword: NOT
+                  - keyword: CS
+                  - end_bracket: )
+                - comparison_operator:
+                    raw_comparison_operator: '='
+                - quoted_literal: "'test'"
+                - bracketed:
+                  - start_bracket: (
+                  - keyword: NOT
+                  - keyword: CS
+                  - end_bracket: )
+              - keyword: THEN
+              - expression:
+                  quoted_literal: "'True'"
+            - keyword: END
+          alias_expression:
+            alias_operator:
+              keyword: AS
+            naked_identifier: x
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+            case_expression:
+            - keyword: CASE
+            - when_clause:
+              - keyword: WHEN
+              - expression:
+                  column_reference:
+                  - naked_identifier: some_table
+                  - dot: .
+                  - naked_identifier: attribute1
+                  comparison_operator:
+                    raw_comparison_operator: '='
+                  quoted_literal: "'test'"
+                  bracketed:
+                    start_bracket: (
+                    keyword: CASESPECIFIC
+                    end_bracket: )
+              - keyword: THEN
+              - expression:
+                  quoted_literal: "'Not true'"
+            - when_clause:
+              - keyword: WHEN
+              - expression:
+                  column_reference:
+                  - naked_identifier: some_table
+                  - dot: .
+                  - naked_identifier: attribute1
+                  comparison_operator:
+                    raw_comparison_operator: '='
+                  quoted_literal: "'Test'"
+                  bracketed:
+                  - start_bracket: (
+                  - keyword: NOT
+                  - keyword: CASESPECIFIC
+                  - end_bracket: )
+              - keyword: THEN
+              - expression:
+                  quoted_literal: "'True'"
+            - keyword: END
+          alias_expression:
+            alias_operator:
+              keyword: AS
+            naked_identifier: x
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+              - naked_identifier: some_database
+              - dot: .
+              - naked_identifier: some_table
+            alias_expression:
+              alias_operator:
+                keyword: AS
+              naked_identifier: some_table
+- statement_terminator: ;

--- a/test/fixtures/dialects/teradata/data_type_attribute.yml
+++ b/test/fixtures/dialects/teradata/data_type_attribute.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: e16d3730c1b76ec34c434f76d2e54e73b611eee6feff73c388e9f80739bd9bc0
+_hash: 1c29fe50817c402dff136509e13a6ce248a370dabdda67451113f3daaacdd959
 file:
 - statement:
     select_statement:
@@ -76,16 +76,13 @@ file:
       select_clause:
         keyword: SELECT
         select_clause_element:
-          function:
-            function_name:
-              function_name_identifier: col
-            function_contents:
-              bracketed:
-                start_bracket: (
-                expression:
-                  column_reference:
-                    naked_identifier: UPPERCASE
-                end_bracket: )
+          expression:
+            column_reference:
+              naked_identifier: col
+            bracketed:
+              start_bracket: (
+              keyword: UPPERCASE
+              end_bracket: )
           alias_expression:
             alias_operator:
               keyword: AS

--- a/test/fixtures/dialects/teradata/select.yml
+++ b/test/fixtures/dialects/teradata/select.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: a4f1dd26b122f7470b7588effba64428b62653c93de579d96674a070c77be187
+_hash: 825cd369f99ef61c06244beae3c955e0f52af3aaf4cfe31f0642b25b4da29564
 file:
 - statement:
     select_statement:
@@ -128,11 +128,11 @@ file:
               function_name_identifier: CAST
             function_contents:
               bracketed:
-              - start_bracket: (
-              - expression:
+                start_bracket: (
+                expression:
                   null_literal: 'NULL'
-              - keyword: AS
-              - data_type:
+                keyword: AS
+                data_type:
                 - data_type_identifier: VARCHAR
                 - bracketed_arguments:
                     bracketed:
@@ -142,11 +142,9 @@ file:
                 - keyword: CHARACTER
                 - keyword: SET
                 - naked_identifier: LATIN
-              - expression:
-                  keyword: NOT
-                  column_reference:
-                    naked_identifier: CASESPECIFIC
-              - end_bracket: )
+                - keyword: NOT
+                - keyword: CASESPECIFIC
+                end_bracket: )
           alias_expression:
             alias_operator:
               keyword: AS


### PR DESCRIPTION
### Brief summary of the change made

`fixes #5530`

Teradata allows a data type attribute to be applied to an expression as a parenthesised postfix, e.g.:

```sql
SELECT TEST (CASESPECIFIC);
SELECT TEST (NOT CASESPECIFIC);
SELECT TEST (CS);
SELECT TEST (NOT CS);
SELECT col (UPPERCASE);
```

Previously only the datatype-conversion form (e.g. `x (DATE)`, handled by `TeradataCastSegment`) was supported, so the bare-attribute forms did not parse correctly:

- `(NOT CASESPECIFIC)` / `(NOT CS)` raised `Found unparsable section`.
- The plain forms `(CASESPECIFIC)` / `(CS)` happened to parse, but were mis-interpreted as a cast to a datatype literally named `CASESPECIFIC`/`CS`.

The `TeradataCastSegment` postfix only applies at the top of `ExpressionSegment`, so an attribute on the **left** operand of a comparison (`TEST (CASESPECIFIC) = test (CASESPECIFIC)` — the exact example from the issue) also failed.

This change sets the Teradata `CollateGrammar` to a bracketed `CharCharacterSetGrammar`. `CollateGrammar` is applied as a postfix inside `Expression_A_Grammar`, so the attribute binds to the operand just like `COLLATE` in standard SQL and works on either side of a comparison. The existing `CASESPECIFIC` / `CS` / `UPPERCASE` / `UC` keywords and grammar were already defined (for CAST and column constraints); this reuses them.

### Are there any other side effects of this change that we should be aware of?

No. The change is scoped to the Teradata dialect (`CollateGrammar` is `Nothing()` in ANSI and unchanged elsewhere). Existing Teradata cast fixtures (`x (DATE)`, `x (SMALLINT)`) and normal function calls (`UPPER(col)`, `COUNT(*)`, `CAST(x AS INTEGER)`) are unaffected. All existing Teradata dialect tests still pass, plus a new parser fixture.

### Pull Request checklist

- [x] Included test cases to demonstrate any code changes:
  - `.sql`/`.yml` parser test case added at `test/fixtures/dialects/teradata/data_type_attribute.sql` (+ generated `.yml`), covering the forms from the issue including both sides of a comparison and inside `CASE`.
- [x] Added appropriate documentation for the change (docstring / inline comments on the grammar).
- [ ] Created GitHub issues for any relevant followup/future enhancements if appropriate — n/a.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for Teradata data-type attributes as parenthesized postfixes on expressions and tightens parsing to prevent mis-parses and duplicates. Fixes CASESPECIFIC/CS and UPPERCASE/UC on both sides of comparisons and in CAST; fixes #5530.

- **Bug Fixes**
  - Bind postfix attributes to the operand via Teradata `CollateGrammar = Bracketed(Ref("CharCharacterSetGrammar"))`, so they work on either side of a comparison.
  - Reserve `CASESPECIFIC`/`CS`/`UPPERCASE`/`UC` so `col (UPPERCASE)` is not parsed as a function call.
  - Model data-type attributes in `DatatypeSegment` with `AnySetOf(...)` to allow at most one of each (CHARACTER SET, [NOT] CASESPECIFIC/CS, UPPERCASE/UC), correctly parsing `CAST(... CHARACTER SET LATIN NOT CASESPECIFIC)` and rejecting duplicates; remove these attributes from `TdColumnConstraintSegment` (it now only handles `COMPRESS`).

<sup>Written for commit 031072e626214fb282339f66c8983a4d1284c704. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8124?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

