### PR TITLE
Postgres: stop LT01 splitting psql variables like :status

### DIFF
--- a/src/sqlfluff/core/default_config.cfg
+++ b/src/sqlfluff/core/default_config.cfg
@@ -282,6 +282,9 @@ spacing_within = any
 [sqlfluff:layout:type:bind_variable]
 spacing_within = touch
 
+[sqlfluff:layout:type:psql_variable]
+spacing_within = touch
+
 [sqlfluff:layout:type:placeholder]
 # Placeholders exist "outside" the rendered SQL syntax
 # so we shouldn't enforce any particular spacing around

--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -519,6 +519,14 @@ postgres_dialect.add(
     CreateForeignTableGrammar=Sequence("CREATE", "FOREIGN", "TABLE"),
     IntervalUnitsGrammar=OneOf("YEAR", "MONTH", "DAY", "HOUR", "MINUTE", "SECOND"),
     WalrusOperatorSegment=StringParser(":=", SymbolSegment, type="assignment_operator"),
+    # Colon prefix for psql variables (:var, :'var', :"var"). Distinct from
+    # ColonSegment so the global `spacing_before = touch` on type "colon"
+    # doesn't collapse the space before the variable (e.g. in
+    # `status = :status`, only the space *within* the variable should be
+    # removed, not the one before it).
+    PsqlVariableColonSegment=StringParser(
+        ":", SymbolSegment, type="psql_variable_colon"
+    ),
     MetaCommandQueryBufferSegment=TypedParser(
         "meta_command_query_buffer", SymbolSegment, type="meta_command"
     ),
@@ -987,10 +995,13 @@ class PsqlVariableGrammar(BaseSegment):
 
     match_grammar = Sequence(
         OptionallyBracketed(
-            Ref("ColonSegment"),
-            OneOf(
-                Ref("ParameterNameSegment"),
-                Ref("QuotedLiteralSegment"),
+            Sequence(
+                Ref("PsqlVariableColonSegment"),
+                OneOf(
+                    Ref("ParameterNameSegment"),
+                    Ref("QuotedLiteralSegment"),
+                ),
+                allow_gaps=False,
             ),
         )
     )

--- a/test/fixtures/dialects/postgres/copy.yml
+++ b/test/fixtures/dialects/postgres/copy.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: e828edfa2f9b8f132796188d0568a6face270dee9bd9f5d86e8b2bd7c260a60a
+_hash: 4cb6a08731a239c76f532de4ddb0a900fd8f49607913104a4916aaa85fdc00ff
 file:
 - statement:
     copy_statement:
@@ -1448,7 +1448,7 @@ file:
         naked_identifier: tmp_table
     - keyword: FROM
     - psql_variable:
-        colon: ':'
+        psql_variable_colon: ':'
         parameter: source
 - statement_terminator: ;
 - statement:
@@ -1458,7 +1458,7 @@ file:
         naked_identifier: my_table
     - keyword: FROM
     - psql_variable:
-        colon: ':'
+        psql_variable_colon: ':'
         parameter: source
     - keyword: WITH
     - bracketed:
@@ -1477,7 +1477,7 @@ file:
         naked_identifier: my_table
     - keyword: TO
     - psql_variable:
-        colon: ':'
+        psql_variable_colon: ':'
         parameter: dest
     - keyword: WITH
     - bracketed:
@@ -1493,7 +1493,7 @@ file:
         naked_identifier: my_table
     - keyword: FROM
     - psql_variable:
-        colon: ':'
+        psql_variable_colon: ':'
         quoted_literal: "'fname'"
 - statement_terminator: ;
 - statement:
@@ -1503,7 +1503,7 @@ file:
         naked_identifier: my_table
     - keyword: TO
     - psql_variable:
-        colon: ':'
+        psql_variable_colon: ':'
         parameter: '"out"'
 - statement_terminator: ;
 - statement:
@@ -1514,7 +1514,7 @@ file:
     - keyword: FROM
     - keyword: PROGRAM
     - psql_variable:
-        colon: ':'
+        psql_variable_colon: ':'
         quoted_literal: "'gen_cmd'"
 - statement_terminator: ;
 - statement:
@@ -1525,6 +1525,6 @@ file:
     - keyword: TO
     - keyword: PROGRAM
     - psql_variable:
-        colon: ':'
+        psql_variable_colon: ':'
         parameter: dest_cmd
 - statement_terminator: ;

--- a/test/fixtures/dialects/postgres/meta_commands_query_buffer.yml
+++ b/test/fixtures/dialects/postgres/meta_commands_query_buffer.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: ea6327f25ad6d1824bfb39a6994aaffbda61fcd1ab2e0b6b85854ab8cd52d3bc
+_hash: 3ffd50a7c2e12273b3f820d4d2e08e2bdfdf324b3c3ad6cc2f7f80f086e86d51
 file:
 - statement:
     meta_command_statement:
@@ -175,7 +175,7 @@ file:
           keyword: SELECT
           select_clause_element:
             psql_variable:
-              colon: ':'
+              psql_variable_colon: ':'
               quoted_literal: "'my_psql_var'"
 - statement_terminator: ;
 - statement:

--- a/test/fixtures/dialects/postgres/postgres_postgis_operators.yml
+++ b/test/fixtures/dialects/postgres/postgres_postgis_operators.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 12f503c0d1bc6b05ad3d58352ef3abc3ce719bb0670ba5dc109facbc7cf15f40
+_hash: ef6faa1e0184a8d320dd17d9da5f4ccd41ef9d8b7e4f96f89c0510ed2923c38a
 file:
 - statement:
     select_statement:
@@ -1451,7 +1451,7 @@ file:
                           - comma: ','
                           - expression:
                               psql_variable:
-                                colon: ':'
+                                psql_variable_colon: ':'
                                 parameter: qt
                           - end_bracket: )
                       alias_expression:
@@ -1471,7 +1471,7 @@ file:
                         naked_identifier: tr
                       binary_operator: '|=|'
                       psql_variable:
-                        colon: ':'
+                        psql_variable_colon: ':'
                         parameter: qt
                   limit_clause:
                     keyword: LIMIT

--- a/test/fixtures/dialects/postgres/psql_set_meta_command.yml
+++ b/test/fixtures/dialects/postgres/psql_set_meta_command.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: b1ba39f237e30d6683b9d51312ea356586ffd519806c157a8cb99204a8c041fc
+_hash: 88c81cbb2cfbe12d5f7b8e93a8b477463da7d59884e34c8424a7f0857d485a0f
 file:
 - psql_set_meta_command_statement:
     psql_set_command: \set
@@ -21,6 +21,6 @@ file:
         keyword: SELECT
         select_clause_element:
           psql_variable:
-            colon: ':'
+            psql_variable_colon: ':'
             parameter: myvar
 - statement_terminator: ;

--- a/test/fixtures/dialects/postgres/psql_variable.yml
+++ b/test/fixtures/dialects/postgres/psql_variable.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: c720fe8f98cdb0a19156a0c598ca590f1acc80bc7e6c9d6fa120243035cf06a1
+_hash: 331d86274fee652e2a25d23ba94cb8a30073ee0d7e891a8d6a6c3a9301d7478f
 file:
 - statement:
     select_statement:
@@ -88,7 +88,7 @@ file:
               start_bracket: (
               expression:
                 psql_variable:
-                  colon: ':'
+                  psql_variable_colon: ':'
                   parameter: m1
               end_bracket: )
             casting_operator: '::'
@@ -113,7 +113,7 @@ file:
                       start_bracket: (
                       expression:
                         psql_variable:
-                          colon: ':'
+                          psql_variable_colon: ':'
                           parameter: a
                       end_bracket: )
                     casting_operator: '::'
@@ -206,7 +206,7 @@ file:
         - comparison_operator:
             raw_comparison_operator: '='
         - psql_variable:
-            colon: ':'
+            psql_variable_colon: ':'
             quoted_literal: "'m1'"
         - binary_operator: AND
         - column_reference:
@@ -223,7 +223,7 @@ file:
               - start_bracket: (
               - expression:
                   psql_variable:
-                    colon: ':'
+                    psql_variable_colon: ':'
                     quoted_literal: "'a'"
               - comma: ','
               - expression:

--- a/test/fixtures/dialects/postgres/psql_variable_bare.sql
+++ b/test/fixtures/dialects/postgres/psql_variable_bare.sql
@@ -1,0 +1,14 @@
+-- psql client variable interpolation without surrounding brackets,
+-- as used directly in an expression (see #6686).
+-- https://www.postgresql.org/docs/16/app-psql.html#APP-PSQL-INTERPOLATION
+SELECT count(*)
+FROM foo
+WHERE status = :status;
+
+SELECT count(*)
+FROM foo
+WHERE status = :'status';
+
+SELECT count(*)
+FROM foo
+WHERE status = :"status";

--- a/test/fixtures/dialects/postgres/psql_variable_bare.yml
+++ b/test/fixtures/dialects/postgres/psql_variable_bare.yml
@@ -1,0 +1,100 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 4fccf2ce3b1307c6d4ebe2f7accc1b44750f94476f2b67895744e5adedad0815
+file:
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: count
+            function_contents:
+              bracketed:
+                start_bracket: (
+                star: '*'
+                end_bracket: )
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: foo
+      where_clause:
+        keyword: WHERE
+        expression:
+          column_reference:
+            naked_identifier: status
+          comparison_operator:
+            raw_comparison_operator: '='
+          psql_variable:
+            psql_variable_colon: ':'
+            parameter: status
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: count
+            function_contents:
+              bracketed:
+                start_bracket: (
+                star: '*'
+                end_bracket: )
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: foo
+      where_clause:
+        keyword: WHERE
+        expression:
+          column_reference:
+            naked_identifier: status
+          comparison_operator:
+            raw_comparison_operator: '='
+          psql_variable:
+            psql_variable_colon: ':'
+            quoted_literal: "'status'"
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: count
+            function_contents:
+              bracketed:
+                start_bracket: (
+                star: '*'
+                end_bracket: )
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: foo
+      where_clause:
+        keyword: WHERE
+        expression:
+          column_reference:
+            naked_identifier: status
+          comparison_operator:
+            raw_comparison_operator: '='
+          psql_variable:
+            psql_variable_colon: ':'
+            parameter: '"status"'
+- statement_terminator: ;

--- a/test/fixtures/rules/std_rule_cases/LT01-missing.yml
+++ b/test/fixtures/rules/std_rule_cases/LT01-missing.yml
@@ -172,3 +172,47 @@ test_pass_oracle_substitution_variable_as_table:
   configs:
     core:
       dialect: oracle
+
+# psql client variable interpolation (:var, :'var', :"var") must not be
+# broken by LT01 - see https://github.com/sqlfluff/sqlfluff/issues/6686
+test_pass_postgres_psql_variable_naked:
+  pass_str: |
+    SELECT count(*)
+    FROM foo
+    WHERE status = :status;
+  configs:
+    core:
+      dialect: postgres
+
+test_pass_postgres_psql_variable_quoted_literal:
+  pass_str: |
+    SELECT count(*)
+    FROM foo
+    WHERE status = :'status';
+  configs:
+    core:
+      dialect: postgres
+
+test_pass_postgres_psql_variable_quoted_identifier:
+  pass_str: |
+    SELECT count(*)
+    FROM foo
+    WHERE status = :"status";
+  configs:
+    core:
+      dialect: postgres
+
+test_fail_postgres_psql_variable_excess_space_before_colon:
+  # Excess whitespace before the variable should be collapsed to a single
+  # space (as normal), while the colon and variable name must stay touching.
+  fail_str: |
+    SELECT count(*)
+    FROM foo
+    WHERE status =    :status;
+  fix_str: |
+    SELECT count(*)
+    FROM foo
+    WHERE status = :status;
+  configs:
+    core:
+      dialect: postgres


### PR DESCRIPTION
### Brief summary of the change made

Fixes #6686.

Postgres already parses psql client variables (`:status`, `:'status'`, `:"status"`) via `PsqlVariableGrammar`, but the grammar reused the generic `ColonSegment` (type `colon`). The global layout config for `colon` (`spacing_before = touch`) meant `LT01` "fixed" `WHERE status = :status` into `WHERE status = : status`, which is invalid.

This gives the psql-variable colon its own segment type (`psql_variable_colon`) with `spacing_within = touch` on the enclosing `psql_variable` type — mirroring the existing `bind_colon` / `[sqlfluff:layout:type:bind_variable]` pattern the Oracle dialect uses for `:var` bind variables.

Changes:
- `dialect_postgres.py`: new `PsqlVariableColonSegment`; `PsqlVariableGrammar` uses it with `allow_gaps=False`.
- `core/default_config.cfg`: `[sqlfluff:layout:type:psql_variable]` with `spacing_within = touch`.
- New parse fixture `postgres/psql_variable_bare.sql(.yml)` covering the issue repro for all three variable forms.
- 4 new LT01 rule cases (3 pass-cases showing the variables are left untouched, 1 fail/fix case collapsing excess whitespace while keeping the colon touching the name).
- 5 existing postgres fixture YAMLs regenerated (segment type rename only).

### Are there any other side effects of this change that we should be aware of?

- Parse trees for psql variables now emit `psql_variable_colon` instead of `colon` — visible to anyone consuming the parse tree, but spacing/linting behavior is otherwise unchanged outside psql variables.
- Full `test/dialects/` suite passes (6700 tests), so postgres-derived dialects (redshift etc.) are unaffected.
- The Rust dialect tables were not regenerated locally (no cargo toolchain on this machine); `use_rust_parser = auto` falls back to the Python grammar. Happy to regenerate if CI requires it.
- A related-but-separate array-slice spacing bug mentioned in the issue comments (`some_arr[2 : :limit]` → `[2::limit]`) is a pre-existing issue with the `slice` layout type and is not addressed here.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).

### AI assistance disclosure

This PR was developed with material AI assistance (Claude Code): the approach selection (mirroring the Oracle `bind_colon` precedent), implementation, and test cases were AI-drafted. Validation was run locally: full postgres dialect tests (519), full `test/dialects/` (6700), full rule YAML suite (2261), ruff/mypy on touched files, and manual verification that `sqlfluff fix --rules LT01` leaves all three `:var` forms unchanged.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop LT01 from splitting psql variables so `WHERE status = :status` stays valid. Fixes #6686.

**Bug Fixes**
- Added `PsqlVariableColonSegment` (type `psql_variable_colon`) and updated `PsqlVariableGrammar` with `allow_gaps=False` to keep `:` touching the variable name for `:var`, `:'var'`, `:"var"`.
- Added `[sqlfluff:layout:type:psql_variable]` with `spacing_within = touch` to prevent LT01 from inserting space inside the variable, mirroring Oracle bind variable behavior.
- Updated tests and fixtures: new `postgres/psql_variable_bare` parse fixture and LT01 cases; regenerated existing Postgres fixture YAMLs; parse trees now emit `psql_variable_colon` (no behavior change outside psql variables).

<sup>Written for commit cd8ca18f41f31f5d616620b4be9f28eed6e999ef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8131?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

