### PR TITLE
Add GitHub Actions workflows for agent scan analysis and moderation

### DIFF
--- a/.github/workflows/agent-scan-analyze.yml
+++ b/.github/workflows/agent-scan-analyze.yml
@@ -1,0 +1,47 @@
+name: agent-scan-analyze
+
+on:
+  # DO NOT add action/checkout in this workflow as it use pull_request_target
+  pull_request:
+    types:
+      - opened
+
+permissions:
+  contents: read
+  pull-requests: read
+  actions: read
+
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Run AgentScan classification
+        id: agentscan
+        uses: MatteoGabriele/agentscan-action@c7d61446e7aece6bdd3edcee4558bbfc0392615e # v2.0.1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          mode: "labels"
+          trusted-author-associations: "owner, member"
+
+      - name: Write moderation payload
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          CLASSIFICATION: ${{ steps.agentscan.outputs.classification }}
+          COMMUNITY_FLAGGED: ${{ steps.agentscan.outputs.community-flagged }}
+        run: |
+          cat > moderation.json <<EOF
+          {
+            "pr_number": ${PR_NUMBER},
+            "classification": "${CLASSIFICATION}",
+            "community_flagged": ${COMMUNITY_FLAGGED}
+          }
+          EOF
+
+      - name: Upload moderation payload
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # 7.0.1
+        with:
+          name: agentscan-result
+          path: moderation.json
+          if-no-files-found: error
+          retention-days: 1

--- a/.github/workflows/agent-scan-analyze.yml
+++ b/.github/workflows/agent-scan-analyze.yml
@@ -1,7 +1,6 @@
-name: agent-scan-analyze
+name: AgentScan Analyze
 
 on:
-  # DO NOT add action/checkout in this workflow as it use pull_request_target
   pull_request:
     types:
       - opened
@@ -21,7 +20,7 @@ jobs:
         uses: MatteoGabriele/agentscan-action@c7d61446e7aece6bdd3edcee4558bbfc0392615e # v2.0.1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          mode: "labels"
+          mode: "silent"
           trusted-author-associations: "owner, member"
 
       - name: Write moderation payload
@@ -30,6 +29,13 @@ jobs:
           CLASSIFICATION: ${{ steps.agentscan.outputs.classification }}
           COMMUNITY_FLAGGED: ${{ steps.agentscan.outputs.community-flagged }}
         run: |
+          CLASSIFICATION="${CLASSIFICATION:-organic}"
+          COMMUNITY_FLAGGED="${COMMUNITY_FLAGGED:-false}"
+
+          if [[ "${COMMUNITY_FLAGGED}" != "true" && "${COMMUNITY_FLAGGED}" != "false" ]]; then
+            COMMUNITY_FLAGGED="false"
+          fi
+
           cat > moderation.json <<EOF
           {
             "pr_number": ${PR_NUMBER},

--- a/.github/workflows/agent-scan-moderate.yml
+++ b/.github/workflows/agent-scan-moderate.yml
@@ -1,0 +1,114 @@
+name: agent-scan-moderate
+
+on:
+  workflow_run:
+    workflows:
+      - agent-scan-analyze
+    types:
+      - completed
+
+permissions:
+  actions: read
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: agent-scan-${{ github.event.workflow_run.id }}
+  cancel-in-progress: true
+
+jobs:
+  moderate:
+    if: >
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download moderation payload
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: agentscan-result
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+          path: ./agentscan-result
+
+      - name: Handle flagged PR
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const fs = require("fs");
+            const payload = JSON.parse(
+              fs.readFileSync("./agentscan-result/moderation.json", "utf8")
+            );
+
+            const commentSentinel = "<!-- agentscan:possible-bot-comment:v1 -->";
+            const prNumber = payload.pr_number;
+            const classification = payload.classification;
+            const communityFlagged = Boolean(payload.community_flagged);
+            const shouldAct = ["automation", "mixed"].includes(classification) || communityFlagged;
+            const shouldClose = classification === "automation" || communityFlagged;
+
+            if (!shouldAct) {
+              core.info("PR not flagged. Nothing to do.");
+              return;
+            }
+
+            const { data: issue } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+            });
+
+            const labels = issue.labels?.map(label => label.name) || [];
+            if (!labels.includes("possible bot")) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                labels: ["possible bot"],
+              });
+            }
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              per_page: 100,
+            });
+
+            const alreadyCommented = comments.some(
+              comment =>
+                comment.user.login === "github-actions[bot]" &&
+                comment.body.includes(commentSentinel)
+            );
+
+            if (!alreadyCommented) {
+              const closingNote = shouldClose
+                ? "We're closing this for now as the account looks automated. If we got that wrong, please just reopen the PR and we'll take another look."
+                : "If this was flagged in error, we apologise! Just let us know.";
+
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body: [
+                  commentSentinel,
+                  "We've flagged this as a potential contribution without a human behind it. We welcome the thoughtful use of AI tools when contributing to SQLFluff, but ask all contributors to follow two core principles:",
+                  "",
+                  "1. The contributor remains responsible for the final pull request.",
+                  "2. If AI tools were used in a material way, disclose this in the pull request.",
+                  "",
+                  "Please review our [AI-assisted contribution guidelines](https://github.com/sqlfluff/sqlfluff/blob/main/CONTRIBUTING.md#ai-assisted-contributions) and update this contribution if needed.",
+                  "",
+                  closingNote,
+                ].join("\n"),
+              });
+            }
+
+            if (shouldClose && issue.state === "open" && !alreadyCommented) {
+              await github.rest.pulls.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: prNumber,
+                state: "closed",
+              });
+            }

