### PR TITLE
BigQuery: parse EXCEPT/REPLACE after a wildcard on an array element

### DIFF
--- a/src/sqlfluff/dialects/dialect_bigquery.py
+++ b/src/sqlfluff/dialects/dialect_bigquery.py
@@ -1728,21 +1728,40 @@ class SemiStructuredAccessorSegment(BaseSegment):
     """A semi-structured data accessor segment."""
 
     type = "semi_structured_expression"
-    match_grammar = Sequence(
-        AnyNumberOf(
+    # A wildcard is only valid as the final element of the accessor chain,
+    # and it may carry the EXCEPT/REPLACE modifiers, e.g.
+    # `results[0].* EXCEPT (cola)`.
+    # https://cloud.google.com/bigquery/docs/reference/standard-sql/query-syntax#select_except
+    match_grammar = OneOf(
+        Sequence(
+            AnyNumberOf(
+                Sequence(
+                    Ref("DotSegment"),
+                    Ref("SingleIdentifierGrammar"),
+                    allow_gaps=True,
+                ),
+                Ref("ArrayAccessorSegment", optional=True),
+                allow_gaps=True,
+                min_times=1,
+            ),
             Sequence(
                 Ref("DotSegment"),
-                OneOf(
-                    Ref("SingleIdentifierGrammar"),
-                    Ref("StarSegment"),
-                ),
+                Ref("StarSegment"),
+                Ref("ExceptClauseSegment", optional=True),
+                Ref("ReplaceClauseSegment", optional=True),
                 allow_gaps=True,
+                optional=True,
             ),
-            Ref("ArrayAccessorSegment", optional=True),
             allow_gaps=True,
-            min_times=1,
         ),
-        allow_gaps=True,
+        # A bare `.*` directly on the preceding expression.
+        Sequence(
+            Ref("DotSegment"),
+            Ref("StarSegment"),
+            Ref("ExceptClauseSegment", optional=True),
+            Ref("ReplaceClauseSegment", optional=True),
+            allow_gaps=True,
+        ),
     )
 
 

--- a/src/sqlfluff/dialects/dialect_bigquery.py
+++ b/src/sqlfluff/dialects/dialect_bigquery.py
@@ -395,11 +395,17 @@ bigquery_dialect.replace(
     NaturalJoinKeywordsGrammar=Nothing(),
     UnconditionalCrossJoinKeywordsGrammar=Ref.keyword("CROSS"),
     MergeIntoLiteralGrammar=Sequence("MERGE", Ref.keyword("INTO", optional=True)),
-    AccessorGrammar=AnyNumberOf(
-        Ref("ArrayAccessorSegment"),
-        Ref("ChainedFunctionCallSegment"),
-        # Add in semi structured expressions
-        Ref("SemiStructuredAccessorSegment"),
+    AccessorGrammar=Sequence(
+        AnyNumberOf(
+            Ref("ArrayAccessorSegment"),
+            Ref("ChainedFunctionCallSegment"),
+            # Add in semi structured expressions
+            Ref("SemiStructuredAccessorSegment"),
+        ),
+        # A wildcard terminates the accessor chain, so it sits outside the
+        # repeating part above - nothing may be chained after it.
+        Ref("SemiStructuredWildcardAccessorSegment", optional=True),
+        allow_gaps=True,
     ),
     BracketedSetExpressionGrammar=Bracketed(Ref("SetExpressionSegment")),
     NotEnforcedGrammar=Sequence("NOT", "ENFORCED"),
@@ -1308,7 +1314,13 @@ class FunctionSegment(ansi.FunctionSegment):
                 # Functions returning STRUCTs in BigQuery can have the fields
                 # elements referenced (e.g. ".a"), including wildcards (e.g. ".*")
                 # or multiple nested fields (e.g. ".a.b", or ".a.b.c")
-                Ref("SemiStructuredAccessorSegment", optional=True),
+                OneOf(
+                    # Try the wildcard form first so that a chain ending in `.*`
+                    # (e.g. `.b.*`) stays a single accessor segment.
+                    Ref("SemiStructuredWildcardAccessorSegment"),
+                    Ref("SemiStructuredAccessorSegment"),
+                    optional=True,
+                ),
                 Ref("PostFunctionGrammar", optional=True),
             ),
         ),
@@ -1725,43 +1737,59 @@ class NamedArgumentSegment(BaseSegment):
 
 
 class SemiStructuredAccessorSegment(BaseSegment):
-    """A semi-structured data accessor segment."""
+    """A semi-structured data accessor segment.
+
+    This covers the non-wildcard part of an accessor chain (e.g. `.a`, `.a.b`,
+    `.a[0].b`). A wildcard is handled separately by
+    :class:`SemiStructuredWildcardAccessorSegment` so that it can only appear as
+    the final element of the chain.
+    """
 
     type = "semi_structured_expression"
-    # A wildcard is only valid as the final element of the accessor chain,
-    # and it may carry the EXCEPT/REPLACE modifiers, e.g.
-    # `results[0].* EXCEPT (cola)`.
-    # https://cloud.google.com/bigquery/docs/reference/standard-sql/query-syntax#select_except
-    match_grammar = OneOf(
-        Sequence(
-            AnyNumberOf(
-                Sequence(
-                    Ref("DotSegment"),
-                    Ref("SingleIdentifierGrammar"),
-                    allow_gaps=True,
-                ),
-                Ref("ArrayAccessorSegment", optional=True),
-                allow_gaps=True,
-                min_times=1,
-            ),
+    match_grammar = Sequence(
+        AnyNumberOf(
             Sequence(
                 Ref("DotSegment"),
-                Ref("StarSegment"),
-                Ref("ExceptClauseSegment", optional=True),
-                Ref("ReplaceClauseSegment", optional=True),
+                Ref("SingleIdentifierGrammar"),
                 allow_gaps=True,
-                optional=True,
             ),
+            Ref("ArrayAccessorSegment", optional=True),
+            allow_gaps=True,
+            min_times=1,
+        ),
+        allow_gaps=True,
+    )
+
+
+class SemiStructuredWildcardAccessorSegment(BaseSegment):
+    """A wildcard terminating a semi-structured accessor chain.
+
+    A wildcard is only valid as the *final* element of an accessor chain, and it
+    may carry the EXCEPT/REPLACE modifiers, e.g. `results[0].* EXCEPT (cola)`.
+    Keeping it out of the repeating part of ``AccessorGrammar`` is what stops
+    invalid mid-chain forms such as `a.b.*.c` from parsing.
+
+    https://cloud.google.com/bigquery/docs/reference/standard-sql/query-syntax#select_except
+    """
+
+    type = "semi_structured_expression"
+    match_grammar = Sequence(
+        # Any fields preceding the wildcard are part of the same accessor, so
+        # that `.b.*` stays a single segment rather than being split in two.
+        AnyNumberOf(
+            Sequence(
+                Ref("DotSegment"),
+                Ref("SingleIdentifierGrammar"),
+                allow_gaps=True,
+            ),
+            Ref("ArrayAccessorSegment", optional=True),
             allow_gaps=True,
         ),
-        # A bare `.*` directly on the preceding expression.
-        Sequence(
-            Ref("DotSegment"),
-            Ref("StarSegment"),
-            Ref("ExceptClauseSegment", optional=True),
-            Ref("ReplaceClauseSegment", optional=True),
-            allow_gaps=True,
-        ),
+        Ref("DotSegment"),
+        Ref("StarSegment"),
+        Ref("ExceptClauseSegment", optional=True),
+        Ref("ReplaceClauseSegment", optional=True),
+        allow_gaps=True,
     )
 
 

--- a/src/sqlfluff/dialects/dialect_bigquery.py
+++ b/src/sqlfluff/dialects/dialect_bigquery.py
@@ -1314,13 +1314,12 @@ class FunctionSegment(ansi.FunctionSegment):
                 # Functions returning STRUCTs in BigQuery can have the fields
                 # elements referenced (e.g. ".a"), including wildcards (e.g. ".*")
                 # or multiple nested fields (e.g. ".a.b", or ".a.b.c")
-                OneOf(
-                    # Try the wildcard form first so that a chain ending in `.*`
-                    # (e.g. `.b.*`) stays a single accessor segment.
-                    Ref("SemiStructuredWildcardAccessorSegment"),
-                    Ref("SemiStructuredAccessorSegment"),
-                    optional=True,
-                ),
+                # Note the wildcard form is deliberately *not* matched here. It is
+                # left to `AccessorGrammar`, which is applied after the function and
+                # is the single place that enforces the wildcard being terminal.
+                # Matching it here would let the outer grammar chain a further
+                # accessor after the star (e.g. `f(a).b.*.z`).
+                Ref("SemiStructuredAccessorSegment", optional=True),
                 Ref("PostFunctionGrammar", optional=True),
             ),
         ),

--- a/test/dialects/bigquery_test.py
+++ b/test/dialects/bigquery_test.py
@@ -159,6 +159,10 @@ def test_cast_as_float_fails():
     [
         "SELECT x.y.*.z FROM t",
         "SELECT results[0].*.z FROM t",
+        # The wildcard is equally terminal when the chain hangs off a function.
+        "SELECT testFunction(a).b.*.z FROM t",
+        "SELECT testFunction(a).*.z FROM t",
+        "SELECT testFunction(a)[0].b.*.z FROM t",
     ],
 )
 def test_semi_structured_wildcard_is_terminal(sql):

--- a/test/dialects/bigquery_test.py
+++ b/test/dialects/bigquery_test.py
@@ -152,3 +152,33 @@ def test_cast_as_float_fails():
     parsed = Linter(dialect="bigquery").parse_string(sql)
     # Parsing produces a parse error for the unsupported `FLOAT` type.
     assert parsed.violations
+
+
+@pytest.mark.parametrize(
+    "sql",
+    [
+        "SELECT x.y.*.z FROM t",
+        "SELECT results[0].*.z FROM t",
+    ],
+)
+def test_semi_structured_wildcard_is_terminal(sql):
+    """A wildcard may only be the final element of an accessor chain."""
+    parsed = Linter(dialect="bigquery").parse_string(sql)
+    # Nothing may be chained after the `.*`, so these are a parse error.
+    assert parsed.violations
+
+
+@pytest.mark.parametrize(
+    "sql",
+    [
+        "SELECT results[0].* FROM t",
+        "SELECT results[0].* EXCEPT (cola) FROM t",
+        "SELECT results[0].* REPLACE (1 AS cola) FROM t",
+        "SELECT s.arr[0].field.* EXCEPT (cola) FROM t",
+        "SELECT testFunction(a).b.* FROM t",
+    ],
+)
+def test_semi_structured_wildcard_parses(sql):
+    """A wildcard ending an accessor chain parses, with EXCEPT/REPLACE."""
+    parsed = Linter(dialect="bigquery").parse_string(sql)
+    assert not parsed.violations

--- a/test/fixtures/dialects/bigquery/select_array_element_wildcard_except.sql
+++ b/test/fixtures/dialects/bigquery/select_array_element_wildcard_except.sql
@@ -1,0 +1,18 @@
+-- Wildcard on an array element (or nested field) accepts the EXCEPT and
+-- REPLACE modifiers, just like a plain `t.*` wildcard.
+-- https://github.com/sqlfluff/sqlfluff/issues/8186
+-- https://cloud.google.com/bigquery/docs/reference/standard-sql/query-syntax#select_except
+
+SELECT
+    error,
+    results[0].* EXCEPT (cola)
+FROM `project`.`dataset`.`table`;
+
+SELECT results[0].* REPLACE (1 AS cola)
+FROM `project`.`dataset`.`table`;
+
+SELECT s.arr[0].field.* EXCEPT (x)
+FROM t;
+
+SELECT results[0].*
+FROM t;

--- a/test/fixtures/dialects/bigquery/select_array_element_wildcard_except.yml
+++ b/test/fixtures/dialects/bigquery/select_array_element_wildcard_except.yml
@@ -1,0 +1,135 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: b9f257fceafe98182b7d12f2b1550875fe8c26d60c9639395760d7d63bfe02f8
+file:
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            naked_identifier: error
+      - comma: ','
+      - select_clause_element:
+          expression:
+            column_reference:
+              naked_identifier: results
+            semi_structured_expression:
+              array_accessor:
+                start_square_bracket: '['
+                numeric_literal: '0'
+                end_square_bracket: ']'
+              dot: .
+              star: '*'
+              select_except_clause:
+                keyword: EXCEPT
+                bracketed:
+                  start_bracket: (
+                  naked_identifier: cola
+                  end_bracket: )
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+              - quoted_identifier: '`project`'
+              - dot: .
+              - quoted_identifier: '`dataset`'
+              - dot: .
+              - quoted_identifier: '`table`'
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+            column_reference:
+              naked_identifier: results
+            semi_structured_expression:
+              array_accessor:
+                start_square_bracket: '['
+                numeric_literal: '0'
+                end_square_bracket: ']'
+              dot: .
+              star: '*'
+              select_replace_clause:
+                keyword: REPLACE
+                bracketed:
+                  start_bracket: (
+                  numeric_literal: '1'
+                  keyword: AS
+                  naked_identifier: cola
+                  end_bracket: )
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+              - quoted_identifier: '`project`'
+              - dot: .
+              - quoted_identifier: '`dataset`'
+              - dot: .
+              - quoted_identifier: '`table`'
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+            column_reference:
+            - naked_identifier: s
+            - dot: .
+            - naked_identifier: arr
+            semi_structured_expression:
+            - array_accessor:
+                start_square_bracket: '['
+                numeric_literal: '0'
+                end_square_bracket: ']'
+            - dot: .
+            - naked_identifier: field
+            - dot: .
+            - star: '*'
+            - select_except_clause:
+                keyword: EXCEPT
+                bracketed:
+                  start_bracket: (
+                  naked_identifier: x
+                  end_bracket: )
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: t
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+            column_reference:
+              naked_identifier: results
+            semi_structured_expression:
+              array_accessor:
+                start_square_bracket: '['
+                numeric_literal: '0'
+                end_square_bracket: ']'
+              dot: .
+              star: '*'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: t
+- statement_terminator: ;

--- a/test/fixtures/dialects/bigquery/select_array_element_wildcard_except.yml
+++ b/test/fixtures/dialects/bigquery/select_array_element_wildcard_except.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: b9f257fceafe98182b7d12f2b1550875fe8c26d60c9639395760d7d63bfe02f8
+_hash: d22164279d2a9f21b3dc4215d9033385403ffa85b7ef8dc44620056d5dece296
 file:
 - statement:
     select_statement:
@@ -17,11 +17,11 @@ file:
           expression:
             column_reference:
               naked_identifier: results
+            array_accessor:
+              start_square_bracket: '['
+              numeric_literal: '0'
+              end_square_bracket: ']'
             semi_structured_expression:
-              array_accessor:
-                start_square_bracket: '['
-                numeric_literal: '0'
-                end_square_bracket: ']'
               dot: .
               star: '*'
               select_except_clause:
@@ -50,11 +50,11 @@ file:
           expression:
             column_reference:
               naked_identifier: results
+            array_accessor:
+              start_square_bracket: '['
+              numeric_literal: '0'
+              end_square_bracket: ']'
             semi_structured_expression:
-              array_accessor:
-                start_square_bracket: '['
-                numeric_literal: '0'
-                end_square_bracket: ']'
               dot: .
               star: '*'
               select_replace_clause:
@@ -83,20 +83,21 @@ file:
         keyword: SELECT
         select_clause_element:
           expression:
-            column_reference:
+          - column_reference:
             - naked_identifier: s
             - dot: .
             - naked_identifier: arr
-            semi_structured_expression:
-            - array_accessor:
+          - semi_structured_expression:
+              array_accessor:
                 start_square_bracket: '['
                 numeric_literal: '0'
                 end_square_bracket: ']'
-            - dot: .
-            - naked_identifier: field
-            - dot: .
-            - star: '*'
-            - select_except_clause:
+              dot: .
+              naked_identifier: field
+          - semi_structured_expression:
+              dot: .
+              star: '*'
+              select_except_clause:
                 keyword: EXCEPT
                 bracketed:
                   start_bracket: (
@@ -118,11 +119,11 @@ file:
           expression:
             column_reference:
               naked_identifier: results
+            array_accessor:
+              start_square_bracket: '['
+              numeric_literal: '0'
+              end_square_bracket: ']'
             semi_structured_expression:
-              array_accessor:
-                start_square_bracket: '['
-                numeric_literal: '0'
-                end_square_bracket: ']'
               dot: .
               star: '*'
       from_clause:

--- a/test/fixtures/dialects/bigquery/select_function_object_fields.yml
+++ b/test/fixtures/dialects/bigquery/select_function_object_fields.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: a7e5f99b0d9bbe4f8e15aa356b0abb5965da26b9e09dab2da4f11e9fb7616e90
+_hash: b474d398df2ba827aa378dd14a7f4370e29fc15e6b2de4036de5f0d29c007136
 file:
   statement:
     select_statement:
@@ -29,16 +29,17 @@ file:
             naked_identifier: field
       - comma: ','
       - select_clause_element:
-          function:
-            function_name:
-              function_name_identifier: testFunction
-            function_contents:
-              bracketed:
-                start_bracket: (
-                expression:
-                  column_reference:
-                    naked_identifier: a
-                end_bracket: )
+          expression:
+            function:
+              function_name:
+                function_name_identifier: testFunction
+              function_contents:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    column_reference:
+                      naked_identifier: a
+                  end_bracket: )
             semi_structured_expression:
               dot: .
               star: '*'
@@ -69,50 +70,53 @@ file:
             naked_identifier: field_with_field
       - comma: ','
       - select_clause_element:
-          function:
-            function_name:
-              function_name_identifier: testFunction
-            function_contents:
-              bracketed:
-                start_bracket: (
-                expression:
-                  column_reference:
-                    naked_identifier: a
-                end_bracket: )
+          expression:
+            function:
+              function_name:
+                function_name_identifier: testFunction
+              function_contents:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    column_reference:
+                      naked_identifier: a
+                  end_bracket: )
+              semi_structured_expression:
+                dot: .
+                naked_identifier: b
             semi_structured_expression:
