### PR TITLE
BigQuery: model pipe syntax as a postfix on selectables

### DIFF
--- a/src/sqlfluff/dialects/dialect_bigquery.py
+++ b/src/sqlfluff/dialects/dialect_bigquery.py
@@ -755,7 +755,6 @@ class StatementSegment(ansi.StatementSegment):
             Ref("DropAssignmentStatementSegment"),
             Ref("DropTableFunctionStatementSegment"),
             Ref("CreateTableFunctionStatementSegment"),
-            Ref("PipeStatementSegment"),
         ],
     )
 
@@ -3638,7 +3637,7 @@ class DropAssignmentStatementSegment(BaseSegment):
 
 
 class PipeStatementSegment(BaseSegment):
-    """A `PIPE` statement.
+    """A pipe query: a base query followed by pipe operators.
 
     https://cloud.google.com/bigquery/docs/reference/standard-sql/pipe-syntax
     """
@@ -3651,11 +3650,34 @@ class PipeStatementSegment(BaseSegment):
             AnyNumberOf(Ref("PipeOperatorClauseSegment")),
         ),
         Sequence(
-            Ref("SelectableGrammar"),
+            OneOf(
+                OptionallyBracketed(Ref("SelectStatementSegment")),
+                Ref("SetExpressionSegment"),
+                Bracketed(Ref("SelectableGrammar")),
+            ),
             Ref("AliasExpressionSegment", optional=True),
             AnyNumberOf(Ref("PipeOperatorClauseSegment"), min_times=1),
         ),
     )
+
+
+bigquery_dialect.replace(
+    NonWithSelectableGrammar=OneOf(
+        Ref("SetExpressionSegment"),
+        OptionallyBracketed(Ref("SelectStatementSegment")),
+        Ref("NonSetSelectableGrammar"),
+        Ref("PipeStatementSegment"),
+    ),
+    NonSetSelectableGrammar=OneOf(
+        Ref("ValuesClauseSegment"),
+        Ref("UnorderedSelectStatementSegment"),
+        Bracketed(Ref("SelectStatementSegment")),
+        Bracketed(Ref("WithCompoundStatementSegment")),
+        Bracketed(Ref("NonSetSelectableGrammar")),
+        Bracketed(Ref("PipeStatementSegment")),
+        Ref("BracketedSetExpressionGrammar"),
+    ),
+)
 
 
 class PipeOperatorClauseSegment(BaseSegment):
@@ -3854,45 +3876,6 @@ class UnpivotOperatorSegment(BaseSegment):
     match_grammar: Matchable = Sequence(
         Ref("FromUnpivotExpressionSegment"),
         Ref("AliasExpressionSegment", optional=True),
-    )
-
-
-class CTEDefinitionSegment(ansi.CTEDefinitionSegment):
-    """A CTE Definition from a WITH statement.
-
-    BigQuery allows FROM clauses directly in CTEs without requiring SELECT statements.
-    This extends the ANSI definition to support this pipe syntax.
-    """
-
-    match_grammar = Sequence(
-        Ref("SingleIdentifierGrammar"),
-        Ref("CTEColumnList", optional=True),
-        Ref.keyword("AS", optional=True),
-        Bracketed(
-            OneOf(Ref("SelectableGrammar"), Ref("PipeStatementSegment")),
-            parse_mode=ParseMode.GREEDY,
-        ),
-    )
-
-
-class WithCompoundStatementSegment(ansi.WithCompoundStatementSegment):
-    """A `WITH` statement, which in BigQuery may end in a pipe query.
-
-    BigQuery allows the query following the CTE list to be written with pipe
-    syntax (``FROM ... |> ...``), not just a SELECT / set expression. This
-    extends the ANSI definition so the trailing element also accepts a
-    ``PipeStatementSegment``, mirroring how ``CTEDefinitionSegment`` already
-    allows pipe syntax inside CTE bodies.
-    """
-
-    match_grammar = ansi.WithCompoundStatementSegment.match_grammar.copy(
-        insert=[
-            OneOf(
-                Ref("NonWithSelectableGrammar"),
-                Ref("PipeStatementSegment"),
-            ),
-        ],
-        remove=[Ref("NonWithSelectableGrammar")],
     )
 
 

--- a/test/fixtures/dialects/bigquery/pipe_statement.sql
+++ b/test/fixtures/dialects/bigquery/pipe_statement.sql
@@ -171,3 +171,13 @@ WITH bar AS (
 FROM bar
 |> WHERE sales >= 3
 |> SELECT item, sales;
+
+SELECT t.item
+FROM (
+    FROM foo
+    |> WHERE sales >= 3
+) AS t;
+
+(FROM foo |> WHERE sales >= 3)
+UNION ALL
+SELECT item, sales FROM bar;

--- a/test/fixtures/dialects/bigquery/pipe_statement.yml
+++ b/test/fixtures/dialects/bigquery/pipe_statement.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 2759f64a6e9b046386490936ace2237520f8b35608dda19cb907ad4353d3c75d
+_hash: 903cd5f8bc6f71f5c3875bcb50788a9ae2ecf4b6b0ef344423f67dfe9e065c85
 file:
 - statement:
     pipe_statement:
@@ -1797,4 +1797,90 @@ file:
           - select_clause_element:
               column_reference:
                 naked_identifier: sales
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          column_reference:
+          - naked_identifier: t
+          - dot: .
+          - naked_identifier: item
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              bracketed:
+                start_bracket: (
+                pipe_statement:
+                  from_clause:
+                    keyword: FROM
+                    from_expression:
+                      from_expression_element:
+                        table_expression:
+                          table_reference:
+                            naked_identifier: foo
+                  pipe_operator_clause:
+                    pipe_operator: '|>'
+                    where_clause:
+                      keyword: WHERE
+                      expression:
+                        column_reference:
+                          naked_identifier: sales
+                        comparison_operator:
+                        - raw_comparison_operator: '>'
+                        - raw_comparison_operator: '='
+                        numeric_literal: '3'
+                end_bracket: )
+            alias_expression:
+              alias_operator:
+                keyword: AS
+              naked_identifier: t
+- statement_terminator: ;
+- statement:
+    set_expression:
+      bracketed:
+        start_bracket: (
+        pipe_statement:
+          from_clause:
+            keyword: FROM
+            from_expression:
+              from_expression_element:
+                table_expression:
+                  table_reference:
+                    naked_identifier: foo
+          pipe_operator_clause:
+            pipe_operator: '|>'
+            where_clause:
+              keyword: WHERE
+              expression:
+                column_reference:
+                  naked_identifier: sales
+                comparison_operator:
+                - raw_comparison_operator: '>'
+                - raw_comparison_operator: '='
+                numeric_literal: '3'
+        end_bracket: )
+      set_operator:
+      - keyword: UNION
+      - keyword: ALL
+      select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            column_reference:
+              naked_identifier: item
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+              naked_identifier: sales
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: bar
 - statement_terminator: ;


### PR DESCRIPTION
### Brief summary of the change made

Follow-up to #8191 (as discussed there). Instead of a distinct `PipeStatementSegment` that has to be *added* to each position it's allowed, a pipe query is now **any base query optionally followed by pipe operators**, folded once into `NonWithSelectableGrammar`:

```python
bigquery_dialect.replace(
    NonWithSelectableGrammar=OneOf(
        Ref("SetExpressionSegment"),
        OptionallyBracketed(Ref("SelectStatementSegment")),
        Ref("NonSetSelectableGrammar"),
        Ref("PipeStatementSegment"),   # folded in here
    ),
)
```

Because `StatementSegment -> SelectableGrammar -> NonWithSelectableGrammar`, pipe queries now work in every selectable position through one path: top-level, subquery, set operand, CTE body, and the query after a `WITH`.

### Why this is not left-recursive

Earlier discussion on #8191 showed that folding pipe into the selectable grammars naively triggers `RecursionError: Self referential grammar detected` (because `PipeStatementSegment`'s base was the full `SelectableGrammar`). This avoids that with two properties:

1. Pipe operators only ever **trail** the base query, so folding `PipeStatementSegment` into `NonWithSelectableGrammar` leaves that grammar's first-set unchanged (`{FROM, SELECT, VALUES, (}`).
2. The query-initial base references `SelectStatementSegment` / `SetExpressionSegment` / `Bracketed(SelectableGrammar)` **directly** rather than `SelectableGrammar`, so the chain `SelectableGrammar -> NonWithSelectableGrammar -> PipeStatementSegment -> SelectStatement/SetExpression/(…)` terminates rather than cycling.

### Net simplification

Removes three special cases:

- `PipeStatementSegment` listed explicitly in `StatementSegment`
- `OneOf(SelectableGrammar, PipeStatementSegment)` in `CTEDefinitionSegment` (#7180) — the whole override reverts to the identical ANSI grammar and is deleted
- the `WithCompoundStatementSegment` override added in #8191 — its trailing `NonWithSelectableGrammar` now already accepts pipe queries

and adds pipe-in-subquery as a side benefit.

### Are there any side effects?

Only `test/fixtures/dialects/bigquery/pipe_statement.yml` re-nests (pipe queries are now selectables). All other 428 BigQuery fixtures are unchanged.

### Tests

- Added fixtures for pipe-after-`WITH` and pipe-in-subquery.
- `pytest test/dialects/dialects_test.py` — **6588 passed** (full all-dialect suite; BigQuery subset 429 passed).
- `ruff check` / `ruff format --check` / `yamllint` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactors BigQuery pipe syntax to be a postfix on selectables by folding `PipeStatementSegment` into `NonWithSelectableGrammar` and, bracketed, into `NonSetSelectableGrammar`. This simplifies the grammar and enables pipe queries in all selectable positions without left recursion.

- **New Features**
  - Pipe queries now work everywhere selectables are allowed: top-level, subquery, CTE body, after WITH, and as a bracketed set operand.

- **Refactors**
  - Removed explicit pipe handling in `StatementSegment`, `CTEDefinitionSegment`, and `WithCompoundStatementSegment`.
  - Avoided left recursion by using a narrow, non-pipe base (`SelectStatementSegment` / `SetExpressionSegment` / bracketed selectable) and trailing-only pipe operators.

<sup>Written for commit b1ecb1fa889eb115999819d539ce6758caac1128. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8195?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

