### PR TITLE
Fix CV10 corrupting string literals that use quote-doubling escapes

### DIFF
--- a/src/sqlfluff/rules/convention/CV10.py
+++ b/src/sqlfluff/rules/convention/CV10.py
@@ -255,6 +255,19 @@ class Rule_CV10(BaseRule):
         escaped_orig_quote = regex.compile(rf"([^\\]|^)\\((?:\\\\)*){orig_quote}")
         body = s[first_quote_pos + len(orig_quote) : -len(orig_quote)]
 
+        unescaped_orig_quote = regex.compile(rf"(([^\\]|^)(\\\\)*){orig_quote}")
+        if unescaped_orig_quote.search(body):
+            # SQL escapes an embedded quote by doubling it (e.g. 'O''Brien'), which
+            # this backslash-oriented logic cannot re-encode for the new quote char.
+            # Copying the doubled quotes through unchanged would silently alter the
+            # value of the literal, so leave it alone.
+            self.logger.debug(
+                "Body %s contains an unescaped orig_quote, which suggests "
+                "quote doubling. Converting safely is impossible so skipping.",
+                body,
+            )
+            return s
+
         if "r" in prefix.lower():
             if unescaped_new_quote.search(body):
                 self.logger.debug(

--- a/test/rules/std_CV10_test.py
+++ b/test/rules/std_CV10_test.py
@@ -1,0 +1,25 @@
+"""Tests the python routines within CV10."""
+
+import sqlfluff
+
+
+def test__rules__std_CV10_quote_doubling_not_converted() -> None:
+    """CV10 leaves literals that escape a quote by doubling it alone.
+
+    Rewriting them would copy the doubled quotes into the other quote style,
+    where they are not an escape, silently changing the value of the literal.
+    The leading literal sets the consistent style, so the second one would
+    otherwise be converted.
+    """
+    sql = "SELECT \"x\", 'O''Brien' FROM t\n"
+    result = sqlfluff.fix(sql, rules=["CV10"], dialect="mysql")
+
+    assert "'O''Brien'" in result
+
+
+def test__rules__std_CV10_quote_doubling_not_converted_double_quotes() -> None:
+    """The same holds in the double-quoted direction."""
+    sql = 'SELECT \'x\', "say ""hi""" FROM t\n'
+    result = sqlfluff.fix(sql, rules=["CV10"], dialect="mysql")
+
+    assert '"say ""hi"""' in result


### PR DESCRIPTION
### Brief summary of the change made
Fixes #8179.

`CV10`'s quote normalizer was adapted from Black and understands only backslash escaping. SQL escapes an embedded quote by doubling it, so when the rule converted a literal to the other quote char it copied the doubled quotes through unchanged — where they are no longer an escape. `'O''Brien'` became `"O''Brien"`, silently changing the value the query returns.

This takes the minimal option from the issue: skip the fix when the literal body contains an unescaped `orig_quote`, mirroring the bail-out the raw-string branch already uses for cases it can't convert safely.

### Are there any other side effects of this change that we should be aware of?
Literals that use quote doubling are now left as-is rather than being restyled, so `consistent`/`single_quotes`/`double_quotes` will no longer flag them. Backslash-escaped literals and all other conversions are unaffected. Re-encoding the doubling for the target quote char would be the fuller fix, but that depends on per-dialect escape semantics.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other: `test/rules/std_CV10_test.py` — both directions, failing before this change and passing after.
- Added appropriate documentation for the change. N/A — no user-facing documentation change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate. N/A


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent CV10 from corrupting SQL string literals that use quote-doubling by skipping conversion when the literal contains an unescaped original quote. This preserves the literal’s value while keeping other conversions intact.

- **Bug Fixes**
  - Skip conversion if the body has an unescaped original quote (indicates quote-doubling).
  - Add tests covering both single- and double-quote directions.
  - Literals using quote-doubling are left as-is; `consistent`/`single_quotes`/`double_quotes` no longer flag them. Backslash-escaped cases are unchanged.

<sup>Written for commit 70984cc7b9f035195a679b32cea91a783053f9a6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8213?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

