### PR TITLE
Fix CI lint instability caused by upgrading to Ruff 0.16.0 in scheduled runs.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -235,9 +235,10 @@ line-length = 88
 
 [tool.ruff.format]
 quote-style = "double"
+exclude = ["*.md"]
 
 [tool.ruff.lint]
-extend-select = ["I", "D"]
+select = ["E4", "E7", "E9", "F", "I", "D"]
 
 # D105: Missing docstring in magic method
 # D107: Missing docstring in __init__


### PR DESCRIPTION
### Brief summary of the change made

Ruff 0.16.0 changed behavior when relying on defaults, which unexpectedly enabled many additional rules and caused ~1.7k lint violations in CI. It also began checking Markdown formatting, creating extra noise.

Made Ruff lint selection explicit in pyproject.toml:
* select = ["E4", "E7", "E9", "F", "I", "D"]
* Excluded Markdown from Ruff formatting checks:

### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [ ] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes CI linting after `ruff` 0.16.0 changed defaults, which triggered ~1.7k unexpected violations in scheduled runs. We now explicitly select our rules and skip Markdown formatting to reduce noise.

- **Bug Fixes**
  - Set `tool.ruff.lint.select = ["E4","E7","E9","F","I","D"]` to avoid implicit rule changes.
  - Added `tool.ruff.format.exclude = ["*.md"]` to stop formatting checks on Markdown files.

<sup>Written for commit 4ebfec62266b7ef6e8852651ec7293f5d8cf16ab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8211?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

