### PR TITLE
feat(mysql): support GROUP BY ... WITH ROLLUP (supersedes #8066, indent-safe)

### DIFF
--- a/src/sqlfluff/dialects/dialect_mysql.py
+++ b/src/sqlfluff/dialects/dialect_mysql.py
@@ -372,6 +372,36 @@ mysql_dialect.add(
 )
 
 
+class GroupByClauseSegment(ansi.GroupByClauseSegment):
+    """A MySQL `GROUP BY` clause, adding the `WITH ROLLUP` modifier.
+
+    https://dev.mysql.com/doc/refman/8.0/en/group-by-modifiers.html
+    """
+
+    match_grammar: Matchable = Sequence(
+        "GROUP",
+        "BY",
+        Indent,
+        OneOf(
+            "ALL",
+            Ref("GroupingSetsClauseSegment"),
+            Ref("CubeRollupClauseSegment"),
+            Sequence(
+                Delimited(
+                    OneOf(
+                        Ref("ColumnReferenceSegment"),
+                        Ref("NumericLiteralSegment"),
+                        Ref("ExpressionSegment"),
+                    ),
+                    terminators=[Ref("GroupByClauseTerminatorGrammar")],
+                ),
+            ),
+        ),
+        Dedent,
+        Sequence("WITH", "ROLLUP", optional=True),
+    )
+
+
 class TableReferenceSegment(ansi.TableReferenceSegment):
     """A reference to a table.
 

--- a/src/sqlfluff/dialects/dialect_mysql.py
+++ b/src/sqlfluff/dialects/dialect_mysql.py
@@ -378,27 +378,8 @@ class GroupByClauseSegment(ansi.GroupByClauseSegment):
     https://dev.mysql.com/doc/refman/8.0/en/group-by-modifiers.html
     """
 
-    match_grammar: Matchable = Sequence(
-        "GROUP",
-        "BY",
-        Indent,
-        OneOf(
-            "ALL",
-            Ref("GroupingSetsClauseSegment"),
-            Ref("CubeRollupClauseSegment"),
-            Sequence(
-                Delimited(
-                    OneOf(
-                        Ref("ColumnReferenceSegment"),
-                        Ref("NumericLiteralSegment"),
-                        Ref("ExpressionSegment"),
-                    ),
-                    terminators=[Ref("GroupByClauseTerminatorGrammar")],
-                ),
-            ),
-        ),
-        Dedent,
-        Sequence("WITH", "ROLLUP", optional=True),
+    match_grammar = ansi.GroupByClauseSegment.match_grammar.copy(
+        insert=[Sequence("WITH", "ROLLUP", optional=True)],
     )
 
 

--- a/src/sqlfluff/dialects/dialect_mysql.py
+++ b/src/sqlfluff/dialects/dialect_mysql.py
@@ -380,6 +380,10 @@ class GroupByClauseSegment(ansi.GroupByClauseSegment):
 
     match_grammar = ansi.GroupByClauseSegment.match_grammar.copy(
         insert=[Sequence("WITH", "ROLLUP", optional=True)],
+        # Insert before ANSI's trailing ``Dedent`` so ``WITH ROLLUP`` stays
+        # inside the ``GROUP BY`` indentation block rather than escaping it and
+        # dedenting onto its own line (review feedback on #8066).
+        before=Dedent,
     )
 
 

--- a/test/fixtures/dialects/mysql/group_by_with_rollup.sql
+++ b/test/fixtures/dialects/mysql/group_by_with_rollup.sql
@@ -1,0 +1,10 @@
+-- MySQL GROUP BY ... WITH ROLLUP modifier
+-- https://dev.mysql.com/doc/refman/8.0/en/group-by-modifiers.html
+
+SELECT a, SUM(b) FROM t GROUP BY a WITH ROLLUP;
+
+SELECT a, b, SUM(c) FROM t GROUP BY a, b WITH ROLLUP;
+
+SELECT a, SUM(b) FROM t GROUP BY 1 WITH ROLLUP HAVING SUM(b) > 10;
+
+SELECT a, SUM(b) FROM t GROUP BY a WITH ROLLUP ORDER BY a;

--- a/test/fixtures/dialects/mysql/group_by_with_rollup.yml
+++ b/test/fixtures/dialects/mysql/group_by_with_rollup.yml
@@ -1,0 +1,170 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 0a52bf288644dbfa06f5c0d7fdfbf6a43b652f4260377e80449183f112f141bf
+file:
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            naked_identifier: a
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: SUM
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  column_reference:
+                    naked_identifier: b
+                end_bracket: )
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: t
+      groupby_clause:
+      - keyword: GROUP
+      - keyword: BY
+      - column_reference:
+          naked_identifier: a
+      - keyword: WITH
+      - keyword: ROLLUP
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            naked_identifier: a
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            naked_identifier: b
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: SUM
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  column_reference:
+                    naked_identifier: c
+                end_bracket: )
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: t
+      groupby_clause:
+      - keyword: GROUP
+      - keyword: BY
+      - column_reference:
+          naked_identifier: a
+      - comma: ','
+      - column_reference:
+          naked_identifier: b
+      - keyword: WITH
+      - keyword: ROLLUP
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            naked_identifier: a
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: SUM
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  column_reference:
+                    naked_identifier: b
+                end_bracket: )
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: t
+      groupby_clause:
+      - keyword: GROUP
+      - keyword: BY
+      - numeric_literal: '1'
+      - keyword: WITH
+      - keyword: ROLLUP
+      having_clause:
+        keyword: HAVING
+        expression:
+          function:
+            function_name:
+              function_name_identifier: SUM
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  column_reference:
+                    naked_identifier: b
+                end_bracket: )
+          comparison_operator:
+            raw_comparison_operator: '>'
+          numeric_literal: '10'
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            naked_identifier: a
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: SUM
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  column_reference:
+                    naked_identifier: b
+                end_bracket: )
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: t
+      groupby_clause:
+      - keyword: GROUP
+      - keyword: BY
+      - column_reference:
+          naked_identifier: a
+      - keyword: WITH
+      - keyword: ROLLUP
+      orderby_clause:
+      - keyword: ORDER
+      - keyword: BY
+      - column_reference:
+          naked_identifier: a
+- statement_terminator: ;