--- a/.github/workflows/agent-scan-moderate.yml
+++ b/.github/workflows/agent-scan-moderate.yml
@@ -1,9 +1,9 @@
-name: agent-scan-moderate
+name: AgentScan Moderate
 
 on:
   workflow_run:
     workflows:
-      - agent-scan-analyze
+      - AgentScan Analyze
     types:
       - completed
 
@@ -104,7 +104,7 @@ jobs:
               });
             }
 
-            if (shouldClose && issue.state === "open" && !alreadyCommented) {
+            if (shouldClose && issue.state === "open") {
               await github.rest.pulls.update({
                 owner: context.repo.owner,
                 repo: context.repo.repo,

--- a/.github/workflows/agent-scan-moderate.yml
+++ b/.github/workflows/agent-scan-moderate.yml
@@ -40,10 +40,22 @@ jobs:
               fs.readFileSync("./agentscan-result/moderation.json", "utf8")
             );
 
-            const eventPrNumber = context.payload.workflow_run?.pull_requests?.[0]?.number;
+            let eventPrNumber = context.payload.workflow_run?.pull_requests?.[0]?.number;
             if (!eventPrNumber) {
-              core.setFailed("No pull request associated with this workflow_run event.");
-              return;
+              // Fork-originated PRs arrive with pull_requests empty; resolve via head SHA.
+              const headSha = context.payload.workflow_run.head_sha;
+              const { data: matchedPRs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                commit_sha: headSha,
+              });
+              const openPR = matchedPRs.find(pr => pr.state === "open");
+              eventPrNumber = openPR?.number;
+              if (!eventPrNumber) {
+                core.setFailed(`No open pull request found for commit ${headSha}.`);
+                return;
+              }
+              core.info(`Resolved PR #${eventPrNumber} from head SHA ${headSha}.`);
             }
 
             const payloadPrNumber = Number(payload.pr_number);

--- a/.github/workflows/agent-scan-moderate.yml
+++ b/.github/workflows/agent-scan-moderate.yml
@@ -40,10 +40,26 @@ jobs:
               fs.readFileSync("./agentscan-result/moderation.json", "utf8")
             );
 
+            const eventPrNumber = context.payload.workflow_run?.pull_requests?.[0]?.number;
+            if (!eventPrNumber) {
+              core.setFailed("No pull request associated with this workflow_run event.");
+              return;
+            }
+
+            const payloadPrNumber = Number(payload.pr_number);
+            if (Number.isFinite(payloadPrNumber) && payloadPrNumber !== eventPrNumber) {
+              core.warning(
+                `Ignoring artifact PR number ${payloadPrNumber}; using event PR number ${eventPrNumber}.`
+              );
+            }
+
             const commentSentinel = "<!-- agentscan:possible-bot-comment:v1 -->";
-            const prNumber = payload.pr_number;
-            const classification = payload.classification;
-            const communityFlagged = Boolean(payload.community_flagged);
+            const prNumber = eventPrNumber;
+            const allowedClassifications = ["organic", "mixed", "automation"];
+            const classification = allowedClassifications.includes(payload.classification)
+              ? payload.classification
+              : "organic";
+            const communityFlagged = payload.community_flagged === true || payload.community_flagged === "true";
             const shouldAct = ["automation", "mixed"].includes(classification) || communityFlagged;
             const shouldClose = classification === "automation" || communityFlagged;
 

--- a/.github/workflows/agent-scan-moderate.yml
+++ b/.github/workflows/agent-scan-moderate.yml
@@ -49,7 +49,12 @@ jobs:
                 repo: context.repo.repo,
                 commit_sha: headSha,
               });
-              const openPR = matchedPRs.find(pr => pr.state === "open");
+              const run = context.payload.workflow_run;
+              const openPR = matchedPRs.find(pr =>
+                pr.state === "open" &&
+                pr.head.sha === run.head_sha &&
+                pr.head.repo?.full_name === run.head_repository?.full_name
+              );
               eventPrNumber = openPR?.number;
               if (!eventPrNumber) {
                 core.setFailed(`No open pull request found for commit ${headSha}.`);


### PR DESCRIPTION
### Brief summary of the change made

This PR adds an AgentScan-based moderation flow for new pull requests using two workflows:

* analyze workflow: runs on PR open, classifies the PR with AgentScan, and uploads a small moderation payload artifact.
* moderate workflow: runs after analyze completes, reads the payload, labels flagged PRs as possible bot, posts a single guidance comment, and closes clearly automated/community-flagged PRs.

The flow is designed to be idempotent (sentinel comment check), with minimal-permission.

PS: For obvious reasons I could not test it in real life.

### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds two GitHub Actions to scan new PRs with AgentScan and auto-moderate suspicious ones. Flagged PRs get a "possible bot" label and one guidance comment; "automation" or community-flagged PRs are closed, while "mixed" are not.

- **New Features**
  - agent-scan-analyze: runs on PR open; classifies via `MatteoGabriele/agentscan-action` (silent; trusted: owner, member); writes `moderation.json` with defaults; uploads via `actions/upload-artifact` (1 day).
  - agent-scan-moderate: triggers on successful analyze `workflow_run`; downloads via `actions/download-artifact`; labels "possible bot"; posts one sentinel-guarded comment via `actions/github-script`; closes only when "automation" or community-flagged. Minimal permissions, pinned SHAs, run-level concurrency.

- **Bug Fixes**
  - PR resolution: derives PR from `workflow_run`; resolves forks via head SHA; enforces repo + head SHA match; ignores artifact PR mismatches; runs only for successful PR-triggered runs.
  - Payload safety: restricts `classification` to `organic|mixed|automation` (default `organic`); coerces `community_flagged` to boolean.

<sup>Written for commit 7331107d740a464e039c7f5aaf6e5aaec6400bde. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8208?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



