### PR TITLE
Add a Python-vs-Rust parser/lexer parity test harness

### DIFF
--- a/src/sqlfluff/core/parser/rust_parser.py
+++ b/src/sqlfluff/core/parser/rust_parser.py
@@ -104,6 +104,11 @@ def set_native_ast(enabled: bool) -> None:
     _NATIVE_AST_ENABLED = enabled
 
 
+def get_native_ast() -> bool:
+    """Return whether the fused (native) BaseSegment builder is enabled."""
+    return _NATIVE_AST_ENABLED
+
+
 try:
     from sqlfluffrs import RsMatchResult, RsParseError, RsParser, RsToken
 

--- a/test/core/parser/parity/__init__.py
+++ b/test/core/parser/parity/__init__.py
@@ -1,0 +1,1 @@
+"""Python-vs-Rust engine parity suite."""

--- a/test/core/parser/parity/cases_test.py
+++ b/test/core/parser/parity/cases_test.py
@@ -1,0 +1,97 @@
+"""Drivers for the parity case corpus in ``test/fixtures/parity/``.
+
+Each YAML case is just data: SQL (inline or from a dialect-corpus fixture),
+dialect, config and metadata. ``compare.py`` holds the shared capture and
+comparison logic that every driver uses, so every case is checked at the
+same strict level. Known differences are recorded in the fixture as a
+strict xfail for the specific leg they affect (python_vs_rust or
+native_vs_legacy).
+"""
+
+import pytest
+
+from .compare import (
+    PARSER_LEGS,
+    build_config,
+    check_expectations,
+    lex_capture,
+    linted_parse_capture,
+    load_case_params,
+    load_reference_case_params,
+    parse_capture,
+    raw_match_violations,
+    reference_capture,
+    requires_rust_parser,
+    resolve_case_sql,
+)
+
+
+@pytest.mark.parametrize("case", load_reference_case_params("parser"))
+def test__parity__parser_case_reference_expectations(case):
+    """Confirm the Python parser still behaves as this case's ``expect`` claims.
+
+    This is a regression guard on the pinned case itself, not an engine
+    comparison: it catches the Python parser's behavior changing on this SQL
+    (or ``expect`` having been wrong all along). It runs as its own test, so
+    it still catches that even when the case is marked as a known engine
+    divergence (xfail) in the comparison test below.
+    """
+    check_expectations(case, reference_capture(case))
+
+
+@requires_rust_parser
+@pytest.mark.parametrize("case,leg", load_case_params("parser", legs=list(PARSER_LEGS)))
+def test__parity__parser_case(case, leg):
+    """Confirm both engines of the leg produce identical parse results."""
+    sql = resolve_case_sql(case)
+
+    if case.get("templater"):
+        # Templated cases go through linted_parse_capture, which builds its own
+        # config; don't build one here (it would be discarded).
+        left_engine, right_engine = PARSER_LEGS[leg]
+        left = linted_parse_capture(
+            left_engine,
+            sql,
+            dialect=case.get("dialect", "ansi"),
+            configs=case.get("configs"),
+            context=case.get("context"),
+        )
+        right = linted_parse_capture(
+            right_engine,
+            sql,
+            dialect=case.get("dialect", "ansi"),
+            configs=case.get("configs"),
+            context=case.get("context"),
+        )
+        assert left == right
+        return
+
+    from sqlfluff.core.parser import Lexer
+
+    config = build_config(case.get("dialect", "ansi"), case.get("configs"))
+    # Both engines parse the SAME lexed segments: this isolates parser
+    # parity from lexer parity (which has its own leg).
+    segments, _ = Lexer(config=config).lex(sql)
+    left_engine, right_engine = PARSER_LEGS[leg]
+    left = parse_capture(left_engine, config, segments)
+    right = parse_capture(right_engine, config, segments)
+    assert left == right
+
+
+@requires_rust_parser
+@pytest.mark.parametrize("case,leg", load_case_params("lexer", legs=["lexer"]))
+def test__parity__lexer_case(case, leg):
+    """Confirm PyRsLexer's token stream and errors match PyLexer's exactly."""
+    sql = resolve_case_sql(case)
+    config = build_config(case.get("dialect", "ansi"), case.get("configs"))
+    assert lex_capture("rust", config, sql) == lex_capture("python", config, sql)
+
+
+@requires_rust_parser
+@pytest.mark.parametrize(
+    "case,leg", load_case_params("invariants", legs=["invariants"])
+)
+def test__parity__match_result_invariants(case, leg):
+    """Confirm the returned RsMatchResults, as in the internal tree, are structurally well-formed."""
+    sql = resolve_case_sql(case)
+    assert raw_match_violations(sql, case.get("dialect", "ansi")) == []

