### PR TITLE
fix(rust): name the TemplatedFile cache entry type to satisfy clippy

### DIFF
--- a/sqlfluffrs/sqlfluffrs_python/src/templater/templatefile.rs
+++ b/sqlfluffrs/sqlfluffrs_python/src/templater/templatefile.rs
@@ -13,6 +13,11 @@ use sqlfluffrs_types::templater::fileslice::{RawFileSlice, TemplatedFileSlice};
 use once_cell::sync::Lazy;
 use sqlfluffrs_types::templater::templatefile::TemplatedFile;
 
+/// One conversion-cache entry: the normalized `Arc` all markers from a given
+/// Python object must share, plus the `weakref.ref` kept alive so its eviction
+/// callback fires.
+type TemplatedFileCacheEntry = (Arc<TemplatedFile>, Py<PyAny>);
+
 /// Cache of Python→Rust `TemplatedFile` conversions, keyed by the SOURCE
 /// PYTHON OBJECT's address. It exists for two reasons: repeated extraction of
 /// the same `TemplatedFile` (every position marker crossing the FFI boundary
@@ -29,7 +34,7 @@ use sqlfluffrs_types::templater::templatefile::TemplatedFile;
 /// source object is garbage collected (the ref must be kept alive for the
 /// callback to fire) — so the cache is bounded by LIVE TemplatedFiles and a
 /// recycled object address can never hit a stale entry.
-static PY_TEMPLATED_FILE_CACHE: Lazy<Mutex<HashMap<usize, (Arc<TemplatedFile>, Py<PyAny>)>>> =
+static PY_TEMPLATED_FILE_CACHE: Lazy<Mutex<HashMap<usize, TemplatedFileCacheEntry>>> =
     Lazy::new(|| Mutex::new(HashMap::new()));
 
 /// Weakref callback target: drop one conversion-cache entry. Bound to its key


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
This fixes the clippy warning that exists on main.

### Are there any other side effects of this change that we should be aware of?
None

### Pull Request checklist
- [ ] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Name the `TemplatedFileCacheEntry` type for the Python→Rust `TemplatedFile` conversion cache to satisfy Clippy and make the code clearer. No functional changes.

<sup>Written for commit 96498ed331a23a94ea0a4e12dd69d48f93ee4198. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8158?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

