### PR TITLE
BigQuery: support EXCEPT/REPLACE after semi-structured star

### DIFF
--- a/src/sqlfluff/dialects/dialect_bigquery.py
+++ b/src/sqlfluff/dialects/dialect_bigquery.py
@@ -1499,20 +1499,35 @@ class FunctionDefinitionGrammar(ansi.FunctionDefinitionGrammar):
 class WildcardExpressionSegment(ansi.WildcardExpressionSegment):
     """An extension of the star expression for Bigquery."""
 
-    match_grammar = Sequence(
-        OneOf(
-            # *, blah.*, blah.blah.*, etc.
-            Ref("WildcardIdentifierSegment"),
-            # Star following a semi-structured accessor, e.g. results[0].*
-            Sequence(
-                Ref("ColumnReferenceSegment"),
-                Ref("StarSemiStructuredAccessorSegment"),
+    match_grammar = OneOf(
+        Sequence(
+            OneOf(
+                # *, blah.*, blah.blah.*, etc.
+                Ref("WildcardIdentifierSegment"),
+                # Star following a semi-structured accessor, e.g. results[0].*
+                Sequence(
+                    Ref("ColumnReferenceSegment"),
+                    Ref("StarSemiStructuredAccessorSegment"),
+                ),
+            ),
+            # Optional EXCEPT or REPLACE clause
+            # https://cloud.google.com/bigquery/docs/reference/standard-sql/query-syntax#select_replace
+            Ref("ExceptClauseSegment", optional=True),
+            Ref("ReplaceClauseSegment", optional=True),
+        ),
+        # Functions returning STRUCTs consume any trailing `.*` themselves
+        # (via their semi-structured accessor), so only match here when an
+        # EXCEPT or REPLACE clause follows, e.g. as_struct(a, b).* EXCEPT (a)
+        Sequence(
+            Ref("FunctionSegment"),
+            OneOf(
+                Sequence(
+                    Ref("ExceptClauseSegment"),
+                    Ref("ReplaceClauseSegment", optional=True),
+                ),
+                Ref("ReplaceClauseSegment"),
             ),
         ),
-        # Optional EXCEPT or REPLACE clause
-        # https://cloud.google.com/bigquery/docs/reference/standard-sql/query-syntax#select_replace
-        Ref("ExceptClauseSegment", optional=True),
-        Ref("ReplaceClauseSegment", optional=True),
     )
 
 

--- a/src/sqlfluff/dialects/dialect_bigquery.py
+++ b/src/sqlfluff/dialects/dialect_bigquery.py
@@ -1499,13 +1499,20 @@ class FunctionDefinitionGrammar(ansi.FunctionDefinitionGrammar):
 class WildcardExpressionSegment(ansi.WildcardExpressionSegment):
     """An extension of the star expression for Bigquery."""
 
-    match_grammar = ansi.WildcardExpressionSegment.match_grammar.copy(
-        insert=[
-            # Optional EXCEPT or REPLACE clause
-            # https://cloud.google.com/bigquery/docs/reference/standard-sql/query-syntax#select_replace
-            Ref("ExceptClauseSegment", optional=True),
-            Ref("ReplaceClauseSegment", optional=True),
-        ]
+    match_grammar = Sequence(
+        OneOf(
+            # *, blah.*, blah.blah.*, etc.
+            Ref("WildcardIdentifierSegment"),
+            # Star following a semi-structured accessor, e.g. results[0].*
+            Sequence(
+                Ref("ColumnReferenceSegment"),
+                Ref("StarSemiStructuredAccessorSegment"),
+            ),
+        ),
+        # Optional EXCEPT or REPLACE clause
+        # https://cloud.google.com/bigquery/docs/reference/standard-sql/query-syntax#select_replace
+        Ref("ExceptClauseSegment", optional=True),
+        Ref("ReplaceClauseSegment", optional=True),
     )
 
 
@@ -1741,6 +1748,27 @@ class SemiStructuredAccessorSegment(BaseSegment):
             allow_gaps=True,
             min_times=1,
         ),
+        allow_gaps=True,
+    )
+
+
+class StarSemiStructuredAccessorSegment(BaseSegment):
+    """A semi-structured data accessor ending with a star, e.g. `[OFFSET(0)].*`."""
+
+    type = "semi_structured_expression"
+    match_grammar = Sequence(
+        AnyNumberOf(
+            Ref("ArrayAccessorSegment"),
+            Sequence(
+                Ref("DotSegment"),
+                Ref("SingleIdentifierGrammar"),
+                allow_gaps=True,
+            ),
+            allow_gaps=True,
+            min_times=1,
+        ),
+        Ref("DotSegment"),
+        Ref("StarSegment"),
         allow_gaps=True,
     )
 

--- a/test/fixtures/dialects/bigquery/select_except.sql
+++ b/test/fixtures/dialects/bigquery/select_except.sql
@@ -26,3 +26,11 @@ select
   error,
   results[0].* except (cola)
 from my_tbl;
+
+-- Replace following a semi-structured accessor
+select
+  results[0].* replace ('x' as colb)
+from my_tbl;
+
+-- Except following a function call returning a struct
+select as_struct(col_a, col_b).* except (col_a) from t;

--- a/test/fixtures/dialects/bigquery/select_except.sql
+++ b/test/fixtures/dialects/bigquery/select_except.sql
@@ -19,3 +19,10 @@ select
   foo.* except (some_column),
   bar.* except (other_column)
 from my_tbl;
+
+-- Except following a semi-structured accessor
+-- https://github.com/sqlfluff/sqlfluff/issues/8186
+select
+  error,
+  results[0].* except (cola)
+from my_tbl;

--- a/test/fixtures/dialects/bigquery/select_except.yml
+++ b/test/fixtures/dialects/bigquery/select_except.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 2a75600fe8b482cc8901bff063da812fa022262d426181aa1619a9b917d0f09c
+_hash: 3790599e472495d3b316a4f4f45e24467d626241c397fd27086d7bf65f25ab4c
 file:
 - statement:
     select_statement:
@@ -141,6 +141,39 @@ file:
               bracketed:
                 start_bracket: (
                 naked_identifier: other_column
+                end_bracket: )
+      from_clause:
+        keyword: from
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: my_tbl
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: select
+      - select_clause_element:
+          column_reference:
+            naked_identifier: error
+      - comma: ','
+      - select_clause_element:
+          wildcard_expression:
+            column_reference:
+              naked_identifier: results
+            semi_structured_expression:
+              array_accessor:
+                start_square_bracket: '['
+                numeric_literal: '0'
+                end_square_bracket: ']'
+              dot: .
+              star: '*'
+            select_except_clause:
+              keyword: except
+              bracketed:
+                start_bracket: (
+                naked_identifier: cola
                 end_bracket: )
       from_clause:
         keyword: from

--- a/test/fixtures/dialects/bigquery/select_except.yml
+++ b/test/fixtures/dialects/bigquery/select_except.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 3790599e472495d3b316a4f4f45e24467d626241c397fd27086d7bf65f25ab4c
+_hash: d5d8bbe252690668f326f89fb41206c700eab8780f59c3ad1b41a22696d77f2e
 file:
 - statement:
     select_statement:
@@ -182,4 +182,72 @@ file:
             table_expression:
               table_reference:
                 naked_identifier: my_tbl
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: select
+        select_clause_element:
+          wildcard_expression:
+            column_reference:
+              naked_identifier: results
+            semi_structured_expression:
+              array_accessor:
+                start_square_bracket: '['
+                numeric_literal: '0'
+                end_square_bracket: ']'
+              dot: .
+              star: '*'
+            select_replace_clause:
+              keyword: replace
+              bracketed:
+                start_bracket: (
+                quoted_literal: "'x'"
+                keyword: as
+                naked_identifier: colb
+                end_bracket: )
+      from_clause:
+        keyword: from
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: my_tbl
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: select
+        select_clause_element:
+          wildcard_expression:
+            function:
+              function_name:
+                function_name_identifier: as_struct
+              function_contents:
+                bracketed:
+                - start_bracket: (
+                - expression:
+                    column_reference:
+                      naked_identifier: col_a
+                - comma: ','
+                - expression:
+                    column_reference:
+                      naked_identifier: col_b
+                - end_bracket: )
+              semi_structured_expression:
+                dot: .
+                star: '*'
+            select_except_clause:
+              keyword: except
+              bracketed:
+                start_bracket: (
+                naked_identifier: col_a
+                end_bracket: )
+      from_clause:
+        keyword: from
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: t
 - statement_terminator: ;


### PR DESCRIPTION
### Brief summary of the change made

Fixes #8186

BigQuery allows `EXCEPT`/`REPLACE` modifiers after a star that follows a semi-structured accessor, e.g.:

```sql
SELECT results[0].* EXCEPT (cola) FROM t
```

Previously the `EXCEPT (cola)` part was flagged as unparsable, because `WildcardExpressionSegment` only matched plain wildcard identifiers (`*`, `tbl.*`). This PR extends the BigQuery `WildcardExpressionSegment` with a second branch matching a column reference followed by a new `StarSemiStructuredAccessorSegment` - a semi-structured accessor that must end in `.*` (so ordinary semi-structured expressions like `results[0].col` are unaffected and still parse as expressions).

Disclosure: this change was made with AI assistance (Devin), reviewed and tested before submission.

### Are there any other side effects of this change that we should be aware of?

Selects like `results[0].*` (even without EXCEPT/REPLACE) now parse as `wildcard_expression` instead of a plain expression, which means code that treats wildcard selects specially (e.g. query analysis) now recognises them as wildcards.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (added to `bigquery/select_except`).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add BigQuery support for EXCEPT/REPLACE after a semi-structured star and after a struct-returning function star, e.g. `results[0].* EXCEPT (cola)` and `as_struct(a, b).* EXCEPT (a)`. This fixes unparsable errors and aligns the parser with BigQuery syntax.

- **Bug Fixes**
  - Extend BigQuery `WildcardExpressionSegment` to accept a column reference followed by `StarSemiStructuredAccessorSegment` (e.g. `results[0].*`).
  - Support EXCEPT/REPLACE after a struct-returning function star (e.g. `as_struct(...).* EXCEPT (...)`).
  - Add `StarSemiStructuredAccessorSegment` to parse semi-structured accessors ending with `.*`.
  - Add tests for EXCEPT and REPLACE after semi-structured and function stars.

- **Migration**
  - Expressions like `results[0].*` now parse as `wildcard_expression` instead of a plain expression. Update any logic that treats wildcard selects specially if it relies on the AST node type.

<sup>Written for commit 81d8ea3a0e6065c7c0b21c57a70d15ae20892307. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8214?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

