### PR TITLE
Leave a schema-qualified NVL/IFNULL alone

### DIFF
--- a/src/sqlfluff/rules/convention/CV02.py
+++ b/src/sqlfluff/rules/convention/CV02.py
@@ -54,6 +54,12 @@ class Rule_CV02(BaseRule):
         if context.segment.raw_upper not in {"IFNULL", "NVL"}:
             return None
 
+        # A qualified function_name (i.e. with more than one part) is a user
+        # defined function that merely shares the name, not the builtin.
+        parent = context.parent_stack[-1] if context.parent_stack else None
+        if parent and parent.is_type("function_name") and len(parent.segments) != 1:
+            return None
+
         # Create fix to replace ``IFNULL`` or ``NVL`` with ``COALESCE``.
         fix = LintFix.replace(
             context.segment,

--- a/test/fixtures/rules/std_rule_cases/CV02.yml
+++ b/test/fixtures/rules/std_rule_cases/CV02.yml
@@ -5,6 +5,12 @@ test_pass_coalesce:
     SELECT coalesce(foo, 0) AS bar,
     FROM baz;
 
+test_pass_qualified_udf:
+  # A qualified name is a user-defined function, not the builtin NVL.
+  pass_str: |
+    SELECT myschema.nvl(foo, 0) AS bar,
+    FROM baz;
+
 test_fail_ifnull:
   fail_str: |
     SELECT ifnull(foo, 0) AS bar,


### PR DESCRIPTION
### Brief summary of the change made

CV02 rewrites any function called `NVL`/`IFNULL` into `COALESCE`, including a schema-qualified one — which is a user-defined function that merely shares the name, not the builtin:

```
SELECT myschema.nvl(a, 0) FROM t
```

`sqlfluff fix --rules CV02` turns it into:

```
SELECT myschema.COALESCE(a, 0) FROM t
```

`myschema.COALESCE` almost certainly doesn't exist, so the output won't run. The rule crawls `function_name_identifier` and never looks at whether its parent `function_name` is qualified.

CP01 already codifies exactly this distinction, and I've mirrored its check and its reasoning:

> If it's a qualified function_name (i.e with more than one part to function_name). Then it is likely an existing user defined function (UDF) which are case sensitive so ignore for this.

The parse tree makes the test straightforward — `myschema.nvl` gives a `function_name` with three children (`naked_identifier`, `dot`, `function_name_identifier`), a bare `nvl` gives one.

### Are there any other side effects of this change that we should be aware of?

Only qualified names stop being rewritten. The rule's actual purpose is untouched — I checked that bare `nvl(a, 0)` and `ifnull(a, 0)` still become `COALESCE(a, 0)`, so this isn't a blanket disable. Three-part names (`db.myschema.ifnull(...)`) are also left alone.

`Rule_CV02` isn't subclassed by anything, so the blast radius is this rule.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - [x] `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`. — added `test_pass_qualified_udf` to `CV02.yml`. It fails on `main` and passes here. There was no qualified-name coverage at all (`CV02.yml` had zero cases with a dotted function name), which is presumably why this survived. `test/rules/`: unchanged from `main` apart from the new case. `ruff check`/`format` clean.
  - [ ] `.sql`/`.yml` parser test cases in `test/fixtures/dialects` — not applicable, no parser change.
  - [ ] Full autofix test cases in `test/fixtures/linter/autofix` — not applicable; the change is that no autofix is produced for qualified names.
  - [ ] Other.
- [ ] Added appropriate documentation for the change. — none needed: the rule's docstring already describes it as replacing the `IFNULL`/`NVL` builtins, which is what this makes it actually do.
- [ ] Created GitHub issues for any relevant followup/future enhancements if appropriate. — none needed.

### Disclosure

AI-assisted, and I'd rather say so plainly. The reproducer, the bare-`nvl` control, the three-part-name case, the parse-tree structure, and the before/after test runs are all things I ran and read myself rather than assumed.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop `CV02` from rewriting schema-qualified `NVL`/`IFNULL` calls to `COALESCE`. This prevents breaking UDFs like `myschema.nvl(...)` and keeps fixes limited to builtin calls.

- **Bug Fixes**
  - Skip autofix when `function_name` is qualified (e.g., `myschema.nvl(...)`).
  - Keep behavior for unqualified `NVL`/`IFNULL` (still rewritten to `COALESCE`).
  - Add `test_pass_qualified_udf` to cover dotted names.

<sup>Written for commit d7bd402e3ee56abf01b6605540a655360e50ec97. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8172?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

