### PR TITLE
Don't hoist a subquery correlated in a later set expression branch

### DIFF
--- a/src/sqlfluff/rules/structure/ST05.py
+++ b/src/sqlfluff/rules/structure/ST05.py
@@ -267,10 +267,14 @@ class Rule_ST05(BaseRule):
                         or any(ps.segment.is_type(*parent_types) for ps in path_to)
                     ):
                         continue
-                    if _is_correlated_subquery(
-                        Segments(query.selectables[0].selectable),
-                        select_source_names,
-                        dialect,
+                    # A set expression has one selectable per branch.
+                    if any(
+                        _is_correlated_subquery(
+                            Segments(selectable_.selectable),
+                            select_source_names,
+                            dialect,
+                        )
+                        for selectable_ in query.selectables
                     ):
                         continue
                     yield _NestedSubQuerySummary(

--- a/test/fixtures/rules/std_rule_cases/ST05.yml
+++ b/test/fixtures/rules/std_rule_cases/ST05.yml
@@ -501,6 +501,21 @@ issue_3572_correlated_subquery_3:
          from events as ce
          where ce.name = person_dates.name)
 
+correlated_subquery_in_later_set_expression_branch:
+  # The correlation is in the second branch of the set expression; issue_3572
+  # above only covers a plain select, where it happens to be the first.
+  pass_str: |
+    select
+        pd.*
+    from person_dates as pd
+    join
+        (select name
+         from events as ce
+         union all
+         select name
+         from events2 as ce2
+         where ce2.name = pd.name)
+
 issue_3598_avoid_looping_1:
   fail_str: |
     WITH cte1 AS (


### PR DESCRIPTION
### Brief summary of the change made

ST05 refuses to hoist a correlated subquery into a CTE — correctly, since the correlation would fall out of scope. But when the subquery is a set expression, it only checks the **first** branch, so a correlation in any later branch slips through and `sqlfluff fix` rewrites the query into something that no longer means the same thing.

`_nested_subqueries` passes `query.selectables[0]` to `_is_correlated_subquery`. A set expression's `Query` has one selectable per branch — this checks the first and ignores the rest.

**Reproducer** (default rules, default config):

```sql
select a.x, b.z from a join (select x, z from b1 union all select x, z from b2 where b2.k = a.k) as b using(x)
```

`sqlfluff fix --dialect ansi --rules ST05` turns it into:

```sql
with b as (select x, z from b1 union all select x, z from b2 where b2.k = a.k)
select a.x, b.z from a join b using(x)
```

`a.k` is now referenced from inside a CTE that has no `a`. **sqlfluff's own RF01 condemns the output:**

```
L:   1 | P:  75 | RF01 | Reference 'a.k' refers to table/view not found in the
                       | FROM clause or found in ancestor statement.
```

Moving the *same* `where ... = a.k` into the **first** branch is correctly refused and the file is left untouched — the only difference between the two is which branch the correlation lives in.

Confirming the mechanism directly on the parsed tree:

```
Query selectables=1
  [0] select a.x, b.z from a join (select x, z from b1 union all sel...
  Query selectables=2
    [0] select x, z from b1                        <- checked
    [1] select x, z from b2 where b2.k = a.k       <- correlated, never looked at
```

This is the default rule set and `fix` writes the file in place, which is why I'd rate it above cosmetic.

### Are there any other side effects of this change that we should be aware of?

The rule now declines to fix a case it previously "fixed" incorrectly, so some currently-rewritten queries will be left alone (and still flagged). That's the intended direction — the existing output is broken SQL.

Non-correlated set expressions are unaffected: I checked explicitly that `... join (select x, z from b1 union all select x, z from b2) as b using(x)` is still hoisted, so this isn't a blanket disable.

One thing I noticed but deliberately did **not** touch: `query.selectables[0]` appears in the same shape in AM04, RF03 and AM07. I haven't checked whether those rules should also consider every branch — it may well be correct for them — and I'd rather keep this PR to the one rule I can demonstrate is wrong. Happy to look into them separately if that's useful.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - [x] `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`. — added `correlated_subquery_in_later_set_expression_branch` to `ST05.yml` as a `pass_str`, next to the existing `issue_3572_correlated_subquery_*` cases. Those only cover a plain select, where the correlation lands in the first (and only) selectable, which is why this gap survived. It fails on `main` and passes here. `test/rules/`: **2453 passed, 101 skipped**, unchanged from `main` apart from the new case.
  - [ ] `.sql`/`.yml` parser test cases in `test/fixtures/dialects` — not applicable, no parser change.
  - [ ] Full autofix test cases in `test/fixtures/linter/autofix` — not applicable; the fix is that no autofix is produced.
  - [ ] Other.
- [ ] Added appropriate documentation for the change. — none needed: ST05's documented contract already says correlated subqueries aren't converted (issue 3572). This makes the code match the documentation rather than changing it.
- [ ] Created GitHub issues for any relevant followup/future enhancements if appropriate. — not filed; the AM04/RF03/AM07 observation above is unverified and I didn't want to open a speculative issue. Happy to if you'd like it tracked.

### Disclosure

AI-assisted, and I'd rather say so plainly. The reproducer, the RF01 cross-check, the `selectables` dump, the first-branch control, the non-correlated control, and the before/after test runs are all things I ran and read myself rather than assumed.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent `ST05` from hoisting set-expression subqueries when any branch is correlated, avoiding invalid rewrites that reference outer tables from inside the CTE.

- **Bug Fixes**
  - Check all selectables in a set expression for correlation, not just the first.
  - Skip hoisting if any branch is correlated, aligning behavior with `RF01`.
  - Added test case `correlated_subquery_in_later_set_expression_branch` to `ST05.yml`.

<sup>Written for commit a1e6d262105b0beabcf6a95d42dfa293415d2d8b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8169?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

