### PR TITLE
feat(postgres): support GENERATED ALWAYS AS (...) VIRTUAL (#8139)

### DIFF
--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -3971,7 +3971,13 @@ class ColumnConstraintSegment(ansi.ColumnConstraintSegment):
                     Ref("ExpressionSegment"),
                 ),
             ),
-            Sequence("GENERATED", "ALWAYS", "AS", Ref("ExpressionSegment"), "STORED"),
+            Sequence(
+                "GENERATED",
+                "ALWAYS",
+                "AS",
+                Ref("ExpressionSegment"),
+                OneOf("STORED", "VIRTUAL", optional=True),
+            ),
             Sequence(
                 "GENERATED",
                 OneOf("ALWAYS", Sequence("BY", "DEFAULT")),
@@ -4056,8 +4062,14 @@ class ForeignTableColumnConstraintSegment(ansi.ColumnConstraintSegment):
                     Ref("ExpressionSegment"),
                 ),
             ),
-            # GENERATED ALWAYS AS ( generation_expr ) STORED
-            Sequence("GENERATED", "ALWAYS", "AS", Ref("ExpressionSegment"), "STORED"),
+            # GENERATED ALWAYS AS ( generation_expr ) [ STORED | VIRTUAL ]
+            Sequence(
+                "GENERATED",
+                "ALWAYS",
+                "AS",
+                Ref("ExpressionSegment"),
+                OneOf("STORED", "VIRTUAL", optional=True),
+            ),
         ),
     )
 

--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -3975,7 +3975,7 @@ class ColumnConstraintSegment(ansi.ColumnConstraintSegment):
                 "GENERATED",
                 "ALWAYS",
                 "AS",
-                Ref("ExpressionSegment"),
+                Bracketed(Ref("ExpressionSegment")),
                 OneOf("STORED", "VIRTUAL", optional=True),
             ),
             Sequence(
@@ -4067,7 +4067,7 @@ class ForeignTableColumnConstraintSegment(ansi.ColumnConstraintSegment):
                 "GENERATED",
                 "ALWAYS",
                 "AS",
-                Ref("ExpressionSegment"),
+                Bracketed(Ref("ExpressionSegment")),
                 OneOf("STORED", "VIRTUAL", optional=True),
             ),
         ),

--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -4034,7 +4034,7 @@ class ColumnConstraintSegment(ansi.ColumnConstraintSegment):
                 "GENERATED",
                 "ALWAYS",
                 "AS",
-                Ref("ExpressionSegment"),
+                Bracketed(Ref("ExpressionSegment")),
                 OneOf("STORED", "VIRTUAL", optional=True),
             ),
             Sequence(
@@ -4126,7 +4126,7 @@ class ForeignTableColumnConstraintSegment(ansi.ColumnConstraintSegment):
                 "GENERATED",
                 "ALWAYS",
                 "AS",
-                Ref("ExpressionSegment"),
+                Bracketed(Ref("ExpressionSegment")),
                 OneOf("STORED", "VIRTUAL", optional=True),
             ),
         ),

--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -4030,7 +4030,13 @@ class ColumnConstraintSegment(ansi.ColumnConstraintSegment):
                     Ref("ExpressionSegment"),
                 ),
             ),
-            Sequence("GENERATED", "ALWAYS", "AS", Ref("ExpressionSegment"), "STORED"),
+            Sequence(
+                "GENERATED",
+                "ALWAYS",
+                "AS",
+                Ref("ExpressionSegment"),
+                OneOf("STORED", "VIRTUAL", optional=True),
+            ),
             Sequence(
                 "GENERATED",
                 OneOf("ALWAYS", Sequence("BY", "DEFAULT")),
@@ -4115,8 +4121,14 @@ class ForeignTableColumnConstraintSegment(ansi.ColumnConstraintSegment):
                     Ref("ExpressionSegment"),
                 ),
             ),
-            # GENERATED ALWAYS AS ( generation_expr ) STORED
-            Sequence("GENERATED", "ALWAYS", "AS", Ref("ExpressionSegment"), "STORED"),
+            # GENERATED ALWAYS AS ( generation_expr ) [ STORED | VIRTUAL ]
+            Sequence(
+                "GENERATED",
+                "ALWAYS",
+                "AS",
+                Ref("ExpressionSegment"),
+                OneOf("STORED", "VIRTUAL", optional=True),
+            ),
         ),
     )
 

