### PR TITLE
fix(rust): match Python's repr()-quoted, truncated unlexable-error text in the Rust lexer

### DIFF
--- a/sqlfluffrs/sqlfluffrs_lexer/src/lexer.rs
+++ b/sqlfluffrs/sqlfluffrs_lexer/src/lexer.rs
@@ -425,7 +425,7 @@ impl Lexer {
                 SQLLexError::new(
                     Some(format!(
                         "Unable to lex characters: {}",
-                        token.raw().chars().take(10).collect::<String>()
+                        python_repr_str(&truncate_like_python(token.raw()))
                     )),
                     token.pos_marker.clone(),
                     None,
@@ -437,6 +437,65 @@ impl Lexer {
             })
             .collect()
     }
+}
+
+/// Truncates to match Python's `segment.raw[:10] + "..." if
+/// len(segment.raw) > 9 else segment.raw` (lexer.py's
+/// `violations_from_segments`), counting and slicing by Unicode codepoint
+/// so multi-byte characters truncate the same way Python's `len` and
+/// slicing do.
+fn truncate_like_python(raw: &str) -> String {
+    if raw.chars().count() > 9 {
+        let mut truncated: String = raw.chars().take(10).collect();
+        truncated.push_str("...");
+        truncated
+    } else {
+        raw.to_string()
+    }
+}
+
+/// Quotes and escapes a string the way Python's `repr()` would, so the
+/// `SQLLexError` description (`"Unable to lex characters:
+/// {!r}".format(...)` in lexer.py's `violations_from_segments`) reads the
+/// same from both lexers even when the unlexable text carries control
+/// characters.
+///
+/// Escapes ASCII/C1 control characters and non-space Unicode whitespace,
+/// which covers the punctuation and symbols that typically show up in
+/// unlexable input. Format (Cf), private-use (Co), and unassigned (Cn)
+/// codepoints are printed as-is for now; extend the match below if
+/// real-world input needs them escaped too.
+fn python_repr_str(s: &str) -> String {
+    let use_double_quotes = s.contains('\'') && !s.contains('"');
+    let quote_char = if use_double_quotes { '"' } else { '\'' };
+
+    let mut out = String::with_capacity(s.len() + 2);
+    out.push(quote_char);
+    for c in s.chars() {
+        match c {
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            c if c == quote_char => {
+                out.push('\\');
+                out.push(c);
+            }
+            c if c.is_control() || (c.is_whitespace() && c != ' ') => {
+                let cp = c as u32;
+                if cp <= 0xff {
+                    out.push_str(&format!("\\x{cp:02x}"));
+                } else if cp <= 0xffff {
+                    out.push_str(&format!("\\u{cp:04x}"));
+                } else {
+                    out.push_str(&format!("\\U{cp:08x}"));
+                }
+            }
+            c => out.push(c),
+        }
+    }
+    out.push(quote_char);
+    out
 }
 
 fn iter_tokens(

--- a/test/core/parser/rust_parser_test.py
+++ b/test/core/parser/rust_parser_test.py
@@ -1043,31 +1043,29 @@ def test__rust_parser__vs_python_tsql_sqlcmd_command_loses_token_type():
 
 
 @pytest.mark.skipif(not _HAS_RUST_PARSER, reason="Rust parser not available")
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "Regression: for an unlexable character run, PyLexer's "
-        "violations_from_segments (src/sqlfluff/core/parser/lexer.py:"
-        "838-847) builds the SQLLexError description via "
-        "'Unable to lex characters: {!r}'.format(...) - repr()-quoting and "
-        "escaping the raw text, and truncating to 9 characters plus a "
-        "literal '...' marker when longer. The Rust lexer's equivalent "
-        "(sqlfluffrs_lexer/src/lexer.rs:420-439, violations_from_tokens) "
-        'instead does format!("Unable to lex characters: {}", '
-        "token.raw().chars().take(10).collect::<String>()) - embedding the "
-        "raw characters directly with no quoting/escaping, no truncation "
-        "marker, and a 10- vs 9-character cutoff. SQLLexError.from_rs_error "
-        "(src/sqlfluff/core/errors.py:190-200) passes the Rust description "
-        "through verbatim, so real lint/parse output can contain literal "
-        "unescaped control bytes or unicode where the Python lexer would "
-        "have produced a safely quoted repr()-style string."
-    ),
-)
 def test__rust_parser__vs_python_lexer_unlexable_error_message():
