### PR TITLE
fix(ST08): preserve composite DISTINCT projections

### DIFF
--- a/src/sqlfluff/rules/structure/ST08.py
+++ b/src/sqlfluff/rules/structure/ST08.py
@@ -39,6 +39,14 @@ class Rule_ST08(BaseRule):
     crawl_behaviour = SegmentSeekerCrawler({"select_clause", "function"})
     is_fix_compatible = True
 
+    @staticmethod
+    def _has_top_level_comma(bracketed: BaseSegment) -> bool:
+        """Return whether brackets contain a row/composite delimiter."""
+        inner_expression = bracketed.get_child("expression")
+        if inner_expression:
+            return bool(inner_expression.get_child("comma"))
+        return bool(bracketed.get_child("comma"))
+
     def _eval(self, context: RuleContext) -> Optional[LintResult]:
         """Looking for DISTINCT before a bracket.
 
@@ -60,7 +68,19 @@ class Rule_ST08(BaseRule):
             if modifier and bracketed:
                 # If there's nothing else in the expression, remove the brackets.
                 if len(expression[0].segments) == 1:
-                    anchor, seq = self._remove_unneeded_brackets(context, bracketed)
+                    bracketed_segment = bracketed.get()
+                    if bracketed_segment and self._has_top_level_comma(
+                        bracketed_segment
+                    ):
+                        anchor = modifier[0]
+                        seq = ReflowSequence.from_around_target(
+                            modifier[0],
+                            context.parent_stack[0],
+                            config=context.config,
+                            sides="after",
+                        )
+                    else:
+                        anchor, seq = self._remove_unneeded_brackets(context, bracketed)
                 # Otherwise, still make sure there's a space after the DISTINCT.
                 else:
                     anchor = modifier[0]

--- a/test/fixtures/rules/std_rule_cases/ST08.yml
+++ b/test/fixtures/rules/std_rule_cases/ST08.yml
@@ -41,6 +41,22 @@ test_fail_distinct_with_parenthesis_7:
     core:
       dialect: postgres
 
+test_pass_distinct_composite_projection:
+  pass_str: |
+    SELECT DISTINCT (a, b) FROM t;
+  configs:
+    core:
+      dialect: postgres
+
+test_fail_distinct_composite_projection_spacing:
+  fail_str: |
+    SELECT DISTINCT(a, b) FROM t;
+  fix_str: |
+    SELECT DISTINCT (a, b) FROM t;
+  configs:
+    core:
+      dialect: postgres
+
 test_pass_no_distinct:
   pass_str: |
     SELECT a, b


### PR DESCRIPTION
## Summary

- Prevent ST08 from removing parentheses around comma-delimited PostgreSQL composite projections.
- Check direct top-level comma structure before removing brackets.
- Preserve ST08 spacing enforcement around composite projections.
- Add a PostgreSQL regression fixture.

## Reproduction

```sql
SELECT DISTINCT (a, b) FROM t;
```

On `main`, ST08 can rewrite this to `SELECT DISTINCT a, b FROM t;`, changing one composite projection into two scalar projections.

## Testing

- `pytest -q test/rules/yaml_test_cases_test.py -k ST08`: 13 passed
- Ruff 0.15.5 check and format check: passed
- YAML lint: passed
- `git diff --check`: passed

## AI assistance

This change was prepared with Codex assistance for diagnosis, implementation, rebase, and test execution. I authorized the submission and remain responsible for the change. The validation above was rerun against current `main`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent ST08 from removing parentheses in PostgreSQL composite DISTINCT projections and fix spacing. Avoids rewriting `SELECT DISTINCT (a, b)` to `SELECT DISTINCT a, b` and corrects `DISTINCT(a, b)` to `DISTINCT (a, b)`.

- **Bug Fixes**
  - Detect a top-level comma in bracketed expressions to treat them as composite rows; skip bracket removal and only add a space after `DISTINCT`.
  - Add Postgres regression tests for `SELECT DISTINCT (a, b) FROM t;` and spacing correction from `DISTINCT(a, b)` to `DISTINCT (a, b)`.

<sup>Written for commit 956d2192bf5e3768833e6df822cad0ca6da12355. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8205?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