--- a/src/sqlfluff/dialects/dialect_postgres_keywords.py
+++ b/src/sqlfluff/dialects/dialect_postgres_keywords.py
@@ -890,6 +890,7 @@ postgres_docs_keywords = [
     ("VERSIONING", "not-keyword"),
     ("VIEW", "non-reserved"),
     ("VIEWS", "non-reserved"),
+    ("VIRTUAL", "non-reserved"),
     ("VOLATILE", "non-reserved"),
     ("WHEN", "reserved"),
     ("WHENEVER", "not-keyword"),

--- a/test/fixtures/dialects/postgres/create_foreign_table.yml
+++ b/test/fixtures/dialects/postgres/create_foreign_table.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: cdcbe24329fb7f0e321e4ad584f94a5d6e918340c17cc53d61af8dedc57a473d
+_hash: 4f1734f630ee47d7a045af95feeabe73761863f3bcf3815ace163a70b26ef29b
 file:
 - statement:
     create_foreign_table_statement:
@@ -100,15 +100,14 @@ file:
         - keyword: GENERATED
         - keyword: ALWAYS
         - keyword: AS
-        - expression:
-            bracketed:
-              start_bracket: (
-              expression:
-                column_reference:
-                  naked_identifier: simple_column
-                binary_operator: '*'
-                numeric_literal: '2'
-              end_bracket: )
+        - bracketed:
+            start_bracket: (
+            expression:
+              column_reference:
+                naked_identifier: simple_column
+              binary_operator: '*'
+              numeric_literal: '2'
+            end_bracket: )
         - keyword: STORED
       - comma: ','
       - column_reference:
@@ -802,15 +801,14 @@ file:
         - keyword: GENERATED
         - keyword: ALWAYS
         - keyword: AS
-        - expression:
-            bracketed:
-              start_bracket: (
-              expression:
-                column_reference:
-                  naked_identifier: simple_column
-                binary_operator: '*'
-                numeric_literal: '2'
-              end_bracket: )
+        - bracketed:
+            start_bracket: (
+            expression:
+              column_reference:
+                naked_identifier: simple_column
+              binary_operator: '*'
+              numeric_literal: '2'
+            end_bracket: )
         - keyword: STORED
       - comma: ','
       - column_reference:

--- a/test/fixtures/dialects/postgres/create_table.sql
+++ b/test/fixtures/dialects/postgres/create_table.sql
@@ -370,3 +370,24 @@ CREATE TABLE myschema.user (
 CREATE TABLE my_table (
   interval  bigint
 );
+
+-- PostgreSQL 18: virtual generated columns (GENERATED ALWAYS AS (...) VIRTUAL)
+CREATE TABLE virtual_generated (
+    id bigint PRIMARY KEY,
+    is_small boolean GENERATED ALWAYS AS (id < 10) VIRTUAL,
+    full_name text GENERATED ALWAYS AS (first_name || ' ' || last_name) VIRTUAL
+);
+
+-- STORED form (pre-18, still valid)
+CREATE TABLE stored_generated (
+    id bigint PRIMARY KEY,
+    sum_col integer GENERATED ALWAYS AS (a + b) STORED
+);
+
+-- GENERATED ALWAYS AS (...) with no STORED/VIRTUAL keyword
+-- (optional in the grammar, though Postgres currently requires one at runtime;
+-- the dialect accepts the bare form for parser completeness)
+CREATE TABLE bare_generated (
+    id bigint PRIMARY KEY,
+    flag boolean GENERATED ALWAYS AS (id > 0)
+);

--- a/test/fixtures/dialects/postgres/create_table.yml
+++ b/test/fixtures/dialects/postgres/create_table.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: b18abb6574c720134a4a1fb94d742923fdf23a612ff691f5184af935367756cc
+_hash: d5a6173033c7aa06874524e8ab8886df5e14c9654f44f9db86af393b804c5e45
 file:
 - statement:
     create_table_statement:
@@ -2501,16 +2501,15 @@ file:
           - keyword: GENERATED
           - keyword: ALWAYS
           - keyword: AS
-          - expression:
-              bracketed:
-                start_bracket: (
-                expression:
-                  column_reference:
-                    naked_identifier: id
-                  comparison_operator:
-                    raw_comparison_operator: <
-                  numeric_literal: '10'
-                end_bracket: )
+          - bracketed:
+              start_bracket: (
+              expression:
+                column_reference:
+                  naked_identifier: id
+                comparison_operator:
+                  raw_comparison_operator: <
+                numeric_literal: '10'
+              end_bracket: )
           - keyword: VIRTUAL
       - comma: ','
       - column_definition:
@@ -2521,22 +2520,21 @@ file:
           - keyword: GENERATED
           - keyword: ALWAYS
           - keyword: AS
-          - expression:
-              bracketed:
-                start_bracket: (
-                expression:
-                - column_reference:
-                    naked_identifier: first_name
-                - binary_operator:
-                  - pipe: '|'
-                  - pipe: '|'
-                - quoted_literal: "' '"
-                - binary_operator:
-                  - pipe: '|'
-                  - pipe: '|'
-                - column_reference:
-                    naked_identifier: last_name
-                end_bracket: )
+          - bracketed:
+              start_bracket: (
+              expression:
+              - column_reference:
+                  naked_identifier: first_name
+              - binary_operator:
+                - pipe: '|'
+                - pipe: '|'
+              - quoted_literal: "' '"
+              - binary_operator:
+                - pipe: '|'
+                - pipe: '|'
+              - column_reference:
+                  naked_identifier: last_name
+              end_bracket: )
           - keyword: VIRTUAL
       - end_bracket: )
 - statement_terminator: ;
@@ -2564,16 +2562,15 @@ file:
           - keyword: GENERATED
           - keyword: ALWAYS
           - keyword: AS
-          - expression:
-              bracketed:
-                start_bracket: (
-                expression:
-                - column_reference:
-                    naked_identifier: a
-                - binary_operator: +
-                - column_reference:
-                    naked_identifier: b
-                end_bracket: )
+          - bracketed:
+              start_bracket: (
+              expression:
+              - column_reference:
+                  naked_identifier: a
+              - binary_operator: +
+              - column_reference:
+                  naked_identifier: b
+              end_bracket: )
           - keyword: STORED
       - end_bracket: )
 - statement_terminator: ;
