### PR TITLE
fix: RF02 should not flag BigQuery whole-row table references

### DIFF
--- a/src/sqlfluff/rules/references/RF02.py
+++ b/src/sqlfluff/rules/references/RF02.py
@@ -46,6 +46,11 @@ class Rule_RF02(Rule_AL04):
     config_keywords = [
         "subqueries_ignore_external_references",
     ]
+    _dialects_with_row_references = [
+        "bigquery",
+        "postgres",
+        "redshift",
+    ]
 
     # Config type hints
     ignore_words_regex: str
@@ -95,6 +100,11 @@ class Rule_RF02(Rule_AL04):
             ignore_words_list = self._init_ignore_words_list()
 
         sql_variables = self._find_sql_variables(rule_context)
+        row_reference_aliases = (
+            {alias.segment.raw_normalized() for alias in table_aliases if alias.segment}
+            if rule_context.dialect.name in self._dialects_with_row_references
+            else set()
+        )
 
         # A buffer to keep any violations.
         violation_buff = []
@@ -131,6 +141,9 @@ class Rule_RF02(Rule_AL04):
                 # Allow columns defined as standalone aliases
                 # (e.g. value table functions from bigquery)
                 and r.raw not in [a.raw for a in standalone_aliases]
+                # Allow whole-row references to table aliases in dialects that
+                # support them.
+                and r.raw_normalized() not in row_reference_aliases
             ):
                 violation_buff.append(
                     LintResult(

--- a/test/fixtures/rules/std_rule_cases/RF02.yml
+++ b/test/fixtures/rules/std_rule_cases/RF02.yml
@@ -223,6 +223,28 @@ test_fail_unqualified_references_multi_table_statements_mysql:
     core:
       dialect: mysql
 
+test_pass_bigquery_normalized_whole_row_alias_references:
+  pass_str: |
+    SELECT FORMAT('%t', s1), s2.id
+    FROM main AS S1
+    JOIN secondary AS s2 ON S1.id = s2.id;
+
+    SELECT FORMAT('%t', `s1`), s2.id
+    FROM main AS `s1`
+    JOIN secondary AS s2 ON `s1`.id = s2.id
+  configs:
+    core:
+      dialect: bigquery
+
+test_fail_mysql_alias_named_unqualified_column:
+  fail_str: |
+    SELECT o, s.id
+    FROM orders AS o
+    JOIN shipments AS s ON o.id = s.order_id
+  configs:
+    core:
+      dialect: mysql
+
 test_fail_column_and_alias_same_name_mysql:
   # See issue #2169
   fail_str: |


### PR DESCRIPTION
### Brief summary of the change made

RF02 flagged BigQuery whole-row references such as `format('%t', s1)` as unqualified column references, but `s1` there is a table/row reference (a STRUCT-valued whole-row value), not a column. This teaches RF02 to recognize whole-row aliases: it normalizes aliases before matching row references and restricts whole-row alias matching to the dialects that support it, so the false positive on valid BigQuery SQL is gone.

fixes #4079

### Are there any other side effects of this change that we should be aware of?

The whole-row alias handling is gated to the dialects that support it, so other dialects still flag a genuinely unqualified reference exactly as before. No change to autofix behavior.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`: added BigQuery whole-row alias cases and a guard case in `test/fixtures/rules/std_rule_cases/RF02.yml`.
- Added appropriate documentation for the change: not applicable (rule-behavior fix; no user-facing docs change).
- Created GitHub issues for any relevant followup/future enhancements if appropriate: not applicable.

AI was used for assistance.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `RF02` false positives on BigQuery whole-row table references (e.g., FORMAT('%t', s1)) by recognizing whole-row aliases and keeping other dialects unchanged.

- **Bug Fixes**
  - Normalize aliases and treat them as valid whole-row references where supported.
  - Limit whole-row handling to `bigquery`, `postgres`, and `redshift`.
  - Add tests: BigQuery pass cases and a MySQL guard case.

<sup>Written for commit ea69760e684908e9e35c3a989d650626dab19a7c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8133?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

