### PR TITLE
RF01: resolve UPDATE target alias nested in from_expression (MySQL)

### DIFF
--- a/src/sqlfluff/utils/analysis/query.py
+++ b/src/sqlfluff/utils/analysis/query.py
@@ -85,6 +85,19 @@ class Selectable:
             # (https://www.postgresql.org/docs/8.2/sql-values.html).
             values = Segments(self.selectable)
             alias_expression = values.children().first(sp.is_type("alias_expression"))
+            if not alias_expression:
+                # In some dialects (e.g. MySQL), the target table of an
+                # UPDATE statement is parsed as a from_expression, so any
+                # alias is nested inside a from_expression_element rather
+                # than being a direct child of the statement.
+                # https://github.com/sqlfluff/sqlfluff/issues/6147
+                alias_expression = (
+                    values.children(sp.is_type("from_expression"))
+                    .children(sp.is_type("from_expression_element"))
+                    .first()
+                    .children()
+                    .first(sp.is_type("alias_expression"))
+                )
             name = alias_expression.children().first(
                 sp.is_type("naked_identifier", "quoted_identifier")
             )

--- a/src/sqlfluff/utils/analysis/query.py
+++ b/src/sqlfluff/utils/analysis/query.py
@@ -8,7 +8,11 @@ from functools import cached_property
 from typing import Generic, NamedTuple, Optional, TypeVar, Union, cast
 
 from sqlfluff.core.dialects.base import Dialect
