### PR TITLE
fix(config): coerce quoted allow_implicit_indents deprecation value

### DIFF
--- a/src/sqlfluff/core/config/removed.py
+++ b/src/sqlfluff/core/config/removed.py
@@ -4,6 +4,7 @@ import logging
 from dataclasses import dataclass
 from typing import Callable, Optional, Union
 
+from sqlfluff.core.config.ini import coerce_value
 from sqlfluff.core.errors import SQLFluffUserError
 from sqlfluff.core.helpers.dict import (
     NestedStringDict,
@@ -15,6 +16,30 @@ from sqlfluff.core.types import ConfigMappingType, ConfigValueOrListType
 
 # Instantiate the config logger
 config_logger = logging.getLogger("sqlfluff.config")
+
+
+def _translate_allow_implicit_indents(
+    value: ConfigValueOrListType,
+) -> ConfigValueOrListType:
+    """Translate a deprecated ``allow_implicit_indents`` value.
+
+    The old value was a boolean, where ``true`` maps to ``allow`` and
+    ``false`` maps to ``forbid``. Ini config values are already coerced to
+    real booleans before they reach here, but toml preserves the written
+    type, so a quoted boolean (e.g. ``allow_implicit_indents = "false"``)
+    arrives as a string. Coerce string values the same way ini does before
+    testing them, so that a quoted ``"false"`` still maps to ``forbid``
+    rather than being treated as a truthy string.
+
+    Args:
+        value: The deprecated config value.
+
+    Returns:
+        ``"allow"`` for truthy values, otherwise ``"forbid"``.
+    """
+    if isinstance(value, str):
+        value = coerce_value(value)
+    return "allow" if value else "forbid"
 
 
 @dataclass
@@ -165,7 +190,7 @@ REMOVED_CONFIGS = [
             "Use 'forbid' (was false), 'allow' (was true), or 'require' instead."
         ),
         ("indentation", "implicit_indents"),
-        lambda x: "allow" if x else "forbid",
+        _translate_allow_implicit_indents,
     ),
 ]
 

--- a/test/core/config/validate_test.py
+++ b/test/core/config/validate_test.py
@@ -70,6 +70,37 @@ def test__validate_configs_precedence_same_file():
 
 
 @pytest.mark.parametrize(
+    "old_value,expected",
+    [
+        # Booleans, as produced by ini configs and native toml booleans.
+        (False, "forbid"),
+        (True, "allow"),
+        # Quoted booleans, as preserved by toml (e.g. `= "false"`). These must
+        # coerce like ini values so that a quoted "false" still maps to "forbid"
+        # rather than being treated as a truthy string.
+        ("false", "forbid"),
+        ("true", "allow"),
+        ("False", "forbid"),
+        ("True", "allow"),
+    ],
+)
+def test__validate_configs_allow_implicit_indents_translation(old_value, expected):
+    """Test translation of the deprecated allow_implicit_indents config."""
+    old_key = ("indentation", "allow_implicit_indents")
+    new_key = ("indentation", "implicit_indents")
+    # Confirm this key is still translated (guards against the test drifting).
+    assert any(
+        k.old_path == old_key and k.new_path == new_key for k in REMOVED_CONFIGS
+    ), (
+        "This test depends on this key still being removed. Update the test to "
+        "one that is if this one isn't."
+    )
+    config = records_to_nested_dict([(old_key, old_value)])
+    validate_config_dict_for_removed(config, "<test>")
+    assert config == {"indentation": {"implicit_indents": expected}}
+
+
+@pytest.mark.parametrize(
     "config_dict,config_warning",
     [
         ({"layout": "foo"}, "Found value 'foo' instead of a valid layout section"),


### PR DESCRIPTION

### Brief summary of the change made

The deprecation mapping for the removed `allow_implicit_indents` config translates
the old boolean to the new `implicit_indents` string (`true` -> `allow`,
`false` -> `forbid`). It did this with a truthiness test:

```python
lambda x: "allow" if x else "forbid"
```

That relies on the value already being a real boolean. For `.sqlfluff`/ini config
that holds, because ini values are coerced (`coerce_value` turns `false` into the
Python bool `False`) before this translation runs. TOML is different: it preserves
the written type, so a quoted boolean in `pyproject.toml` survives as a string:

```toml
[tool.sqlfluff.indentation]
allow_implicit_indents = "false"
```

Here `x` is the non-empty string `"false"`, which is truthy, so the value migrates
to `implicit_indents = allow`, the exact opposite of what the user asked for, and
silently (no error, no warning).

This change coerces string values the same way ini does before the truthiness test,
so a quoted `"false"` maps to `forbid`. The inline lambda is pulled out into a small
named helper (`_translate_allow_implicit_indents`) so the coercion has somewhere to
live and can be documented. Native booleans, native TOML booleans, and ini values
are unaffected.

Before / after for the four value shapes a config can carry:

| value in config              | before this PR    | after this PR   |
|------------------------------|-------------------|-----------------|
| `false` (ini or native toml) | forbid (correct)  | forbid          |
| `"false"` (quoted in toml)   | allow (wrong)     | forbid (fixed)  |
| `true` (ini or native toml)  | allow (correct)   | allow           |
| `"true"` (quoted in toml)    | allow (correct)   | allow           |

Only the quoted-`"false"` case was inverted; this PR corrects exactly that and
leaves the already-correct cases unchanged.

### Are there any other side effects of this change that we should be aware of?

None. The change is scoped to the single `allow_implicit_indents` removed-config
entry and only adds a coercion step for string inputs; behaviour for boolean inputs
(ini and native TOML) is identical to before. It adds one intra-`core` import
(`sqlfluff.core.config.ini.coerce_value`), which stays inside the `core` layer, so
the import-linter contracts are unaffected. No other removed-config translation
functions are touched.


- [x] Included test cases to demonstrate the code change:
  - **Other:** a parametrized unit test
    `test__validate_configs_allow_implicit_indents_translation` in
    `test/core/config/validate_test.py`, covering native booleans and quoted
    booleans (`"false"`, `"true"`, `"False"`, `"True"`). It also asserts the key is
    still present in `REMOVED_CONFIGS` so the test fails loudly if the mapping is
    later removed. (This is a config-translation fix, so ini/parser fixture harnesses
    do not apply; a unit test on the translation is the right level.)
- [x] Added appropriate documentation for the change: the new helper carries a
  Google-style docstring explaining the ini-vs-toml coercion difference. No
  user-facing docs change is needed (the config key is deprecated, not new).
- [x] Created GitHub issues for relevant followups if appropriate: none needed; the
  fix is self-contained.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the deprecated allow_implicit_indents translation so quoted TOML booleans are coerced before mapping to implicit_indents. This prevents inverted behavior where `allow_implicit_indents = "false"` incorrectly became `implicit_indents = allow`.

- **Bug Fixes**
  - Coerce string inputs via `coerce_value` in a new `_translate_allow_implicit_indents` helper so `"false"` maps to `"forbid"` and `"true"` to `"allow"`.
  - Added tests for boolean and quoted-boolean cases (including `"False"`/`"True"`).
  - Change is limited to this removed-config key; native boolean behavior is unchanged.

<sup>Written for commit 59cbd1f40b78adc7f28345686367c408485df639. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8135?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

