### PR TITLE
fix(convention): build CV11 replacements parse-shaped

### DIFF
--- a/src/sqlfluff/rules/convention/CV11.py
+++ b/src/sqlfluff/rules/convention/CV11.py
@@ -10,8 +10,14 @@ from sqlfluff.core.parser import (
     WhitespaceSegment,
     WordSegment,
 )
+from sqlfluff.core.parser.segments.bracketed import BracketedSegment
 from sqlfluff.core.rules import BaseRule, LintFix, LintResult, RuleContext
 from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
+from sqlfluff.dialects.dialect_ansi import (
+    FunctionContentsSegment,
+    FunctionNameSegment,
+    FunctionSegment,
+)
 from sqlfluff.utils.functional import FunctionalContext, Segments, sp
 
 
@@ -85,91 +91,113 @@ class Rule_CV11(BaseRule):
         )
 
     @staticmethod
+    def _build_function(name: str, contents: list[BaseSegment]) -> FunctionSegment:
+        """Construct a parse-shaped ``function`` segment.
+
+        The nesting (``function > function_name`` and ``function >
+        function_contents > bracketed``) must mirror how the same SQL would
+        parse. The fix loop doesn't reparse between rule passes, so a flat
+        sequence of raw tokens here would present a different shape to
+        later rules in the same pass — reflow spacing (LT01) keys "touch"
+        off the ``function_name``/``function_contents`` containers and would
+        wrongly insert a space after the function name (which the next,
+        freshly-parsed run would then remove again: a non-convergent fix).
+        """
+        start = SymbolSegment("(", type="start_bracket")
+        end = SymbolSegment(")", type="end_bracket")
+        return FunctionSegment(
+            segments=(
+                FunctionNameSegment(
+                    segments=(WordSegment(name, type="function_name_identifier"),)
+                ),
+                FunctionContentsSegment(
+                    segments=(
+                        BracketedSegment(
+                            segments=(start, *contents, end),
+                            start_bracket=(start,),
+                            end_bracket=(end,),
+                        ),
+                    )
+                ),
+            )
+        )
+
+    @classmethod
     def _cast_fix_list(
+        cls,
         context: RuleContext,
         cast_arg_1: Iterable[BaseSegment],
         cast_arg_2: BaseSegment,
         later_types: Optional[Segments] = None,
     ) -> list[LintFix]:
         """Generate list of fixes to convert CONVERT and ShorthandCast to CAST."""
-        # Add cast and opening parenthesis.
-        edits = (
-            [
-                WordSegment("cast", type="function_name_identifier"),
-                SymbolSegment("(", type="start_bracket"),
-            ]
-            + list(cast_arg_1)
+        cast_function = cls._build_function(
+            "cast",
+            list(cast_arg_1)
             + [
                 WhitespaceSegment(),
                 KeywordSegment("as"),
                 WhitespaceSegment(),
                 cast_arg_2,
-                SymbolSegment(")", type="end_bracket"),
-            ]
+            ],
         )
 
         if later_types:
-            pre_edits: list[BaseSegment] = [
-                WordSegment("cast", type="function_name_identifier"),
-                SymbolSegment("(", type="start_bracket"),
-            ]
-            in_edits: list[BaseSegment] = [
-                WhitespaceSegment(),
-                KeywordSegment("as"),
-                WhitespaceSegment(),
-            ]
-            post_edits: list[BaseSegment] = [
-                SymbolSegment(")", type="end_bracket"),
-            ]
             for _type in later_types:
-                edits = pre_edits + edits + in_edits + [_type] + post_edits
+                cast_function = cls._build_function(
+                    "cast",
+                    [
+                        cast_function,
+                        WhitespaceSegment(),
+                        KeywordSegment("as"),
+                        WhitespaceSegment(),
+                        _type,
+                    ],
+                )
 
         fixes = [
             LintFix.replace(
                 context.segment,
-                edits,
+                [cast_function],
             )
         ]
         return fixes
 
-    @staticmethod
+    @classmethod
     def _convert_fix_list(
+        cls,
         context: RuleContext,
         convert_arg_1: BaseSegment,
         convert_arg_2: BaseSegment,
         later_types=None,
     ) -> list[LintFix]:
         """Generate list of fixes to convert CAST and ShorthandCast to CONVERT."""
-        # Add convert and opening parenthesis.
-        edits = [
-            WordSegment("convert", type="function_name_identifier"),
-            SymbolSegment("(", type="start_bracket"),
-            convert_arg_1,
-            SymbolSegment(",", type="comma"),
-            WhitespaceSegment(),
-            convert_arg_2,
-            SymbolSegment(")", type="end_bracket"),
-        ]
-
-        if later_types:
-            pre_edits: list[BaseSegment] = [
-                WordSegment("convert", type="function_name_identifier"),
-                SymbolSegment("(", type="start_bracket"),
-            ]
-            in_edits: list[BaseSegment] = [
+        convert_function = cls._build_function(
+            "convert",
+            [
+                convert_arg_1,
                 SymbolSegment(",", type="comma"),
                 WhitespaceSegment(),
-            ]
-            post_edits: list[BaseSegment] = [
-                SymbolSegment(")", type="end_bracket"),
-            ]
+                convert_arg_2,
+            ],
+        )
+
+        if later_types:
             for _type in later_types:
-                edits = pre_edits + [_type] + in_edits + edits + post_edits
+                convert_function = cls._build_function(
+                    "convert",
+                    [
+                        _type,
+                        SymbolSegment(",", type="comma"),
+                        WhitespaceSegment(),
+                        convert_function,
+                    ],
+                )
 
         fixes = [
             LintFix.replace(
                 context.segment,
-                edits,
+                [convert_function],
             )
         ]
         return fixes


### PR DESCRIPTION
### Brief summary of the change made

CV11 constructed its `cast()`/`convert()` rewrites as a **flat** run of raw tokens (`function_name_identifier`, `start_bracket`, ...). The fix loop doesn't reparse between rule passes, so later rules in the same pass saw that flat shape — and reflow keys its "touch" spacing off the `function_name`/`function_contents` containers, so LT01 inserted a stray space after the constructed name (`cast (col1 as integer)`) that a fresh parse would flag and remove: a non-convergent fix (reproducible with CV11+LT01 on `redshift/cast_conversion.sql` and `tsql/binary_constants_functions.sql`).

`_build_function` now nests the replacement exactly as it would parse (`function` > `function_name` + `function_contents` > `bracketed`), for both the cast and convert styles, including the chained-cast `later_types` loop. First-run output now matches what a second run used to produce.

### Are there any other side effects of this change that we should be aware of?

None — CV11's own fix output is unchanged (38 tests pass); only the *tree shape* handed to subsequent rules in the same pass changes.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - Covered by the existing CV11 `.yml` rule test cases and autofix cases.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Builds CV11 `CAST`/`CONVERT` rewrites as parse-shaped function segments to match the parser and stop LT01 from inserting a stray space. Fixes the non-convergent behavior so the first run matches subsequent runs.

- **Bug Fixes**
  - Added `_build_function()` to create nested `function` → `function_name` + `function_contents` → `bracketed` segments using `FunctionSegment`, `FunctionNameSegment`, `FunctionContentsSegment`, and `BracketedSegment`.
  - Applied to both `cast(...)` and `convert(...)`, including chained casts via `later_types`.
  - Removes cases like `cast (col1 as integer)` caused by flat token edits.
  - `CV11` output stays the same; only the tree shape for later rules changes.

<sup>Written for commit 5069bc95a94f2e739176cdf54f0dff9b24d4f8fd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8142?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