@@ -2601,15 +2598,14 @@ file:
           - keyword: GENERATED
           - keyword: ALWAYS
           - keyword: AS
-          - expression:
-              bracketed:
-                start_bracket: (
-                expression:
-                  column_reference:
-                    naked_identifier: id
-                  comparison_operator:
-                    raw_comparison_operator: '>'
-                  numeric_literal: '0'
-                end_bracket: )
+          - bracketed:
+              start_bracket: (
+              expression:
+                column_reference:
+                  naked_identifier: id
+                comparison_operator:
+                  raw_comparison_operator: '>'
+                numeric_literal: '0'
+              end_bracket: )
       - end_bracket: )
 - statement_terminator: ;

--- a/test/fixtures/dialects/postgres/create_table.yml
+++ b/test/fixtures/dialects/postgres/create_table.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 38b09e8ec8aacea1a432798cbc2b874c94fdbf2b3ab4d7eeda65bcb4b11198db
+_hash: b18abb6574c720134a4a1fb94d742923fdf23a612ff691f5184af935367756cc
 file:
 - statement:
     create_table_statement:
@@ -2476,4 +2476,140 @@ file:
           data_type:
             keyword: bigint
         end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: virtual_generated
+    - bracketed:
+      - start_bracket: (
+      - column_definition:
+          naked_identifier: id
+          data_type:
+            keyword: bigint
+          column_constraint_segment:
+          - keyword: PRIMARY
+          - keyword: KEY
+      - comma: ','
+      - column_definition:
+          naked_identifier: is_small
+          data_type:
+            keyword: boolean
+          column_constraint_segment:
+          - keyword: GENERATED
+          - keyword: ALWAYS
+          - keyword: AS
+          - expression:
+              bracketed:
+                start_bracket: (
+                expression:
+                  column_reference:
+                    naked_identifier: id
+                  comparison_operator:
+                    raw_comparison_operator: <
+                  numeric_literal: '10'
+                end_bracket: )
+          - keyword: VIRTUAL
+      - comma: ','
+      - column_definition:
+          naked_identifier: full_name
+          data_type:
+            keyword: text
+          column_constraint_segment:
+          - keyword: GENERATED
+          - keyword: ALWAYS
+          - keyword: AS
+          - expression:
+              bracketed:
+                start_bracket: (
+                expression:
+                - column_reference:
+                    naked_identifier: first_name
+                - binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                - quoted_literal: "' '"
+                - binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                - column_reference:
+                    naked_identifier: last_name
+                end_bracket: )
+          - keyword: VIRTUAL
+      - end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: stored_generated
+    - bracketed:
+      - start_bracket: (
+      - column_definition:
+          naked_identifier: id
+          data_type:
+            keyword: bigint
+          column_constraint_segment:
+          - keyword: PRIMARY
+          - keyword: KEY
+      - comma: ','
+      - column_definition:
+          naked_identifier: sum_col
+          data_type:
+            keyword: integer
+          column_constraint_segment:
+          - keyword: GENERATED
+          - keyword: ALWAYS
+          - keyword: AS
+          - expression:
+              bracketed:
+                start_bracket: (
+                expression:
+                - column_reference:
+                    naked_identifier: a
+                - binary_operator: +
+                - column_reference:
+                    naked_identifier: b
+                end_bracket: )
+          - keyword: STORED
+      - end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: bare_generated
+    - bracketed:
+      - start_bracket: (
+      - column_definition:
+          naked_identifier: id
+          data_type:
+            keyword: bigint
+          column_constraint_segment:
+          - keyword: PRIMARY
+          - keyword: KEY
+      - comma: ','
+      - column_definition:
+          naked_identifier: flag
+          data_type:
+            keyword: boolean
+          column_constraint_segment:
+          - keyword: GENERATED
+          - keyword: ALWAYS
+          - keyword: AS
+          - expression:
+              bracketed:
+                start_bracket: (
+                expression:
+                  column_reference:
+                    naked_identifier: id
+                  comparison_operator:
+                    raw_comparison_operator: '>'
+                  numeric_literal: '0'
+                end_bracket: )
+      - end_bracket: )
 - statement_terminator: ;

--- a/test/fixtures/dialects/postgres/create_table.yml
+++ b/test/fixtures/dialects/postgres/create_table.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: d5a6173033c7aa06874524e8ab8886df5e14c9654f44f9db86af393b804c5e45
+_hash: e45d64e7f1ba4a073b4f47c57318e3eac62243a2e18b657a59404e9041f2c925
 file:
 - statement:
     create_table_statement:
@@ -81,10 +81,12 @@ file:
           naked_identifier: vector
           data_type:
           - keyword: int
-          - start_square_bracket: '['
-          - end_square_bracket: ']'
-          - start_square_bracket: '['
-          - end_square_bracket: ']'
+          - array_type_suffix:
+              start_square_bracket: '['
+              end_square_bracket: ']'
+          - array_type_suffix:
+              start_square_bracket: '['
+              end_square_bracket: ']'
         end_bracket: )
 - statement_terminator: ;
 - statement:

--- a/test/fixtures/dialects/postgres/create_table.yml
+++ b/test/fixtures/dialects/postgres/create_table.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 7c8ef6046a12da5416a7f53a483423ece5bc65ab618f64ab1df1ff86aeb80b1a
+_hash: b18abb6574c720134a4a1fb94d742923fdf23a612ff691f5184af935367756cc
 file:
 - statement:
     create_table_statement:
@@ -81,12 +81,10 @@ file:
           naked_identifier: vector
           data_type:
           - keyword: int
-          - array_type_suffix:
-              start_square_bracket: '['
-              end_square_bracket: ']'
-          - array_type_suffix:
-              start_square_bracket: '['
-              end_square_bracket: ']'
+          - start_square_bracket: '['
+          - end_square_bracket: ']'
+          - start_square_bracket: '['
+          - end_square_bracket: ']'
         end_bracket: )
 - statement_terminator: ;
 - statement:
