### PR TITLE
fix(core): remove orphaned temp file when safe file replace fails

### DIFF
--- a/src/sqlfluff/core/linter/linted_file.py
+++ b/src/sqlfluff/core/linter/linted_file.py
@@ -433,19 +433,34 @@ class LintedFile(NamedTuple):
             if stat.S_ISREG(status.st_mode):
                 mode = stat.S_IMODE(status.st_mode)
         dirname, basename = os.path.split(output_path)
-        with tempfile.NamedTemporaryFile(
-            mode="w",
-            encoding=encoding,
-            newline="",  # NOTE: No newline conversion. Write as read.
-            prefix=basename,
-            dir=dirname,
-            suffix=os.path.splitext(output_path)[1],
-            delete=False,
-        ) as tmp:
-            tmp.file.write(write_buff)
-            tmp.flush()
-            os.fsync(tmp.fileno())
-        # Once the temp file is safely written, replace the existing file.
-        if mode is not None:
-            os.chmod(tmp.name, mode)
-        shutil.move(tmp.name, output_path)
+        # NOTE: The temp file is created with ``delete=False`` so it survives the
+        # ``with`` block, which means we're responsible for removing it if a
+        # later step fails. Track its name and clean it up on error so a failed
+        # write, chmod or move never leaves an orphaned temp file next to the
+        # user's file (which, sharing the .sql suffix, looks like a real one).
+        tmp_name: Optional[str] = None
+        try:
+            with tempfile.NamedTemporaryFile(
+                mode="w",
+                encoding=encoding,
+                newline="",  # NOTE: No newline conversion. Write as read.
+                prefix=basename,
+                dir=dirname,
+                suffix=os.path.splitext(output_path)[1],
+                delete=False,
+            ) as tmp:
+                tmp_name = tmp.name
+                tmp.file.write(write_buff)
+                tmp.flush()
+                os.fsync(tmp.fileno())
+            # Once the temp file is safely written, replace the existing file.
+            if mode is not None:
+                os.chmod(tmp_name, mode)
+            shutil.move(tmp_name, output_path)
+        except BaseException:
+            # The ``with`` block above has already closed the file descriptor by
+            # the time we get here, so removing the temp file is safe on every
+            # platform (including Windows, where an open file cannot be removed).
+            if tmp_name is not None and os.path.exists(tmp_name):
+                os.remove(tmp_name)
+            raise

--- a/test/core/linter/linted_file_test.py
+++ b/test/core/linter/linted_file_test.py
@@ -1,6 +1,7 @@
 """Tests covering the LintedFile class and it's methods."""
 
 import logging
+from unittest import mock
 
 import pytest
 
@@ -263,6 +264,46 @@ def test_safe_create_replace_file(case, tmp_path):
         pass
     actual = p.read_text(encoding=case["encoding"])
     assert case["expected"] == actual
+
+
+@pytest.mark.parametrize(
+    "failure",
+    [
+        # os.chmod failing (e.g. EPERM/EACCES on a restrictive/foreign target dir).
+        dict(target="os.chmod", exc=PermissionError("chmod denied")),
+        # shutil.move failing (e.g. read-only target, ENOSPC, cross-device edge).
+        dict(target="shutil.move", exc=OSError("move failed")),
+    ],
+    ids=lambda failure: failure["target"],
+)
+def test_safe_create_replace_file_cleans_up_on_failure(failure, tmp_path):
+    """A failure after the temp file is written must not orphan it.
+
+    ``_safe_create_replace_file`` writes to a temp file (created with
+    ``delete=False``) before replacing the target, so if chmod or move fails
+    afterwards the temp file must be removed rather than left next to the user's
+    file (where, sharing the .sql suffix, it looks like a real one).
+    """
+    p = tmp_path / "test.sql"
+    p.write_text("original")
+    target = f"sqlfluff.core.linter.linted_file.{failure['target']}"
+    with mock.patch(target, side_effect=failure["exc"]):
+        with pytest.raises(type(failure["exc"])):
+            LintedFile._safe_create_replace_file(str(p), str(p), "updated", "utf-8")
+    # The original file is untouched and no temp file was left behind.
+    assert p.read_text() == "original"
+    assert [entry.name for entry in tmp_path.iterdir()] == ["test.sql"]
+
+
+def test_safe_create_replace_file_cleans_up_on_encoding_error(tmp_path):
+    """An encoding failure while writing must not orphan the temp file."""
+    p = tmp_path / "test.sql"
+    p.write_text("original")
+    # A right-arrow is not representable in Windows-1252, so the write raises.
+    with pytest.raises(UnicodeEncodeError):
+        LintedFile._safe_create_replace_file(str(p), str(p), "\u2192", "Windows-1252")
+    assert p.read_text() == "original"
+    assert [entry.name for entry in tmp_path.iterdir()] == ["test.sql"]
 
 
 def test__linted_file__fix_string_generates_patches_when_not_precomputed():