--- a/test/core/parser/parity/compare.py
+++ b/test/core/parser/parity/compare.py
@@ -1,0 +1,570 @@
+"""Shared capture and comparison logic for the Python-vs-Rust parity suite.
+
+Parity tests are differential: the same input runs through two (or three)
+engine paths, and the results should match exactly. Each surface (parse,
+templated parse, lex) has one capture function, and each records at maximum
+strictness:
+
+* the tree in tuple form, with raws, metas and position markers,
+* ``stringify()`` bytes (carrying UnparsableSegment "Expected:" messages),
+* the raw round-trip,
+* the normalization kwargs carried by every segment
+  (quoted_value / escape_replacements / trim_chars / casefold),
+* the full ``class_types`` chain of every leaf segment (not just its
+  primary ``get_type()``, which is all ``to_tuple()``/``stringify()`` see),
+* whether the tree contains an ``UnparsableSegment`` anywhere,
+* or, for a raised exception, its type, message and ``SQLBaseError``
+  position/flag attributes (``PanicException`` is a BaseException, so every
+  raising path is caught).
+
+Known differences are handled per-case in the fixture corpus
+(``test/fixtures/parity/*.yml``) with an explicit, reasoned ``xfail`` entry,
+keeping every pinned repro at the same strictness. That's also why fixing
+an engine gap flips CI: the strict xfail then reports as an unexpected pass.
+
+The engine legs compared:
+
+* ``python_vs_rust``  - pure-Python ``Parser`` vs ``RustParser`` (legacy
+  convert+apply build path). The Python parser is the reference.
+* ``native_vs_legacy`` - ``RustParser``'s fused native-AST build path vs its
+  legacy convert+apply path. Both consume the same Rust match result, so any
+  difference points to a bug in one of the two builders.
+* ``lexer``           - ``PyLexer`` vs ``PyRsLexer`` token streams.
+* ``invariants``      - structural well-formedness of raw ``RsMatchResult``
+  trees, checked directly rather than compared (a violation is a rust-core
+  bug by definition).
+
+Python-vs-native parity follows transitively from the two parser legs.
+"""
+
+from functools import lru_cache
+from pathlib import Path
+
+import pytest
+import yaml
+
+try:
+    from sqlfluff.core.parser.rust_parser import _HAS_RUST_PARSER, RustParser
+except ImportError:  # pragma: no cover
+    _HAS_RUST_PARSER = False
+    RustParser = None
+
+requires_rust_parser = pytest.mark.skipif(
+    not _HAS_RUST_PARSER, reason="Rust parser not available"
+)
+
+_TEST_DIR = Path(__file__).resolve().parents[3]
+PARITY_CASE_DIR = _TEST_DIR / "fixtures" / "parity"
+DIALECT_FIXTURE_DIR = _TEST_DIR / "fixtures" / "dialects"
+
+_TREE_TUPLE_KWARGS = dict(
+    code_only=False, show_raw=True, include_meta=True, include_position=True
+)
+
+# The parser-leg engines, keyed by (left, right) per leg. The right-hand
+# engine is the reference the left-hand one must match.
+PARSER_LEGS = {
+    "python_vs_rust": ("rust", "python"),
+    "native_vs_legacy": ("rust-native", "rust"),
+}
+
+
+def _normalize_kwarg(value):
+    # ``casefold`` holds a callable (e.g. ``str.upper``); compare by name.
+    return getattr(value, "__qualname__", value) if callable(value) else value
+
+
+def _tree_fingerprints(tree):
+    """Compute the three re-walk fingerprints of a tree in a single pass.
+
+    Captured per tree, and each of these would otherwise re-crawl the whole
+    thing (``recursive_crawl_all`` twice plus a ``recursive_crawl`` for the
+    unparsable check). Folding them into one walk keeps the captures identical
+    while paying for the traversal once:
+
+    * ``segment_kwargs`` - the normalization kwargs carried by each segment
+      that has any. Rules like RF06 use these (e.g. for quote normalization);
+      they stay hidden from ``to_tuple()`` and ``stringify()``, yet an engine
+      difference here still shows up through rule behaviour.
+    * ``has_unparsable`` - whether any ``UnparsableSegment`` is present
+      (``is_type("unparsable")`` over the full crawl is equivalent to
+      ``any(recursive_crawl("unparsable"))``: both consider self and all
+      descendants).
+    * ``class_types`` - the full ``class_types`` set of every leaf segment.
+      ``to_tuple()``/``stringify()`` only record ``get_type()`` (the primary
+      type); a bare-class ``Ref`` wrapping a matched token in an ANCESTOR
+      class can produce the right primary type via ``instance_types`` while
+      still losing class-level types from the token's own lineage - invisible
+      to a ``to_tuple()``/``stringify()`` comparison alone (#8138).
+    """
+    segment_kwargs = []
+    class_types = []
+    has_unparsable = False
+    for seg in tree.recursive_crawl_all():
+        kwargs = tuple(
+            _normalize_kwarg(getattr(seg, attr, None))
+            for attr in (
+                "quoted_value",
+                "escape_replacements",
+                "trim_chars",
+                "casefold",
+            )
+        )
+        if any(value is not None for value in kwargs):
+            segment_kwargs.append((seg.raw, *kwargs))
+        if not seg.segments:
+            class_types.append((seg.raw, tuple(sorted(seg.class_types))))
+        if seg.is_type("unparsable"):
+            has_unparsable = True
+    return segment_kwargs, has_unparsable, class_types
+
+
+def _exception_capture(err):
+    return (
+        "exc",
+        type(err).__name__,
+        str(err),
+        getattr(err, "line_no", None),
+        getattr(err, "line_pos", None),
+        getattr(err, "fatal", None),
+        getattr(err, "ignore", None),
+        getattr(err, "warning", None),
+    )
+
+
+def _tree_capture(tree):
+    segment_kwargs, has_unparsable, class_types = _tree_fingerprints(tree)
+    return (
+        "tree",
+        tree.to_tuple(**_TREE_TUPLE_KWARGS),
+        tree.stringify(),
+        tree.raw,
+        segment_kwargs,
+        has_unparsable,
+        class_types,
+    )
+
+
+@lru_cache(maxsize=None)
+def _base_config(dialect):
+    """A fully-expanded FluffConfig for a dialect, cached across the suite.
+
+    Constructing a FluffConfig expands the dialect grammar (the expensive part,
+    ~3.5ms); ``.copy()`` shares that expanded ``dialect_obj`` and only re-copies
+    the small ``_configs`` dict (~0.15ms). The dialect-corpus sweep alone builds
+    one config per fixture (thousands), so caching the base and copying it saves
+    the bulk of that work.
+    """
+    from sqlfluff.core import FluffConfig
+
+    return FluffConfig(overrides={"dialect": dialect})
+
+
+def build_config(dialect="ansi", configs=None, extra_overrides=None):
+    """Build a FluffConfig from a parity case's dialect/configs fields.
+
+    ``configs`` keys are either plain override names (e.g. ``max_parse_depth``)
+    or dotted section paths (e.g. ``indentation.indented_joins``) applied via
+    ``set_value`` - which mirrors how ini-file values arrive (int-typed, not
+    bool), a distinction at least one pinned bug depends on.
+    """
+    from sqlfluff.core import FluffConfig
+
+    # Fast path: a plain dialect (no extra overrides, no configs) is the
+    # overwhelming majority of calls. Hand out a cheap copy of the cached base
+    # so the dialect is expanded once per dialect, not once per fixture. The
+    # copy is independently mutable, so callers stay isolated.
+    if not configs and not extra_overrides:
+        return _base_config(dialect).copy()
+
+    overrides = {"dialect": dialect}
+    overrides.update(extra_overrides or {})
+    dotted = {}
+    for key, value in (configs or {}).items():
+        if "." in key:
+            dotted[key] = value
+        else:
+            overrides[key] = value
+    config = FluffConfig(overrides=overrides)
+    for key, value in dotted.items():
+        config.set_value(key.split("."), value)
+    return config
+
+
+def parse_capture(engine, config, segments, fname="t.sql"):
+    """Parse pre-lexed segments with one engine; capture at full strictness.
+
+    ``engine`` is ``python`` (pure-Python ``Parser``), ``rust`` (``RustParser``
+    legacy convert+apply path) or ``rust-native`` (``RustParser`` fused
+    native-AST path).
+    """
+    from sqlfluff.core.parser import Parser
+    from sqlfluff.core.parser.rust_parser import get_native_ast, set_native_ast
+
+    parser_cls = Parser if engine == "python" else RustParser
+    previous_native_ast = get_native_ast()
+    # Pin the native-AST flag to exactly this leg, never the ambient global:
+    # the 'rust' (legacy) leg must run with it OFF even when the environment
+    # (SQLFLUFF_RS_NATIVE_AST) has turned it on, or native_vs_legacy compares
+    # the native builder against itself.
+    set_native_ast(engine == "rust-native")
+    try:
+        tree = parser_cls(config=config).parse(segments, fname=fname)
+    except BaseException as err:  # PanicException is a BaseException
+        return _exception_capture(err)
+    finally:
+        set_native_ast(previous_native_ast)
+    if tree is None:
+        return ("none",)
+    return _tree_capture(tree)
+
+
+def linted_parse_capture(engine, sql, dialect="ansi", configs=None, context=None):
+    """Template+lex+parse ``sql`` through the Linter with one engine.
+
+    Used for templated cases: TemplateSegment placeholder tokens and the
+    Linter-driven parse path can't be reached by ``parse_capture``. Captures
+    the tree at full strictness plus all violations. Jinja block UUIDs are
+    freshly randomized on every lex, so they are normalized out of the
+    stringify comparison.
+    """
+    import re
+
+    from sqlfluff.core import Linter
+    from sqlfluff.core.parser.rust_parser import get_native_ast, set_native_ast
+
+    config = build_config(
+        dialect=dialect,
+        configs=configs,
+        extra_overrides={
+            "templater": "jinja",
+            "rules": "none",
+            "use_rust_parser": engine != "python",
+        },
+    )
+    for key, value in (context or {}).items():
+        config.set_value(["templater", "jinja", "context", key], value)
+
+    previous_native_ast = get_native_ast()
+    # See parse_capture: pin the flag to this leg, never the ambient global.
+    set_native_ast(engine == "rust-native")
+    try:
+        parsed = Linter(config=config).parse_string(sql, fname="t.sql")
+    except BaseException as err:  # PanicException is a BaseException
+        return {"violations": [], "tree": None, "exc": _exception_capture(err)}
+    finally:
+        set_native_ast(previous_native_ast)
+
+    # A template that fails to render yields no parsed variants, and the
+    # .tree property asserts on that - treat it as tree=None (the violations
+    # then carry the templating error for comparison).
+    tree = parsed.tree if parsed.parsed_variants else None
+    capture = {
+        "violations": [(type(v).__name__, str(v)) for v in parsed.violations],
+        "tree": None,
+    }
+    if tree is not None:
+        segment_kwargs, has_unparsable, class_types = _tree_fingerprints(tree)
+        capture["tree"] = tree.to_tuple(**_TREE_TUPLE_KWARGS)
+        capture["stringify"] = re.sub(
+            r"Block: '[0-9a-f]+'", "Block: '<uuid>'", tree.stringify()
+        )
+        capture["raw"] = tree.raw
+        capture["segment_kwargs"] = segment_kwargs
+        capture["has_unparsable"] = has_unparsable
+        capture["class_types"] = class_types
+    return capture
+
+
+def _linted_capture_as_tuple(capture):
+    """Adapt linted_parse_capture's dict shape to check_expectations's shape.
+
+    Lets templated cases share the same expectation checks as plain parser
+    cases.
+    """
+    if capture.get("exc") is not None:
+        return capture["exc"]
+    if capture["tree"] is None:
+        message = "; ".join(msg for _, msg in capture["violations"])
+        return ("exc", "TemplateOrParseFailure", message, None, None, None, None, None)
+    return (
+        "tree",
+        capture["tree"],
+        capture["stringify"],
+        capture["raw"],
+        capture["segment_kwargs"],
+        capture["has_unparsable"],
+        capture["class_types"],
+    )
+
+
+def lex_capture(engine, config, sql):
+    """Lex ``sql`` with one lexer (``python``/``rust``); capture the stream.
+
+    Tokens are fingerprinted with their class, raw, type, position marker,
+    instance types and all normalization kwargs; lex errors with their type
+    and message.
+    """
+    from sqlfluff.core.parser.lexer import PyLexer, PyRsLexer
+
+    lexer_cls = PyLexer if engine == "python" else PyRsLexer
+    tokens, errors = lexer_cls(config=config).lex(sql)
+
+    def token_fingerprint(seg):
+        pos = seg.pos_marker
+        return (
+            type(seg).__name__,
+            seg.raw,
+            seg.get_type(),
+            tuple(sorted(seg.class_types)),
+            (
+                (pos.source_slice.start, pos.source_slice.stop),
+                (pos.templated_slice.start, pos.templated_slice.stop),
+                pos.working_line_no,
+                pos.working_line_pos,
+            )
+            if pos
+            else None,
+            tuple(
+                _normalize_kwarg(getattr(seg, attr, None))
+                for attr in (
+                    "trim_start",
+                    "trim_chars",
+                    "quoted_value",
+                    "escape_replacements",
+                    "casefold",
+                )
+            ),
+        )
+
+    return (
+        [token_fingerprint(token) for token in tokens],
+        [(type(err).__name__, str(err)) for err in errors],
+    )
+
+
+# ---------------------------------------------------------------------------
+# RsMatchResult structural invariants.
+#
+# A malformed match result (out-of-bounds slice, overlapping/unsorted
+# children, zero-length node carrying a class or children) is a rust-core bug
+# by definition: MatchResult.apply raises its internal "Segment skip ahead"
+# ValueError on overlap instead of a parse error, and silent shapes would
+# corrupt trees.
+# ---------------------------------------------------------------------------
+
+
+def _match_result_violations(rs_match, n_tokens, path="root"):
+    start, stop = rs_match.matched_slice
+    if start > stop:
+        yield (path, f"inverted slice ({start},{stop})")
+    if stop > n_tokens:
+        yield (path, f"slice out of bounds ({start},{stop}) n={n_tokens}")
+    if start == stop:
+        if rs_match.matched_class:
+            yield (path, f"zero-length with class {rs_match.matched_class}")
+        if rs_match.child_matches:
+            yield (path, "zero-length with children")
+    prev_end = start
+    prev_start = None
+    for i, child in enumerate(rs_match.child_matches):
+        cs, ce = child.matched_slice
+        if cs < start or ce > stop:
+            yield (
+                f"{path}[{i}]",
+                f"child ({cs},{ce}) outside parent ({start},{stop})",
+            )
+        if prev_start is not None and cs < prev_start:
+            yield (f"{path}[{i}]", f"children unsorted ({cs} after {prev_start})")
+        if cs < prev_end:
+            yield (
+                f"{path}[{i}]",
+                f"overlap: child starts {cs} before prev end {prev_end}",
+            )
+        prev_end = max(prev_end, ce)
+        prev_start = cs
+        yield from _match_result_violations(
+            child, n_tokens, f"{path}>{child.matched_class or '?'}[{i}]"
+        )
+    for idx, _seg_type, _impl in rs_match.insert_segments or []:
+        if idx < start or idx > stop:
+            yield (path, f"insert @{idx} outside ({start},{stop})")
+
+
+def raw_match_violations(sql, dialect):
+    """Parse SQL to a raw RsMatchResult and list structural violations."""
+    from sqlfluff.core.parser import Lexer
+
+    config = build_config(dialect=dialect)
+    segments, _ = Lexer(config=config).lex(sql)
+    parser = RustParser(config=config)
+    start = 0
+    for start in range(len(segments)):
+        if segments[start].is_code:
+            break
+    end = len(segments)
+    for end in range(len(segments), start - 1, -1):
+        if segments[end - 1].is_code:
+            break
+    if start == end:
+        return []
+    tokens = parser._extract_tokens_from_segments(segments[start:end])
+    try:
+        rs_match = parser._rs_parser.parse_match_result_from_tokens(tokens)
+    except Exception:
+        # Raising a parse error is fine; we only audit *returned* results.
+        # Deliberately NOT `except BaseException`: a rust-core panic surfaces
+        # as pyo3's PanicException (a BaseException, not an Exception) and is
+        # exactly the failure this leg exists to surface, so it must propagate
+        # and fail the test rather than be reported as zero violations.
+        return []
+    return list(_match_result_violations(rs_match, len(tokens)))
+
+
+# ---------------------------------------------------------------------------
+# Fixture-corpus loading (see test/fixtures/parity/README.md for the format).
+# ---------------------------------------------------------------------------
+
+
+def resolve_case_sql(case):
+    """Return the case's SQL: inline, or read from the dialect corpus."""
+    if "sql" in case:
+        return case["sql"]
+    return (DIALECT_FIXTURE_DIR / case["sql_fixture"]).read_text(encoding="utf-8")
+
+
+@lru_cache(maxsize=None)
+def _load_case_file(path_str):
+    """Parse one parity fixture file, cached by path.
+
+    ``load_case_params`` and ``load_reference_case_params`` each iterate every
+    fixture file for every kind, so without a cache the same YAML is re-parsed
+    several times per collection. The cached mapping is never mutated below
+    (``_meta`` is read, not popped), so the shared object is safe to reuse.
+    """
+    return yaml.safe_load(Path(path_str).read_text(encoding="utf-8"))
+
+
+def _iter_case_files(kind):
+    for path in sorted(PARITY_CASE_DIR.glob("*.yml")):
+        data = _load_case_file(str(path))
+        # An empty or comment-only fixture file parses to None (or an empty
+        # mapping); skip it rather than crashing collection of the whole suite.
+        if not data:
+            continue
+        meta = data.get("_meta", {})
+        if meta.get("kind", "parser") != kind:
+            continue
+        cases = {name: case for name, case in data.items() if name != "_meta"}
+        yield path, cases
+
+
+def load_case_params(kind, legs):
+    """Build pytest params: one per (case, leg), with per-leg strict xfails.
+
+    Every case runs on every leg of its kind. A known divergence is declared
+    per-leg in the case's ``xfail`` mapping, which becomes a STRICT xfail:
+    the moment the underlying gap is fixed, CI flags the stale marker.
+
+    Every key in a case's ``xfail`` mapping must name a real leg of the case's
+    kind. An unknown key (a typo, or a marker scoped to a leg this kind doesn't
+    run) is silently ignored by the per-leg lookup below and would leave a known
+    divergence unguarded, so it is rejected loudly at collection time instead.
+    """
+    valid_legs = set(legs)
+    params = []
+    for path, cases in _iter_case_files(kind):
+        for name, case in cases.items():
+            unknown = set(case.get("xfail") or {}) - valid_legs
+            if unknown:
+                raise ValueError(
+                    f"{path.name}:{name}: xfail leg(s) {sorted(unknown)} are not "
+                    f"valid legs for kind {kind!r} (expected one of {sorted(valid_legs)})"
+                )
+            for leg in legs:
+                marks = []
+                reason = (case.get("xfail") or {}).get(leg)
+                if reason:
+                    marks.append(pytest.mark.xfail(strict=True, reason=reason))
+                params.append(
+                    pytest.param(case, leg, id=f"{path.stem}:{name}:{leg}", marks=marks)
+                )
+    return params
+
+
+def load_reference_case_params(kind):
+    """Build pytest params for the reference-expectation sweep.
+
+    One per case that declares an ``expect`` (cases without one have nothing
+    to check).
+
+    Unlike ``load_case_params`` these carry no per-leg xfail marks - the
+    reference-expectation check runs unconditionally on the pure-Python leg, so
+    that a case whose parity comparison is a strict xfail still has its ``expect``
+    sanity conditions enforced (under the parity test the comparison assert fails
+    first and the strict xfail swallows any later ``expect`` failure).
+    """
+    params = []
+    for path, cases in _iter_case_files(kind):
+        for name, case in cases.items():
+            if case.get("expect"):
+                params.append(pytest.param(case, id=f"{path.stem}:{name}"))
+    return params
+
+
+def reference_capture(case):
+    """Capture the pure-Python reference leg for a parser case (templated or not).
+
+    Returns a tuple in the same shape ``check_expectations`` consumes.
+    """
+    sql = resolve_case_sql(case)
+    dialect = case.get("dialect", "ansi")
+    if case.get("templater"):
+        return _linted_capture_as_tuple(
+            linted_parse_capture(
+                "python",
+                sql,
+                dialect=dialect,
+                configs=case.get("configs"),
+                context=case.get("context"),
+            )
+        )
+    from sqlfluff.core.parser import Lexer
+
+    config = build_config(dialect, case.get("configs"))
+    segments, _ = Lexer(config=config).lex(sql)
+    return parse_capture("python", config, segments)
+
+
+def check_expectations(case, reference_capture):
+    """Assert the case's ``expect`` sanity conditions on the reference capture.
+
+    Expectations catch a case that quietly stops testing anything real (e.g.
+    "parses cleanly on both engines" would also pass if both engines crashed
+    the same way). They apply to the reference (pure-Python) leg only.
+    """
+    expectations = case.get("expect") or []
+    if isinstance(expectations, str):
+        expectations = [expectations]
+    for expectation in expectations:
+        if expectation == "tree":
+            assert reference_capture[0] == "tree", (
+                f"expected a parse tree, got: {reference_capture[:3]}"
+            )
+        elif expectation == "clean_tree":
+            assert reference_capture[0] == "tree", (
+                f"expected a parse tree, got: {reference_capture[:3]}"
+            )
+            assert not reference_capture[5], (
+                "expected a clean parse without unparsable segments"
+            )
+        elif expectation == "error":
+            assert reference_capture[0] == "exc", (
+                f"expected a raised error, got: {reference_capture[0]}"
+            )
+        elif expectation == "quoted_kwargs":
+            assert reference_capture[0] == "tree" and reference_capture[4], (
+                "expected at least one segment carrying normalization kwargs"
+            )
+        else:
+            raise ValueError(f"Unknown expectation: {expectation!r}")

