### PR TITLE
AM04: resolve each UNION branch's wildcard against its own branch

### DIFF
--- a/src/sqlfluff/rules/ambiguous/AM04.py
+++ b/src/sqlfluff/rules/ambiguous/AM04.py
@@ -126,15 +126,15 @@ class Rule_AM04(BaseRule):
                 else:
                     # No table was specified with the wildcard. Assume we're
                     # querying from a nested select in FROM.
-                    for o in query.crawl_sources(query.selectables[0].selectable, True):
+                    for o in query.crawl_sources(selectable.selectable, True):
                         if isinstance(o, Query):
                             self._analyze_result_columns(o)
                             return None
                     self.logger.debug(
-                        f'Query target "{query.selectables[0].selectable.raw}" has no '
+                        f'Query target "{selectable.selectable.raw}" has no '
                         "targets. Generating warning."
                     )
-                    raise RuleFailure(query.selectables[0].selectable)
+                    raise RuleFailure(selectable.selectable)
 
     def _eval(self, context: RuleContext) -> Optional[LintResult]:
         """Outermost query should produce known number of columns."""

--- a/test/fixtures/rules/std_rule_cases/AM04.yml
+++ b/test/fixtures/rules/std_rule_cases/AM04.yml
@@ -677,3 +677,12 @@ test_pass_placeholder_templater_explicit_columns:
       placeholder:
         param_style: dollar
         CATALOG: my_catalog
+
+test_pass_resolvable_wildcard_in_non_first_union_branch:
+  # A resolvable wildcard in a non-first UNION branch must not be flagged: the
+  # number of result columns is known (previously AM04 resolved every branch's
+  # wildcard against the first branch only).
+  pass_str: |
+    SELECT a, b FROM t
+    UNION
+    SELECT * FROM (SELECT c, d FROM tbl2)


### PR DESCRIPTION
### Brief summary of the change made

AM04 iterates every branch of a set expression (`for selectable in
query.selectables`), but the bare-wildcard else-branch resolved
`query.selectables[0]` — the **first** branch — instead of the current
`selectable`. So a resolvable `SELECT *` in a non-first `UNION` branch was
checked against the wrong branch:

```sql
SELECT a, b FROM t
UNION
SELECT * FROM (SELECT c, d FROM tbl2)
```

The `*` resolves to `c, d` (2 known columns) and branch 1 is `a, b` (2 known),
so the result-column count is fully known — but AM04 flagged *"Query produces
an unknown number of result columns."* This is a false positive on valid SQL,
and AM04 is default-enabled. Resolving against `selectable` (the branch being
iterated) fixes it; a `SELECT *` in the first branch was already handled
correctly.

This is the same `selectables[0]`-over-a-set-expression oversight that was fixed
for ST05 in #8169.

### Are there any other side effects of this change that we should be aware of?

Only the else-branch (a bare wildcard resolved from a nested select in `FROM`)
changes; the qualified / external-table path already used `selectable` and is
untouched. All 61 existing AM04 fixtures pass; the added
`test_pass_resolvable_wildcard_in_non_first_union_branch` fails on `main` and
passes here.

Note: the open draft #8087 (a Copilot bot PR, dormant since 2026-07-08)
refactors the same `_analyze_result_columns` function but keeps the three
`query.selectables[0]` references, so it does not fix this. Happy to rebase onto
whichever lands first.

### Pull Request checklist

- [x] `.yml` rule test case added in `test/fixtures/rules/std_rule_cases/AM04.yml`.
- [ ] Documentation — not applicable (no user-facing behaviour docs for this fix).
- [ ] Follow-up issues — none needed.

---

Disclosure: this PR was authored by an AI coding agent (Claude Code) running on
this account — it found the mismatch (a sibling of the #8169 fix), reproduced
the false positive, wrote the fix and the test, and wrote this description. The
account holder reviews every change and is accountable for it, and the
verification above is real and re-runnable from the diff. Happy to close it if
it isn't the kind of contribution you want.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `AM04` to resolve a bare `SELECT *` in each `UNION` branch against that branch instead of the first branch. This removes false positives that reported an unknown column count when the wildcard resolves to known columns in a non-first branch.

- **Bug Fixes**
  - Use the current branch’s selectable when resolving wildcards in set expressions.
  - Update log/exception targets to the current branch.
  - Add fixture `test_pass_resolvable_wildcard_in_non_first_union_branch`.

<sup>Written for commit 801fb091751730abf0298aab936f2ad27fe80cbc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8183?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

