### PR TITLE
fix(parser): stop genexpr/comprehension recursion from halving safe parse-tree depth

### DIFF
--- a/src/sqlfluff/core/parser/rust_parser.py
+++ b/src/sqlfluff/core/parser/rust_parser.py
@@ -523,14 +523,18 @@ try:
             # Convert child matches recursively
             # Note: Transparent grammar nodes are now flattened on the Rust side,
             # so we don't need to do it here anymore
-            child_matches = (
-                tuple(
+            #
+            # NOTE: Keep this a plain loop rather than a generator expression:
+            # a genexpr would add its own stack frame per nesting level on top
+            # of this recursive call, which halves the safe recursion depth.
+            # Matches _apply_rs_match_result's plain for loop below, so both
+            # AST-building paths tolerate the same nesting depth.
+            child_matches_list = []
+            for child in rs_match.child_matches:
+                child_matches_list.append(
                     self._convert_rs_match_result(child, segments, depth + 1)
-                    for child in rs_match.child_matches
                 )
-                if rs_match.child_matches
-                else ()
-            )
+            child_matches = tuple(child_matches_list)
 
             return MatchResult(
                 matched_slice=slice(start, stop),

--- a/src/sqlfluff/core/parser/segments/base.py
+++ b/src/sqlfluff/core/parser/segments/base.py
@@ -345,26 +345,34 @@ class BaseSegment(metaclass=SegmentMetaclass):
         return tuple(idx for idx, seg in enumerate(self.segments) if seg.is_code)
 
     @cached_property
-    def is_comment(self) -> bool:  # pragma: no cover TODO?
+    def is_comment(self) -> bool:
         """Return True if this is entirely made of comments.
 
         NOTE: Plain loop, for the same stack-depth reason as is_code().
+
+        NOTE: The final `return True` is unreachable in practice, since no
+        dialect groups comment tokens into a container without some other
+        whitespace/newline/meta child alongside them.
         """
         for seg in self.segments:
             if not seg.is_comment:
                 return False
-        return True
+        return True  # pragma: no cover
 
     @cached_property
     def is_whitespace(self) -> bool:
         """Return True if this segment is entirely whitespace.
 
         NOTE: Plain loop, for the same stack-depth reason as is_code().
+
+        NOTE: The final `return True` is unreachable in practice, same as
+        is_comment() above, since e.g. the file root always ends with a
+        non-whitespace `end_of_file` meta.
         """
         for seg in self.segments:
             if not seg.is_whitespace:
                 return False
-        return True
+        return True  # pragma: no cover
 
     @cached_property
     def raw(self) -> str:

--- a/src/sqlfluff/core/parser/segments/base.py
+++ b/src/sqlfluff/core/parser/segments/base.py
@@ -325,8 +325,16 @@ class BaseSegment(metaclass=SegmentMetaclass):
     # ################ PUBLIC PROPERTIES
     @cached_property
     def is_code(self) -> bool:
-        """Return True if this segment contains any code."""
-        return any(seg.is_code for seg in self.segments)
+        """Return True if this segment contains any code.
+
+        NOTE: Written as a plain loop rather than any() over a generator
+        expression, so each nesting level costs one Python stack frame
+        instead of two, keeping the safe tree depth as high as possible.
+        """
+        for seg in self.segments:
+            if seg.is_code:
+                return True
+        return False
 
     @cached_property
     def _code_indices(self) -> tuple[int, ...]:
@@ -338,18 +346,38 @@ class BaseSegment(metaclass=SegmentMetaclass):
 
     @cached_property
     def is_comment(self) -> bool:  # pragma: no cover TODO?
-        """Return True if this is entirely made of comments."""
-        return all(seg.is_comment for seg in self.segments)
+        """Return True if this is entirely made of comments.
+
+        NOTE: Plain loop, for the same stack-depth reason as is_code().
+        """
+        for seg in self.segments:
+            if not seg.is_comment:
+                return False
+        return True
 
     @cached_property
     def is_whitespace(self) -> bool:
-        """Return True if this segment is entirely whitespace."""
-        return all(seg.is_whitespace for seg in self.segments)
+        """Return True if this segment is entirely whitespace.
+
+        NOTE: Plain loop, for the same stack-depth reason as is_code().
+        """
+        for seg in self.segments:
+            if not seg.is_whitespace:
+                return False
+        return True
 
     @cached_property
     def raw(self) -> str:
-        """Make a string from the segments of this segment."""
-        return "".join(seg.raw for seg in self.segments)
+        """Make a string from the segments of this segment.
+
+        NOTE: Plain loop, for the same stack-depth reason as is_code().
+        Worth keeping in mind here especially, since `.raw` is one of the
+        most frequently accessed properties in the codebase.
+        """
+        parts = []
+        for seg in self.segments:
+            parts.append(seg.raw)
+        return "".join(parts)
 
     @property
     def class_types(self) -> frozenset[str]:
@@ -366,12 +394,14 @@ class BaseSegment(metaclass=SegmentMetaclass):
         This is used for rule crawling.
 
         NOTE: Does not include the types of the parent segment itself.
+
+        NOTE: Plain loop, for the same stack-depth reason as is_code().
         """
-        return frozenset(
-            chain.from_iterable(
-                seg.descendant_type_set | seg.class_types for seg in self.segments
-            )
-        )
+        result: set[str] = set()
+        for seg in self.segments:
+            result.update(seg.descendant_type_set)
+            result.update(seg.class_types)
+        return frozenset(result)
 
     @cached_property
     def direct_descendant_type_set(self) -> set[str]:
@@ -390,14 +420,29 @@ class BaseSegment(metaclass=SegmentMetaclass):
 
     @cached_property
     def raw_segments(self) -> list[RawSegment]:
-        """Returns a list of raw segments in this segment."""
-        return self.get_raw_segments()
+        """Returns a list of raw segments in this segment.
+
+        NOTE: Plain loop, for the same stack-depth reason as is_code().
+        Recurses directly into each child's `raw_segments` (rather than
+        through `get_raw_segments()`, which now just delegates back to
+        this cached_property) so that every descendant's `raw_segments`
+        stays cached as a side effect of computing this one, same as
+        before, without paying for an extra pass-through frame per level.
+        """
+        result: list[RawSegment] = []
+        for seg in self.segments:
+            result.extend(seg.raw_segments)
+        return result
 
     @cached_property
     def raw_segments_with_ancestors(
         self,
     ) -> list[tuple[RawSegment, list[PathStep]]]:
-        """Returns a list of raw segments in this segment with the ancestors."""
+        """Returns a list of raw segments in this segment with the ancestors.
+
+        NOTE: The recursive branch below is a plain loop, for the same
+        stack-depth reason as is_code().
+        """
         buffer = []
         for idx, seg in enumerate(self.segments):
             # If it's a raw, yield it with this segment as the parent
@@ -406,18 +451,20 @@ class BaseSegment(metaclass=SegmentMetaclass):
                 buffer.append((cast("RawSegment", seg), new_step))
             # If it's not, recurse - prepending self to the ancestor stack
             else:
-                buffer.extend(
-                    [
-                        (raw_seg, new_step + stack)
-                        for raw_seg, stack in seg.raw_segments_with_ancestors
-                    ]
-                )
+                for raw_seg, stack in seg.raw_segments_with_ancestors:
+                    buffer.append((raw_seg, new_step + stack))
         return buffer
 
     @cached_property
     def source_fixes(self) -> list[SourceFix]:
-        """Return any source fixes as list."""
-        return list(chain.from_iterable(s.source_fixes for s in self.segments))
+        """Return any source fixes as list.
+
+        NOTE: Plain loop, for the same stack-depth reason as is_code().
+        """
+        fixes: list[SourceFix] = []
+        for seg in self.segments:
+            fixes.extend(seg.source_fixes)
+        return fixes
 
     @cached_property
     def first_non_whitespace_segment_raw_upper(self) -> Optional[str]:
@@ -799,12 +846,15 @@ class BaseSegment(metaclass=SegmentMetaclass):
         return self.type
 
     def count_segments(self, raw_only: bool = False) -> int:
-        """Returns the number of segments in this segment."""
+        """Returns the number of segments in this segment.
+
+        NOTE: Plain loop, for the same stack-depth reason as is_code().
+        """
         if self.segments:
-            self_count = 0 if raw_only else 1
-            return self_count + sum(
-                seg.count_segments(raw_only=raw_only) for seg in self.segments
-            )
+            total = 0 if raw_only else 1
+            for seg in self.segments:
+                total += seg.count_segments(raw_only=raw_only)
+            return total
         else:
             return 1
 
@@ -894,7 +944,11 @@ class BaseSegment(metaclass=SegmentMetaclass):
         include_meta: bool = False,
         include_position: bool = False,
     ) -> TupleSerialisedSegment:
-        """Return a tuple structure from this segment."""
+        """Return a tuple structure from this segment.
+
+        NOTE: The child tuples are built with plain loops, for the same
+        stack-depth reason as is_code().
+        """
         # works for both base and raw
 
         # Build the base tuple (2 elements)
@@ -905,33 +959,31 @@ class BaseSegment(metaclass=SegmentMetaclass):
         if show_raw and not self.segments:
             base_tuple = (self.get_type(), self.raw)
         elif code_only:
-            base_tuple = (
-                self.get_type(),
-                tuple(
-                    seg.to_tuple(
-                        code_only=code_only,
-                        show_raw=show_raw,
-                        include_meta=include_meta,
-                        include_position=include_position,
+            child_tuples = []
+            for seg in self.segments:
+                if seg.is_code and not seg.is_meta:
+                    child_tuples.append(
+                        seg.to_tuple(
+                            code_only=code_only,
+                            show_raw=show_raw,
+                            include_meta=include_meta,
+                            include_position=include_position,
+                        )
                     )
-                    for seg in self.segments
-                    if seg.is_code and not seg.is_meta
-                ),
-            )
+            base_tuple = (self.get_type(), tuple(child_tuples))
         else:
-            base_tuple = (
-                self.get_type(),
-                tuple(
-                    seg.to_tuple(
-                        code_only=code_only,
-                        show_raw=show_raw,
-                        include_meta=include_meta,
-                        include_position=include_position,
+            child_tuples = []
+            for seg in self.segments:
+                if include_meta or not seg.is_meta:
+                    child_tuples.append(
+                        seg.to_tuple(
+                            code_only=code_only,
+                            show_raw=show_raw,
+                            include_meta=include_meta,
+                            include_position=include_position,
+                        )
                     )
-                    for seg in self.segments
-                    if include_meta or not seg.is_meta
-                ),
-            )
+            base_tuple = (self.get_type(), tuple(child_tuples))
 
         # Add position as third element only if requested
         if include_position and self.pos_marker:
@@ -987,11 +1039,14 @@ class BaseSegment(metaclass=SegmentMetaclass):
         # so that the same logic is applied in recursion.
         # We set the parent for children directly on the copy method
         # to ensure those line up properly.
+        #
+        # NOTE: Built with a plain loop, for the same stack-depth reason
+        # as is_code() above.
         else:
-            new_segment.segments = tuple(
-                seg.copy(parent=new_segment, parent_idx=idx)
-                for idx, seg in enumerate(self.segments)
-            )
+            copied_segments = []
+            for idx, seg in enumerate(self.segments):
+                copied_segments.append(seg.copy(parent=new_segment, parent_idx=idx))
+            new_segment.segments = tuple(copied_segments)
 
         return new_segment
 
@@ -1004,8 +1059,19 @@ class BaseSegment(metaclass=SegmentMetaclass):
         return self.structural_simplify(self.to_tuple(**kwargs))
 
     def get_raw_segments(self) -> list[RawSegment]:
-        """Iterate raw segments, mostly for searching."""
-        return [item for s in self.segments for item in s.raw_segments]
+        """Iterate raw segments, mostly for searching.
+
+        NOTE: Delegates to the `raw_segments` cached_property, which does
+        the actual (plain-loop) recursion. This used to be the other way
+        round, with `raw_segments` delegating here - but that made every
+        level of recursion pay for this method's own frame *on top of*
+        the cached_property descriptor's frame, doubling the stack cost
+        this whole module works to avoid. Keeping the recursion inside
+        `raw_segments` itself matches the pattern used by is_code() et
+        al., and still lets every descendant's `raw_segments` end up
+        cached as a side effect, same as before.
+        """
+        return self.raw_segments
 
     def raw_normalized(self, casefold: bool = True) -> str:
         """Iterate raw segments, return normalized value."""

--- a/test/core/parser/rust_parser_test.py
+++ b/test/core/parser/rust_parser_test.py
@@ -628,6 +628,20 @@ def test__rust_parser__native_ast_recursion_depth_asymmetry():
     frames per nesting level. With max_parse_depth raised well above its
     default (600) so the depth guard doesn't mask the difference first,
     this checks the two paths stay in parity.
+
+    NOTE: at this depth (70) both paths simply succeed - the interesting
+    parity holds deeper too, confirmed manually: from ~140 bracket levels
+    both raise a clean RecursionError (Python's own recursion-limit check,
+    inside _apply_rs_match_result/_convert_rs_match_result), and from ~400
+    both raise SQLParseError (the Rust matcher's own counted max_parse_depth
+    check). There is also a narrow band (~120-140 bracket levels, with
+    max_parse_depth raised this high) where the shared Rust grammar matcher
+    overflows its native call stack and hard-crashes the process for both
+    settings alike - unprotected by either language's recursion guard. That
+    band isn't asserted here since its exact location is native-stack-size
+    dependent (platform/OS/Rust build), not a stable cross-platform value;
+    under the shipped default max_parse_depth (600) it's unreachable, since
+    the counted guard trips at a much shallower physical depth first.
     """
     from sqlfluff.core import FluffConfig
     from sqlfluff.core.parser import Lexer

--- a/test/core/parser/rust_parser_test.py
+++ b/test/core/parser/rust_parser_test.py
@@ -619,25 +619,15 @@ def test__rust_parser__native_ast_parity(sqlfile):
 
 
 @pytest.mark.skipif(not _HAS_RUST_PARSER, reason="Rust parser not available")
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "Regression: _convert_rs_match_result (the native_ast=False tree "
-        "builder) recurses through an extra generator-expression stack frame "
-        "per nesting level that _apply_rs_match_result (the fused "
-        "native_ast=True builder) doesn't have, so the legacy path blows the "
-        "Python call stack roughly twice as early as the fused path for the "
-        "same deeply-nested input. Only reachable when max_parse_depth is "
-        "raised above its default (600): at the default, the depth guard "
-        "fires first on both paths identically, masking the divergence."
-    ),
-)
 def test__rust_parser__native_ast_recursion_depth_asymmetry():
