### PR TITLE
Teradata: lex scientific-notation and leading-dot numeric literals

### DIFF
--- a/src/sqlfluff/dialects/dialect_teradata.py
+++ b/src/sqlfluff/dialects/dialect_teradata.py
@@ -43,10 +43,12 @@ teradata_dialect = ansi_dialect.copy_as(
 
 teradata_dialect.patch_lexer_matchers(
     [
-        # so it also matches 1.
+        # Match the ansi numeric literal form so scientific notation
+        # (1E10, 1.5e3) and leading-dot decimals (.5) lex as one token,
+        # while still matching a trailing dot (1.).
         RegexLexer(
             "numeric_literal",
-            r"([0-9]+(\.[0-9]*)?)",
+            r"(?>\d+\.\d+|\d+\.(?![\.\w])|\.\d+|\d+)(\.?[eE][+-]?\d+)?((?<=\.)|(?=\b))",
             CodeSegment,
         ),
     ]

--- a/test/fixtures/dialects/teradata/numeric_literals.sql
+++ b/test/fixtures/dialects/teradata/numeric_literals.sql
@@ -1,0 +1,11 @@
+-- Numeric literals, including scientific-notation (E) floating point
+-- literals and leading-dot decimals, alongside the plain integer and
+-- decimal forms.
+SELECT 1E10;
+SELECT 1.5e3;
+SELECT 1E+10;
+SELECT 1.5E-3;
+SELECT .5;
+SELECT 100;
+SELECT 1.;
+SELECT 3.14;

--- a/test/fixtures/dialects/teradata/numeric_literals.yml
+++ b/test/fixtures/dialects/teradata/numeric_literals.yml
@@ -1,0 +1,63 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: b87f19964e9d15523f51c97b56a73541af9a14d587d1af693fd6793d25ed67eb
+file:
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          numeric_literal: 1E10
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          numeric_literal: 1.5e3
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          numeric_literal: 1E+10
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          numeric_literal: '1.5E-3'
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          numeric_literal: '.5'
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          numeric_literal: '100'
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          numeric_literal: '1.'
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          numeric_literal: '3.14'
+- statement_terminator: ;


### PR DESCRIPTION
### Brief summary of the change made

Teradata's `numeric_literal` lexer used `[0-9]+(\.[0-9]*)?`, which does not
cover scientific-notation floats (`1E10`, `1.5e3`, `1E+10`) or leading-dot
decimals (`.5`). Under `--dialect teradata`:

```
SELECT 1E10;      -->  numeric_literal '1'  +  naked_identifier 'E10'   (silently parsed as `1` aliased E10)
SELECT 1E10 AS x; -->  Found unparsable section
SELECT .5;        -->  Found unparsable section
```

Scientific notation is valid Teradata floating-point literal syntax
([Floating Point Literals](https://docs.teradata.com/r/Enterprise_IntelliFlex_VMware/SQL-Data-Types-and-Literals/Data-Literals/Numeric-Literals/Floating-Point-Literals)),
so the bare `SELECT 1E10` case is the worst of these — it parses without error
but means something different from what was written.

This aligns the Teradata `numeric_literal` regex with the ansi form that every
other dialect already uses, so these literals lex as a single token. The
existing integer, decimal and trailing-dot (`1.`) forms are unchanged.

### Are there any other side effects of this change that we should be aware of?

The change is confined to the Teradata lexer patch, and no other dialect
inherits Teradata, so nothing else is affected. All 51 existing Teradata
dialect parse tests still pass; the new `numeric_literals` fixture fails on
`main` (scientific notation is misparsed / unparsable) and passes with this
change.

### Pull Request checklist

- [x] `.sql`/`.yml` parser test cases in
  `test/fixtures/dialects/teradata/numeric_literals.{sql,yml}`.
- [ ] Documentation — n/a (no user-facing docs for dialect lexing).
- [ ] Followup issues — none needed.

---

Disclosure (per the *AI-Assisted Contributions* guideline): this change was
authored by an AI coding agent (Claude Code) running on this account — the AI
found the gap, reproduced it, wrote the fix and the parser fixture, and wrote
this description. **AI-assisted: all of the above. Manual validation:** the
account holder reviews every change and is accountable for it; the repro, the
red/green fixture behaviour and the dialect test run are real and re-runnable
from the branch. Scientific-notation (`1E10`) support is the confirmed-valid
core of the fix; the leading-dot `.5` form is included for consistency with
the ansi lexer. If this isn't a change you want, say so and I'll close it.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Teradata numeric literal lexing to support scientific notation (1E10, 1.5e3, 1E+10) and leading-dot decimals (.5), matching the ANSI form. This prevents `SELECT 1E10` from being misparsed as `1` aliased `E10`; existing integer/decimal forms still work.

- **Bug Fixes**
  - Updated `numeric_literal` regex to the ANSI form so these values lex as a single token, including trailing-dot `1.`.
  - Added Teradata parse fixtures for new and existing cases; change is isolated to the Teradata dialect.

<sup>Written for commit 912fb86ff448e15afbb4059b4618c52cc2c8af60. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8181?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

