### PR TITLE
fix(CV12): preserve SQLite outer join semantics

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -2,7 +2,7 @@
 
 # code linting and formatting
 # ---------------------------
-ruff
+ruff==0.15.5
 import-linter
 yamllint
 

--- a/src/sqlfluff/rules/convention/CV12.py
+++ b/src/sqlfluff/rules/convention/CV12.py
@@ -140,6 +140,16 @@ class Rule_CV12(BaseRule):
                 # Join condition is present, no error reported.
                 continue
 
+            # Moving a WHERE predicate into ON changes which null-extended
+            # rows survive an outer join. SQLite makes this directly visible
+            # for LEFT JOIN, so retain the diagnostic but suppress the fix.
+            if context.dialect.name == "sqlite" and any(
+                kw.raw_upper in ("LEFT", "RIGHT", "FULL", "OUTER")
+                for kw in join_clause_keywords
+            ):
+                yield LintResult(anchor=join_clause)
+                continue
+
             if not where_clause_simplifable:
                 yield LintResult(anchor=join_clause)
             else:

--- a/src/sqlfluff/rules/convention/CV12.py
+++ b/src/sqlfluff/rules/convention/CV12.py
@@ -141,12 +141,17 @@ class Rule_CV12(BaseRule):
                 continue
 
             # Moving a WHERE predicate into ON changes which null-extended
-            # rows survive an outer join. SQLite makes this directly visible
-            # for LEFT JOIN, so retain the diagnostic but suppress the fix.
-            if context.dialect.name == "sqlite" and any(
+            # rows survive an outer join, so retain the diagnostic but
+            # suppress the fix for all outer joins. SEMI and ANTI joins are
+            # filtering joins, not null-extending outer joins.
+            is_outer_join = any(
                 kw.raw_upper in ("LEFT", "RIGHT", "FULL", "OUTER")
                 for kw in join_clause_keywords
-            ):
+            )
+            is_semi_or_anti_join = any(
+                kw.raw_upper in ("SEMI", "ANTI") for kw in join_clause_keywords
+            )
+            if is_outer_join and not is_semi_or_anti_join:
                 yield LintResult(anchor=join_clause)
                 continue
 

--- a/src/sqlfluff/rules/convention/CV12.py
+++ b/src/sqlfluff/rules/convention/CV12.py
@@ -152,6 +152,21 @@ class Rule_CV12(BaseRule):
                 yield LintResult(anchor=join_clause)
                 continue
 
+            # Moving a WHERE predicate into ON changes which null-extended
+            # rows survive an outer join, so retain the diagnostic but
+            # suppress the fix for all outer joins. SEMI and ANTI joins are
+            # filtering joins, not null-extending outer joins.
+            is_outer_join = any(
+                kw.raw_upper in ("LEFT", "RIGHT", "FULL", "OUTER")
+                for kw in join_clause_keywords
+            )
+            is_semi_or_anti_join = any(
+                kw.raw_upper in ("SEMI", "ANTI") for kw in join_clause_keywords
+            )
+            if is_outer_join and not is_semi_or_anti_join:
+                yield LintResult(anchor=join_clause)
+                continue
+
             if not where_clause_simplifable:
                 yield LintResult(anchor=join_clause)
             else:

--- a/test/fixtures/rules/std_rule_cases/AL05_CV12.yml
+++ b/test/fixtures/rules/std_rule_cases/AL05_CV12.yml
@@ -1,15 +1,17 @@
 rule: AL05,CV12
 
 test_rule_fix_conflict_deleted_where_reference:
+  # Use an inner join here so this still exercises the AL05/CV12 fix
+  # interaction; CV12 intentionally does not auto-fix outer joins.
   fail_str: |
     select a.a
     from table_a as a
-    left join table_b as b
+    join table_b as b
     where a.id = b.id
   fix_str: |
     select a.a
     from table_a as a
-    left join table_b as b ON a.id = b.id
+    join table_b as b ON a.id = b.id
 
 test_rule_fix_conflict_modified_where_reference:
   fail_str: |

