### PR TITLE
fix(oracle): allow trailing-dot numeric literals like 1.

### DIFF
--- a/src/sqlfluff/dialects/dialect_oracle.py
+++ b/src/sqlfluff/dialects/dialect_oracle.py
@@ -107,12 +107,10 @@ oracle_dialect.patch_lexer_matchers(
         ),
         RegexLexer(
             "numeric_literal",
-            # Like ANSI, but:
-            # - no bare leading-dot form (.\d+)
-            # - no trailing (?=\b) gate (that blocked Oracle size suffixes
-            #   such as 256K). Trailing-dot numerics like 1. are allowed by
-            #   the \d+\.(?![\.\w]) alternative (#8110).
-            r"(?>\d+\.\d+|\d+\.(?![\.\w])|\d+)(\.?[eE][+-]?\d+)?",
+            # Like ANSI, but no bare leading-dot form (.\d+). Allow trailing-dot
+            # numerics (1.) via \d+\.(?![\.\w]), keep (?=\b) for digit/identifier
+            # splits, and also allow Oracle size suffixes (256K) (#8110).
+            r"(?>\d+\.\d+|\d+\.(?![\.\w])|\d+)(\.?[eE][+-]?\d+)?((?<=\.)|(?=\b)|(?=[KMGTkmg]\b))",
             LiteralSegment,
         ),
     ]

--- a/src/sqlfluff/dialects/dialect_oracle.py
+++ b/src/sqlfluff/dialects/dialect_oracle.py
@@ -107,7 +107,9 @@ oracle_dialect.patch_lexer_matchers(
         ),
         RegexLexer(
             "numeric_literal",
-            r"(?>\d+\.\d+|\d+\.(?![\.\w])|\d+)(\.?[eE][+-]?\d+)?((?<!\.)|(?=\b))",
+            # Same shape as ANSI, but without a bare leading-dot form (.\d+).
+            # The (?<=\.) branch allows trailing-dot numerics such as 1. (#8110).
+            r"(?>\d+\.\d+|\d+\.(?![\.\w])|\d+)(\.?[eE][+-]?\d+)?((?<=\.)|(?=\b))",
             LiteralSegment,
         ),
     ]

--- a/src/sqlfluff/dialects/dialect_oracle.py
+++ b/src/sqlfluff/dialects/dialect_oracle.py
@@ -107,9 +107,12 @@ oracle_dialect.patch_lexer_matchers(
         ),
         RegexLexer(
             "numeric_literal",
-            # Same shape as ANSI, but without a bare leading-dot form (.\d+).
-            # The (?<=\.) branch allows trailing-dot numerics such as 1. (#8110).
-            r"(?>\d+\.\d+|\d+\.(?![\.\w])|\d+)(\.?[eE][+-]?\d+)?((?<=\.)|(?=\b))",
+            # Like ANSI, but:
+            # - no bare leading-dot form (.\d+)
+            # - no trailing (?=\b) gate (that blocked Oracle size suffixes
+            #   such as 256K). Trailing-dot numerics like 1. are allowed by
+            #   the \d+\.(?![\.\w]) alternative (#8110).
+            r"(?>\d+\.\d+|\d+\.(?![\.\w])|\d+)(\.?[eE][+-]?\d+)?",
             LiteralSegment,
         ),
     ]

--- a/src/sqlfluff/dialects/dialect_oracle.py
+++ b/src/sqlfluff/dialects/dialect_oracle.py
@@ -109,8 +109,9 @@ oracle_dialect.patch_lexer_matchers(
             "numeric_literal",
             # Like ANSI, but no bare leading-dot form (.\d+). Allow trailing-dot
             # numerics (1.) via \d+\.(?![\.\w]), keep (?=\b) for digit/identifier
-            # splits, and also allow Oracle size suffixes (256K) (#8110).
-            r"(?>\d+\.\d+|\d+\.(?![\.\w])|\d+)(\.?[eE][+-]?\d+)?((?<=\.)|(?=\b)|(?=[KMGTkmg]\b))",
+            # splits, and also allow Oracle size suffixes (256K / 10P / 10E)
+            # matching SizeClauseGrammar's K/M/G/T/P/E (case-insensitive) (#8110).
+            r"(?>\d+\.\d+|\d+\.(?![\.\w])|\d+)(\.?[eE][+-]?\d+)?((?<=\.)|(?=\b)|(?=[KMGTPEkmgtpe]\b))",
             LiteralSegment,
         ),
     ]

