### PR TITLE
Athena: accept ARRAY(type) as well as ARRAY<type>

### DIFF
--- a/src/sqlfluff/dialects/dialect_athena.py
+++ b/src/sqlfluff/dialects/dialect_athena.py
@@ -344,13 +344,24 @@ class ArrayTypeSegment(ansi.ArrayTypeSegment):
 
 
 class ArrayTypeSchemaSegment(ansi.ArrayTypeSegment):
-    """Prefix for array literals specifying the type."""
+    """Data type segment of the array.
+
+    Athena supports ARRAY<DATA_TYPE> in DDL and ARRAY(DATA_TYPE) in queries.
+    https://docs.aws.amazon.com/athena/latest/ug/data-types.html
+    """
 
     type = "array_type_schema"
-    match_grammar = Bracketed(
-        Ref("DatatypeSegment"),
-        bracket_pairs_set="angle_bracket_pairs",
-        bracket_type="angle",
+    match_grammar = OneOf(
+        Bracketed(
+            Ref("DatatypeSegment"),
+            bracket_pairs_set="angle_bracket_pairs",
+            bracket_type="angle",
+        ),
+        Bracketed(
+            Ref("DatatypeSegment"),
+            bracket_pairs_set="bracket_pairs",
+            bracket_type="round",
+        ),
     )
 
 

--- a/test/fixtures/dialects/athena/select_cast_array_type.sql
+++ b/test/fixtures/dialects/athena/select_cast_array_type.sql
@@ -1,0 +1,13 @@
+-- Athena uses Trino data type names in DML, so an array type is ARRAY(type).
+-- https://github.com/sqlfluff/sqlfluff/issues/4193
+SELECT CAST(col1 AS ARRAY(VARCHAR)) AS c1;
+
+SELECT CAST(col1 AS ARRAY(ROW(id VARCHAR))) AS c1;
+
+SELECT CAST(
+    ROW(ARRAY[CAST(ROW('') AS ROW(id VARCHAR))], CAST(ROW('') AS ROW(id VARCHAR)), 'Approved')
+    AS ROW(approvers ARRAY(ROW(id VARCHAR)), performer ROW(id VARCHAR), approvalstatus VARCHAR)
+) AS test;
+
+-- DDL still uses the Hive spelling.
+CREATE EXTERNAL TABLE array_table (c1 ARRAY<INTEGER>) LOCATION 's3://bucket/path/';

--- a/test/fixtures/dialects/athena/select_cast_array_type.yml
+++ b/test/fixtures/dialects/athena/select_cast_array_type.yml
@@ -1,0 +1,229 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 095fc3eb43cbfb5a604599386818e2b16d384890bb510883bf3e8a87dfeaf086
+file:
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: CAST
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  column_reference:
+                    naked_identifier: col1
+                keyword: AS
+                data_type:
+                  array_type:
+                    keyword: ARRAY
+                    array_type_schema:
+                      bracketed:
+                        start_bracket: (
+                        data_type:
+                          primitive_type:
+                            keyword: VARCHAR
+                        end_bracket: )
+                end_bracket: )
+          alias_expression:
+            alias_operator:
+              keyword: AS
+            naked_identifier: c1
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: CAST
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  column_reference:
+                    naked_identifier: col1
+                keyword: AS
+                data_type:
+                  array_type:
+                    keyword: ARRAY
+                    array_type_schema:
+                      bracketed:
+                        start_bracket: (
+                        data_type:
+                          keyword: ROW
+                          bracketed:
+                            start_bracket: (
+                            naked_identifier: id
+                            data_type:
+                              primitive_type:
+                                keyword: VARCHAR
+                            end_bracket: )
+                        end_bracket: )
+                end_bracket: )
+          alias_expression:
+            alias_operator:
+              keyword: AS
+            naked_identifier: c1
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: CAST
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  function:
+                    function_name:
+                      function_name_identifier: ROW
+                    function_contents:
+                      bracketed:
+                      - start_bracket: (
+                      - expression:
+                          typed_array_literal:
+                            array_type:
+                              keyword: ARRAY
+                            array_literal:
+                              start_square_bracket: '['
+                              function:
+                                function_name:
+                                  function_name_identifier: CAST
+                                function_contents:
+                                  bracketed:
+                                    start_bracket: (
+                                    expression:
+                                      function:
+                                        function_name:
+                                          function_name_identifier: ROW
+                                        function_contents:
+                                          bracketed:
+                                            start_bracket: (
+                                            expression:
+                                              quoted_literal: "''"
+                                            end_bracket: )
+                                    keyword: AS
+                                    data_type:
+                                      keyword: ROW
+                                      bracketed:
+                                        start_bracket: (
+                                        naked_identifier: id
+                                        data_type:
+                                          primitive_type:
+                                            keyword: VARCHAR
+                                        end_bracket: )
+                                    end_bracket: )
+                              end_square_bracket: ']'
+                      - comma: ','
+                      - expression:
+                          function:
+                            function_name:
+                              function_name_identifier: CAST
+                            function_contents:
+                              bracketed:
+                                start_bracket: (
+                                expression:
+                                  function:
+                                    function_name:
+                                      function_name_identifier: ROW
+                                    function_contents:
+                                      bracketed:
+                                        start_bracket: (
+                                        expression:
+                                          quoted_literal: "''"
+                                        end_bracket: )
+                                keyword: AS
+                                data_type:
+                                  keyword: ROW
+                                  bracketed:
+                                    start_bracket: (
+                                    naked_identifier: id
+                                    data_type:
+                                      primitive_type:
+                                        keyword: VARCHAR
+                                    end_bracket: )
+                                end_bracket: )
+                      - comma: ','
+                      - expression:
+                          quoted_literal: "'Approved'"
+                      - end_bracket: )
+                keyword: AS
+                data_type:
+                  keyword: ROW
+                  bracketed:
+                  - start_bracket: (
+                  - naked_identifier: approvers
+                  - data_type:
+                      array_type:
+                        keyword: ARRAY
+                        array_type_schema:
+                          bracketed:
+                            start_bracket: (
+                            data_type:
+                              keyword: ROW
+                              bracketed:
+                                start_bracket: (
+                                naked_identifier: id
+                                data_type:
+                                  primitive_type:
+                                    keyword: VARCHAR
+                                end_bracket: )
+                            end_bracket: )
+                  - comma: ','
+                  - naked_identifier: performer
+                  - data_type:
+                      keyword: ROW
+                      bracketed:
+                        start_bracket: (
+                        naked_identifier: id
+                        data_type:
+                          primitive_type:
+                            keyword: VARCHAR
+                        end_bracket: )
+                  - comma: ','
+                  - naked_identifier: approvalstatus
+                  - data_type:
+                      primitive_type:
+                        keyword: VARCHAR
+                  - end_bracket: )
+                end_bracket: )
+          alias_expression:
+            alias_operator:
+              keyword: AS
+            naked_identifier: test
+- statement_terminator: ;
+- statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: EXTERNAL
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: array_table
+    - bracketed:
+        start_bracket: (
+        column_definition:
+          naked_identifier: c1
+          data_type:
+            array_type:
+              keyword: ARRAY
+              array_type_schema:
+                start_angle_bracket: <
+                data_type:
+                  primitive_type:
+                    keyword: INTEGER
+                end_angle_bracket: '>'
+        end_bracket: )
+    - keyword: LOCATION
+    - quoted_literal: "'s3://bucket/path/'"
+- statement_terminator: ;


### PR DESCRIPTION
### Brief summary of the change made

`CAST(x AS ARRAY(varchar))` didn't parse in athena, only the angle form `ARRAY<varchar>` did. Made the array type take either bracket, same as trino already does. DDL `ARRAY<type>` still works.

#4391 fixed most of #4193 back in 2023 but skipped this, on the grounds that `ARRAY(...)` isn't a type. It is in DML though: athena uses trino type names there (hive names for DDL), and the trino dialect here already parses `CAST(ARRAY[1,2] AS ARRAY(DOUBLE))`.

Fixes #4193.

### Are there any other side effects of this change that we should be aware of?

No, athena only and additive. No other ymls moved.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases:
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects/athena`.