-    """native_ast=True tolerates deeper bracket nesting than native_ast=False.
+    """native_ast=True and native_ast=False now tolerate the same bracket nesting depth.
 
-    Minimal repro for a real (if narrow) correctness divergence: with the
-    depth guard raised out of the way, the two AST-building paths do not
-    fail at the same input size for identical SQL and identical config.
+    _convert_rs_match_result (native_ast=False) and _apply_rs_match_result
+    (native_ast=True) should fail at the same input size for identical SQL
+    and config, since they should cost the same number of Python stack
+    frames per nesting level. With max_parse_depth raised well above its
+    default (600) so the depth guard doesn't mask the difference first,
+    this checks the two paths stay in parity.
     """
     from sqlfluff.core import FluffConfig
     from sqlfluff.core.parser import Lexer

--- a/test/core/parser/segments/segments_base_test.py
+++ b/test/core/parser/segments/segments_base_test.py
@@ -322,23 +322,9 @@ def _build_nested_segment(DummyAuxSegment, leaf_segments, depth):
 
 
 # ---------------------------------------------------------------------------
-# Deep-nesting regression tests: these BaseSegment properties/methods should
-# recurse via a plain loop rather than a generator expression or
-# comprehension, keeping one Python stack frame per nesting level instead of
-# two, so deep parse trees stay well within Python's default recursion limit
-# (1000). Same fix as the RustParser native_ast recursion-depth-asymmetry
-# regression in rust_parser.py's _convert_rs_match_result.
-#
-# Each test below generates its own fresh leaf segments and stays in its own
-# function, rather than sharing the module-scoped `raw_segments` fixture or a
-# tree across tests, to keep each test's available stack headroom
-# independent and representative of a single recursive call in isolation.
-# Wrapping the shared `raw_segments` fixture at these depths also left
-# test__parser__base_segments_parent_ref seeing a stale parent on
-# raw_segments[0]; fresh leaves avoid that too.
-#
-# Depths are chosen with a comfortable margin either side of where the
-# pre-fix implementation starts raising RecursionError.
+# Deep-nesting regression tests: guard against these methods regressing back
+# to a genexpr/comprehension, which costs an extra stack frame per nesting
+# level and can blow Python's recursion limit on deep parse trees.
 # ---------------------------------------------------------------------------
 
 
@@ -386,21 +372,10 @@ def test__parser__base_segments_deep_nesting_no_recursion_error(
 ):
     """Recursive BaseSegment methods/properties survive deep nesting.
 
