### PR TITLE
fix(rust): bare-class grammars consume matching tokens unchanged

### DIFF
--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/core.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/core.rs
@@ -1369,10 +1369,21 @@ impl<'a> Parser<'a> {
         // Extract token_type from tables
         let tables = self.grammar_ctx.tables();
 
-        // Token stores token_type string id in aux_data at the instruction's
-        // aux_data_offsets index (the generator emits the type id there).
-        let token_type_id = tables.aux_data_offsets[grammar_id.get() as usize];
-        let token_type = tables.get_string(token_type_id).to_string();
+        // Token aux block: [type_id, class_name_id, flags, ct_count, ct_ids...].
+        // A bare class matches iff the token is already an isinstance, and is
+        // then kept unchanged (no re-mint). isinstance = class's _class_types ⊆
+        // token's class chain, plus is_code/is_comment/is_whitespace equality
+        // for raw targets (flags bit3): CodeSegment's chain is only {base,raw},
+        // so without the flags a whitespace/comment token passes the subset.
+        let (aux_start, aux_end) = aux_block_bounds(tables, grammar_id);
+        #[cfg(feature = "verbose-debug")]
+        let token_type = tables.get_string(tables.aux_data[aux_start]).to_string();
+        let class_flags = if aux_start + 2 < aux_end {
+            tables.aux_data[aux_start + 2]
+        } else {
+            0
+        };
+        let class_type_ids = read_string_ids_from_aux(tables, aux_start + 3, aux_end);
 
         vdebug!(
             "Token[table]: pos={}, token_type='{}'",
@@ -1380,24 +1391,40 @@ impl<'a> Parser<'a> {
             token_type
         );
 
+        let is_instance = |tok: &sqlfluffrs_types::Token| -> bool {
+            let chain = &tok.class_types;
+            if !class_type_ids
+                .iter()
+                .all(|id| chain.contains(tables.get_string(*id)))
+            {
+                return false;
+            }
+            if class_flags & 0b1000 != 0 {
+                tok.is_code() == (class_flags & 0b0001 != 0)
+                    && tok.is_comment() == (class_flags & 0b0010 != 0)
+                    && tok.is_whitespace() == (class_flags & 0b0100 != 0)
+            } else {
+                true
+            }
+        };
+
         match self.peek() {
-            Some(tok) if tok.is_type(&[&token_type]) => {
+            Some(tok) if is_instance(tok) => {
                 let token_pos = self.pos;
                 #[cfg(feature = "verbose-debug")]
                 let raw = tok.raw().to_owned();
                 self.bump();
 
                 vdebug!(
-                    "Token[table] MATCHED: type='{}', raw='{}' at pos={}",
+                    "Token[table] MATCHED (instance, kept unchanged): type='{}', raw='{}' at pos={}",
                     token_type,
                     raw,
                     token_pos
                 );
 
-                // Return MatchResult spanning this single token
-                // The apply() method will retrieve token data from the tokens array
                 Ok(MatchResult {
                     matched_slice: token_pos..token_pos + 1,
+                    matched_class: None,
                     ..Default::default()
                 })
             }

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/ref_grammar.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/ref_grammar.rs
@@ -245,102 +245,39 @@ impl Parser<'_> {
                 "Ref[table] Combining DEBUG: accumulated nodes={:?}",
                 ref_match_result
             );
-            // TODO: make this cleaner
-            // Python parity for leaf token grammars (CodeSegment, WordSegment etc.):
-            // When `Ref("CodeSegment")` resolves to Token("raw") and matches a token,
-            // Python uses isinstance() which preserves the token's original class.
-            // A WordSegment token matched by CodeSegment stays a WordSegment (type="word"),
-            // not gets retyped to "raw".
-            //
-            // We detect this "isinstance path" when:
-            //   1. The resolved segment_type matches a "base" class type like "raw" (= CodeSegment.type)
-            //   2. The child match is a bare token match (no matched_class, exactly 1 token)
-            //
-            // In that case, use the actual token's effective type (instance_types[0] or token_type).
-            // `state.segment_type` is `Option<&'static str>` (Copy), so binding by
-            // value keeps the `'static` lifetime — the common case borrows the
-            // grammar-table string into the node with no allocation. Only the
-            // isinstance override (a runtime token type) takes the owned branch.
-            // Holds the token's full instance type list when the isinstance
-            // path below overrides the grammar-table segment_type, so
-            // `segment_kwargs.instance_types` (below) can carry every type the
-            // token is an instance of - not just the effective/leaf one -
-            // matching Python's `RawSegment.class_types` (instance_types ∪
-            // class_types), which RustParser.parse()'s Python-side tree
-            // builder reads its type override from.
-            let mut isinstance_override: Option<Vec<String>> = None;
-            let effective_segment_type: Cow<'static, str> = if let Some(seg_type) =
-                state.segment_type
-            {
-                // Check if the child match is a bare single-token match (no matched_class)
-                // by looking at the match_result's matched_class and slice length
-                let is_bare_token_match = ref_match_result.matched_class.is_none()
-                    && ref_match_result.matched_slice.len() == 1
-                    && ref_match_result.child_matches.is_empty();
-
-                if is_bare_token_match {
-                    let token_idx = ref_match_result.matched_slice.start;
-                    if let Some(tok) = self.tokens.get(token_idx) {
-                        // Get effective type as &str WITHOUT cloning first so the common
-                        // case (types already match) pays no allocation cost.
-                        // Python RawSegment.get_type() = instance_types[0] if set else class.type
-                        let effective = tok
-                            .instance_types
-                            .first()
-                            .map(String::as_str)
-                            .unwrap_or(tok.token_type.as_ref());
-
-                        if effective != seg_type {
-                            vdebug!(
-                                "Ref[table] isinstance-path: preserving token type '{}' over segment_type '{}' for token '{}'",
-                                effective,
-                                seg_type,
-                                tok.raw()
-                            );
-                            isinstance_override = Some(if tok.instance_types.is_empty() {
-                                vec![effective.to_string()]
-                            } else {
-                                tok.instance_types.clone()
-                            });
-                            Cow::Owned(effective.to_string())
-                        } else {
-                            Cow::Borrowed(seg_type)
-                        }
-                    } else {
-                        Cow::Borrowed(seg_type)
-                    }
-                } else {
-                    Cow::Borrowed(seg_type)
-                }
-            } else {
-                Cow::Borrowed(state.segment_type.unwrap_or_default())
-            };
+            // A Ref to a bare (match_grammar-less) class mirrors native
+            // BaseSegment.match's isinstance path: consume the matched token
+            // unchanged, no class wrap, so its lexed type/class chain survives.
+            let is_token_target = self.grammar_ctx.variant(state.child_grammar_id)
+                == sqlfluffrs_types::GrammarVariant::Token;
 
             vdebug!(
-                "Ref[table] Combining: name='{}', effective_segment_type='{}', creating ref_match",
+                "Ref[table] Combining: name='{}', is_token_target={}, creating ref_match",
                 state.name,
-                effective_segment_type
+                is_token_target
             );
-            let matched_class = if !effective_segment_type.is_empty()
+            let matched_class = if is_token_target {
+                None
+            } else if state.segment_type.is_some_and(|t| !t.is_empty())
                 || state.segment_class_name.is_some()
             {
+                // `state.segment_type` is `Option<&'static str>` (Copy), so
+                // binding by value keeps the `'static` lifetime — this
+                // borrows the grammar-table string into the node with no
+                // allocation.
+                let segment_type: Cow<'static, str> =
+                    Cow::Borrowed(state.segment_type.unwrap_or_default());
                 // Look up the Python _class_types hierarchy for this grammar from codegen tables.
                 let class_types = self.grammar_ctx.segment_class_types(state.grammar_id);
-                // rust_parser.py's tree builder (_rs_match_fields/
-                // _apply_rs_match_result) reads its type override from
-                // `segment_kwargs["instance_types"]`; `MatchedClass.segment_type`
-                // only feeds Rust's internal Node tree.
-                let instance_types = isinstance_override;
                 Some(MatchedClass {
                     // take() instead of clone() + unwrap — frame context is not read
                     // again after this point (state transitions to Complete).
                     // segment_class_name is Option<&'static str> (PR #8002), so
                     // borrow the grammar-table class name straight into the node.
                     class_name: Cow::Borrowed(state.segment_class_name.take().unwrap_or_default()),
-                    segment_type: Some(effective_segment_type),
+                    segment_type: Some(segment_type),
                     segment_kwargs: SegmentKwargs {
                         class_types,
-                        instance_types,
                         ..Default::default()
                     },
                 })

--- a/test/core/parser/rust_parser_test.py
+++ b/test/core/parser/rust_parser_test.py
@@ -1076,7 +1076,7 @@ def test__rust_parser__vs_python_bare_class_ref_preserves_class_types(dialect, s
     def leaves(tree):
         return [s for s in tree.recursive_crawl_all() if not s.segments]
 
-    for py_leaf, rs_leaf in zip(leaves(python_tree), leaves(rust_tree)):
+    for py_leaf, rs_leaf in zip(leaves(python_tree), leaves(rust_tree), strict=True):
         assert set(rs_leaf.class_types) == set(py_leaf.class_types), (
             f"class_types diverge for {py_leaf.raw!r}: "
             f"python={sorted(set(py_leaf.class_types))} "

--- a/test/core/parser/rust_parser_test.py
+++ b/test/core/parser/rust_parser_test.py
@@ -975,15 +975,11 @@ def test__rust_parser__vs_python_snowflake_numeric_literal_mistyped():
     a bare segment class with no dialect-specific match_grammar, so
     Python's isinstance fast path returns the already-lexed "10" token
     unwrapped, preserving its lex-time "numeric_literal" type.
-    RustParser's `handle_ref_combining` (ref_grammar.rs) computed that same
-    preserved type, but only fed it into `MatchedClass.segment_type` -
-    which feeds Rust's internal Node tree, not the Python-facing tree
-    RustParser.parse() actually builds. That builder reads the override
-    from `segment_kwargs["instance_types"]` instead, so the correct type
-    was silently dropped in favor of the generic "literal" default.
-
-    Fixed by also setting `segment_kwargs.instance_types` whenever the
-    isinstance-override applies.
+    RustParser's `handle_ref_combining` (ref_grammar.rs) used to wrap the
+    matched token in the grammar's class, re-typing it to the generic
+    "literal" default. It now mirrors native `BaseSegment.match`: a Ref to
+    a bare (match_grammar-less) class consumes the token UNCHANGED, so its
+    lexer-assigned type and full class chain are preserved.
 
     Uses the real, already-shipped snowflake/create_catalog_integration.sql
     fixture.
@@ -1026,16 +1022,66 @@ def test__rust_parser__vs_python_tsql_sqlcmd_command_loses_token_type():
 
     Same root cause and fix as
     test__rust_parser__vs_python_snowflake_numeric_literal_mistyped: a
-    `Ref` to a bare segment class hits Python's isinstance fast path,
-    and the preserved type now gets threaded through
-    `segment_kwargs.instance_types` so RustParser.parse()'s Python-side
-    tree builder picks it up too.
+    `Ref` to a bare segment class hits Python's isinstance fast path, so
+    the matched token is now consumed UNCHANGED (no class wrap, no
+    re-mint), preserving its lexer-assigned type and full class chain.
 
     Uses the real, already-shipped tsql/sqlcmd_command.sql fixture.
     """
     sql = _read_fixture("tsql", "sqlcmd_command.sql")
     rust_result, python_result = _compare_parser_vs_rust(sql, dialect="tsql")
     assert rust_result == python_result
+
+
+@pytest.mark.skipif(not _HAS_RUST_PARSER, reason="Rust parser not available")
+@pytest.mark.parametrize(
+    "dialect,sql",
+    [
+        # A numeric value routes a LiteralSegment (class chain includes the
+        # class-level `literal`) through the bare `Ref("CodeSegment")` that
+        # matches :setvar content - an ANCESTOR of the token's class.
+        ("tsql", ":setvar count 10"),
+        # The shipped fixture's quoted/word values are CodeSegment instances
+        # directly, so they were always safe - kept here as a control.
+        ("tsql", ':setvar count "variable_value"'),
+        # Snowflake numeric literal via a bare `LiteralSegment` reference.
+        (
+            "snowflake",
+            "CREATE CATALOG INTEGRATION glue_int CATALOG_SOURCE = GLUE "
+            "REFRESH_INTERVAL_SECONDS = 10;",
+        ),
+    ],
+)
+def test__rust_parser__vs_python_bare_class_ref_preserves_class_types(dialect, sql):
+    """A bare-class ``Ref`` must preserve the token's FULL class_types chain.
+
+    Guards a blind spot: ``to_tuple`` (used by ``_compare_parser_vs_rust``)
+    only records each leaf's ``get_type()``, not its ``class_types`` set.
+    When a bare-class ``Ref`` targets an ANCESTOR of the matched token's
+    class (e.g. ``Ref("CodeSegment")`` over a ``LiteralSegment`` numeric
+    value in ``:setvar count 10``), an earlier fix that rebuilt the chain
+    as ``ancestor-class ∪ instance_types`` produced the right ``get_type()``
+    but silently dropped the class-level type (here ``literal``) - invisible
+    to a ``to_tuple`` comparison. Bare-class grammars now consume the token
+    unchanged, so its native ``class_types`` is preserved exactly.
+    """
+    from sqlfluff.core import FluffConfig
+    from sqlfluff.core.parser import Lexer, Parser
+
+    config = FluffConfig(overrides={"dialect": dialect})
+    segments, _ = Lexer(config=config).lex(sql)
+    python_tree = Parser(config=config).parse(segments, fname="t.sql")
+    rust_tree = RustParser(config=config).parse(segments, fname="t.sql")
+
+    def leaves(tree):
+        return [s for s in tree.recursive_crawl_all() if not s.segments]
+
+    for py_leaf, rs_leaf in zip(leaves(python_tree), leaves(rust_tree)):
+        assert set(rs_leaf.class_types) == set(py_leaf.class_types), (
+            f"class_types diverge for {py_leaf.raw!r}: "
+            f"python={sorted(set(py_leaf.class_types))} "
+            f"rust={sorted(set(rs_leaf.class_types))}"
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/utils/build_parsers.py
+++ b/utils/build_parsers.py
@@ -27,6 +27,7 @@ from sqlfluff.core.parser.parsers import (
 )
 from sqlfluff.core.parser.segments.base import BaseSegment, SegmentMetaclass
 from sqlfluff.core.parser.segments.meta import MetaSegment
+from sqlfluff.core.parser.segments.raw import RawSegment
 
 
 @dataclass
@@ -1298,8 +1299,33 @@ class TableBuilder:
         )
 
     def _handle_token(self, grammar, parse_context) -> GrammarInstData:
-        """Convert Token (BaseSegment without match_grammar) to GrammarInst."""
+        """Convert Token (BaseSegment without match_grammar) to GrammarInst.
+
+        Aux block: ``[type_id, class_name_id, flags, ct_count, ct_ids...]``.
+        A bare class matches iff the token is already an ``isinstance`` (kept
+        unchanged), reproduced as ``_class_types`` ⊆ the token's class chain
+        plus, for RawSegment subclasses, ``is_code``/``is_comment``/
+        ``is_whitespace`` equality (flags word: bit3 = raw-target valid,
+        bit0/1/2 = is_code/is_comment/is_whitespace). The flags are needed
+        because ``CodeSegment``'s chain is only ``{base, raw}``.
+        """
         type_id = self._add_string(grammar.type)
+        class_id = self._add_string(grammar.__name__)
+        class_types = sorted(getattr(grammar, "_class_types", frozenset()))
+        flags = 0
+        if issubclass(grammar, RawSegment):
+            flags = (
+                0b1000
+                | (0b0001 if grammar._is_code else 0)
+                | (0b0010 if grammar._is_comment else 0)
+                | (0b0100 if grammar._is_whitespace else 0)
+            )
+        aux_offset = len(self.aux_data)
+        self.aux_data.append(type_id)
+        self.aux_data.append(class_id)
+        self.aux_data.append(flags)
+        self.aux_data.append(len(class_types))
+        self.aux_data.extend(self._add_string(t) for t in class_types)
         return GrammarInstData(
             variant="Token",
             flags=0,
@@ -1309,7 +1335,7 @@ class TableBuilder:
             min_times=0,
             first_terminator_idx=len(self.terminators),
             terminator_count=0,
-            aux_data_offset=type_id,
+            aux_data_offset=aux_offset,
             simple_hint_idx=0,
             comment=f'Token("{grammar.type}")',
         )


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
A Ref to a bare (`match_grammar`-less) segment class now consumes the matched token unchanged, mirroring native `BaseSegment.match`'s `isinstance` path instead of re-wrapping it in the referenced class. 

#8122 corrected the reported `get_type()` for these tokens but rebuilt class_types as referenced-class ∪ instance_types, which silently dropped the token's class-level types when the Ref targeted an ancestor of the token's class. Example: `:setvar count 10`, where a `LiteralSegment` numeric value is matched by `Ref("CodeSegment")`:

| | `class_types` |
|---|---|
| Python `Parser` | `{base, raw, literal, numeric_literal}` |
| RustParser (#8122) | `{base, raw, numeric_literal}` ← `literal` dropped |
| RustParser (this PR) | `{base, raw, literal, numeric_literal}` ✅ |

`get_type()` was already correct on both sides, so `to_tuple`-based tests couldn't see the divergence but rules matching on `is_type("literal")` could.

### Are there any other side effects of this change that we should be aware of?
None

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bare-class `Ref` grammars now consume the matched token unchanged in the Rust parser, matching Python’s isinstance path so tokens keep their lexer-assigned type and full class chain. Fixes cases where ancestor-class refs (e.g., `Ref("CodeSegment")`) dropped class-level types like `literal`.

- **Bug Fixes**
  - Match bare-class refs via an isinstance check: `_class_types` subset plus raw-segment flags for `is_code`/`is_comment`/`is_whitespace`; no re-minting.
  - Do not wrap tokens for bare-class refs (`matched_class: None`), preserving original types and `class_types`.
  - Extend codegen aux data to `[type_id, class_name_id, flags, ct_count, ct_ids...]` and read it in the matcher.
  - Add tests asserting `class_types` parity with Python for TSQL `:setvar` values and Snowflake numeric literals; use strict zip to ensure leaf alignment.

<sup>Written for commit 834389b31cd370ddf625b6bfdc06226e74f0f8c9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8138?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