--- a/test/core/parser/parity/corpus_test.py
+++ b/test/core/parser/parity/corpus_test.py
@@ -1,0 +1,151 @@
+"""Three-way parity sweep over the whole dialect fixture corpus.
+
+For every ``test/fixtures/dialects/**/*.sql`` fixture, parse the same lexer
+output three ways - the pure-Python Parser, RustParser's legacy convert+apply
+path, and RustParser's fused native-AST builder - and assert all three results
+are identical at full strictness.
+
+Parity must hold for every dialect since the engine flags affect all of them;
+covering the whole corpus also exercises the rarer builder branches (e.g.
+zero-length matches).
+"""
+
+import pytest
+
+from .compare import (
+    DIALECT_FIXTURE_DIR,
+    build_config,
+    parse_capture,
+    requires_rust_parser,
+)
+
+_FIXTURE_SQL = sorted(DIALECT_FIXTURE_DIR.glob("*/*.sql"))
+
+# Fixtures with a *known*, already-documented Python-vs-RustParser divergence
+# (pin each with a dedicated case in test/fixtures/parity/ before listing it
+# here). Three-way parity below is expected to fail on exactly these until
+# those bugs are fixed; everywhere else in the corpus, all three tree-building
+# paths must agree.
+_KNOWN_PYTHON_RUST_DIVERGENCES: set = {
+    # All of the fixtures below hit the same bug: RustParser forwards a
+    # re-wrapped token's lexer-level trim_chars (e.g. the '@'/'@@'
+    # sigil trimmed off MySQL/MariaDB/BigQuery session-variable and parameter
+    # tokens) into the new segment's kwargs, where Python's
+    # RawSegment.from_result_segments only ever carries over
+    # quoted_value/escape_replacements/casefold, never trim_chars. See the
+    # pinned case parser_created_segments_drop_token_trim_chars in
+    # test/fixtures/parity/regressions.yml.
+    ("bigquery", "handle_exception.sql"),
+    ("bigquery", "parameters.sql"),
+    ("bigquery", "set_variable_single.sql"),
+    ("mariadb", "call_statement.sql"),
+    ("mariadb", "create_trigger.sql"),
+    ("mariadb", "create_user.sql"),
+    ("mariadb", "execute_prepared_stmt_using.sql"),
+    ("mariadb", "execute_prepared_stmt_using_multiple_variable.sql"),
+    ("mariadb", "fetch_session.sql"),
+    ("mariadb", "fetch_session_multiple.sql"),
+    ("mariadb", "function_definer.sql"),
+    ("mariadb", "get_diagnostics_condition_info_multiple_variable.sql"),
+    ("mariadb", "get_diagnostics_condition_info_session_variable.sql"),
+    ("mariadb", "get_diagnostics_condition_session_variable.sql"),
+    ("mariadb", "get_diagnostics_number.sql"),
+    ("mariadb", "get_diagnostics_row_count.sql"),
+    ("mariadb", "grant.sql"),
+    ("mariadb", "if.sql"),
+    ("mariadb", "if_else.sql"),
+    ("mariadb", "if_elseif.sql"),
+    ("mariadb", "if_multiple_expression.sql"),
+    ("mariadb", "if_nested.sql"),
+    ("mariadb", "if_session_variable.sql"),
+    ("mariadb", "if_subquery_expression.sql"),
+    ("mariadb", "json_table.sql"),
+    ("mariadb", "load_data.sql"),
+    ("mariadb", "nested_begin.sql"),
+    ("mariadb", "prepare_session_variable.sql"),
+    ("mariadb", "procedure_definer.sql"),
+    ("mariadb", "repeat_label.sql"),
+    ("mariadb", "repeat_multiple_statements.sql"),
+    ("mariadb", "repeat_no_label.sql"),
+    ("mariadb", "select_into_multiple_variable.sql"),
+    ("mariadb", "select_into_session_variable.sql"),
+    ("mariadb", "select_session_variable.sql"),
+    ("mariadb", "set.sql"),
+    ("mariadb", "system_variables.sql"),
+    ("mariadb", "variable_assignment.sql"),
+    ("mysql", "call_statement.sql"),
+    ("mysql", "create_trigger.sql"),
+    ("mysql", "create_user.sql"),
+    ("mysql", "execute_prepared_stmt_using.sql"),
+    ("mysql", "execute_prepared_stmt_using_multiple_variable.sql"),
+    ("mysql", "fetch_session.sql"),
+    ("mysql", "fetch_session_multiple.sql"),
+    ("mysql", "function_definer.sql"),
+    ("mysql", "get_diagnostics_condition_info_multiple_variable.sql"),
+    ("mysql", "get_diagnostics_condition_info_session_variable.sql"),
+    ("mysql", "get_diagnostics_condition_session_variable.sql"),
+    ("mysql", "get_diagnostics_number.sql"),
+    ("mysql", "get_diagnostics_row_count.sql"),
+    ("mysql", "grant.sql"),
+    ("mysql", "if.sql"),
+    ("mysql", "if_else.sql"),
+    ("mysql", "if_elseif.sql"),
+    ("mysql", "if_multiple_expression.sql"),
+    ("mysql", "if_nested.sql"),
+    ("mysql", "if_session_variable.sql"),
+    ("mysql", "if_subquery_expression.sql"),
+    ("mysql", "json_table.sql"),
+    ("mysql", "load_data.sql"),
+    ("mysql", "nested_begin.sql"),
+    ("mysql", "prepare_session_variable.sql"),
+    ("mysql", "procedure_definer.sql"),
+    ("mysql", "repeat_label.sql"),
+    ("mysql", "repeat_multiple_statements.sql"),
+    ("mysql", "repeat_no_label.sql"),
+    ("mysql", "select_into_multiple_variable.sql"),
+    ("mysql", "select_into_session_variable.sql"),
+    ("mysql", "select_session_variable.sql"),
+    ("mysql", "set.sql"),
+    ("mysql", "system_variables.sql"),
+    ("mysql", "variable_assignment.sql"),
+}
+
+
+_KNOWN_DIVERGENCE_REASON = (
+    "Known Python-vs-RustParser divergence on this fixture; "
+    "see the pinned case in test/fixtures/parity/."
+)
+
+
+@requires_rust_parser
+@pytest.mark.parametrize(
+    "sqlfile",
+    _FIXTURE_SQL,
+    ids=[str(p.relative_to(DIALECT_FIXTURE_DIR)) for p in _FIXTURE_SQL],
+)
+def test__parity__dialect_fixture_corpus(sqlfile):
+    """All three tree-building paths agree on this fixture."""
+    from sqlfluff.core.parser import Lexer
+
+    config = build_config(dialect=sqlfile.parent.name)
+    segments, _ = Lexer(config=config).lex(sqlfile.read_text(encoding="utf-8"))
+
+    python_capture = parse_capture("python", config, segments, fname=str(sqlfile))
+    rust_capture = parse_capture("rust", config, segments, fname=str(sqlfile))
+    native_capture = parse_capture("rust-native", config, segments, fname=str(sqlfile))
+
+    # Native-vs-legacy parity is never a "known divergence": a failure here is
+    # always a bug in one of RustParser's two build paths, so it must never be
+    # silently swallowed by a python-vs-rust xfail below.
+    assert native_capture == rust_capture, "native-AST path diverges from convert+apply"
+
+    is_known = (sqlfile.parent.name, sqlfile.name) in _KNOWN_PYTHON_RUST_DIVERGENCES
+    matches = python_capture == rust_capture
+    if is_known:
+        if matches:
+            pytest.fail(
+                f"{sqlfile}: no longer diverges; remove this fixture from "
+                "_KNOWN_PYTHON_RUST_DIVERGENCES"
+            )
+        pytest.xfail(_KNOWN_DIVERGENCE_REASON)
+    assert matches, "RustParser diverges from Python Parser"