@@ -2478,4 +2476,140 @@ file:
           data_type:
             keyword: bigint
         end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: virtual_generated
+    - bracketed:
+      - start_bracket: (
+      - column_definition:
+          naked_identifier: id
+          data_type:
+            keyword: bigint
+          column_constraint_segment:
+          - keyword: PRIMARY
+          - keyword: KEY
+      - comma: ','
+      - column_definition:
+          naked_identifier: is_small
+          data_type:
+            keyword: boolean
+          column_constraint_segment:
+          - keyword: GENERATED
+          - keyword: ALWAYS
+          - keyword: AS
+          - expression:
+              bracketed:
+                start_bracket: (
+                expression:
+                  column_reference:
+                    naked_identifier: id
+                  comparison_operator:
+                    raw_comparison_operator: <
+                  numeric_literal: '10'
+                end_bracket: )
+          - keyword: VIRTUAL
+      - comma: ','
+      - column_definition:
+          naked_identifier: full_name
+          data_type:
+            keyword: text
+          column_constraint_segment:
+          - keyword: GENERATED
+          - keyword: ALWAYS
+          - keyword: AS
+          - expression:
+              bracketed:
+                start_bracket: (
+                expression:
+                - column_reference:
+                    naked_identifier: first_name
+                - binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                - quoted_literal: "' '"
+                - binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                - column_reference:
+                    naked_identifier: last_name
+                end_bracket: )
+          - keyword: VIRTUAL
+      - end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: stored_generated
+    - bracketed:
+      - start_bracket: (
+      - column_definition:
+          naked_identifier: id
+          data_type:
+            keyword: bigint
+          column_constraint_segment:
+          - keyword: PRIMARY
+          - keyword: KEY
+      - comma: ','
+      - column_definition:
+          naked_identifier: sum_col
+          data_type:
+            keyword: integer
+          column_constraint_segment:
+          - keyword: GENERATED
+          - keyword: ALWAYS
+          - keyword: AS
+          - expression:
+              bracketed:
+                start_bracket: (
+                expression:
+                - column_reference:
+                    naked_identifier: a
+                - binary_operator: +
+                - column_reference:
+                    naked_identifier: b
+                end_bracket: )
+          - keyword: STORED
+      - end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: bare_generated
+    - bracketed:
+      - start_bracket: (
+      - column_definition:
+          naked_identifier: id
+          data_type:
+            keyword: bigint
+          column_constraint_segment:
+          - keyword: PRIMARY
+          - keyword: KEY
+      - comma: ','
+      - column_definition:
+          naked_identifier: flag
+          data_type:
+            keyword: boolean
+          column_constraint_segment:
+          - keyword: GENERATED
+          - keyword: ALWAYS
+          - keyword: AS
+          - expression:
+              bracketed:
+                start_bracket: (
+                expression:
+                  column_reference:
+                    naked_identifier: id
+                  comparison_operator:
+                    raw_comparison_operator: '>'
+                  numeric_literal: '0'
+                end_bracket: )
+      - end_bracket: )
 - statement_terminator: ;

--- a/test/fixtures/dialects/postgres/json_value.yml
+++ b/test/fixtures/dialects/postgres/json_value.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: b2736a250bfb8d0c167f41e321b12cd16f3f6fcc8b29794fc625fc339cf5a8f8
+_hash: b4a1c1aa9cbe071e8dcf394962e8a8917a5fd679382124b9dc80393044a66ba4
 file:
 - statement:
     select_statement:
@@ -159,27 +159,26 @@ file:
           - keyword: GENERATED
           - keyword: ALWAYS
           - keyword: AS
-          - expression:
-              bracketed:
-                start_bracket: (
-                expression:
-                  function:
-                    function_name:
-                      function_name_identifier: json_value
-                    function_contents:
-                      bracketed:
-                      - start_bracket: (
-                      - expression:
-                          column_reference:
-                            naked_identifier: raw_data
-                      - comma: ','
-                      - expression:
-                          quoted_literal: "'$.\"action_type\"'"
-                      - keyword: RETURNING
-                      - data_type:
-                          keyword: smallint
-                      - end_bracket: )
-                end_bracket: )
+          - bracketed:
+              start_bracket: (
+              expression:
+                function:
+                  function_name:
+                    function_name_identifier: json_value
+                  function_contents:
+                    bracketed:
+                    - start_bracket: (
+                    - expression:
+                        column_reference:
+                          naked_identifier: raw_data
+                    - comma: ','
+                    - expression:
+                        quoted_literal: "'$.\"action_type\"'"
+                    - keyword: RETURNING
+                    - data_type:
+                        keyword: smallint
+                    - end_bracket: )
+              end_bracket: )
           - keyword: STORED
         - column_constraint_segment:
           - keyword: NOT
@@ -193,27 +192,26 @@ file:
           - keyword: GENERATED
           - keyword: ALWAYS
           - keyword: AS
-          - expression:
-              bracketed:
-                start_bracket: (
-                expression:
-                  function:
-                    function_name:
-                      function_name_identifier: json_value
-                    function_contents:
-                      bracketed:
-                      - start_bracket: (
-                      - expression:
-                          column_reference:
-                            naked_identifier: raw_data
-                      - comma: ','
-                      - expression:
-                          quoted_literal: "'$.\"target_id\"'"
-                      - keyword: RETURNING
-                      - data_type:
-                          keyword: bigint
-                      - end_bracket: )
-                end_bracket: )
+          - bracketed:
+              start_bracket: (
+              expression:
+                function:
+                  function_name:
+                    function_name_identifier: json_value
+                  function_contents:
+                    bracketed:
+                    - start_bracket: (
+                    - expression:
+                        column_reference:
+                          naked_identifier: raw_data
+                    - comma: ','
+                    - expression:
+                        quoted_literal: "'$.\"target_id\"'"
+                    - keyword: RETURNING
+                    - data_type:
+                        keyword: bigint
+                    - end_bracket: )
+              end_bracket: )
           - keyword: STORED
       - end_bracket: )
 - statement_terminator: ;


### PR DESCRIPTION
## Summary

Closes #8139. The Postgres dialect only accepted the `STORED` form of `GENERATED ALWAYS AS (...)`, so PostgreSQL 18's new **virtual** generated columns (`GENERATED ALWAYS AS (...) VIRTUAL`) reported `Found unparsable section`.

## Change

Make the storage qualifier optional with `OneOf("STORED", "VIRTUAL", optional=True)` in both `ColumnConstraintSegment` and `ForeignTableColumnConstraintSegment`, and register `VIRTUAL` as a `non-reserved` keyword in `dialect_postgres_keywords.py`. This matches the SQLite dialect precedent (`dialect_sqlite.py`), which already uses `OneOf("STORED", "VIRTUAL", optional=True)` for generated columns.

This implements the diff the reporter (@danielkklein) pasted in the issue comment — full credit to them for the diagnosis and the exact fix.

## Why `optional=True`

The bare form (no `STORED`/`VIRTUAL`) is accepted by the grammar for parser completeness, matching SQLite's precedent. PostgreSQL itself currently requires `STORED` or `VIRTUAL` at runtime — that's a semantic/validation concern, not a parse-shape one, so the dialect accepting the bare form is consistent with how the SQLite dialect (which Postgres at runtime also doesn't run, but whose generated-column grammar shape this mirrors) already behaves.

## Tests

Added three cases to the Postgres `create_table` fixture and regenerated its yml via `test/generate_parse_fixture_yml.py --dialect postgres`:

- `GENERATED ALWAYS AS (...) VIRTUAL` (the #8139 case)
- `GENERATED ALWAYS AS (...) STORED` (pre-18, still valid — regression guard)
- `GENERATED ALWAYS AS (...)` with no keyword (bare form)

All 166 postgres fixtures regenerated successfully (no parse errors on the new cases), and the full dialects suite passes: **6712 passed, 0 failed**.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Postgres dialect support for PostgreSQL 18 virtual generated columns and tightens parsing by requiring parentheses in `GENERATED ALWAYS AS` expressions. Previously only `STORED` was accepted and `GENERATED ALWAYS AS IDENTITY` could be misparsed; now `VIRTUAL` and `STORED` (or no qualifier) are accepted and identity constraints parse correctly.

- Accepts `VIRTUAL`, `STORED`, or no qualifier for generated columns in table and foreign table constraints.
- Parses `GENERATED ALWAYS AS (expr)` only, preventing `GENERATED ALWAYS AS IDENTITY` from matching the generated-column branch.
- Registers `VIRTUAL` as a non-reserved keyword.
- Regenerates Postgres fixtures and adds coverage for `VIRTUAL`, `STORED`, and bare forms.

<sup>Written for commit 081becf90588a712f9f1e8ecf8659d235078d34c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8146?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

