### PR TITLE
MySQL: don't flag index prefix length with LT01

### DIFF
--- a/src/sqlfluff/dialects/dialect_mysql.py
+++ b/src/sqlfluff/dialects/dialect_mysql.py
@@ -1433,7 +1433,9 @@ mysql_dialect.add(
                     Ref("ColumnReferenceSegment"),
                     Sequence(
                         Ref("ColumnReferenceSegment"),
-                        Bracketed(Ref("NumericLiteralSegment")),
+                        # Index prefix length, e.g. `col(10)`. Reuse the datatype
+                        # length segment so LT01 lets it touch, like `VARCHAR(255)`.
+                        Ref("BracketedArguments"),
                     ),
                     Bracketed(Ref("ExpressionSegment")),
                 ),

--- a/src/sqlfluff/dialects/dialect_mysql.py
+++ b/src/sqlfluff/dialects/dialect_mysql.py
@@ -1433,9 +1433,7 @@ mysql_dialect.add(
                     Ref("ColumnReferenceSegment"),
                     Sequence(
                         Ref("ColumnReferenceSegment"),
-                        # Index prefix length, e.g. `col(10)`. Reuse the datatype
-                        # length segment so LT01 lets it touch, like `VARCHAR(255)`.
-                        Ref("BracketedArguments"),
+                        Ref("IndexColumnPrefixLengthSegment"),
                     ),
                     Bracketed(Ref("ExpressionSegment")),
                 ),
@@ -1490,6 +1488,20 @@ mysql_dialect.insert_lexer_matchers(
     ],
     before="greater_than",
 )
+
+
+class IndexColumnPrefixLengthSegment(BaseSegment):
+    """A column prefix length in an index key part, e.g. `col(10)`.
+
+    Only a single numeric literal is valid here. Typed as `bracketed_arguments`
+    so LT01 lets it touch the column name like a data type length such as
+    `VARCHAR(255)`, rather than a plain bracket.
+
+    https://dev.mysql.com/doc/refman/8.0/en/create-index.html#create-index-column-prefixes
+    """
+
+    type = "bracketed_arguments"
+    match_grammar = Bracketed(Ref("NumericLiteralSegment"))
 
 
 class RoleReferenceSegment(ansi.RoleReferenceSegment):

--- a/test/fixtures/dialects/mariadb/create_index.yml
+++ b/test/fixtures/dialects/mariadb/create_index.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 70e8096d9ebac30601b9494145812f9a3a853e35558fb69843eed2d9413be171
+_hash: e32490ca7c7975a89e1ca9bf7f1af1b13b6596ffc9e17069670163a6838c6d04
 file:
 - statement:
     create_index_statement:
@@ -149,10 +149,11 @@ file:
         start_bracket: (
         column_reference:
           naked_identifier: name
-        bracketed:
-          start_bracket: (
-          numeric_literal: '10'
-          end_bracket: )
+        bracketed_arguments:
+          bracketed:
+            start_bracket: (
+            numeric_literal: '10'
+            end_bracket: )
         end_bracket: )
 - statement_terminator: ;
 - statement:

--- a/test/fixtures/dialects/mariadb/create_table_index.yml
+++ b/test/fixtures/dialects/mariadb/create_table_index.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 99426d9a1d7e06af48cd81e5c09abd4f275ecd5dec99e2f398195bd08c14f018
+_hash: a52767362a971d70cbf2364c0aaf7803e9d1e3cb4c645ee96e558e67c2f52913
 file:
   statement:
     create_table_statement:
@@ -79,10 +79,11 @@ file:
             start_bracket: (
             column_reference:
               naked_identifier: a
-            bracketed:
-              start_bracket: (
-              numeric_literal: '20'
-              end_bracket: )
+            bracketed_arguments:
+              bracketed:
+                start_bracket: (
+                numeric_literal: '20'
+                end_bracket: )
             end_bracket: )
       - comma: ','
       - table_constraint:

