### PR TITLE
BigQuery: allow a pipe query after a WITH clause

### DIFF
--- a/src/sqlfluff/dialects/dialect_bigquery.py
+++ b/src/sqlfluff/dialects/dialect_bigquery.py
@@ -3871,6 +3871,27 @@ class CTEDefinitionSegment(ansi.CTEDefinitionSegment):
     )
 
 
+class WithCompoundStatementSegment(ansi.WithCompoundStatementSegment):
+    """A `WITH` statement, which in BigQuery may end in a pipe query.
+
+    BigQuery allows the query following the CTE list to be written with pipe
+    syntax (``FROM ... |> ...``), not just a SELECT / set expression. This
+    extends the ANSI definition so the trailing element also accepts a
+    ``PipeStatementSegment``, mirroring how ``CTEDefinitionSegment`` already
+    allows pipe syntax inside CTE bodies.
+    """
+
+    match_grammar = ansi.WithCompoundStatementSegment.match_grammar.copy(
+        insert=[
+            OneOf(
+                Ref("NonWithSelectableGrammar"),
+                Ref("PipeStatementSegment"),
+            ),
+        ],
+        remove=[Ref("NonWithSelectableGrammar")],
+    )
+
+
 class ChainedFunctionCallSegment(BaseSegment):
     """Postfix chained function call accessor: .FUNC(args...) in BigQuery."""
 

--- a/test/fixtures/dialects/bigquery/pipe_statement.sql
+++ b/test/fixtures/dialects/bigquery/pipe_statement.sql
@@ -163,3 +163,11 @@ WITH bar AS (
 )
 
 SELECT * FROM bar;
+
+WITH bar AS (
+    FROM foo
+)
+
+FROM bar
+|> WHERE sales >= 3
+|> SELECT item, sales;

--- a/test/fixtures/dialects/bigquery/pipe_statement.yml
+++ b/test/fixtures/dialects/bigquery/pipe_statement.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 54e1c2e3c2c96bb46231eb8080e885c5ed15cde697a19d81e6ec0c53f01de497
+_hash: 2759f64a6e9b046386490936ace2237520f8b35608dda19cb907ad4353d3c75d
 file:
 - statement:
     pipe_statement:
@@ -1251,54 +1251,54 @@ file:
             end_bracket: )
 - statement_terminator: ;
 - statement:
-    pipe_statement:
-      with_compound_statement:
-        keyword: WITH
-        common_table_expression:
-          naked_identifier: NumbersTable
-          keyword: AS
-          bracketed:
-            start_bracket: (
-            set_expression:
-            - select_statement:
-                select_clause:
-                - keyword: SELECT
-                - select_clause_element:
-                    numeric_literal: '1'
-                    alias_expression:
-                      alias_operator:
-                        keyword: AS
-                      naked_identifier: one_digit
-                - comma: ','
-                - select_clause_element:
-                    numeric_literal: '10'
-                    alias_expression:
-                      alias_operator:
-                        keyword: AS
-                      naked_identifier: two_digit
-            - set_operator:
-              - keyword: UNION
-              - keyword: ALL
-            - select_statement:
-                select_clause:
-                - keyword: SELECT
-                - select_clause_element:
-                    numeric_literal: '2'
-                - comma: ','
-                - select_clause_element:
-                    numeric_literal: '20'
-            - set_operator:
-              - keyword: UNION
-              - keyword: ALL
-            - select_statement:
-                select_clause:
-                - keyword: SELECT
-                - select_clause_element:
-                    numeric_literal: '3'
-                - comma: ','
-                - select_clause_element:
-                    numeric_literal: '30'
-            end_bracket: )
+    with_compound_statement:
+      keyword: WITH
+      common_table_expression:
+        naked_identifier: NumbersTable
+        keyword: AS
+        bracketed:
+          start_bracket: (
+          set_expression:
+          - select_statement:
+              select_clause:
+              - keyword: SELECT
+              - select_clause_element:
+                  numeric_literal: '1'
+                  alias_expression:
+                    alias_operator:
+                      keyword: AS
+                    naked_identifier: one_digit
+              - comma: ','
+              - select_clause_element:
+                  numeric_literal: '10'
+                  alias_expression:
+                    alias_operator:
+                      keyword: AS
+                    naked_identifier: two_digit
+          - set_operator:
+            - keyword: UNION
+            - keyword: ALL
+          - select_statement:
+              select_clause:
+              - keyword: SELECT
+              - select_clause_element:
+                  numeric_literal: '2'
+              - comma: ','
+              - select_clause_element:
+                  numeric_literal: '20'
+          - set_operator:
+            - keyword: UNION
+            - keyword: ALL
+          - select_statement:
+              select_clause:
+              - keyword: SELECT
+              - select_clause_element:
+                  numeric_literal: '3'
+              - comma: ','
+              - select_clause_element:
+                  numeric_literal: '30'
+          end_bracket: )
+      pipe_statement:
         select_statement:
           select_clause:
           - keyword: SELECT
@@ -1316,33 +1316,33 @@ file:
                 table_expression:
                   table_reference:
                     naked_identifier: NumbersTable
