### PR TITLE
Add rule RF07 to flag window-clause references that shadow a select alias

### DIFF
--- a/src/sqlfluff/core/default_config.cfg
+++ b/src/sqlfluff/core/default_config.cfg
@@ -505,6 +505,11 @@ ignore_words = None
 ignore_words_regex = None
 case_sensitive = True
 
+[sqlfluff:rules:references.window_alias]
+# Window clause references which shadow a select alias.
+# Disabled by default unless explicitly enabled.
+force_enable = False
+
 [sqlfluff:rules:layout.long_lines]
 # Line length
 ignore_comment_lines = False

--- a/src/sqlfluff/rules/references/RF07.py
+++ b/src/sqlfluff/rules/references/RF07.py
@@ -43,7 +43,9 @@ class Rule_RF07(BaseRule):
 
     name = "references.window_alias"
     groups = ("all", "references")
-    crawl_behaviour = SegmentSeekerCrawler({"over_clause"})
+    # A window_specification holds the PARTITION BY/ORDER BY of both an inline
+    # OVER (...) and a named WINDOW ... AS (...) definition.
+    crawl_behaviour = SegmentSeekerCrawler({"window_specification"})
 
     def _eval(self, context: RuleContext) -> EvalResultType:
         select_statement = None
@@ -60,9 +62,18 @@ class Rule_RF07(BaseRule):
         if not select_info or len(select_info.table_aliases) <= 1:
             return None
 
-        # Names of the aliases declared in this SELECT. Matched by raw spelling,
-        # consistent with how RF02 compares column aliases.
-        alias_names = {c.alias_identifier_name for c in select_info.col_aliases}
+        # Dialect-normalized names of the aliases declared in this SELECT, so
+        # that case variants of unquoted identifiers are matched.
+        alias_names = {
+            identifier.raw_normalized()
+            for element in select_statement.recursive_crawl(
+                "select_clause_element", no_recursive_seg_type="select_statement"
+            )
+            for alias_expression in element.recursive_crawl(
+                "alias_expression", no_recursive_seg_type="select_statement"
+            )
+            for identifier in alias_expression.recursive_crawl("identifier")
+        }
         if not alias_names:
             return None
 
@@ -75,7 +86,7 @@ class Rule_RF07(BaseRule):
             ):
                 if qualification(reference, context.dialect.name) != "unqualified":
                     continue
