### PR TITLE
Fix clippy failures blocking main CI

### DIFF
--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/cache.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/cache.rs
@@ -154,6 +154,11 @@ impl TableParseCache {
     pub fn len(&self) -> usize {
         self.cache.len()
     }
+
+    /// Iterate over cache entries (for analysis/debugging)
+    pub fn iter(&self) -> impl Iterator<Item = (&TableCacheKey, &TableCacheValue)> {
+        self.cache.iter()
+    }
 }
 
 impl Default for TableParseCache {

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/cache.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/cache.rs
@@ -154,11 +154,6 @@ impl TableParseCache {
     pub fn len(&self) -> usize {
         self.cache.len()
     }
-
-    /// Iterate over cache entries (for analysis/debugging)
-    pub fn iter(&self) -> impl Iterator<Item = (&TableCacheKey, &TableCacheValue)> {
-        self.cache.iter()
-    }
 }
 
 impl Default for TableParseCache {

--- a/sqlfluffrs/sqlfluffrs_python/src/templater/templatefile.rs
+++ b/sqlfluffrs/sqlfluffrs_python/src/templater/templatefile.rs
@@ -29,8 +29,10 @@ use sqlfluffrs_types::templater::templatefile::TemplatedFile;
 /// source object is garbage collected (the ref must be kept alive for the
 /// callback to fire) — so the cache is bounded by LIVE TemplatedFiles and a
 /// recycled object address can never hit a stale entry.
-static PY_TEMPLATED_FILE_CACHE: Lazy<Mutex<HashMap<usize, (Arc<TemplatedFile>, Py<PyAny>)>>> =
-    Lazy::new(|| Mutex::new(HashMap::new()));
+type TemplatedFileCacheEntry = (Arc<TemplatedFile>, Py<PyAny>);
+type TemplatedFileCache = Lazy<Mutex<HashMap<usize, TemplatedFileCacheEntry>>>;
+
+static PY_TEMPLATED_FILE_CACHE: TemplatedFileCache = Lazy::new(|| Mutex::new(HashMap::new()));
 
 /// Weakref callback target: drop one conversion-cache entry. Bound to its key
 /// with `functools.partial`; the weakref machinery passes the (dead) ref as a


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
Main was red on the `rust-lint` job after `#8098` turned on `-D warnings` for clippy, which surfaced two pre-existing lints:
- `clippy::type_complexity` on the `PY_TEMPLATED_FILE_CACHE` static in `sqlfluffrs_python/src/templater/templatefile.rs` which refactored the nested type into `TemplatedFileCacheEntry`/`TemplatedFileCache` aliases.

### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [ ] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Clippy warnings blocking the Rust lint job to restore green CI on main. Simplifies the static cache type in the Python templater binding.

- **Bug Fixes**
  - Replaced the nested `HashMap` value with `TemplatedFileCacheEntry` and `TemplatedFileCache` aliases to satisfy `clippy::type_complexity` in `sqlfluffrs_python/src/templater/templatefile.rs`.

<sup>Written for commit 798e09dbe2923d1a03619324dcf342302d61f588. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8160?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