-            - dot: .
-            - naked_identifier: b
-            - dot: .
-            - star: '*'
+              dot: .
+              star: '*'
           alias_expression:
             alias_operator:
               keyword: AS
             naked_identifier: field_with_wildcard
       - comma: ','
       - select_clause_element:
-          function:
-            function_name:
-              function_name_identifier: testFunction
-            function_contents:
-              bracketed:
-                start_bracket: (
+          expression:
+            function:
+              function_name:
+                function_name_identifier: testFunction
+              function_contents:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    column_reference:
+                      naked_identifier: a
+                  end_bracket: )
+              array_accessor:
+                start_square_bracket: '['
                 expression:
-                  column_reference:
-                    naked_identifier: a
-                end_bracket: )
-            array_accessor:
-              start_square_bracket: '['
-              expression:
-                function:
-                  function_name:
-                    function_name_identifier: OFFSET
-                  function_contents:
-                    bracketed:
-                      start_bracket: (
-                      expression:
-                        numeric_literal: '0'
-                      end_bracket: )
-              end_square_bracket: ']'
+                  function:
+                    function_name:
+                      function_name_identifier: OFFSET
+                    function_contents:
+                      bracketed:
+                        start_bracket: (
+                        expression:
+                          numeric_literal: '0'
+                        end_bracket: )
+                end_square_bracket: ']'
             semi_structured_expression:
               dot: .
               star: '*'
