### PR TITLE
Fix IndexError on a two-character inline config value ending in a colon

### DIFF
--- a/src/sqlfluff/core/helpers/string.py
+++ b/src/sqlfluff/core/helpers/string.py
@@ -46,6 +46,10 @@ def split_colon_separated_string(in_str: str) -> tuple[tuple[str, ...], str]:
     (('foo', 'bar'), '{"k":"v"}')
     >>> split_colon_separated_string('foo:bar:[{"k":"v"}]')
     (('foo', 'bar'), '[{"k":"v"}]')
+
+    A two-character value ending in a colon is not a Windows path.
+    >>> split_colon_separated_string("foo:a:")
+    (('foo', 'a'), '')
     """
     config_path: list[str] = []
     leftover = in_str
@@ -65,7 +69,7 @@ def split_colon_separated_string(in_str: str) -> tuple[tuple[str, ...], str]:
 
 def should_split_on_colon(value: str) -> bool:
     """Heuristic for legit values containing comma."""
-    if len(value) >= 2 and value[1] == ":" and value[2] == "\\":
+    if len(value) >= 3 and value[1] == ":" and value[2] == "\\":
         # Likely a Windows path
         return False
     if len(value) >= 2 and (value[0] == "[" and value[-1] == "]"):


### PR DESCRIPTION
### Brief summary of the change made

`should_split_on_colon` checks `len(value) >= 2` and then reads `value[2]`, so a value of exactly two characters ending in a colon raises `IndexError` instead of being split.

```python
if len(value) >= 2 and value[1] == ":" and value[2] == "\\":
    # Likely a Windows path
```

An inline config comment carrying such a value crashes `sqlfluff lint` with a bare traceback:

```sql
-- sqlfluff:templater:jinja:context:my_var:a:
SELECT 1
```

```
  File ".../sqlfluff/core/helpers/string.py", line 68, in should_split_on_colon
    if len(value) >= 2 and value[1] == ":" and value[2] == "\\":
                                               ~~~~~^^^
IndexError: string index out of range
```

The path is `cli.commands.lint` → `linter.lint_paths` → `load_raw_file_and_config` → `process_raw_file_for_config` → `split_colon_separated_string` → `should_split_on_colon`; `fluffconfig.py:729` is the only caller.

The two checks directly below it are the giveaway — they guard `>= 2` and index `[0]`/`[-1]`, which is consistent. Only this one reaches further than its own guard allows.

Changed the guard to `>= 3` to match what the check actually reads.

### Are there any other side effects of this change that we should be aware of?

None that I can find. The only values that change behaviour are exactly the ones that used to crash: two characters with a colon in position 1. A real Windows path (`C:\...`) is at least three characters, so it is still recognised — I checked `should_split_on_colon("C:\\")` is still `False` and `split_colon_separated_string("foo:bar:C:\\Users")` still returns `(('foo', 'bar'), 'C:\\Users')`.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - [ ] `.yml` rule test cases in `test/fixtures/rules/std_rule_cases` — not applicable, no rule change.
  - [ ] `.sql`/`.yml` parser test cases in `test/fixtures/dialects` — not applicable, no parser change.
  - [ ] Full autofix test cases in `test/fixtures/linter/autofix` — not applicable.
  - [x] Other — added a doctest to `split_colon_separated_string`, which is where this function's existing coverage lives (there are no tests for it under `test/`). It raises `IndexError` on `main` and passes here. `test/core/config/` + `test/core/linter/`: 221 passed. `test/core/`: unchanged from `main` (3 pre-existing `plugin_test.py` failures in my sandbox, identical in both runs — the example plugin isn't installed locally). `ruff check`/`format` clean.
- [ ] Added appropriate documentation for the change. — none needed; this restores the documented behaviour rather than changing it.
- [ ] Created GitHub issues for any relevant followup/future enhancements if appropriate. — none needed.

### Disclosure

AI-assisted, and I'd rather say so plainly. The reproducer, the traceback, the caller trace, and the Windows-path regression checks are all things I ran and read myself rather than assumed.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes an IndexError when an inline config value is exactly two characters ending with a colon (e.g., "a:") by correcting the Windows-path heuristic used during splitting. `sqlfluff` no longer crashes and splits such values correctly, while Windows path detection remains unchanged.

- **Bug Fixes**
  - Updated `should_split_on_colon` to require `len(value) >= 3` before accessing `value[2]`.
  - Added a doctest to `split_colon_separated_string` for the case `"foo:a:"`.

<sup>Written for commit 1710b088bc342e4153fac0606dc56fa675596fe8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8170?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

