### PR TITLE
RF03: treat Athena as a struct dialect

### DIFF
--- a/src/sqlfluff/rules/references/RF03.py
+++ b/src/sqlfluff/rules/references/RF03.py
@@ -33,7 +33,7 @@ class Rule_RF03(BaseRule):
     """Column references should be qualified consistently in single table statements.
 
     .. note::
-        For BigQuery, Hive and Redshift this rule is disabled by default.
+        For Athena, BigQuery, Hive and Redshift this rule is disabled by default.
         This is due to historical false positives associated with STRUCT data types.
         This default behaviour may be changed in the future.
         The rule can be enabled with the ``force_enable = True`` flag.
@@ -82,7 +82,11 @@ class Rule_RF03(BaseRule):
     # because they will more accurately process any internal references.
     crawl_behaviour = SegmentSeekerCrawler(set(_START_TYPES), allow_recurse=False)
     _is_struct_dialect = False
-    _dialects_with_structs = ["bigquery", "hive", "redshift"]
+    # Dialects with STRUCT-like data types accessed via dot syntax (e.g.
+    # `col.field.subfield`), which can be misread as table-qualified column
+    # references (`table.column`) in single table SELECTs.
+    # https://docs.aws.amazon.com/athena/latest/ug/filtering-with-dot.html
+    _dialects_with_structs = ["athena", "bigquery", "hive", "redshift"]
     # This could be turned into an option
     _fix_inconsistent_to = "qualified"
     is_fix_compatible = True

--- a/test/fixtures/rules/std_rule_cases/RF03.yml
+++ b/test/fixtures/rules/std_rule_cases/RF03.yml
@@ -682,3 +682,89 @@ test_pass_whole_row_reference_mixed_qualification:
   # column reference (and so must not be "fixed" to `tbl.tbl`).
   # https://github.com/sqlfluff/sqlfluff/issues/6904
   pass_str: SELECT tbl, tbl.a FROM tbl
+
+test_pass_athena_struct_disabled_by_default:
+  # RF03 is disabled by default for Athena (like BigQuery/Hive/Redshift) due to
+  # historical false positives with STRUCT dot-access, so this passes even
+  # though `c.struct.val` would otherwise look like a qualified reference.
+  # https://github.com/sqlfluff/sqlfluff/issues/6250
+  pass_str: |
+    select
+        a,
+        b,
+        c.struct.val
+    from sch.t1
+  configs:
+    core:
+      dialect: athena
+    rules:
+      references.consistent:
+        single_table_references: consistent
+
+test_pass_athena_struct_field_access_consistent:
+  # With force_enable, `c.struct.val` is recognised as a struct field access
+  # (its leading part "c" is not the table alias "t1"), so it is treated as
+  # unqualified -- consistent with the other bare columns `a` and `b`.
+  # https://github.com/sqlfluff/sqlfluff/issues/6250
+  pass_str: |
+    select
+        a,
+        b,
+        c.struct.val
+    from sch.t1
+  configs:
+    core:
+      dialect: athena
+    rules:
+      references.consistent:
+        single_table_references: consistent
+        force_enable: true
+
+test_fail_athena_struct_field_access_genuine_inconsistency:
+  # A genuinely table-qualified reference (`t1.b`) alongside unqualified
+  # references and a struct field access should still be flagged: the struct
+  # access and `a` are both unqualified, but `t1.b` is genuinely qualified and
+  # inconsistent with them.
+  # https://github.com/sqlfluff/sqlfluff/issues/6250
+  fail_str: |
+    select
+        a,
+        t1.b,
+        c.struct.val
+    from sch.t1
+  fix_str: |
+    select
+        t1.a,
+        t1.b,
+        t1.c.struct.val
+    from sch.t1
+  configs:
+    core:
+      dialect: athena
+    rules:
+      references.consistent:
+        single_table_references: consistent
+        force_enable: true
+
+test_fail_athena_struct_field_access_qualified_config:
+  # With single_table_references=qualified and force_enable, the struct field
+  # access `c.struct.val` is recognised as unqualified (its leading part "c"
+  # is not the table alias "t1") and so must be qualified like the rest.
+  # https://github.com/sqlfluff/sqlfluff/issues/6250
+  fail_str: |
+    select
+        a,
+        c.struct.val
+    from sch.t1
+  fix_str: |
+    select
+        t1.a,
+        t1.c.struct.val
+    from sch.t1
+  configs:
+    core:
+      dialect: athena
+    rules:
+      references.consistent:
+        single_table_references: qualified
+        force_enable: true


### PR DESCRIPTION
### Brief summary of the change made

Fixes #6250.

Athena supports STRUCT dot access (`col.field.subfield`), but `RF03` (`references.consistent`, which owns `single_table_references`) only applied its struct-vs-table-reference disambiguation for `bigquery`, `hive` and `redshift`. On Athena, `select a, b, c.struct.val from sch.t1` misread `c.struct.val` as a table-qualified reference, flagged it as inconsistent with the bare columns, and the fix directive then flagged `a` and `b` too.

Fix: add `athena` to `Rule_RF03._dialects_with_structs`, matching the existing precedent — and matching `RF01`, which already lists athena in its dot-access dialect set (and therefore doesn't misfire on this SQL).

Added 4 RF03 rule test cases: default-disabled pass, `force_enable` + consistent pass (struct access disambiguated), and two genuine-inconsistency fail/fix cases under `force_enable`.

### Are there any other side effects of this change that we should be aware of?

RF03 is now **disabled by default for the athena dialect** (like bigquery/hive/redshift, re-enable with `force_enable = True`). This is a deliberate behavior change for athena users, consistent with how the other struct dialects are handled; the rule docstring note is updated accordingly.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
- Added appropriate documentation for the change (rule docstring note updated).

### AI assistance disclosure

This PR was developed with material AI assistance (Claude Code): root-cause analysis, the fix, and test cases were AI-drafted. Validation was run locally: RF03 YAML cases (60), full `test/rules/` suite (2419 passed), ruff/mypy on touched files, and manual verification of the issue's repro SQL under default config, `force_enable`, and genuine-inconsistency variants.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `RF03` treat `athena` as a struct dialect so dot-access like `c.struct.val` isn’t mistaken for table qualification. Fixes false positives (issue #6250) and disables `RF03` by default for `athena`, matching `bigquery`, `hive`, and `redshift`.

- **Bug Fixes**
  - Added `athena` to `_dialects_with_structs` in `RF03` and updated the rule note.
  - Added `RF03` tests for `athena`: default-disabled pass, `force_enable` consistent pass, and two fail/fix cases.

- **Migration**
  - If you need `references.consistent` on `athena`, enable with `force_enable: true`.

<sup>Written for commit 183e1a8b72ac96d29dc0be3063acc40a5d57144e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8132?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