--- a/test/core/parser/rust_parser_test.py
+++ b/test/core/parser/rust_parser_test.py
@@ -529,93 +529,12 @@ def test__rust_parser__profiling_accumulates_and_resets():
 # Native (fused) AST builder parity
 # ---------------------------------------------------------------------------
 
-# All dialect fixtures, parametrized as (dialect, sqlfile). Parity must hold for
-# every dialect since the flag affects all of them; covering the whole corpus
-# also exercises the fused builder's rarer branches (e.g. zero-length matches).
+# The whole-corpus three-way sweep (Python vs RustParser legacy vs fused
+# native-AST) now lives in test/core/parser/parity/corpus_test.py, which
+# captures at strictly higher strictness (position markers, stringify,
+# class_types, normalization kwargs) than a to_tuple-only comparison here
+# would - so it is not duplicated in this module.
 _FIXTURE_DIR = Path(__file__).resolve().parents[3] / "test" / "fixtures" / "dialects"
-_FIXTURE_SQL = sorted(_FIXTURE_DIR.glob("*/*.sql"))
-
-# Fixtures with a *known*, already-documented Python-vs-RustParser divergence
-# (see the dedicated regression tests in this file). Three-way parity below
-# is expected to fail on exactly these until those bugs are fixed; everywhere
-# else in the corpus, all three tree-building paths must agree. Currently
-# empty: the pivot/unpivot divergences are fixed by this branch and the
-# snowflake/tsql ones were fixed on main.
-_KNOWN_PYTHON_RUST_DIVERGENCES: set = set()
-
-
-def _fixture_param(sqlfile: Path):
-    key = (sqlfile.parent.name, sqlfile.name)
-    if key in _KNOWN_PYTHON_RUST_DIVERGENCES:
-        return pytest.param(
-            sqlfile,
-            marks=pytest.mark.xfail(
-                strict=True,
-                reason=(
-                    "Known Python-vs-RustParser divergence on this fixture; "
-                    "see the dedicated test__rust_parser__vs_python_* "
-                    "regression for this file elsewhere in this module."
-                ),
-            ),
-        )
-    return pytest.param(sqlfile)
-
-
-@pytest.mark.skipif(not _HAS_RUST_PARSER, reason="Rust parser not available")
-@pytest.mark.parametrize(
-    "sqlfile",
-    [_fixture_param(p) for p in _FIXTURE_SQL],
-    ids=[str(p.relative_to(_FIXTURE_DIR)) for p in _FIXTURE_SQL],
-)
-def test__rust_parser__native_ast_parity(sqlfile):
-    """All three tree-building paths must agree: Python, RustParser, fused.
-
-    For every dialect fixture, parse the same lexer output three ways - the
-    pure-Python Parser, RustParser's legacy convert+apply path, and
-    RustParser's fused native-AST builder - and assert the resulting
-    BaseSegment trees (or raised exceptions) are all identical. Fixtures with
-    an already-documented Python-vs-RustParser divergence are marked xfail
-    (see _KNOWN_PYTHON_RUST_DIVERGENCES); every other fixture must agree
-    across all three paths.
-    """
-    from sqlfluff.core import FluffConfig
-    from sqlfluff.core.parser import Lexer, Parser
-    from sqlfluff.core.parser.rust_parser import set_native_ast
-
-    config = FluffConfig(overrides={"dialect": sqlfile.parent.name})
-    segments, _ = Lexer(config=config).lex(sqlfile.read_text(encoding="utf-8"))
-
-    def result_for(tree):
-        return (
-            "tree",
-            tree.to_tuple(code_only=False, show_raw=True, include_meta=True)
-            if tree
-            else None,
-        )
-
-    def build_rust(native: bool):
-        set_native_ast(native)
-        try:
-            tree = RustParser(config=config).parse(segments, fname=str(sqlfile))
-            return result_for(tree)
-        except BaseException as err:  # PanicException is a BaseException
-            return ("exc", type(err).__name__)
-        finally:
-            set_native_ast(False)
-
-    def build_python():
-        try:
-            tree = Parser(config=config).parse(segments, fname=str(sqlfile))
-            return result_for(tree)
-        except BaseException as err:
-            return ("exc", type(err).__name__)
-
-    python_result = build_python()
-    rust_default = build_rust(native=False)
-    rust_native = build_rust(native=True)
-
-    assert rust_native == rust_default, "native-AST path diverges from convert+apply"
-    assert python_result == rust_default, "RustParser diverges from Python Parser"
 
 
 @pytest.mark.skipif(not _HAS_RUST_PARSER, reason="Rust parser not available")

