### PR TITLE
fix(ST05): avoid generated CTE name capture

### DIFF
--- a/src/sqlfluff/rules/structure/ST05.py
+++ b/src/sqlfluff/rules/structure/ST05.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Iterator
 from functools import partial
+from itertools import chain
 from typing import NamedTuple, Optional, TypeVar, cast
 
 from sqlfluff.core.dialects.base import Dialect
@@ -9,6 +10,7 @@ from sqlfluff.core.dialects.common import (
     AliasInfo,
     ObjectReferenceLevel,
     extract_possible_references,
+    iter_raw_references,
 )
 from sqlfluff.core.parser import (
     BaseSegment,
@@ -53,6 +55,17 @@ class _NestedSubQuerySummary(NamedTuple):
     selectable: Selectable
     table_alias: AliasInfo
     select_source_names: set[str]
+
+
+_NormalizedTableReference = tuple[BaseSegment, str]
+
+
+class _VisibleTableReferenceIndex(NamedTuple):
+    """Cached table references grouped by their top-level visibility scope."""
+
+    ctes: tuple[CTEDefinitionSegment, ...]
+    cte_references: tuple[tuple[_NormalizedTableReference, ...], ...]
+    root_references: tuple[_NormalizedTableReference, ...]
 
 
 class Rule_ST05(BaseRule):
@@ -180,6 +193,7 @@ class Rule_ST05(BaseRule):
             ctes=ctes,
             case_preference=case_preference,
             clone_map=clone_map,
+            root_segment=context.segment,
         )
 
         results_list: list[tuple[LintResult, BaseSegment, str, BaseSegment, bool]] = []
@@ -291,16 +305,13 @@ class Rule_ST05(BaseRule):
         ctes: "_CTEBuilder",
         case_preference: str,
         clone_map,
+        root_segment: BaseSegment,
     ) -> Iterator[tuple[LintResult, BaseSegment, str, BaseSegment, bool]]:
         """Given the root query, compute lint warnings."""
         nsq: _NestedSubQuerySummary
         for nsq in self._nested_subqueries(query, dialect):
-            alias_name, _ = ctes.create_cte_alias(nsq.table_alias)
             # 'anchor' is the TableExpressionSegment we fix/replace w/CTE name.
             anchor = nsq.table_alias.from_expression_element.segments[0]
-            # If we have duplicate CTE names just don't fix anything
-            # Return the lint warnings anyway
-            is_fixable = alias_name not in ctes.list_used_names()
 
             # if the subquery is table_expression, get the bracketed child instead.
             if anchor.is_type("table_expression"):
@@ -312,10 +323,32 @@ class Rule_ST05(BaseRule):
                 bracket_anchor = anchor
 
             # we can't create a CTE from a nested subquery here, ignore it.
