### PR TITLE
fix(RF03): preserve quoted qualifier identity

### DIFF
--- a/src/sqlfluff/rules/references/RF03.py
+++ b/src/sqlfluff/rules/references/RF03.py
@@ -196,8 +196,19 @@ def _check_references(
     """Iterate through references and check consistency."""
     # A buffer to keep any violations.
     col_alias_names: list[str] = [c.alias_identifier_name for c in col_aliases]
-    table_ref_str: str = table_aliases[0].ref_str
-    table_ref_str_source = table_aliases[0].segment
+    table_alias = table_aliases[0]
+    table_ref_str: str = table_alias.ref_str
+    if table_alias.aliased:
+        table_ref_str_sources = [table_alias.segment] if table_alias.segment else []
+    elif table_alias.object_reference:
+        raw_references = list(
+            iter_raw_references(table_alias.object_reference, dialect_name)
+        )
+        table_ref_str_sources = (
+            list(raw_references[-1].segments) if raw_references else []
+        )
+    else:  # pragma: no cover
+        table_ref_str_sources = []
     # Check all the references that we have.
     seen_ref_types: set[str] = set()
     for ref in references:
@@ -219,7 +230,19 @@ def _check_references(
             continue
         if this_ref_type == "qualified" and is_struct_dialect:
             # If this col appears "qualified" check if it is more logically a struct.
-            if next(iter_raw_references(ref, dialect_name)).part != table_ref_str:
+            leading_ref = next(iter_raw_references(ref, dialect_name))
+            leading_ref_part = leading_ref.part
+            if (
+                leading_ref_part != table_ref_str
+                and len(leading_ref.segments) == 1
+                and leading_ref.segments[0].is_type("quoted_identifier")
+            ):
+                whole_quoted_identifier = leading_ref.segments[0].raw_normalized(
+                    casefold=False
+                )
+                if whole_quoted_identifier == table_ref_str:
+                    leading_ref_part = whole_quoted_identifier
+            if leading_ref_part != table_ref_str:
                 this_ref_type = "unqualified"
 
         lint_res = _validate_one_reference(
@@ -228,7 +251,7 @@ def _check_references(
             this_ref_type,
             standalone_aliases,
             table_ref_str,
-            table_ref_str_source,
+            table_ref_str_sources,
             col_alias_names,
             seen_ref_types,
             fixable,
@@ -267,7 +290,7 @@ def _validate_one_reference(
     this_ref_type: str,
     standalone_aliases: list[BaseSegment],
     table_ref_str: str,
-    table_ref_str_source: Optional[BaseSegment],
+    table_ref_str_sources: list[BaseSegment],
     col_alias_names: list[str],
     seen_ref_types: set[str],
     fixable: bool,
@@ -344,15 +367,33 @@ def _validate_one_reference(
 
     fixes = None
     if fixable:
+        if len(table_ref_str_sources) == 1:
+            qualifier = [table_ref_str_sources[0].copy()]
+            qualifier_source = table_ref_str_sources
+        elif table_ref_str_sources and dialect_name == "bigquery":
+            # BigQuery permits dashes in an unquoted table name in FROM, but
+            # the same logical identifier must be quoted when used as a
+            # qualifier so it parses as one reference part.
+            qualifier = [
+                IdentifierSegment(
+                    raw=f"`{table_ref_str}`",
+                    instance_types=("quoted_identifier", "identifier", "back_quote"),
+                    trim_chars=("`",),
+                    quoted_value=(r"`((?:[^`\\]|\\.)*)`", 1),
+                    escape_replacements=[(r"\\`", "`")],
+                    casefold=str.upper,
+                )
+            ]
+            qualifier_source = table_ref_str_sources
+        else:
+            qualifier = [IdentifierSegment(raw=table_ref_str, type="naked_identifier")]
+            qualifier_source = None
         fixes = [
             LintFix.create_before(
                 ref.segments[0] if len(ref.segments) else ref,
-                source=[table_ref_str_source] if table_ref_str_source else None,
+                source=qualifier_source,
                 edit_segments=[
-                    IdentifierSegment(
-                        raw=table_ref_str,
-                        type="naked_identifier",
-                    ),
+                    *qualifier,
                     SymbolSegment(raw=".", type="symbol"),
                 ],
             )

--- a/test/fixtures/rules/std_rule_cases/RF03.yml
+++ b/test/fixtures/rules/std_rule_cases/RF03.yml
@@ -768,3 +768,52 @@ test_fail_athena_struct_field_access_qualified_config:
       references.consistent:
         single_table_references: qualified
         force_enable: true
+
+test_fail_postgres_quoted_alias_preserves_identity:
+  fail_str: |
+    SELECT "T".a, b FROM foo AS "T";
+  fix_str: |
+    SELECT "T".a, "T".b FROM foo AS "T";
+  configs:
+    core:
+      dialect: postgres
+
+test_fail_bigquery_dashed_table_preserves_complete_qualifier:
+  fail_str: |
+    SELECT col FROM table-a123
+  fix_str: |
+    SELECT `table-a123`.col FROM table-a123
+  configs:
+    core:
+      dialect: bigquery
+    rules:
+      references.consistent:
+        single_table_references: qualified
+        force_enable: true
+
+test_fail_bigquery_templated_dashed_table_has_no_unsafe_fix:
+  fail_str: |
+    SELECT col FROM project-{{ suffix }}
+  configs:
+    core:
+      dialect: bigquery
+      templater: jinja
+    templater:
+      jinja:
+        context:
+          suffix: prod
+    rules:
+      references.consistent:
+        single_table_references: qualified
+        force_enable: true
+
+test_pass_bigquery_quoted_dotted_column_path:
+  pass_str: |
+    SELECT `t.col` FROM foo AS t
+  configs:
+    core:
+      dialect: bigquery
+    rules:
+      references.consistent:
+        single_table_references: qualified
+        force_enable: true


### PR DESCRIPTION
## Summary

- Preserve BigQuery quoted dotted-column path classification.
- Preserve template-safety tracking for generated BigQuery qualifiers.
- Preserve the original alias identifier segment when RF03 generates a qualifier.
- Retain PostgreSQL quoting and case-sensitive identifier identity.
- Add a PostgreSQL regression fixture.

## Reproduction

```sql
SELECT "T".a, b
FROM foo AS "T";
```

On `main`, RF03 can insert `T.b`. PostgreSQL folds that naked identifier, so it is not the same alias as `"T"`. This change inserts `"T".b`.

## Testing

- `pytest -q test/rules/yaml_test_cases_test.py -k RF03`: 64 passed
- Ruff 0.15.5 check and format check: passed
- YAML lint: passed
- `git diff --check`: passed

## AI assistance

This change was prepared with Codex assistance for diagnosis, implementation, rebase, and test execution. I authorized the submission and remain responsible for the change. The validation above was rerun against current `main`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix RF03 to preserve the original qualifier tokens so quoted aliases and BigQuery identifiers keep their identity when auto-qualifying. Inserts "T".b instead of T.b on Postgres, backticks dashed tables on BigQuery (`table-a123`.col), skips unsafe fixes for templated dashed names, recognizes `t.col` as a single quoted identifier, and adds regression tests.

<sup>Written for commit baef57aad384932cd7850e185d6f09b098f6eda2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8207?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

