### PR TITLE
fix(ST02): preserve indexed expressions in NULL simplification

### DIFF
--- a/src/sqlfluff/rules/structure/ST02.py
+++ b/src/sqlfluff/rules/structure/ST02.py
@@ -143,13 +143,13 @@ class Rule_ST02(BaseRule):
     @staticmethod
     def _column_only_fix_list(
         context: RuleContext,
-        column_reference_segment: BaseSegment,
+        replacement_segment: BaseSegment,
     ) -> list[LintFix]:
-        """Generate list of fixes to reduce CASE statement to a single column."""
+        """Generate fixes to reduce CASE to the complete matched expression."""
         fixes = [
             LintFix.replace(
                 context.segment,
-                [column_reference_segment],
+                [replacement_segment],
             )
         ]
         return fixes
@@ -275,7 +275,7 @@ class Rule_ST02(BaseRule):
                             anchor=condition_expression,
                             fixes=self._column_only_fix_list(
                                 context,
-                                column_reference_segment,
+                                coalesce_arg_1,
                             ),
                             description="Unnecessary CASE statement. "
                             f"Just use column '{column_reference_segment.raw}'.",
@@ -299,7 +299,7 @@ class Rule_ST02(BaseRule):
                         anchor=condition_expression,
                         fixes=self._column_only_fix_list(
                             context,
-                            column_reference_segment,
+                            then_expression,
                         ),
                         description="Unnecessary CASE statement. "
                         f"Just use column '{column_reference_segment.raw}'.",

--- a/src/sqlfluff/rules/structure/ST02.py
+++ b/src/sqlfluff/rules/structure/ST02.py
@@ -285,8 +285,8 @@ class Rule_ST02(BaseRule):
                 ):
                     return None
 
-                condition_operand_raw_upper = "".join(
-                    segment.raw_upper for segment in condition_operand_segments
+                condition_operand_raw = "".join(
+                    segment.raw for segment in condition_operand_segments
                 )
 
                 if else_clauses:
@@ -295,14 +295,11 @@ class Rule_ST02(BaseRule):
                     # function.
                     if (
                         not is_not_prefix
-                        and condition_operand_raw_upper == else_expression.raw_upper
+                        and condition_operand_raw == else_expression.raw
                     ):
                         coalesce_arg_1 = else_expression
                         coalesce_arg_2 = then_expression
-                    elif (
-                        is_not_prefix
-                        and condition_operand_raw_upper == then_expression.raw_upper
-                    ):
+                    elif is_not_prefix and condition_operand_raw == then_expression.raw:
                         coalesce_arg_1 = then_expression
                         coalesce_arg_2 = else_expression
                     else:
@@ -331,10 +328,7 @@ class Rule_ST02(BaseRule):
                         description="Unnecessary CASE statement. "
                         "Use COALESCE function instead.",
                     )
-                elif (
-                    is_not_prefix
-                    and condition_operand_raw_upper == then_expression.raw_upper
-                ):
+                elif is_not_prefix and condition_operand_raw == then_expression.raw:
                     # Can just specify the column on it's own
                     # rather than using a COALESCE function.
                     # In this case no ELSE statement is equivalent to ELSE NULL.

--- a/src/sqlfluff/rules/structure/ST02.py
+++ b/src/sqlfluff/rules/structure/ST02.py
@@ -154,6 +154,31 @@ class Rule_ST02(BaseRule):
         ]
         return fixes
 
+    @staticmethod
+    def _segment_identity(segment: BaseSegment) -> tuple[object, ...]:
+        """Build a dialect-aware identity while preserving segment boundaries."""
+        if segment.segments:
+            return (
+                segment.get_type(),
+                tuple(
+                    Rule_ST02._segment_identity(child)
+                    for child in segment.segments
+                    if not child.is_whitespace and not child.is_meta
+                ),
+            )
+        return segment.get_type(), segment.raw_normalized()
+
+    @staticmethod
+    def _expression_identity(
+        expression: BaseSegment,
+    ) -> tuple[tuple[object, ...], ...]:
+        """Build identity for an expression's non-whitespace top-level segments."""
+        return tuple(
+            Rule_ST02._segment_identity(segment)
+            for segment in expression.segments
+            if not segment.is_whitespace and not segment.is_meta
+        )
+
     def _eval(self, context: RuleContext) -> Optional[LintResult]:
         """Unnecessary CASE statement."""
         # Look for CASE expression.
