### PR TITLE
Fix Databricks materialized view expectation constraints

### DIFF
--- a/src/sqlfluff/dialects/dialect_databricks.py
+++ b/src/sqlfluff/dialects/dialect_databricks.py
@@ -948,6 +948,28 @@ class CreateViewStatementSegment(BaseSegment):
     )
 
 
+class MaterializedViewExpectationConstraintSegment(BaseSegment):
+    """A data quality expectation for a materialized view."""
+
+    type = "constraint_statement"
+
+    match_grammar = Sequence(
+        "CONSTRAINT",
+        Ref("ObjectReferenceSegment"),
+        "EXPECT",
+        Bracketed(Ref("ExpressionSegment")),
+        Sequence(
+            "ON",
+            "VIOLATION",
+            OneOf(
+                Sequence("FAIL", "UPDATE"),
+                Sequence("DROP", "ROW"),
+            ),
+            optional=True,
+        ),
+    )
+
+
 class CreateMaterializedViewStatementSegment(BaseSegment):
     """A `CREATE MATERIALIZED VIEW` Statement.
 
@@ -1026,6 +1048,7 @@ class CreateMaterializedViewStatementSegment(BaseSegment):
             Delimited(
                 OneOf(
                     Ref("ColumnFieldDefinitionSegment"),
+                    Ref("MaterializedViewExpectationConstraintSegment"),
                     Ref("TableConstraintSegment"),
                 ),
             ),

--- a/src/sqlfluff/dialects/dialect_databricks.py
+++ b/src/sqlfluff/dialects/dialect_databricks.py
@@ -1045,11 +1045,25 @@ class CreateMaterializedViewStatementSegment(BaseSegment):
         Ref("IfNotExistsGrammar", optional=True),
         Ref("TableReferenceSegment"),
         Bracketed(
-            Delimited(
-                OneOf(
-                    Ref("ColumnFieldDefinitionSegment"),
-                    Ref("MaterializedViewExpectationConstraintSegment"),
-                    Ref("TableConstraintSegment"),
+            Sequence(
+                Ref("ColumnFieldDefinitionSegment"),
+                AnyNumberOf(
+                    Sequence(
+                        Ref("CommaSegment"),
+                        Ref("ColumnFieldDefinitionSegment"),
+                    ),
+                ),
+                AnyNumberOf(
+                    Sequence(
+                        Ref("CommaSegment"),
+                        Ref("MaterializedViewExpectationConstraintSegment"),
+                    ),
+                ),
+                AnyNumberOf(
+                    Sequence(
+                        Ref("CommaSegment"),
+                        Ref("TableConstraintSegment"),
+                    ),
                 ),
             ),
             optional=True,

--- a/test/dialects/databricks_test.py
+++ b/test/dialects/databricks_test.py
@@ -1,0 +1,39 @@
+"""Databricks dialect-specific parser rejection tests."""
+
+import pytest
+
+from sqlfluff.core import Linter
+
+
+def _violations(sql: str) -> list:
+    """Return all parse errors, including unparsable nodes in the tree."""
+    parsed = Linter(dialect="databricks").parse_string(sql)
+    violations: list = list(parsed.violations)
+    if parsed.tree:
+        violations += list(parsed.tree.recursive_crawl("unparsable"))
+    return violations
+
+
+@pytest.mark.parametrize(
+    "sql",
+    [
+        pytest.param(
+            """CREATE MATERIALIZED VIEW bad_mv (
+                CONSTRAINT c EXPECT (value > 0),
+                value INT
+            ) AS SELECT 1 AS value;""",
+            id="expectation_before_column",
+        ),
+        pytest.param(
+            """CREATE MATERIALIZED VIEW bad_mv (
+                value INT,
+                CONSTRAINT pk PRIMARY KEY (value),
+                CONSTRAINT c EXPECT (value > 0)
+            ) AS SELECT 1 AS value;""",
+            id="expectation_after_table_constraint",
+        ),
+    ],
+)
+def test_materialized_view_constraints_reject_invalid_order(sql: str) -> None:
+    """Materialized view constraints must follow columns and expectations."""
+    assert _violations(sql), f"Expected violations but got none for:\n{sql}"

--- a/test/fixtures/dialects/databricks/create_materialized_view.sql
+++ b/test/fixtures/dialects/databricks/create_materialized_view.sql
@@ -17,6 +17,21 @@ CREATE MATERIALIZED VIEW typed_mv (
     amount DECIMAL(10, 2)
 ) AS SELECT id, name, amount FROM orders;
 
+CREATE MATERIALIZED VIEW expect_mv (
+    value INT,
+    CONSTRAINT positive_value EXPECT (value > 0)
+) AS SELECT 1 AS value;
+
+CREATE MATERIALIZED VIEW fail_update_mv (
+    value INT,
+    CONSTRAINT positive_value EXPECT (value > 0) ON VIOLATION FAIL UPDATE
+) AS SELECT 1 AS value;
+
+CREATE MATERIALIZED VIEW drop_row_mv (
+    value INT,
+    CONSTRAINT positive_value EXPECT (value > 0) ON VIOLATION DROP ROW
+) AS SELECT 1 AS value;
+
 CREATE MATERIALIZED VIEW sales_mv
 COMMENT 'Materialized view for sales analytics'
 AS SELECT region, SUM(amount) as total FROM sales GROUP BY region;

--- a/test/fixtures/dialects/databricks/create_materialized_view.sql
+++ b/test/fixtures/dialects/databricks/create_materialized_view.sql
@@ -22,6 +22,18 @@ CREATE MATERIALIZED VIEW expect_mv (
     CONSTRAINT positive_value EXPECT (value > 0)
 ) AS SELECT 1 AS value;
 
+CREATE MATERIALIZED VIEW multiple_expectations_mv (
+    value INT,
+    CONSTRAINT positive_value EXPECT (value > 0),
+    CONSTRAINT small_value EXPECT (value < 10)
+) AS SELECT 1 AS value;
+
+CREATE MATERIALIZED VIEW ordered_constraints_mv (
+    value INT,
+    CONSTRAINT positive_value EXPECT (value > 0),
+    CONSTRAINT pk_ordered_constraints_mv PRIMARY KEY (value)
+) AS SELECT 1 AS value;
+
 CREATE MATERIALIZED VIEW fail_update_mv (
     value INT,
     CONSTRAINT positive_value EXPECT (value > 0) ON VIOLATION FAIL UPDATE

--- a/test/fixtures/dialects/databricks/create_materialized_view.yml
+++ b/test/fixtures/dialects/databricks/create_materialized_view.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: cb4449e3f689b62380dcd9908fb116858f0f3ac98cd9491e6a4752d08018c65f
+_hash: 46fd70fc308cabcbe991692118ce1403c717eb119b002a183a60a5dd11260b70
 file:
 - statement:
     create_materialized_view_statement:
@@ -150,6 +150,140 @@ file:
               table_expression:
                 table_reference:
                   naked_identifier: orders
+- statement_terminator: ;
+- statement:
+    create_materialized_view_statement:
+    - keyword: CREATE
+    - keyword: MATERIALIZED
+    - keyword: VIEW
+    - table_reference:
+        naked_identifier: expect_mv
+    - bracketed:
+        start_bracket: (
+        column_definition:
+          column_reference:
+            naked_identifier: value
+          data_type:
+            primitive_type:
+              keyword: INT
+        comma: ','
+        constraint_statement:
+        - keyword: CONSTRAINT
+        - object_reference:
+            naked_identifier: positive_value
+        - keyword: EXPECT
+        - bracketed:
+            start_bracket: (
+            expression:
+              column_reference:
+                naked_identifier: value
+              comparison_operator:
+                raw_comparison_operator: '>'
+              numeric_literal: '0'
+            end_bracket: )
+        end_bracket: )
+    - keyword: AS
+    - select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            numeric_literal: '1'
+            alias_expression:
+              alias_operator:
+                keyword: AS
+              naked_identifier: value
+- statement_terminator: ;
+- statement:
+    create_materialized_view_statement:
+    - keyword: CREATE
+    - keyword: MATERIALIZED
+    - keyword: VIEW
+    - table_reference:
+        naked_identifier: fail_update_mv
+    - bracketed:
+        start_bracket: (
+        column_definition:
+          column_reference:
+            naked_identifier: value
+          data_type:
+            primitive_type:
+              keyword: INT
+        comma: ','
+        constraint_statement:
+        - keyword: CONSTRAINT
+        - object_reference:
+            naked_identifier: positive_value
+        - keyword: EXPECT
+        - bracketed:
+            start_bracket: (
+            expression:
+              column_reference:
+                naked_identifier: value
+              comparison_operator:
+                raw_comparison_operator: '>'
+              numeric_literal: '0'
+            end_bracket: )
+        - keyword: 'ON'
+        - keyword: VIOLATION
+        - keyword: FAIL
+        - keyword: UPDATE
+        end_bracket: )
+    - keyword: AS
+    - select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            numeric_literal: '1'
+            alias_expression:
+              alias_operator:
+                keyword: AS
+              naked_identifier: value
+- statement_terminator: ;
+- statement:
+    create_materialized_view_statement:
+    - keyword: CREATE
+    - keyword: MATERIALIZED
+    - keyword: VIEW
+    - table_reference:
+        naked_identifier: drop_row_mv
+    - bracketed:
+        start_bracket: (
+        column_definition:
+          column_reference:
+            naked_identifier: value
+          data_type:
+            primitive_type:
+              keyword: INT
+        comma: ','
+        constraint_statement:
+        - keyword: CONSTRAINT
+        - object_reference:
+            naked_identifier: positive_value
+        - keyword: EXPECT
+        - bracketed:
+            start_bracket: (
+            expression:
+              column_reference:
+                naked_identifier: value
+              comparison_operator:
+                raw_comparison_operator: '>'
+              numeric_literal: '0'
+            end_bracket: )
+        - keyword: 'ON'
+        - keyword: VIOLATION
+        - keyword: DROP
+        - keyword: ROW
+        end_bracket: )
+    - keyword: AS
+    - select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            numeric_literal: '1'
+            alias_expression:
+              alias_operator:
+                keyword: AS
+              naked_identifier: value
 - statement_terminator: ;
 - statement:
     create_materialized_view_statement:

--- a/test/fixtures/dialects/databricks/create_materialized_view.yml
+++ b/test/fixtures/dialects/databricks/create_materialized_view.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 46fd70fc308cabcbe991692118ce1403c717eb119b002a183a60a5dd11260b70
+_hash: 7bb724f518b9dd85bd4eb4bb2b071a52c4ac1756b518a457e43e2b14dc7f52d0
 file:
 - statement:
     create_materialized_view_statement:
@@ -182,6 +182,117 @@ file:
               numeric_literal: '0'
             end_bracket: )
         end_bracket: )
+    - keyword: AS
+    - select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            numeric_literal: '1'
+            alias_expression:
+              alias_operator:
+                keyword: AS
+              naked_identifier: value
+- statement_terminator: ;
+- statement:
+    create_materialized_view_statement:
+    - keyword: CREATE
+    - keyword: MATERIALIZED
+    - keyword: VIEW
+    - table_reference:
+        naked_identifier: multiple_expectations_mv
+    - bracketed:
+      - start_bracket: (
+      - column_definition:
+          column_reference:
+            naked_identifier: value
+          data_type:
+            primitive_type:
+              keyword: INT
+      - comma: ','
+      - constraint_statement:
+        - keyword: CONSTRAINT
+        - object_reference:
+            naked_identifier: positive_value
+        - keyword: EXPECT
+        - bracketed:
+            start_bracket: (
+            expression:
+              column_reference:
+                naked_identifier: value
+              comparison_operator:
+                raw_comparison_operator: '>'
+              numeric_literal: '0'
+            end_bracket: )
+      - comma: ','
+      - constraint_statement:
+        - keyword: CONSTRAINT
+        - object_reference:
+            naked_identifier: small_value
+        - keyword: EXPECT
+        - bracketed:
+            start_bracket: (
+            expression:
+              column_reference:
+                naked_identifier: value
+              comparison_operator:
+                raw_comparison_operator: <
+              numeric_literal: '10'
+            end_bracket: )
+      - end_bracket: )
+    - keyword: AS
+    - select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            numeric_literal: '1'
+            alias_expression:
+              alias_operator:
+                keyword: AS
+              naked_identifier: value
+- statement_terminator: ;
+- statement:
+    create_materialized_view_statement:
+    - keyword: CREATE
+    - keyword: MATERIALIZED
+    - keyword: VIEW
+    - table_reference:
+        naked_identifier: ordered_constraints_mv
+    - bracketed:
+      - start_bracket: (
+      - column_definition:
+          column_reference:
+            naked_identifier: value
+          data_type:
+            primitive_type:
+              keyword: INT
+      - comma: ','
+      - constraint_statement:
+        - keyword: CONSTRAINT
+        - object_reference:
+            naked_identifier: positive_value
+        - keyword: EXPECT
+        - bracketed:
+            start_bracket: (
+            expression:
+              column_reference:
+                naked_identifier: value
+              comparison_operator:
+                raw_comparison_operator: '>'
+              numeric_literal: '0'
+            end_bracket: )
+      - comma: ','
+      - table_constraint:
+        - keyword: CONSTRAINT
+        - object_reference:
+            naked_identifier: pk_ordered_constraints_mv
+        - keyword: PRIMARY
+        - keyword: KEY
+        - bracketed:
+            start_bracket: (
+            column_reference:
+              naked_identifier: value
+            end_bracket: )
+      - end_bracket: )
     - keyword: AS
     - select_statement:
         select_clause:


### PR DESCRIPTION
### Brief summary of the change made

Fixes #8196.

Databricks materialized views support expectation constraints in the column list:

- `CONSTRAINT <name> EXPECT (...)`
- optional `ON VIOLATION FAIL UPDATE`
- optional `ON VIOLATION DROP ROW`

This adds a dedicated materialized-view expectation constraint segment and wires it only into `CREATE MATERIALIZED VIEW`. The shared table-constraint grammar remains unchanged, so the patch does not broaden this syntax into unrelated constraint contexts.

### Are there any other side effects of this change that we should be aware of?

None expected. Incomplete `ON VIOLATION` forms remain unparsable.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - [x] `.sql`/`.yml` parser test cases in `test/fixtures/dialects`.
- Added appropriate documentation for the change. Existing Databricks documentation already describes this syntax; no SQLFluff documentation change is needed.
- Created GitHub issues for any relevant followup/future enhancements if appropriate. Not needed.

### AI assistance

AI-assisted tooling was used during implementation and validation; I reviewed and verified the final change.

Validation:
- `.venv/bin/python test/generate_parse_fixture_yml.py -d databricks`
- `.venv/bin/python -m pytest test/dialects/dialects_test.py -k "databricks and create_materialized_view"`
- `.venv/bin/python -m pytest test/dialects/dialects_test.py -k databricks`
- `.venv/bin/ruff check src/sqlfluff/dialects/dialect_databricks.py`
- `.venv/bin/ruff format --check src/sqlfluff/dialects/dialect_databricks.py`
- `git diff --check`