@@ -122,29 +126,30 @@ file:
             naked_identifier: field_with_offset_wildcard
       - comma: ','
       - select_clause_element:
-          function:
-            function_name:
-              function_name_identifier: testFunction
-            function_contents:
-              bracketed:
-                start_bracket: (
+          expression:
+            function:
+              function_name:
+                function_name_identifier: testFunction
+              function_contents:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    column_reference:
+                      naked_identifier: a
+                  end_bracket: )
+              array_accessor:
+                start_square_bracket: '['
                 expression:
-                  column_reference:
-                    naked_identifier: a
-                end_bracket: )
-            array_accessor:
-              start_square_bracket: '['
-              expression:
-                function:
-                  function_name:
-                    function_name_identifier: SAFE_OFFSET
-                  function_contents:
-                    bracketed:
-                      start_bracket: (
-                      expression:
-                        numeric_literal: '0'
-                      end_bracket: )
-              end_square_bracket: ']'
+                  function:
+                    function_name:
+                      function_name_identifier: SAFE_OFFSET
+                    function_contents:
+                      bracketed:
+                        start_bracket: (
+                        expression:
+                          numeric_literal: '0'
+                        end_bracket: )
+                end_square_bracket: ']'
             semi_structured_expression:
               dot: .
               star: '*'
