### PR TITLE
Impala: add support for VALUES aliases

### DIFF
--- a/src/sqlfluff/dialects/dialect_impala.py
+++ b/src/sqlfluff/dialects/dialect_impala.py
@@ -38,10 +38,10 @@ impala_dialect.replace(
 )
 
 
-class InsertValuesClauseSegment(ansi.ValuesClauseSegment):
-    """A `VALUES` clause like in `INSERT` for Impala.
+class ValuesClauseSegment(ansi.ValuesClauseSegment):
+    """A `VALUES` clause like in `INSERT` and `SELECT` for Impala.
 
-    See: https://impala.apache.org/docs/build/html/topics/impala_insert.html.
+    See: https://impala.apache.org/docs/build/html/topics/impala_values.html
     """
 
     type = "values_clause"
@@ -51,6 +51,15 @@ class InsertValuesClauseSegment(ansi.ValuesClauseSegment):
             Sequence(
                 Bracketed(
                     Delimited(
+                        "DEFAULT",
+                        Sequence(
+                            OneOf(
+                                "DEFAULT",
+                                Ref("LiteralGrammar"),
+                                Ref("ExpressionSegment"),
+                            ),
+                            Ref("AliasExpressionSegment"),
+                        ),
                         Ref("LiteralGrammar"),
                         Ref("ExpressionSegment"),
                     ),

--- a/src/sqlfluff/dialects/dialect_impala.py
+++ b/src/sqlfluff/dialects/dialect_impala.py
@@ -6,11 +6,14 @@ from sqlfluff.core.parser import (
     BinaryOperatorSegment,
     Bracketed,
     Delimited,
+    Matchable,
     OneOf,
+    ParseMode,
     Ref,
     Sequence,
     StringParser,
 )
+from sqlfluff.dialects import dialect_ansi as ansi
 from sqlfluff.dialects import dialect_hive as hive
 from sqlfluff.dialects.dialect_impala_keywords import (
     RESERVED_KEYWORDS,
@@ -33,6 +36,29 @@ impala_dialect.replace(
         StringParser("/", BinaryOperatorSegment),
     )
 )
+
+
+class InsertValuesClauseSegment(ansi.ValuesClauseSegment):
+    """A `VALUES` clause like in `INSERT` for Impala.
+
+    See: https://impala.apache.org/docs/build/html/topics/impala_insert.html.
+    """
+
+    type = "values_clause"
+    match_grammar: Matchable = Sequence(
+        "VALUES",
+        Delimited(
+            Sequence(
+                Bracketed(
+                    Delimited(
+                        Ref("LiteralGrammar"),
+                        Ref("ExpressionSegment"),
+                    ),
+                    parse_mode=ParseMode.GREEDY,
+                ),
+            ),
+        ),
+    )
 
 
 class StatementSegment(hive.StatementSegment):

--- a/test/fixtures/dialects/impala/values_as.sql
+++ b/test/fixtures/dialects/impala/values_as.sql
@@ -1,0 +1,3 @@
+SELECT name, age FROM people UNION VALUES ('John Doe' AS name, 31 AS age), ('Jane Doe', 31);
+
+SELECT name, age FROM people UNION VALUES ('John Doe' AS name, 31);

--- a/test/fixtures/dialects/impala/values_as.sql
+++ b/test/fixtures/dialects/impala/values_as.sql
@@ -1,3 +1,13 @@
 SELECT name, age FROM people UNION VALUES ('John Doe' AS name, 31 AS age), ('Jane Doe', 31);
 
 SELECT name, age FROM people UNION VALUES ('John Doe' AS name, 31);
+
+SELECT name, age FROM people UNION VALUES (DEFAULT, 31);
+
+SELECT name, age FROM people UNION VALUES ('John', 31), (DEFAULT as name, 21 as age);
+
+INSERT INTO people VALUES ('John Doe' as name, DEFAULT as age);
+
+INSERT INTO people VALUES ('John Doe' as name, 31 as age), ('Jane Doe' as name, 31 as age);
+
+INSERT INTO people VALUES ('John Doe' as name, 31), ('Jane Doe' as name, 31 as age);

--- a/test/fixtures/dialects/impala/values_as.yml
+++ b/test/fixtures/dialects/impala/values_as.yml
@@ -1,0 +1,86 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 188744b62148386b8c49475d1d84cd956837d21ccfe391cd9a9dbe6cf717620f
+file:
+- statement:
+    set_expression:
+      select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            column_reference:
+              naked_identifier: name
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+              naked_identifier: age
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: people
+      set_operator:
+        keyword: UNION
+      values_clause:
+      - keyword: VALUES
+      - bracketed:
+        - start_bracket: (
+        - quoted_literal: "'John Doe'"
+        - alias_expression:
+            alias_operator:
+              keyword: AS
+            naked_identifier: name
+        - comma: ','
+        - numeric_literal: '31'
+        - alias_expression:
+            alias_operator:
+              keyword: AS
+            naked_identifier: age
+        - end_bracket: )
+      - comma: ','
+      - bracketed:
+          start_bracket: (
+          quoted_literal: "'Jane Doe'"
+          comma: ','
+          numeric_literal: '31'
+          end_bracket: )
+- statement_terminator: ;
+- statement:
+    set_expression:
+      select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            column_reference:
+              naked_identifier: name
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+              naked_identifier: age
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: people
+      set_operator:
+        keyword: UNION
+      values_clause:
+        keyword: VALUES
+        bracketed:
+          start_bracket: (
+          quoted_literal: "'John Doe'"
+          alias_expression:
+            alias_operator:
+              keyword: AS
+            naked_identifier: name
+          comma: ','
+          numeric_literal: '31'
+          end_bracket: )
+- statement_terminator: ;

--- a/test/fixtures/dialects/impala/values_as.yml
+++ b/test/fixtures/dialects/impala/values_as.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 188744b62148386b8c49475d1d84cd956837d21ccfe391cd9a9dbe6cf717620f
+_hash: 41b469860c41587ba93d32595c7e543935151fd6f6c68f6335afec7a4af416bb
 file:
 - statement:
     set_expression:
@@ -83,4 +83,174 @@ file:
           comma: ','
           numeric_literal: '31'
           end_bracket: )
+- statement_terminator: ;
+- statement:
+    set_expression:
+      select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            column_reference:
+              naked_identifier: name
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+              naked_identifier: age
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: people
+      set_operator:
+        keyword: UNION
+      values_clause:
+        keyword: VALUES
+        bracketed:
+          start_bracket: (
+          keyword: DEFAULT
+          comma: ','
+          numeric_literal: '31'
+          end_bracket: )
+- statement_terminator: ;
+- statement:
+    set_expression:
+      select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            column_reference:
+              naked_identifier: name
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+              naked_identifier: age
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: people
+      set_operator:
+        keyword: UNION
+      values_clause:
+      - keyword: VALUES
+      - bracketed:
+          start_bracket: (
+          quoted_literal: "'John'"
+          comma: ','
+          numeric_literal: '31'
+          end_bracket: )
+      - comma: ','
+      - bracketed:
+        - start_bracket: (
+        - keyword: DEFAULT
+        - alias_expression:
+            alias_operator:
+              keyword: as
+            naked_identifier: name
+        - comma: ','
+        - numeric_literal: '21'
+        - alias_expression:
+            alias_operator:
+              keyword: as
+            naked_identifier: age
+        - end_bracket: )
+- statement_terminator: ;
+- statement:
+    insert_statement:
+    - keyword: INSERT
+    - keyword: INTO
+    - table_reference:
+        naked_identifier: people
+    - values_clause:
+        keyword: VALUES
+        bracketed:
+        - start_bracket: (
+        - quoted_literal: "'John Doe'"
+        - alias_expression:
+            alias_operator:
+              keyword: as
+            naked_identifier: name
+        - comma: ','
+        - keyword: DEFAULT
+        - alias_expression:
+            alias_operator:
+              keyword: as
+            naked_identifier: age
+        - end_bracket: )
+- statement_terminator: ;
+- statement:
+    insert_statement:
+    - keyword: INSERT
+    - keyword: INTO
+    - table_reference:
+        naked_identifier: people
+    - values_clause:
+      - keyword: VALUES
+      - bracketed:
+        - start_bracket: (
+        - quoted_literal: "'John Doe'"
+        - alias_expression:
+            alias_operator:
+              keyword: as
+            naked_identifier: name
+        - comma: ','
+        - numeric_literal: '31'
+        - alias_expression:
+            alias_operator:
+              keyword: as
+            naked_identifier: age
+        - end_bracket: )
+      - comma: ','
+      - bracketed:
+        - start_bracket: (
+        - quoted_literal: "'Jane Doe'"
+        - alias_expression:
+            alias_operator:
+              keyword: as
+            naked_identifier: name
+        - comma: ','
+        - numeric_literal: '31'
+        - alias_expression:
+            alias_operator:
+              keyword: as
+            naked_identifier: age
+        - end_bracket: )
+- statement_terminator: ;
+- statement:
+    insert_statement:
+    - keyword: INSERT
+    - keyword: INTO
+    - table_reference:
+        naked_identifier: people
+    - values_clause:
+      - keyword: VALUES
+      - bracketed:
+          start_bracket: (
+          quoted_literal: "'John Doe'"
+          alias_expression:
+            alias_operator:
+              keyword: as
+            naked_identifier: name
+          comma: ','
+          numeric_literal: '31'
+          end_bracket: )
+      - comma: ','
+      - bracketed:
+        - start_bracket: (
+        - quoted_literal: "'Jane Doe'"
+        - alias_expression:
+            alias_operator:
+              keyword: as
+            naked_identifier: name
+        - comma: ','
+        - numeric_literal: '31'
+        - alias_expression:
+            alias_operator:
+              keyword: as
+            naked_identifier: age
+        - end_bracket: )
 - statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->

Updates both Hive and Impala dialects. Hive:

- ~Added DEFAULT as unreserved keyword (see docs at <https://hive.apache.org/docs/latest/language/languagemanual-ddl/#keywords-non-reserved-keywords-and-reserved-keywords>)~
- ~improved VALUES clause:~
  - ~allow DEFAULT clauses in INSERT (supported from version 3.0.0, see <https://issues.apache.org/jira/browse/HIVE-18726> and <https://issues.apache.org/jira/browse/HIVE-19059>).~
  - ~allow aliases in VALUES clauses, only in first row, couldn't find documentation tried in hive container instead.~

~Commands on a Hive container:~
 
- ~[run_hive.sh](https://github.com/user-attachments/files/30202726/run_hive.sh)~
- ~[hive_output.txt](https://github.com/user-attachments/files/30202727/hive_output.txt)~
- ~[values_as.sql](https://github.com/user-attachments/files/30202728/values_as.sql)~

Impala:

- Support for aliases in VALUES, ~except when in INSERT clauses~ (see here for aliasing <https://impala.apache.org/docs/build/html/topics/impala_values.html> and here <https://impala.apache.org/docs/build/html/topics/impala_insert.html> for supported insert syntax).

### Are there any other side effects of this change that we should be aware of?

No

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - [x] `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Impala support for aliases in VALUES tuples (with DEFAULT) across SELECT/UNION and INSERT, and adds focused parser tests. Also simplifies the Impala grammar; Hive behavior remains as previously updated.

- **New Features**
  - Hive: `DEFAULT` is unreserved; allowed only in INSERT. Aliases allowed only in the first `VALUES` row.
  - Impala: `VALUES` supports aliases and `DEFAULT` in both SELECT/UNION and INSERT. Added fixtures validating both contexts.

- **Refactors**
  - Impala: Extend `ansi.ValuesClauseSegment` and consolidate match grammar with greedy parsing to reduce complexity.

<sup>Written for commit 1e57442b6b013945f4516669c1b2d131fb257acc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8185?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->