-      pipe_operator_clause:
-        pipe_operator: '|>'
-        set_operator_clause:
-          set_operator:
-          - keyword: INTERSECT
-          - keyword: DISTINCT
-          - keyword: BY
-          - keyword: NAME
-          bracketed:
-            start_bracket: (
-            select_statement:
-              select_clause:
-              - keyword: SELECT
-              - select_clause_element:
-                  numeric_literal: '10'
-                  alias_expression:
-                    alias_operator:
-                      keyword: AS
-                    naked_identifier: two_digit
-              - comma: ','
-              - select_clause_element:
-                  numeric_literal: '1'
-                  alias_expression:
-                    alias_operator:
-                      keyword: AS
-                    naked_identifier: one_digit
-            end_bracket: )
+        pipe_operator_clause:
+          pipe_operator: '|>'
+          set_operator_clause:
+            set_operator:
+            - keyword: INTERSECT
+            - keyword: DISTINCT
+            - keyword: BY
+            - keyword: NAME
+            bracketed:
+              start_bracket: (
+              select_statement:
+                select_clause:
+                - keyword: SELECT
+                - select_clause_element:
+                    numeric_literal: '10'
+                    alias_expression:
+                      alias_operator:
+                        keyword: AS
+                      naked_identifier: two_digit
+                - comma: ','
+                - select_clause_element:
+                    numeric_literal: '1'
+                    alias_expression:
+                      alias_operator:
+                        keyword: AS
+                      naked_identifier: one_digit
+              end_bracket: )
 - statement_terminator: ;
 - statement:
     pipe_statement:
@@ -1749,4 +1749,52 @@ file:
               table_expression:
                 table_reference:
                   naked_identifier: bar
+- statement_terminator: ;
+- statement:
+    with_compound_statement:
+      keyword: WITH
+      common_table_expression:
+        naked_identifier: bar
+        keyword: AS
+        bracketed:
+          start_bracket: (
+          pipe_statement:
+            from_clause:
+              keyword: FROM
+              from_expression:
+                from_expression_element:
+                  table_expression:
+                    table_reference:
+                      naked_identifier: foo
+          end_bracket: )
+      pipe_statement:
+      - from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: bar
+      - pipe_operator_clause:
+          pipe_operator: '|>'
+          where_clause:
+            keyword: WHERE
+            expression:
+              column_reference:
+                naked_identifier: sales
+              comparison_operator:
+              - raw_comparison_operator: '>'
+              - raw_comparison_operator: '='
+              numeric_literal: '3'
+      - pipe_operator_clause:
+          pipe_operator: '|>'
+          select_clause:
+          - keyword: SELECT
+          - select_clause_element:
+              column_reference:
+                naked_identifier: item
+          - comma: ','
+          - select_clause_element:
+              column_reference:
+                naked_identifier: sales
 - statement_terminator: ;


### PR DESCRIPTION
### Brief summary of the change made

`WithCompoundStatementSegment` (inherited from ANSI) ends with `NonWithSelectableGrammar`, so the query following the CTE list may only be a `SELECT` / set expression — never a pipe query. As a result a CTE chain whose final query uses pipe syntax is reported as an **unparsable section**:

```sql
WITH cte AS (
    SELECT 1 AS n
)

FROM cte
|> WHERE n > 0
|> SELECT n;
```

This is despite the fact that bare top-level pipe queries (#6870) and pipe syntax *inside* CTE bodies (#7180) already parse fine.

This PR overrides `WithCompoundStatementSegment` in the BigQuery dialect so its trailing element is `OneOf(NonWithSelectableGrammar, PipeStatementSegment)`, mirroring how `CTEDefinitionSegment` already accepts a `PipeStatementSegment` inside CTE bodies.

### Are there any other side effects?

One existing fixture case (`WITH … SELECT … |> INTERSECT DISTINCT BY NAME …`) now nests as `with_compound_statement > pipe_statement` instead of `pipe_statement > with_compound_statement`. Both fully parse; the new nesting treats the `WITH` as the outer scope and its trailing pipe query as the inner statement, which matches the semantics more closely. The fixture YAML is regenerated accordingly.

### Tests

- Added a `WITH … FROM … |> …` case to `test/fixtures/dialects/bigquery/pipe_statement.sql` and regenerated its YAML.
- `pytest test/dialects/dialects_test.py -k bigquery` — 429 passed.
- `ruff check` / `ruff format --check` / `yamllint` clean on the changes.

Related to the BigQuery pipe-syntax support in #6870 / #7180.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow BigQuery `WITH` statements to end with a pipe query (`FROM ... |> ...`). Fixes unparsable CTE chains where the final query uses pipe syntax.

- **Bug Fixes**
  - Extended BigQuery `WithCompoundStatementSegment` to accept `PipeStatementSegment` after the CTE list.
  - Added a `WITH … FROM … |> …` test and updated fixtures; an existing case now nests as `with_compound_statement > pipe_statement`.

<sup>Written for commit 283576a2985696d9ce8b58105466258c980eefac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8191?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

