### PR TITLE
fix(ST06): protect materialized view column order

### DIFF
--- a/src/sqlfluff/rules/structure/ST06.py
+++ b/src/sqlfluff/rules/structure/ST06.py
@@ -57,11 +57,13 @@ class Rule_ST06(BaseRule):
             context: The rule context containing parent stack
 
         Returns:
-            True if this SELECT is in a CREATE VIEW with explicit columns
+            True if this SELECT is in a CREATE VIEW or MATERIALIZED VIEW with explicit columns
         """
-        # Traverse parent stack looking for create_view_statement
+        # Traverse parent stack looking for a view statement.
         for parent in context.parent_stack:
-            if parent.is_type("create_view_statement"):
+            if parent.is_type(
+                "create_view_statement", "create_materialized_view_statement"
+            ):
                 # Check if the view has an explicit column list
                 # Look for a bracketed segment containing column references
                 for child in parent.segments:

--- a/test/fixtures/rules/std_rule_cases/ST06.yml
+++ b/test/fixtures/rules/std_rule_cases/ST06.yml
@@ -370,6 +370,7 @@ test_fail_create_view_without_explicit_columns_tsql:
       TRY_CAST(e.id AS INT) AS employee_id,
       e.department
     FROM employees e
+
   line_numbers: [2]
 
   fix_str: |
@@ -415,3 +416,13 @@ test_pass_create_view_with_explicit_quoted_columns_clickhouse:
       TRY_CAST(e.id AS INT) AS eid,
       e.dept
     FROM employees e
+
+test_pass_create_materialized_view_with_explicit_columns_databricks:
+  configs:
+    core:
+      dialect: databricks
+  pass_str: |
+    CREATE MATERIALIZED VIEW typed_mv (first_value INT, second_value INT) AS
+    SELECT SUM(amount) AS total, id
+    FROM orders
+    GROUP BY id;


### PR DESCRIPTION
## Summary

- Prevent ST06 from reordering projections behind explicit Databricks materialized-view columns.
- Extend the existing explicit-column guard to `create_materialized_view_statement`.
- Add a Databricks regression fixture.

This is a distinct materialized-view AST path related to #8178, which covers ordinary BigQuery and ClickHouse `CREATE VIEW` column lists.

## Reproduction

```sql
CREATE MATERIALIZED VIEW typed_mv (
    first_value INT,
    second_value INT
) AS
SELECT SUM(amount) AS total, id
FROM orders
GROUP BY id;
```

On `main`, ST06 can reorder the projection to `id, SUM(amount) AS total`, changing positional output mapping while the declared column list stays unchanged.

## Testing

- `pytest -q test/rules/yaml_test_cases_test.py -k ST06`: 28 passed
- Ruff 0.15.5 check and format check: passed
- YAML lint: passed
- `git diff --check`: passed

## AI assistance

This change was prepared with Codex assistance for diagnosis, implementation, rebase, and test execution. I authorized the submission and remain responsible for the change. The validation above was rerun against current `main`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent `ST06` from reordering SELECT lists in `CREATE MATERIALIZED VIEW` statements with explicit column lists, preserving declared column order and positional mapping. Extends the explicit-column guard to cover Databricks materialized views.

- **Bug Fixes**
  - Handle `create_materialized_view_statement` in the explicit-column check so projections are not reordered when columns are declared.
  - Add a Databricks regression case to ensure `CREATE MATERIALIZED VIEW (...) AS SELECT ...` remains stable.

<sup>Written for commit f562a0a1abee4eb367d4749d8aed4d9feb9f8a85. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8199?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