--- a/test/fixtures/rules/std_rule_cases/CV12.yml
+++ b/test/fixtures/rules/std_rule_cases/CV12.yml
@@ -1,5 +1,11 @@
 rule: CV12
 
+test_fail_sqlite_left_join_without_fix:
+  fail_str: SELECT a.k, b.k FROM a LEFT JOIN b WHERE a.k = b.k;
+  configs:
+    core:
+      dialect: sqlite
+
 test_noop_select_comma:
   # this syntax is currently not covered by CV12
   pass_str: |
@@ -155,3 +161,12 @@ test_pass_left_join_unnest_where_unaliased:
       UNNEST(t.purchases)
     WHERE
       t.user_id != 1
+
+test_pass_sqlite_left_join_with_on_and_where:
+  pass_str: |
+    SELECT a.k, b.k
+    FROM a LEFT JOIN b ON a.k = b.k
+    WHERE a.active
+  configs:
+    core:
+      dialect: sqlite

--- a/test/fixtures/rules/std_rule_cases/CV12.yml
+++ b/test/fixtures/rules/std_rule_cases/CV12.yml
@@ -55,6 +55,12 @@ test_fail_natural_join_mixed_with_later_join:
   fix_str: |
     SELECT * FROM a NATURAL JOIN b JOIN c ON a.m = c.m WHERE a.k = b.k
 
+test_fail_natural_join_mixed_with_later_outer_join:
+  # A later outer join must keep both predicates in WHERE because moving one
+  # into ON could change the result set.
+  fail_str: |
+    SELECT * FROM a NATURAL JOIN b LEFT JOIN c WHERE a.k = b.k AND a.m = c.m
+
 test_fail_cross_join_mixed_with_later_join:
   # Same as above for a skipped CROSS JOIN: a.k = b.k references neither the
   # JOIN's table nor an ON-able join, so it stays in the WHERE clause.
@@ -62,6 +68,11 @@ test_fail_cross_join_mixed_with_later_join:
     SELECT * FROM a CROSS JOIN b JOIN c WHERE a.k = b.k AND a.m = c.m
   fix_str: |
     SELECT * FROM a CROSS JOIN b JOIN c ON a.m = c.m WHERE a.k = b.k
+
+test_fail_cross_join_mixed_with_later_outer_join:
+  # The outer join must not move the predicate into its ON clause.
+  fail_str: |
+    SELECT * FROM a CROSS JOIN b LEFT JOIN c WHERE a.k = b.k AND a.m = c.m
 
 test_fail_sparksql_left_semi_join_with_fix:
   fail_str: |

--- a/test/fixtures/rules/std_rule_cases/CV12.yml
+++ b/test/fixtures/rules/std_rule_cases/CV12.yml
@@ -6,6 +6,15 @@ test_fail_sqlite_left_join_without_fix:
     core:
       dialect: sqlite
 
+test_fail_ansi_left_join_without_fix:
+  fail_str: SELECT a.k, b.k FROM a LEFT JOIN b WHERE a.k = b.k;
+
+test_fail_ansi_right_join_without_fix:
+  fail_str: SELECT a.k, b.k FROM a RIGHT JOIN b WHERE a.k = b.k;
+
+test_fail_ansi_full_outer_join_without_fix:
+  fail_str: SELECT a.k, b.k FROM a FULL OUTER JOIN b WHERE a.k = b.k;
+
 test_noop_select_comma:
   # this syntax is currently not covered by CV12
   pass_str: |
@@ -39,20 +48,34 @@ test_noop_natural_join:
 
 test_fail_natural_join_mixed_with_later_join:
   # The NATURAL JOIN is skipped, but its predicate (a.k = b.k) must not be
-  # hoisted into the following LEFT JOIN's ON clause: only conditions that
+  # hoisted into the following JOIN's ON clause: only conditions that
   # reference the joined table itself may be moved.
   fail_str: |
-    SELECT * FROM a NATURAL JOIN b LEFT JOIN c WHERE a.k = b.k AND a.m = c.m
+    SELECT * FROM a NATURAL JOIN b JOIN c WHERE a.k = b.k AND a.m = c.m
   fix_str: |
