### PR TITLE
fix(ST04): avoid flattening volatile case operands

### DIFF
--- a/src/sqlfluff/rules/structure/ST04.py
+++ b/src/sqlfluff/rules/structure/ST04.py
@@ -69,6 +69,21 @@ class Rule_ST04(BaseRule):
         case2_first_when = case2_children.first(
             sp.is_type("when_clause", "else_clause")
         ).get()
+        # Repeating a function or other volatile expression can change the
+        # result. Flattening would evaluate the simple-CASE operand only once.
+        if any(
+            seg.is_type("function", "bare_function")
+            for operand in (
+                case1_children.select(
+                    start_seg=case1_first_case, stop_seg=case1_first_when
+                ),
+                case2_children.select(
+                    start_seg=case2_first_case, stop_seg=case2_first_when
+                ),
+            )
+            for seg in operand.recursive_crawl("function", "bare_function")
+        ):
+            return LintResult()
         # The len() checks below are for safety, to ensure the CASE inside
         # the ELSE is not part of a larger expression. In that case, it's
         # not safe to simplify in this way -- we'd be deleting other code.

--- a/test/fixtures/rules/std_rule_cases/ST04.yml
+++ b/test/fixtures/rules/std_rule_cases/ST04.yml
@@ -1,5 +1,16 @@
 rule: ST04
 
+test_pass_sqlite_repeated_function_operand:
+  configs:
+    core:
+      dialect: sqlite
+  pass_str: |
+    SELECT CASE tick() WHEN 1 THEN 'first' ELSE CASE tick() WHEN 2 THEN 'second' ELSE 'other' END END;
+
+test_pass_ansi_repeated_bare_function_operand:
+  pass_str: |
+    SELECT CASE CURRENT_DATE WHEN '2026-01-01' THEN 1 ELSE CASE CURRENT_DATE WHEN '2026-01-02' THEN 2 ELSE 3 END END;
+
 test_pass_1:
   # The nested CASE is under a "WHEN", not an "ELSE".
   pass_str: |


### PR DESCRIPTION
## Summary

- Avoid flattening nested simple `CASE` expressions when either operand contains a function call before its first `WHEN`.
- Preserve the existing flattening behavior for stable literal operands.
- Add a SQLite regression fixture.

## Reproduction

```sql
SELECT CASE tick()
    WHEN 1 THEN 'first'
    ELSE CASE tick() WHEN 2 THEN 'second' ELSE 'other' END
END;
```

With a SQLite `tick()` UDF returning `[0, 2]`, the original evaluates the function twice and returns `second`. The current ST04 fix evaluates it once and returns `other`.

## Testing

- `pytest -q test/rules/yaml_test_cases_test.py -k ST04`: 18 passed
- Ruff 0.15.5 check and format check: passed
- YAML lint: passed
- `git diff --check`: passed

## AI assistance

This change was prepared with Codex assistance for diagnosis, implementation, rebase, and test execution. I authorized the submission and remain responsible for the change. The validation above was rerun against current `main`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop ST04 from flattening nested simple CASE expressions when either operand includes a function or bare function before the first WHEN. This avoids extra evaluations of volatile expressions and preserves correct results; flattening still applies to literal operands, and SQLite + ANSI regression tests were added (including a bare-function case like CURRENT_DATE).

<sup>Written for commit 3fbe0d66f9771211f27f65fb81b1f282b8290879. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8200?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