-from sqlfluff.core.dialects.common import AliasInfo, is_qualified
+from sqlfluff.core.dialects.common import (
+    AliasInfo,
+    get_from_clause_aliases,
+    is_qualified,
+)
 from sqlfluff.core.parser import BaseSegment
 from sqlfluff.dialects.dialect_ansi import ObjectReferenceSegment
 from sqlfluff.utils.analysis.select import (
@@ -85,39 +89,42 @@ class Selectable:
             # (https://www.postgresql.org/docs/8.2/sql-values.html).
             values = Segments(self.selectable)
             alias_expressions = values.children(sp.is_type("alias_expression"))
-            if not alias_expressions:
-                # In some dialects (e.g. MySQL), the target table(s) of an
-                # UPDATE statement are parsed as a from_expression, so any
-                # aliases are nested inside from_expression_elements
-                # (including inside join clauses for multi-table updates)
-                # rather than being direct children of the statement.
-                # https://github.com/sqlfluff/sqlfluff/issues/6147
-                from_expressions = values.children(sp.is_type("from_expression"))
-                target_elements = from_expressions.children(
-                    sp.is_type("from_expression_element")
-                ) + from_expressions.children(sp.is_type("join_clause")).children(
-                    sp.is_type("from_expression_element")
-                )
-                alias_expressions = target_elements.children(
-                    sp.is_type("alias_expression")
-                )
-            table_aliases = []
-            for alias_expression in alias_expressions:
-                name = (
-                    Segments(alias_expression)
-                    .children()
-                    .first(sp.is_type("naked_identifier", "quoted_identifier"))
-                )
-                table_aliases.append(
-                    AliasInfo(
-                        name[0].raw if name else "",
-                        name[0] if name else None,
-                        bool(name),
-                        self.selectable,
-                        alias_expression,
-                        None,
+            table_aliases: list[AliasInfo] = []
+            if alias_expressions:
+                # A VALUES clause carries its alias as a direct child.
+                for alias_expression in alias_expressions:
+                    name = (
+                        Segments(alias_expression)
+                        .children()
+                        .first(sp.is_type("naked_identifier", "quoted_identifier"))
                     )
-                )
+                    table_aliases.append(
+                        AliasInfo(
+                            name[0].raw if name else "",
+                            name[0] if name else None,
+                            bool(name),
+                            self.selectable,
+                            alias_expression,
+                            None,
+                        )
+                    )
+            elif values.children(sp.is_type("from_expression")):
+                # In some dialects (e.g. MySQL) the target table(s) of an
+                # UPDATE are parsed as from_expression(s), so their aliases live
+                # inside from_expression_elements (and join clauses, for
+                # multi-table updates) rather than as direct children. Reuse the
+                # canonical from-clause alias resolution instead of re-deriving
+                # aliases here, so joined and nested targets resolve exactly as
+                # they do in a SELECT.
+                # https://github.com/sqlfluff/sqlfluff/issues/6147
+                dialect_name = self.dialect.name if self.dialect else None
+                table_aliases = [
+                    alias
+                    for _, alias in get_from_clause_aliases(
+                        self.selectable, dialect_name
+                    )
+                ]
+
             if not table_aliases:
                 # Preserve the longstanding behavior of always registering
                 # one (possibly anonymous) alias for the DML target.

--- a/src/sqlfluff/utils/analysis/query.py
+++ b/src/sqlfluff/utils/analysis/query.py
@@ -121,7 +121,9 @@ class Selectable:
             if not table_aliases:
                 # Preserve the longstanding behavior of always registering
                 # one (possibly anonymous) alias for the DML target.
-                table_aliases = [AliasInfo("", None, False, self.selectable, None, None)]
+                table_aliases = [
+                    AliasInfo("", None, False, self.selectable, None, None)
+                ]
 
             return SelectStatementColumnsAndTables(
                 select_statement=self.selectable,

--- a/src/sqlfluff/utils/analysis/query.py
+++ b/src/sqlfluff/utils/analysis/query.py
@@ -84,35 +84,48 @@ class Selectable:
             # source), see the "Examples" section of the Postgres docs page:
             # (https://www.postgresql.org/docs/8.2/sql-values.html).
             values = Segments(self.selectable)
-            alias_expression = values.children().first(sp.is_type("alias_expression"))
-            if not alias_expression:
-                # In some dialects (e.g. MySQL), the target table of an
-                # UPDATE statement is parsed as a from_expression, so any
-                # alias is nested inside a from_expression_element rather
-                # than being a direct child of the statement.
+            alias_expressions = values.children(sp.is_type("alias_expression"))
+            if not alias_expressions:
+                # In some dialects (e.g. MySQL), the target table(s) of an
+                # UPDATE statement are parsed as a from_expression, so any
+                # aliases are nested inside from_expression_elements
+                # (including inside join clauses for multi-table updates)
+                # rather than being direct children of the statement.
                 # https://github.com/sqlfluff/sqlfluff/issues/6147
-                alias_expression = (
-                    values.children(sp.is_type("from_expression"))
-                    .children(sp.is_type("from_expression_element"))
-                    .first()
-                    .children()
-                    .first(sp.is_type("alias_expression"))
+                from_expressions = values.children(sp.is_type("from_expression"))
+                target_elements = from_expressions.children(
+                    sp.is_type("from_expression_element")
+                ) + from_expressions.children(sp.is_type("join_clause")).children(
+                    sp.is_type("from_expression_element")
                 )
-            name = alias_expression.children().first(
-                sp.is_type("naked_identifier", "quoted_identifier")
-            )
-            alias_info = AliasInfo(
-                name[0].raw if name else "",
-                name[0] if name else None,
-                bool(name),
-                self.selectable,
-                alias_expression[0] if alias_expression else None,
-                None,
-            )
+                alias_expressions = target_elements.children(
+                    sp.is_type("alias_expression")
+                )
+            table_aliases = []
+            for alias_expression in alias_expressions:
+                name = (
+                    Segments(alias_expression)
+                    .children()
+                    .first(sp.is_type("naked_identifier", "quoted_identifier"))
+                )
+                table_aliases.append(
+                    AliasInfo(
+                        name[0].raw if name else "",
+                        name[0] if name else None,
+                        bool(name),
+                        self.selectable,
+                        alias_expression,
+                        None,
+                    )
+                )
+            if not table_aliases:
+                # Preserve the longstanding behavior of always registering
+                # one (possibly anonymous) alias for the DML target.
+                table_aliases = [AliasInfo("", None, False, self.selectable, None, None)]
 
             return SelectStatementColumnsAndTables(
                 select_statement=self.selectable,
-                table_aliases=[alias_info],
+                table_aliases=table_aliases,
                 standalone_aliases=[],
                 reference_buffer=[],
                 select_targets=[],

--- a/test/fixtures/rules/std_rule_cases/RF01.yml
+++ b/test/fixtures/rules/std_rule_cases/RF01.yml
@@ -878,3 +878,19 @@ test_pass_mysql_update_alias_correlated_subquery:
   configs:
     core:
       dialect: mysql
+
+test_pass_mysql_multi_table_update_alias_correlated_subquery:
+  # https://github.com/sqlfluff/sqlfluff/issues/6147
+  # Aliases of every target of a multi-table UPDATE (including joined
+  # tables) should resolve from correlated subqueries.
+  pass_str: |
+    UPDATE t1 AS a
+    INNER JOIN t2 AS b ON a.id = b.id
+    SET a.x = (
+        SELECT SUM(c.v)
+        FROM t3 AS c
+        WHERE c.k = b.id
+    );
+  configs:
+    core:
+      dialect: mysql

--- a/test/fixtures/rules/std_rule_cases/RF01.yml
+++ b/test/fixtures/rules/std_rule_cases/RF01.yml
@@ -862,3 +862,19 @@ test_pass_tsql_containstable_join_arguments:
   configs:
     core:
       dialect: tsql
+
+test_pass_mysql_update_alias_correlated_subquery:
+  # https://github.com/sqlfluff/sqlfluff/issues/6147
+  # In MySQL the target table of an UPDATE is parsed as a from_expression,
+  # so the alias `p` is nested inside a from_expression_element. References
+  # to that alias inside a correlated subquery should still resolve.
+  pass_str: |
+    UPDATE llx_product AS p
+    SET p.stock = (
+        SELECT SUM(ps.reel)
+        FROM llx_product_stock AS ps
+        WHERE ps.fk_product = p.rowid
+    );
+  configs:
+    core:
+      dialect: mysql

--- a/test/fixtures/rules/std_rule_cases/RF01.yml
+++ b/test/fixtures/rules/std_rule_cases/RF01.yml
@@ -894,3 +894,19 @@ test_pass_mysql_multi_table_update_alias_correlated_subquery:
   configs:
     core:
       dialect: mysql
+
+test_pass_mysql_comma_multi_table_update_alias_correlated_subquery:
+  # https://github.com/sqlfluff/sqlfluff/issues/6147
+  # The comma-style multi-table UPDATE parses each target as a sibling
+  # from_expression (not a join_clause), so every alias must still resolve
+  # from a correlated subquery.
+  pass_str: |
+    UPDATE t1 AS a, t2 AS b
+    SET a.x = (
+        SELECT SUM(c.v)
+        FROM t3 AS c
+        WHERE c.k = b.id
+    );
+  configs:
+    core:
+      dialect: mysql


### PR DESCRIPTION
Fixes #6147.

RF01 falsely flags references to the UPDATE target's alias inside correlated subqueries on MySQL/MariaDB:

```sql
UPDATE llx_product AS p
SET p.stock = (
    SELECT SUM(ps.reel)
    FROM llx_product_stock AS ps
    WHERE ps.fk_product = p.rowid
);
```
```
L:5 | P:22 | RF01 | Reference 'p.rowid' refers to table/view not found in the FROM clause or found in ancestor statement.
```

The same statement lints clean with `--dialect ansi`, which isolates the cause: ANSI's grammar puts the UPDATE target's `alias_expression` directly under the statement, where `Selectable.select_info` fabricates the DML alias from a *direct child* lookup. MySQL parses the target as `from_expression → from_expression_element → [table_expression, alias_expression]` — one level deeper — so the alias was never registered and subquery references to it failed to resolve.

Fix: in the DML branch of `select_info`, fall back to the nested location when no direct-child alias exists. The fallback only activates when the direct lookup finds nothing, so ANSI and other dialects are untouched. Living in shared analysis code, it also benefits the other rules built on `Query` (RF02/RF03/ST rules).

New pass-case in RF01.yml (fails on main, passes with the fix); all 80 RF01 cases green; full `test/rules/` + `test/utils/analysis/`: 2474 passed locally.

AI disclosure (per CONTRIBUTING): the diagnosis and patch were AI-assisted; I validated the repro, fix behaviour and test runs locally myself.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes RF01 false positives on MySQL/MariaDB where correlated subqueries couldn’t reference UPDATE target aliases. The analyzer now resolves aliases from the UPDATE’s nested from-clause, including all targets in multi-table UPDATEs (resolves #6147).

- **Bug Fixes**
  - In select_info, when no direct alias_expression exists, delegate alias discovery to the canonical from-clause resolver to collect all UPDATE target aliases (joins, nested targets, and comma-style multi-table UPDATEs).
  - Added RF01 pass cases for single-table, join-based multi-table, and comma-style multi-table UPDATE correlated subqueries on mysql; applied ruff-format.
  - Kept legacy behavior: register one anonymous DML alias when none found; other dialects unchanged; shared analysis benefits other Query-based rules.

<sup>Written for commit 681ecd2f746b1379fb63c144ad4b2cdc4c7a2b3b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8176?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