-                if reference.raw in alias_names:
+                if reference.raw_normalized() in alias_names:
                     results.append(
                         LintResult(
                             anchor=reference,

--- a/src/sqlfluff/rules/references/RF07.py
+++ b/src/sqlfluff/rules/references/RF07.py
@@ -16,7 +16,7 @@ def _identifier_key(identifier: BaseSegment) -> tuple[bool, str]:
     same spelling, mirroring ANSI quoted identifier semantics.
     """
     if identifier.is_type("quoted_identifier"):
-        return (True, identifier.raw_normalized(casefold=False))
+        return (True, identifier.raw_normalized())
     return (False, identifier.raw_normalized())
 
 

--- a/src/sqlfluff/rules/references/RF07.py
+++ b/src/sqlfluff/rules/references/RF07.py
@@ -57,22 +57,12 @@ class Rule_RF07(BaseRule):
         select_info = get_select_statement_info(select_statement, context.dialect)
         # Only relevant when the alias could collide with a column on another
         # table, i.e. when more than one table is referenced.
-        if not select_info:  # pragma: no cover
-            return None
-        if len(select_info.table_aliases) <= 1:
+        if not select_info or len(select_info.table_aliases) <= 1:
             return None
 
-        # Normalized names of the aliases declared in this SELECT.
-        alias_names = {
-            identifier.raw_normalized()
-            for element in select_statement.recursive_crawl(
-                "select_clause_element", no_recursive_seg_type="select_statement"
-            )
-            for alias_expression in element.recursive_crawl(
-                "alias_expression", no_recursive_seg_type="select_statement"
-            )
-            for identifier in alias_expression.recursive_crawl("identifier")
-        }
+        # Names of the aliases declared in this SELECT. Matched by raw spelling,
+        # consistent with how RF02 compares column aliases.
+        alias_names = {c.alias_identifier_name for c in select_info.col_aliases}
         if not alias_names:
             return None
 
@@ -85,7 +75,7 @@ class Rule_RF07(BaseRule):
             ):
                 if qualification(reference, context.dialect.name) != "unqualified":
                     continue
-                if reference.raw_normalized() in alias_names:
+                if reference.raw in alias_names:
                     results.append(
                         LintResult(
                             anchor=reference,

--- a/src/sqlfluff/rules/references/RF07.py
+++ b/src/sqlfluff/rules/references/RF07.py
@@ -1,9 +1,23 @@
 """Implementation of Rule RF07."""
 
 from sqlfluff.core.dialects.common import qualification
+from sqlfluff.core.parser import BaseSegment
 from sqlfluff.core.rules import BaseRule, EvalResultType, LintResult, RuleContext
 from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
 from sqlfluff.utils.analysis.select import get_select_statement_info
+
+
+def _identifier_key(identifier: BaseSegment) -> tuple[bool, str]:
+    """Return a comparison key of quoting style and normalized name.
+
+    Unquoted identifiers fold case according to the dialect, so they compare
+    case-insensitively with each other. A quoted identifier keeps its exact
+    spelling and only compares equal to another quoted identifier with the
+    same spelling, mirroring ANSI quoted identifier semantics.
+    """
+    if identifier.is_type("quoted_identifier"):
+        return (True, identifier.raw_normalized(casefold=False))
+    return (False, identifier.raw_normalized())
 
 
 class Rule_RF07(BaseRule):
@@ -14,6 +28,10 @@ class Rule_RF07(BaseRule):
     which happens to match an alias does not resolve to that alias. When more
     than one table is in scope it silently resolves to a real column on one of
     them instead, changing the result without any error.
+
+    .. note::
+       This rule is disabled by default. Enable it with the
+       ``force_enable = True`` flag.
 
     **Anti-pattern**
 
@@ -43,11 +61,16 @@ class Rule_RF07(BaseRule):
 
     name = "references.window_alias"
     groups = ("all", "references")
+    config_keywords = ["force_enable"]
     # A window_specification holds the PARTITION BY/ORDER BY of both an inline
     # OVER (...) and a named WINDOW ... AS (...) definition.
     crawl_behaviour = SegmentSeekerCrawler({"window_specification"})
 
     def _eval(self, context: RuleContext) -> EvalResultType:
+        self.force_enable: bool
+        if not self.force_enable:
+            return None
+
         select_statement = None
         for parent in reversed(context.parent_stack):
             if parent.is_type("select_statement"):
@@ -62,10 +85,10 @@ class Rule_RF07(BaseRule):
         if not select_info or len(select_info.table_aliases) <= 1:
             return None
 
-        # Dialect-normalized names of the aliases declared in this SELECT, so
-        # that case variants of unquoted identifiers are matched.
+        # Comparison keys of the aliases declared in this SELECT: case variants
+        # of unquoted identifiers match, quoted identifiers match exactly.
         alias_names = {
-            identifier.raw_normalized()
+            _identifier_key(identifier)
             for element in select_statement.recursive_crawl(
                 "select_clause_element", no_recursive_seg_type="select_statement"
             )
@@ -86,7 +109,11 @@ class Rule_RF07(BaseRule):
             ):
                 if qualification(reference, context.dialect.name) != "unqualified":
                     continue
-                if reference.raw_normalized() in alias_names:
+                # An unqualified reference contains a single identifier.
+                identifier = next(reference.recursive_crawl("identifier"), None)
+                if identifier is None:  # pragma: no cover
+                    continue
+                if _identifier_key(identifier) in alias_names:
                     results.append(
                         LintResult(
                             anchor=reference,

--- a/src/sqlfluff/rules/references/RF07.py
+++ b/src/sqlfluff/rules/references/RF07.py
@@ -1,8 +1,8 @@
 """Implementation of Rule RF07."""
 
+from sqlfluff.core.dialects.common import qualification
 from sqlfluff.core.rules import BaseRule, EvalResultType, LintResult, RuleContext
 from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
-from sqlfluff.dialects.dialect_ansi import ObjectReferenceSegment
 from sqlfluff.utils.analysis.select import get_select_statement_info
 
 
@@ -51,16 +51,28 @@ class Rule_RF07(BaseRule):
             if parent.is_type("select_statement"):
                 select_statement = parent
                 break
-        if select_statement is None:
+        if select_statement is None:  # pragma: no cover
             return None
 
         select_info = get_select_statement_info(select_statement, context.dialect)
         # Only relevant when the alias could collide with a column on another
         # table, i.e. when more than one table is referenced.
-        if not select_info or len(select_info.table_aliases) <= 1:
+        if not select_info:  # pragma: no cover
+            return None
+        if len(select_info.table_aliases) <= 1:
             return None
 
-        alias_names = {c.alias_identifier_name for c in select_info.col_aliases}
+        # Normalized names of the aliases declared in this SELECT.
+        alias_names = {
+            identifier.raw_normalized()
+            for element in select_statement.recursive_crawl(
+                "select_clause_element", no_recursive_seg_type="select_statement"
+            )
+            for alias_expression in element.recursive_crawl(
+                "alias_expression", no_recursive_seg_type="select_statement"
+            )
+            for identifier in alias_expression.recursive_crawl("identifier")
+        }
         if not alias_names:
             return None
 
@@ -71,11 +83,9 @@ class Rule_RF07(BaseRule):
             for reference in clause.recursive_crawl(
                 "column_reference", no_recursive_seg_type="select_statement"
             ):
-                if not isinstance(reference, ObjectReferenceSegment):
+                if qualification(reference, context.dialect.name) != "unqualified":
                     continue
-                if reference.qualification() != "unqualified":
-                    continue
-                if reference.raw in alias_names:
+                if reference.raw_normalized() in alias_names:
                     results.append(
                         LintResult(
                             anchor=reference,

--- a/src/sqlfluff/rules/references/RF07.py
+++ b/src/sqlfluff/rules/references/RF07.py
@@ -1,0 +1,89 @@
+"""Implementation of Rule RF07."""
+
+from sqlfluff.core.rules import BaseRule, EvalResultType, LintResult, RuleContext
+from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
+from sqlfluff.dialects.dialect_ansi import ObjectReferenceSegment
+from sqlfluff.utils.analysis.select import get_select_statement_info
+
+
+class Rule_RF07(BaseRule):
+    """Do not reference a column alias inside its own ``OVER`` clause.
+
+    Window functions are evaluated before the ``SELECT`` list aliases are
+    applied, so an unqualified reference in a ``PARTITION BY`` or ``ORDER BY``
+    which happens to match an alias does not resolve to that alias. When more
+    than one table is in scope it silently resolves to a real column on one of
+    them instead, changing the result without any error.
+
+    **Anti-pattern**
+
+    ``id`` is an alias for ``t1.col1``, but inside the window it resolves to
+    ``t2.id`` from the joined table.
+
+    .. code-block:: sql
+
+        SELECT
+            t1.col1 AS id,
+            ROW_NUMBER() OVER (PARTITION BY id ORDER BY t1.ts) AS rn
+        FROM t1
+        LEFT JOIN t2 ON t1.col1 = t2.id
+
+    **Best practice**
+
+    Qualify the reference with its table so the intended column is used.
+
+    .. code-block:: sql
+
+        SELECT
+            t1.col1 AS id,
+            ROW_NUMBER() OVER (PARTITION BY t1.col1 ORDER BY t1.ts) AS rn
+        FROM t1
+        LEFT JOIN t2 ON t1.col1 = t2.id
+    """
+
+    name = "references.window_alias"
+    groups = ("all", "references")
+    crawl_behaviour = SegmentSeekerCrawler({"over_clause"})
+
+    def _eval(self, context: RuleContext) -> EvalResultType:
+        select_statement = None
+        for parent in reversed(context.parent_stack):
+            if parent.is_type("select_statement"):
+                select_statement = parent
+                break
+        if select_statement is None:
+            return None
+
+        select_info = get_select_statement_info(select_statement, context.dialect)
+        # Only relevant when the alias could collide with a column on another
+        # table, i.e. when more than one table is referenced.
+        if not select_info or len(select_info.table_aliases) <= 1:
+            return None
+
+        alias_names = {c.alias_identifier_name for c in select_info.col_aliases}
+        if not alias_names:
+            return None
+
+        results: list[LintResult] = []
+        for clause in context.segment.recursive_crawl(
+            "partitionby_clause", "orderby_clause"
+        ):
+            for reference in clause.recursive_crawl(
+                "column_reference", no_recursive_seg_type="select_statement"
+            ):
+                if not isinstance(reference, ObjectReferenceSegment):
+                    continue
+                if reference.qualification() != "unqualified":
+                    continue
+                if reference.raw in alias_names:
+                    results.append(
+                        LintResult(
+                            anchor=reference,
+                            description=(
+                                f"Reference {reference.raw!r} in window clause "
+                                "matches a select alias but resolves to a table "
+                                "column. Qualify it with its table."
+                            ),
+                        )
+                    )
+        return results or None

--- a/src/sqlfluff/rules/references/__init__.py
+++ b/src/sqlfluff/rules/references/__init__.py
@@ -73,5 +73,14 @@ def get_rules() -> list[type[BaseRule]]:
     from sqlfluff.rules.references.RF04 import Rule_RF04
     from sqlfluff.rules.references.RF05 import Rule_RF05
     from sqlfluff.rules.references.RF06 import Rule_RF06
+    from sqlfluff.rules.references.RF07 import Rule_RF07
 
-    return [Rule_RF01, Rule_RF02, Rule_RF03, Rule_RF04, Rule_RF05, Rule_RF06]
+    return [
+        Rule_RF01,
+        Rule_RF02,
+        Rule_RF03,
+        Rule_RF04,
+        Rule_RF05,
+        Rule_RF06,
+        Rule_RF07,
+    ]

--- a/test/fixtures/rules/std_rule_cases/RF07.yml
+++ b/test/fixtures/rules/std_rule_cases/RF07.yml
@@ -1,0 +1,53 @@
+rule: RF07
+
+test_fail_alias_in_partition_by:
+  fail_str: |
+    SELECT
+        t1.col1 AS id,
+        ROW_NUMBER() OVER (PARTITION BY id ORDER BY t1.ts) AS rn
+    FROM t1
+    LEFT JOIN t2 ON t1.col1 = t2.id
+
+test_fail_alias_in_order_by:
+  fail_str: |
+    SELECT
+        t1.col1 AS id,
+        ROW_NUMBER() OVER (PARTITION BY t1.grp ORDER BY id) AS rn
+    FROM t1
+    LEFT JOIN t2 ON t1.col1 = t2.id
+
+test_pass_qualified_window_reference:
+  pass_str: |
+    SELECT
+        t1.col1 AS id,
+        ROW_NUMBER() OVER (PARTITION BY t1.col1 ORDER BY t1.ts) AS rn
+    FROM t1
+    LEFT JOIN t2 ON t1.col1 = t2.id
+
+test_pass_unqualified_reference_that_is_not_an_alias:
+  # A plain unqualified reference is RF02's concern, not RF07's.
+  pass_str: |
+    SELECT
+        t1.col1 AS id,
+        LAG(t1.c) OVER (PARTITION BY t1.col1 ORDER BY dt) AS v
+    FROM t1
+    LEFT JOIN t2 ON t1.col1 = t2.id
+
+test_pass_single_table:
+  # With a single table there is no ambiguity to flag.
+  pass_str: |
+    SELECT
+        col1 AS id,
+        ROW_NUMBER() OVER (PARTITION BY id ORDER BY ts) AS rn
+    FROM t1
+
+test_pass_window_in_subquery_scope:
+  # The window belongs to the subquery, whose aliases differ from the outer query.
+  pass_str: |
+    SELECT
+        t1.col1 AS id,
+        (
+            SELECT MAX(x) OVER (PARTITION BY sid) FROM s
+        ) AS mx
+    FROM t1
+    LEFT JOIN t2 ON t1.col1 = t2.id

--- a/test/fixtures/rules/std_rule_cases/RF07.yml
+++ b/test/fixtures/rules/std_rule_cases/RF07.yml
@@ -16,15 +16,6 @@ test_fail_alias_in_order_by:
     FROM t1
     LEFT JOIN t2 ON t1.col1 = t2.id
 
-test_fail_alias_case_insensitive:
-  # Unquoted identifiers are case-insensitive: AS ID and PARTITION BY id match.
-  fail_str: |
-    SELECT
-        t1.col1 AS ID,
-        ROW_NUMBER() OVER (PARTITION BY id ORDER BY t1.ts) AS rn
-    FROM t1
-    LEFT JOIN t2 ON t1.col1 = t2.id
-
 test_pass_no_select_aliases:
   # No select aliases means nothing for a window reference to shadow.
   pass_str: |

--- a/test/fixtures/rules/std_rule_cases/RF07.yml
+++ b/test/fixtures/rules/std_rule_cases/RF07.yml
@@ -16,6 +16,24 @@ test_fail_alias_in_order_by:
     FROM t1
     LEFT JOIN t2 ON t1.col1 = t2.id
 
+test_fail_alias_case_insensitive:
+  # Unquoted identifiers are case-insensitive: AS ID and PARTITION BY id match.
+  fail_str: |
+    SELECT
+        t1.col1 AS ID,
+        ROW_NUMBER() OVER (PARTITION BY id ORDER BY t1.ts) AS rn
+    FROM t1
+    LEFT JOIN t2 ON t1.col1 = t2.id
+
+test_pass_no_select_aliases:
+  # No select aliases means nothing for a window reference to shadow.
+  pass_str: |
+    SELECT
+        t1.col1,
+        ROW_NUMBER() OVER (PARTITION BY t2.grp ORDER BY t1.ts)
+    FROM t1
+    LEFT JOIN t2 ON t1.col1 = t2.id
+
 test_pass_qualified_window_reference:
   pass_str: |
     SELECT

--- a/test/fixtures/rules/std_rule_cases/RF07.yml
+++ b/test/fixtures/rules/std_rule_cases/RF07.yml
@@ -16,6 +16,35 @@ test_fail_alias_in_order_by:
     FROM t1
     LEFT JOIN t2 ON t1.col1 = t2.id
 
+test_fail_alias_case_insensitive:
+  # Unquoted identifiers are case-insensitive, so AS ID and PARTITION BY id
+  # are the same name.
+  fail_str: |
+    SELECT
+        t1.col1 AS ID,
+        SUM(t2.v) OVER (PARTITION BY id ORDER BY t1.ts) AS s
+    FROM t1
+    JOIN t2 ON t1.col1 = t2.id
+
+test_fail_alias_in_named_window:
+  # The PARTITION BY of a named WINDOW definition is checked too.
+  fail_str: |
+    SELECT
+        t1.col1 AS id,
+        ROW_NUMBER() OVER w AS rn
+    FROM t1
+    JOIN t2 ON t1.col1 = t2.id
+    WINDOW w AS (PARTITION BY id ORDER BY t1.ts)
+
+test_pass_qualified_named_window:
+  pass_str: |
+    SELECT
+        t1.col1 AS id,
+        ROW_NUMBER() OVER w AS rn
+    FROM t1
+    JOIN t2 ON t1.col1 = t2.id
+    WINDOW w AS (PARTITION BY t1.col1 ORDER BY t1.ts)
+
 test_pass_no_select_aliases:
   # No select aliases means nothing for a window reference to shadow.
   pass_str: |

--- a/test/fixtures/rules/std_rule_cases/RF07.yml
+++ b/test/fixtures/rules/std_rule_cases/RF07.yml
@@ -1,5 +1,15 @@
 rule: RF07
 
+test_pass_disabled_by_default:
+  # The rule is opt-in: without force_enable it stays quiet even for
+  # SQL it would otherwise flag.
+  pass_str: |
+    SELECT
+        t1.col1 AS id,
+        ROW_NUMBER() OVER (PARTITION BY id ORDER BY t1.ts) AS rn
+    FROM t1
+    LEFT JOIN t2 ON t1.col1 = t2.id
+
 test_fail_alias_in_partition_by:
   fail_str: |
     SELECT
@@ -7,6 +17,10 @@ test_fail_alias_in_partition_by:
         ROW_NUMBER() OVER (PARTITION BY id ORDER BY t1.ts) AS rn
     FROM t1
     LEFT JOIN t2 ON t1.col1 = t2.id
+  configs:
+    rules:
+      references.window_alias:
+        force_enable: true
 
 test_fail_alias_in_order_by:
   fail_str: |
@@ -15,6 +29,10 @@ test_fail_alias_in_order_by:
         ROW_NUMBER() OVER (PARTITION BY t1.grp ORDER BY id) AS rn
     FROM t1
     LEFT JOIN t2 ON t1.col1 = t2.id
+  configs:
+    rules:
+      references.window_alias:
+        force_enable: true
 
 test_fail_alias_case_insensitive:
   # Unquoted identifiers are case-insensitive, so AS ID and PARTITION BY id
@@ -25,6 +43,10 @@ test_fail_alias_case_insensitive:
         SUM(t2.v) OVER (PARTITION BY id ORDER BY t1.ts) AS s
     FROM t1
     JOIN t2 ON t1.col1 = t2.id
+  configs:
+    rules:
+      references.window_alias:
+        force_enable: true
 
 test_fail_alias_in_named_window:
   # The PARTITION BY of a named WINDOW definition is checked too.
@@ -35,6 +57,50 @@ test_fail_alias_in_named_window:
     FROM t1
     JOIN t2 ON t1.col1 = t2.id
     WINDOW w AS (PARTITION BY id ORDER BY t1.ts)
+  configs:
+    rules:
+      references.window_alias:
+        force_enable: true
+
+test_fail_quoted_alias_quoted_reference:
+  # A quoted alias matches a quoted reference with the same spelling.
+  fail_str: |
+    SELECT
+        t1.col1 AS "id",
+        SUM(t2.v) OVER (PARTITION BY "id" ORDER BY t1.ts) AS s
+    FROM t1
+    JOIN t2 ON t1.col1 = t2.id
+  configs:
+    rules:
+      references.window_alias:
+        force_enable: true
+
+test_pass_quoted_alias_unquoted_reference:
+  # A quoted alias preserves its case, so it is not the same identifier
+  # as an unquoted (case-folded) reference.
+  pass_str: |
+    SELECT
+        t1.col1 AS "ID",
+        SUM(t2.v) OVER (PARTITION BY id ORDER BY t1.ts) AS s
+    FROM t1
+    JOIN t2 ON t1.col1 = t2.id
+  configs:
+    rules:
+      references.window_alias:
+        force_enable: true
+
+test_pass_quoted_alias_quoted_reference_case_mismatch:
+  # Quoted identifiers are case-sensitive, so "ID" and "id" differ.
+  pass_str: |
+    SELECT
+        t1.col1 AS "ID",
+        SUM(t2.v) OVER (PARTITION BY "id" ORDER BY t1.ts) AS s
+    FROM t1
+    JOIN t2 ON t1.col1 = t2.id
+  configs:
+    rules:
+      references.window_alias:
+        force_enable: true
 
 test_pass_qualified_named_window:
   pass_str: |
@@ -44,6 +110,10 @@ test_pass_qualified_named_window:
     FROM t1
     JOIN t2 ON t1.col1 = t2.id
     WINDOW w AS (PARTITION BY t1.col1 ORDER BY t1.ts)
+  configs:
+    rules:
+      references.window_alias:
+        force_enable: true
 
 test_pass_no_select_aliases:
   # No select aliases means nothing for a window reference to shadow.
@@ -53,6 +123,10 @@ test_pass_no_select_aliases:
         ROW_NUMBER() OVER (PARTITION BY t2.grp ORDER BY t1.ts)
     FROM t1
     LEFT JOIN t2 ON t1.col1 = t2.id
+  configs:
+    rules:
+      references.window_alias:
+        force_enable: true
 
 test_pass_qualified_window_reference:
   pass_str: |
@@ -61,6 +135,10 @@ test_pass_qualified_window_reference:
         ROW_NUMBER() OVER (PARTITION BY t1.col1 ORDER BY t1.ts) AS rn
     FROM t1
     LEFT JOIN t2 ON t1.col1 = t2.id
+  configs:
+    rules:
+      references.window_alias:
+        force_enable: true
 
 test_pass_unqualified_reference_that_is_not_an_alias:
   # A plain unqualified reference is RF02's concern, not RF07's.
@@ -70,6 +148,10 @@ test_pass_unqualified_reference_that_is_not_an_alias:
         LAG(t1.c) OVER (PARTITION BY t1.col1 ORDER BY dt) AS v
     FROM t1
     LEFT JOIN t2 ON t1.col1 = t2.id
+  configs:
+    rules:
+      references.window_alias:
+        force_enable: true
 
 test_pass_single_table:
   # With a single table there is no ambiguity to flag.
@@ -78,6 +160,10 @@ test_pass_single_table:
         col1 AS id,
         ROW_NUMBER() OVER (PARTITION BY id ORDER BY ts) AS rn
     FROM t1
+  configs:
+    rules:
+      references.window_alias:
+        force_enable: true
 
 test_pass_window_in_subquery_scope:
   # The window belongs to the subquery, whose aliases differ from the outer query.
@@ -89,3 +175,7 @@ test_pass_window_in_subquery_scope:
         ) AS mx
     FROM t1
     LEFT JOIN t2 ON t1.col1 = t2.id
+  configs:
+    rules:
+      references.window_alias:
+        force_enable: true


### PR DESCRIPTION
Closes #7395.

## What

Adds a new rule `RF07` (`references.window_alias`). It flags an unqualified column reference in a window function's `PARTITION BY` or `ORDER BY` that matches a column alias defined in the same `SELECT`, when more than one table is in scope.

## Why

Window functions are evaluated before the `SELECT` list aliases are applied, so such a reference does not resolve to the alias. With more than one table in scope it silently resolves to a real column on one of them, changing the results with no error:

```sql
SELECT
    t1.col1 AS id,
    ROW_NUMBER() OVER (PARTITION BY id ORDER BY t1.ts) AS rn  -- 'id' -> t2.id, not the alias
FROM t1
LEFT JOIN t2 ON t1.col1 = t2.id
```

RF02 deliberately allows references that match a select alias, so this is added as a separate rule rather than an extension of RF02. It reuses RF02's ambiguity gate (only fires when more than one table is referenced).

## Tests

`test/fixtures/rules/std_rule_cases/RF07.yml` covers the partition-by and order-by failures plus passing cases (qualified reference, non-alias reference, single table, and a window scoped to a subquery).

## AI disclosure

Per CONTRIBUTING (AI-Assisted Contributions): the rule and its fixtures were drafted with AI assistance. I validated manually by running the rule against the example in #7395 and the yaml pass/fail cases, and by confirming `ruff`, `ruff-format`, `mypy`, the docstring meta-test, and the references-rule regression all pass locally.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds rule RF07 (`references.window_alias`) to flag unqualified references in window PARTITION BY/ORDER BY that shadow a SELECT alias when multiple tables are in scope, preventing silent binding to a table column. Supports named WINDOWs, case-insensitive matching for unquoted names, and quoted-identifier exact-match semantics; disabled by default via `force_enable`.

- **New Features**
  - Fires only when multiple tables are referenced (RF02 ambiguity gate) and suggests qualifying with a table.
  - Checks inline and named WINDOW `PARTITION BY`/`ORDER BY`; uses `qualification()` from `sqlfluff.core.dialects.common`.
  - Compares identifiers as (quoted, name): unquoted names match case-insensitively; quoted names match only on exact quoted spelling. Opt-in via `rules.references.window_alias.force_enable: true`.

<sup>Written for commit 573ec809da10e506e57aa890b878b31828fbf71d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8153?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

