### PR TITLE
feat(clickhouse): add clickhouse specific truncate table grammar

### DIFF
--- a/src/sqlfluff/dialects/dialect_clickhouse.py
+++ b/src/sqlfluff/dialects/dialect_clickhouse.py
@@ -1988,6 +1988,27 @@ class CreateDictionaryStatementSegment(BaseSegment):
     )
 
 
+class TruncateStatementSegment(ansi.TruncateStatementSegment):
+    """A `TRUNCATE TABLE` statement.
+
+    As specified in
+    https://clickhouse.com/docs/sql-reference/statements/truncate
+    """
+
+    type = "truncate_table"
+
+    match_grammar: Matchable = Sequence(
+        "TRUNCATE",
+        # TABLE keyword is optional, even though the documentation
+        # doesn't state it
+        Ref.keyword("TABLE", optional=True),
+        Ref("IfExistsGrammar", optional=True),
+        Ref("TableReferenceSegment"),
+        Ref("OnClusterClauseSegment", optional=True),
+        Ref.keyword("SYNC", optional=True),
+    )
+
+
 class DropTableStatementSegment(ansi.DropTableStatementSegment):
     """A `DROP TABLE` statement.
 

--- a/test/fixtures/dialects/clickhouse/truncate_table.sql
+++ b/test/fixtures/dialects/clickhouse/truncate_table.sql
@@ -1,0 +1,63 @@
+TRUNCATE TABLE IF EXISTS default.users;
+
+TRUNCATE TABLE IF EXISTS users;
+
+TRUNCATE TABLE default.users;
+
+TRUNCATE TABLE users;
+
+TRUNCATE TABLE IF EXISTS default.users ON CLUSTER clstr;
+
+TRUNCATE TABLE IF EXISTS users ON CLUSTER clstr;
+
+TRUNCATE TABLE default.users ON CLUSTER clstr;
+
+TRUNCATE TABLE users ON CLUSTER clstr;
+
+TRUNCATE TABLE IF EXISTS default.users SYNC;
+
+TRUNCATE TABLE IF EXISTS users SYNC;
+
+TRUNCATE TABLE default.users SYNC;
+
+TRUNCATE TABLE users SYNC;
+
+TRUNCATE TABLE IF EXISTS default.users ON CLUSTER clstr SYNC;
+
+TRUNCATE TABLE IF EXISTS users ON CLUSTER clstr SYNC;
+
+TRUNCATE TABLE default.users ON CLUSTER clstr SYNC;
+
+TRUNCATE TABLE users ON CLUSTER clstr SYNC;
+
+TRUNCATE IF EXISTS default.users;
+
+TRUNCATE IF EXISTS users;
+
+TRUNCATE default.users;
+
+TRUNCATE users;
+
+TRUNCATE IF EXISTS default.users ON CLUSTER clstr;
+
+TRUNCATE IF EXISTS users ON CLUSTER clstr;
+
+TRUNCATE default.users ON CLUSTER clstr;
+
+TRUNCATE users ON CLUSTER clstr;
+
+TRUNCATE IF EXISTS default.users SYNC;
+
+TRUNCATE IF EXISTS users SYNC;
+
+TRUNCATE default.users SYNC;
+
+TRUNCATE users SYNC;
+
+TRUNCATE IF EXISTS default.users ON CLUSTER clstr SYNC;
+
+TRUNCATE IF EXISTS users ON CLUSTER clstr SYNC;
+
+TRUNCATE default.users ON CLUSTER clstr SYNC;
+
+TRUNCATE users ON CLUSTER clstr SYNC;

--- a/test/fixtures/dialects/clickhouse/truncate_table.yml
+++ b/test/fixtures/dialects/clickhouse/truncate_table.yml
@@ -1,0 +1,359 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 33775e0659109c407d7dab47d68c69ec25d350645a94b5db0cd7d4c36bce6f67
+file:
+- statement:
+    truncate_table:
+    - keyword: TRUNCATE
+    - keyword: TABLE
+    - keyword: IF
+    - keyword: EXISTS
+    - table_reference:
+      - naked_identifier: default
+      - dot: .
+      - naked_identifier: users
+- statement_terminator: ;
+- statement:
+    truncate_table:
+    - keyword: TRUNCATE
+    - keyword: TABLE
+    - keyword: IF
+    - keyword: EXISTS
+    - table_reference:
+        naked_identifier: users
+- statement_terminator: ;
+- statement:
+    truncate_table:
+    - keyword: TRUNCATE
+    - keyword: TABLE
+    - table_reference:
+      - naked_identifier: default
+      - dot: .
+      - naked_identifier: users
+- statement_terminator: ;
+- statement:
+    truncate_table:
+    - keyword: TRUNCATE
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: users
+- statement_terminator: ;
+- statement:
+    truncate_table:
+    - keyword: TRUNCATE
+    - keyword: TABLE
+    - keyword: IF
+    - keyword: EXISTS
+    - table_reference:
+      - naked_identifier: default
+      - dot: .
+      - naked_identifier: users
+    - on_cluster_clause:
+      - keyword: 'ON'
+      - keyword: CLUSTER
+      - naked_identifier: clstr
+- statement_terminator: ;
+- statement:
+    truncate_table:
+    - keyword: TRUNCATE
+    - keyword: TABLE
+    - keyword: IF
+    - keyword: EXISTS
+    - table_reference:
+        naked_identifier: users
+    - on_cluster_clause:
+      - keyword: 'ON'
+      - keyword: CLUSTER
+      - naked_identifier: clstr
+- statement_terminator: ;
+- statement:
+    truncate_table:
+    - keyword: TRUNCATE
+    - keyword: TABLE
+    - table_reference:
+      - naked_identifier: default
+      - dot: .
+      - naked_identifier: users
+    - on_cluster_clause:
+      - keyword: 'ON'
+      - keyword: CLUSTER
+      - naked_identifier: clstr
+- statement_terminator: ;
+- statement:
+    truncate_table:
+    - keyword: TRUNCATE
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: users
+    - on_cluster_clause:
+      - keyword: 'ON'
+      - keyword: CLUSTER
+      - naked_identifier: clstr
+- statement_terminator: ;
+- statement:
+    truncate_table:
+    - keyword: TRUNCATE
+    - keyword: TABLE
+    - keyword: IF
+    - keyword: EXISTS
+    - table_reference:
+      - naked_identifier: default
+      - dot: .
+      - naked_identifier: users
+    - keyword: SYNC
+- statement_terminator: ;
+- statement:
+    truncate_table:
+    - keyword: TRUNCATE
+    - keyword: TABLE
+    - keyword: IF
+    - keyword: EXISTS
+    - table_reference:
+        naked_identifier: users
+    - keyword: SYNC
+- statement_terminator: ;
+- statement:
+    truncate_table:
+    - keyword: TRUNCATE
+    - keyword: TABLE
+    - table_reference:
+      - naked_identifier: default
+      - dot: .
+      - naked_identifier: users
+    - keyword: SYNC
+- statement_terminator: ;
+- statement:
+    truncate_table:
+    - keyword: TRUNCATE
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: users
+    - keyword: SYNC
+- statement_terminator: ;
+- statement:
+    truncate_table:
+    - keyword: TRUNCATE
+    - keyword: TABLE
+    - keyword: IF
+    - keyword: EXISTS
+    - table_reference:
+      - naked_identifier: default
+      - dot: .
+      - naked_identifier: users
+    - on_cluster_clause:
+      - keyword: 'ON'
+      - keyword: CLUSTER
+      - naked_identifier: clstr
+    - keyword: SYNC
+- statement_terminator: ;
+- statement:
+    truncate_table:
+    - keyword: TRUNCATE
+    - keyword: TABLE
+    - keyword: IF
+    - keyword: EXISTS
+    - table_reference:
+        naked_identifier: users
+    - on_cluster_clause:
+      - keyword: 'ON'
+      - keyword: CLUSTER
+      - naked_identifier: clstr
+    - keyword: SYNC
+- statement_terminator: ;
+- statement:
+    truncate_table:
+    - keyword: TRUNCATE
+    - keyword: TABLE
+    - table_reference:
+      - naked_identifier: default
+      - dot: .
+      - naked_identifier: users
+    - on_cluster_clause:
+      - keyword: 'ON'
+      - keyword: CLUSTER
+      - naked_identifier: clstr
+    - keyword: SYNC
+- statement_terminator: ;
+- statement:
+    truncate_table:
+    - keyword: TRUNCATE
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: users
+    - on_cluster_clause:
+      - keyword: 'ON'
+      - keyword: CLUSTER
+      - naked_identifier: clstr
+    - keyword: SYNC
+- statement_terminator: ;
+- statement:
+    truncate_table:
+    - keyword: TRUNCATE
+    - keyword: IF
+    - keyword: EXISTS
+    - table_reference:
+      - naked_identifier: default
+      - dot: .
+      - naked_identifier: users
+- statement_terminator: ;
+- statement:
+    truncate_table:
+    - keyword: TRUNCATE
+    - keyword: IF
+    - keyword: EXISTS
+    - table_reference:
+        naked_identifier: users
+- statement_terminator: ;
+- statement:
+    truncate_table:
+      keyword: TRUNCATE
+      table_reference:
+      - naked_identifier: default
+      - dot: .
+      - naked_identifier: users
+- statement_terminator: ;
+- statement:
+    truncate_table:
+      keyword: TRUNCATE
+      table_reference:
+        naked_identifier: users
+- statement_terminator: ;
+- statement:
+    truncate_table:
+    - keyword: TRUNCATE
+    - keyword: IF
+    - keyword: EXISTS
+    - table_reference:
+      - naked_identifier: default
+      - dot: .
+      - naked_identifier: users
+    - on_cluster_clause:
+      - keyword: 'ON'
+      - keyword: CLUSTER
+      - naked_identifier: clstr
+- statement_terminator: ;
+- statement:
+    truncate_table:
+    - keyword: TRUNCATE
+    - keyword: IF
+    - keyword: EXISTS
+    - table_reference:
+        naked_identifier: users
+    - on_cluster_clause:
+      - keyword: 'ON'
+      - keyword: CLUSTER
+      - naked_identifier: clstr
+- statement_terminator: ;
+- statement:
+    truncate_table:
+      keyword: TRUNCATE
+      table_reference:
+      - naked_identifier: default
+      - dot: .
+      - naked_identifier: users
+      on_cluster_clause:
+      - keyword: 'ON'
+      - keyword: CLUSTER
+      - naked_identifier: clstr
+- statement_terminator: ;
+- statement:
+    truncate_table:
+      keyword: TRUNCATE
+      table_reference:
+        naked_identifier: users
+      on_cluster_clause:
+      - keyword: 'ON'
+      - keyword: CLUSTER
+      - naked_identifier: clstr
+- statement_terminator: ;
+- statement:
+    truncate_table:
+    - keyword: TRUNCATE
+    - keyword: IF
+    - keyword: EXISTS
+    - table_reference:
+      - naked_identifier: default
+      - dot: .
+      - naked_identifier: users
+    - keyword: SYNC
+- statement_terminator: ;
+- statement:
+    truncate_table:
+    - keyword: TRUNCATE
+    - keyword: IF
+    - keyword: EXISTS
+    - table_reference:
+        naked_identifier: users
+    - keyword: SYNC
+- statement_terminator: ;
+- statement:
+    truncate_table:
+    - keyword: TRUNCATE
+    - table_reference:
+      - naked_identifier: default
+      - dot: .
+      - naked_identifier: users
+    - keyword: SYNC
+- statement_terminator: ;
+- statement:
+    truncate_table:
+    - keyword: TRUNCATE
+    - table_reference:
+        naked_identifier: users
+    - keyword: SYNC
+- statement_terminator: ;
+- statement:
+    truncate_table:
+    - keyword: TRUNCATE
+    - keyword: IF
+    - keyword: EXISTS
+    - table_reference:
+      - naked_identifier: default
+      - dot: .
+      - naked_identifier: users
+    - on_cluster_clause:
+      - keyword: 'ON'
+      - keyword: CLUSTER
+      - naked_identifier: clstr
+    - keyword: SYNC
+- statement_terminator: ;
+- statement:
+    truncate_table:
+    - keyword: TRUNCATE
+    - keyword: IF
+    - keyword: EXISTS
+    - table_reference:
+        naked_identifier: users
+    - on_cluster_clause:
+      - keyword: 'ON'
+      - keyword: CLUSTER
+      - naked_identifier: clstr
+    - keyword: SYNC
+- statement_terminator: ;
+- statement:
+    truncate_table:
+    - keyword: TRUNCATE
+    - table_reference:
+      - naked_identifier: default
+      - dot: .
+      - naked_identifier: users
+    - on_cluster_clause:
+      - keyword: 'ON'
+      - keyword: CLUSTER
+      - naked_identifier: clstr
+    - keyword: SYNC
+- statement_terminator: ;
+- statement:
+    truncate_table:
+    - keyword: TRUNCATE
+    - table_reference:
+        naked_identifier: users
+    - on_cluster_clause:
+      - keyword: 'ON'
+      - keyword: CLUSTER
+      - naked_identifier: clstr
+    - keyword: SYNC
+- statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
fixes #8209. Adds support for Clickhouse specific clauses like `ON CLUSTER cluster` and ```SYNC```, as well as ```IF EXISTS``` for ```TRUNCATE [TABLE]```
https://clickhouse.com/docs/sql-reference/statements/truncate#truncate-table 
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->


### Are there any other side effects of this change that we should be aware of?
There should not be any

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
- Added appropriate documentation for the change.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add ClickHouse-specific TRUNCATE parsing so SQLFluff understands ClickHouse-only options and syntax. Fixes #8209.

- **New Features**
  - Support both `TRUNCATE TABLE` and `TRUNCATE`, with `IF EXISTS`, `ON CLUSTER <cluster>`, and `SYNC`.
  - Added fixtures covering schema-qualified and unqualified tables, with/without cluster and sync.

<sup>Written for commit 3d72bd758016a02e520533907cc2048c09d410cd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8210?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



