### PR TITLE
CV10: don't corrupt string literals that use quote-doubling escapes (fixes #8179)

### DIFF
--- a/src/sqlfluff/rules/convention/CV10.py
+++ b/src/sqlfluff/rules/convention/CV10.py
@@ -255,6 +255,22 @@ class Rule_CV10(BaseRule):
         escaped_orig_quote = regex.compile(rf"([^\\]|^)\\((?:\\\\)*){orig_quote}")
         body = s[first_quote_pos + len(orig_quote) : -len(orig_quote)]
 
+        if len(orig_quote) == 1 and regex.search(
+            rf"(?:[^\\]|^)(?:\\\\)*{regex.escape(orig_quote)}", body
+        ):
+            # SQL escapes an embedded quote by doubling it (``''`` / ``""``), but
+            # this normaliser (adapted from Black) only understands backslash
+            # escapes. A bare orig_quote in the body is therefore a doubled
+            # quote; re-quoting would copy it through unchanged and silently
+            # alter the literal's value. Leave it untouched, as the raw-string
+            # branch below already does when it cannot convert safely.
+            self.logger.debug(
+                "Body of %s uses quote-doubling escapes that this rule cannot "
+                "safely re-encode. Skipping.",
+                s,
+            )
+            return s
+
         if "r" in prefix.lower():
             if unescaped_new_quote.search(body):
                 self.logger.debug(

--- a/test/fixtures/rules/std_rule_cases/CV10.yml
+++ b/test/fixtures/rules/std_rule_cases/CV10.yml
@@ -185,6 +185,45 @@ test_fail_edge_case_tripple_quoted_string_ending_with_double_quote:
       convention.quoted_literals:
         preferred_quoted_literal_style: double_quotes
 
+test_pass_single_quote_doubling_is_not_corrupted:
+  # A fix must never change a literal's value. 'O''Brien' escapes the quote by
+  # doubling it (value O'Brien); converting to double quotes would copy the
+  # doubling through unchanged and change the value, so it is left alone.
+  pass_str: |
+    SELECT "x", 'O''Brien'
+  configs:
+    core:
+      dialect: mysql
+    rules:
+      convention.quoted_literals:
+        preferred_quoted_literal_style: double_quotes
+
+test_pass_double_quote_doubling_is_not_corrupted:
+  # The same in reverse: "say ""hi""" (value say "hi") must not be rewritten to
+  # 'say ""hi""', which would change the value.
+  pass_str: |
+    SELECT 'x', "say ""hi"""
+  configs:
+    core:
+      dialect: mysql
+    rules:
+      convention.quoted_literals:
+        preferred_quoted_literal_style: single_quotes
+
+test_fail_backslash_escaped_quote_still_converts:
+  # The doubling guard is narrow: backslash-escaped quotes are re-encodable and
+  # must still convert.
+  fail_str: |
+    SELECT 'it\'s'
+  fix_str: |
+    SELECT "it's"
+  configs:
+    core:
+      dialect: mysql
+    rules:
+      convention.quoted_literals:
+        preferred_quoted_literal_style: double_quotes
+
 test_pass_lots_of_quotes:
   # Test that we can handle complex quoting scenarios
   pass_str: |


### PR DESCRIPTION
### Brief summary of the change made

Fixes #8179

CV10 (`convention.quoted_literals`) silently changed the **value** of a string literal when it rewrote the quote style, if that literal used SQL's quote-doubling escape (`''` inside `'…'`, `""` inside `"…"`).

The rule's normaliser (`_normalize_preferred_quoted_literal_style`) was adapted from Black and understands only **backslash** escaping. SQL escapes an embedded quote by **doubling** it, so when CV10 converted a literal to the other quote char it copied the doubled quotes through unchanged and they stopped being an escape:

```sql
-- input (default full ruleset, dialect mysql), first literal is double-quoted
select "x", 'O''Brien'
-- before this change: 'O''Brien' (value O'Brien) -> "O''Brien" (value O''Brien)
```

The reverse direction corrupts too: `"say ""hi"""` (value `say "hi"`) → `'say ""hi""'`. Because `preferred_quoted_literal_style = consistent` (the default) derives the target quote from the file's first literal, any file whose first string is double-quoted corrupts later quote-doubled single-quoted literals.

**Fix** — take the same conservative path the raw-string branch already uses (`return s` when it can't convert safely): skip the fix when the literal body contains a **bare, non-backslash-escaped** `orig_quote`. In a well-formed literal a bare quote can only be one half of a `''`/`""` doubling pair, which this backslash-based logic can't re-encode, so converting would change the value. Backslash-escaped quotes (`'it\'s'`) contain no bare quote and still convert as before, so the guard is narrow. Triple-quoted literals are unaffected (the guard is limited to single-character quotes).

The fuller alternative — re-encoding the doubling for the target quote char — depends on per-dialect escape semantics and is left as a follow-up; never changing a literal's value is the floor this change guarantees.

### Are there any other side effects of this change that we should be aware of?

None expected. The guard only suppresses fixes that would otherwise corrupt a value; literals without quote-doubling (the vast majority, and all existing fixtures) convert exactly as before. All 35 existing + new CV10 YAML cases pass, as do `std_test.py` and `std_roundtrip_test.py`.

### Pull Request checklist

- [x] Included test cases to demonstrate the code change:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases/CV10.yml`: two `pass` cases (single→double and double→single quote-doubling left unchanged) and one `fail` case proving backslash-escaped quotes still convert. The two `pass` cases were confirmed to **fail on `main`** (they corrupt the value) and pass with this change.
- [x] Added appropriate documentation for the change (rule docstring behaviour is unchanged; the fix only prevents value-changing rewrites).
- [ ] Created GitHub issues for any relevant followup — the fuller re-encoding option is noted in #8179's scope discussion.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent `CV10` (`convention.quoted_literals`) from changing string literal values when SQL quote-doubling escapes are used; fixes #8179. We now skip re-quoting in those cases to preserve values, while keeping normal conversions for backslash-escaped quotes.

- **Bug Fixes**
  - Skip conversion when the body contains a bare, non-backslash-escaped original quote (signals SQL quote-doubling).
  - Backslash-escaped quotes still convert; triple-quoted strings unaffected.
  - Added rule tests for single↔double quote-doubling and backslash-escape behavior.

<sup>Written for commit 0707359554e2c8bcd2219eb6201a19d871d48554. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8193?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