-    """PyRsLexer's SQLLexError text differs from PyLexer's for unlexable input.
+    """PyRsLexer's SQLLexError text now matches PyLexer's for unlexable input.
 
-    Uses a non-ASCII character that neither lexer can tokenize, forcing the
-    <unlexable> fallback path on both sides.
+    Regression test: for an unlexable character run, PyLexer's
+    violations_from_segments (src/sqlfluff/core/parser/lexer.py:838-847)
+    builds the SQLLexError description via
+    'Unable to lex characters: {!r}'.format(...) - repr()-quoting and
+    escaping the raw text, and truncating to 9 characters plus a literal
+    '...' marker when longer. The Rust lexer's equivalent
+    (sqlfluffrs_lexer/src/lexer.rs, violations_from_tokens) used to embed
+    the raw characters directly with no quoting/escaping, no truncation
+    marker, and a 10- vs 9-character cutoff. SQLLexError.from_rs_error
+    (src/sqlfluff/core/errors.py:190-200) passes the Rust description
+    through verbatim, so real lint/parse output could contain literal
+    unescaped control bytes or unicode where the Python lexer would have
+    produced a safely quoted repr()-style string.
+
+    Fixed by adding python_repr_str/truncate_like_python helpers in
+    lexer.rs that replicate Python's repr()-quoting (quote-character
+    selection, backslash/quote/control-character escaping) and the
+    9-character truncation-plus-"..." cutoff. Uses a non-ASCII character
+    that neither lexer can tokenize, forcing the <unlexable> fallback
+    path on both sides.
     """
     from sqlfluff.core import FluffConfig
     from sqlfluff.core.parser.lexer import PyLexer, PyRsLexer


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
When SQL contains characters that can't be lexed, the Python parser raises a `SQLLexError` whose message includes a Python `repr()`-style rendering of the offending text, truncated for long strings. The Rust parser's equivalent error message was built differently, so the text didn't match between the two backends.

```sql
SELECT \xa1 FROM t
```

(`\xa1` here is a single non-ASCII character, U+00A1, that neither lexer can tokenize, forcing the unlexable fallback path on both sides.)

Added `python_repr_str` and `truncate_like_python` helpers in `sqlfluffrs_lexer/src/lexer.rs` that reproduce Python's `repr()`-style quoting/escaping and its 9-character truncation-plus-`...` cutoff, and used them when building the `SQLLexError` message so it matches the Python parser's wording for the common case: control characters, punctuation, and symbols.

Also un-xfails `test__rust_parser__vs_python_lexer_unlexable_error_message` in `test/core/parser/rust_parser_test.py`, which was previously marked `xfail(strict=True)` for this exact mismatch and now asserts the two backends produce identical error text.

### Are there any other side effects of this change that we should be aware of?

The escaping logic approximates Python's `str.isprintable()` check with `char::is_control()` plus non-space Unicode whitespace. This covers control characters, punctuation, and symbols, i.e. the characters that typically make input unlexable, but it does not yet cover the rarer Unicode categories Cf (format, e.g. zero-width space), Co (private use), and Cn (unassigned). For those, Python's `repr()` would escape the codepoint but the Rust output currently prints it raw. Rust's standard library exposes no Unicode General_Category lookup, so escaping the remaining Cf/Co/Cn codepoints would require adding a new dependency (e.g. unicode-general-category) or manual mapping.

### Pull Request checklist
- [ ] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the Rust lexer’s unlexable error text with Python by using repr()-style quoting and the same truncation. This makes messages identical across backends and prevents raw control characters from appearing in output.

- Bug Fixes
  - Build errors with repr()-style quoting and a 9-char + "..." truncation to match Python.
  - Added `python_repr_str` and `truncate_like_python` in `sqlfluffrs_lexer/src/lexer.rs`.
  - Updated `test__rust_parser__vs_python_lexer_unlexable_error_message` to assert identical messages (removed xfail).

<sup>Written for commit 443d3dad608c3bf8c5632ad9ac62878b4328044a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8147?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

