### PR TITLE
Added support for * EXCEPT (col1, col2) in MERGE statement for SparkSQL

### DIFF
--- a/src/sqlfluff/dialects/dialect_databricks.py
+++ b/src/sqlfluff/dialects/dialect_databricks.py
@@ -1563,7 +1563,7 @@ class MergeInsertClauseSegment(sparksql.MergeInsertClauseSegment):
     match_grammar: Matchable = Sequence(
         "INSERT",
         OneOf(
-            Ref("WildcardIdentifierSegment"),
+            Ref("WildcardExpressionSegment"),
             Sequence(
                 Indent,
                 Ref("BracketedColumnReferenceListGrammar"),

--- a/src/sqlfluff/dialects/dialect_sparksql.py
+++ b/src/sqlfluff/dialects/dialect_sparksql.py
@@ -3284,7 +3284,7 @@ class MergeUpdateClauseSegment(ansi.MergeUpdateClauseSegment):
     match_grammar: Matchable = Sequence(
         "UPDATE",
         OneOf(
-            Sequence("SET", Ref("WildcardIdentifierSegment")),
+            Sequence("SET", Ref("WildcardExpressionSegment")),
             Sequence(
                 Indent,
                 Ref("SetClauseListSegment"),
@@ -3301,7 +3301,7 @@ class MergeInsertClauseSegment(ansi.MergeInsertClauseSegment):
     match_grammar: Matchable = Sequence(
         "INSERT",
         OneOf(
-            Ref("WildcardIdentifierSegment"),
+            Ref("WildcardExpressionSegment"),
             Sequence(
                 Indent,
                 Ref("BracketedColumnReferenceListGrammar"),
@@ -3591,12 +3591,18 @@ class ConstraintStatementSegment(BaseSegment):
 
 
 class WildcardExpressionSegment(ansi.WildcardExpressionSegment):
-    """An extension of the star expression for Databricks."""
+    """An extension of the star expression for SparkSQL.
+
+    Adds support for the optional ``EXCEPT`` clause, which prunes columns
+    from the referenceable set of columns identified in the star clause.
+
+    https://spark.apache.org/docs/latest/sql-ref-syntax-qry-star.html
+    """
 
     match_grammar = ansi.WildcardExpressionSegment.match_grammar.copy(
         insert=[
             # Optional EXCEPT clause
-            # https://docs.databricks.com/release-notes/runtime/9.0.html#exclude-columns-in-select--public-preview
+            # https://spark.apache.org/docs/latest/sql-ref-syntax-qry-star.html
             Ref("ExceptClauseSegment", optional=True),
         ]
     )

--- a/test/fixtures/dialects/databricks/merge_into.sql
+++ b/test/fixtures/dialects/databricks/merge_into.sql
@@ -88,4 +88,3 @@ update set * except (last_updated)
 when not matched then
 insert * except (last_updated)
 ;
-

--- a/test/fixtures/dialects/databricks/merge_into.sql
+++ b/test/fixtures/dialects/databricks/merge_into.sql
@@ -78,3 +78,14 @@ when not matched by target and src.is_valid = true then
 insert (id, file_path) values (src.id, src.file_path)
 when not matched by source and dest.is_active = true then
 update set dest.is_active = false
+;
+
+-- INSERT * EXCEPT: validates the Databricks-specific MergeInsertClauseSegment
+-- override (explicit VALUES matching) continues to support EXCEPT
+merge into t using u on (t.key = u.key)
+when matched then
+update set * except (last_updated)
+when not matched then
+insert * except (last_updated)
+;
+

--- a/test/fixtures/dialects/databricks/merge_into.yml
+++ b/test/fixtures/dialects/databricks/merge_into.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: cd1d2ac61d2e5112a678d93d35976e01448dd14e63b3f0774e89a8285bbfb4b7
+_hash: 044ceb415c03af02b4a55903cab890dbadc739f7c381de57284232a5d2488c5d
 file:
 - statement:
     merge_statement:
@@ -436,8 +436,9 @@ file:
         - merge_update_clause:
           - keyword: update
           - keyword: set
-          - wildcard_identifier:
-              star: '*'
+          - wildcard_expression:
+              wildcard_identifier:
+                star: '*'
         merge_when_not_matched_clause:
         - keyword: when
         - keyword: not
@@ -445,8 +446,9 @@ file:
         - keyword: then
         - merge_insert_clause:
             keyword: insert
-            wildcard_identifier:
-              star: '*'
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
 - statement_terminator: ;
 - statement:
     merge_statement:
@@ -550,3 +552,65 @@ file:
                 comparison_operator:
                   raw_comparison_operator: '='
                 boolean_literal: 'false'
+- statement_terminator: ;
+- statement:
+    merge_statement:
+    - keyword: merge
+    - keyword: into
+    - table_reference:
+        naked_identifier: t
+    - keyword: using
+    - table_reference:
+        naked_identifier: u
+    - join_on_condition:
+        keyword: 'on'
+        bracketed:
+          start_bracket: (
+          expression:
+          - column_reference:
+            - naked_identifier: t
+            - dot: .
+            - naked_identifier: key
+          - comparison_operator:
+              raw_comparison_operator: '='
+          - column_reference:
+            - naked_identifier: u
+            - dot: .
+            - naked_identifier: key
+          end_bracket: )
+    - merge_match:
+        merge_when_matched_clause:
+        - keyword: when
+        - keyword: matched
+        - keyword: then
+        - merge_update_clause:
+          - keyword: update
+          - keyword: set
+          - wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+              select_except_clause:
+                keyword: except
+                bracketed:
+                  start_bracket: (
+                  column_reference:
+                    naked_identifier: last_updated
+                  end_bracket: )
+        merge_when_not_matched_clause:
+        - keyword: when
+        - keyword: not
+        - keyword: matched
+        - keyword: then
+        - merge_insert_clause:
+            keyword: insert
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+              select_except_clause:
+                keyword: except
+                bracketed:
+                  start_bracket: (
+                  column_reference:
+                    naked_identifier: last_updated
+                  end_bracket: )
+- statement_terminator: ;

--- a/test/fixtures/dialects/sparksql/delta_merge.yml
+++ b/test/fixtures/dialects/sparksql/delta_merge.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 8ccf6bc5f00c697fe4ccc0dfb790d4fe997c5da83b3595b2c28583be696a103e
+_hash: 3420c515508fcf06c437727979c28ce35a5c03fc0c045d3d405df5f1be493649
 file:
 - statement:
     merge_statement:
@@ -231,8 +231,9 @@ file:
         - keyword: THEN
         - merge_insert_clause:
             keyword: INSERT
-            wildcard_identifier:
-              star: '*'
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
 - statement_terminator: ;
 - statement:
     merge_statement:
@@ -305,8 +306,9 @@ file:
         - keyword: THEN
         - merge_insert_clause:
             keyword: INSERT
-            wildcard_identifier:
-              star: '*'
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
 - statement_terminator: ;
 - statement:
     merge_statement:

--- a/test/fixtures/dialects/sparksql/merge_into.sql
+++ b/test/fixtures/dialects/sparksql/merge_into.sql
@@ -55,3 +55,30 @@ WHEN NOT MATCHED BY TARGET AND a < b THEN
 INSERT (a, c) VALUES (b, d)
 WHEN NOT MATCHED BY SOURCE AND c < d THEN
 DELETE;
+
+-- Merge with UPDATE SET * EXCEPT (...)
+MERGE INTO t USING u ON (a = b)
+WHEN MATCHED THEN
+UPDATE SET * EXCEPT (col1);
+
+-- Merge with UPDATE SET * EXCEPT multiple columns
+MERGE INTO t USING u ON (a = b)
+WHEN MATCHED THEN
+UPDATE SET * EXCEPT (col1, col2, col3);
+
+-- Merge with INSERT * EXCEPT (...)
+MERGE INTO t USING u ON (a = b)
+WHEN NOT MATCHED THEN
+INSERT * EXCEPT (col1);
+
+-- Merge with INSERT * EXCEPT multiple columns
+MERGE INTO t USING u ON (a = b)
+WHEN NOT MATCHED THEN
+INSERT * EXCEPT (col1, col2, col3);
+
+-- Merge with both UPDATE SET * EXCEPT and INSERT * EXCEPT
+MERGE INTO t USING u ON (t.key = u.key)
+WHEN MATCHED THEN
+UPDATE SET * EXCEPT (last_updated)
+WHEN NOT MATCHED THEN
+INSERT * EXCEPT (last_updated);

--- a/test/fixtures/dialects/sparksql/merge_into.yml
+++ b/test/fixtures/dialects/sparksql/merge_into.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: fbae8c3b1cba41f10d2316a3fb0c2726ae16fb4283fe600c9d19c8c005f4cf3d
+_hash: d2960f8fdc0b2169491ace5fc16a69c9520aa015fe75218ff96fa0327d955199
 file:
 - statement:
     merge_statement:
@@ -330,8 +330,9 @@ file:
         - merge_update_clause:
           - keyword: UPDATE
           - keyword: SET
-          - wildcard_identifier:
-              star: '*'
+          - wildcard_expression:
+              wildcard_identifier:
+                star: '*'
         merge_when_not_matched_clause:
         - keyword: WHEN
         - keyword: NOT
@@ -339,8 +340,9 @@ file:
         - keyword: THEN
         - merge_insert_clause:
             keyword: INSERT
-            wildcard_identifier:
-              star: '*'
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
 - statement_terminator: ;
 - statement:
     merge_statement:
@@ -573,4 +575,237 @@ file:
         - keyword: THEN
         - merge_delete_clause:
             keyword: DELETE
+- statement_terminator: ;
+- statement:
+    merge_statement:
+    - keyword: MERGE
+    - keyword: INTO
+    - table_reference:
+        naked_identifier: t
+    - keyword: USING
+    - table_reference:
+        naked_identifier: u
+    - join_on_condition:
+        keyword: 'ON'
+        bracketed:
+          start_bracket: (
+          expression:
+          - column_reference:
+              naked_identifier: a
+          - comparison_operator:
+              raw_comparison_operator: '='
+          - column_reference:
+              naked_identifier: b
+          end_bracket: )
+    - merge_match:
+        merge_when_matched_clause:
+        - keyword: WHEN
+        - keyword: MATCHED
+        - keyword: THEN
+        - merge_update_clause:
+          - keyword: UPDATE
+          - keyword: SET
+          - wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+              select_except_clause:
+                keyword: EXCEPT
+                bracketed:
+                  start_bracket: (
+                  column_reference:
+                    naked_identifier: col1
+                  end_bracket: )
+- statement_terminator: ;
+- statement:
+    merge_statement:
+    - keyword: MERGE
+    - keyword: INTO
+    - table_reference:
+        naked_identifier: t
+    - keyword: USING
+    - table_reference:
+        naked_identifier: u
+    - join_on_condition:
+        keyword: 'ON'
+        bracketed:
+          start_bracket: (
+          expression:
+          - column_reference:
+              naked_identifier: a
+          - comparison_operator:
+              raw_comparison_operator: '='
+          - column_reference:
+              naked_identifier: b
+          end_bracket: )
+    - merge_match:
+        merge_when_matched_clause:
+        - keyword: WHEN
+        - keyword: MATCHED
+        - keyword: THEN
+        - merge_update_clause:
+          - keyword: UPDATE
+          - keyword: SET
+          - wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+              select_except_clause:
+                keyword: EXCEPT
+                bracketed:
+                - start_bracket: (
+                - column_reference:
+                    naked_identifier: col1
+                - comma: ','
+                - column_reference:
+                    naked_identifier: col2
+                - comma: ','
+                - column_reference:
+                    naked_identifier: col3
+                - end_bracket: )
+- statement_terminator: ;
+- statement:
+    merge_statement:
+    - keyword: MERGE
+    - keyword: INTO
+    - table_reference:
+        naked_identifier: t
+    - keyword: USING
+    - table_reference:
+        naked_identifier: u
+    - join_on_condition:
+        keyword: 'ON'
+        bracketed:
+          start_bracket: (
+          expression:
+          - column_reference:
+              naked_identifier: a
+          - comparison_operator:
+              raw_comparison_operator: '='
+          - column_reference:
+              naked_identifier: b
+          end_bracket: )
+    - merge_match:
+        merge_when_not_matched_clause:
+        - keyword: WHEN
+        - keyword: NOT
+        - keyword: MATCHED
+        - keyword: THEN
+        - merge_insert_clause:
+            keyword: INSERT
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+              select_except_clause:
+                keyword: EXCEPT
+                bracketed:
+                  start_bracket: (
+                  column_reference:
+                    naked_identifier: col1
+                  end_bracket: )
+- statement_terminator: ;
+- statement:
+    merge_statement:
+    - keyword: MERGE
+    - keyword: INTO
+    - table_reference:
+        naked_identifier: t
+    - keyword: USING
+    - table_reference:
+        naked_identifier: u
+    - join_on_condition:
+        keyword: 'ON'
+        bracketed:
+          start_bracket: (
+          expression:
+          - column_reference:
+              naked_identifier: a
+          - comparison_operator:
+              raw_comparison_operator: '='
+          - column_reference:
+              naked_identifier: b
+          end_bracket: )
+    - merge_match:
+        merge_when_not_matched_clause:
+        - keyword: WHEN
+        - keyword: NOT
+        - keyword: MATCHED
+        - keyword: THEN
+        - merge_insert_clause:
+            keyword: INSERT
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+              select_except_clause:
+                keyword: EXCEPT
+                bracketed:
+                - start_bracket: (
+                - column_reference:
+                    naked_identifier: col1
+                - comma: ','
+                - column_reference:
+                    naked_identifier: col2
+                - comma: ','
+                - column_reference:
+                    naked_identifier: col3
+                - end_bracket: )
+- statement_terminator: ;
+- statement:
+    merge_statement:
+    - keyword: MERGE
+    - keyword: INTO
+    - table_reference:
+        naked_identifier: t
+    - keyword: USING
+    - table_reference:
+        naked_identifier: u
+    - join_on_condition:
+        keyword: 'ON'
+        bracketed:
+          start_bracket: (
+          expression:
+          - column_reference:
+            - naked_identifier: t
+            - dot: .
+            - naked_identifier: key
+          - comparison_operator:
+              raw_comparison_operator: '='
+          - column_reference:
+            - naked_identifier: u
+            - dot: .
+            - naked_identifier: key
+          end_bracket: )
+    - merge_match:
+        merge_when_matched_clause:
+        - keyword: WHEN
+        - keyword: MATCHED
+        - keyword: THEN
+        - merge_update_clause:
+          - keyword: UPDATE
+          - keyword: SET
+          - wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+              select_except_clause:
+                keyword: EXCEPT
+                bracketed:
+                  start_bracket: (
+                  column_reference:
+                    naked_identifier: last_updated
+                  end_bracket: )
+        merge_when_not_matched_clause:
+        - keyword: WHEN
+        - keyword: NOT
+        - keyword: MATCHED
+        - keyword: THEN
+        - merge_insert_clause:
+            keyword: INSERT
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+              select_except_clause:
+                keyword: EXCEPT
+                bracketed:
+                  start_bracket: (
+                  column_reference:
+                    naked_identifier: last_updated
+                  end_bracket: )
 - statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
Adds support to the SparkSQL dialect for * EXCEPT (col1, col2) in the MERGE statement.

Spark SQL documents the except clause as a standard optional part of the star clause (see [Star (*) Clause](https://spark.apache.org/docs/latest/sql-ref-syntax-qry-star.html)). This is also useful for the Databricks dialect, which inherits from SparkSQL in SQLFluff and supports BY NAME as well.
The except clause was already added to the dialect, but not yet used in the MERGE statement.


### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for the star EXCEPT clause in SparkSQL MERGE, allowing UPDATE SET * EXCEPT (...) and INSERT * EXCEPT (...) to prune columns. Also enabled in the Databricks dialect.

- **New Features**
  - Extended `WildcardExpressionSegment` in SparkSQL to include optional `EXCEPT`.
  - Updated MERGE to use `WildcardExpressionSegment` in `MergeUpdateClauseSegment` and `MergeInsertClauseSegment` (SparkSQL and Databricks).
  - Added tests for single/multi-column `EXCEPT` in UPDATE and INSERT, including combined cases; validated Databricks override remains compatible.

<sup>Written for commit c0eb8f372c46ff591ac9fdbabdcd03f81509f255. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8154?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