-    SELECT * FROM a NATURAL JOIN b LEFT JOIN c ON a.m = c.m WHERE a.k = b.k
+    SELECT * FROM a NATURAL JOIN b JOIN c ON a.m = c.m WHERE a.k = b.k
 
 test_fail_cross_join_mixed_with_later_join:
   # Same as above for a skipped CROSS JOIN: a.k = b.k references neither the
-  # LEFT JOIN's table nor an ON-able join, so it stays in the WHERE clause.
+  # JOIN's table nor an ON-able join, so it stays in the WHERE clause.
   fail_str: |
-    SELECT * FROM a CROSS JOIN b LEFT JOIN c WHERE a.k = b.k AND a.m = c.m
+    SELECT * FROM a CROSS JOIN b JOIN c WHERE a.k = b.k AND a.m = c.m
   fix_str: |
-    SELECT * FROM a CROSS JOIN b LEFT JOIN c ON a.m = c.m WHERE a.k = b.k
+    SELECT * FROM a CROSS JOIN b JOIN c ON a.m = c.m WHERE a.k = b.k
+
+test_fail_sparksql_left_semi_join_with_fix:
+  fail_str: |
+    SELECT employee.id
+    FROM employee
+    LEFT SEMI JOIN department
+    WHERE employee.deptno = department.deptno
+  fix_str: |
+    SELECT employee.id
+    FROM employee
+    LEFT SEMI JOIN department ON employee.deptno = department.deptno
+  configs:
+    core:
+      dialect: sparksql
 
 test_noop_using:
   pass_str: |

--- a/test/fixtures/rules/std_rule_cases/CV12.yml
+++ b/test/fixtures/rules/std_rule_cases/CV12.yml
@@ -1,5 +1,20 @@
 rule: CV12
 
+test_fail_sqlite_left_join_without_fix:
+  fail_str: SELECT a.k, b.k FROM a LEFT JOIN b WHERE a.k = b.k;
+  configs:
+    core:
+      dialect: sqlite
+
+test_fail_ansi_left_join_without_fix:
+  fail_str: SELECT a.k, b.k FROM a LEFT JOIN b WHERE a.k = b.k;
+
+test_fail_ansi_right_join_without_fix:
+  fail_str: SELECT a.k, b.k FROM a RIGHT JOIN b WHERE a.k = b.k;
+
+test_fail_ansi_full_outer_join_without_fix:
+  fail_str: SELECT a.k, b.k FROM a FULL OUTER JOIN b WHERE a.k = b.k;
+
 test_noop_select_comma:
   # this syntax is currently not covered by CV12
   pass_str: |
@@ -33,20 +48,59 @@ test_noop_natural_join:
 
 test_fail_natural_join_mixed_with_later_join:
   # The NATURAL JOIN is skipped, but its predicate (a.k = b.k) must not be
-  # hoisted into the following LEFT JOIN's ON clause: only conditions that
+  # hoisted into the following JOIN's ON clause: only conditions that
   # reference the joined table itself may be moved.
   fail_str: |
-    SELECT * FROM a NATURAL JOIN b LEFT JOIN c WHERE a.k = b.k AND a.m = c.m
+    SELECT * FROM a NATURAL JOIN b JOIN c WHERE a.k = b.k AND a.m = c.m
   fix_str: |
-    SELECT * FROM a NATURAL JOIN b LEFT JOIN c ON a.m = c.m WHERE a.k = b.k
+    SELECT * FROM a NATURAL JOIN b JOIN c ON a.m = c.m WHERE a.k = b.k
+
+test_fail_natural_join_mixed_with_later_outer_join:
+  # A later outer join must keep both predicates in WHERE because moving one
+  # into ON could change the result set.
+  fail_str: |
+    SELECT * FROM a NATURAL JOIN b LEFT JOIN c WHERE a.k = b.k AND a.m = c.m
 
 test_fail_cross_join_mixed_with_later_join:
   # Same as above for a skipped CROSS JOIN: a.k = b.k references neither the
