### PR TITLE
Leave the jinja context out of config path resolution

### DIFF
--- a/src/sqlfluff/core/config/file.py
+++ b/src/sqlfluff/core/config/file.py
@@ -30,6 +30,9 @@ COMMA_SEPARATED_PATH_KEYS = (
     "exclude_macros_from_path",
 )
 RESOLVE_PATH_SUFFIXES = ("_path", "_dir")
+# Values in this section are arbitrary user data for templating, so the path
+# heuristics below must not be applied to them.
+OPAQUE_SECTION_KEY_PATH = ("templater", "jinja", "context")
 
 
 def _load_raw_file_as_dict(filepath: str) -> ConfigMappingType:
@@ -58,7 +61,10 @@ def _resolve_path(filepath: str, val: str) -> list[str]:
 
 
 def _resolve_paths_in_config(
-    config: ConfigMappingType, filepath: str, logging_reference: Optional[str] = None
+    config: ConfigMappingType,
+    filepath: str,
+    logging_reference: Optional[str] = None,
+    key_path: tuple[str, ...] = (),
 ) -> None:
     """Attempt to resolve any paths found in the config file.
 
@@ -69,7 +75,13 @@ def _resolve_paths_in_config(
     for key, val in config.items():
         # If it's a dict, recurse.
         if isinstance(val, dict):
-            _resolve_paths_in_config(val, filepath, logging_reference=logging_reference)
+            if key_path + (key.lower(),) != OPAQUE_SECTION_KEY_PATH:
+                _resolve_paths_in_config(
+                    val,
+                    filepath,
+                    logging_reference=logging_reference,
+                    key_path=key_path + (key.lower(),),
+                )
         # If it's a potential multi-path, split, resolve and join
         if key.lower() in COMMA_SEPARATED_PATH_KEYS:
             assert isinstance(val, str), (

--- a/test/core/config/fluffconfig_test.py
+++ b/test/core/config/fluffconfig_test.py
@@ -550,3 +550,33 @@ def test_resolve_paths_in_config_no_matches_fallback(tmp_path):
     # Should keep original pattern when no matches
     resolved_path = test_config["templater:jinja"]["load_macros_from_path"]
     assert resolved_path == "empty/*.sql, nonexistent/*.sql"
+
+
+def test_resolve_paths_in_config_skips_jinja_context(tmp_path):
+    """Test that _resolve_paths_in_config leaves the jinja context alone.
+
+    Values in the jinja context are arbitrary user data, so the `_path`/`_dir`
+    suffix heuristics must not be applied to them. The inline config route
+    already guarantees this (see the `my_path` case in
+    test_process_inline_config), and the file route should match it.
+    """
+    from sqlfluff.core.config.file import _resolve_paths_in_config
+
+    (tmp_path / "data").mkdir()
+
+    test_config = {
+        "templater": {
+            "jinja": {
+                "context": {
+                    "tbl_path": "data",
+                    "is_dir": True,
+                },
+            },
+        },
+    }
+
+    _resolve_paths_in_config(test_config, str(tmp_path / ".sqlfluff"))
+
+    context = test_config["templater"]["jinja"]["context"]
+    assert context["tbl_path"] == "data"
+    assert context["is_dir"] is True


### PR DESCRIPTION
## What

`_resolve_paths_in_config` walks the whole config tree and applies its `_path`/`_dir` suffix
heuristics to every key it finds, including the values under `templater:jinja:context`. Those
are arbitrary user data for templating, not paths.

## Why it matters

**The same value renders differently depending on the variable's name — and on whether an
unrelated directory happens to exist.**

```ini
# .sqlfluff
[sqlfluff]
templater = jinja
dialect = ansi

[sqlfluff:templater:jinja:context]
tbl_path = data
plain = data
```

```sql
-- q.sql
SELECT '{{ tbl_path }}', '{{ plain }}' FROM t
```

With a `data/` directory present:

```
$ sqlfluff render q.sql
SELECT '/abs/path/to/data', 'data' FROM t
```

Remove the (entirely unrelated) `data/` directory and the same config renders:

```
$ rmdir data && sqlfluff render q.sql
SELECT 'data', 'data' FROM t
```

So the SQL that gets linted depends on the filesystem around it.

Separately, any non-string value raises a bare `AssertionError`, so using a `_dir`-suffixed
Jinja flag fails outright:

```ini
[sqlfluff:templater:jinja:context]
is_dir = True
```

```
AssertionError: Value for is_dir in /path/.sqlfluff must be a string not <class 'bool'>.
```

## The inconsistency this resolves

The inline-config route already leaves these values alone. `test_process_inline_config` asserts
it explicitly:

```python
# Check that Windows paths don't get mangled
cfg.process_inline_config("-- sqlfluff:jinja:my_path:c:\\foo", "test.sql")
assert cfg.get("my_path", section="jinja") == "c:\\foo"
```

The file route did the opposite. This makes the two agree.

## The change

Track the key path while recursing and skip `templater:jinja:context`.

`library_path` — the one key under `templater:jinja` that genuinely relies on the suffix rule —
still resolves to an absolute path; there is a check for that in the verification below.

## Verification

- New test `test_resolve_paths_in_config_skips_jinja_context` fails before the change
  (`AssertionError` at `file.py:88`) and passes after.
- End-to-end, via the CLI: both symptoms above are gone, and `is_dir = True` is correctly
  truthy in the template.
- Control: `library_path = libs` still resolves to an absolute path after the change.
- Full test suite run; the failures present are also present on an unmodified `upstream/main`
  checkout (see the note below).

## AI disclosure

Per the AI-Assisted Contributions section of CONTRIBUTING, which asks for what was AI-assisted
and what was manually validated:

**This contribution is fully AI-authored and autonomous** (Claude Code, acting on this account).
An AI found the bug, built the reproducers, wrote the fix and the test, ran the suites, and wrote
this description. **What was manually validated by a human: nothing.** The human operator of this
account did not hand-review the diff or run the tests.

The verification above is real and re-runnable from the diff — it was just done by the AI rather
than by a person. If unsupervised AI contributions are not what you want here, say so and I will
close this.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip applying `_path`/`_dir` heuristics to values under templater:jinja:context so Jinja context data isn’t treated as paths. This fixes inconsistent renders and the AssertionError when non-string context values are used.

- **Bug Fixes**
  - Track the key path in `_resolve_paths_in_config` and skip `templater:jinja:context`; `library_path` under `templater:jinja` still resolves to an absolute path.
  - Added `test_resolve_paths_in_config_skips_jinja_context`.
  - Verified via CLI: context strings remain unchanged and booleans work as expected.

<sup>Written for commit bd40f5fc9b9ac583bfaa4a7efbf08dd77d388f76. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8173?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

