### PR TITLE
fix(dialects/postgres): parse ORDER BY ... USING operator

### DIFF
--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -1694,6 +1694,45 @@ class OffsetClauseSegment(ansi.OffsetClauseSegment):
     )
 
 
+class OrderByClauseSegment(ansi.OrderByClauseSegment):
+    """An `ORDER BY` clause.
+
+    Adds PostgreSQL's ``USING operator`` sort option, which selects an
+    explicit ordering operator instead of ``ASC``/``DESC``.
+    https://www.postgresql.org/docs/current/queries-order.html
+    """
+
+    type = "orderby_clause"
+    match_grammar: Matchable = Sequence(
+        "ORDER",
+        "BY",
+        Indent,
+        Delimited(
+            Sequence(
+                OneOf(
+                    Ref("ColumnReferenceSegment"),
+                    # Can `ORDER BY 1`
+                    Ref("NumericLiteralSegment"),
+                    # Can order by an expression
+                    Ref("ExpressionSegment"),
+                ),
+                OneOf(
+                    "ASC",
+                    "DESC",
+                    # PostgreSQL allows an explicit sort operator, e.g.
+                    # `ORDER BY a USING <` or `ORDER BY a USING OPERATOR(schema.<)`.
+                    Sequence("USING", Ref("ComparisonOperatorGrammar")),
+                    optional=True,
+                ),
+                Sequence("NULLS", OneOf("FIRST", "LAST"), optional=True),
+                Ref("WithFillSegment", optional=True),
+            ),
+            terminators=[Ref("LimitClauseSegment"), Ref("FrameClauseUnitGrammar")],
+        ),
+        Dedent,
+    )
+
+
 class CreateProcedureStatementSegment(BaseSegment):
     """A `CREATE PROCEDURE` statement.
 

--- a/test/fixtures/dialects/postgres/select_order_by_using_operator.sql
+++ b/test/fixtures/dialects/postgres/select_order_by_using_operator.sql
@@ -1,0 +1,10 @@
+-- PostgreSQL allows an explicit sort operator via `USING operator`
+-- instead of ASC/DESC.
+-- https://www.postgresql.org/docs/current/queries-order.html
+SELECT * FROM t ORDER BY a USING <;
+
+SELECT * FROM t ORDER BY a USING >;
+
+SELECT * FROM t ORDER BY a USING < NULLS FIRST, b USING > NULLS LAST;
+
+SELECT * FROM t ORDER BY a USING OPERATOR(pg_catalog.<);

--- a/test/fixtures/dialects/postgres/select_order_by_using_operator.yml
+++ b/test/fixtures/dialects/postgres/select_order_by_using_operator.yml
@@ -1,0 +1,119 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 66ed80b038ab6cb88f387b938a63be2c96f016823d66efd1eb2e411f05b7763b
+file:
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: t
+      orderby_clause:
+      - keyword: ORDER
+      - keyword: BY
+      - column_reference:
+          naked_identifier: a
+      - keyword: USING
+      - comparison_operator:
+          raw_comparison_operator: <
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: t
+      orderby_clause:
+      - keyword: ORDER
+      - keyword: BY
+      - column_reference:
+          naked_identifier: a
+      - keyword: USING
+      - comparison_operator:
+          raw_comparison_operator: '>'
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: t
+      orderby_clause:
+      - keyword: ORDER
+      - keyword: BY
+      - column_reference:
+          naked_identifier: a
+      - keyword: USING
+      - comparison_operator:
+          raw_comparison_operator: <
+      - keyword: NULLS
+      - keyword: FIRST
+      - comma: ','
+      - column_reference:
+          naked_identifier: b
+      - keyword: USING
+      - comparison_operator:
+          raw_comparison_operator: '>'
+      - keyword: NULLS
+      - keyword: LAST
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: t
+      orderby_clause:
+      - keyword: ORDER
+      - keyword: BY
+      - column_reference:
+          naked_identifier: a
+      - keyword: USING
+      - qualified_operator:
+          keyword: OPERATOR
+          bracketed:
+            start_bracket: (
+            naked_identifier: pg_catalog
+            dot: .
+            operator: <
+            end_bracket: )
+- statement_terminator: ;


### PR DESCRIPTION
### The bug

PostgreSQL's `ORDER BY` clause allows an explicit ordering operator via `USING operator` as an alternative to `ASC`/`DESC`:

> `ORDER BY expression [ ASC | DESC | USING operator ] [ NULLS { FIRST | LAST } ]`

— [SELECT reference](https://www.postgresql.org/docs/current/sql-select.html) / [ordering docs](https://www.postgresql.org/docs/current/queries-order.html).

The Postgres dialect had no `OrderByClauseSegment` override, so it inherited ANSI's, whose sort option is only `OneOf("ASC", "DESC", optional=True)`. As a result valid Postgres like:

```sql
SELECT * FROM t ORDER BY a USING <;
SELECT * FROM t ORDER BY a USING > NULLS FIRST;
SELECT * FROM t ORDER BY a USING OPERATOR(pg_catalog.<);
```

produced an `unparsable` section (`USING <`).

### The fix

Add a Postgres `OrderByClauseSegment` that mirrors the ANSI grammar and adds a `USING <operator>` branch to the sort option, reusing the existing `ComparisonOperatorGrammar` — which already covers `<`, `>`, `<=`, `>=`, `=`, `<>`, the extension operators, and `OPERATOR(schema.op)` (`QualifiedOperatorSegment`).

### Verification

- The four `USING` forms above go from unparsable to a clean parse (`keyword: USING` + `comparison_operator`, and `qualified_operator` for the `OPERATOR(...)` form). Bare user-defined operators (e.g. `~<~`) remain out of scope — they don't lex as expression operators elsewhere in the dialect either.
- ANSI still correctly rejects `ORDER BY ... USING <` (this is Postgres-only). Redshift/Greenplum inherit from Postgres (`copy_as`), consistent with how the dialect already shares Postgres extensions.
- New fixture `test/fixtures/dialects/postgres/select_order_by_using_operator.sql` (+ generated `.yml`); postgres/redshift/greenplum dialect suites pass (771 passed, 0 failed); `ruff check`/`ruff format`/`mypy` clean.

---

This PR was authored by an AI coding agent (Claude Code) running on this account: the AI found the bug, ran the repro against sqlfluff's parser, generated the fixture the standard way, and wrote this description. The human account holder reviews every change and is accountable for it. The verification above is real and re-runnable from the diff. If this isn't the kind of contribution you want, say so and I'll close it.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes PostgreSQL parsing for ORDER BY ... USING <operator>. Queries using explicit sort operators (including OPERATOR(schema.op)) now parse correctly; ANSI remains unchanged.

- **Bug Fixes**
  - Add Postgres-specific `OrderByClauseSegment` with a USING <operator> branch using `ComparisonOperatorGrammar`.
  - Support NULLS FIRST/LAST and multiple ORDER BY items with USING operators.
  - Add fixtures for the four USING forms; Redshift and Greenplum inherit the fix.

<sup>Written for commit 45ee4d2dd0ab88d76acad1ebb492700d7e71b02e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8182?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