### PR DESCRIPTION

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made

`LintedFile._safe_create_replace_file` is the writer `sqlfluff fix` uses to
atomically replace a file. Its docstring promises it writes to a temporary file
first "so in case of encoding or other issues, we don't delete or corrupt the
user's existing file."

The temp file is created with `tempfile.NamedTemporaryFile(..., delete=False)`,
so it is not auto-removed when the `with` block closes the descriptor. The steps
that follow (`os.chmod`, then `shutil.move`), and the write inside the block, had
no cleanup. If any of them raised, the temp file was left behind next to the
target. Because it is created with the target's basename as prefix and the same
suffix (e.g. `.sql`), the leftover looks like a real SQL file sitting next to the
user's file, so a systematically failing target directory drops one stray temp
file per file on every `sqlfluff fix`.

Realistic triggers: `EPERM`/`EACCES` from `chmod` on a restrictive or foreign
target directory (network/FUSE mounts, unusual umask), or `shutil.move` failing
on a read-only target, out of disk space (`ENOSPC`), or a cross-device edge; plus
an encoding error while writing (e.g. a character not representable in the
configured encoding).

This wraps the write, chmod and move in a `try`/`except` that removes the temp
file on any failure before re-raising, restoring the "no orphaned artifact"
guarantee. The enclosing `with` has already closed the descriptor by the time
cleanup runs, so `os.remove` is safe on every platform (including Windows, where
an open file cannot be removed). The happy path is unchanged.

Tests added in `test/core/linter/linted_file_test.py` cover the three failure
paths (`chmod` failure, `move` failure, and an encoding error via
`Windows-1252`) and assert both that the original file is untouched and that no
temp file is left in the directory.

### Are there any other side effects of this change that we should be aware of?

No behavioural change on the success path (verified end to end: a real
`SELECT  1` -> `SELECT 1` LT01 fix still rewrites the file through the move path
with no leftover temp file). The `except` clause catches `BaseException` on
purpose, so the temp file is also cleaned up if the write is interrupted (for
example by `KeyboardInterrupt`); it always re-raises, so no error is swallowed.
`BaseException` is already used elsewhere in this package
(`core/linter/runner.py`). Automated checks (ruff format, ruff check, mypy strict,
pytest for the linter package and the fix-related CLI tests) pass locally.


- Included test cases to demonstrate the code change:
  - Other: unit tests in `test/core/linter/linted_file_test.py` covering the
    chmod, move and encoding failure paths (this is core file-writing behaviour,
    not a rule or dialect, so the rule/parser/autofix fixture harnesses do not
    apply).
- The change is small and self-documenting; no user-facing docs change is
  needed.
- No follow-up issues required.

> AI assistance disclosure (per CONTRIBUTING "AI-Assisted Contributions"): AI
> tools were used to help locate the leak, draft the fix, and write the
> regression tests. I reviewed the diff, confirmed the failure modes, and
> validated it manually: I reverted only the source hunk and watched the three
> new tests fail leaving a real orphaned `.sql` temp file, then re-applied the
> fix and confirmed they pass, and I ran a real `sqlfluff fix` end to end to
> confirm the success path is unchanged and leaves no temp file. I take
> responsibility for its correctness, tests, and maintainability.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent orphaned temp files when `sqlfluff fix` fails to replace a file. `_safe_create_replace_file` now cleans up the temp file on any error so directories don’t fill with stray `.sql` files.

- **Bug Fixes**
  - Wrap temp write, `os.chmod`, and `shutil.move` in a try/except; delete the temp file and re-raise the error (safe on Windows).
  - Add tests for `chmod` failure, `move` failure, and an encoding error; verify the original file is unchanged and no temp file remains.
  - No change to the success path.

<sup>Written for commit 771dccd40e717ac0efd7b1cb0e6ba0c84bbf4a8b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8134?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