-            if not bracket_anchor.is_type("bracketed") or bracket_anchor.get_child(
-                "table_expression"
-            ):
-                is_fixable = False
+            structurally_fixable = bracket_anchor.is_type(
+                "bracketed"
+            ) and not bracket_anchor.get_child("table_expression")
+            visible_table_names = (
+                ctes.list_visible_table_names(
+                    parent_selectable=nsq.selectable.selectable,
+                    extracted_subquery=bracket_anchor,
+                    root_segment=root_segment,
+                    dialect_name=dialect.name,
+                )
+                if structurally_fixable
+                else set()
+            )
+            alias_name, _ = ctes.create_cte_alias(
+                nsq.table_alias,
+                dialect=dialect,
+                reserved_names=visible_table_names,
+            )
+            # If we have duplicate CTE names just don't fix anything.
+            # Return the lint warnings anyway.
+            is_fixable = (
+                structurally_fixable
+                and alias_name not in ctes.list_used_names()
+                and _normalize_generated_identifier(alias_name, dialect)
+                not in visible_table_names
+            )
             if is_fixable:
                 new_cte = _create_cte_seg(  # 'prep_1 as (select ...)'
                     alias_name=alias_name,
@@ -388,6 +421,9 @@ class _CTEBuilder:
     def __init__(self) -> None:
         self.ctes: list[CTEDefinitionSegment] = []
         self.name_idx = 0
+        self._visible_table_reference_indexes: dict[
+            tuple[int, str], _VisibleTableReferenceIndex
+        ] = {}
 
     def list_used_names(self) -> list[str]:
         """Check CTEs and return used aliases."""
@@ -407,7 +443,13 @@ class _CTEBuilder:
         inbound_subquery = (
             Segments(cte).children().last(lambda seg: bool(seg.pos_marker))
         )
-        insert_position = next(
+        insert_position = self._insertion_position(inbound_subquery)
+
+        self.ctes.insert(insert_position, cte)
+
+    def _insertion_position(self, inbound_subquery: Segments) -> int:
+        """Return where a CTE must be inserted to precede its consumer."""
+        return next(
             (
                 i
                 for i, el in enumerate(self.ctes)
@@ -416,9 +458,182 @@ class _CTEBuilder:
             len(self.ctes),
         )
 
-        self.ctes.insert(insert_position, cte)
+    def list_visible_table_names(
+        self,
+        parent_selectable: BaseSegment,
+        extracted_subquery: BaseSegment,
+        root_segment: BaseSegment,
+        dialect_name: str,
+    ) -> set[str]:
+        """Return table names that a generated CTE could capture."""
+        reference_index = self._get_visible_table_reference_index(
+            root_segment, dialect_name
+        )
+        insert_position = next(
+            (
+                i
+                for i, cte in enumerate(reference_index.ctes)
+                if _is_child(
+                    Segments(cte).children().last(), Segments(parent_selectable)
+                )
+            ),
+            len(reference_index.ctes),
+        )
+        # SQLite permits forward references to later CTEs, so adding a CTE can
+        # also capture a physical-table reference in an earlier CTE body.
+        cte_references = (
+            reference_index.cte_references
+            if dialect_name == "sqlite"
+            else reference_index.cte_references[insert_position:]
+        )
+        table_references = chain.from_iterable(
+            (*cte_references, reference_index.root_references)
+        )
+        return {
+            normalized_reference
+            for table_reference, normalized_reference in table_references
+            if not _is_child(Segments(extracted_subquery), Segments(table_reference))
+        }
 
-    def create_cte_alias(self, alias: Optional[AliasInfo]) -> tuple[str, bool]:
+    def _get_visible_table_reference_index(
+        self, root_segment: BaseSegment, dialect_name: str
+    ) -> _VisibleTableReferenceIndex:
+        """Return a cached reference index for one parsed statement."""
+        cache_key = (id(root_segment), dialect_name)
+        cached_index = self._visible_table_reference_indexes.get(cache_key)
+        if cached_index is not None:
+            return cached_index
+
+        # The parsed statement is immutable during this rule evaluation. New
+        # generated CTEs reuse subqueries already present in this tree, so their
+        # references are already represented by this index.
+        ctes = tuple(
+            cast(CTEDefinitionSegment, child)
+            for child in root_segment.segments
+            if child.is_type("common_table_expression")
+        )
+        existing_cte_names = {
+            identifier.raw_normalized(casefold=True)
+            for cte in ctes
+            if (identifier := cte.get_identifier())
+        }
+
+        def normalized_references(
+            segment: BaseSegment,
+        ) -> Iterator[_NormalizedTableReference]:
+            for table_reference in self._iter_unshadowed_table_references(
+                segment, existing_cte_names, dialect_name
+            ):
+                normalized_reference = self._normalize_table_reference(
+                    table_reference, dialect_name
+                )
+                if normalized_reference:
+                    yield table_reference, normalized_reference
+
+        reference_index = _VisibleTableReferenceIndex(
+            ctes=ctes,
+            cte_references=tuple(tuple(normalized_references(cte)) for cte in ctes),
+            root_references=tuple(
+                reference
+                for child in root_segment.segments
+                if not child.is_type("common_table_expression")
+                for reference in normalized_references(child)
+            ),
+        )
+        self._visible_table_reference_indexes[cache_key] = reference_index
+        return reference_index
+
+    @classmethod
+    def _iter_unshadowed_table_references(
+        cls,
+        segment: BaseSegment,
+        scoped_cte_names: set[str],
+        dialect_name: str,
+    ) -> Iterator[BaseSegment]:
+        """Yield references that are not resolved by a nested CTE scope."""
+        if segment.is_type("with_compound_statement"):
+            ctes = [
+                cast(CTEDefinitionSegment, cte)
+                for cte in segment.segments
+                if cte.is_type("common_table_expression")
+            ]
+            if dialect_name == "sqlite":
+                # SQLite allows CTE bodies to refer to later CTE declarations.
+                local_cte_names = scoped_cte_names | {
+                    identifier.raw_normalized(casefold=True)
+                    for cte in ctes
+                    if (identifier := cte.get_identifier())
+                }
+                for child in segment.segments:
+                    yield from cls._iter_unshadowed_table_references(
+                        child, local_cte_names, dialect_name
+                    )
+                return
+
+            # Other supported dialects expose CTEs in declaration order. A
+            # recursive CTE can also see its own name while its body is parsed.
+            visible_cte_names = set(scoped_cte_names)
+            is_recursive = any(
+                child.is_type("keyword") and child.raw_upper == "RECURSIVE"
+                for child in segment.segments
+            )
+            for child in segment.segments:
+                if child.is_type("common_table_expression"):
+                    cte = cast(CTEDefinitionSegment, child)
+                    identifier = cte.get_identifier()
+                    cte_name = (
+                        identifier.raw_normalized(casefold=True) if identifier else None
+                    )
+                    child_scope = visible_cte_names
+                    if is_recursive and cte_name:
+                        child_scope = visible_cte_names | {cte_name}
+                    yield from cls._iter_unshadowed_table_references(
+                        child, child_scope, dialect_name
+                    )
+                    if cte_name:
+                        visible_cte_names.add(cte_name)
+                else:
+                    yield from cls._iter_unshadowed_table_references(
+                        child, visible_cte_names, dialect_name
+                    )
+            return
+
+        if segment.is_type("table_reference"):
+            normalized_reference = cls._normalize_table_reference(segment, dialect_name)
+            if (
+                normalized_reference is None
+                or normalized_reference not in scoped_cte_names
+            ):
+                yield segment
+            return
+        for child in segment.segments:
+            yield from cls._iter_unshadowed_table_references(
+                child, scoped_cte_names, dialect_name
+            )
+
+    @staticmethod
+    def _normalize_table_reference(
+        table_reference: BaseSegment, dialect_name: str
+    ) -> Optional[str]:
+        """Normalize an unqualified table reference using dialect case rules."""
+        reference_parts = list(
+            iter_raw_references(table_reference, dialect_name=dialect_name)
+        )
+        if len(reference_parts) != 1:
+            # A generated unqualified CTE name cannot capture a qualified
+            # reference such as schema.table.
+            return None
+        return "".join(
+            segment.raw_normalized(casefold=True)
+            for segment in reference_parts[0].segments
+        )
+
+    def create_cte_alias(
+        self,
+        alias: Optional[AliasInfo],
+        dialect: Dialect,
+        reserved_names: set[str] | None = None,
+    ) -> tuple[str, bool]:
         """Find or create the name for the next CTE."""
         if alias and alias.aliased and alias.ref_str:
             # If we know the name use it
@@ -426,9 +641,13 @@ class _CTEBuilder:
 
         self.name_idx = self.name_idx + 1
         name = f"prep_{self.name_idx}"
-        if name in self.list_used_names():
+        if name in self.list_used_names() or _normalize_generated_identifier(
+            name, dialect
+        ) in (reserved_names or set()):
             # corner case where prep_x exists in origin query
-            return self.create_cte_alias(None)
+            return self.create_cte_alias(
+                None, dialect=dialect, reserved_names=reserved_names
+            )
         return name, True
 
     def get_cte_segments(self) -> list[BaseSegment]:
@@ -571,6 +790,12 @@ def _create_cte_seg(
         )
     )
     return element
+
+
+def _normalize_generated_identifier(identifier: str, dialect: Dialect) -> str:
+    """Normalize a generated naked identifier using dialect case rules."""
+    casefold = getattr(dialect.ref("NakedIdentifierSegment"), "casefold", None)
+    return casefold(identifier) if casefold else identifier
 
 
 def _create_table_ref(table_name: str, dialect: Dialect) -> TableExpressionSegment:

--- a/src/sqlfluff/rules/structure/ST05.py
+++ b/src/sqlfluff/rules/structure/ST05.py
@@ -622,6 +622,8 @@ class _CTEBuilder:
 
             # Other supported dialects expose CTEs in declaration order. A
             # recursive CTE can also see its own name while its body is parsed.
+            # Oracle and Snowflake allow recursive CTEs without a RECURSIVE
+            # keyword, so their CTE definitions always introduce a local name.
             visible_cte_names = set(scoped_cte_names)
             for child in segment.segments:
                 if child.is_type("common_table_expression"):
@@ -631,7 +633,9 @@ class _CTEBuilder:
                         identifier.raw_normalized(casefold=True) if identifier else None
                     )
                     child_scope = visible_cte_names
-                    if is_recursive and cte_name:
+                    if (
+                        is_recursive or dialect_name in ("oracle", "snowflake")
+                    ) and cte_name:
                         child_scope = visible_cte_names | {cte_name}
                     yield from cls._iter_unshadowed_table_references(
                         child, child_scope, dialect_name

--- a/src/sqlfluff/rules/structure/ST05.py
+++ b/src/sqlfluff/rules/structure/ST05.py
@@ -488,7 +488,12 @@ class _CTEBuilder:
             for position, cte in enumerate(reference_index.ctes)
         }
         cte_is_forward_visible = dialect_name == "sqlite"
-        cte_is_self_visible = dialect_name in ("snowflake", "sqlite", "tsql")
+        cte_is_self_visible = dialect_name in (
+            "oracle",
+            "snowflake",
+            "sqlite",
+            "tsql",
+        )
         # SQLite permits forward references to later CTEs, so adding a CTE can
         # also capture a physical-table reference in an earlier CTE body.
         cte_references = (
@@ -512,8 +517,9 @@ class _CTEBuilder:
             for cte in self.ctes[:insert_position]
             if self._cte_position_key(cte) not in original_cte_positions
         )
-        # Snowflake, SQLite, and T-SQL expose a CTE name inside its own body,
-        # so those references can also be captured when the subquery becomes a CTE.
+        # Oracle, Snowflake, SQLite, and T-SQL expose a CTE name inside its own
+        # body, so those references can also be captured when the subquery becomes
+        # a CTE.
         return {
             normalized_reference
             for table_reference, normalized_reference in table_references

--- a/src/sqlfluff/rules/structure/ST05.py
+++ b/src/sqlfluff/rules/structure/ST05.py
@@ -346,8 +346,9 @@ class Rule_ST05(BaseRule):
             is_fixable = (
                 structurally_fixable
                 and alias_name not in ctes.list_used_names()
-                and _normalize_generated_identifier(alias_name, dialect)
-                not in visible_table_names
+                and not _identifier_is_reserved(
+                    alias_name, dialect, visible_table_names
+                )
             )
             if is_fixable:
                 new_cte = _create_cte_seg(  # 'prep_1 as (select ...)'
@@ -641,9 +642,9 @@ class _CTEBuilder:
 
         self.name_idx = self.name_idx + 1
         name = f"prep_{self.name_idx}"
-        if name in self.list_used_names() or _normalize_generated_identifier(
-            name, dialect
-        ) in (reserved_names or set()):
+        if name in self.list_used_names() or _identifier_is_reserved(
+            name, dialect, reserved_names
+        ):
             # corner case where prep_x exists in origin query
             return self.create_cte_alias(
                 None, dialect=dialect, reserved_names=reserved_names
@@ -796,6 +797,18 @@ def _normalize_generated_identifier(identifier: str, dialect: Dialect) -> str:
     """Normalize a generated naked identifier using dialect case rules."""
     casefold = getattr(dialect.ref("NakedIdentifierSegment"), "casefold", None)
     return casefold(identifier) if casefold else identifier
+
+
+def _identifier_is_reserved(
+    identifier: str, dialect: Dialect, reserved_names: set[str] | None
+) -> bool:
+    """Return whether raw or dialect-normalized identifier is reserved."""
+    if not reserved_names:
+        return False
+    return bool(
+        {identifier, _normalize_generated_identifier(identifier, dialect)}
+        & reserved_names
+    )
 
 
 def _create_table_ref(table_name: str, dialect: Dialect) -> TableExpressionSegment:

--- a/src/sqlfluff/rules/structure/ST05.py
+++ b/src/sqlfluff/rules/structure/ST05.py
@@ -490,10 +490,13 @@ class _CTEBuilder:
         table_references = chain.from_iterable(
             (*cte_references, reference_index.root_references)
         )
+        # SQLite exposes a CTE name inside its own body, so those references
+        # can also be captured when the subquery becomes a CTE.
         return {
             normalized_reference
             for table_reference, normalized_reference in table_references
-            if not _is_child(Segments(extracted_subquery), Segments(table_reference))
+            if dialect_name == "sqlite"
+            or not _is_child(Segments(extracted_subquery), Segments(table_reference))
         }
 
     def _get_visible_table_reference_index(

--- a/src/sqlfluff/rules/structure/ST05.py
+++ b/src/sqlfluff/rules/structure/ST05.py
@@ -488,7 +488,7 @@ class _CTEBuilder:
             for position, cte in enumerate(reference_index.ctes)
         }
         cte_is_forward_visible = dialect_name == "sqlite"
-        cte_is_self_visible = dialect_name in ("sqlite", "tsql")
+        cte_is_self_visible = dialect_name in ("snowflake", "sqlite", "tsql")
         # SQLite permits forward references to later CTEs, so adding a CTE can
         # also capture a physical-table reference in an earlier CTE body.
         cte_references = (
@@ -512,8 +512,8 @@ class _CTEBuilder:
             for cte in self.ctes[:insert_position]
             if self._cte_position_key(cte) not in original_cte_positions
         )
-        # SQLite and T-SQL expose a CTE name inside its own body, so those
-        # references can also be captured when the subquery becomes a CTE.
+        # Snowflake, SQLite, and T-SQL expose a CTE name inside its own body,
+        # so those references can also be captured when the subquery becomes a CTE.
         return {
             normalized_reference
             for table_reference, normalized_reference in table_references

--- a/src/sqlfluff/rules/structure/ST05.py
+++ b/src/sqlfluff/rules/structure/ST05.py
@@ -594,8 +594,15 @@ class _CTEBuilder:
                 for cte in segment.segments
                 if cte.is_type("common_table_expression")
             ]
-            if dialect_name == "sqlite":
-                # SQLite allows CTE bodies to refer to later CTE declarations.
+            is_recursive = any(
+                child.is_type("keyword") and child.raw_upper == "RECURSIVE"
+                for child in segment.segments
+            )
+            if dialect_name == "sqlite" or (
+                dialect_name == "bigquery" and is_recursive
+            ):
+                # SQLite always permits forward CTE references. BigQuery does
+                # so when the WITH clause includes the RECURSIVE keyword.
                 local_cte_names = scoped_cte_names | {
                     identifier.raw_normalized(casefold=True)
                     for cte in ctes
@@ -610,10 +617,6 @@ class _CTEBuilder:
             # Other supported dialects expose CTEs in declaration order. A
             # recursive CTE can also see its own name while its body is parsed.
             visible_cte_names = set(scoped_cte_names)
-            is_recursive = any(
-                child.is_type("keyword") and child.raw_upper == "RECURSIVE"
-                for child in segment.segments
-            )
             for child in segment.segments:
                 if child.is_type("common_table_expression"):
                     cte = cast(CTEDefinitionSegment, child)

--- a/src/sqlfluff/rules/structure/ST05.py
+++ b/src/sqlfluff/rules/structure/ST05.py
@@ -328,7 +328,6 @@ class Rule_ST05(BaseRule):
             ) and not bracket_anchor.get_child("table_expression")
             visible_table_names = (
                 ctes.list_visible_table_names(
-                    parent_selectable=nsq.selectable.selectable,
                     extracted_subquery=bracket_anchor,
                     root_segment=root_segment,
                     dialect_name=dialect.name,
@@ -461,7 +460,6 @@ class _CTEBuilder:
 
     def list_visible_table_names(
         self,
-        parent_selectable: BaseSegment,
         extracted_subquery: BaseSegment,
         root_segment: BaseSegment,
         dialect_name: str,
@@ -470,33 +468,51 @@ class _CTEBuilder:
         reference_index = self._get_visible_table_reference_index(
             root_segment, dialect_name
         )
-        insert_position = next(
-            (
-                i
-                for i, cte in enumerate(reference_index.ctes)
-                if _is_child(
-                    Segments(cte).children().last(), Segments(parent_selectable)
-                )
-            ),
-            len(reference_index.ctes),
-        )
+        insert_position = self._insertion_position(Segments(extracted_subquery))
+        original_cte_positions = {
+            id(cte): position for position, cte in enumerate(reference_index.ctes)
+        }
+        cte_is_forward_visible = dialect_name == "sqlite"
+        cte_is_self_visible = dialect_name in ("sqlite", "tsql")
         # SQLite permits forward references to later CTEs, so adding a CTE can
         # also capture a physical-table reference in an earlier CTE body.
         cte_references = (
             reference_index.cte_references
-            if dialect_name == "sqlite"
-            else reference_index.cte_references[insert_position:]
+            if cte_is_forward_visible
+            else tuple(
+                reference_index.cte_references[original_cte_positions[id(cte)]]
+                for cte in self.ctes[insert_position:]
+                if id(cte) in original_cte_positions
+            )
         )
         table_references = chain.from_iterable(
             (*cte_references, reference_index.root_references)
+        )
+        # A generated CTE before the insertion point cannot see the new CTE in
+        # sequential-scope dialects, so its body cannot be captured.
+        preceding_generated_cte_bodies = tuple(
+            Segments(cte).children().last()
+            for cte in self.ctes[:insert_position]
+            if id(cte) not in original_cte_positions
         )
         # SQLite and T-SQL expose a CTE name inside its own body, so those
         # references can also be captured when the subquery becomes a CTE.
         return {
             normalized_reference
             for table_reference, normalized_reference in table_references
-            if dialect_name in ("sqlite", "tsql")
-            or not _is_child(Segments(extracted_subquery), Segments(table_reference))
+            if (
+                cte_is_self_visible
+                or not _is_child(
+                    Segments(extracted_subquery), Segments(table_reference)
+                )
+            )
+            and (
+                cte_is_forward_visible
+                or not any(
+                    _is_child(generated_cte_body, Segments(table_reference))
+                    for generated_cte_body in preceding_generated_cte_bodies
+                )
+            )
         }
 
     def _get_visible_table_reference_index(

--- a/src/sqlfluff/rules/structure/ST05.py
+++ b/src/sqlfluff/rules/structure/ST05.py
@@ -704,16 +704,16 @@ class _CTEBuilder:
             # If we know the name use it
             return alias.ref_str, False
 
-        self.name_idx = self.name_idx + 1
-        name = f"prep_{self.name_idx}"
-        if name in self.list_used_names() or _identifier_is_reserved(
-            name, dialect, reserved_names
-        ):
-            # corner case where prep_x exists in origin query
-            return self.create_cte_alias(
-                None, dialect=dialect, reserved_names=reserved_names
-            )
-        return name, True
+        used_names = set(self.list_used_names())
+        while True:
+            self.name_idx += 1
+            name = f"prep_{self.name_idx}"
+            if name in used_names or _identifier_is_reserved(
+                name, dialect, reserved_names
+            ):
+                # Corner case where prep_x exists in the original query.
+                continue
+            return name, True
 
     def get_cte_segments(self) -> list[BaseSegment]:
         """Return a valid list of CTES with required padding segments."""

--- a/src/sqlfluff/rules/structure/ST05.py
+++ b/src/sqlfluff/rules/structure/ST05.py
@@ -490,12 +490,12 @@ class _CTEBuilder:
         table_references = chain.from_iterable(
             (*cte_references, reference_index.root_references)
         )
-        # SQLite exposes a CTE name inside its own body, so those references
-        # can also be captured when the subquery becomes a CTE.
+        # SQLite and T-SQL expose a CTE name inside its own body, so those
+        # references can also be captured when the subquery becomes a CTE.
         return {
             normalized_reference
             for table_reference, normalized_reference in table_references
-            if dialect_name == "sqlite"
+            if dialect_name in ("sqlite", "tsql")
             or not _is_child(Segments(extracted_subquery), Segments(table_reference))
         }
 

--- a/src/sqlfluff/rules/structure/ST05.py
+++ b/src/sqlfluff/rules/structure/ST05.py
@@ -458,6 +458,20 @@ class _CTEBuilder:
             len(self.ctes),
         )
 
+    @staticmethod
+    def _cte_position_key(cte: CTEDefinitionSegment) -> tuple[int, int, int, int]:
+        """Return a clone-stable source and templated span for a CTE body."""
+        cte_body = Segments(cte).children().last()[0]
+        assert cte_body.pos_marker
+        source_slice = cte_body.pos_marker.source_slice
+        templated_slice = cte_body.pos_marker.templated_slice
+        return (
+            source_slice.start,
+            source_slice.stop,
+            templated_slice.start,
+            templated_slice.stop,
+        )
+
     def list_visible_table_names(
         self,
         extracted_subquery: BaseSegment,
@@ -470,7 +484,8 @@ class _CTEBuilder:
         )
         insert_position = self._insertion_position(Segments(extracted_subquery))
         original_cte_positions = {
-            id(cte): position for position, cte in enumerate(reference_index.ctes)
+            self._cte_position_key(cte): position
+            for position, cte in enumerate(reference_index.ctes)
         }
         cte_is_forward_visible = dialect_name == "sqlite"
         cte_is_self_visible = dialect_name in ("sqlite", "tsql")
@@ -480,9 +495,11 @@ class _CTEBuilder:
             reference_index.cte_references
             if cte_is_forward_visible
             else tuple(
-                reference_index.cte_references[original_cte_positions[id(cte)]]
+                reference_index.cte_references[
+                    original_cte_positions[self._cte_position_key(cte)]
+                ]
                 for cte in self.ctes[insert_position:]
-                if id(cte) in original_cte_positions
+                if self._cte_position_key(cte) in original_cte_positions
             )
         )
         table_references = chain.from_iterable(
@@ -493,7 +510,7 @@ class _CTEBuilder:
         preceding_generated_cte_bodies = tuple(
             Segments(cte).children().last()
             for cte in self.ctes[:insert_position]
-            if id(cte) not in original_cte_positions
+            if self._cte_position_key(cte) not in original_cte_positions
         )
         # SQLite and T-SQL expose a CTE name inside its own body, so those
         # references can also be captured when the subquery becomes a CTE.
@@ -626,7 +643,22 @@ class _CTEBuilder:
             ):
                 yield segment
             return
+        # An INSERT target is not resolved through the CTE relation namespace.
+        insert_target = (
+            next(
+                (
+                    child
+                    for child in segment.segments
+                    if child.is_type("table_reference")
+                ),
+                None,
+            )
+            if segment.is_type("insert_statement")
+            else None
+        )
         for child in segment.segments:
+            if child is insert_target:
+                continue
             yield from cls._iter_unshadowed_table_references(
                 child, scoped_cte_names, dialect_name
             )

--- a/test/fixtures/rules/std_rule_cases/ST05.yml
+++ b/test/fixtures/rules/std_rule_cases/ST05.yml
@@ -1,5 +1,118 @@
 rule: ST05
 
+generated_cte_does_not_shadow_physical_table:
+  fail_str: |
+    WITH cte_a AS (
+      SELECT anchor.v
+      FROM (SELECT 1 AS v) AS anchor
+      JOIN (SELECT 2 AS v) AS victim ON 1 = 1
+    ),
+    cte_b AS (SELECT v FROM victim)
+    SELECT cte_a.v, cte_b.v FROM cte_a JOIN cte_b ON 1 = 1;
+
+generated_cte_does_not_shadow_quoted_physical_table:
+  fail_str: |
+    WITH cte_a AS (
+      SELECT anchor.v
+      FROM (SELECT 1 AS v) AS anchor
+      JOIN (SELECT 2 AS v) AS victim ON 1 = 1
+    ),
+    cte_b AS (SELECT v FROM "victim")
+    SELECT cte_a.v, cte_b.v FROM cte_a JOIN cte_b ON 1 = 1;
+  configs:
+    core:
+      dialect: sqlite
+
+generated_cte_does_not_shadow_forward_visible_earlier_cte_reference:
+  fail_str: |
+    WITH cte_earlier AS (
+      SELECT v FROM victim
+    ),
+    cte_later AS (
+      SELECT anchor.v
+      FROM (SELECT 1 AS v) AS anchor
+      JOIN (SELECT 2 AS v) AS victim ON 1 = 1
+    )
+    SELECT cte_earlier.v, cte_later.v FROM cte_earlier JOIN cte_later ON 1 = 1;
+  configs:
+    core:
+      dialect: sqlite
+
+generated_cte_does_not_shadow_later_nested_cte_name:
+  fail_str: |
+    WITH cte_earlier AS (
+      SELECT anchor.v
+      FROM (SELECT 1 AS v) AS anchor
+      JOIN (SELECT 2 AS v) AS victim ON 1 = 1
+    ),
+    cte_later AS (
+      WITH a AS (SELECT v FROM victim),
+      victim AS (SELECT 9 AS v)
+      SELECT v FROM a
+    )
+    SELECT cte_earlier.v, cte_later.v FROM cte_earlier JOIN cte_later ON 1 = 1;
+  configs:
+    core:
+      dialect: postgres
+
+generated_cte_may_reuse_prior_nested_cte_name:
+  fail_str: |
+    WITH cte_earlier AS (
+      SELECT anchor.v
+      FROM (SELECT 1 AS v) AS anchor
+      JOIN (SELECT 2 AS v) AS victim ON 1 = 1
+    ),
+    cte_later AS (
+      WITH victim AS (SELECT 9 AS v),
+      a AS (SELECT v FROM victim)
+      SELECT v FROM a
+    )
+    SELECT cte_earlier.v, cte_later.v FROM cte_earlier JOIN cte_later ON 1 = 1;
+  fix_str: |
+    WITH victim AS (SELECT 2 AS v),
+    cte_earlier AS (
+      SELECT anchor.v
+      FROM (SELECT 1 AS v) AS anchor
+      JOIN victim ON 1 = 1
+    ),
+    cte_later AS (
+      WITH victim AS (SELECT 9 AS v),
+      a AS (SELECT v FROM victim)
+      SELECT v FROM a
+    )
+    SELECT cte_earlier.v, cte_later.v FROM cte_earlier JOIN cte_later ON 1 = 1;
+  configs:
+    core:
+      dialect: postgres
+
+generated_cte_may_reuse_nested_locally_shadowed_name:
+  fail_str: |
+    WITH cte_earlier AS (
+      SELECT anchor.v
+      FROM (SELECT 1 AS v) AS anchor
+      JOIN (SELECT 2 AS v) AS victim ON 1 = 1
+    ),
+    cte_later AS (
+      WITH victim AS (SELECT 9 AS v)
+      SELECT v FROM victim
+    )
+    SELECT cte_earlier.v, cte_later.v FROM cte_earlier JOIN cte_later ON 1 = 1;
+  fix_str: |
+    WITH victim AS (SELECT 2 AS v),
+    cte_earlier AS (
+      SELECT anchor.v
+      FROM (SELECT 1 AS v) AS anchor
+      JOIN victim ON 1 = 1
+    ),
+    cte_later AS (
+      WITH victim AS (SELECT 9 AS v)
+      SELECT v FROM victim
+    )
+    SELECT cte_earlier.v, cte_later.v FROM cte_earlier JOIN cte_later ON 1 = 1;
+  configs:
+    core:
+      dialect: sqlite
+
 select_fail:
   fail_str: |
     select

--- a/test/fixtures/rules/std_rule_cases/ST05.yml
+++ b/test/fixtures/rules/std_rule_cases/ST05.yml
@@ -123,6 +123,30 @@ generated_cte_does_not_self_capture_snowflake_physical_table:
     core:
       dialect: snowflake
 
+generated_cte_does_not_self_capture_oracle_physical_table:
+  fail_str: |
+    SELECT *
+    FROM base
+    JOIN (SELECT v FROM victim) victim ON 1 = 1
+  fix_str: |
+    SELECT *
+    FROM base
+    JOIN (SELECT v FROM victim) victim ON 1 = 1
+  violations_after_fix:
+    - description: select_statement clauses should not contain subqueries. Use CTEs instead
+      name: structure.subquery
+      warning: false
+      fixes: []
+      start_line_no: 3
+      start_line_pos: 6
+      start_file_pos: 24
+      end_line_no: 3
+      end_line_pos: 7
+      end_file_pos: 25
+  configs:
+    core:
+      dialect: oracle
+
 generated_cte_may_reuse_postgres_body_table_name:
   fail_str: |
     SELECT *

--- a/test/fixtures/rules/std_rule_cases/ST05.yml
+++ b/test/fixtures/rules/std_rule_cases/ST05.yml
@@ -172,6 +172,85 @@ generated_ctes_skip_unsafe_backward_dependency:
     core:
       dialect: postgres
 
+generated_ctes_keep_existing_cte_reference_group_after_clone:
+  fail_str: |
+    WITH host AS (
+      SELECT *
+      FROM victim AS vbase
+      JOIN (SELECT 1 AS v) AS first ON true
+      JOIN (SELECT 2 AS v) AS victim ON true
+    )
+    SELECT * FROM host
+  fix_str: |
+    WITH first AS (SELECT 1 AS v),
+    host AS (
+      SELECT *
+      FROM victim AS vbase
+      JOIN first ON true
+      JOIN (SELECT 2 AS v) AS victim ON true
+    )
+    SELECT * FROM host
+  violations_after_fix:
+    - description: select_statement clauses should not contain subqueries. Use CTEs instead
+      name: structure.subquery
+      warning: false
+      fixes: []
+      start_line_no: 6
+      start_line_pos: 8
+      start_file_pos: 103
+      end_line_no: 6
+      end_line_pos: 9
+      end_file_pos: 104
+  configs:
+    core:
+      dialect: postgres
+
+generated_cte_ignores_postgres_insert_target:
+  fail_str: |
+    WITH seed AS (SELECT 1 AS v)
+    INSERT INTO victim
+    SELECT seed.v
+    FROM seed
+    JOIN (SELECT 2 AS v) AS victim ON true
+  fix_str: |
+    WITH seed AS (SELECT 1 AS v),
+    victim AS (SELECT 2 AS v)
+    INSERT INTO victim
+    SELECT seed.v
+    FROM seed
+    JOIN victim ON true
+  configs:
+    core:
+      dialect: postgres
+
+generated_cte_preserves_postgres_insert_source_reference:
+  fail_str: |
+    WITH seed AS (SELECT 1 AS v)
+    INSERT INTO sink
+    SELECT source.v
+    FROM victim AS source
+    JOIN (SELECT 2 AS v) AS victim ON true
+  fix_str: |
+    WITH seed AS (SELECT 1 AS v)
+    INSERT INTO sink
+    SELECT source.v
+    FROM victim AS source
+    JOIN (SELECT 2 AS v) AS victim ON true
+  violations_after_fix:
+    - description: select_statement clauses should not contain subqueries. Use CTEs instead
+      name: structure.subquery
+      warning: false
+      fixes: []
+      start_line_no: 5
+      start_line_pos: 6
+      start_file_pos: 89
+      end_line_no: 5
+      end_line_pos: 7
+      end_file_pos: 90
+  configs:
+    core:
+      dialect: postgres
+
 generated_cte_does_not_shadow_forward_visible_earlier_cte_reference:
   fail_str: |
     WITH cte_earlier AS (

--- a/test/fixtures/rules/std_rule_cases/ST05.yml
+++ b/test/fixtures/rules/std_rule_cases/ST05.yml
@@ -113,6 +113,28 @@ generated_cte_may_reuse_postgres_body_table_name:
     core:
       dialect: postgres
 
+generated_cte_may_reuse_bigquery_recursive_sibling_name:
+  fail_str: |
+    SELECT *
+    FROM base
+    JOIN (
+      WITH RECURSIVE a AS (SELECT * FROM victim),
+      victim AS (SELECT 1 AS v)
+      SELECT * FROM a
+    ) AS victim ON true
+  fix_str: |
+    WITH victim AS (
+      WITH RECURSIVE a AS (SELECT * FROM victim),
+      victim AS (SELECT 1 AS v)
+      SELECT * FROM a
+    )
+    SELECT *
+    FROM base
+    JOIN victim ON true
+  configs:
+    core:
+      dialect: bigquery
+
 generated_ctes_extract_safe_forward_dependency_in_one_pass:
   fail_str: |
     SELECT *

--- a/test/fixtures/rules/std_rule_cases/ST05.yml
+++ b/test/fixtures/rules/std_rule_cases/ST05.yml
@@ -75,6 +75,30 @@ generated_cte_does_not_self_capture_sqlite_physical_table:
     core:
       dialect: sqlite
 
+generated_cte_does_not_self_capture_tsql_physical_table:
+  fail_str: |
+    SELECT *
+    FROM base
+    JOIN (SELECT v FROM victim) AS victim ON 1 = 1
+  fix_str: |
+    SELECT *
+    FROM base
+    JOIN (SELECT v FROM victim) AS victim ON 1 = 1
+  violations_after_fix:
+    - description: select_statement clauses should not contain subqueries. Use CTEs instead
+      name: structure.subquery
+      warning: false
+      fixes: []
+      start_line_no: 3
+      start_line_pos: 6
+      start_file_pos: 24
+      end_line_no: 3
+      end_line_pos: 7
+      end_file_pos: 25
+  configs:
+    core:
+      dialect: tsql
+
 generated_cte_may_reuse_postgres_body_table_name:
   fail_str: |
     SELECT *

--- a/test/fixtures/rules/std_rule_cases/ST05.yml
+++ b/test/fixtures/rules/std_rule_cases/ST05.yml
@@ -99,6 +99,30 @@ generated_cte_does_not_self_capture_tsql_physical_table:
     core:
       dialect: tsql
 
+generated_cte_does_not_self_capture_snowflake_physical_table:
+  fail_str: |
+    SELECT *
+    FROM base
+    JOIN (SELECT v FROM victim) AS victim ON true
+  fix_str: |
+    SELECT *
+    FROM base
+    JOIN (SELECT v FROM victim) AS victim ON true
+  violations_after_fix:
+    - description: select_statement clauses should not contain subqueries. Use CTEs instead
+      name: structure.subquery
+      warning: false
+      fixes: []
+      start_line_no: 3
+      start_line_pos: 6
+      start_file_pos: 24
+      end_line_no: 3
+      end_line_pos: 7
+      end_file_pos: 25
+  configs:
+    core:
+      dialect: snowflake
+
 generated_cte_may_reuse_postgres_body_table_name:
   fail_str: |
     SELECT *

--- a/test/fixtures/rules/std_rule_cases/ST05.yml
+++ b/test/fixtures/rules/std_rule_cases/ST05.yml
@@ -147,6 +147,62 @@ generated_cte_does_not_self_capture_oracle_physical_table:
     core:
       dialect: oracle
 
+generated_cte_may_reuse_snowflake_keywordless_recursive_cte_name:
+  fail_str: |
+    SELECT *
+    FROM base
+    JOIN (
+      WITH victim(n) AS (
+        SELECT 1
+        UNION ALL
+        SELECT n + 1 FROM victim WHERE n < 2
+      )
+      SELECT * FROM victim
+    ) AS victim ON true
+  fix_str: |
+    WITH victim AS (
+      WITH victim(n) AS (
+        SELECT 1
+        UNION ALL
+        SELECT n + 1 FROM victim WHERE n < 2
+      )
+      SELECT * FROM victim
+    )
+    SELECT *
+    FROM base
+    JOIN victim ON true
+  configs:
+    core:
+      dialect: snowflake
+
+generated_cte_may_reuse_oracle_keywordless_recursive_cte_name:
+  fail_str: |
+    SELECT *
+    FROM base
+    JOIN (
+      WITH victim(n) AS (
+        SELECT 1 FROM dual
+        UNION ALL
+        SELECT n + 1 FROM victim WHERE n < 2
+      )
+      SELECT * FROM victim
+    ) victim ON 1 = 1
+  fix_str: |
+    WITH victim AS (
+      WITH victim(n) AS (
+        SELECT 1 FROM dual
+        UNION ALL
+        SELECT n + 1 FROM victim WHERE n < 2
+      )
+      SELECT * FROM victim
+    )
+    SELECT *
+    FROM base
+    JOIN victim ON 1 = 1
+  configs:
+    core:
+      dialect: oracle
+
 generated_cte_may_reuse_postgres_body_table_name:
   fail_str: |
     SELECT *

--- a/test/fixtures/rules/std_rule_cases/ST05.yml
+++ b/test/fixtures/rules/std_rule_cases/ST05.yml
@@ -23,6 +23,34 @@ generated_cte_does_not_shadow_quoted_physical_table:
     core:
       dialect: sqlite
 
+generated_cte_does_not_shadow_bigquery_physical_table:
+  fail_str: |
+    SELECT b.y
+    FROM prep_1 AS b
+    JOIN (SELECT 0 AS y) ON b.y >= 0
+  fix_str: |
+    WITH prep_2 AS (SELECT 0 AS y)
+    SELECT b.y
+    FROM prep_1 AS b
+    JOIN prep_2 ON b.y >= 0
+  configs:
+    core:
+      dialect: bigquery
+
+generated_cte_may_reuse_bigquery_qualified_table_name:
+  fail_str: |
+    SELECT b.y
+    FROM dataset.prep_1 AS b
+    JOIN (SELECT 0 AS y) ON b.y >= 0
+  fix_str: |
+    WITH prep_1 AS (SELECT 0 AS y)
+    SELECT b.y
+    FROM dataset.prep_1 AS b
+    JOIN prep_1 ON b.y >= 0
+  configs:
+    core:
+      dialect: bigquery
+
 generated_cte_does_not_shadow_forward_visible_earlier_cte_reference:
   fail_str: |
     WITH cte_earlier AS (

--- a/test/fixtures/rules/std_rule_cases/ST05.yml
+++ b/test/fixtures/rules/std_rule_cases/ST05.yml
@@ -113,6 +113,65 @@ generated_cte_may_reuse_postgres_body_table_name:
     core:
       dialect: postgres
 
+generated_ctes_extract_safe_forward_dependency_in_one_pass:
+  fail_str: |
+    SELECT *
+    FROM base
+    JOIN (SELECT v FROM physical_later) AS earlier ON true
+    JOIN (SELECT v FROM source_table) AS physical_later ON true
+  fix_str: |
+    WITH earlier AS (SELECT v FROM physical_later),
+    physical_later AS (SELECT v FROM source_table)
+    SELECT *
+    FROM base
+    JOIN earlier ON true
+    JOIN physical_later ON true
+  configs:
+    core:
+      dialect: postgres
+      runaway_limit: 2
+
+generated_ctes_skip_unsafe_backward_dependency:
+  fail_str: |
+    SELECT *
+    FROM base
+    JOIN (SELECT 1 AS v) AS victim ON true
+    JOIN (SELECT v FROM victim) AS later ON true
+  fix_str: |
+    WITH later AS (SELECT v FROM victim)
+    SELECT *
+    FROM base
+    JOIN (SELECT 1 AS v) AS victim ON true
+    JOIN later ON true
+  violations_after_fix:
+    - description: select_statement clauses should not contain subqueries. Use CTEs instead
+      name: structure.subquery
+      warning: false
+      fixes:
+        - type: replace
+          edit: |-
+            WITH later AS (SELECT v FROM victim),
+            victim AS (SELECT 1 AS v)
+            SELECT *
+            FROM base
+            JOIN victim ON true
+            JOIN later ON true
+          start_line_no: 1
+          start_line_pos: 1
+          start_file_pos: 0
+          end_line_no: 5
+          end_line_pos: 19
+          end_file_pos: 113
+      start_line_no: 4
+      start_line_pos: 6
+      start_file_pos: 61
+      end_line_no: 4
+      end_line_pos: 7
+      end_file_pos: 62
+  configs:
+    core:
+      dialect: postgres
+
 generated_cte_does_not_shadow_forward_visible_earlier_cte_reference:
   fail_str: |
     WITH cte_earlier AS (

--- a/test/fixtures/rules/std_rule_cases/ST05.yml
+++ b/test/fixtures/rules/std_rule_cases/ST05.yml
@@ -51,6 +51,44 @@ generated_cte_may_reuse_bigquery_qualified_table_name:
     core:
       dialect: bigquery
 
+generated_cte_does_not_self_capture_sqlite_physical_table:
+  fail_str: |
+    SELECT *
+    FROM base
+    JOIN (SELECT v FROM victim) AS victim ON true
+  fix_str: |
+    SELECT *
+    FROM base
+    JOIN (SELECT v FROM victim) AS victim ON true
+  violations_after_fix:
+    - description: select_statement clauses should not contain subqueries. Use CTEs instead
+      name: structure.subquery
+      warning: false
+      fixes: []
+      start_line_no: 3
+      start_line_pos: 6
+      start_file_pos: 24
+      end_line_no: 3
+      end_line_pos: 7
+      end_file_pos: 25
+  configs:
+    core:
+      dialect: sqlite
+
+generated_cte_may_reuse_postgres_body_table_name:
+  fail_str: |
+    SELECT *
+    FROM base
+    JOIN (SELECT v FROM victim) AS victim ON true
+  fix_str: |
+    WITH victim AS (SELECT v FROM victim)
+    SELECT *
+    FROM base
+    JOIN victim ON true
+  configs:
+    core:
+      dialect: postgres
+
 generated_cte_does_not_shadow_forward_visible_earlier_cte_reference:
   fail_str: |
     WITH cte_earlier AS (

--- a/test/rules/std_ST05_test.py
+++ b/test/rules/std_ST05_test.py
@@ -1,0 +1,15 @@
+"""Tests specific to ST05."""
+
+from sqlfluff.core.dialects import dialect_selector
+from sqlfluff.rules.structure.ST05 import _CTEBuilder
+
+
+def test__rules__std_ST05_allocates_generated_alias_iteratively() -> None:
+    """A long run of reserved aliases does not exhaust Python's call stack."""
+    reserved_names = {f"prep_{index}" for index in range(1, 2001)}
+
+    assert _CTEBuilder().create_cte_alias(
+        None,
+        dialect=dialect_selector("ansi"),
+        reserved_names=reserved_names,
+    ) == ("prep_2001", True)


### PR DESCRIPTION
### Brief summary of the change made

ST05 can generate a CTE name that captures an existing physical-table reference. This change:

- accounts for SQLite forward CTE visibility and nested CTE shadowing;
- reserves visible physical-table names during generated-name selection;
- caches normalized table-reference groups once per parsed statement, avoiding a recursive full-statement walk for every offending subquery;
- adds focused regression fixtures for capture, declaration order, and nested shadowing.

Reproduction:

```sql
WITH cte_a AS (
    SELECT anchor.v
    FROM (SELECT 1 AS v) AS anchor
    JOIN (SELECT 2 AS v) AS victim ON 1 = 1
),
cte_b AS (SELECT v FROM victim)
SELECT cte_a.v, cte_b.v
FROM cte_a JOIN cte_b ON 1 = 1;
```

On `main`, ST05 can generate a CTE named `victim`, causing the later unqualified reference to resolve to the generated CTE instead of the physical table.

### Are there any other side effects of this change that we should be aware of?

The cache is private to one ST05 evaluation and keyed by the parsed statement and dialect. The parsed statement is immutable during evaluation; generated CTEs reuse subqueries already present in that tree. There are no configuration or public API changes.

### Validation

- `uv run pytest test/rules/yaml_test_cases_test.py -k ST05 -q`: 50 passed.
- `uv run pytest test/rules/std_ST05_LT08_test.py test/rules/std_ST05_LT09_test.py -q`: 3 passed.
- `uv run pytest test/rules -q`: 2,471 passed, 101 skipped.
- Ruff format and check: passed.
- MyPy for `ST05.py`: passed.
- `git diff --check`: passed.

Repository CI has not been scheduled for this fork update; maintainer review remains pending.

### Pull Request checklist

- [x] Included YAML rule test cases that demonstrate the bug and fixed output.
- [ ] Added documentation (not required; no user-facing behavior or configuration is added).
- [ ] Created follow-up issues (none are required).

### AI-assisted contribution disclosure

Codex assisted with diagnosis, implementation, review-response changes, and test execution. I reviewed the final diff, authorized the submission, and remain responsible for correctness and maintainability. The validation listed above was run locally against this commit.