### PR TITLE
fix(convention): make CV07's fix order deterministic

### DIFF
--- a/src/sqlfluff/rules/convention/CV07.py
+++ b/src/sqlfluff/rules/convention/CV07.py
@@ -104,7 +104,12 @@ class Rule_CV07(BaseRule):
                 .reversed()
             )
             self.logger.debug("Trailing: %s", trailing)
-            lift_nodes = set(leading + trailing)
+            # Order-preserving dedupe (leading and trailing can overlap when
+            # everything inside the brackets is liftable). A ``set`` here made
+            # the DELETE fix order — and therefore the serialised lint record
+            # — depend on segment hashes, which are PYTHONHASHSEED-salted,
+            # i.e. nondeterministic across runs.
+            lift_nodes = list(dict.fromkeys(leading + trailing))
             fixes = []
             if lift_nodes:
                 fixes.append(LintFix.create_before(parent, list(leading)))


### PR DESCRIPTION
### Brief summary of the change made

CV07 collected its lift-out segments in a `set`, so the order of the DELETE fixes — and therefore the `fixes` payload in serialized lint records (json/yaml) — depended on segment hash values, which are `PYTHONHASHSEED`-salted: the same invocation could produce differently ordered output run to run (verified: three seeds, three orders). The final *fixed text* was always deterministic; only the reported fix ordering wobbled.

An order-preserving dedupe (`dict.fromkeys`) keeps the overlap handling (leading and trailing can share segments when everything inside the brackets is liftable) while emitting fixes in document order.

### Are there any other side effects of this change that we should be aware of?

None — fix output is unchanged; only the ordering of the emitted `LintFix`es becomes stable (document order).

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - Covered by the existing CV07 `.yml` rule test cases (behavior-neutral; ordering was previously unasserted *because* it was random).
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make CV07’s DELETE fix order deterministic so lint records have a stable `fixes` list across runs. Replaces a `set` with ordered dedupe; fixed text is unchanged.

- **Bug Fixes**
  - Dedupes lift-out segments with `list(dict.fromkeys(leading + trailing))` to preserve order and handle overlap.
  - Emits `LintFix`es in document order; `json/yaml` `fixes` no longer vary with `PYTHONHASHSEED`.
  - Aligns the Rust engine façade’s lint record order with the Python engine for the same inputs.

<sup>Written for commit 724d69300e15a4d18b59ea15841a2e446af1eacb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8144?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