-    Each should recurse via a plain loop rather than a generator expression
-    or comprehension, keeping one Python stack frame per nesting level
-    instead of two, so deep parse trees stay well within Python's default
-    recursion limit (1000). Same fix as the RustParser native_ast
-    recursion-depth-asymmetry regression in rust_parser.py's
-    _convert_rs_match_result.
-
-    Fresh leaf segments are generated per call (rather than reusing the
-    module-scoped `raw_segments` fixture) so each case's available stack
-    headroom is independent and representative of a single recursive call
-    in isolation, and so wrapping them at these depths doesn't leave
-    test__parser__base_segments_parent_ref seeing a stale parent.
-
-    Depths are chosen with a comfortable margin either side of where the
-    pre-fix implementation starts raising RecursionError.
+    Fresh leaf segments are generated per call, rather than reusing the
+    module-scoped `raw_segments` fixture, so wrapping them at these depths
+    doesn't leave test__parser__base_segments_parent_ref seeing a stale
+    parent.
     """
     leaf_segments = generate_test_segments(["foobar", ".barfoo"])
     depth, check = _DEEP_NESTING_CASES[name]

--- a/test/core/parser/segments/segments_base_test.py
+++ b/test/core/parser/segments/segments_base_test.py
@@ -309,6 +309,105 @@ def test__parser__base_segments_copy_isolation(DummySegment, raw_segments):
     assert b_seg.pos_marker
 
 
+def _build_nested_segment(DummyAuxSegment, leaf_segments, depth):
+    """Build a segment nested `depth` levels deep, wrapping `leaf_segments`.
+
+    Built iteratively (no recursion here) so the test setup itself never
+    contributes to the recursion depth being probed.
+    """
+    node = DummyAuxSegment(leaf_segments)
+    for _ in range(depth):
+        node = DummyAuxSegment((node,))
+    return node
+
+
+# ---------------------------------------------------------------------------
+# Deep-nesting regression tests: these BaseSegment properties/methods should
+# recurse via a plain loop rather than a generator expression or
+# comprehension, keeping one Python stack frame per nesting level instead of
+# two, so deep parse trees stay well within Python's default recursion limit
+# (1000). Same fix as the RustParser native_ast recursion-depth-asymmetry
+# regression in rust_parser.py's _convert_rs_match_result.
+#
+# Each test below generates its own fresh leaf segments and stays in its own
+# function, rather than sharing the module-scoped `raw_segments` fixture or a
+# tree across tests, to keep each test's available stack headroom
+# independent and representative of a single recursive call in isolation.
+# Wrapping the shared `raw_segments` fixture at these depths also left
+# test__parser__base_segments_parent_ref seeing a stale parent on
+# raw_segments[0]; fresh leaves avoid that too.
+#
+# Depths are chosen with a comfortable margin either side of where the
+# pre-fix implementation starts raising RecursionError.
+# ---------------------------------------------------------------------------
+
+
+def _check_count_segments(tree, leaf_segments, depth):
+    # +1 for the innermost DummyAuxSegment directly wrapping the leaves,
+    # plus one more DummyAuxSegment per nesting level.
+    assert tree.count_segments() == depth + 1 + len(leaf_segments)
+
+
+def _check_copy(tree, leaf_segments, depth):
+    assert tree.copy().raw == tree.raw
+
+
+def _check_descendant_type_set(tree, leaf_segments, depth):
+    assert "raw" in tree.descendant_type_set
+
+
+# Each entry maps a recursive method/property to (depth, check). `check` just
+# needs to call the accessor and confirm it doesn't raise RecursionError;
+# a handful also assert a value, where that's cheap to do. Return shapes are
+# already covered by the non-deep-nesting tests elsewhere in this file.
+_DEEP_NESTING_CASES = {
+    "count_segments": (400, _check_count_segments),
+    "copy": (400, _check_copy),
+    "to_tuple": (400, lambda tree, leaf_segments, depth: tree.to_tuple()),
+    "descendant_type_set": (350, _check_descendant_type_set),
+    "is_code": (400, lambda tree, leaf_segments, depth: tree.is_code),
+    "is_comment": (400, lambda tree, leaf_segments, depth: tree.is_comment),
+    "is_whitespace": (400, lambda tree, leaf_segments, depth: tree.is_whitespace),
+    "raw_segments_with_ancestors": (
+        400,
+        lambda tree, leaf_segments, depth: tree.raw_segments_with_ancestors,
+    ),
+    "source_fixes": (400, lambda tree, leaf_segments, depth: tree.source_fixes),
+    "get_raw_segments": (
+        400,
+        lambda tree, leaf_segments, depth: tree.get_raw_segments(),
+    ),
+}
+
+
+@pytest.mark.parametrize("name", list(_DEEP_NESTING_CASES))
+def test__parser__base_segments_deep_nesting_no_recursion_error(
+    generate_test_segments, DummyAuxSegment, name
+):
+    """Recursive BaseSegment methods/properties survive deep nesting.
+
+    Each should recurse via a plain loop rather than a generator expression
+    or comprehension, keeping one Python stack frame per nesting level
+    instead of two, so deep parse trees stay well within Python's default
+    recursion limit (1000). Same fix as the RustParser native_ast
+    recursion-depth-asymmetry regression in rust_parser.py's
+    _convert_rs_match_result.
+
+    Fresh leaf segments are generated per call (rather than reusing the
+    module-scoped `raw_segments` fixture) so each case's available stack
+    headroom is independent and representative of a single recursive call
+    in isolation, and so wrapping them at these depths doesn't leave
+    test__parser__base_segments_parent_ref seeing a stale parent.
+
+    Depths are chosen with a comfortable margin either side of where the
+    pre-fix implementation starts raising RecursionError.
+    """
+    leaf_segments = generate_test_segments(["foobar", ".barfoo"])
+    depth, check = _DEEP_NESTING_CASES[name]
+    tree = _build_nested_segment(DummyAuxSegment, leaf_segments, depth)
+    check(tree, leaf_segments, depth)
+
+
 def test__parser__base_segments_parent_ref(DummySegment, raw_segments):
     """Test getting and setting parents on BaseSegment."""
     # Check initially no parent (because not set)

--- a/test/core/parser/segments/segments_base_test.py
+++ b/test/core/parser/segments/segments_base_test.py
@@ -4,6 +4,7 @@ import pickle
 
 import pytest
 
+from sqlfluff.core import Linter
 from sqlfluff.core.parser import BaseSegment, PositionMarker, RawSegment
 from sqlfluff.core.parser.segments.base import PathStep
 from sqlfluff.core.rules.base import LintFix
@@ -181,6 +182,19 @@ def test__parser__base_segments_path_to(raw_segments, DummySegment, DummyAuxSegm
         PathStep(test_seg_b, 0, 1, (0,)),
         PathStep(test_seg_a, 1, 2, (0, 1)),
     ]
+
+
+def test__parser__base_segments_is_code_false_for_comment_only_file():
+    """Test .is_code() is False for a file containing only a comment.
+
+    `.is_code()` loops over `self.segments` and only reaches its final
+    `return False` once every child has been checked without finding any
+    code, so a real SQL file with no code content is needed to cover that
+    path.
+    """
+    linter = Linter(dialect="ansi")
+    tree = linter.parse_string("-- just a comment\n").tree
+    assert tree.is_code is False
 
 
 def test__parser__base_segments_stubs():


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
Several recursive tree-walking methods, i.e. `RustParser`'s legacy tree builder (`_convert_rs_match_result`) and various `BaseSegment` methods (`descendant_type_set`, `count_segments`, `to_tuple`, `copy`, `is_code`, `is_comment`, `is_whitespace`, `raw`, `raw_segments_with_ancestors`, `source_fixes`, `get_raw_segments`), recursed via a generator expression/comprehension. In CPython that costs an extra stack frame per level, roughly halving the safe nesting depth before hitting Python's recursion limit.                                                                                                                                                                                                                                                                                                                                                                                                                                                                          

`Parser` and `RustParser` share the same `max_parse_depth` guard during matching, which rejects deep nesting under the default limit (600) long before this bug is reached. It only bites once `max_parse_depth` is deliberately raised above default, where the affected methods hit `RecursionError` at about half the depth that raising the limit was meant to allow.

The fix rewrote each method as a plain `for` loop instead of a genexpr/comprehension. `get_raw_segments` needed one extra change: it recursed through the separately-cached `raw_segments` property, which added its own indirection frame regardless of the loop conversion, i.e. the recursion now lives in `raw_segments` directly, with `get_raw_segments` as a thin wrapper.                                                                                                                                                                                                                                                                                                                                                                                                                                                                        

### Are there any other side effects of this change that we should be aware of?
While testing, I found a separate, pre-existing problem where extreme nesting can hard-crash the Rust matching engine's native                                                                                                                                                                       stack which is uncatchable in Python, unrelated to this fix, and not reachable under default config:
```python
def deeply_nested_sql() -> str:
   return "SELECT " + "(" * 130 + "1" + ")" * 130
```


### Pull Request checklist
- [ ] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops generator-expression recursion from halving safe parse-tree depth. Deeply nested parses now behave as expected when `max_parse_depth` is raised, and both AST builders fail at the same depth.

- Bug Fixes
  - Replaced generator-expression recursion with plain loops in `RustParser._convert_rs_match_result` to match `_apply_rs_match_result` stack usage.
  - Converted recursive `BaseSegment` methods/properties to plain loops: `descendant_type_set`, `count_segments`, `to_tuple`, `copy`, `is_code`, `is_comment`, `is_whitespace`, `raw`, `raw_segments_with_ancestors`, `source_fixes`.
  - Moved recursion into the `raw_segments` cached property; `get_raw_segments()` now delegates to it to avoid extra stack frames.
  - Added regression tests for deep nesting across these accessors, native vs. legacy AST builder parity, and `.is_code` on a comment-only file.

<sup>Written for commit 7feb33f717540089a5dcc7fc5a286ed33de4f976. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8148?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

