### PR TITLE
Rename Rust skip-backward-to-code helpers to match Python

### DIFF
--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/helpers.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/helpers.rs
@@ -139,7 +139,9 @@ impl<'a> Parser<'a> {
     /// Move an index backward through tokens until tokens[index - 1] is code or comment.
     /// Returns the index after the last code/comment token, or min_idx if none found.
     /// IMPORTANT: Comments are NOT skipped - they should be collected like code tokens!
-    pub(crate) fn skip_stop_index_backward_to_code(
+    /// Note: this keeps comments, unlike Python's `skip_stop_index_backward_to_code`,
+    /// so the name spells out what it actually keeps.
+    pub(crate) fn skip_stop_index_backward_to_code_or_comment(
         &self,
         stop_idx: usize,
         min_idx: usize,
@@ -157,14 +159,14 @@ impl<'a> Parser<'a> {
     /// trimming trailing comments too. Matches Python's canonical
     /// `skip_stop_index_backward_to_code` (src/sqlfluff/core/parser/
     /// match_algorithms.py), which checks only `segments[_idx - 1].is_code`.
-    /// Use this (rather than `skip_stop_index_backward_to_code` above, which
-    /// keeps comments for `calculate_max_idx`) when trimming a GREEDY-mode
+    /// Use this (rather than `skip_stop_index_backward_to_code_or_comment` above,
+    /// which keeps comments for `calculate_max_idx`) when trimming a GREEDY-mode
     /// "leftover content" span before wrapping it as UnparsableSegment (e.g.
     /// Bracketed.match's gap/leftover handling): a trailing comment there
     /// should stay outside the unparsable span as its own sibling, the same
     /// as trailing whitespace.
     /// Returns the index after the last code token, or `min_idx` if none found.
-    pub(crate) fn skip_stop_index_backward_to_code_excluding_comments(
+    pub(crate) fn skip_stop_index_backward_to_code(
         &self,
         stop_idx: usize,
         min_idx: usize,
@@ -273,7 +275,7 @@ impl<'a> Parser<'a> {
 
         // Trim backward to last code token
         if max_idx > 0 {
-            max_idx = self.skip_stop_index_backward_to_code(max_idx, start_idx);
+            max_idx = self.skip_stop_index_backward_to_code_or_comment(max_idx, start_idx);
         }
 
         // Apply parent's constraint

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/bracketed.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/bracketed.rs
@@ -454,15 +454,12 @@ impl Parser<'_> {
                         // GREEDY mode: Create unparsable section for tokens between content end and closing bracket
                         //
                         // PYTHON PARITY: trim trailing non-code and comments off
-                        // the unparsable span (via the `_excluding_comments`
-                        // variant below), matching Python's Bracketed.match. Any
+                        // the unparsable span (via `skip_stop_index_backward_to_code`,
+                        // the code-only variant), matching Python's Bracketed.match. Any
                         // trimmed gap stays as untouched, raw sibling content
                         // between here and the closing bracket.
-                        let unparsable_stop = self
-                            .skip_stop_index_backward_to_code_excluding_comments(
-                                expected_close_pos,
-                                check_pos,
-                            );
+                        let unparsable_stop =
+                            self.skip_stop_index_backward_to_code(expected_close_pos, check_pos);
 
                         // Guard against a zero-length span (mirrors sequence.rs's
                         // analogous GREEDY-leftover handling in

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/match_algorithms.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/match_algorithms.rs
@@ -104,24 +104,6 @@ fn find_mismatched_closing_bracket(tokens: &[Token], from_idx: usize) -> Option<
     None
 }
 
-pub(crate) fn skip_stop_index_backward_to_code(
-    tokens: &[Token],
-    start_idx: usize,
-    min_idx: usize,
-) -> usize {
-    let mut idx = start_idx;
-    while idx > min_idx {
-        idx -= 1;
-        // Here we would check if the token at idx is a "code" token.
-        // For this example, let's assume all tokens are code tokens.
-        let is_code_token = tokens[idx].is_code();
-        if is_code_token {
-            return idx;
-        }
-    }
-    min_idx
-}
-
 impl Parser<'_> {
     pub(crate) fn try_match_grammar(
         &mut self,
@@ -328,8 +310,8 @@ impl Parser<'_> {
                         term_id,
                         i
                     );
-                    let last_code_idx = skip_stop_index_backward_to_code(tokens, i, start_idx);
-                    return Ok((i, last_code_idx + 1));
+                    let stop_idx = self.skip_stop_index_backward_to_code(i, start_idx);
+                    return Ok((i, stop_idx));
                 }
             }
             i += 1;

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/sequence.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/sequence.rs
@@ -795,7 +795,7 @@ impl Parser<'_> {
             {
                 // Skip to code token position
                 let _idx = self.skip_start_index_forward_to_code(matched_idx, max_idx);
-                let _stop_idx = self.skip_stop_index_backward_to_code(max_idx, _idx);
+                let _stop_idx = self.skip_stop_index_backward_to_code_or_comment(max_idx, _idx);
 
                 if _stop_idx > _idx {
                     vdebug!(


### PR DESCRIPTION
### Brief summary of the change made

The Rust method `skip_stop_index_backward_to_code` kept comments, the opposite of Python's function of the same name, so the name matching Python had inverted behaviour.

- Renamed the comment-keeping one to `skip_stop_index_backward_to_code_or_comment`.
- Gave the canonical name to the `_excluding_comments` variant, since that's the one that mirrors Python.
- Collapsed the duplicate free fn in `match_algorithms.rs` into the method (it returned `idx` vs the method's `idx + 1`, so the caller was adding `+ 1` by hand).

Naming/dedup only, no behaviour change. `fixture_tests` yaml-vs-Python still passes across all dialects.

Fixes #8129.

### Are there any other side effects of this change that we should be aware of?

No.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.