--- a/test/fixtures/dialects/mysql/create_index.yml
+++ b/test/fixtures/dialects/mysql/create_index.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 5ba008b762b05319be63ea1b01262c62e054e8ba120801da8589dc396cd1fdd3
+_hash: 8c197e2deea337bb0dd431527a77cdb39ad9973c6b3f71955d5c4c675f249e05
 file:
 - statement:
     create_index_statement:
@@ -149,10 +149,11 @@ file:
         start_bracket: (
         column_reference:
           naked_identifier: name
-        bracketed:
-          start_bracket: (
-          numeric_literal: '10'
-          end_bracket: )
+        bracketed_arguments:
+          bracketed:
+            start_bracket: (
+            numeric_literal: '10'
+            end_bracket: )
         end_bracket: )
 - statement_terminator: ;
 - statement:

--- a/test/fixtures/dialects/mysql/create_table_index.yml
+++ b/test/fixtures/dialects/mysql/create_table_index.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 99426d9a1d7e06af48cd81e5c09abd4f275ecd5dec99e2f398195bd08c14f018
+_hash: a52767362a971d70cbf2364c0aaf7803e9d1e3cb4c645ee96e558e67c2f52913
 file:
   statement:
     create_table_statement:
@@ -79,10 +79,11 @@ file:
             start_bracket: (
             column_reference:
               naked_identifier: a
-            bracketed:
-              start_bracket: (
-              numeric_literal: '20'
-              end_bracket: )
+            bracketed_arguments:
+              bracketed:
+                start_bracket: (
+                numeric_literal: '20'
+                end_bracket: )
             end_bracket: )
       - comma: ','
       - table_constraint:

--- a/test/fixtures/rules/std_rule_cases/LT01-brackets.yml
+++ b/test/fixtures/rules/std_rule_cases/LT01-brackets.yml
@@ -71,3 +71,22 @@ test_pass_mysql_bracketed_data_types:
   configs:
     core:
       dialect: mysql
+
+test_pass_mysql_index_prefix_length:
+  # A column prefix length in an index shouldn't be spaced, same as a data type
+  # length. https://github.com/sqlfluff/sqlfluff/issues/4541
+  pass_str: |
+    CREATE TABLE test (blob_col BLOB, INDEX (blob_col(10)));
+  configs:
+    core:
+      dialect: mysql
+
+test_fail_mysql_index_prefix_length:
+  # The rule still enforces touch spacing on the prefix length.
+  fail_str: |
+    CREATE TABLE test (blob_col BLOB, INDEX (blob_col (10)));
+  fix_str: |
+    CREATE TABLE test (blob_col BLOB, INDEX (blob_col(10)));
+  configs:
+    core:
+      dialect: mysql


### PR DESCRIPTION
### Brief summary of the change made

LT01 wanted a space in `INDEX (blob_col(10))`. The prefix length was parsed as a column reference plus a plain bracket, so the rule treated `(10)` like a function call and asked for a space before it.

Parse the length as `BracketedArguments` instead, same segment a data type length like `VARCHAR(255)` uses, which LT01 already lets touch. The rule still enforces touch, so `blob_col (10)` gets fixed back to `blob_col(10)`.

Two existing mysql ymls moved since `(10)` is now `bracketed_arguments`.

Fixes #4541.

### Are there any other side effects of this change that we should be aware of?

No, mysql only.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - Regenerated `.yml` parser fixtures in `test/fixtures/dialects/mysql`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix LT01 spacing for MySQL index prefix lengths so INDEX (col(10)) is not flagged; col (10) still fixes to col(10). Tightened parsing to accept only a single numeric length. Fixes #4541.

- **Bug Fixes**
  - Use `IndexColumnPrefixLengthSegment` (typed `bracketed_arguments`) to parse `col(10)` as one numeric literal; prevents LT01 spacing and rejects `col('10')`/`col(10, 20)`; updated MySQL/MariaDB fixtures and LT01 tests.

<sup>Written for commit fddd3eb641bfa7501080090067e187c33c836d32. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8128?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

