### PR TITLE
Snowflake: parse scripting bind variables (:var) in expressions

### DIFF
--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -695,6 +695,11 @@ snowflake_dialect.replace(
     LiteralGrammar=ansi_dialect.get_grammar("LiteralGrammar").copy(
         insert=[
             Ref("ReferencedVariableNameSegment"),
+            # Snowflake Scripting bind variables, e.g. :my_variable. These are
+            # usable wherever a literal value is expected (VALUES lists, WHERE
+            # clauses, etc.).
+            # https://docs.snowflake.com/en/developer-guide/snowflake-scripting/variables#using-a-variable-in-a-sql-statement-binding
+            Ref("BindVariableSegment"),
         ]
     ),
     AccessorGrammar=AnyNumberOf(

--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -10108,9 +10108,14 @@ class BindVariableSegment(BaseSegment):
 
     type = "bind_variable"
 
+    # allow_gaps=False so the colon and the variable name must be adjacent.
+    # Otherwise, when this is reachable in general expressions, input like
+    # `SET a = : WHERE id = 1` would parse `: WHERE` as a bind variable and
+    # corrupt the statement structure instead of failing cleanly.
     match_grammar = Sequence(
         Ref("ColonPrefixSegment"),
         Ref("LocalVariableNameSegment"),
+        allow_gaps=False,
     )
 
 

--- a/test/fixtures/dialects/snowflake/let.yml
+++ b/test/fixtures/dialects/snowflake/let.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 1ca3842cfc1260c844ba4fb9c33b0b9bfe0a36b89bcd7194d999b1e2e37d6c1e
+_hash: 224d88960ce97b1f2e0f9faf4645cb6df93034eea4f41210c6a6f30833ec018b
 file:
 - statement:
     scripting_block_statement:
@@ -170,9 +170,9 @@ file:
       select_clause:
         keyword: SELECT
         select_clause_element:
-          variable: ':'
-          alias_expression:
-            naked_identifier: variable
+          bind_variable:
+            colon_prefix: ':'
+            variable: variable
       from_clause:
         keyword: FROM
         from_expression:

--- a/test/fixtures/dialects/snowflake/snowflake_scripting_bind_variables.sql
+++ b/test/fixtures/dialects/snowflake/snowflake_scripting_bind_variables.sql
@@ -1,0 +1,25 @@
+-- Snowflake Scripting bind variables used in SQL statements.
+-- https://docs.snowflake.com/en/developer-guide/snowflake-scripting/variables#using-a-variable-in-a-sql-statement-binding
+-- https://github.com/sqlfluff/sqlfluff/issues/5427
+
+-- Bind variables in DML value positions.
+INSERT INTO some_db.some_schema.debug_log (process, msg) VALUES (:process, 'START RUN');
+
+SELECT :process;
+
+SELECT a FROM t WHERE a = :process;
+
+UPDATE t SET a = :new_value WHERE id = :target_id;
+
+DELETE FROM t WHERE id = :target_id;
+
+-- The reproduction case from the issue (schema renamed to avoid the
+-- unrelated reserved-keyword clash on INPUT).
+CREATE OR REPLACE PROCEDURE some_db.some_schema.i_am_a_procedure()
+RETURNS BOOLEAN
+LANGUAGE SQL
+AS
+BEGIN
+    LET process VARCHAR := 'THIS_PROCEDURE_PROCESS_KEY';
+    INSERT INTO some_db.some_schema.debug_log (process, msg) VALUES (:process, 'START RUN');
+END;

--- a/test/fixtures/dialects/snowflake/snowflake_scripting_bind_variables.yml
+++ b/test/fixtures/dialects/snowflake/snowflake_scripting_bind_variables.yml
@@ -1,0 +1,182 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 406ef8c69fb19cfab7da6cba349dbbff2c309a4356aa7f74603e5fce94d07ac6
+file:
+- statement:
+    insert_statement:
+    - keyword: INSERT
+    - keyword: INTO
+    - table_reference:
+      - naked_identifier: some_db
+      - dot: .
+      - naked_identifier: some_schema
+      - dot: .
+      - naked_identifier: debug_log
+    - bracketed:
+      - start_bracket: (
+      - column_reference:
+          naked_identifier: process
+      - comma: ','
+      - column_reference:
+          naked_identifier: msg
+      - end_bracket: )
+    - values_clause:
+        keyword: VALUES
+        bracketed:
+        - start_bracket: (
+        - expression:
+            bind_variable:
+              colon_prefix: ':'
+              variable: process
+        - comma: ','
+        - expression:
+            quoted_literal: "'START RUN'"
+        - end_bracket: )
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          bind_variable:
+            colon_prefix: ':'
+            variable: process
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          column_reference:
+            naked_identifier: a
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: t
+      where_clause:
+        keyword: WHERE
+        expression:
+          column_reference:
+            naked_identifier: a
+          comparison_operator:
+            raw_comparison_operator: '='
+          bind_variable:
+            colon_prefix: ':'
+            variable: process
+- statement_terminator: ;
+- statement:
+    update_statement:
+      keyword: UPDATE
+      table_reference:
+        naked_identifier: t
+      set_clause_list:
+        keyword: SET
+        set_clause:
+          column_reference:
+            naked_identifier: a
+          comparison_operator:
+            raw_comparison_operator: '='
+          bind_variable:
+            colon_prefix: ':'
+            variable: new_value
+      where_clause:
+        keyword: WHERE
+        expression:
+          column_reference:
+            naked_identifier: id
+          comparison_operator:
+            raw_comparison_operator: '='
+          bind_variable:
+            colon_prefix: ':'
+            variable: target_id
+- statement_terminator: ;
+- statement:
+    delete_statement:
+    - keyword: DELETE
+    - keyword: FROM
+    - table_reference:
+        naked_identifier: t
+    - where_clause:
+        keyword: WHERE
+        expression:
+          column_reference:
+            naked_identifier: id
+          comparison_operator:
+            raw_comparison_operator: '='
+          bind_variable:
+            colon_prefix: ':'
+            variable: target_id
+- statement_terminator: ;
+- statement:
+    create_procedure_statement:
+    - keyword: CREATE
+    - keyword: OR
+    - keyword: REPLACE
+    - keyword: PROCEDURE
+    - function_name:
+      - naked_identifier: some_db
+      - dot: .
+      - naked_identifier: some_schema
+      - dot: .
+      - function_name_identifier: i_am_a_procedure
+    - function_parameter_list:
+        bracketed:
+          start_bracket: (
+          end_bracket: )
+    - keyword: RETURNS
+    - data_type:
+        data_type_identifier: BOOLEAN
+    - keyword: LANGUAGE
+    - keyword: SQL
+    - keyword: AS
+    - scripting_block_statement:
+      - keyword: BEGIN
+      - statement:
+          scripting_let_statement:
+            keyword: LET
+            variable: process
+            data_type:
+              data_type_identifier: VARCHAR
+            assignment_operator: :=
+            expression:
+              quoted_literal: "'THIS_PROCEDURE_PROCESS_KEY'"
+      - statement_terminator: ;
+      - statement:
+          insert_statement:
+          - keyword: INSERT
+          - keyword: INTO
+          - table_reference:
+            - naked_identifier: some_db
+            - dot: .
+            - naked_identifier: some_schema
+            - dot: .
+            - naked_identifier: debug_log
+          - bracketed:
+            - start_bracket: (
+            - column_reference:
+                naked_identifier: process
+            - comma: ','
+            - column_reference:
+                naked_identifier: msg
+            - end_bracket: )
+          - values_clause:
+              keyword: VALUES
+              bracketed:
+              - start_bracket: (
+              - expression:
+                  bind_variable:
+                    colon_prefix: ':'
+                    variable: process
+              - comma: ','
+              - expression:
+                  quoted_literal: "'START RUN'"
+              - end_bracket: )
+      - statement_terminator: ;
+      - keyword: END
+- statement_terminator: ;


### PR DESCRIPTION
### Brief summary of the change made

fixes #5427

Snowflake Scripting bind variables (e.g. `:my_variable`) could only be parsed inside `EXECUTE IMMEDIATE ... USING (...)` lists. Using one in a SQL statement — the primary way they are used per the [Snowflake docs](https://docs.snowflake.com/en/developer-guide/snowflake-scripting/variables#using-a-variable-in-a-sql-statement-binding) — failed to parse:

```sql
INSERT INTO debug_log (process, msg) VALUES (:process, 'START RUN');  -- unparsable
SELECT a FROM t WHERE a = :process;                                  -- unparsable
UPDATE t SET a = :new_value WHERE id = :target_id;                   -- unparsable
```

`SELECT :process` also silently **mis-parsed** — as a bare colon `variable` with the variable name swallowed as an alias (visible in the old `let.yml` fixture tree).

This change adds the already-existing `BindVariableSegment` to the Snowflake `LiteralGrammar` (next to `ReferencedVariableNameSegment`, the `$var` equivalent), so bind variables parse wherever a literal is accepted and produce a proper `bind_variable(colon_prefix + variable)` node.

One note on the original repro: its `CREATE OR REPLACE PROCEDURE SOME.INPUT.…` also fails because `INPUT` is a reserved keyword clash on the schema name — that is unrelated to binding and out of scope here (the fixture uses a different schema name).

### Are there any other side effects of this change that we should be aware of?

No. Semi-structured accessors (`SELECT v:name FROM t`) are unaffected — they attach to a preceding column reference, while a bind variable requires the colon in expression-start position. Session variables (`$var`), array accessors and the full Snowflake dialect suite all pass (629 passed; the one updated fixture is `let.yml`, whose stored tree encoded the old mis-parse of `SELECT :variable`).

### Pull Request checklist

- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes:
  - `.sql`/`.yml` parser test case added at `test/fixtures/dialects/snowflake/snowflake_scripting_bind_variables.sql` (+ generated `.yml`) covering INSERT/SELECT/WHERE/UPDATE/DELETE binds and the full procedure from the issue.
  - `let.yml` regenerated (tree corrected from the old mis-parse).
- Added appropriate documentation for the change (inline grammar comment with doc link).
- Created GitHub issues for any relevant followup/future enhancements if appropriate — n/a.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Parse Snowflake Scripting bind variables (:var) in SQL expressions and correct the `SELECT :var` mis-parse. Require the colon and variable name to be adjacent so malformed inputs (e.g., `: WHERE`) fail cleanly; fixes #5427.

- **Bug Fixes**
  - Added `BindVariableSegment` to Snowflake `LiteralGrammar` so `:var` parses wherever a literal is allowed (VALUES, WHERE, SET, SELECT), and corrected `SELECT :var` to produce a `bind_variable` node.
  - Set `allow_gaps=False` so the colon and name must be adjacent, preventing accidental matches like `: WHERE`.
  - Added fixture tests for INSERT/SELECT/WHERE/UPDATE/DELETE and the issue repro; regenerated `let.yml`.

<sup>Written for commit daa7e8fa34f40356aec32b7aaae8ea9236df83c9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8163?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



