### PR TITLE
Guard BigQuery and ClickHouse explicit view column lists in ST06

### DIFF
--- a/src/sqlfluff/rules/structure/ST06.py
+++ b/src/sqlfluff/rules/structure/ST06.py
@@ -80,6 +80,22 @@ class Rule_ST06(BaseRule):
                             for seg in child.recursive_crawl("index_column_definition")
                         ):
                             return True
+                        # BigQuery represents the view column list with
+                        # column_definition segments instead
+                        if any(
+                            seg.is_type("column_definition")
+                            for seg in child.recursive_crawl("column_definition")
+                        ):
+                            return True
+                        # ClickHouse lists the columns as bare identifiers
+                        # directly in the brackets. Only the column list holds
+                        # them at the top level -- a parenthesized `AS (SELECT
+                        # ...)` body wraps them in a select_statement instead --
+                        # so check the bracket's direct children.
+                        if any(
+                            seg.is_type("naked_identifier") for seg in child.segments
+                        ):
+                            return True
                 # Found a CREATE VIEW but no explicit column list
                 return False
         return False

--- a/src/sqlfluff/rules/structure/ST06.py
+++ b/src/sqlfluff/rules/structure/ST06.py
@@ -93,7 +93,8 @@ class Rule_ST06(BaseRule):
                         # ...)` body wraps them in a select_statement instead --
                         # so check the bracket's direct children.
                         if any(
-                            seg.is_type("naked_identifier") for seg in child.segments
+                            seg.is_type("naked_identifier", "quoted_identifier")
+                            for seg in child.segments
                         ):
                             return True
                 # Found a CREATE VIEW but no explicit column list

--- a/test/fixtures/rules/std_rule_cases/ST06.yml
+++ b/test/fixtures/rules/std_rule_cases/ST06.yml
@@ -379,3 +379,27 @@ test_fail_create_view_without_explicit_columns_tsql:
       e.department,
       TRY_CAST(e.id AS INT) AS employee_id
     FROM employees e
+
+test_pass_create_view_with_explicit_columns_bigquery:
+  configs:
+    core:
+      dialect: bigquery
+  pass_str: |
+    CREATE VIEW v (nm, i, d) AS
+    SELECT
+      e.name,
+      TRY_CAST(e.id AS INT) AS eid,
+      e.dept
+    FROM employees e
+
+test_pass_create_view_with_explicit_columns_clickhouse:
+  configs:
+    core:
+      dialect: clickhouse
+  pass_str: |
+    CREATE VIEW v (nm, i, d) AS
+    SELECT
+      e.name,
+      TRY_CAST(e.id AS INT) AS eid,
+      e.dept
+    FROM employees e

--- a/test/fixtures/rules/std_rule_cases/ST06.yml
+++ b/test/fixtures/rules/std_rule_cases/ST06.yml
@@ -403,3 +403,15 @@ test_pass_create_view_with_explicit_columns_clickhouse:
       TRY_CAST(e.id AS INT) AS eid,
       e.dept
     FROM employees e
+
+test_pass_create_view_with_explicit_quoted_columns_clickhouse:
+  configs:
+    core:
+      dialect: clickhouse
+  pass_str: |
+    CREATE VIEW v (`nm`, `i`, `d`) AS
+    SELECT
+      e.name,
+      TRY_CAST(e.id AS INT) AS eid,
+      e.dept
+    FROM employees e


### PR DESCRIPTION
## What

ST06 reorders `SELECT` columns simplest-first. It deliberately skips a `CREATE VIEW` that declares an explicit column list, because that list binds **positionally** to the SELECT, so reordering the SELECT silently changes what each column returns.

`_is_view_with_explicit_columns` only recognised two column-list shapes — `column_reference` (ANSI/Snowflake/Postgres) and `index_column_definition` (T-SQL). BigQuery and ClickHouse use different shapes, so their views fell through the guard and got reordered:

```sql
-- dialect: bigquery (same for clickhouse)
CREATE VIEW v (nm, i, d) AS
SELECT e.name, TRY_CAST(e.id AS INT) AS eid, e.dept
FROM employees e
```

`sqlfluff fix` (ST06 is enabled by default) rewrites the SELECT to `e.name, e.dept, TRY_CAST(e.id AS INT) AS eid`, so the view now exposes `dept` values under column `i` and `id` values under column `d` — a silent semantic change.

## Fix

Extend the guard to also recognise:
- `column_definition` — BigQuery's view column list.
- bare identifiers directly inside the brackets — ClickHouse. A parenthesised `AS (SELECT ...)` body also lives in a bracket, but it holds a `select_statement` rather than top-level identifiers, so it is not affected.

No grammar changes — this is contained to the rule's guard. Views without an explicit column list still reorder as before; `pass` cases for BigQuery and ClickHouse are added to `ST06.yml`, and the existing 24 ST06 cases stay green.

This is the same regression as #6807, and picks up the guard half of the inactive #8056 (thanks @CodeBlackwell) — but only the guard, without the ANSI `CREATE VIEW` wrapper change that was questioned there, since (as noted on that PR) BigQuery and ClickHouse define their own `CREATE VIEW` grammar.

Fixes #6807.

---

*AI disclosure (per the AI-assisted contributions policy): this change was authored end-to-end by an AI agent (Claude Code, on this account) — it found the two uncovered dialects, wrote the guard and the YAML cases, and ran the verification below. The human account holder reviews every change and is accountable for it; the validation is real and re-runnable from the diff, it was just performed by the agent. Verified: the reordering reproduces on `bigquery` and `clickhouse` before the change and is guarded after; the two new `ST06.yml` cases fail without the guard and pass with it; full `test/rules/yaml_test_cases_test.py` is green (2294 passed); `ruff check`/`format` clean.*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent ST06 from reordering SELECT columns in CREATE VIEW statements that declare explicit column lists in BigQuery and ClickHouse, including quoted identifiers. This avoids silent column misalignment from positional binding and fixes #6807.

- **Bug Fixes**
  - Extend the guard to detect BigQuery `column_definition` and ClickHouse bare or quoted identifiers in the view column list.
  - Add passing ST06 cases for both dialects, including quoted columns in ClickHouse; no grammar changes.

<sup>Written for commit d21e6c014e9b815f80de868d0d84a0395abd5c08. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8178?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

