### PR TITLE
perf: lazy SegmentCloneMap in ST05 — clone only when a subquery is rewritten

### DIFF
--- a/src/sqlfluff/rules/structure/ST05.py
+++ b/src/sqlfluff/rules/structure/ST05.py
@@ -619,17 +619,34 @@ def _segmentify(input_el: str, casing: str) -> BaseSegment:
 
 
 class SegmentCloneMap:
-    """Clones a segment tree, maps from original segments to their clones."""
+    """Clones a segment tree, maps from original segments to their clones.
+
+    The clone (a full ``segment.copy()``) is built lazily on first lookup: the
+    caller builds the map for every SELECT statement but only *uses* it when
+    there are subqueries to rewrite, so deferring avoids cloning the whole
+    statement tree on the common no-subquery path (a notable cost over the Rust
+    arena façade, where copy() materialises real segments).
+    """
 
     def __init__(self, segment: BaseSegment):
+        self._segment = segment
+        self.segment_map: Optional[dict[int, BaseSegment]] = None
+
+    def _build(self) -> dict[int, BaseSegment]:
+        segment = self._segment
         segment_copy = segment.copy()
-        self.segment_map = {}
+        segment_map: dict[int, BaseSegment] = {}
         for old_segment, new_segment in zip(
             segment.recursive_crawl_all(),
             segment_copy.recursive_crawl_all(),
         ):
             new_segment.pos_marker = old_segment.pos_marker
-            self.segment_map[id(old_segment)] = new_segment
+            segment_map[id(old_segment)] = new_segment
+        self.segment_map = segment_map
+        return segment_map
 
     def __getitem__(self, old_segment: BaseSegment) -> BaseSegment:
-        return self.segment_map[id(old_segment)]
+        segment_map = self.segment_map
+        if segment_map is None:
+            segment_map = self._build()
+        return segment_map[id(old_segment)]


### PR DESCRIPTION
### Brief summary of the change made

ST05 built `SegmentCloneMap` (a full `segment.copy()` of the SELECT statement tree) for every `select_statement`, before `_lint_query` determines whether there is any subquery to extract. The clone is only *used* when there are results, so this builds it lazily on first `__getitem__`. On the no-subquery path (the common case) nothing is cloned.

This is a straightforward perf win natively (segment `copy()` is a `__dict__` update per segment, per subtree), and matters more for alternative segment implementations where `copy()` is more expensive. Measured on a 20x-duplicated file with an all-74-rule crawl: non-reflow rule cost 26.9→14.5 ms.

### Are there any other side effects of this change that we should be aware of?

None — ST05 output is unchanged (`pytest test/rules -k ST05` = 47 passed).

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - Covered by the existing ST05 `.yml` rule test cases (no behavior change).
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `SegmentCloneMap` in ST05 lazy so the SELECT tree is only cloned when a subquery is actually rewritten. This removes unnecessary cloning on the common no-subquery path and speeds up ST05 without changing output.

- **Refactors**
  - Defer the full clone to first `__getitem__`; store the original segment until then.
  - Preserve `pos_marker` mapping; ST05 behavior unchanged (tests pass).
  - Perf: non-reflow subset ~26.9→14.5 ms; all-rules crawl ~130→103 ms on the façade (native ~109→92 ms).

<sup>Written for commit 6c6f1eb6a90ebc973caae53364e015e21b9c1acd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8141?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

