### PR TITLE
fix(config): validate render_variant_limit and runaway_limit

### DIFF
--- a/src/sqlfluff/core/config/validate.py
+++ b/src/sqlfluff/core/config/validate.py
@@ -189,6 +189,39 @@ def _validate_max_parse_nodes_config(
         )
 
 
+def _validate_int_config(
+    config: ConfigMappingType, key: str, minimum: int, logging_reference: str
+) -> None:
+    """Validate that a core integer config value is a valid integer.
+
+    Unlike ``max_parse_depth``/``max_parse_nodes`` there is no ``0`` sentinel
+    for these options, so any non-integer or out-of-range value is rejected with
+    a clean ``SQLFluffUserError`` rather than being allowed to reach numeric-use
+    sites and crash with an opaque ``TypeError``.
+    """
+    core_section = config.get("core", {})
+    if not core_section:
+        return None
+
+    assert isinstance(core_section, dict)
+    if key not in core_section:
+        return None
+
+    value = core_section.get(key)
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise SQLFluffUserError(
+            f"Config file {logging_reference!r} set an invalid value for "
+            f"`{key}`: {value!r}. This value must be an integer."
+        )
+
+    if value < minimum:
+        raise SQLFluffUserError(
+            f"Config file {logging_reference!r} set an invalid value for "
+            f"`{key}`: {value!r}. This value must be an integer of at least "
+            f"{minimum}."
+        )
+
+
 def validate_config_dict(config: ConfigMappingType, logging_reference: str) -> None:
     """Validate a config dict.
 
@@ -212,3 +245,6 @@ def validate_config_dict(config: ConfigMappingType, logging_reference: str) -> N
     _validate_max_parse_depth_config(config, logging_reference)
     # Validate max parse nodes config
     _validate_max_parse_nodes_config(config, logging_reference)
+    # Validate other core integer limits which have no disable sentinel.
+    _validate_int_config(config, "render_variant_limit", 1, logging_reference)
+    _validate_int_config(config, "runaway_limit", 1, logging_reference)

--- a/test/core/config/validate_test.py
+++ b/test/core/config/validate_test.py
@@ -8,9 +8,11 @@ from sqlfluff.core.config.removed import (
 )
 from sqlfluff.core.config.validate import (
     _validate_indentation_config,
+    _validate_int_config,
     _validate_layout_config,
     _validate_max_parse_depth_config,
     _validate_max_parse_nodes_config,
+    validate_config_dict,
 )
 from sqlfluff.core.errors import SQLFluffUserError
 from sqlfluff.core.helpers.dict import (
@@ -223,4 +225,83 @@ def test__validate_max_parse_nodes_invalid(config_dict, config_warning):
     """Test invalid max_parse_nodes values are rejected."""
     with pytest.raises(SQLFluffUserError) as excinfo:
         _validate_max_parse_nodes_config(config_dict, "<test>")
+    assert config_warning in str(excinfo.value)
+
+
+@pytest.mark.parametrize(
+    "config_dict",
+    [
+        {"core": {"render_variant_limit": 1}},
+        {"core": {"runaway_limit": 10}},
+        {"core": {}},  # missing key should be ok
+        {},  # no core section should be ok
+    ],
+)
+def test__validate_int_config_valid(config_dict):
+    """Test valid integer core config values are accepted."""
+    # Should not raise for either key.
+    _validate_int_config(config_dict, "render_variant_limit", 1, "<test>")
+    _validate_int_config(config_dict, "runaway_limit", 1, "<test>")
+
+
+@pytest.mark.parametrize(
+    "config_dict,key,config_warning",
+    [
+        (
+            {"core": {"render_variant_limit": "lots"}},
+            "render_variant_limit",
+            "set an invalid value for `render_variant_limit`: 'lots'",
+        ),
+        (
+            {"core": {"render_variant_limit": True}},
+            "render_variant_limit",
+            "set an invalid value for `render_variant_limit`: True",
+        ),
+        (
+            {"core": {"render_variant_limit": 0}},
+            "render_variant_limit",
+            "set an invalid value for `render_variant_limit`: 0",
+        ),
+        (
+            {"core": {"runaway_limit": "lots"}},
+            "runaway_limit",
+            "set an invalid value for `runaway_limit`: 'lots'",
+        ),
+        (
+            {"core": {"runaway_limit": -1}},
+            "runaway_limit",
+            "set an invalid value for `runaway_limit`: -1",
+        ),
+    ],
+)
+def test__validate_int_config_invalid(config_dict, key, config_warning):
+    """Test invalid integer core config values are rejected."""
+    with pytest.raises(SQLFluffUserError) as excinfo:
+        _validate_int_config(config_dict, key, 1, "<test>")
+    assert config_warning in str(excinfo.value)
+
+
+@pytest.mark.parametrize(
+    "config_dict,config_warning",
+    [
+        (
+            {"core": {"render_variant_limit": "lots"}},
+            "set an invalid value for `render_variant_limit`: 'lots'",
+        ),
+        (
+            {"core": {"runaway_limit": "lots"}},
+            "set an invalid value for `runaway_limit`: 'lots'",
+        ),
+    ],
+)
+def test__validate_config_dict_rejects_bad_int_limits(config_dict, config_warning):
+    """A non-integer render_variant_limit/runaway_limit raises a clean error.
+
+    Previously these flowed unchecked to numeric-use sites: a bad
+    render_variant_limit crashed `sqlfluff lint` with an uncaught TypeError, and
+    a bad runaway_limit was swallowed as an 'internal error' during
+    `sqlfluff fix`. They should behave like their validated siblings.
+    """
+    with pytest.raises(SQLFluffUserError) as excinfo:
+        validate_config_dict(config_dict, "<test>")
     assert config_warning in str(excinfo.value)


### PR DESCRIPTION

### What

Two core integer config options were never validated, so a bad value flowed
unchecked all the way to its numeric-use site and failed there instead of being
caught with a clean `SQLFluffUserError` like the other core limits.

- `render_variant_limit`: a non-integer value crashes `sqlfluff lint` with an
  uncaught `TypeError`. It is read in `src/sqlfluff/core/linter/linter.py` and
  used at `if len(templated_variants) >= variant_limit:`, so a string value
  raises `TypeError: '>=' not supported between instances of 'int' and 'str'`.
  Because it is not a `SQLFluffUserError`, the CLI's error handler does not
  intercept it and the user gets a full traceback (exit 1).
- `runaway_limit`: a non-integer value is read in the fix loop and used as
  `range(loop_limit ...)`, which raises `TypeError: 'str' object cannot be
  interpreted as an integer`. That exception is caught by the per-file runner,
  logged as an internal error with a "please report this as an issue" message,
  and the file is then skipped. `sqlfluff fix` exits 0 and the file is left
  unfixed, so a plain config typo is mis-reported as a SQLFluff bug and looks
  like success.

For contrast, `max_parse_depth` and `max_parse_nodes` live in the same
`[sqlfluff]` section and already raise a clean `SQLFluffUserError` for bad
values, thanks to the validators in `src/sqlfluff/core/config/validate.py`.

### Repro (on `main` before this change)

`.sqlfluff`:

```ini
[sqlfluff]
dialect = ansi
render_variant_limit = lots
```

```bash
sqlfluff lint q.sql
# ... Traceback ...
# TypeError: '>=' not supported between instances of 'int' and 'str'   (exit 1)
```

`.sqlfluff`:

```ini
[sqlfluff]
dialect = ansi
runaway_limit = lots
```

```bash
sqlfluff fix q.sql --rules LT12
# "Unable to lint ... due to an internal error. Please report this as an issue"
# file skipped, "All Finished!", exit 0   (silent failure)
```

### Fix

Add a small `_validate_int_config(config, key, minimum, logging_reference)`
helper in `src/sqlfluff/core/config/validate.py` that mirrors the existing
`_validate_max_parse_depth_config` / `_validate_max_parse_nodes_config`
validators (same structure, same `bool`-before-`int` guard, same error
phrasing), and call it from `validate_config_dict` for both options.

The minimum is `1`, not `0`, because unlike `max_parse_*` neither option has a
`0`/empty "disable" sentinel: `runaway_limit = 0` would give an empty fix loop
and `render_variant_limit = 0` an empty variant loop, both degenerate. The docs
already describe `render_variant_limit = 1` as a valid, useful value, and the
defaults (`render_variant_limit = 5`, `runaway_limit = 10`) are unaffected.

After the change, both bad values raise a clean `SQLFluffUserError`:

```
Config file '...' set an invalid value for `render_variant_limit`: 'lots'.
This value must be an integer.
```

and out-of-range values report `... must be an integer of at least 1.`

### Tests

`test/core/config/validate_test.py`:

- Unit tests for `_validate_int_config` (valid values, missing key, missing core
  section, and invalid: non-int string, `bool`, and below-minimum for both
  keys).
- An end-to-end test that drives `validate_config_dict` directly and asserts a
  non-integer `render_variant_limit` / `runaway_limit` raises `SQLFluffUserError`
  (this is the test that guards the actual wiring, not just the helper).

The change is additive only (+117, no existing lines modified), so it does not
reduce coverage.

### Out of scope (deliberate)

`large_file_skip_char_limit` (in `src/sqlfluff/core/templaters/base.py`) is
plausibly in the same class of unvalidated integer option, but I did not prove a
concrete crash for it, so I left it out to keep this change focused. Happy to
follow up separately if maintainers want it covered too.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validate `render_variant_limit` and `runaway_limit` in core config to prevent crashes and surface clear `SQLFluffUserError`s. Adds a shared `_validate_int_config` used by `validate_config_dict` with a minimum value of 1.

- **Bug Fixes**
  - Non-integer `render_variant_limit` no longer crashes `sqlfluff lint`; now raises a clear `SQLFluffUserError`.
  - Non-integer `runaway_limit` no longer logs an “internal error” and skips files during `sqlfluff fix`; now raises a clear `SQLFluffUserError`.
  - Values below 1 are rejected (no `0` sentinel); defaults remain unchanged.
  - Mirrors existing validation for `max_parse_depth` and `max_parse_nodes`; adds unit and end-to-end tests for the new checks.

<sup>Written for commit 23414533550b1d6a77e622de7b295e85cd252744. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8152?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

