### PR TITLE
perf(rust): frame-free terminal evaluation

### DIFF
--- a/sqlfluffrs/sqlfluffrs_benchmarks/examples/time_tpc.rs
+++ b/sqlfluffrs/sqlfluffrs_benchmarks/examples/time_tpc.rs
@@ -36,6 +36,8 @@ struct RunStats {
     complete_match_early_exits: usize,
     terminator_checks: usize,
     terminator_hits: usize,
+    terminal_fast_path_hits: usize,
+    terminal_fast_path_misses: usize,
 }
 
 impl RunStats {
@@ -55,6 +57,8 @@ impl RunStats {
             complete_match_early_exits: m.complete_match_early_exits.get(),
             terminator_checks: m.terminator_checks.get(),
             terminator_hits: m.terminator_hits.get(),
+            terminal_fast_path_hits: m.terminal_fast_path_hits.get(),
+            terminal_fast_path_misses: m.terminal_fast_path_misses.get(),
         }
     }
 }
@@ -73,6 +77,8 @@ struct Avg {
     early_exits: f64,
     term_checks: f64,
     term_hit_pct: f64,
+    fast_path_hits: f64,
+    fast_path_hit_pct: f64,
 }
 
 fn avg(runs: &[RunStats]) -> Avg {
@@ -92,6 +98,8 @@ fn avg(runs: &[RunStats]) -> Avg {
     let successes = stat(|r| r.match_successes);
     let t_checks = stat(|r| r.terminator_checks);
     let t_hits = stat(|r| r.terminator_hits);
+    let fp_hits = stat(|r| r.terminal_fast_path_hits);
+    let fp_misses = stat(|r| r.terminal_fast_path_misses);
     Avg {
         mean,
         min: runs
@@ -117,6 +125,12 @@ fn avg(runs: &[RunStats]) -> Avg {
         term_checks: t_checks,
         term_hit_pct: if t_checks > 0.0 {
             t_hits / t_checks * 100.0
+        } else {
+            0.0
+        },
+        fast_path_hits: fp_hits,
+        fast_path_hit_pct: if (fp_hits + fp_misses) > 0.0 {
+            fp_hits / (fp_hits + fp_misses) * 100.0
         } else {
             0.0
         },
@@ -147,6 +161,10 @@ fn print_avg(label: &str, a: &Avg) {
     println!(
         "    Terminators   {:.0} checks  {:.1}% hit",
         a.term_checks, a.term_hit_pct,
+    );
+    println!(
+        "    Fast path     {:.0} hits  {:.1}% of terminal-inline probes",
+        a.fast_path_hits, a.fast_path_hit_pct,
     );
 }
 
@@ -194,6 +212,8 @@ fn timed_suite_runs(all_tokens: &[Vec<Token>]) -> Vec<RunStats> {
             let mut early_exits = 0;
             let mut term_checks = 0;
             let mut term_hits = 0;
+            let mut fast_path_hits = 0;
+            let mut fast_path_misses = 0;
             for tokens in all_tokens {
                 let mut p = Parser::new(tokens, Dialect::Ansi, hashbrown::HashMap::new());
                 p.call_rule_as_root().expect("Parse failed");
@@ -210,6 +230,8 @@ fn timed_suite_runs(all_tokens: &[Vec<Token>]) -> Vec<RunStats> {
                 early_exits += m.complete_match_early_exits.get();
                 term_checks += m.terminator_checks.get();
                 term_hits += m.terminator_hits.get();
+                fast_path_hits += m.terminal_fast_path_hits.get();
+                fast_path_misses += m.terminal_fast_path_misses.get();
             }
             RunStats {
                 duration_secs: t0.elapsed().as_secs_f64(),
@@ -224,6 +246,8 @@ fn timed_suite_runs(all_tokens: &[Vec<Token>]) -> Vec<RunStats> {
                 complete_match_early_exits: early_exits,
                 terminator_checks: term_checks,
                 terminator_hits: term_hits,
+                terminal_fast_path_hits: fast_path_hits,
+                terminal_fast_path_misses: fast_path_misses,
             }
         })
         .collect()

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/core.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/core.rs
@@ -599,14 +599,30 @@ impl<'a> Parser<'a> {
         &mut self,
         mut frame: TableParseFrame,
     ) -> Result<TableFrameResult, ParseError> {
-        let ctx = &self.grammar_ctx;
-        let grammar_id = frame.grammar_id;
         vdebug!(
             "START TypedParser: frame_id={}, pos={}, grammar_id={:?}",
             frame.frame_id,
             frame.pos,
-            grammar_id
+            frame.grammar_id
         );
+        self.pos = frame.pos;
+        let match_result = self.typed_parser_match(frame.grammar_id)?;
+        // On a failed match `typed_parser_match` leaves the position at the
+        // frame position, so `self.pos` is the correct end position either way.
+        frame.end_pos = Some(self.pos);
+        frame.state = FrameState::Complete(Arc::new(match_result));
+        Ok(TableFrameResult::Push(frame))
+    }
+
+    /// Frame-less core of the TypedParser match, shared by the frame handler
+    /// above and the inline terminal fast path in OneOf. Matches at
+    /// `self.pos`, which is advanced past the token on success and left
+    /// unchanged on a failed match.
+    pub(crate) fn typed_parser_match(
+        &mut self,
+        grammar_id: GrammarId,
+    ) -> Result<MatchResult, ParseError> {
+        let ctx = &self.grammar_ctx;
         // Extract all data from tables first (before any self methods)
         let tables = ctx.tables();
 
@@ -644,8 +660,6 @@ impl<'a> Parser<'a> {
         let casefold = self.grammar_ctx.casefold(grammar_id);
         let grammar_trim_chars = self.grammar_ctx.trim_chars(grammar_id);
 
-        self.pos = frame.pos;
-
         vdebug!(
             "TypedParser[table]: pos={}, template='{}', token_type='{}'",
             self.pos,
@@ -673,8 +687,7 @@ impl<'a> Parser<'a> {
 
                     // Extra debug: show token instance/class types
                     vdebug!(
-                        "TypedParser[table] MATCH DETAILS: frame_id={}, grammar_id={:?}, token_idx={}, instance_types={:?}, class_types={:?}",
-                        frame.frame_id,
+                        "TypedParser[table] MATCH DETAILS: grammar_id={:?}, token_idx={}, instance_types={:?}, class_types={:?}",
                         grammar_id,
                         token_pos,
                         inst_types,
@@ -789,9 +802,7 @@ impl<'a> Parser<'a> {
                 // Advance position after capturing token data
                 self.bump();
 
-                frame.state = FrameState::Complete(Arc::new(match_result));
-                frame.end_pos = Some(self.pos);
-                Ok(TableFrameResult::Push(frame))
+                Ok(match_result)
             }
             Some(_tok) => {
                 // Include instance and class type diagnostics to help debug why a
@@ -809,16 +820,12 @@ impl<'a> Parser<'a> {
                     inst_types,
                     class_types
                 );
-                frame.state = FrameState::Complete(Arc::new(MatchResult::empty_at(frame.pos)));
-                frame.end_pos = Some(frame.pos);
-                Ok(TableFrameResult::Push(frame))
+                Ok(MatchResult::empty_at(self.pos))
             }
 
             None => {
                 vdebug!("TypedParser[table] NOMATCH: EOF at pos={}", self.pos);
-                frame.state = FrameState::Complete(Arc::new(MatchResult::empty_at(frame.pos)));
-                frame.end_pos = Some(frame.pos);
-                Ok(TableFrameResult::Push(frame))
+                Ok(MatchResult::empty_at(self.pos))
             }
         }
     }

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/core.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/core.rs
@@ -107,6 +107,11 @@ pub struct ParserMetrics {
     pub terminator_checks: std::cell::Cell<usize>,
     /// Terminator hits (early exits caused by a terminator).
     pub terminator_hits: std::cell::Cell<usize>,
+    /// `try_terminal_inline` calls that matched a terminal variant frame-free.
+    pub terminal_fast_path_hits: std::cell::Cell<usize>,
+    /// `try_terminal_inline` calls that fell back to the frame-based path
+    /// (candidate was not a synchronous terminal variant).
+    pub terminal_fast_path_misses: std::cell::Cell<usize>,
 }
 
 impl ParserMetrics {
@@ -129,6 +134,14 @@ impl ParserMetrics {
             self.terminator_checks.get(),
         );
         m.insert("terminator_hits".to_string(), self.terminator_hits.get());
+        m.insert(
+            "terminal_fast_path_hits".to_string(),
+            self.terminal_fast_path_hits.get(),
+        );
+        m.insert(
+            "terminal_fast_path_misses".to_string(),
+            self.terminal_fast_path_misses.get(),
+        );
         m
     }
 }

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/frame.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/frame.rs
@@ -219,9 +219,6 @@ pub struct OneOfState {
 #[derive(Debug, Clone)]
 pub struct RefState {
     pub grammar_id: GrammarId,
-    pub name: &'static str,
-    pub segment_class_name: Option<&'static str>,
-    pub segment_type: Option<&'static str>,
     /// Position the child was started at (after any leading-transparent skip);
     /// the position restored when the child comes back empty.
     pub saved_pos: usize,

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/helpers.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/helpers.rs
@@ -573,29 +573,16 @@ impl<'a> Parser<'a> {
                 continue;
             }
 
-            // Cache miss - do full parse
-            let check_pos = self.pos;
-            self.pos = saved_pos;
-
-            if let Ok(mr) = self.parse_table_iterative_match_result(*term_id, &[]) {
-                let is_empty = mr.is_empty();
-                self.pos = check_pos;
-
-                // Cache the result
-                self.terminator_match_cache.insert(cache_key, !is_empty);
-
-                if !is_empty {
-                    vdebug!("  TERMED Terminator matched (table-driven): {:?}", term_id);
-                    self.pos = init_pos;
-                    self.metrics
-                        .terminator_hits
-                        .set(self.metrics.terminator_hits.get() + 1);
-                    return true;
-                }
-            } else {
-                self.pos = check_pos;
-                // Cache the failure
-                self.terminator_match_cache.insert(cache_key, false);
+            // Cache miss - probe the terminator (frame-free for terminals).
+            let matched = self.terminator_matches_at(*term_id, saved_pos, &[]);
+            self.terminator_match_cache.insert(cache_key, matched);
+            if matched {
+                vdebug!("  TERMED Terminator matched (table-driven): {:?}", term_id);
+                self.pos = init_pos;
+                self.metrics
+                    .terminator_hits
+                    .set(self.metrics.terminator_hits.get() + 1);
+                return true;
             }
             vdebug!("  Terminator did not match (table-driven): {:?}", term_id);
         }
@@ -603,6 +590,35 @@ impl<'a> Parser<'a> {
         vdebug!("  NOTERM No terminators matched");
         self.pos = init_pos;
         false
+    }
+
+    /// Check whether a single terminator grammar matches at `pos`.
+    ///
+    /// Terminal terminators (keywords, symbols, typed/token matchers - the
+    /// overwhelming majority) are evaluated frame-free via
+    /// `try_terminal_inline`; compound terminators fall back to a full
+    /// sub-parse through `try_match_grammar`. The parser position is
+    /// restored afterwards. A probe that errors counts as "no match",
+    /// matching the previous call sites' behaviour.
+    #[inline]
+    pub(crate) fn terminator_matches_at(
+        &mut self,
+        term_id: GrammarId,
+        pos: usize,
+        sub_terminators: &[GrammarId],
+    ) -> bool {
+        let saved = self.pos;
+        self.pos = pos;
+        let matched = match self.try_terminal_inline(term_id, None) {
+            Ok(Some(mr)) => !mr.is_empty(),
+            Ok(None) => self
+                .try_match_grammar(term_id, pos, sub_terminators)
+                .map(|end_pos| end_pos > pos)
+                .unwrap_or(false),
+            Err(_) => false,
+        };
+        self.pos = saved;
+        matched
     }
 
     /// Prune terminators for table-driven parsing based on simple matchers.
@@ -645,7 +661,7 @@ impl<'a> Parser<'a> {
                 grammar_name,
                 start_idx
             );
-            if let Ok(_m) = self.try_match_grammar(*term, start_idx, &[]) {
+            if self.terminator_matches_at(*term, start_idx, &[]) {
                 vdebug!(
                     "[TRIM_TO_TERM_TABLE] Terminator {:?} (name: {}) matched immediately at idx={}, returning start_idx={}",
                     term,

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/anynumberof.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/anynumberof.rs
@@ -189,6 +189,15 @@ impl Parser<'_> {
         // Move terminators into frame (no clone)
         frame.table_terminators = all_terminators;
 
+        // Inline fast path: terminal candidates need no frame machinery.
+        // Feed the result straight into the shared candidate-handling logic.
+        self.pos = start_pos;
+        if let Some(mr) = self.try_terminal_inline(first_element, Some(max_idx))? {
+            let end_pos = self.pos;
+            let arc = Arc::new(mr);
+            return self.handle_anynumberof_waiting_for_child(frame, &arc, &end_pos, stack);
+        }
+
         // Create initial child frame for the first element candidate and
         // let the WaitingForChild handler iterate remaining candidates.
         let child_frame = TableParseFrame::new_child(
@@ -298,12 +307,28 @@ impl Parser<'_> {
             .expect("Expected AnyNumberOf context");
         let next_element_idx = ctx.tried_elements;
         let next_candidate = ctx.pruned_children[next_element_idx];
+        let working_idx = ctx.working_idx;
+        let max_idx = ctx.max_idx;
 
         vdebug!(
             "AnyNumberOf[table]: Trying next element candidate idx={} gid={}",
             next_element_idx,
             next_candidate.0
         );
+
+        // Inline fast path for terminal candidates (see try_terminal_inline);
+        // recursion depth is bounded by the candidate count of this grammar.
+        self.pos = working_idx;
+        if let Some(mr) = self.try_terminal_inline(next_candidate, Some(max_idx))? {
+            let end_pos = self.pos;
+            let arc = Arc::new(mr);
+            return self.handle_anynumberof_waiting_for_child(frame, &arc, &end_pos, stack);
+        }
+
+        let ctx = frame
+            .context
+            .as_anynumberof_mut()
+            .expect("Expected AnyNumberOf context");
 
         // Create and push child frame
         let child_frame = TableParseFrame::new_child(

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/anynumberof.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/anynumberof.rs
@@ -236,113 +236,114 @@ impl Parser<'_> {
         child_end_pos: &usize,
         stack: &mut TableParseFrameStack,
     ) -> Result<TableFrameResult, ParseError> {
-        // Make frame mutable so we can obtain &mut references to context fields.
-        let ctx = frame
-            .context
-            .as_anynumberof_mut()
-            .expect("Expected AnyNumberOf context");
+        // Owned so the inline-terminal-candidate loop below can rebind them
+        // in place across candidates instead of recursing once per
+        // candidate - native recursion depth would otherwise be bounded
+        // only by this AnyNumberOf's candidate count (see handle_oneof_waiting_for_child).
+        let mut child_match = Arc::clone(child_match);
+        let mut child_end_pos = *child_end_pos;
 
-        // Get current candidate for tracking
-        let current_element_idx = ctx.next_candidate_idx();
-        let current_candidate = ctx
-            .pruned_children
-            .get(current_element_idx)
-            .copied()
-            .unwrap_or(ctx.pruned_children[0]);
+        loop {
+            // Make frame mutable so we can obtain &mut references to context fields.
+            let ctx = frame
+                .context
+                .as_anynumberof_mut()
+                .expect("Expected AnyNumberOf context");
 
-        #[cfg(feature = "verbose-debug")]
-        {
-            vdebug!(
-                "AnyNumberOf[table] WaitingForChild: frame_id={}, child_empty={}, count={}, matched_idx={}, trying_idx={}/{}, tried_elements={}",
-                frame.frame_id,
-                child_match.is_empty(),
-                ctx.count,
-                ctx.matched_idx,
-                current_element_idx,
-                ctx.pruned_children.len(),
-                ctx.tried_elements
-            );
+            // Get current candidate for tracking
+            let current_element_idx = ctx.next_candidate_idx();
+            let current_candidate = ctx
+                .pruned_children
+                .get(current_element_idx)
+                .copied()
+                .unwrap_or(ctx.pruned_children[0]);
 
-            // Extra debug: show pruned_children and parent table_terminators for this frame
-            let pruned_dbg: Vec<u64> = ctx.pruned_children.iter().map(|g| g.0 as u64).collect();
-            let table_term_names: Vec<String> = frame
-                .table_terminators
-                .iter()
-                .map(|gid| self.grammar_ctx.grammar_id_name(*gid))
-                .collect();
-            vdebug!(
-                "AnyNumberOf[table] WaitingForChild DEBUG: pruned_children_ids={:?} table_terminators_count={} names={:?}",
-                pruned_dbg,
-                frame.table_terminators.len(),
-                table_term_names
-            );
+            #[cfg(feature = "verbose-debug")]
+            {
+                vdebug!(
+                    "AnyNumberOf[table] WaitingForChild: frame_id={}, child_empty={}, count={}, matched_idx={}, trying_idx={}/{}, tried_elements={}",
+                    frame.frame_id,
+                    child_match.is_empty(),
+                    ctx.count,
+                    ctx.matched_idx,
+                    current_element_idx,
+                    ctx.pruned_children.len(),
+                    ctx.tried_elements
+                );
+
+                // Extra debug: show pruned_children and parent table_terminators for this frame
+                let pruned_dbg: Vec<u64> = ctx.pruned_children.iter().map(|g| g.0 as u64).collect();
+                let table_term_names: Vec<String> = frame
+                    .table_terminators
+                    .iter()
+                    .map(|gid| self.grammar_ctx.grammar_id_name(*gid))
+                    .collect();
+                vdebug!(
+                    "AnyNumberOf[table] WaitingForChild DEBUG: pruned_children_ids={:?} table_terminators_count={} names={:?}",
+                    pruned_dbg,
+                    frame.table_terminators.len(),
+                    table_term_names
+                );
+            }
+
+            // Update longest_match if this child is better
+            if !child_match.is_empty() && child_end_pos <= ctx.max_idx {
+                ctx.update_longest_match(
+                    Arc::clone(&child_match),
+                    child_end_pos,
+                    current_candidate,
+                );
+            }
+
+            ctx.tried_elements += 1;
+
+            // Try next element candidate if there are more
+            if ctx.has_more_candidates() {
+                let next_element_idx = ctx.tried_elements;
+                let next_candidate = ctx.pruned_children[next_element_idx];
+                let working_idx = ctx.working_idx;
+                let max_idx = ctx.max_idx;
+
+                vdebug!(
+                    "AnyNumberOf[table]: Trying next element candidate idx={} gid={}",
+                    next_element_idx,
+                    next_candidate.0
+                );
+
+                // Inline fast path for terminal candidates (see
+                // try_terminal_inline): loop back to the top with the new
+                // candidate's result instead of recursing, so a run of
+                // consecutive terminal candidates costs no extra native stack.
+                self.pos = working_idx;
+                if let Some(mr) = self.try_terminal_inline(next_candidate, Some(max_idx))? {
+                    child_end_pos = self.pos;
+                    child_match = Arc::new(mr);
+                    continue;
+                }
+
+                let ctx = frame
+                    .context
+                    .as_anynumberof_mut()
+                    .expect("Expected AnyNumberOf context");
+
+                // Create and push child frame
+                let child_frame = TableParseFrame::new_child(
+                    stack.frame_id_counter,
+                    next_candidate,
+                    ctx.working_idx,
+                    &frame.table_terminators,
+                    Some(ctx.max_idx),
+                );
+
+                // Update last_child_frame_id
+                ctx.last_child_frame_id = Some(stack.frame_id_counter);
+
+                return Ok(stack.push_child_and_wait(frame, child_frame, next_element_idx));
+            }
+
+            // All candidates tried - process longest match or finalize
+            return self.process_anynumberof_longest_match(frame, stack);
         }
-
-        // Update longest_match if this child is better
-        if !child_match.is_empty() && *child_end_pos <= ctx.max_idx {
-            ctx.update_longest_match(Arc::clone(child_match), *child_end_pos, current_candidate);
-        }
-
-        ctx.tried_elements += 1;
-
-        // Try next element candidate if there are more
-        if ctx.has_more_candidates() {
-            return self.try_next_anynumberof_candidate(frame, stack);
-        }
-
-        // All candidates tried - process longest match or finalize
-        self.process_anynumberof_longest_match(frame, stack)
-    }
-
-    /// Try the next element candidate in AnyNumberOf
-    #[inline]
-    fn try_next_anynumberof_candidate(
-        &mut self,
-        mut frame: TableParseFrame,
-        stack: &mut TableParseFrameStack,
-    ) -> Result<TableFrameResult, ParseError> {
-        let ctx = frame
-            .context
-            .as_anynumberof_mut()
-            .expect("Expected AnyNumberOf context");
-        let next_element_idx = ctx.tried_elements;
-        let next_candidate = ctx.pruned_children[next_element_idx];
-        let working_idx = ctx.working_idx;
-        let max_idx = ctx.max_idx;
-
-        vdebug!(
-            "AnyNumberOf[table]: Trying next element candidate idx={} gid={}",
-            next_element_idx,
-            next_candidate.0
-        );
-
-        // Inline fast path for terminal candidates (see try_terminal_inline);
-        // recursion depth is bounded by the candidate count of this grammar.
-        self.pos = working_idx;
-        if let Some(mr) = self.try_terminal_inline(next_candidate, Some(max_idx))? {
-            let end_pos = self.pos;
-            let arc = Arc::new(mr);
-            return self.handle_anynumberof_waiting_for_child(frame, &arc, &end_pos, stack);
-        }
-
-        let ctx = frame
-            .context
-            .as_anynumberof_mut()
-            .expect("Expected AnyNumberOf context");
-
-        // Create and push child frame
-        let child_frame = TableParseFrame::new_child(
-            stack.frame_id_counter,
-            next_candidate,
-            ctx.working_idx,
-            &frame.table_terminators,
-            Some(ctx.max_idx),
-        );
-
-        // Update last_child_frame_id
-        ctx.last_child_frame_id = Some(stack.frame_id_counter);
-
-        Ok(stack.push_child_and_wait(frame, child_frame, next_element_idx))
     }
 
     /// Process the longest match after all candidates are tried

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/bracketed.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/bracketed.rs
@@ -34,7 +34,7 @@ impl Parser<'_> {
             &frame.table_terminators,
             reset_terminators,
         );
-        let all_children: Vec<GrammarId> = self.grammar_ctx.children(grammar_id).collect();
+        let all_children: &[GrammarId] = self.grammar_ctx.children_ids_slice(grammar_id);
         vdebug!(
             "Bracketed[table] children count={}, children={:?}",
             all_children.len(),
@@ -120,7 +120,7 @@ impl Parser<'_> {
     ) -> Result<TableFrameResult, ParseError> {
         // Work with MatchResult directly (Python parity)
         let child_is_empty = child_match.is_empty();
-        let all_children: Vec<GrammarId> = self.grammar_ctx.children(frame.grammar_id).collect();
+        let all_children: &[GrammarId] = self.grammar_ctx.children_ids_slice(frame.grammar_id);
         let (start_bracket_idx, end_bracket_idx) =
             self.grammar_ctx.bracketed_config(frame.grammar_id);
         let close_bracket_id = all_children[end_bracket_idx];
@@ -296,7 +296,7 @@ impl Parser<'_> {
     ) -> Result<TableFrameResult, ParseError> {
         // Work with MatchResult directly (Python parity)
         let child_is_empty = child_match.is_empty();
-        let all_children: Vec<GrammarId> = self.grammar_ctx.children(frame.grammar_id).collect();
+        let all_children: &[GrammarId] = self.grammar_ctx.children_ids_slice(frame.grammar_id);
         let FrameContext::Bracketed(BracketedState {
             grammar_id,
             phase: bracket_state,

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/delimited.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/delimited.rs
@@ -38,7 +38,7 @@ impl Parser<'_> {
         );
 
         // Get children: [elements_or_oneof, delimiter]
-        let all_children: Vec<GrammarId> = self.grammar_ctx.children(grammar_id).collect();
+        let all_children: &[GrammarId] = self.grammar_ctx.children_ids_slice(grammar_id);
         if all_children.len() != 2 {
             vdebug!(
                 "Delimited[table]: Expected exactly 2 children (elements + delimiter), got {}",
@@ -706,7 +706,7 @@ impl Parser<'_> {
     /// Layout contract: a Delimited grammar has exactly 2 children,
     /// `[elements_or_oneof, delimiter]`.
     fn delimited_frame_config(&self, grammar_id: GrammarId) -> DelimitedFrameConfig {
-        let all_children: Vec<GrammarId> = self.grammar_ctx.children(grammar_id).collect();
+        let all_children: &[GrammarId] = self.grammar_ctx.children_ids_slice(grammar_id);
         if all_children.len() != 2 {
             panic!(
                 "Delimited[table]: Expected exactly 2 children (elements + delimiter), got {}",

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/delimited.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/delimited.rs
@@ -146,20 +146,6 @@ impl Parser<'_> {
             );
         }
 
-        // Build the child frame from the still-local child_terminators (this
-        // copies them into the new frame's own SmallVec), so the fallback
-        // path below doesn't need to borrow them back out of frame.context
-        // after the move a few lines down.
-        // Pass child_terminators to allow the element matcher to try all candidates
-        // without early termination from local terminators (e.g., ObjectReferenceTerminator).
-        let child_frame = TableParseFrame::new_child(
-            stack.frame_id_counter,
-            elements_id,
-            start_pos,
-            &child_terminators,
-            Some(max_idx),
-        );
-
         // Store context for the element/delimiter phase loop.
         frame.context = FrameContext::Delimited(DelimitedState {
             grammar_id,
@@ -184,6 +170,21 @@ impl Parser<'_> {
             let arc = Arc::new(mr);
             return self.handle_delimited_waiting_for_child(frame, &arc, &end_pos, stack);
         }
+
+        // Pass child_terminators to allow the element matcher to try all candidates
+        // without early termination from local terminators (e.g., ObjectReferenceTerminator).
+        let child_frame = {
+            let FrameContext::Delimited(state) = &frame.context else {
+                unreachable!("Delimited context was just set");
+            };
+            TableParseFrame::new_child(
+                stack.frame_id_counter,
+                elements_id,
+                start_pos,
+                &state.child_terminators,
+                Some(max_idx),
+            )
+        };
 
         // Push child to match element(s).
         Ok(stack.push_child_and_wait(frame, child_frame, 0))

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/delimited.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/delimited.rs
@@ -146,16 +146,6 @@ impl Parser<'_> {
             );
         }
 
-        // Pass child_terminators to allow the element matcher to try all candidates
-        // without early termination from local terminators (e.g., ObjectReferenceTerminator).
-        let child_frame = TableParseFrame::new_child(
-            stack.frame_id_counter,
-            elements_id,
-            start_pos,
-            &child_terminators,
-            Some(max_idx),
-        );
-
         // Store context for the element/delimiter phase loop.
         frame.context = FrameContext::Delimited(DelimitedState {
             grammar_id,
@@ -170,6 +160,31 @@ impl Parser<'_> {
             child_terminators, // Move, no clone
             working_match: Arc::new(MatchResult::empty_at(start_pos)),
         });
+
+        // Inline fast path: a terminal element (e.g. a Ref to an identifier
+        // parser) needs no frame machinery. Feed the result straight into the
+        // element-phase handler.
+        self.pos = start_pos;
+        if let Some(mr) = self.try_terminal_inline(elements_id, Some(max_idx))? {
+            let end_pos = self.pos;
+            let arc = Arc::new(mr);
+            return self.handle_delimited_waiting_for_child(frame, &arc, &end_pos, stack);
+        }
+
+        // Pass child_terminators to allow the element matcher to try all candidates
+        // without early termination from local terminators (e.g., ObjectReferenceTerminator).
+        let child_frame = {
+            let FrameContext::Delimited(state) = &frame.context else {
+                unreachable!("Delimited context was just set");
+            };
+            TableParseFrame::new_child(
+                stack.frame_id_counter,
+                elements_id,
+                start_pos,
+                &state.child_terminators,
+                Some(max_idx),
+            )
+        };
 
         // Push child to match element(s).
         Ok(stack.push_child_and_wait(frame, child_frame, 0))
@@ -384,6 +399,21 @@ impl Parser<'_> {
 
         // Transition to MatchingDelimiter
         *delim_state = DelimitedPhase::MatchingDelimiter;
+        let delimiter_pos = *working_idx;
+
+        frame.state = FrameState::WaitingForChild { child_index: 0 };
+
+        // Inline fast path: comma-style delimiters are terminal parsers
+        // (usually a Ref to a StringParser) and need no frame machinery.
+        // Feed the result straight into the delimiter-phase handler; that
+        // handler always pushes a frame or finalizes, so recursion depth
+        // stays bounded.
+        self.pos = delimiter_pos;
+        if let Some(mr) = self.try_terminal_inline(delimiter_id, None)? {
+            let end_pos = self.pos;
+            let arc = Arc::new(mr);
+            return self.handle_delimited_delimiter_result(frame, &arc, &end_pos, stack);
+        }
 
         // IMPORTANT: Don't pass max_idx to delimiter frame!
         // The delimiter should be matchable at the current position even if
@@ -392,12 +422,10 @@ impl Parser<'_> {
         let delimiter_frame = TableParseFrame::new_child(
             stack.frame_id_counter,
             delimiter_id,
-            *working_idx,
+            delimiter_pos,
             &frame.table_terminators,
             None, // Don't constrain delimiter by max_idx
         );
-
-        frame.state = FrameState::WaitingForChild { child_index: 0 };
 
         stack.push_child_and_update_parent(frame, delimiter_frame, GrammarVariant::Delimited);
         Ok(TableFrameResult::Done)

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/delimited.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/delimited.rs
@@ -146,6 +146,20 @@ impl Parser<'_> {
             );
         }
 
+        // Build the child frame from the still-local child_terminators (this
+        // copies them into the new frame's own SmallVec), so the fallback
+        // path below doesn't need to borrow them back out of frame.context
+        // after the move a few lines down.
+        // Pass child_terminators to allow the element matcher to try all candidates
+        // without early termination from local terminators (e.g., ObjectReferenceTerminator).
+        let child_frame = TableParseFrame::new_child(
+            stack.frame_id_counter,
+            elements_id,
+            start_pos,
+            &child_terminators,
+            Some(max_idx),
+        );
+
         // Store context for the element/delimiter phase loop.
         frame.context = FrameContext::Delimited(DelimitedState {
             grammar_id,
@@ -170,21 +184,6 @@ impl Parser<'_> {
             let arc = Arc::new(mr);
             return self.handle_delimited_waiting_for_child(frame, &arc, &end_pos, stack);
         }
-
-        // Pass child_terminators to allow the element matcher to try all candidates
-        // without early termination from local terminators (e.g., ObjectReferenceTerminator).
-        let child_frame = {
-            let FrameContext::Delimited(state) = &frame.context else {
-                unreachable!("Delimited context was just set");
-            };
-            TableParseFrame::new_child(
-                stack.frame_id_counter,
-                elements_id,
-                start_pos,
-                &state.child_terminators,
-                Some(max_idx),
-            )
-        };
 
         // Push child to match element(s).
         Ok(stack.push_child_and_wait(frame, child_frame, 0))

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/iterative.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/iterative.rs
@@ -806,7 +806,7 @@ impl Parser<'_> {
     /// Backed by `ref_child_cache` (shared with `handle_ref_initial`) so the
     /// by-name dialect lookup runs at most once per Ref.
     #[inline]
-    fn resolve_ref_target(&mut self, grammar_id: GrammarId) -> Option<GrammarId> {
+    pub(crate) fn resolve_ref_target(&mut self, grammar_id: GrammarId) -> Option<GrammarId> {
         if let Some(&cached) = self.ref_child_cache.get(&grammar_id.0) {
             return cached.map(GrammarId);
         }

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/match_algorithms.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/match_algorithms.rs
@@ -216,14 +216,13 @@ impl Parser<'_> {
                 "[GREEDY_MATCH_TABLE] greedy_match: checking immediate terminator match for {:?} at {}",
                 term_id, start_idx
             );
-            if let Ok(end_pos) = self.try_match_grammar(term_id, start_idx, terminators) {
-                if end_pos > start_idx {
-                    vdebug!(
-                        "[GREEDY_MATCH_TABLE] greedy_match: immediate terminator {:?} matched at {}",
-                        term_id, start_idx
-                    );
-                    return Ok((start_idx, start_idx));
-                }
+            if self.terminator_matches_at(term_id, start_idx, terminators) {
+                vdebug!(
+                    "[GREEDY_MATCH_TABLE] greedy_match: immediate terminator {:?} matched at {}",
+                    term_id,
+                    start_idx
+                );
+                return Ok((start_idx, start_idx));
             }
         }
 
@@ -321,10 +320,9 @@ impl Parser<'_> {
                 let matched = if let Some(hit) = cached {
                     hit
                 } else {
-                    let result = self
-                        .try_match_grammar(term_id, i, terminators)
-                        .map(|end_pos| end_pos > i)
-                        .unwrap_or(false);
+                    // Frame-free for terminal terminators (see
+                    // terminator_matches_at); full sub-parse otherwise.
+                    let result = self.terminator_matches_at(term_id, i, terminators);
                     self.terminator_match_cache.insert(cache_key, result);
                     result
                 };

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/oneof.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/oneof.rs
@@ -203,7 +203,7 @@ impl Parser<'_> {
     /// left at the candidate position on a failed match, exactly as the
     /// frame-based handlers do. Terminal variants are never frame-cached
     /// (see `parity::is_frame_cacheable`), so no cache semantics are lost.
-    fn try_terminal_inline(
+    pub(crate) fn try_terminal_inline(
         &mut self,
         grammar_id: GrammarId,
     ) -> Result<Option<MatchResult>, ParseError> {

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/oneof.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/oneof.rs
@@ -163,7 +163,7 @@ impl Parser<'_> {
         // Inline fast path: terminal candidates need no frame machinery.
         // Feed the result straight into the shared candidate-handling logic.
         self.pos = post_skip_pos;
-        if let Some(mr) = self.try_terminal_inline(first_child)? {
+        if let Some(mr) = self.try_terminal_inline(first_child, Some(max_idx))? {
             let end_pos = self.pos;
             let arc = Arc::new(mr);
             return self.handle_oneof_waiting_for_child(frame, &arc, &end_pos, stack);
@@ -206,6 +206,7 @@ impl Parser<'_> {
     pub(crate) fn try_terminal_inline(
         &mut self,
         grammar_id: GrammarId,
+        parent_max_idx: Option<usize>,
     ) -> Result<Option<MatchResult>, ParseError> {
         use sqlfluffrs_types::GrammarVariant;
         let res = match self.grammar_ctx.variant(grammar_id) {
@@ -214,6 +215,9 @@ impl Parser<'_> {
             GrammarVariant::MultiStringParser => self.handle_multi_string_parser(grammar_id),
             GrammarVariant::RegexParser => self.handle_regex_parser(grammar_id),
             GrammarVariant::Token => self.handle_token(grammar_id),
+            // Refs resolving to a terminal target (e.g. keyword segments)
+            // are evaluated frame-free too, including the Ref wrapping.
+            GrammarVariant::Ref => return self.try_ref_terminal_inline(grammar_id, parent_max_idx),
             _ => return Ok(None),
         };
         res.map(Some)
@@ -385,7 +389,7 @@ impl Parser<'_> {
             // Inline fast path for terminal candidates (see
             // try_terminal_inline); recursion depth is bounded by the
             // candidate count of this OneOf.
-            if let Some(mr) = self.try_terminal_inline(next_child)? {
+            if let Some(mr) = self.try_terminal_inline(next_child, Some(*max_idx))? {
                 let end_pos = self.pos;
                 let arc = Arc::new(mr);
                 return self.handle_oneof_waiting_for_child(frame, &arc, &end_pos, stack);

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/oneof.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/oneof.rs
@@ -201,8 +201,14 @@ impl Parser<'_> {
     /// variant (the caller falls back to the frame path). On `Ok(Some(..))`
     /// the parser position has been advanced past the match on success, or
     /// left at the candidate position on a failed match, exactly as the
-    /// frame-based handlers do. Terminal variants are never frame-cached
-    /// (see `parity::is_frame_cacheable`), so no cache semantics are lost.
+    /// frame-based handlers do. The StringParser/TypedParser/MultiStringParser/
+    /// RegexParser/Token variants are never frame-cached (see
+    /// `parity::is_frame_cacheable`), so no cache semantics are lost for
+    /// them. `Ref` IS listed as frame-cacheable there, and a `Ref` resolving
+    /// to a terminal target loses that memoization by going through this
+    /// path instead of the frame path's cache check - accepted here because
+    /// the underlying match is a single-token comparison, cheap enough that
+    /// a cache lookup is unlikely to be a net win anyway.
     pub(crate) fn try_terminal_inline(
         &mut self,
         grammar_id: GrammarId,

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/oneof.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/oneof.rs
@@ -231,62 +231,70 @@ impl Parser<'_> {
         child_end_pos: &usize,
         stack: &mut TableParseFrameStack,
     ) -> Result<TableFrameResult, ParseError> {
-        let FrameContext::OneOf(OneOfState {
-            pruned_children,
-            post_skip_pos,
-            longest_match,
-            tried_elements,
-            max_idx,
-            current_child_id,
-            ..
-        }) = &mut frame.context
-        else {
-            unreachable!("Expected OneOf context");
-        };
+        // Owned so the inline-terminal-candidate loop below can rebind them
+        // in place across candidates instead of recursing once per
+        // candidate - native recursion depth would otherwise be bounded
+        // only by this OneOf's candidate count.
+        let mut child_match = Arc::clone(child_match);
+        let mut child_end_pos = *child_end_pos;
 
-        let consumed = *child_end_pos - *post_skip_pos;
-        let current_child = current_child_id.expect("current_child_id should be set");
-
-        // Store the child result for reuse
-        let child_match_rc = Arc::clone(child_match);
-
-        // Values needed for logic (always computed)
-        let child_end_pos_val = *child_end_pos;
-        let child_is_clean = if child_match.is_empty() {
-            false
-        } else {
-            !child_match.contains_unparsable()
-        };
-
-        // Expensive debug-only variable collection (gated by verbose-debug feature)
-        #[cfg(feature = "verbose-debug")]
-        {
-            let child_consumed = consumed;
-            let child_name = match self.grammar_ctx.variant(current_child) {
-                sqlfluffrs_types::GrammarVariant::Ref => {
-                    self.grammar_ctx.ref_name(current_child).to_string()
-                }
-                sqlfluffrs_types::GrammarVariant::StringParser
-                | sqlfluffrs_types::GrammarVariant::TypedParser
-                | sqlfluffrs_types::GrammarVariant::RegexParser => {
-                    self.grammar_ctx.template(current_child).to_string()
-                }
-                other => format!("{:?}", other),
+        loop {
+            let FrameContext::OneOf(OneOfState {
+                pruned_children,
+                post_skip_pos,
+                longest_match,
+                tried_elements,
+                max_idx,
+                current_child_id,
+                ..
+            }) = &mut frame.context
+            else {
+                unreachable!("Expected OneOf context");
             };
 
-            // Collect the raw tokens consumed by this candidate for debugging (bounded)
-            let mut candidate_tokens: Vec<String> = Vec::new();
-            if child_end_pos_val > *post_skip_pos {
-                let start_idx = (*post_skip_pos).min(self.tokens.len());
-                let end_idx = child_end_pos_val.min(self.tokens.len());
-                if start_idx < end_idx {
-                    for tok in &self.tokens[start_idx..end_idx] {
-                        candidate_tokens.push(tok.raw().to_owned());
+            let consumed = child_end_pos - *post_skip_pos;
+            let current_child = current_child_id.expect("current_child_id should be set");
+
+            // Store the child result for reuse
+            let child_match_rc = Arc::clone(&child_match);
+
+            // Values needed for logic (always computed)
+            let child_end_pos_val = child_end_pos;
+            let child_is_clean = if child_match.is_empty() {
+                false
+            } else {
+                !child_match.contains_unparsable()
+            };
+
+            // Expensive debug-only variable collection (gated by verbose-debug feature)
+            #[cfg(feature = "verbose-debug")]
+            {
+                let child_consumed = consumed;
+                let child_name = match self.grammar_ctx.variant(current_child) {
+                    sqlfluffrs_types::GrammarVariant::Ref => {
+                        self.grammar_ctx.ref_name(current_child).to_string()
+                    }
+                    sqlfluffrs_types::GrammarVariant::StringParser
+                    | sqlfluffrs_types::GrammarVariant::TypedParser
+                    | sqlfluffrs_types::GrammarVariant::RegexParser => {
+                        self.grammar_ctx.template(current_child).to_string()
+                    }
+                    other => format!("{:?}", other),
+                };
+
+                // Collect the raw tokens consumed by this candidate for debugging (bounded)
+                let mut candidate_tokens: Vec<String> = Vec::new();
+                if child_end_pos_val > *post_skip_pos {
+                    let start_idx = (*post_skip_pos).min(self.tokens.len());
+                    let end_idx = child_end_pos_val.min(self.tokens.len());
+                    if start_idx < end_idx {
+                        for tok in &self.tokens[start_idx..end_idx] {
+                            candidate_tokens.push(tok.raw().to_owned());
+                        }
                     }
                 }
-            }
 
-            vdebug!(
+                vdebug!(
                 "OneOf[table] WaitingForChild: frame_id={}, child_empty={}, consumed={}, tried={}/{}, candidate_id={}, candidate_name={}, candidate_end_pos={}, candidate_consumed={}, candidate_clean={}, candidate_tokens={:?}",
                 frame.frame_id,
                 child_match.is_empty(),
@@ -300,117 +308,120 @@ impl Parser<'_> {
                 child_is_clean,
                 candidate_tokens
             );
-        }
+            }
 
-        // PYTHON PARITY: Check for COMPLETE match first (matched all available segments)
-        // If we matched up to max_idx, we can return immediately without trying other options
-        // This is a major optimization for expressions with many alternatives
-        // See Python's longest_match() lines 245-246
-        if !child_match.is_empty() && child_end_pos_val >= *max_idx {
-            vdebug!(
+            // PYTHON PARITY: Check for COMPLETE match first (matched all available segments)
+            // If we matched up to max_idx, we can return immediately without trying other options
+            // This is a major optimization for expressions with many alternatives
+            // See Python's longest_match() lines 245-246
+            if !child_match.is_empty() && child_end_pos_val >= *max_idx {
+                vdebug!(
                 "OneOf[table]: COMPLETE MATCH - child {} matched all segments up to max_idx={}, returning immediately",
                 current_child.0,
                 max_idx
             );
-            // Track early exit for stats
-            self.metrics
-                .complete_match_early_exits
-                .set(self.metrics.complete_match_early_exits.get() + 1);
-            *longest_match = Some((child_match_rc, consumed, current_child));
-            // Skip directly to Combining state
-            frame.state = FrameState::Combining;
-            stack.push(frame);
-            return Ok(TableFrameResult::Done);
-        }
-
-        // Update longest match if this is better
-        let mut should_early_terminate = false;
-        if !child_match.is_empty() {
-            let is_better = if let Some((ref current_best, current_consumed, _)) = longest_match {
-                // Use MatchResult's contains_unparsable instead of is_node_clean
-                let current_is_clean = !current_best.contains_unparsable();
-                parity::is_better_candidate(
-                    parity::MatchQualityPolicy::LongestClean,
-                    consumed,
-                    child_is_clean,
-                    *current_consumed,
-                    current_is_clean,
-                )
-            } else {
-                true
-            };
-
-            if is_better {
+                // Track early exit for stats
+                self.metrics
+                    .complete_match_early_exits
+                    .set(self.metrics.complete_match_early_exits.get() + 1);
                 *longest_match = Some((child_match_rc, consumed, current_child));
+                // Skip directly to Combining state
+                frame.state = FrameState::Combining;
+                stack.push(frame);
+                return Ok(TableFrameResult::Done);
+            }
+
+            // Update longest match if this is better
+            let mut should_early_terminate = false;
+            if !child_match.is_empty() {
+                let is_better = if let Some((ref current_best, current_consumed, _)) = longest_match
+                {
+                    // Use MatchResult's contains_unparsable instead of is_node_clean
+                    let current_is_clean = !current_best.contains_unparsable();
+                    parity::is_better_candidate(
+                        parity::MatchQualityPolicy::LongestClean,
+                        consumed,
+                        child_is_clean,
+                        *current_consumed,
+                        current_is_clean,
+                    )
+                } else {
+                    true
+                };
+
+                if is_better {
+                    *longest_match = Some((child_match_rc, consumed, current_child));
+                    vdebug!(
+                        "OneOf[table]: longest_match set: child_id={}, consumed={}",
+                        current_child.0,
+                        consumed
+                    );
+
+                    let next_code_pos =
+                        self.skip_start_index_forward_to_code(child_end_pos_val, *max_idx);
+                    self.pos = next_code_pos;
+                    should_early_terminate = self.is_terminated(&frame.table_terminators);
+                }
+            }
+
+            *tried_elements += 1;
+
+            // Early termination: If last option OR terminated by terminators, go straight to Combining
+            let is_last_option = *tried_elements >= pruned_children.len();
+            if should_early_terminate || is_last_option {
                 vdebug!(
-                    "OneOf[table]: longest_match set: child_id={}, consumed={}",
-                    current_child.0,
-                    consumed
+                    "OneOf[table]: {} - transitioning to Combining (tried {}/{})",
+                    if should_early_terminate {
+                        "Early termination"
+                    } else {
+                        "Last option"
+                    },
+                    tried_elements,
+                    pruned_children.len()
+                );
+                frame.state = FrameState::Combining;
+                stack.push(frame);
+                return Ok(TableFrameResult::Done);
+            }
+
+            // Try next child
+            if *tried_elements < pruned_children.len() {
+                self.pos = *post_skip_pos;
+                let next_child = pruned_children[*tried_elements];
+                *current_child_id = Some(next_child);
+
+                vdebug!(
+                    "OneOf[table]: Trying next child grammar_id={}",
+                    next_child.0
                 );
 
-                let next_code_pos =
-                    self.skip_start_index_forward_to_code(child_end_pos_val, *max_idx);
-                self.pos = next_code_pos;
-                should_early_terminate = self.is_terminated(&frame.table_terminators);
+                // Inline fast path for terminal candidates (see
+                // try_terminal_inline): loop back to the top with the new
+                // candidate's result instead of recursing, so a run of
+                // consecutive terminal candidates costs no extra native stack.
+                if let Some(mr) = self.try_terminal_inline(next_child, Some(*max_idx))? {
+                    child_end_pos = self.pos;
+                    child_match = Arc::new(mr);
+                    continue;
+                }
+
+                frame.state = FrameState::WaitingForChild { child_index: 0 };
+
+                // Build child frame using same table_terminators as parent
+                let child_frame = TableParseFrame::new_child(
+                    stack.frame_id_counter,
+                    next_child,
+                    *post_skip_pos,
+                    &frame.table_terminators,
+                    Some(*max_idx),
+                );
+
+                stack.push_child_and_update_parent(frame, child_frame, GrammarVariant::OneOf);
+                return Ok(TableFrameResult::Done);
+            } else {
+                // Should never reach here due to early termination logic above
+                unreachable!("OneOf should have terminated in early termination check")
             }
-        }
-
-        *tried_elements += 1;
-
-        // Early termination: If last option OR terminated by terminators, go straight to Combining
-        let is_last_option = *tried_elements >= pruned_children.len();
-        if should_early_terminate || is_last_option {
-            vdebug!(
-                "OneOf[table]: {} - transitioning to Combining (tried {}/{})",
-                if should_early_terminate {
-                    "Early termination"
-                } else {
-                    "Last option"
-                },
-                tried_elements,
-                pruned_children.len()
-            );
-            frame.state = FrameState::Combining;
-            stack.push(frame);
-            return Ok(TableFrameResult::Done);
-        }
-
-        // Try next child
-        if *tried_elements < pruned_children.len() {
-            self.pos = *post_skip_pos;
-            let next_child = pruned_children[*tried_elements];
-            *current_child_id = Some(next_child);
-
-            vdebug!(
-                "OneOf[table]: Trying next child grammar_id={}",
-                next_child.0
-            );
-
-            // Inline fast path for terminal candidates (see
-            // try_terminal_inline); recursion depth is bounded by the
-            // candidate count of this OneOf.
-            if let Some(mr) = self.try_terminal_inline(next_child, Some(*max_idx))? {
-                let end_pos = self.pos;
-                let arc = Arc::new(mr);
-                return self.handle_oneof_waiting_for_child(frame, &arc, &end_pos, stack);
-            }
-
-            frame.state = FrameState::WaitingForChild { child_index: 0 };
-
-            // Build child frame using same table_terminators as parent
-            let child_frame = TableParseFrame::new_child(
-                stack.frame_id_counter,
-                next_child,
-                *post_skip_pos,
-                &frame.table_terminators,
-                Some(*max_idx),
-            );
-
-            stack.push_child_and_update_parent(frame, child_frame, GrammarVariant::OneOf);
-            Ok(TableFrameResult::Done)
-        } else {
-            // Should never reach here due to early termination logic above
-            unreachable!("OneOf should have terminated in early termination check")
         }
     }
 

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/oneof.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/oneof.rs
@@ -215,18 +215,57 @@ impl Parser<'_> {
         parent_max_idx: Option<usize>,
     ) -> Result<Option<MatchResult>, ParseError> {
         use sqlfluffrs_types::GrammarVariant;
-        let res = match self.grammar_ctx.variant(grammar_id) {
+        let variant = self.grammar_ctx.variant(grammar_id);
+        // Refs resolving to a terminal target (e.g. keyword segments) are
+        // evaluated frame-free too, including the Ref wrapping.
+        if matches!(variant, GrammarVariant::Ref) {
+            return self.try_ref_terminal_inline(grammar_id, parent_max_idx);
+        }
+        if !Self::is_terminal_variant(variant) {
+            return Ok(None);
+        }
+        self.dispatch_terminal_match(variant, grammar_id).map(Some)
+    }
+
+    /// The set of `GrammarVariant`s that can be evaluated frame-free by
+    /// [`Self::dispatch_terminal_match`]: single-token parsers with no
+    /// sub-grammar of their own. Shared by `try_terminal_inline` and
+    /// `try_ref_terminal_inline`'s own terminal-target check so the two
+    /// "is this variant terminal" answers cannot drift.
+    #[inline]
+    pub(crate) fn is_terminal_variant(variant: sqlfluffrs_types::GrammarVariant) -> bool {
+        use sqlfluffrs_types::GrammarVariant;
+        matches!(
+            variant,
+            GrammarVariant::StringParser
+                | GrammarVariant::TypedParser
+                | GrammarVariant::MultiStringParser
+                | GrammarVariant::RegexParser
+                | GrammarVariant::Token
+        )
+    }
+
+    /// Dispatch a single-token terminal match for `grammar_id`, given its
+    /// already-known `variant` (one of [`Self::is_terminal_variant`]'s set).
+    /// Shared by `try_terminal_inline` and `try_ref_terminal_inline` so the
+    /// two "which handler for which variant" mappings cannot drift.
+    #[inline]
+    pub(crate) fn dispatch_terminal_match(
+        &mut self,
+        variant: sqlfluffrs_types::GrammarVariant,
+        grammar_id: GrammarId,
+    ) -> Result<MatchResult, ParseError> {
+        use sqlfluffrs_types::GrammarVariant;
+        match variant {
             GrammarVariant::StringParser => self.handle_string_parser(grammar_id),
             GrammarVariant::TypedParser => self.typed_parser_match(grammar_id),
             GrammarVariant::MultiStringParser => self.handle_multi_string_parser(grammar_id),
             GrammarVariant::RegexParser => self.handle_regex_parser(grammar_id),
             GrammarVariant::Token => self.handle_token(grammar_id),
-            // Refs resolving to a terminal target (e.g. keyword segments)
-            // are evaluated frame-free too, including the Ref wrapping.
-            GrammarVariant::Ref => return self.try_ref_terminal_inline(grammar_id, parent_max_idx),
-            _ => return Ok(None),
-        };
-        res.map(Some)
+            other => {
+                unreachable!("dispatch_terminal_match called with non-terminal variant {other:?}")
+            }
+        }
     }
 
     /// Handle OneOf WaitingForChild state using table-driven approach

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/oneof.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/oneof.rs
@@ -160,6 +160,15 @@ impl Parser<'_> {
         // Move terminators into frame (no clone)
         frame.table_terminators = all_terminators;
 
+        // Inline fast path: terminal candidates need no frame machinery.
+        // Feed the result straight into the shared candidate-handling logic.
+        self.pos = post_skip_pos;
+        if let Some(mr) = self.try_terminal_inline(first_child)? {
+            let end_pos = self.pos;
+            let arc = Arc::new(mr);
+            return self.handle_oneof_waiting_for_child(frame, &arc, &end_pos, stack);
+        }
+
         // Create table-driven child frame (copy terminators from frame)
         let child_frame = TableParseFrame::new_child(
             stack.frame_id_counter,
@@ -178,6 +187,36 @@ impl Parser<'_> {
 
         // Transition: push child and wait
         Ok(stack.push_child_and_wait(frame, child_frame, 0))
+    }
+
+    /// Try to match a terminal (frame-less) grammar candidate inline.
+    ///
+    /// OneOf candidates are dominated by synchronous terminal parsers
+    /// (keywords and typed/token matchers) which succeed or fail on a single
+    /// token comparison. Routing each of them through the frame machine cost
+    /// a frame allocation, two stack transitions and an empty-result Arc per
+    /// failed candidate. This evaluates them directly instead.
+    ///
+    /// Returns `Ok(None)` when the candidate is not a synchronous terminal
+    /// variant (the caller falls back to the frame path). On `Ok(Some(..))`
+    /// the parser position has been advanced past the match on success, or
+    /// left at the candidate position on a failed match, exactly as the
+    /// frame-based handlers do. Terminal variants are never frame-cached
+    /// (see `parity::is_frame_cacheable`), so no cache semantics are lost.
+    fn try_terminal_inline(
+        &mut self,
+        grammar_id: GrammarId,
+    ) -> Result<Option<MatchResult>, ParseError> {
+        use sqlfluffrs_types::GrammarVariant;
+        let res = match self.grammar_ctx.variant(grammar_id) {
+            GrammarVariant::StringParser => self.handle_string_parser(grammar_id),
+            GrammarVariant::TypedParser => self.typed_parser_match(grammar_id),
+            GrammarVariant::MultiStringParser => self.handle_multi_string_parser(grammar_id),
+            GrammarVariant::RegexParser => self.handle_regex_parser(grammar_id),
+            GrammarVariant::Token => self.handle_token(grammar_id),
+            _ => return Ok(None),
+        };
+        res.map(Some)
     }
 
     /// Handle OneOf WaitingForChild state using table-driven approach
@@ -342,6 +381,15 @@ impl Parser<'_> {
                 "OneOf[table]: Trying next child grammar_id={}",
                 next_child.0
             );
+
+            // Inline fast path for terminal candidates (see
+            // try_terminal_inline); recursion depth is bounded by the
+            // candidate count of this OneOf.
+            if let Some(mr) = self.try_terminal_inline(next_child)? {
+                let end_pos = self.pos;
+                let arc = Arc::new(mr);
+                return self.handle_oneof_waiting_for_child(frame, &arc, &end_pos, stack);
+            }
 
             frame.state = FrameState::WaitingForChild { child_index: 0 };
 

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/oneof.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/oneof.rs
@@ -218,13 +218,25 @@ impl Parser<'_> {
         let variant = self.grammar_ctx.variant(grammar_id);
         // Refs resolving to a terminal target (e.g. keyword segments) are
         // evaluated frame-free too, including the Ref wrapping.
-        if matches!(variant, GrammarVariant::Ref) {
-            return self.try_ref_terminal_inline(grammar_id, parent_max_idx);
+        let result = if matches!(variant, GrammarVariant::Ref) {
+            self.try_ref_terminal_inline(grammar_id, parent_max_idx)
+        } else if !Self::is_terminal_variant(variant) {
+            Ok(None)
+        } else {
+            self.dispatch_terminal_match(variant, grammar_id).map(Some)
+        };
+        match result {
+            Ok(Some(_)) => self
+                .metrics
+                .terminal_fast_path_hits
+                .set(self.metrics.terminal_fast_path_hits.get() + 1),
+            Ok(None) => self
+                .metrics
+                .terminal_fast_path_misses
+                .set(self.metrics.terminal_fast_path_misses.get() + 1),
+            Err(_) => {}
         }
-        if !Self::is_terminal_variant(variant) {
-            return Ok(None);
-        }
-        self.dispatch_terminal_match(variant, grammar_id).map(Some)
+        result
     }
 
     /// The set of `GrammarVariant`s that can be evaluated frame-free by

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/ref_grammar.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/ref_grammar.rs
@@ -240,60 +240,22 @@ impl Parser<'_> {
         // Build final result
         let final_pos = frame.end_pos.unwrap_or(frame.pos);
         let result_match = if let Some(ref_match_result) = &state.match_result {
-            // Debug: print accumulated children to inspect whether typed tokens are present
-            vdebug!(
-                "Ref[table] Combining DEBUG: accumulated nodes={:?}",
-                ref_match_result
-            );
-            // A Ref to a bare (match_grammar-less) class mirrors native
-            // BaseSegment.match's isinstance path: consume the matched token
-            // unchanged, no class wrap, so its lexed type/class chain survives.
-            let is_token_target = self.grammar_ctx.variant(state.child_grammar_id)
-                == sqlfluffrs_types::GrammarVariant::Token;
-
-            vdebug!(
-                "Ref[table] Combining: name='{}', is_token_target={}, creating ref_match",
-                state.name,
-                is_token_target
-            );
-            let matched_class = if is_token_target {
-                None
-            } else if state.segment_type.is_some_and(|t| !t.is_empty())
-                || state.segment_class_name.is_some()
-            {
-                // `state.segment_type` is `Option<&'static str>` (Copy), so
-                // binding by value keeps the `'static` lifetime — this
-                // borrows the grammar-table string into the node with no
-                // allocation.
-                let segment_type: Cow<'static, str> =
-                    Cow::Borrowed(state.segment_type.unwrap_or_default());
-                // Look up the Python _class_types hierarchy for this grammar from codegen tables.
-                let class_types = self.grammar_ctx.segment_class_types(state.grammar_id);
-                Some(MatchedClass {
-                    // take() instead of clone() + unwrap — frame context is not read
-                    // again after this point (state transitions to Complete).
-                    // segment_class_name is Option<&'static str> (PR #8002), so
-                    // borrow the grammar-table class name straight into the node.
-                    class_name: Cow::Borrowed(state.segment_class_name.take().unwrap_or_default()),
-                    segment_type: Some(segment_type),
-                    segment_kwargs: SegmentKwargs {
-                        class_types,
-                        ..Default::default()
-                    },
-                })
-            } else {
-                None
-            };
-
-            // let start_idx = self.skip_start_index_forward_to_code(*saved_pos, final_pos);
-
-            MatchResult::ref_match(
-                state.name,
-                matched_class,
-                // start_idx,
-                state.saved_pos,
+            let child = Arc::clone(ref_match_result);
+            let name = state.name;
+            let grammar_id = state.grammar_id;
+            let child_grammar_id = state.child_grammar_id;
+            let segment_class_name = state.segment_class_name.take();
+            let segment_type = state.segment_type;
+            let saved_pos = state.saved_pos;
+            self.build_ref_wrap(
+                name,
+                grammar_id,
+                child_grammar_id,
+                segment_class_name,
+                segment_type,
+                saved_pos,
                 final_pos,
-                vec![Arc::clone(ref_match_result)],
+                &child,
             )
         } else {
             MatchResult::empty_at(frame.pos)
@@ -304,5 +266,165 @@ impl Parser<'_> {
         frame.state = FrameState::Complete(Arc::new(result_match));
 
         Ok(TableFrameResult::Push(frame))
+    }
+
+    /// Wrap a Ref target's match result exactly as `handle_ref_combining`
+    /// does: build the MatchedClass from the grammar tables (or skip it
+    /// entirely for a bare Token target, mirroring Python's isinstance
+    /// path) and produce the final `ref_match`. Shared by the frame-based
+    /// combining handler and the frame-free Ref fast path.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn build_ref_wrap(
+        &mut self,
+        name: &'static str,
+        grammar_id: GrammarId,
+        child_grammar_id: GrammarId,
+        segment_class_name: Option<&'static str>,
+        segment_type: Option<&'static str>,
+        saved_pos: usize,
+        final_pos: usize,
+        ref_match_result: &Arc<MatchResult>,
+    ) -> MatchResult {
+        {
+            // Debug: print accumulated children to inspect whether typed tokens are present
+            vdebug!(
+                "Ref[table] Combining DEBUG: accumulated nodes={:?}",
+                ref_match_result
+            );
+            // A Ref to a bare (match_grammar-less) class mirrors native
+            // BaseSegment.match's isinstance path: consume the matched token
+            // unchanged, no class wrap, so its lexed type/class chain survives.
+            let is_token_target = self.grammar_ctx.variant(child_grammar_id)
+                == sqlfluffrs_types::GrammarVariant::Token;
+
+            vdebug!(
+                "Ref[table] Combining: name='{}', is_token_target={}, creating ref_match",
+                name,
+                is_token_target
+            );
+            let matched_class = if is_token_target {
+                None
+            } else if segment_type.is_some_and(|t| !t.is_empty()) || segment_class_name.is_some()
+            {
+                // `segment_type` is `Option<&'static str>` (Copy), so
+                // binding by value keeps the `'static` lifetime — this
+                // borrows the grammar-table string into the node with no
+                // allocation.
+                let segment_type: Cow<'static, str> =
+                    Cow::Borrowed(segment_type.unwrap_or_default());
+                // Look up the Python _class_types hierarchy for this grammar from codegen tables.
+                let class_types = self.grammar_ctx.segment_class_types(grammar_id);
+                Some(MatchedClass {
+                    // segment_class_name is Option<&'static str> (PR #8002), so
+                    // borrow the grammar-table class name straight into the node.
+                    class_name: Cow::Borrowed(segment_class_name.unwrap_or_default()),
+                    segment_type: Some(segment_type),
+                    segment_kwargs: SegmentKwargs {
+                        class_types,
+                        ..Default::default()
+                    },
+                })
+            } else {
+                None
+            };
+
+            MatchResult::ref_match(
+                name,
+                matched_class,
+                saved_pos,
+                final_pos,
+                vec![Arc::clone(ref_match_result)],
+            )
+        }
+    }
+
+    /// Frame-free fast path for `Ref` grammars whose resolved target is a
+    /// terminal parser.
+    ///
+    /// Mirrors the frame-based Ref handlers step for step: the
+    /// parent-max-idx guard and failed-resolution behaviour of
+    /// `handle_ref_initial` (empty result at the pre-skip position), the
+    /// leading-gap skip when the target allows gaps, the failed-child
+    /// position semantics of `handle_ref_waiting_for_child` (position and
+    /// reported extent at the post-skip position), and the result wrapping
+    /// of `handle_ref_combining` (via `build_ref_wrap`). Refs with an
+    /// exclude grammar or a non-terminal target return `Ok(None)` and take
+    /// the frame path.
+    pub(crate) fn try_ref_terminal_inline(
+        &mut self,
+        grammar_id: GrammarId,
+        parent_max_idx: Option<usize>,
+    ) -> Result<Option<MatchResult>, ParseError> {
+        use sqlfluffrs_types::GrammarVariant;
+
+        // Excludes can be compound grammars; leave those to the frame path.
+        if self.grammar_ctx.exclude(grammar_id).is_some() {
+            return Ok(None);
+        }
+        let start_pos = self.pos;
+        let Some(child_id) = self.resolve_ref_target(grammar_id) else {
+            // No element child and no dialect mapping: Ref yields Empty.
+            return Ok(Some(MatchResult::empty_at(start_pos)));
+        };
+        let child_variant = self.grammar_ctx.variant(child_id);
+        let is_terminal = matches!(
+            child_variant,
+            GrammarVariant::StringParser
+                | GrammarVariant::TypedParser
+                | GrammarVariant::MultiStringParser
+                | GrammarVariant::RegexParser
+                | GrammarVariant::Token
+        );
+        if !is_terminal {
+            return Ok(None);
+        }
+        // Python parity: beyond the parent's ceiling a Ref returns Empty.
+        if let Some(parent_max) = parent_max_idx {
+            if start_pos >= parent_max {
+                return Ok(Some(MatchResult::empty_at(start_pos)));
+            }
+        }
+        // Skip leading non-code when the target allows gaps (mirrors
+        // handle_ref_initial's child_start_pos).
+        let child_allows_gaps = self.grammar_ctx.inst(child_id).flags.allow_gaps();
+        let child_start_pos = if child_allows_gaps {
+            self.skip_start_index_forward_to_code(start_pos, self.tokens.len())
+        } else {
+            start_pos
+        };
+        self.pos = child_start_pos;
+        let mr = match child_variant {
+            GrammarVariant::StringParser => self.handle_string_parser(child_id)?,
+            GrammarVariant::TypedParser => self.typed_parser_match(child_id)?,
+            GrammarVariant::MultiStringParser => self.handle_multi_string_parser(child_id)?,
+            GrammarVariant::RegexParser => self.handle_regex_parser(child_id)?,
+            GrammarVariant::Token => self.handle_token(child_id)?,
+            _ => unreachable!(),
+        };
+        if mr.is_empty() {
+            // Failed child: extent and position are the post-skip position
+            // (handle_ref_waiting_for_child's original_pos semantics), while
+            // the empty result itself sits at the Ref's own position
+            // (handle_ref_combining's `empty_at(frame.pos)`).
+            self.pos = child_start_pos;
+            return Ok(Some(MatchResult::empty_at(start_pos)));
+        }
+        let final_pos = self.pos;
+        let rule_name = self.grammar_ctx.ref_name(grammar_id);
+        let segment_class_name = self.grammar_ctx.segment_class(grammar_id);
+        let segment_type = self.grammar_ctx.segment_type(grammar_id);
+        let child = Arc::new(mr);
+        let wrapped = self.build_ref_wrap(
+            rule_name,
+            grammar_id,
+            child_id,
+            segment_class_name,
+            segment_type,
+            child_start_pos,
+            final_pos,
+            &child,
+        );
+        self.pos = final_pos;
+        Ok(Some(wrapped))
     }
 }

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/ref_grammar.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/ref_grammar.rs
@@ -361,13 +361,22 @@ impl Parser<'_> {
             }
         }
         // Skip leading non-code when the target allows gaps (mirrors
-        // handle_ref_initial's child_start_pos).
+        // handle_ref_initial's child_start_pos). Bounded by the parent's
+        // ceiling so a gap that runs up to (or past) the terminator can't
+        // push the child start beyond what the enclosing Sequence allows.
         let child_allows_gaps = self.grammar_ctx.inst(child_id).flags.allow_gaps();
+        let skip_bound = parent_max_idx.unwrap_or(self.tokens.len());
         let child_start_pos = if child_allows_gaps {
-            self.skip_start_index_forward_to_code(start_pos, self.tokens.len())
+            self.skip_start_index_forward_to_code(start_pos, skip_bound)
         } else {
             start_pos
         };
+        if let Some(parent_max) = parent_max_idx {
+            if child_start_pos >= parent_max {
+                self.pos = child_start_pos;
+                return Ok(Some(MatchResult::empty_at(start_pos)));
+            }
+        }
         self.pos = child_start_pos;
         let mr = self.dispatch_terminal_match(child_variant, child_id)?;
         if mr.is_empty() {

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/ref_grammar.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/ref_grammar.rs
@@ -304,8 +304,7 @@ impl Parser<'_> {
             );
             let matched_class = if is_token_target {
                 None
-            } else if segment_type.is_some_and(|t| !t.is_empty()) || segment_class_name.is_some()
-            {
+            } else if segment_type.is_some_and(|t| !t.is_empty()) || segment_class_name.is_some() {
                 // `segment_type` is `Option<&'static str>` (Copy), so
                 // binding by value keeps the `'static` lifetime — this
                 // borrows the grammar-table string into the node with no

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/ref_grammar.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/ref_grammar.rs
@@ -354,8 +354,6 @@ impl Parser<'_> {
         grammar_id: GrammarId,
         parent_max_idx: Option<usize>,
     ) -> Result<Option<MatchResult>, ParseError> {
-        use sqlfluffrs_types::GrammarVariant;
-
         // Excludes can be compound grammars; leave those to the frame path.
         if self.grammar_ctx.exclude(grammar_id).is_some() {
             return Ok(None);
@@ -366,15 +364,7 @@ impl Parser<'_> {
             return Ok(Some(MatchResult::empty_at(start_pos)));
         };
         let child_variant = self.grammar_ctx.variant(child_id);
-        let is_terminal = matches!(
-            child_variant,
-            GrammarVariant::StringParser
-                | GrammarVariant::TypedParser
-                | GrammarVariant::MultiStringParser
-                | GrammarVariant::RegexParser
-                | GrammarVariant::Token
-        );
-        if !is_terminal {
+        if !Self::is_terminal_variant(child_variant) {
             return Ok(None);
         }
         // Python parity: beyond the parent's ceiling a Ref returns Empty.
@@ -392,14 +382,7 @@ impl Parser<'_> {
             start_pos
         };
         self.pos = child_start_pos;
-        let mr = match child_variant {
-            GrammarVariant::StringParser => self.handle_string_parser(child_id)?,
-            GrammarVariant::TypedParser => self.typed_parser_match(child_id)?,
-            GrammarVariant::MultiStringParser => self.handle_multi_string_parser(child_id)?,
-            GrammarVariant::RegexParser => self.handle_regex_parser(child_id)?,
-            GrammarVariant::Token => self.handle_token(child_id)?,
-            _ => unreachable!(),
-        };
+        let mr = self.dispatch_terminal_match(child_variant, child_id)?;
         if mr.is_empty() {
             // Failed child: extent and position are the post-skip position
             // (handle_ref_waiting_for_child's original_pos semantics), while

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/ref_grammar.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/ref_grammar.rs
@@ -110,30 +110,24 @@ impl Parser<'_> {
         // If the explicit child grammar allows gaps, collect leading transparent
         // tokens so child parsing starts at the next non-transparent token.
         let child_allows_gaps = self.grammar_ctx.inst(child_grammar_id).flags.allow_gaps();
-        let this_type = self.grammar_ctx.segment_type(grammar_id);
         let child_start_pos = if child_allows_gaps {
             self.skip_start_index_forward_to_code(start_pos, self.tokens.len())
         } else {
             start_pos
         };
 
-        // Determine the segment_class (Python class name) from tables
-        // This is what gets stored in matched_class for Python lookup
-        // e.g., "ProcedureDefinitionGrammar", "SelectStatementSegment", etc.
-        let table_segment_class = self.grammar_ctx.segment_class(grammar_id);
-
+        // name/segment_class/segment_type are pure functions of grammar_id,
+        // so build_ref_wrap looks them up itself rather than RefState
+        // storing a redundant copy here.
         vdebug!(
             "Ref[table]: rule_name='{}', table_segment_class={:?}",
             rule_name,
-            table_segment_class
+            self.grammar_ctx.segment_class(grammar_id)
         );
 
         // Store context with collected leading transparent tokens
         frame.context = FrameContext::Ref(RefState {
             grammar_id,
-            name: rule_name,
-            segment_class_name: table_segment_class,
-            segment_type: this_type,
             saved_pos: child_start_pos,
             last_child_frame_id: Some(stack.frame_id_counter),
             child_grammar_id,
@@ -241,22 +235,10 @@ impl Parser<'_> {
         let final_pos = frame.end_pos.unwrap_or(frame.pos);
         let result_match = if let Some(ref_match_result) = &state.match_result {
             let child = Arc::clone(ref_match_result);
-            let name = state.name;
             let grammar_id = state.grammar_id;
             let child_grammar_id = state.child_grammar_id;
-            let segment_class_name = state.segment_class_name.take();
-            let segment_type = state.segment_type;
             let saved_pos = state.saved_pos;
-            self.build_ref_wrap(
-                name,
-                grammar_id,
-                child_grammar_id,
-                segment_class_name,
-                segment_type,
-                saved_pos,
-                final_pos,
-                &child,
-            )
+            self.build_ref_wrap(grammar_id, child_grammar_id, saved_pos, final_pos, &child)
         } else {
             MatchResult::empty_at(frame.pos)
         };
@@ -273,19 +255,24 @@ impl Parser<'_> {
     /// entirely for a bare Token target, mirroring Python's isinstance
     /// path) and produce the final `ref_match`. Shared by the frame-based
     /// combining handler and the frame-free Ref fast path.
-    #[allow(clippy::too_many_arguments)]
+    ///
+    /// `name`/`segment_class_name`/`segment_type` are pure functions of
+    /// `grammar_id` (looked up here, not taken as separate parameters) -
+    /// both call sites would otherwise have to fetch and thread through
+    /// values already fully determined by `grammar_id`.
     pub(crate) fn build_ref_wrap(
         &mut self,
-        name: &'static str,
         grammar_id: GrammarId,
         child_grammar_id: GrammarId,
-        segment_class_name: Option<&'static str>,
-        segment_type: Option<&'static str>,
         saved_pos: usize,
         final_pos: usize,
         ref_match_result: &Arc<MatchResult>,
     ) -> MatchResult {
         {
+            let name = self.grammar_ctx.ref_name(grammar_id);
+            let segment_class_name = self.grammar_ctx.segment_class(grammar_id);
+            let segment_type = self.grammar_ctx.segment_type(grammar_id);
+
             // Debug: print accumulated children to inspect whether typed tokens are present
             vdebug!(
                 "Ref[table] Combining DEBUG: accumulated nodes={:?}",
@@ -392,20 +379,8 @@ impl Parser<'_> {
             return Ok(Some(MatchResult::empty_at(start_pos)));
         }
         let final_pos = self.pos;
-        let rule_name = self.grammar_ctx.ref_name(grammar_id);
-        let segment_class_name = self.grammar_ctx.segment_class(grammar_id);
-        let segment_type = self.grammar_ctx.segment_type(grammar_id);
         let child = Arc::new(mr);
-        let wrapped = self.build_ref_wrap(
-            rule_name,
-            grammar_id,
-            child_id,
-            segment_class_name,
-            segment_type,
-            child_start_pos,
-            final_pos,
-            &child,
-        );
+        let wrapped = self.build_ref_wrap(grammar_id, child_id, child_start_pos, final_pos, &child);
         self.pos = final_pos;
         Ok(Some(wrapped))
     }

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/sequence.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/sequence.rs
@@ -144,7 +144,7 @@ impl Parser<'_> {
         // current_element_idx; mirror push_child_and_wait's state transition
         // and feed the result straight to the waiting handler.
         self.pos = child_start_pos;
-        if let Some(mr) = self.try_terminal_inline(elements[current_element_idx])? {
+        if let Some(mr) = self.try_terminal_inline(elements[current_element_idx], Some(max_idx))? {
             frame.state = FrameState::WaitingForChild {
                 child_index: current_element_idx,
             };
@@ -402,7 +402,7 @@ impl Parser<'_> {
             // Inline fast path for terminal elements (see try_terminal_inline);
             // mirrors update_sequence_parent_and_push_child's cursor updates.
             self.pos = child_start_pos;
-            if let Some(mr) = self.try_terminal_inline(elements[next_element_idx])? {
+            if let Some(mr) = self.try_terminal_inline(elements[next_element_idx], Some(max_idx))? {
                 {
                     let ctx = frame.context.as_sequence_mut().unwrap();
                     ctx.current_element_idx = next_element_idx;
@@ -651,7 +651,7 @@ impl Parser<'_> {
             if self.grammar_ctx.is_optional(next_element) {
                 // Inline fast path for terminal elements (see try_terminal_inline).
                 self.pos = matched_idx;
-                if let Some(mr) = self.try_terminal_inline(next_element)? {
+                if let Some(mr) = self.try_terminal_inline(next_element, Some(max_idx))? {
                     {
                         let ctx = frame.context.as_sequence_mut().unwrap();
                         ctx.current_element_idx = current_idx;
@@ -728,7 +728,7 @@ impl Parser<'_> {
 
         // Inline fast path for terminal elements (see try_terminal_inline).
         self.pos = child_start_pos;
-        if let Some(mr) = self.try_terminal_inline(next_element)? {
+        if let Some(mr) = self.try_terminal_inline(next_element, Some(max_idx))? {
             {
                 let ctx = frame.context.as_sequence_mut().unwrap();
                 ctx.current_element_idx = current_idx;

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/sequence.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/sequence.rs
@@ -139,6 +139,20 @@ impl Parser<'_> {
             return Ok(stack.transition_to_combining(frame, Some(frame_pos)));
         }
 
+        // Inline fast path: terminal first elements need no frame machinery
+        // (see try_terminal_inline). The context cursor is already at
+        // current_element_idx; mirror push_child_and_wait's state transition
+        // and feed the result straight to the waiting handler.
+        self.pos = child_start_pos;
+        if let Some(mr) = self.try_terminal_inline(elements[current_element_idx])? {
+            frame.state = FrameState::WaitingForChild {
+                child_index: current_element_idx,
+            };
+            let end_pos = self.pos;
+            let arc = Arc::new(mr);
+            return self.handle_sequence_waiting_for_child(frame, &arc, &end_pos, stack);
+        }
+
         // Create child frame with potentially new element after meta buffering
         // PYTHON PARITY: Pass only parent terminators to children (not Sequence's own).
         let child_terms = Self::sequence_child_terminators(&mut frame);
@@ -205,7 +219,7 @@ impl Parser<'_> {
             .parse_mode_override
             .unwrap_or_else(|| self.grammar_ctx.inst(seq_grammar_id).parse_mode);
         let allow_gaps = self.grammar_ctx.inst(seq_grammar_id).flags.allow_gaps();
-        let elements: Vec<GrammarId> = self.grammar_ctx.children(seq_grammar_id).collect();
+        let elements: &[GrammarId] = self.grammar_ctx.children_ids_slice(seq_grammar_id);
         let current_element_grammar_id = elements[current_element_idx];
         let current_element_optional = self.grammar_ctx.is_optional(current_element_grammar_id);
 
@@ -235,7 +249,7 @@ impl Parser<'_> {
                 start_idx,
                 max_idx,
                 allow_gaps,
-                &elements,
+                elements,
                 stack,
             );
         }
@@ -247,7 +261,7 @@ impl Parser<'_> {
             *child_end_pos,
             allow_gaps,
             parse_mode,
-            &elements,
+            elements,
             stack,
         )
     }
@@ -383,6 +397,22 @@ impl Parser<'_> {
                 let end_pos = unparsable_match.end();
                 stack.insert_result(frame.frame_id, unparsable_match, end_pos);
                 return Ok(TableFrameResult::Done);
+            }
+
+            // Inline fast path for terminal elements (see try_terminal_inline);
+            // mirrors update_sequence_parent_and_push_child's cursor updates.
+            self.pos = child_start_pos;
+            if let Some(mr) = self.try_terminal_inline(elements[next_element_idx])? {
+                {
+                    let ctx = frame.context.as_sequence_mut().unwrap();
+                    ctx.current_element_idx = next_element_idx;
+                }
+                frame.state = FrameState::WaitingForChild {
+                    child_index: next_element_idx,
+                };
+                let end_pos = self.pos;
+                let arc = Arc::new(mr);
+                return self.handle_sequence_waiting_for_child(frame, &arc, &end_pos, stack);
             }
 
             let child_frame_id = stack.frame_id_counter;
@@ -619,6 +649,21 @@ impl Parser<'_> {
         if child_start_pos >= max_idx {
             // Check if next element is optional - if so, create child frame for it
             if self.grammar_ctx.is_optional(next_element) {
+                // Inline fast path for terminal elements (see try_terminal_inline).
+                self.pos = matched_idx;
+                if let Some(mr) = self.try_terminal_inline(next_element)? {
+                    {
+                        let ctx = frame.context.as_sequence_mut().unwrap();
+                        ctx.current_element_idx = current_idx;
+                    }
+                    frame.state = FrameState::WaitingForChild {
+                        child_index: current_idx,
+                    };
+                    let end_pos = self.pos;
+                    let arc = Arc::new(mr);
+                    return self.handle_sequence_waiting_for_child(frame, &arc, &end_pos, stack);
+                }
+
                 // PYTHON PARITY: Use parent terminators (without Sequence's own) for children
                 let child_terms = Self::sequence_child_terminators(&mut frame);
                 let child_frame_id = stack.frame_id_counter;
@@ -679,6 +724,21 @@ impl Parser<'_> {
             let end_pos = unparsable_match.end();
             stack.insert_result(frame.frame_id, unparsable_match, end_pos);
             return Ok(TableFrameResult::Done);
+        }
+
+        // Inline fast path for terminal elements (see try_terminal_inline).
+        self.pos = child_start_pos;
+        if let Some(mr) = self.try_terminal_inline(next_element)? {
+            {
+                let ctx = frame.context.as_sequence_mut().unwrap();
+                ctx.current_element_idx = current_idx;
+            }
+            frame.state = FrameState::WaitingForChild {
+                child_index: current_idx,
+            };
+            let end_pos = self.pos;
+            let arc = Arc::new(mr);
+            return self.handle_sequence_waiting_for_child(frame, &arc, &end_pos, stack);
         }
 
         // Create child frame for next element

--- a/sqlfluffrs/sqlfluffrs_types/src/grammar_api.rs
+++ b/sqlfluffrs/sqlfluffrs_types/src/grammar_api.rs
@@ -142,6 +142,18 @@ impl<'a> GrammarContext<'a> {
         self.tables.get_children(inst)
     }
 
+    /// Like [`Self::children_slice`], but typed as `GrammarId`s - no per-call
+    /// `Vec` allocation. `GrammarId` is `#[repr(transparent)]` over `u32`,
+    /// so the cast is layout-safe.
+    #[inline]
+    pub fn children_ids_slice(&self, id: GrammarId) -> &'a [GrammarId] {
+        let inst = self.inst(id);
+        let ids: &'a [u32] = self.tables.get_children(inst);
+        // SAFETY: GrammarId is #[repr(transparent)] over u32, so &[u32] and
+        // &[GrammarId] have identical layout.
+        unsafe { std::slice::from_raw_parts(ids.as_ptr() as *const GrammarId, ids.len()) }
+    }
+
     /// Get number of children
     #[inline]
     pub fn children_count(&self, id: GrammarId) -> usize {

--- a/sqlfluffrs/sqlfluffrs_types/src/grammar_inst.rs
+++ b/sqlfluffrs/sqlfluffrs_types/src/grammar_inst.rs
@@ -374,7 +374,11 @@ impl fmt::Display for GrammarInst {
 /// Newtype wrapper for grammar instruction IDs
 ///
 /// Provides type safety when indexing into GRAMMAR_TABLE.
+/// `repr(transparent)` guarantees identical layout to `u32`, which
+/// `GrammarContext::children_ids_slice` relies on for its `&[u32]` ->
+/// `&[GrammarId]` cast.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[repr(transparent)]
 pub struct GrammarId(pub u32);
 
 impl GrammarId {


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
The parser previously allocated a full parse "frame" (context object) any time it evaluated a candidate grammar element, even when that candidate was a terminal (a plain token match with no nested sub-grammar). This branch adds fast paths that recognize terminal candidates ahead of time and match them directly against the token stream, skipping frame allocation entirely.

It applies to:
- `OneOf` candidates that are terminals
- `Sequence` elements that are terminals
- `Ref`-to-terminal grammars, plus inlined terminator probes
- `Delimited` / `AnyNumberOf` terminal children
- Consecutive terminal `OneOf` candidates are now looped over rather than recursed, avoiding stack overhead

Common parsing paths (OneOf/Sequence/Delimited/Ref matching) do meaningfully less allocation per token, with no change in matching semantics.

Roughly 1 in 5 `try_terminal_inline` calls actually takes the frame-free path across both workloads:
* TPC-H full suite (22 queries): 21.8% of terminal-inline probes
* TPC-DS full suite (99 queries): 21.1% of terminal-inline probes

| [Benchmark](https://app.codspeed.io/tobycraft/sqlfluff/runs/compare/6a5723f54f11c32691035e66..6a598059c5e2df2326242ba5?q=mode%3Awalltime) | Change | Before | After |
|---|---|---|---|
| test_native_ast_tpch | +2% | 1.1s | 1.1s |
| test_native_ast_tpcds | +2% | 10.7s | 10.5s |
| test_parse_tpch | +1% | 1.1s | 1.1s |
| test_parse_tpcds | +1% | 11.4s | 11.2s |
| test_parse_tpcds_python | 0% | 65.9s | 65.7s |
| test_parse_tpch_python | 0% | 6s | 6s |

Using our internal Athena query, measured locally and always subject to a bit more noise, I get the following numbers:
| Metric | Before | After | Improvement |
 |---|---|---|---|
 | `parse_athena` (criterion, median) | 1.8s | 1.4s | 20% faster |
 | Python-only total parse time | 22.5s | 21.5s | 4% faster |
 | Rust (current) total parse time | 7.3s | 7.3s | noise |
 | Rust (native AST) total parse time | 6.3s | 5.9s | 7.5% faster |

### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [ ] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