@@ -154,29 +159,30 @@ file:
             naked_identifier: field_with_safe_offset_wildcard
       - comma: ','
       - select_clause_element:
-          function:
-            function_name:
-              function_name_identifier: testFunction
-            function_contents:
-              bracketed:
-                start_bracket: (
+          expression:
+            function:
+              function_name:
+                function_name_identifier: testFunction
+              function_contents:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    column_reference:
+                      naked_identifier: a
+                  end_bracket: )
+              array_accessor:
+                start_square_bracket: '['
                 expression:
-                  column_reference:
-                    naked_identifier: a
-                end_bracket: )
-            array_accessor:
-              start_square_bracket: '['
-              expression:
-                function:
-                  function_name:
-                    function_name_identifier: ORDINAL
-                  function_contents:
-                    bracketed:
-                      start_bracket: (
-                      expression:
-                        numeric_literal: '1'
-                      end_bracket: )
-              end_square_bracket: ']'
+                  function:
+                    function_name:
+                      function_name_identifier: ORDINAL
+                    function_contents:
+                      bracketed:
+                        start_bracket: (
+                        expression:
+                          numeric_literal: '1'
+                        end_bracket: )
+                end_square_bracket: ']'
             semi_structured_expression:
               dot: .
               star: '*'


### PR DESCRIPTION
### Brief summary of the change made