@@ -268,25 +293,19 @@ class Rule_ST02(BaseRule):
 
                 if any(
                     child.is_code
-                    and not child.is_type("array_accessor", "symbol", "literal")
+                    and (
+                        child.is_type("parameter")
+                        or not child.is_type("array_accessor", "symbol", "literal")
+                    )
                     for segment in condition_operand_segments
                     if segment.is_type("array_accessor")
                     for child in segment.recursive_crawl_all()
                 ):
                     return None
 
-                # Quoted identifiers can be case-sensitive, so raw_upper is
-                # not sufficient to prove that the condition and result refer
-                # to the same column.
-                if any(
-                    child.is_type("quoted_identifier")
+                condition_operand_identity = tuple(
+                    self._segment_identity(segment)
                     for segment in condition_operand_segments
-                    for child in segment.recursive_crawl_all()
-                ):
-                    return None
-
-                condition_operand_raw = "".join(
-                    segment.raw for segment in condition_operand_segments
                 )
 
                 if else_clauses:
@@ -295,11 +314,16 @@ class Rule_ST02(BaseRule):
                     # function.
                     if (
                         not is_not_prefix
-                        and condition_operand_raw == else_expression.raw
+                        and condition_operand_identity
+                        == self._expression_identity(else_expression)
                     ):
                         coalesce_arg_1 = else_expression
                         coalesce_arg_2 = then_expression
-                    elif is_not_prefix and condition_operand_raw == then_expression.raw:
+                    elif (
+                        is_not_prefix
+                        and condition_operand_identity
+                        == self._expression_identity(then_expression)
+                    ):
                         coalesce_arg_1 = then_expression
                         coalesce_arg_2 = else_expression
                     else:
@@ -328,7 +352,11 @@ class Rule_ST02(BaseRule):
                         description="Unnecessary CASE statement. "
                         "Use COALESCE function instead.",
                     )
-                elif is_not_prefix and condition_operand_raw == then_expression.raw:
+                elif (
+                    is_not_prefix
+                    and condition_operand_identity
+                    == self._expression_identity(then_expression)
+                ):
                     # Can just specify the column on it's own
                     # rather than using a COALESCE function.
                     # In this case no ELSE statement is equivalent to ELSE NULL.

--- a/src/sqlfluff/rules/structure/ST02.py
+++ b/src/sqlfluff/rules/structure/ST02.py
@@ -275,6 +275,16 @@ class Rule_ST02(BaseRule):
                 ):
                     return None
 
+                # Quoted identifiers can be case-sensitive, so raw_upper is
+                # not sufficient to prove that the condition and result refer
+                # to the same column.
+                if any(
+                    child.is_type("quoted_identifier")
+                    for segment in condition_operand_segments
+                    for child in segment.recursive_crawl_all()
+                ):
+                    return None
+
                 condition_operand_raw_upper = "".join(
                     segment.raw_upper for segment in condition_operand_segments
                 )

--- a/src/sqlfluff/rules/structure/ST02.py
+++ b/src/sqlfluff/rules/structure/ST02.py
@@ -227,25 +227,20 @@ class Rule_ST02(BaseRule):
                     .children(sp.is_type("column_reference"))
                     .get()
                 )
-                array_accessor_segment = (
-                    Segments(condition_expression)
-                    .children(sp.is_type("array_accessor"))
-                    .get()
-                )
-
                 # Return None if none found (this condition does not apply to functions)
                 if not column_reference_segment:
                     return None
 
-                if array_accessor_segment:
-                    column_reference_segment_raw_upper = (
-                        column_reference_segment.raw_upper
-                        + array_accessor_segment.raw_upper
-                    )
-                else:
-                    column_reference_segment_raw_upper = (
-                        column_reference_segment.raw_upper
-                    )
+                is_segment_index = next(
+                    index
+                    for index, segment in enumerate(condition_expression.segments)
+                    if segment.raw_upper == "IS"
+                )
+                condition_operand_raw_upper = "".join(
+                    segment.raw_upper
+                    for segment in condition_expression.segments[:is_segment_index]
+                    if not segment.is_whitespace and not segment.is_meta
+                )
 
                 if else_clauses:
                     else_expression = else_clauses.children(sp.is_type("expression"))[0]
