### PR TITLE
docs(reflow): fix ReflowSequence.respace filter value in docstring

### DIFF
--- a/src/sqlfluff/utils/reflow/sequence.py
+++ b/src/sqlfluff/utils/reflow/sequence.py
@@ -492,9 +492,9 @@ class ReflowSequence:
                 `reindent` or `reflow` methods.
             filter (:obj:`str`): Optionally filter which reflow points
                 to respace. Default configuration is `all`. Other options
-                are `line_break` which only respaces points containing
+                are `newline` which only respaces points containing
                 a `newline` or followed by an `end_of_file` marker, or
-                `inline` which is the inverse of `line_break`. This is
+                `inline` which is the inverse of `newline`. This is
                 most useful for filtering between trailing whitespace
                 and fixes between content on a line.
 


### PR DESCRIPTION
### Brief summary of the change made

`ReflowSequence.respace` documents its `filter` argument as accepting
`line_break`, but the method only accepts `all`, `newline`, or `inline`. The
assertion and the active branch both key off `newline`:

    assert filter in ("all", "newline", "inline"), \
        f"Unexpected value for filter: {filter}"

So a caller who follows the docstring and passes `filter="line_break"` hits
`AssertionError: Unexpected value for filter: line_break`. The correct value has
always been `newline`; only the docstring was wrong. This corrects the two
`line_break` references in the docstring to `newline`.

`ReflowSequence` is rendered in the API reference via the `autoclass` directive
in `docs/source/reference/internals/reflow.rst`, so this also fixes the wrong
value published on the docs site.

### Are there any other side effects of this change that we should be aware of?

No. This is a documentation-only change: it edits the `respace` docstring and
does not touch any runtime code path. The accepted filter values (`all`,
`newline`, `inline`) are unchanged.

- [x] Added appropriate documentation for the change.
- [x] Checked for duplicate PRs before opening.

No new test case is included: `newline` is already the accepted value and is
covered by the parametrized respace-filter test in
`test/utils/reflow/sequence_test.py` (over `all`/`newline`/`inline`). A test
asserting that the removed, never-valid `line_break` raises would not guard any
real behavior.

### Verification
- `ruff format --check src/sqlfluff/utils/reflow/sequence.py` -> already formatted
- `ruff check src/sqlfluff/utils/reflow/sequence.py` -> All checks passed
- `mypy src/sqlfluff/utils/reflow/sequence.py` -> Success, no issues found
- `python -m pytest test/utils/reflow/respace_test.py test/utils/reflow/sequence_test.py` -> 33 passed
- Empirically, after the change: `respace(filter="newline")` (and `all`/`inline`)
  succeeds, while `respace(filter="line_break")` still (correctly) raises
  `AssertionError`.

I did not run a full Sphinx docs build locally; the change is a plain docstring
edit and CI builds the docs.

AI-assisted disclosure: I used AI assistance to locate the mismatch between the
docstring and the assertion, confirm `line_break` was never a valid value, and
draft this documentation fix. I reviewed the final diff and ran the checks above
before submitting.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrected the `ReflowSequence.respace` docstring to use `filter="newline"` instead of `line_break`, matching the implementation. This updates the API docs so users pass a valid value (`all`, `newline`, or `inline`) and avoid assertion errors.

<sup>Written for commit 744cbf42926707e81759c6e47558256aed2bfc7c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8136?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

