### PR TITLE
docs: update dialect contributing guide to current grammar API

### DIFF
--- a/docs/source/guides/contributing/dialect.rst
+++ b/docs/source/guides/contributing/dialect.rst
@@ -828,7 +828,7 @@ remember :code:`Ref` always picks the dialect-specific grammar first -->
 :code:`ansi.BaseExpressionElementGrammar` -->
 :code:`ansi.ExpressionSegment` --> :code:`ansi.Expression_A_Grammar` -->
 :code:`ansi.Expression_C_Grammar` --> :code:`ansi.Expression_D_Grammar` -->
-notice this at the end of the sequence --> :code:`postgres.Accessor_Grammar`
+notice this at the end of the sequence --> :code:`postgres.AccessorGrammar`
 --> :code:`postgres.ArrayAccessorSegment`. As you navigate, always remember to
 check for dialect-specific grammar before falling back to the inherited grammar
 (e.g. ANSI). Finally, we have found the part of the grammar that corresponds to

--- a/docs/source/guides/contributing/dialect.rst
+++ b/docs/source/guides/contributing/dialect.rst
@@ -40,45 +40,36 @@ this:
        """A group of elements in a select target statement."""
 
        type = "select_clause"
-       match_grammar = StartsWith(
-           Sequence("SELECT", Ref("WildcardExpressionSegment", optional=True)),
-           terminator=OneOf(
-               "FROM",
-               "WHERE",
-               "ORDER",
-               "LIMIT",
-               "OVERLAPS",
-               Ref("SetOperatorSegment"),
+       match_grammar: Matchable = Sequence(
+           "SELECT",
+           Ref("SelectClauseModifierSegment", optional=True),
+           Indent,
+           Delimited(
+               Ref("SelectClauseElementSegment"),
+               allow_trailing=True,
            ),
-           enforce_whitespace_preceding_terminator=True,
+           Dedent,
+           terminators=[Ref("SelectClauseTerminatorGrammar")],
+           parse_mode=ParseMode.GREEDY_ONCE_STARTED,
        )
 
-       parse_grammar = Ref("SelectClauseSegmentGrammar")
+This says the :code:`SelectClauseSegment` starts with :code:`SELECT`, contains a
+delimited list of select elements, and ends when it encounters a :code:`FROM`,
+:code:`WHERE`, :code:`ORDER BY`...etc. clause (the terminators).
 
-This says the :code:`SelectClauseSegment` starts with :code:`SELECT` or
-:code:`SELECT *` and ends when it encounters a :code:`FROM`, :code:`WHERE`,
-:code:`ORDER`...etc. line.
+The :code:`match_grammar` is what is used to match and parse the statement. The
+:code:`terminators` tell the parser where this segment ends: parsing can be quite
+intensive and complicated as the parser tries various combinations of classes
+and segments to match the SQL, so knowing where a segment stops (here at the
+start of the next clause, such as :code:`FROM` or :code:`WHERE`) helps it match
+efficiently. The :code:`parse_mode` of
+:code:`ParseMode.GREEDY_ONCE_STARTED` tells the parser to greedily claim
+everything up to a terminator once it has matched the start of the segment,
+which lets any unexpected content surface as an :code:`unparsable` section
+rather than silently failing the whole match.
 
-The :code:`match_grammar` is what is used primarily to try to match and parse
-the statement. It can be relatively simple (as in this case), to quickly match
-just the start and terminating clauses. If that is the case, then a
-:code:`parse_grammar` is needed to actually delve into the statement itself
-with all the clauses and parts it is made up of. The :code:`parse_grammar`
-can be fully defined in the class or, like above example, reference another
-class with the definition.
-
-The :code:`match_grammar` is used to quickly identify the start and end of
-this block, as parsing can be quite intensive and complicated as the parser
-tries various combinations of classes and segments to match the SQL
-(particularly optional ones like the :code:`WildcardExpressionSegment` above,
-or when there is a choice of statements that could be used).
-
-For some statements a quick match is not needed, and so we can delve straight
-into the full grammar definition. In that case the :code:`match_grammar` will
-be sufficient and we don't need the optional :code:`parse_grammar`.
-
-Here's another statement, which only uses the :code:`match_grammar` and doesn't
-have (or need!) an optional :code:`parse_grammar`:
+Here's another statement, which uses a plain :code:`match_grammar` with no
+terminators or greedy parse mode, because it is short and unambiguous:
 
 .. code-block:: python
 
@@ -135,7 +126,7 @@ definition:
 
 .. code-block:: python
 
-   parse_grammar = Sequence(
+   match_grammar = Sequence(
        "DELETE",
        Ref("FromClauseSegment"),
        Ref("WhereClauseSegment", optional=True),
@@ -153,7 +144,7 @@ Segments and Grammars
 
 A Segment is a piece of the syntax which defines a :code:`type` (which can
 be useful to reference later in rules or parse trees). This can be through
-one of the functions that creates a Segment (e.g. :code:`NamedParser`,
+one of the functions that creates a Segment (e.g. :code:`TypedParser`,
 :code:`SegmentGenerator`...etc.) or through a class.
 
 A Grammar is a section of syntax that can be used in a Segment. Typically
@@ -441,7 +432,7 @@ This was in the :code:`postgres` dialect, so I had a look at
 
 .. code-block:: python
 
-   parse_grammar = Sequence(
+   match_grammar = Sequence(
        "CREATE",
        Sequence("OR", "REPLACE", optional=True),
        Ref("TemporaryGrammar", optional=True),
@@ -481,7 +472,7 @@ another return option:
 
 .. code-block:: python
 
-   parse_grammar = Sequence(
+   match_grammar = Sequence(
        "CREATE",
        Sequence("OR", "REPLACE", optional=True),
        Ref("TemporaryGrammar", optional=True),
@@ -832,9 +823,7 @@ corresponding SQLFluff grammar in a similar top-down way:
 :code:`postgres.SelectStatementSegment` --> we see it's mostly a copy of
 the ANSI select statement, so --> :code:`ansi.SelectStatementSegment` -->
 remember :code:`Ref` always picks the dialect-specific grammar first -->
-:code:`postgres.SelectClauseSegment` -->
-:code:`ansi.SelectClauseSegment.parse_grammar` -->
-:code:`postgres.SelectClauseSegmentGrammar` -->
+:code:`postgres.SelectClauseSegment.match_grammar` -->
 :code:`ansi.SelectClauseElementSegment` -->
 :code:`ansi.BaseExpressionElementGrammar` -->
 :code:`ansi.ExpressionSegment` --> :code:`ansi.Expression_A_Grammar` -->

--- a/docsv/development/dialect.md
+++ b/docsv/development/dialect.md
@@ -31,46 +31,38 @@ this:
 ```python
 class SelectClauseSegment(BaseSegment):
     """A group of elements in a select target statement."""
+
     type = "select_clause"
-    match_grammar = StartsWith(
-        Sequence("SELECT", Ref("WildcardExpressionSegment", optional=True)),
-        terminator=OneOf(
-            "FROM",
-            "WHERE",
-            "ORDER",
-            "LIMIT",
-            "OVERLAPS",
-            Ref("SetOperatorSegment"),
+    match_grammar: Matchable = Sequence(
+        "SELECT",
+        Ref("SelectClauseModifierSegment", optional=True),
+        Indent,
+        Delimited(
+            Ref("SelectClauseElementSegment"),
+            allow_trailing=True,
         ),
-        enforce_whitespace_preceding_terminator=True,
+        Dedent,
+        terminators=[Ref("SelectClauseTerminatorGrammar")],
+        parse_mode=ParseMode.GREEDY_ONCE_STARTED,
     )
-    parse_grammar = Ref("SelectClauseSegmentGrammar")
 ```
 
-This says the `SelectClauseSegment` starts with `SELECT` or
-`SELECT *` and ends when it encounters a `FROM`, `WHERE`,
-`ORDER`...etc. line.
+This says the `SelectClauseSegment` starts with `SELECT`, contains a
+delimited list of select elements, and ends when it encounters a `FROM`,
+`WHERE`, `ORDER BY`...etc. clause (the terminators).
 
-The `match_grammar` is what is used primarily to try to match and parse
-the statement. It can be relatively simple (as in this case), to quickly match
-just the start and terminating clauses. If that is the case, then a
-`parse_grammar` is needed to actually delve into the statement itself
-with all the clauses and parts it is made up of. The `parse_grammar`
-can be fully defined in the class or, like above example, reference another
-class with the definition.
+The `match_grammar` is what is used to match and parse the statement. The
+`terminators` tell the parser where this segment ends: parsing can be quite
+intensive and complicated as the parser tries various combinations of classes
+and segments to match the SQL, so knowing where a segment stops (here at the
+start of the next clause, such as `FROM` or `WHERE`) helps it match efficiently.
+The `parse_mode` of `ParseMode.GREEDY_ONCE_STARTED` tells the parser to greedily
+claim everything up to a terminator once it has matched the start of the
+segment, which lets any unexpected content surface as an `unparsable` section
+rather than silently failing the whole match.
 
-The `match_grammar` is used to quickly identify the start and end of
-this block, as parsing can be quite intensive and complicated as the parser
-tries various combinations of classes and segments to match the SQL
-(particularly optional ones like the `WildcardExpressionSegment` above,
-or when there is a choice of statements that could be used).
-
-For some statements a quick match is not needed, and so we can delve straight
-into the full grammar definition. In that case the `match_grammar` will
-be sufficient and we don't need the optional `parse_grammar`.
-
-Here's another statement, which only uses the `match_grammar` and doesn't
-have (or need!) an optional `parse_grammar`:
+Here's another statement, which uses a plain `match_grammar` with no
+terminators or greedy parse mode, because it is short and unambiguous:
 
 ```python
 class JoinOnConditionSegment(BaseSegment):
@@ -107,7 +99,7 @@ make up of a SQL statement. Here's the `DeleteStatementSegment`
 definition:
 
 ```python
-parse_grammar = Sequence(
+match_grammar = Sequence(
     "DELETE",
     Ref("FromClauseSegment"),
     Ref("WhereClauseSegment", optional=True),
@@ -125,7 +117,7 @@ to define SQL syntax.
 
 A Segment is a piece of the syntax which defines a `type` (which can
 be useful to reference later in rules or parse trees). This can be through
-one of the functions that creates a Segment (e.g. `NamedParser`,
+one of the functions that creates a Segment (e.g. `TypedParser`,
 `SegmentGenerator`...etc.) or through a class.
 
 A Grammar is a section of syntax that can be used in a Segment. Typically
@@ -384,7 +376,7 @@ This was in the `postgres` dialect, so I had a look at
 [dialect_postgres.py](https://github.com/sqlfluff/sqlfluff/blob/main/src/sqlfluff/dialects/dialect_postgres.py) and found the code in `CreateFunctionStatementSegment` which had the following:
 
 ```python
-parse_grammar = Sequence(
+match_grammar = Sequence(
     "CREATE",
     Sequence("OR", "REPLACE", optional=True),
     Ref("TemporaryGrammar", optional=True),
@@ -424,7 +416,7 @@ Fixing the issue was as simple as adding the `SETOF` structure as
 another return option:
 
 ```python
-parse_grammar = Sequence(
+match_grammar = Sequence(
     "CREATE",
     Sequence("OR", "REPLACE", optional=True),
     Ref("TemporaryGrammar", optional=True),
@@ -775,14 +767,12 @@ corresponding SQLFluff grammar in a similar top-down way:
 `postgres.SelectStatementSegment` --> we see it's mostly a copy of
 the ANSI select statement, so --> `ansi.SelectStatementSegment` -->
 remember `Ref` always picks the dialect-specific grammar first -->
-`postgres.SelectClauseSegment` -->
-`ansi.SelectClauseSegment.parse_grammar` -->
-`postgres.SelectClauseSegmentGrammar` -->
+`postgres.SelectClauseSegment.match_grammar` -->
 `ansi.SelectClauseElementSegment` -->
 `ansi.BaseExpressionElementGrammar` -->
 `ansi.ExpressionSegment` --> `ansi.Expression_A_Grammar` -->
 `ansi.Expression_C_Grammar` --> `ansi.Expression_D_Grammar` -->
-notice this at the end of the sequence --> `postgres.Accessor_Grammar`
+notice this at the end of the sequence --> `postgres.AccessorGrammar`
 --> `postgres.ArrayAccessorSegment`. As you navigate, always remember to
 check for dialect-specific grammar before falling back to the inherited grammar
 (e.g. ANSI). Finally, we have found the part of the grammar that corresponds to


### PR DESCRIPTION

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made

The "Contributing dialect changes" guide
(`docs/source/guides/contributing/dialect.rst`) is built around three grammar
APIs that have since been removed or renamed, so a contributor who follows it
verbatim hits an error immediately:

- **`parse_grammar`** was removed. A segment that defines it now raises
  `AssertionError` on instantiation:
  `src/sqlfluff/core/parser/segments/base.py`
  (`assert not hasattr(self, "parse_grammar"), "parse_grammar is deprecated."`).
  The guide taught it as current API and pointed readers at `dialect_ansi.py`,
  which no longer contains it.
- **The `StartsWith` grammar class** and its
  **`enforce_whitespace_preceding_terminator`** argument no longer exist
  anywhere in `src/`.
- **`NamedParser`** was renamed to **`TypedParser`**
  (`src/sqlfluff/core/parser/parsers.py`).

This PR modernizes the guide without changing its structure or its
walkthrough. Specifically it:

- Rewrites the `SelectClauseSegment` example so it mirrors the current ANSI
  definition: a single `match_grammar = Sequence(...)` with
  `terminators=[Ref("SelectClauseTerminatorGrammar")]` and
  `parse_mode=ParseMode.GREEDY_ONCE_STARTED`, and rewrites the prose that
  previously explained the old `match_grammar` vs `parse_grammar` split to
  explain `terminators` and `parse_mode` instead.
- Switches the `DeleteStatementSegment` and the two
  `CreateFunctionStatementSegment` worked examples from `parse_grammar` to
  `match_grammar`.
- Replaces the `NamedParser` mention with `TypedParser`.
- Fixes the Example 4 "navigation" walkthrough that still stepped through
  `parse_grammar` and the removed `SelectClauseSegmentGrammar`.

Docs only; no code change.

### Are there any other side effects of this change that we should be aware of?

None. This is documentation only, no runtime or public API change.

Scope note: this PR is intentionally limited to the removed/renamed grammar
APIs (`parse_grammar`, `StartsWith`, `NamedParser`). Some of the older worked
snippets in the same guide still show pre-`Ref` grammar forms (e.g.
`Sequence("OR", "REPLACE", ...)` where the postgres dialect now uses
`Ref("OrReplaceGrammar")`). That drift is pre-existing, the narrative still
reads correctly, and refreshing every snippet body is left out of scope to keep
this change focused and easy to review.


- [x] Included test cases to demonstrate any code changes, which may be one or
  more of the following:
  - N/A. Documentation-only change (no code, so no `.yml`/`.sql`/autofix
    fixtures). Verified locally with the docs build and codespell (see below).
- [x] Added appropriate documentation for the change. (This change *is* the
  documentation fix.)
- [x] Created GitHub issues for any relevant followup/future enhancements if
  appropriate. (See scope note above re: the pre-existing snippet drift; happy
  to open a follow-up issue if maintainers want it tracked.)

---

## Verification performed (for reviewers / not part of the body)

- Every rewritten snippet was checked against current `main`:
  - `SelectClauseSegment` example is a character-for-character match of
    `src/sqlfluff/dialects/dialect_ansi.py` (`SelectClauseSegment.match_grammar`).
  - Terminator prose ("`FROM`, `WHERE`, `ORDER BY`...etc.") matches
    `SelectClauseTerminatorGrammar` in `dialect_ansi.py`.
  - `DeleteStatementSegment` example matches the current segment.
  - Both postgres `CreateFunctionStatementSegment` snippets: postgres now uses
    `match_grammar` there.
  - Example 4 chain now reads
    `postgres.SelectClauseSegment.match_grammar --> ansi.SelectClauseElementSegment`,
    with the removed `SelectClauseSegmentGrammar` dropped.
- `cd docs && make clean && SPHINXOPTS="-W --keep-going" make html` (Sphinx
  9.0.4): build succeeded, zero warnings/errors (warnings-as-errors, as CI runs).
- Rendered `build/html/guides/contributing/dialect.html`: contains
  `GREEDY_ONCE_STARTED`; contains none of `parse_grammar`, `StartsWith`,
  `NamedParser`, `enforce_whitespace_preceding_terminator`.
- `codespell docs/source/guides/contributing/dialect.rst`: clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the “Contributing dialect changes” guide to the current grammar API and mirror the same edits in `docsv/development/dialect.md` so contributors don’t hit errors. Docs only; no runtime or public API changes.

- **Bug Fixes**
  - Replaced deprecated `parse_grammar` with `match_grammar` in worked examples, including `DeleteStatementSegment` and `CreateFunctionStatementSegment`.
  - Rewrote `SelectClauseSegment` example to match current ANSI: a single `Sequence(...)` with `terminators=[Ref("SelectClauseTerminatorGrammar")]` and `parse_mode=ParseMode.GREEDY_ONCE_STARTED`; updated the prose to explain `terminators` and greedy parsing.
  - Removed `StartsWith` and `enforce_whitespace_preceding_terminator`; renamed `NamedParser` to `TypedParser`; fixed Example 4 navigation to reference `.match_grammar` and corrected `postgres.AccessorGrammar` naming.

<sup>Written for commit 17b86379b8bd34cb1cb48abe376906d6485c5678. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8151?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