-  # LEFT JOIN's table nor an ON-able join, so it stays in the WHERE clause.
+  # JOIN's table nor an ON-able join, so it stays in the WHERE clause.
+  fail_str: |
+    SELECT * FROM a CROSS JOIN b JOIN c WHERE a.k = b.k AND a.m = c.m
+  fix_str: |
+    SELECT * FROM a CROSS JOIN b JOIN c ON a.m = c.m WHERE a.k = b.k
+
+test_fail_cross_join_mixed_with_later_outer_join:
+  # The outer join must not move the predicate into its ON clause.
   fail_str: |
     SELECT * FROM a CROSS JOIN b LEFT JOIN c WHERE a.k = b.k AND a.m = c.m
+
+test_fail_sparksql_left_semi_join_with_fix:
+  fail_str: |
+    SELECT employee.id
+    FROM employee
+    LEFT SEMI JOIN department
+    WHERE employee.deptno = department.deptno
   fix_str: |
-    SELECT * FROM a CROSS JOIN b LEFT JOIN c ON a.m = c.m WHERE a.k = b.k
+    SELECT employee.id
+    FROM employee
+    LEFT SEMI JOIN department ON employee.deptno = department.deptno
+  configs:
+    core:
+      dialect: sparksql
+
+test_fail_sparksql_left_anti_join_with_fix:
+  fail_str: |
+    SELECT employee.id
+    FROM employee
+    LEFT ANTI JOIN department
+    WHERE employee.deptno = department.deptno
+  fix_str: |
+    SELECT employee.id
+    FROM employee
+    LEFT ANTI JOIN department ON employee.deptno = department.deptno
+  configs:
+    core:
+      dialect: sparksql
 
 test_noop_using:
   pass_str: |
@@ -192,15 +246,24 @@ test_fail_templated_join_alongside_literal_join:
     select a.id
     from table_a as a
     left join {{ ref('table_b') }} as b
-    left join table_c as c
+    join table_c as c
     where a.region = b.region and a.k = c.k
   fix_str: |
     select a.id
     from table_a as a
     left join {{ ref('table_b') }} as b
-    left join table_c as c ON a.k = c.k
+    join table_c as c ON a.k = c.k
     where a.region = b.region
   configs:
     core:
       dialect: snowflake
       templater: jinja
+
+test_pass_sqlite_left_join_with_on_and_where:
+  pass_str: |
+    SELECT a.k, b.k
+    FROM a LEFT JOIN b ON a.k = b.k
+    WHERE a.active
+  configs:
+    core:
+      dialect: sqlite


### PR DESCRIPTION
## Summary

- Keep CV12 diagnostics for SQLite outer joins but suppress predicate-relocation fixes.
- Cover `LEFT`, `RIGHT`, `FULL`, and explicit `OUTER` joins.
- Add an executable SQLite regression fixture.

## Reproduction

```sql
SELECT a.k, b.k
FROM a LEFT JOIN b
WHERE a.k = b.k;
```

With `a(k)` containing `1, 2` and `b(k)` containing `1`, the original returns one row. Moving the predicate into `ON` also returns the null-extended `[2, NULL]` row, changing the result set.

## Testing

- `pytest -q test/rules/yaml_test_cases_test.py -k CV12`: 27 passed
- Ruff 0.15.5 check and format check: passed
- YAML lint: passed
- `git diff --check`: passed

## AI assistance

This change was prepared with Codex assistance for diagnosis, implementation, rebase, and test execution. I authorized the submission and remain responsible for the change. The validation above was rerun against current `main`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves outer join semantics in CV12 by keeping diagnostics but suppressing the autofix that moves WHERE predicates into ON for outer joins (LEFT/RIGHT/FULL/OUTER). Inner, `SEMI`, and `ANTI` joins still auto-fix.

- **Bug Fixes**
  - Tests: cover SQLite and ANSI outer joins (no fix), NATURAL/CROSS with later outer joins (no fix), templated inner-join guard and templated+literal join mix, SparkSQL `LEFT SEMI` and `LEFT ANTI` joins still auto-fix, preserve existing `ON` conditions, and update AL05 to use an inner join.

- **Dependencies**
  - Synced with `main` and updated Ruff config; pin `ruff` to `0.15.5`.

<sup>Written for commit 809862dfb024a423a07b0eed8617f1632a17d4eb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8203?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