--- a/test/fixtures/parity/README.md
+++ b/test/fixtures/parity/README.md
@@ -1,0 +1,83 @@
+# Parity test cases
+
+Data-driven regression cases for the Python-vs-Rust engine parity suite.
+These fixtures are consumed by `test/core/parser/parity/cases_test.py`; the
+shared capture/compare machinery (and the full strictness contract) lives in
+`test/core/parser/parity/compare.py`.
+
+Parity tests are **differential**: the same input is run through two engine
+paths and the results must be identical. That's why cases carry only the
+input (SQL), the environment (dialect, config) and metadata - never an
+expected output. The Python engine is always the reference.
+
+## What do we mean by "strict" comparisons?
+
+Every comparison captures at **maximal** strictness:
+
+- the parse tree in tuple form with raws, metas and **position markers**,
+- `stringify()` bytes (which carry UnparsableSegment "Expected:" messages),
+- the raw round-trip,
+- per-segment normalization kwargs
+  (`quoted_value` / `escape_replacements` / `trim_chars` / `casefold`),
+- every leaf segment's full `class_types` set, not just its primary type
+  (`to_tuple()`/`stringify()` only ever show the primary type; a bare-class
+  `Ref` that wraps a token in an ancestor class can get the primary type
+  right while still losing class-level types from the token's own lineage),
+- for raised exceptions: type, message, and `SQLBaseError`
+  position/flag attributes (`PanicException` included),
+- for lexer cases: token class, raw, type, class_types, position marker and
+  normalization kwargs, plus lex errors with their messages.
+
+Every case is captured at this same full strictness. A known divergence is
+declared per-leg with an `xfail` entry instead, which becomes a **strict**
+xfail: the moment the underlying gap is fixed, CI flags the stale marker.
+
+## Case format
+
+Each `*.yml` file groups cases for one theme. Top-level keys are case names;
+an optional `_meta: {kind: ...}` key selects the driver:
+
+- `parser` (default) - runs each case on two legs:
+  - `python_vs_rust`: pure-Python `Parser` vs `RustParser` (legacy
+    convert+apply build path),
+  - `native_vs_legacy`: `RustParser`'s fused native-AST build path vs its
+    legacy path (Python-vs-legacy parity follows transitively).
+- `lexer` - one leg (`lexer`): `PyLexer` vs `PyRsLexer` token streams.
+- `invariants` - one leg (`invariants`): checks that the raw `RsMatchResult`
+  is structurally well-formed (bounds, ordering, overlap, zero-length
+  rules). This audits one engine directly rather than comparing two: a
+  violation is a rust-core bug by definition.
+
+Case fields:
+
+| Field         | Meaning |
+|---------------|---------|
+| `sql`         | Inline SQL input (mutually exclusive with `sql_fixture`). |
+| `sql_fixture` | Path under `test/fixtures/dialects/` to read the SQL from - use this when the repro is an already-shipped dialect fixture. |
+| `dialect`     | Dialect label; defaults to `ansi`. |
+| `configs`     | Optional config mapping. Plain keys are `FluffConfig` overrides (e.g. `max_parse_depth`); dotted keys are section paths applied via `set_value` (e.g. `indentation.indented_joins`), matching how ini-file values are typed (as int rather than bool). |
+| `templater`   | Set to `jinja` to drive the case through the Linter (template placeholder tokens; violations are compared too). |
+| `context`     | Jinja context variables for templated cases. |
+| `pins`        | REQUIRED, human documentation: the bug class this case pins, with issue/commit references where they exist. |
+| `expect`      | Optional sanity expectation(s), checked against the reference leg only, so the case keeps testing something real: `tree`, `clean_tree` (tree with no unparsable segments), `error`, `quoted_kwargs`. String or list. |
+| `xfail`       | Optional mapping of leg name → reason. Produces a strict xfail for that leg only. |
+
+## Adding a parity regression
+
+1. Minimize the repro to SQL + dialect + config.
+2. Add a case to the matching theme file (or start a new one) with a `pins`
+   description of the bug class.
+3. If the divergence is real and still open, declare it under `xfail` for
+   the diverging leg with a precise reason - CI will flag the marker as
+   stale the moment the engine gap closes, prompting its removal.
+4. Well-formed SQL that belongs in the dialect corpus should go to
+   `test/fixtures/dialects/` instead (the whole corpus is swept three-way by
+   `test/core/parser/parity/corpus_test.py`); reference it here via
+   `sql_fixture` only if it needs a pinned parity annotation.
+
+## Related testing
+
+- `test/core/parser/parity/corpus_test.py` - three-way sweep of every
+  dialect fixture at the same strictness.
+- `test/core/parser/parity/grammar_test.py` - confirms every ref in each
+  dialect's expanded grammar resolves to a real target.

--- a/test/fixtures/parity/README.md
+++ b/test/fixtures/parity/README.md
@@ -79,5 +79,3 @@ Case fields:
 
 - `test/core/parser/parity/corpus_test.py` - three-way sweep of every
   dialect fixture at the same strictness.
-- `test/core/parser/parity/grammar_test.py` - confirms every ref in each
-  dialect's expanded grammar resolves to a real target.

--- a/test/fixtures/parity/invariants_cases.yml
+++ b/test/fixtures/parity/invariants_cases.yml
@@ -1,0 +1,18 @@
+# Structural-invariant cases for test/core/parser/parity/cases_test.py.
+# See test/fixtures/parity/README.md for the schema and strictness contract.
+#
+# Each case audits (not compares) the raw RsMatchResult the Rust core returns:
+# slice bounds, child ordering, overlap and zero-length rules. A violation is a
+# rust-core bug by definition, so these carry no `xfail` leg.
+_meta:
+  kind: invariants
+nested_bracket_function_calls:
+  sql: SELECT f(a, (b + c), g(d)) FROM t WHERE (x IN (1, 2, 3))
+  pins: General structural well-formedness of a returned RsMatchResult over
+    nested brackets and function calls - guards MatchResult bounds/ordering/
+    overlap/zero-length invariants and keeps the invariants leg live (it
+    previously collected zero cases because no fixture declared kind:invariants).
+case_expression_and_cast:
+  sql: SELECT CASE WHEN a > 1 THEN CAST(b AS INT) ELSE c END FROM t
+  pins: Invariants over CASE/CAST nesting - a second live invariants case so the
+    leg exercises more than one match-tree shape.

--- a/test/fixtures/parity/regressions.yml
+++ b/test/fixtures/parity/regressions.yml
@@ -1,0 +1,264 @@
+# Parity test cases - data for test/core/parser/parity/cases_test.py.
+# See test/fixtures/parity/README.md for the schema and strictness contract.
+
+anything_dialect_exclude_bracket:
+  sql: CREATE TABLE t (c VARCHAR({- 1 -}) AS y)
+  dialect: snowflake
+  expect: tree
+  xfail:
+    python_vs_rust: "The Anything-grammar bracket path (core.rs
+      match_bracket_recursively, reached here via snowflake's
+      Bracketed(Anything()) column-datatype params) recognises the dialect's
+      exclude bracket '{-'/'-}' as a bracket pair, but two things differ from
+      Python's resolve_bracket: the leaf segments are typed
+      exclude_bracket_open/exclude_bracket_close where Python types them
+      start_exclude_bracket/end_exclude_bracket, and Rust does not wrap the
+      pair in its own nested `bracketed` node with indent/dedent metas - it
+      emits the two bracket tokens and their content as flat siblings of the
+      outer bracket instead."
+  pins: Dialect-specific bracket (snowflake's exclude bracket '{-'/'-}')
+    reached via the Anything-grammar bracket path (core.rs
+    match_bracket_recursively) - leaf typing and nested-node wrapping gap;
+    see anything_dialect_exclude_bracket_unclosed and
+    anything_crossed_ascii_bracket_raises for the crossed/unclosed variants of
+    the same path.
+anything_dialect_exclude_bracket_unclosed:
+  sql: CREATE TABLE t (c NUMBER({- x) AS y)
+  dialect: snowflake
+  xfail:
+    python_vs_rust: "For this crossed/unclosed dialect exclude bracket, Python's
+      resolve_bracket raises SQLParseError (\"Found unexpected end bracket!,
+      was expecting <StringParser: '-}'>, but got <StringParser: ')'>\"), but
+      core.rs's match_bracket_recursively does not detect the crossed
+      bracket and returns a fabricated tree instead."
+  pins: Crossed/unclosed variant of anything_dialect_exclude_bracket - Rust
+    does not raise where Python does.
+anything_crossed_ascii_bracket_raises:
+  sql: CREATE TABLE t (col VARCHAR(x ( y ] z )))
+  expect: error
+  xfail:
+    python_vs_rust: "Python's resolve_bracket raises SQLParseError (\"Found
+      unexpected end bracket!, was expecting <StringParser: ')'>, but got
+      <StringParser: ']'>\") for a wrong-type ASCII closing bracket crossed
+      inside an Anything() region, but core.rs's match_bracket_recursively
+      does not raise on the crossed bracket and returns a tree instead."
+  pins: ASCII-bracket variant of the same crossed-bracket detection gap as
+    anything_dialect_exclude_bracket_unclosed.
+bracketed_required_content_fails_at_close_bracket:
+  sql: select CAST(5);
+  dialect: tsql
+  expect: tree
+  xfail:
+    python_vs_rust: "A STRICT Bracketed whose required content element fails
+      exactly at the closing bracket (no trailing gap) still succeeds on the
+      Rust side with partial content. CastFunctionContents is
+      Bracketed(Expression, \"AS\", Datatype): on CAST(5) Expression matches
+      '5', the required \"AS\" fails at ')', and bracketed.rs - because check_pos
+      equals the closing-bracket position - skips the content-failure handling
+      and matches the close bracket anyway, fabricating a function node with
+      just the expression. Python's STRICT Sequence rejects the CAST and falls
+      back to a column_reference with the rest unparsable."
+  pins: tsql CAST(5)-without-AS partial-match-at-close-bracket gap in
+    bracketed.rs's STRICT required-content handling.
+bracketed_optional_content_failure_nothing_here:
+  sql: SELECT SUM(a) OVER (1 2 3) FROM t
+  expect: tree
+  pins: Bracketed content-failure message for a failed *optional* content
+    element (window function's WindowSpecificationSegment, optional=True,
+    parse_mode=GREEDY, failing on '1 2 3') - both engines fall back to the
+    generic "Nothing here." GREEDY-leftover message rather than the
+    required-element-specific "<elem> to start sequence/after X" wording.
+ansi_grant_all_masking_policies:
+  sql: GRANT SELECT ON ALL MASKING POLICIES IN SCHEMA s TO r
+  expect: error
+  xfail:
+    python_vs_rust: "Ansi grammar references the POLICIES keyword without registering it - Python's Ref raises RuntimeError the moment the branch is attempted, while Rust resolves the missing name to Empty and silently fails the branch."
+  pins: ansi grammar references the POLICIES keyword without registering it.
+ansi_grant_future_masking_policies:
+  sql: GRANT SELECT ON FUTURE MASKING POLICIES IN SCHEMA s TO r
+  expect: error
+  xfail:
+    python_vs_rust: 'FUTURE variant of the same POLICIES keyword gap.'
+  pins: FUTURE variant of the POLICIES keyword gap.
+ansi_grant_all_file_formats:
+  sql: GRANT SELECT ON ALL FILE FORMATS IN SCHEMA s TO r
+  expect: error
+  xfail:
+    python_vs_rust: 'Ansi grammar references the FORMATS keyword without registering it, the same dangling-ref class as the POLICIES gap.'
+  pins: ansi grammar references the FORMATS keyword without registering it.
+mysql_exchange_partition_table_reference:
+  sql: ALTER TABLE t EXCHANGE PARTITION p WITH TABLE t2 WITH VALIDATION
+  dialect: mysql
+  expect: error
+  xfail:
+    python_vs_rust: "Mysql EXCHANGE PARTITION grammar has Ref('TableReference') - a typo for TableReferenceSegment."
+  pins: mysql EXCHANGE PARTITION dangling-ref typo (TableReference vs TableReferenceSegment).
+postgres_alter_foreign_table_column_keyword:
+  sql: ALTER FOREIGN TABLE ft ALTER COLUMN c OPTIONS (ADD opt 'v')
+  dialect: postgres
+  expect: error
+  xfail:
+    python_vs_rust: 'Postgres ALTER FOREIGN TABLE ... ALTER COLUMN grammar has a dangling keyword reference.'
+  pins: "postgres ALTER FOREIGN TABLE has Ref('COLUMN') - a segment ref where the
+    COLUMN keyword was intended."
+parser_created_segments_drop_token_trim_chars:
+  sql: SET @errmsg = 'x';
+  dialect: mysql
+  expect: quoted_kwargs
+  xfail:
+    python_vs_rust: "Parser-created segments must inherit only quoted_value/escape_replacements/casefold from the lexed token, not trim_chars, matching RawSegment.from_result_segments - Rust forwards the token's trim_chars ('@',) instead."
+  pins: Rust forwards a re-wrapped token's lexer-level trim_chars (e.g. the '@'
+    sigil) into the new segment's kwargs, where Python's
+    RawSegment.from_result_segments never carries trim_chars over.
+partial_match_failure_keeps_children:
+  sql: SELECT CASE
+  xfail:
+    python_vs_rust: Rust appends a trailing period to the 'Found <Segment>' unparsable message
+      that Python's equivalent omits; the unparsable segment's children and the rest of the
+      tree are otherwise identical between engines.
+  pins: Found-message trailing-period gap, CASE-grammar variant; see sequence_found_message_no_trailing_period
+    for the STRUCT variant.
+stray_closing_bracket_dialect_bracket_set:
+  sql: SELECT 1 -} FROM t
+  dialect: snowflake
+  xfail:
+    python_vs_rust: 'Rust''s unparsable-recovery region for the unmatched dialect-specific
+      closing bracket (snowflake''s exclude-bracket ''-}'') does not stop at the bracket:
+      it keeps consuming subsequent tokens (FROM, the table reference) as raw words inside
+      the same unparsable segment, where Python recovers immediately after the stray bracket
+      and parses the FROM clause normally.'
+  pins: Dialect-specific stray closing bracket (snowflake '-}') recovery never closes.
+int_typed_indentation_config:
+  sql: SELECT a FROM t JOIN u USING (a)
+  configs:
+    indentation.indented_joins: 1
+  expect: tree
+  xfail:
+    python_vs_rust: With indentation.indented_joins set to the int 1 rather than the bool
+      True, Rust adds an extra indent/dedent pair around join_clause that Python's tree does
+      not produce.
+  pins: Int-typed vs bool indentation.indented_joins config value diverges.
+found_token_class_name:
+  sql: SELECT ] FROM t
+  dialect: flink
+  xfail:
+    python_vs_rust: 'Python''s ''Found <ClassName: ...>'' unparsable message names the found
+      token''s class CodeSegment while Rust names the identical token RawSegment, and Rust''s
+      message additionally has a trailing period Python''s omits.'
+  pins: Found-segment class name mismatch (flink ']'); see raw_block_survives for the templated-context
+    variant.
+found_token_repr_quoting:
+  sql: SELECT '
+  xfail:
+    python_vs_rust: For an unterminated string literal, Python's unparsable message wraps
+      the Expected/Found text in single quotes and backslash-escapes embedded apostrophes,
+      while Rust always double-quotes the outer message and escapes the embedded quote character
+      differently, so the same content renders with different quoting/escaping between engines.
+  pins: repr() quote-character/escaping choice differs for the unlexable-token found message.
+expected_message_curtailment:
+  sql: SELECT AS x
+  dialect: databricks
+  xfail:
+    python_vs_rust: When the Expected-grammar description in an unparsable message is long,
+      Rust truncates it mid-word with '...' while Python prints it in full; Rust's message
+      also has a trailing period Python's omits.
+  pins: Long Expected-grammar description gets truncated mid-word in Rust (databricks 'SELECT
+    AS x').
+sequence_found_message_no_trailing_period:
+  sql: SELECT STRUCT<a INT64(1)
+  dialect: bigquery
+  xfail:
+    python_vs_rust: Rust's Found-WordSegment-STRUCT unparsable message ends with a period
+      that Python's identical message omits; no other part of the tree differs.
+  pins: Canonical case for the Found-message trailing-period gap.
+sqlite_nothing_here_expected_message:
+  sql: "WITH cte AS (\n t\n)\nSELECT"
+  dialect: sqlite
+  xfail:
+    python_vs_rust: Where a CTE definition's body fails to start a SelectableGrammar, Python's
+      unparsable message names the specific expected grammar and found token, while Rust falls
+      back to the generic placeholder message 'Nothing here.'
+  pins: Generic vs specific fallback message for an empty CTE body (sqlite).
+materialize_curly_cross_silent_recovery:
+  sql: COPY t FROM STDIN (FORMAT {-
+  dialect: materialize
+  xfail:
+    python_vs_rust: For an unclosed regular bracket followed by an unclosed curly bracket
+      (materialize's COPY ... (FORMAT {- ), Python raises SQLParseError (couldn't find closing
+      bracket for opening bracket), while Rust silently recovers, producing a full tree with
+      the stray '(' and '{' folded into a trailing unparsable segment instead of raising.
+  pins: Crossed bracket-type recovery for materialize COPY ... FORMAT { syntax.
+tsql_cast_structure:
+  sql: select CAST(0X0 uniqueidentifier);
+  dialect: tsql
+  xfail:
+    python_vs_rust: 'Rust does not recognise tsql''s AS-less CAST(literal type) shorthand
+      cast syntax: Python parses it as a function call with a binary_literal argument and
+      a data_type, while Rust parses only CAST as a bare column reference and folds the remainder
+      of the statement into an unparsable segment.'
+  pins: tsql CAST(literal type) shorthand (no AS) grammar gap.
+materialize_webhook_overlapping_matches:
+  sql: "(\n ) ( );\nCREATE SOURCE my_webhook_source IN CLUSTER my_cluster FROM WEBHOOK\n BODY\
+    \ FORMAT JSON\n (\n (\n my_webhook_share"
+  dialect: materialize
+  xfail:
+    python_vs_rust: 'On this heavily cross-bracketed materialize webhook fragment, Python
+      raises a clean SQLParseError (couldn''t find closing bracket for opening bracket, at
+      line 6, position 2), while Rust raises an internal ValueError (segment skip ahead error:
+      an outer match contains overlapping child matches, this MatchResult was wrongly constructed),
+      indicating a genuine invariant violation in the Rust matcher rather than a parse error.'
+  pins: Rust match-invariant crash on deeply crossed/nested unmatched brackets (materialize
+    webhook fixture).
+depth_guard_error_position:
+  sql: SELECT CASE WHEN 1 THEN CASE WHEN 1 THEN CASE WHEN 1 THEN CASE WHEN 1 THEN CASE WHEN
+    1 THEN CASE WHEN 1 THEN CASE WHEN 1 THEN CASE WHEN 1 THEN CASE WHEN 1 THEN CASE WHEN 1
+    THEN CASE WHEN 1 THEN CASE WHEN 1 THEN CASE WHEN 1 THEN CASE WHEN 1 THEN CASE WHEN 1 THEN
+    CASE WHEN 1 THEN CASE WHEN 1 THEN CASE WHEN 1 THEN CASE WHEN 1 THEN CASE WHEN 1 THEN CASE
+    WHEN 1 THEN CASE WHEN 1 THEN CASE WHEN 1 THEN CASE WHEN 1 THEN CASE WHEN 1 THEN CASE WHEN
+    1 THEN CASE WHEN 1 THEN CASE WHEN 1 THEN CASE WHEN 1 THEN CASE WHEN 1 THEN CASE WHEN 1
+    THEN CASE WHEN 1 THEN CASE WHEN 1 THEN CASE WHEN 1 THEN CASE WHEN 1 THEN CASE WHEN 1 THEN
+    CASE WHEN 1 THEN CASE WHEN 1 THEN CASE WHEN 1 THEN CASE WHEN 1 THEN 0 END END END END
+    END END END END END END END END END END END END END END END END END END END END END END
+    END END END END END END END END END END END END END END
+  xfail:
+    python_vs_rust: Both engines raise SQLParseError 'Maximum parse depth exceeded (limit
+      600)...' for this deeply nested CASE expression, but Python attaches the real source
+      position (line 1, position 630) while Rust's exception defaults to (0, 0).
+  pins: Missing position marker on Rust's max-parse-depth exception.
+nested_case_unclosed:
+  sql: SELECT CASE WHEN 1 THEN CASE WHEN 1 THEN CASE WHEN 1 THEN CASE WHEN 1 THEN CASE WHEN
+    1 THEN CASE WHEN 1 THEN CASE WHEN 1 THEN CASE WHEN 1 THEN CASE WHEN 1 THEN CASE WHEN 1
+    THEN CASE WHEN 1 THEN CASE WHEN 1 THEN CASE WHEN 1 THEN CASE WHEN 1 THEN CASE WHEN 1 THEN
+    CASE WHEN 1 THEN CASE WHEN 1 THEN CASE WHEN 1 THEN CASE WHEN 1 THEN CASE WHEN 1 THEN CASE
+    WHEN 1 THEN CASE WHEN 1 THEN CASE WHEN 1 THEN CASE WHEN 1 THEN CASE WHEN 1 THEN CASE WHEN
+    1 THEN CASE WHEN 1 THEN CASE WHEN 1 THEN CASE WHEN 1 THEN CASE WHEN 1 THEN 0
+  xfail:
+    python_vs_rust: For this deeply nested, unclosed CASE expression, Python parses through
+      to a complete tree, while Rust raises a PanicException (parser exceeded maximum iteration
+      limit of 3000000), hitting a different guard than the max-parse-depth guard and producing
+      an exception where Python produces none.
+  pins: Rust iteration-limit panic vs Python full parse on unclosed deep CASE nesting.
+raw_block_survives:
+  sql: '{% raw %}SELECT {{ not_a_var }}{% endraw %} FROM t'
+  templater: jinja
+  context:
+    col: a
+    table: t
+  xfail:
+    python_vs_rust: Inside a jinja raw block that survives templating unexpanded, Python's
+      unparsable message names the found '{' token RawSegment and appends a trailing period,
+      while Rust names it CodeSegment without a trailing period.
+  pins: Found-segment class name and trailing period inside a jinja raw block; see found_token_class_name
+    for the non-templated variant (reversed class-name direction).
+postgres_eszett_function_name:
+  sql: SELECT straße(1)
+  dialect: postgres
+  expect: clean_tree
+  xfail:
+    python_vs_rust: Python's RegexParser matches case-insensitively against raw.upper()
+      - FULL unicode case mapping (eszett straße -> STRASSE) - while Rust's regex crate
+      only does simple case folding, under which the eszett never matches [A-Z]. The
+      word token 'straße' fails FunctionNameIdentifierSegment's template on the Rust
+      side only, so it parses as a bare column_reference there instead of a function
+      call.
+  pins: Unicode full-vs-simple case folding gap in RegexParser accept decisions.


### PR DESCRIPTION
### Brief summary of the change made
As the Rust parser/lexer move toward being the default engine, we need automated coverage that catches any behavioural divergence from the pure-Python engine before it reaches users, rather than relying on manual comparison or bug reports.

This adds a differential test harness, plus initial divergences identified with help of Claude, that runs the same SQL through the pure-Python engine and the Rust engine (`RustParser`/`PyRsLexer`) and asserts the results are identical. This is primarily test infrastructure, no parsing or lexing behaviour changes. However, adding a `get_native_ast` function.

New pieces:

- **`test/core/parser/parity/compare.py` + `cases_test.py`**: shared capture/compare logic and drivers for a data-driven fixture corpus (`test/fixtures/parity/*.yml`), covering four legs. Every comparison captures very strictly: tree tuple form with position markers, `stringify()` text, normalization kwargs, full `class_types` sets, and exception type/message/position (including Rust panics).
  - `python_vs_rust` (pure-Python `Parser` vs `RustParser`'s legacy path, Python as reference),
  - `native_vs_legacy` (RustParser's fused native-AST path vs its legacy path; any difference here is always a bug, never an accepted "known divergence"),
  - `lexer` (`PyLexer` vs `PyRsLexer`), and
  - `invariants` (structural well-formedness of the raw `RsMatchResult` tree).

  Of these, `lexer` is wired up but has no fixture cases yet (no `*.yml` declares `_meta: {kind: lexer}`), so it currently collects as a single empty/skipped parametrization; a follow-up will seed it the way this PR seeded `invariants`.

- **`test/core/parser/parity/corpus_test.py`**: sweeps every fixture under `test/fixtures/dialects/*/*.sql` through all three tree-building paths at the same strictness, so parity is exercised over the whole existing dialect corpus, not just hand-written cases.

- **`test/fixtures/parity/regressions.yml` + `README.md`**: the initial fixture corpus and format docs. A known, still-open divergence is declared per-leg via a **strict** `xfail`, so CI flags it as stale the moment the gap is fixed. This first batch documents 25 currently-known divergences; closing them is split across 5 focused follow-up PRs.

- **`test/fixtures/parity/invariants_cases.yml`**: gives the `invariants` leg its real cases, so it actually runs against real match trees. Currently no known issues but providing two test cases to ensure most obvious regressions don't happen.

- Removes the now-duplicate `test__rust_parser__native_ast_parity` from `rust_parser_test.py`, superseded by the stricter `corpus_test.py` sweep.

- One production-code addition: `rust_parser.py` gains a `get_native_ast()` getter (paired with the existing setter) so the harness can save/restore the native-AST flag per leg; no behaviour change.

### Are there any other side effects of this change that we should be aware of?
- Test suite runtime increases: the corpus sweep parses all dialect fixtures through three engine paths at full strictness, and `regressions.yml` currently carries strict `xfail` cases documenting open Python/Rust divergences, plus further strict xfails in `corpus_test.py` for the single already-diagnosed trim_chars bug across MySQL/MariaDB/BigQuery session-variable fixtures.

- The `lexer` leg exists in the harness but has zero cases today; it doesn't fail, it silently collects nothing. Flagging so it isn't mistaken for coverage that's already in place.

- No behavioural changes to the lexer or parser themselves; the only non-test change is the `get_native_ast()` getter described above.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- [x] Included test cases to demonstrate any code changes, which may be one or more of the following:
  - [ ] `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - [ ] `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - [ ] Full autofix test cases in `test/fixtures/linter/autofix`.
  - [x] Other: new `test/core/parser/parity/` suite plus `test/fixtures/parity/*.yml` fixtures (see above).
- [x] Added appropriate documentation for the change: `test/fixtures/parity/README.md` documents the fixture format and how to add a new parity regression.
- [ ] Created GitHub issues for any relevant followup/future enhancements if appropriate.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a strict Python-vs-Rust parity test harness for the parser and lexer, plus a whole-corpus three-way sweep. This detects divergences early and documents known gaps with strict xfails.

- **New Features**
  - Differential harness with four legs: `python_vs_rust`, `native_vs_legacy`, `lexer`, and `invariants`. Captures tree/positions/stringify/raw/normalization kwargs/class_types and errors for exact matching.
  - Corpus-wide sweep that parses every dialect fixture through `Parser`, `RustParser` (legacy), and `RustParser` native-AST, asserting identical results.
  - New fixture corpus under `test/fixtures/parity/*.yml` with strict per-leg `xfail` and a README for the format.
  - Invariants leg seeded with cases to check raw `RsMatchResult` structure.
  - Added `get_native_ast()` to `rust_parser.py` so tests can save/restore the native-AST flag.

- **Refactors**
  - Removed the weaker duplicate three-way parity test from `rust_parser_test.py`.
  - Test runtime increases due to the corpus sweep; `lexer` leg is wired but has no cases yet.
  - Dropped a stale reference to `grammar_test.py`.

<sup>Written for commit 137e5eae7a17ebe04918a5c1eb3e13164325244a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8198?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

