### PR TITLE
Indent BigQuery pipe AGGREGATE and EXTEND clause lists

### DIFF
--- a/src/sqlfluff/dialects/dialect_bigquery.py
+++ b/src/sqlfluff/dialects/dialect_bigquery.py
@@ -3699,12 +3699,14 @@ class ExtendClauseSegment(BaseSegment):
 
     match_grammar: Matchable = Sequence(
         "EXTEND",
+        Indent,
         Delimited(
             Sequence(
                 Ref("BaseExpressionElementGrammar"),
                 Ref("AliasExpressionSegment", optional=True),
             ),
         ),
+        Dedent,
     )
 
 
@@ -3794,6 +3796,7 @@ class AggregateClauseSegment(BaseSegment):
 
     match_grammar: Matchable = Sequence(
         "AGGREGATE",
+        Indent,
         Delimited(
             Sequence(
                 Ref("BaseExpressionElementGrammar"),
@@ -3805,6 +3808,7 @@ class AggregateClauseSegment(BaseSegment):
                 ),
             ),
         ),
+        Dedent,
         Ref("GroupAndOrderByClauseSegment", optional=True),
     )
 

--- a/test/fixtures/rules/std_rule_cases/LT02-indent.yml
+++ b/test/fixtures/rules/std_rule_cases/LT02-indent.yml
@@ -2975,3 +2975,45 @@ test_pass_mysql_group_by_with_rollup_indented:
   configs:
     core:
       dialect: mysql
+
+test_pass_bigquery_pipe_aggregate_multiline:
+  # Pipe-syntax AGGREGATE lists indent like SELECT / GROUP BY. Previously the
+  # AGGREGATE clause emitted no indent metadata, so the 2nd+ expressions were
+  # wrongly flagged by LT02.
+  pass_str: |
+    FROM my_table
+    |> AGGREGATE
+        SUM(a) AS total_a,
+        SUM(b) AS total_b
+    GROUP BY c
+  configs:
+    core:
+      dialect: bigquery
+
+test_fail_bigquery_pipe_aggregate_multiline_fix:
+  fail_str: |
+    FROM my_table
+    |> AGGREGATE
+    SUM(a) AS total_a,
+    SUM(b) AS total_b
+    GROUP BY c
+  fix_str: |
+    FROM my_table
+    |> AGGREGATE
+        SUM(a) AS total_a,
+        SUM(b) AS total_b
+    GROUP BY c
+  configs:
+    core:
+      dialect: bigquery
+
+test_pass_bigquery_pipe_extend_multiline:
+  # Pipe-syntax EXTEND lists indent like AGGREGATE.
+  pass_str: |
+    FROM my_table
+    |> EXTEND
+        a + 1 AS a1,
+        b + 1 AS b1
+  configs:
+    core:
+      dialect: bigquery


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

### Brief summary of the change made
Fixes #8189.

BigQuery pipe-syntax `AGGREGATE` and `EXTEND` clauses take a
comma-delimited expression list, like `SELECT` and `GROUP BY`, but their
grammar wrapped that list without `Indent` / `Dedent` metadata. As a
result `LT02` (layout.indent) flagged every continuation line as "Line
should not be indented", and `sqlfluff fix` would not indent a
multi-line clause — so an indented multi-line `AGGREGATE` was impossible.

This wraps the `Delimited(...)` list of both `AggregateClauseSegment`
and `ExtendClauseSegment` in `Indent` / `Dedent`, matching how
`GroupAndOrderByClauseSegment` (the `GROUP BY` used in the same pipe
syntax) already behaves.

Before:
```
FROM my_table
|> AGGREGATE
    SUM(a) AS total_a,   -- LT02: Line should not be indented
    SUM(b) AS total_b    -- LT02: Line should not be indented
GROUP BY c
```
After: lints clean, and `fix` indents a flat list to the above.

### Are there any other side effects of this change that we should be aware of?
`Indent` / `Dedent` are meta segments and are excluded from the parse
YAML fixtures, so existing `test/fixtures/dialects/bigquery` fixtures are
unchanged. All 429 bigquery dialect tests and the LT01/LT02/LT03 rule
suites pass. Single-line `AGGREGATE` / `EXTEND` are unaffected.

### Pull Request checklist
- [x] Included test cases to demonstrate the code change:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`
    (`LT02-indent.yml`): a passing indented multi-line `AGGREGATE`, a
    `fail`/`fix` pair, and a passing multi-line `EXTEND`.
- [x] Change is small and self-documenting; no docs change needed.
- [x] Created GitHub issues for any relevant followup — n/a.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix indentation for BigQuery pipe `AGGREGATE` and `EXTEND` clause lists. Adds indent metadata so multi-line lists are indented correctly, removing LT02 false positives and allowing `sqlfluff fix` to format them.

- **Bug Fixes**
  - Wrap the `Delimited(...)` expression list in `Indent`/`Dedent` for both clauses, matching pipe `GROUP BY`.
  - Add LT02 rule cases for multi-line `AGGREGATE` and `EXTEND`, including a fixable failure.

<sup>Written for commit ef0bfab02e15b96235610280da2659ecd2dd5c03. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8190?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

