### PR TITLE
fix(sqlite): parse CTE materialization hints

### DIFF
--- a/src/sqlfluff/dialects/dialect_sqlite.py
+++ b/src/sqlfluff/dialects/dialect_sqlite.py
@@ -1209,3 +1209,24 @@ class StatementSegment(ansi.StatementSegment):
         Ref("UpdateStatementSegment"),
         Bracketed(Ref("StatementSegment")),
     )
+
+
+class CTEDefinitionSegment(ansi.CTEDefinitionSegment):
+    """A CTE Definition from a WITH statement.
+
+    https://sqlite.org/lang_with.html
+
+    Data-Modifying Statements (INSERT, UPDATE, DELETE) in WITH are
+    matched by ansi.SelectableGrammar > NonWithSelectableGrammar.
+    """
+
+    match_grammar = Sequence(
+        Ref("SingleIdentifierGrammar"),
+        Ref("CTEColumnList", optional=True),
+        "AS",
+        Sequence(Ref.keyword("NOT", optional=True), "MATERIALIZED", optional=True),
+        Bracketed(
+            Ref("SelectableGrammar"),
+            parse_mode=ParseMode.GREEDY,
+        ),
+    )

--- a/test/fixtures/dialects/sqlite/with_cte_as_materialized.sql
+++ b/test/fixtures/dialects/sqlite/with_cte_as_materialized.sql
@@ -1,0 +1,4 @@
+WITH cte AS MATERIALIZED (
+    SELECT col FROM t
+)
+SELECT col FROM cte

--- a/test/fixtures/dialects/sqlite/with_cte_as_materialized.yml
+++ b/test/fixtures/dialects/sqlite/with_cte_as_materialized.yml
@@ -1,0 +1,43 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 33d83fd7194b8f7fdcf2d0e02f35a105612b1394fb85098f3c0d5b809dca37ff
+file:
+  statement:
+    with_compound_statement:
+      keyword: WITH
+      common_table_expression:
+      - naked_identifier: cte
+      - keyword: AS
+      - keyword: MATERIALIZED
+      - bracketed:
+          start_bracket: (
+          select_statement:
+            select_clause:
+              keyword: SELECT
+              select_clause_element:
+                column_reference:
+                  naked_identifier: col
+            from_clause:
+              keyword: FROM
+              from_expression:
+                from_expression_element:
+                  table_expression:
+                    table_reference:
+                      naked_identifier: t
+          end_bracket: )
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            column_reference:
+              naked_identifier: col
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: cte

--- a/test/fixtures/dialects/sqlite/with_cte_as_not_materialized.sql
+++ b/test/fixtures/dialects/sqlite/with_cte_as_not_materialized.sql
@@ -1,0 +1,4 @@
+WITH cte AS NOT MATERIALIZED (
+    SELECT col FROM t
+)
+SELECT col FROM cte

--- a/test/fixtures/dialects/sqlite/with_cte_as_not_materialized.yml
+++ b/test/fixtures/dialects/sqlite/with_cte_as_not_materialized.yml
@@ -1,0 +1,44 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 194f6f3dd93ed4731d70ef22aecb01047a284e6b91d4be39187b7cf6799bde1a
+file:
+  statement:
+    with_compound_statement:
+      keyword: WITH
+      common_table_expression:
+      - naked_identifier: cte
+      - keyword: AS
+      - keyword: NOT
+      - keyword: MATERIALIZED
+      - bracketed:
+          start_bracket: (
+          select_statement:
+            select_clause:
+              keyword: SELECT
+              select_clause_element:
+                column_reference:
+                  naked_identifier: col
+            from_clause:
+              keyword: FROM
+              from_expression:
+                from_expression_element:
+                  table_expression:
+                    table_reference:
+                      naked_identifier: t
+          end_bracket: )
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            column_reference:
+              naked_identifier: col
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: cte


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
`fixes #8125` ([issue link](https://github.com/sqlfluff/sqlfluff/issues/8125))

This PR fixes parsing of CTEs with materialization hints (`WITH <cte> AS MATERIALIZED`, `WITH <cte> AS NOT MATERIALIZED`) for the SQLite dialect. More details in the issue linked above if necessary.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
- Created GitHub issues for any relevant followup/future enhancements if appropriate.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix parsing of SQLite CTE materialization hints (AS MATERIALIZED / AS NOT MATERIALIZED) to prevent parse errors in WITH queries. Fixes #8125.

<sup>Written for commit a2a9a58c1c1abd5862730f9b64910a49c4a26c4c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8126?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

