### PR TITLE
fix(AL05): preserve typed PostgreSQL function aliases

### DIFF
--- a/src/sqlfluff/rules/aliasing/AL05.py
+++ b/src/sqlfluff/rules/aliasing/AL05.py
@@ -248,6 +248,21 @@ class Rule_AL05(BaseRule):
         * In the case of a nested SELECT, all dialect checked (MySQL, Postgres,
           T-SQL) require an alias.
         """
+        if dialect_name in ("postgres", "greenplum"):
+            alias_expressions = from_expression_element.get_children(
+                "alias_expression", "bracketed"
+            )
+            for alias_expression in alias_expressions:
+                if alias_expression.is_type("bracketed"):
+                    alias_expression = alias_expression.get_child("alias_expression")
+                if alias_expression and any(
+                    alias_expression.recursive_crawl("data_type")
+                ):
+                    # PostgreSQL record-returning table functions require the
+                    # typed column-definition list in an alias expression even
+                    # when the alias name itself is not referenced.
+                    return True
+
         # Look for a table_expression (i.e. VALUES clause) as a descendant of
         # the FROM expression, potentially nested inside brackets. The reason we
         # allow nesting in brackets is that in some dialects (e.g. TSQL), this
@@ -280,7 +295,7 @@ class Rule_AL05(BaseRule):
                     return (
                         dialect_name in self._dialects_requiring_alias_for_values_clause
                     )
-                elif any(
+                if any(
                     seg.is_type(
                         "select_statement", "set_expression", "with_compound_statement"
                     )

--- a/test/fixtures/rules/std_rule_cases/AL05.yml
+++ b/test/fixtures/rules/std_rule_cases/AL05.yml
@@ -1333,3 +1333,24 @@ test_pass_tsql_nodes_method_requires_alias_unreferenced:
   configs:
     core:
       dialect: tsql
+
+test_pass_postgres_typed_table_function_alias:
+  pass_str: |
+    SELECT a FROM json_to_record('{"a": 1}') AS r(a int);
+  configs:
+    core:
+      dialect: postgres
+
+test_pass_greenplum_typed_table_function_alias:
+  pass_str: |
+    SELECT a FROM json_to_record('{"a": 1}') AS r(a int);
+  configs:
+    core:
+      dialect: greenplum
+
+test_pass_postgres_bracketed_typed_table_function_alias:
+  pass_str: |
+    SELECT a FROM (json_to_record('{"a": 1}') AS r(a int));
+  configs:
+    core:
+      dialect: postgres


### PR DESCRIPTION
## Summary

- Preserve bracketed typed table-function aliases as well.
- Preserve PostgreSQL table-function aliases that contain a typed column-definition list.
- Detect the `data_type` within the alias expression, without exempting ordinary unused aliases.
- Add a PostgreSQL regression fixture.

## Reproduction

```sql
SELECT a
FROM json_to_record('{"a": 1}') AS r(a int);
```

On `main`, AL05 can remove `AS r(a int)` because `r` is not referenced. That also removes the type information required by PostgreSQL for this record-returning function.

## Testing

- `pytest -q test/rules/yaml_test_cases_test.py -k AL05`: 142 passed
- Ruff 0.15.5 check and format check: passed
- YAML lint: passed
- `git diff --check`: passed

## AI assistance

This change was prepared with Codex assistance for diagnosis, implementation, rebase, and test execution. I authorized the submission and remain responsible for the change. The validation above was rerun against current `main`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix AL05 to preserve typed table-function aliases in `postgres` and `greenplum`, including bracketed alias expressions, so column types are kept and queries don’t error.

- **Bug Fixes**
  - In `postgres` and `greenplum`, treat an alias as required when its alias expression includes a typed column list (`data_type`), even if wrapped in brackets.
  - Ensure functions like `json_to_record` keep typed aliases even when the alias name isn’t referenced.
  - Add regression tests in `AL05.yml` for both dialects, plus a bracketed alias case in `postgres`.

<sup>Written for commit 8d277d74f7ce7968e74ff679c2a720b97b9b0a09. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8206?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