@@ -253,15 +248,13 @@ class Rule_ST02(BaseRule):
                     # function.
                     if (
                         not is_not_prefix
-                        and column_reference_segment_raw_upper
-                        == else_expression.raw_upper
+                        and condition_operand_raw_upper == else_expression.raw_upper
                     ):
                         coalesce_arg_1 = else_expression
                         coalesce_arg_2 = then_expression
                     elif (
                         is_not_prefix
-                        and column_reference_segment_raw_upper
-                        == then_expression.raw_upper
+                        and condition_operand_raw_upper == then_expression.raw_upper
                     ):
                         coalesce_arg_1 = then_expression
                         coalesce_arg_2 = else_expression
@@ -293,7 +286,7 @@ class Rule_ST02(BaseRule):
                     )
                 elif (
                     is_not_prefix
-                    and column_reference_segment_raw_upper == then_expression.raw_upper
+                    and condition_operand_raw_upper == then_expression.raw_upper
                 ):
                     # Can just specify the column on it's own
                     # rather than using a COALESCE function.

--- a/src/sqlfluff/rules/structure/ST02.py
+++ b/src/sqlfluff/rules/structure/ST02.py
@@ -291,7 +291,10 @@ class Rule_ST02(BaseRule):
                         description="Unnecessary CASE statement. "
                         "Use COALESCE function instead.",
                     )
-                elif column_reference_segment.raw_upper == then_expression.raw_upper:
+                elif (
+                    is_not_prefix
+                    and column_reference_segment_raw_upper == then_expression.raw_upper
+                ):
                     # Can just specify the column on it's own
                     # rather than using a COALESCE function.
                     # In this case no ELSE statement is equivalent to ELSE NULL.

--- a/src/sqlfluff/rules/structure/ST02.py
+++ b/src/sqlfluff/rules/structure/ST02.py
@@ -236,10 +236,47 @@ class Rule_ST02(BaseRule):
                     for index, segment in enumerate(condition_expression.segments)
                     if segment.raw_upper == "IS"
                 )