--- a/test/fixtures/dialects/oracle/size_suffix_storage.sql
+++ b/test/fixtures/dialects/oracle/size_suffix_storage.sql
@@ -1,0 +1,8 @@
+-- Oracle size units are K/M/G/T/P/E (case-insensitive).
+-- The numeric lexer must accept the digit run when a size suffix follows.
+CREATE TABLE t (c NUMBER)
+STORAGE (
+    INITIAL 10P
+    NEXT 10E
+    MINEXTENTS 1
+);

--- a/test/fixtures/dialects/oracle/size_suffix_storage.yml
+++ b/test/fixtures/dialects/oracle/size_suffix_storage.yml
@@ -1,0 +1,36 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: f1eb72991c388b6afd1fb7fd8a3094a2a6bf57c4a0d849125c1e627fb5431df4
+file:
+  batch:
+    statement:
+      create_table_statement:
+      - keyword: CREATE
+      - keyword: TABLE
+      - table_reference:
+          naked_identifier: t
+      - bracketed:
+          start_bracket: (
+          column_definition:
+            naked_identifier: c
+            data_type:
+              data_type_identifier: NUMBER
+          end_bracket: )
+      - oracle_physical_attributes:
+          storage_clause:
+            keyword: STORAGE
+            bracketed:
+            - start_bracket: (
+            - keyword: INITIAL
+            - numeric_literal: '10'
+            - size_prefix: P
+            - keyword: NEXT
+            - numeric_literal: '10'
+            - size_prefix: E
+            - keyword: MINEXTENTS
+            - numeric_literal: '1'
+            - end_bracket: )
+    statement_terminator: ;

--- a/test/fixtures/dialects/oracle/trailing_decimal_numeric.sql
+++ b/test/fixtures/dialects/oracle/trailing_decimal_numeric.sql
@@ -1,0 +1,7 @@
+-- https://github.com/sqlfluff/sqlfluff/issues/8110
+SELECT
+    1.,
+    1.0,
+    22.50
+FROM ex_tab
+WHERE ex_col = 1.;

--- a/test/fixtures/dialects/oracle/trailing_decimal_numeric.yml
+++ b/test/fixtures/dialects/oracle/trailing_decimal_numeric.yml
@@ -1,0 +1,36 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 76139eac0f982f8533248ffba9eb65a058ad678a6307d5235952f3c6efa6075f
+file:
+  batch:
+    statement:
+      select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            numeric_literal: '1.'
+        - comma: ','
+        - select_clause_element:
+            numeric_literal: '1.0'
+        - comma: ','
+        - select_clause_element:
+            numeric_literal: '22.50'
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: ex_tab
+        where_clause:
+          keyword: WHERE
+          expression:
+            column_reference:
+              naked_identifier: ex_col
+            comparison_operator:
+              raw_comparison_operator: '='
+            numeric_literal: '1.'
+    statement_terminator: ;


### PR DESCRIPTION
Fixes #8110

Oracle rejected numerics such as `1.` because the numeric_literal
lexer used a negative lookbehind (`(?<!\.)`) where ANSI uses a
positive one (`(?<=\.)`) to allow a trailing decimal point.

Aligned that assertion with ANSI (still without ANSI's bare `.\d+`
form). Added an oracle parse fixture covering the reporter's case.

AI disclosure: assisted with investigation and the fixture. I verified
the fail→pass behavior and reviewed the regex change myself.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow trailing-dot numeric literals (e.g., 1.) in the Oracle dialect by updating the `numeric_literal` regex to match ANSI behavior (no leading-dot form). Keeps Oracle size suffixes (K/M/G/T/P/E) working, blocks digit-prefixed identifiers like `1abc` from splitting, and adds parse fixtures to prevent regressions (fixes #8110).

<sup>Written for commit 7d0256db579ba1a7fa7ad060859d0324ef6e1b96. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8155?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