--- a/test/fixtures/rules/std_rule_cases/LT02-indent.yml
+++ b/test/fixtures/rules/std_rule_cases/LT02-indent.yml
@@ -2960,3 +2960,18 @@ test_pass_issue_7543_indentation:
       indented_using_on: true
       template_blocks_indent: true
       implicit_indents: require
+
+test_pass_mysql_group_by_with_rollup_indented:
+  # `WITH ROLLUP` stays inside the GROUP BY indentation block (#8066); it must
+  # not be dedented onto its own line.
+  pass_str: |
+    SELECT
+        a,
+        b
+    FROM t
+    GROUP BY
+        a,
+        b WITH ROLLUP
+  configs:
+    core:
+      dialect: mysql


### PR DESCRIPTION
## Description

Adds support for MySQL's `GROUP BY ... WITH ROLLUP` modifier. This supersedes #8066 (closed for inactivity) and addresses @peterbud's review there — reopening #8066 wasn't possible, hence a fresh PR.

MySQL's `WITH ROLLUP` was unparsable: the mysql dialect inherited ANSI's `GroupByClauseSegment`, which only accepts the `ROLLUP()` function form. The override extends ANSI's grammar with an optional trailing `WITH ROLLUP`.

### Addressing the #8066 review

@peterbud pointed out that inserting `WITH ROLLUP` with `.copy(insert=[...])` appended it **after** ANSI's trailing `Dedent`, so it escaped the `GROUP BY` indentation block and LT02 reindented it onto its own dedented line. This version inserts it **before** the `Dedent` (`copy(insert=[...], before=Dedent)`), so it stays inside the block. His example:

```sql
GROUP BY
    a,
    b WITH ROLLUP
```

now lints clean under LT02 — previously LT02 reported *"Expected line break and no indent before 'WITH'."*

## Tests

- 632 mysql dialect fixtures pass; `test/fixtures/dialects/mysql/group_by_with_rollup.sql` parses.
- Added an LT02 regression case (`test_pass_mysql_group_by_with_rollup_indented`) that **fails without** the `before=Dedent` change and passes with it.

_AI-assisted, disclosed per CONTRIBUTING._


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds MySQL support for GROUP BY ... WITH ROLLUP and keeps it inside the GROUP BY indent block. Previously unparsable queries now parse and lint clean under LT02.

- **New Features**
  - Extend MySQL GroupByClauseSegment by copying ANSI grammar and inserting an optional trailing WITH ROLLUP before Dedent.
  - Supports single/multi-column grouping, HAVING, and ORDER BY.

- **Bug Fixes**
  - Prevent WITH ROLLUP from dedenting onto its own line; it stays within the GROUP BY indentation block (LT02 passes).

<sup>Written for commit bb226fdcf7f948323cbe739bf77d64fe19c5424c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8130?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