-                condition_operand_raw_upper = "".join(
-                    segment.raw_upper
+                condition_operand_segments = tuple(
+                    segment
                     for segment in condition_expression.segments[:is_segment_index]
                     if not segment.is_whitespace and not segment.is_meta
+                )
+                if not condition_operand_segments or any(
+                    not segment.is_type("column_reference", "array_accessor")
+                    for segment in condition_operand_segments
+                ):
+                    return None
+
+                comparison_segments = tuple(
+                    segment
+                    for segment in condition_expression.segments[is_segment_index + 1 :]
+                    if not segment.is_whitespace and not segment.is_meta
+                )
+                if (
+                    len(comparison_segments) == 1
+                    and comparison_segments[0].raw_upper == "NULL"
+                ):
+                    is_not_prefix = False
+                elif (
+                    len(comparison_segments) == 2
+                    and comparison_segments[0].raw_upper == "NOT"
+                    and comparison_segments[1].raw_upper == "NULL"
+                ):
+                    is_not_prefix = True
+                else:
+                    return None
+
+                if any(
+                    child.is_code
+                    and not child.is_type("array_accessor", "symbol", "literal")
+                    for segment in condition_operand_segments
+                    if segment.is_type("array_accessor")
+                    for child in segment.recursive_crawl_all()
+                ):
+                    return None
+
+                condition_operand_raw_upper = "".join(
+                    segment.raw_upper for segment in condition_operand_segments
                 )
 
                 if else_clauses:

--- a/test/fixtures/linter/autofix/snowflake/002_ST02_indexed_expression/after.sql
+++ b/test/fixtures/linter/autofix/snowflake/002_ST02_indexed_expression/after.sql
@@ -1,0 +1,1 @@
+SELECT genres[0];

--- a/test/fixtures/linter/autofix/snowflake/002_ST02_indexed_expression/before.sql
+++ b/test/fixtures/linter/autofix/snowflake/002_ST02_indexed_expression/before.sql
@@ -1,0 +1,4 @@
+SELECT CASE
+    WHEN genres[0] IS NOT NULL THEN genres[0]
+    ELSE NULL
+END;

--- a/test/fixtures/linter/autofix/snowflake/002_ST02_indexed_expression/test-config.yml
+++ b/test/fixtures/linter/autofix/snowflake/002_ST02_indexed_expression/test-config.yml
@@ -1,0 +1,4 @@
+test-config:
+  rules:
+    - ST01
+    - ST02

--- a/test/fixtures/rules/std_rule_cases/ST02.yml
+++ b/test/fixtures/rules/std_rule_cases/ST02.yml
@@ -301,3 +301,21 @@ test_pass_simple_case_ignored:
   configs:
     core:
       dialect: redshift
+
+test_fail_indexed_expression_when_null_else_null:
+  fail_str: |
+    SELECT CASE WHEN genres[0] IS NULL THEN NULL ELSE genres[0] END
+  fix_str: |
+    SELECT genres[0]
+  configs:
+    core:
+      dialect: snowflake
+
+test_fail_indexed_condition_does_not_change_bare_then_expression:
+  fail_str: |
+    SELECT CASE WHEN genres[0] IS NULL THEN genres END
+  fix_str: |
+    SELECT genres
+  configs:
+    core:
+      dialect: snowflake

--- a/test/fixtures/rules/std_rule_cases/ST02.yml
+++ b/test/fixtures/rules/std_rule_cases/ST02.yml
@@ -311,11 +311,25 @@ test_fail_indexed_expression_when_null_else_null:
     core:
       dialect: snowflake
 
-test_fail_indexed_condition_does_not_change_bare_then_expression:
+test_fail_indexed_expression_when_not_null_no_else:
   fail_str: |
-    SELECT CASE WHEN genres[0] IS NULL THEN genres END
+    SELECT CASE WHEN genres[0] IS NOT NULL THEN genres[0] END
   fix_str: |
-    SELECT genres
+    SELECT genres[0]
+  configs:
+    core:
+      dialect: snowflake
+
+test_pass_indexed_condition_does_not_change_bare_then_expression:
+  pass_str: |
+    SELECT CASE WHEN genres[0] IS NOT NULL THEN genres END
+  configs:
+    core:
+      dialect: snowflake
+
+test_pass_null_condition_does_not_change_bare_then_expression:
+  pass_str: |
+    SELECT CASE WHEN genres[0] IS NULL THEN genres END
   configs:
     core:
       dialect: snowflake

--- a/test/fixtures/rules/std_rule_cases/ST02.yml
+++ b/test/fixtures/rules/std_rule_cases/ST02.yml
@@ -338,6 +338,24 @@ test_fail_multiple_indexed_expression_when_not_null_no_else:
     core:
       dialect: snowflake
 
+test_fail_identical_quoted_indexed_expression_when_not_null_no_else:
+  fail_str: |
+    SELECT CASE WHEN "genres"[0] IS NOT NULL THEN "genres"[0] END
+  fix_str: |
+    SELECT "genres"[0]
+  configs:
+    core:
+      dialect: snowflake
+
+test_fail_mixed_case_indexed_expression_when_not_null_no_else:
+  fail_str: |
+    SELECT CASE WHEN genres[0] IS NOT NULL THEN GENRES[0] END
+  fix_str: |
+    SELECT GENRES[0]
+  configs:
+    core:
+      dialect: snowflake
+
 test_pass_indexed_condition_does_not_change_bare_then_expression:
   pass_str: |
     SELECT CASE WHEN genres[0] IS NOT NULL THEN genres END

--- a/test/fixtures/rules/std_rule_cases/ST02.yml
+++ b/test/fixtures/rules/std_rule_cases/ST02.yml
@@ -333,3 +333,27 @@ test_pass_null_condition_does_not_change_bare_then_expression:
   configs:
     core:
       dialect: snowflake
+
+test_pass_null_condition_does_not_change_indexed_then_expression:
+  pass_str: |
+    SELECT CASE WHEN genres[0] IS NULL THEN genres[0] END
+  configs:
+    core:
+      dialect: snowflake
+
+test_pass_composite_condition_does_not_change_indexed_then_expression:
+  pass_str: |
+    SELECT CASE WHEN genres[0] + other IS NOT NULL THEN genres[0] END
+  configs:
+    core:
+      dialect: snowflake
+
+test_pass_composite_condition_with_else_null_does_not_change_indexed_then_expression:
+  pass_str: |
+    SELECT CASE
+      WHEN genres[0] + other IS NOT NULL THEN genres[0]
+      ELSE NULL
+    END
+  configs:
+    core:
+      dialect: snowflake

--- a/test/fixtures/rules/std_rule_cases/ST02.yml
+++ b/test/fixtures/rules/std_rule_cases/ST02.yml
@@ -320,6 +320,24 @@ test_fail_indexed_expression_when_not_null_no_else:
     core:
       dialect: snowflake
 
+test_fail_qualified_indexed_expression_when_not_null_no_else:
+  fail_str: |
+    SELECT CASE WHEN table_name.genres[0] IS NOT NULL THEN table_name.genres[0] END
+  fix_str: |
+    SELECT table_name.genres[0]
+  configs:
+    core:
+      dialect: snowflake
+
+test_fail_multiple_indexed_expression_when_not_null_no_else:
+  fail_str: |
+    SELECT CASE WHEN genres[0][1] IS NOT NULL THEN genres[0][1] END
+  fix_str: |
+    SELECT genres[0][1]
+  configs:
+    core:
+      dialect: snowflake
+
 test_pass_indexed_condition_does_not_change_bare_then_expression:
   pass_str: |
     SELECT CASE WHEN genres[0] IS NOT NULL THEN genres END
@@ -372,6 +390,13 @@ test_pass_dynamic_index_does_not_change_expression:
       WHEN genres[uniform(0, 9, random())] IS NOT NULL
       THEN genres[uniform(0, 9, random())]
     END
+  configs:
+    core:
+      dialect: snowflake
+
+test_pass_differently_cased_quoted_indexed_columns:
+  pass_str: |
+    SELECT CASE WHEN "genres"[0] IS NOT NULL THEN "GENRES"[0] END
   configs:
     core:
       dialect: snowflake

--- a/test/fixtures/rules/std_rule_cases/ST02.yml
+++ b/test/fixtures/rules/std_rule_cases/ST02.yml
@@ -400,3 +400,17 @@ test_pass_differently_cased_quoted_indexed_columns:
   configs:
     core:
       dialect: snowflake
+
+test_pass_differently_cased_clickhouse_indexed_columns_with_else_null:
+  pass_str: |
+    SELECT CASE WHEN genres[1] IS NOT NULL THEN GENRES[1] ELSE NULL END
+  configs:
+    core:
+      dialect: clickhouse
+
+test_pass_differently_cased_clickhouse_indexed_columns_no_else:
+  pass_str: |
+    SELECT CASE WHEN genres[1] IS NOT NULL THEN GENRES[1] END
+  configs:
+    core:
+      dialect: clickhouse

--- a/test/fixtures/rules/std_rule_cases/ST02.yml
+++ b/test/fixtures/rules/std_rule_cases/ST02.yml
@@ -357,3 +357,21 @@ test_pass_composite_condition_with_else_null_does_not_change_indexed_then_expres
   configs:
     core:
       dialect: snowflake
+
+test_pass_distinct_from_null_does_not_change_expression:
+  pass_str: |
+    SELECT CASE WHEN value IS DISTINCT FROM NULL THEN NULL ELSE value END
+
+test_pass_not_distinct_from_null_does_not_change_expression:
+  pass_str: |
+    SELECT CASE WHEN value IS NOT DISTINCT FROM NULL THEN value ELSE NULL END
+
+test_pass_dynamic_index_does_not_change_expression:
+  pass_str: |
+    SELECT CASE
+      WHEN genres[uniform(0, 9, random())] IS NOT NULL
+      THEN genres[uniform(0, 9, random())]
+    END
+  configs:
+    core:
+      dialect: snowflake


### PR DESCRIPTION
## Summary

- Preserve an array accessor when ST02 reduces a NULL-only `CASE` expression to its matched expression.
- Pass the detected accessor through the column-only replacement path.
- Add a Snowflake regression fixture that asserts the exact fixed SQL.

## Reproduction

```sql
SELECT CASE
    WHEN genres[0] IS NULL THEN NULL
    ELSE genres[0]
END;
```

On `main`, the autofix can produce `SELECT genres`, dropping `[0]`. This change produces `SELECT genres[0]`.

## Testing

- `pytest -q test/rules/yaml_test_cases_test.py -k ST02`: 29 passed
- Ruff 0.15.5 check and format check: passed
- YAML lint: passed
- `git diff --check`: passed

## AI assistance

This change was prepared with Codex assistance for diagnosis, implementation, rebase, and test execution. I authorized the submission and remain responsible for the change. The validation above was rerun against current `main`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `ST02` so NULL-only CASE simplification keeps full indexed expressions (e.g., `genres[0]`) and also handles the `IS NOT NULL` no-ELSE form. Adds dialect-aware, case-sensitive matching and Snowflake fixtures to lock the exact output and avoid unsafe fixes.

- **Bug Fixes**
  - Replace CASE with the complete matched expression to preserve `[...]`, stacked indexes, and qualified names.
  - Use dialect-aware operand identity (respects quoted identifiers and casing) to match THEN/ELSE; supports `IS NOT NULL` with no ELSE.
  - Skip simplification for composite conditions or dynamic index expressions; leave bare THEN columns unchanged.

<sup>Written for commit d93def8b7692ef5326eb07fa3afc4469581ab358. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8202?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

