### PR TITLE
Fix ST07 pairing the wrong tables when a comma-join precedes USING

### DIFF
--- a/src/sqlfluff/rules/structure/ST07.py
+++ b/src/sqlfluff/rules/structure/ST07.py
@@ -120,7 +120,16 @@ class Rule_ST07(BaseRule):
 
         to_delete, insert_after_anchor = _extract_deletion_sequence_and_anchor(segment)
 
-        table_a, table_b = table_aliases[:2]
+        # This join connects the base table of its from_expression with the
+        # table joined here -- not necessarily the SELECT's first two tables,
+        # which diverge when a comma-join precedes this USING join.
+        alias_by_element = {id(ta.from_expression_element): ta for ta in table_aliases}
+        left_element = tables_in_join.get(0)
+        right_element = segment.children(sp.is_type("from_expression_element")).get(0)
+        table_a = alias_by_element.get(id(left_element))
+        table_b = alias_by_element.get(id(right_element))
+        if table_a is None or table_b is None:  # pragma: no cover
+            return unfixable_result
         edit_segments = [
             KeywordSegment(raw="ON"),
             WhitespaceSegment(raw=" "),

--- a/src/sqlfluff/rules/structure/ST07.py
+++ b/src/sqlfluff/rules/structure/ST07.py
@@ -123,11 +123,15 @@ class Rule_ST07(BaseRule):
         # This join connects the base table of its from_expression with the
         # table joined here -- not necessarily the SELECT's first two tables,
         # which diverge when a comma-join precedes this USING join.
-        alias_by_element = {id(ta.from_expression_element): ta for ta in table_aliases}
+        alias_by_element = {
+            ta.from_expression_element.uuid: ta
+            for ta in table_aliases
+            if ta.from_expression_element is not None
+        }
         left_element = tables_in_join.get(0)
         right_element = segment.children(sp.is_type("from_expression_element")).get(0)
-        table_a = alias_by_element.get(id(left_element))
-        table_b = alias_by_element.get(id(right_element))
+        table_a = alias_by_element.get(left_element.uuid) if left_element else None
+        table_b = alias_by_element.get(right_element.uuid) if right_element else None
         if table_a is None or table_b is None:  # pragma: no cover
             return unfixable_result
         edit_segments = [

--- a/test/fixtures/rules/std_rule_cases/ST07.yml
+++ b/test/fixtures/rules/std_rule_cases/ST07.yml
@@ -64,6 +64,14 @@ test_fail_parent_child_positioning:
     select * from c1 join c2 ON c1.ID = c2.ID
     join (select * from c3 join c4 ON c3.ID = c4.ID) as c5 on c1.ID = c5.ID
 
+test_fail_comma_join_before_using:
+  # A comma-join before the first USING join must pair the two tables the
+  # join actually connects, not the SELECT's first two tables.
+  fail_str: |
+    SELECT * FROM a, b JOIN c USING (id)
+  fix_str: |
+    SELECT * FROM a, b JOIN c ON b.id = c.id
+
 fail_but_dont_fix_templated_table_names:
   fail_str: |
     SELECT


### PR DESCRIPTION
### Brief summary of the change made

ST07 rewrites `JOIN ... USING (col)` into an explicit `ON`, deriving the two sides from `table_aliases[:2]` — the first two tables of the whole SELECT. That only matches the joined tables when a single table precedes the join. With a comma-join before the first `JOIN ... USING`, the pairing is wrong and the real right-hand table is dropped, silently producing valid SQL with different results:

```sql
-- in
SELECT * FROM a, b JOIN c USING (id)
-- sqlfluff fix, before this PR
SELECT * FROM a, b JOIN c ON a.id = b.id      -- wrong; the join is b JOIN c
```

The `USING` join is `b JOIN c`, so the correct output is `ON b.id = c.id`. ST07 instead correlated `a` with `b` and left `c` uncorrelated — a cartesian product plus wrong rows. The output parses cleanly and ST07 does not re-flag it, so there is no safety net.

This change pairs the base table of the join's own `from_expression` with the table joined there (mapping both back to their `AliasInfo` via `from_expression_element`), instead of the SELECT's first two aliases:

```
FROM a, b JOIN c USING (id)     -> ON b.id = c.id
FROM a, b, e JOIN c USING (id)  -> ON e.id = c.id
FROM o JOIN c USING (id)        -> ON o.id = c.id   (unchanged)
```

### Are there any other side effects of this change that we should be aware of?

None expected. The existing guard already restricts fixes to the first join clause, so chained joins are unaffected. Added `test_fail_comma_join_before_using` to `ST07.yml` (fails before this change, passes after); the full rule suite stays green (`2455 passed, 101 skipped`), and `ruff` check+format and `mypy` are clean.

Heads-up: #8175 also edits `ST07.py` (an unqualified-`USING`-column guard) a few lines above this change — a different bug, so there may be a small textual conflict to resolve, but the two are independent.

---
Disclosure (per the AI-Assisted Contributions guidance): this contribution is fully AI-authored and autonomous (Claude Code, acting on this account). An AI found the bug, ran `sqlfluff fix` to confirm the corruption, wrote the fix and the test fixture, and wrote this description; the human account holder reviews every change and is accountable for it. So "what was manually validated" is: nothing by a human — but the verification above is real and re-runnable from the diff. If unsupervised AI contributions aren't welcome here, say so and I'll close it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes ST07 so `JOIN ... USING` pairs the correct tables when a comma-join comes first, preventing wrong results. The rule now reads join sides from the join’s own `from_expression` and keys alias lookups by stable UUIDs.

- **Bug Fixes**
  - Select left/right tables from the join’s `from_expression` elements, not the SELECT’s first two aliases.
  - Map `from_expression_element` -> alias using `segment.uuid` to avoid object-identity mismatches.
  - Correctly rewrites: `FROM a, b JOIN c USING (id)` -> `ON b.id = c.id`.
  - Added `test_fail_comma_join_before_using`; scope remains limited to the first join clause.

<sup>Written for commit c9eb15d263614ff52bfdbe5b27bb1d562b9f8531. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8180?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