Fixes #8186

A wildcard on an array element or nested field parses through `SemiStructuredAccessorSegment`, which had no hook for the `EXCEPT`/`REPLACE` modifiers, so valid BigQuery like:

```sql
SELECT
    error,
    results[0].* EXCEPT (cola)
FROM `project`.`dataset`.`table`
```

raised `Found unparsable section: 'EXCEPT(cola)'` (and the same for `REPLACE (...)`). The plain `t.*` path via `WildcardExpressionSegment` already supported both modifiers — the gap was only on the semi-structured accessor path.

This restructures the accessor grammar so the wildcard is a **terminal** element of the chain, carrying optional `ExceptClauseSegment`/`ReplaceClauseSegment` ([BigQuery docs](https://cloud.google.com/bigquery/docs/reference/standard-sql/query-syntax#select_except)). The wildcard lives in its own `SemiStructuredWildcardAccessorSegment`, placed outside the repeating part of `AccessorGrammar` so nothing can be chained after it — `a.b.*.c` and `results[0].*.z` are now rejected. The same applies to accessor chains hanging off a function call (`testFunction(a).b.*.z`) — the wildcard is matched only by `AccessorGrammar`, so terminality is enforced in exactly one place rather than two. As a result the wildcard rows of `select_function_object_fields.yml` gain an enclosing `expression` node; non-wildcard rows are unchanged.

Correction to an earlier version of this description: `a.*.b` is **not** affected by this change and still parses. That form goes through `SingleIdentifierWildcardSegment` + `AccessorGrammar` in the ansi `Expression_D_Grammar`, not the semi-structured path, and behaves the same on `main` today. It looked in scope at first; it isn't, and fixing it would mean touching shared ansi grammar from a BigQuery parse fix.

### Are there any other side effects of this change that we should be aware of?

No. Plain wildcards (`* EXCEPT (...)`, `t.* EXCEPT (...)`), ordinary references (`a.b.c`), array element field access (`results[0].field`) and bare array-element wildcards (`results[0].*`) all parse exactly as before — the full BigQuery dialect suite passes (432 tests) with no changes to any existing fixture tree.

### Pull Request checklist

- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes:
  - `.sql`/`.yml` parser test case added at `test/fixtures/dialects/bigquery/select_array_element_wildcard_except.sql` (+ generated `.yml`) covering `EXCEPT`, `REPLACE`, a nested-field wildcard and the plain array-element wildcard.
- Added appropriate documentation for the change (inline grammar comment with doc link).
- Created GitHub issues for any relevant followup/future enhancements if appropriate — n/a.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for `EXCEPT`/`REPLACE` after wildcards on array elements and nested fields in BigQuery (e.g., `results[0].* EXCEPT (cola)`), and makes `.*` truly terminal—even after functions—so mid-chain forms like `x.y.*.z` don’t parse.

- **Bug Fixes**
  - Introduces `SemiStructuredWildcardAccessorSegment` outside the repeating `AccessorGrammar` so nothing can follow `.*`, and it can carry `EXCEPT`/`REPLACE`.
  - Stops matching the wildcard inside `FunctionSegment`; `f(a).b.*.z` and `f(a).*.z` now error, while `f(a).b.*` parses.
  - Adds tests for accepted terminal and rejected mid-chain forms; adds a new fixture and updates `select_function_object_fields.yml` for a minor parse-tree change.

<sup>Written for commit 5e35a278407d959f09c59ce69a6163f88fa03c4a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8194?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->







