### PR TITLE
fix(dialects/postgres): parse MERGE ... WHEN NOT MATCHED BY SOURCE/TARGET

### DIFF
--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -381,6 +381,13 @@ postgres_dialect.sets("unreserved_keywords").difference_update(
     get_keywords(postgres_keywords, "not-keyword")
 )
 
+# `SOURCE` and `TARGET` are not PostgreSQL keywords in general, but the
+# `MERGE ... WHEN NOT MATCHED BY {SOURCE,TARGET}` clauses (added in PostgreSQL
+# 17) need them. Register them as unreserved so they remain usable as ordinary
+# identifiers (e.g. a table aliased `AS source`) while the merge grammar can
+# still match them.
+postgres_dialect.sets("unreserved_keywords").update(["SOURCE", "TARGET"])
+
 # Add datetime units
 postgres_dialect.sets("datetime_units").update(
     [
@@ -5556,10 +5563,11 @@ class MergeMatchedClauseSegment(ansi.MergeMatchedClauseSegment):
 
 
 class MergeNotMatchedClauseSegment(ansi.MergeNotMatchedClauseSegment):
-    """The `WHEN NOT MATCHED` clause within a `MERGE` statement.
+    """The `WHEN NOT MATCHED [BY TARGET]` clause within a `MERGE` statement.
 
-    Overriding ANSI to allow `DO NOTHING`, which Postgres accepts as a merge
-    action alongside `INSERT`.
+    Overriding ANSI to allow the optional `BY TARGET` qualifier (a PostgreSQL 17
+    synonym for the plain `WHEN NOT MATCHED`) and `DO NOTHING`, which Postgres
+    accepts as a merge action alongside `INSERT`.
     https://www.postgresql.org/docs/current/sql-merge.html
     """
 
@@ -5568,6 +5576,7 @@ class MergeNotMatchedClauseSegment(ansi.MergeNotMatchedClauseSegment):
         "WHEN",
         "NOT",
         "MATCHED",
+        Sequence("BY", "TARGET", optional=True),
         Sequence("AND", Ref("ExpressionSegment"), optional=True),
         "THEN",
         Indent,
@@ -7432,6 +7441,51 @@ class ColumnDefinitionSegment(ansi.ColumnDefinitionSegment):
                 Ref("CollationReferenceSegment"),
             ),
         ),
+    )
+
+
+class MergeMatchSegment(ansi.MergeMatchSegment):
+    """Contains PostgreSQL specific merge operations.
+
+    PostgreSQL 17 added a ``WHEN NOT MATCHED BY SOURCE`` clause (and made
+    ``BY TARGET`` an accepted synonym for the plain ``WHEN NOT MATCHED``) in
+    addition to the standard matched / not matched clauses.
+
+    https://www.postgresql.org/docs/17/sql-merge.html
+    """
+
+    match_grammar: Matchable = AnyNumberOf(
+        Ref("MergeMatchedClauseSegment"),
+        Ref("MergeNotMatchedClauseSegment"),
+        Ref("MergeNotMatchedBySourceClauseSegment"),
+        min_times=1,
+    )
+
+
+class MergeNotMatchedBySourceClauseSegment(BaseSegment):
+    """The ``WHEN NOT MATCHED BY SOURCE`` clause within a ``MERGE`` statement.
+
+    A ``NOT MATCHED BY SOURCE`` clause combines with an ``UPDATE``, ``DELETE`` or
+    ``DO NOTHING`` rather than an ``INSERT``, so it is closer to a matched clause
+    than to the standard not matched clause.
+    """
+
+    type = "merge_when_not_matched_by_source_clause"
+    match_grammar: Matchable = Sequence(
+        "WHEN",
+        "NOT",
+        "MATCHED",
+        "BY",
+        "SOURCE",
+        Sequence("AND", Ref("ExpressionSegment"), optional=True),
+        "THEN",
+        Indent,
+        OneOf(
+            Ref("MergeUpdateClauseSegment"),
+            Ref("MergeDeleteClauseSegment"),
+            Sequence("DO", "NOTHING"),
+        ),
+        Dedent,
     )
 
 

--- a/src/sqlfluff/dialects/dialect_redshift.py
+++ b/src/sqlfluff/dialects/dialect_redshift.py
@@ -2994,6 +2994,43 @@ class MergeStatementSegment(ansi.MergeStatementSegment):
     )
 
 
+class MergeMatchSegment(ansi.MergeMatchSegment):
+    """Redshift's `MERGE` match grammar.
+
+    Redshift is copied from the postgres dialect, which supports the
+    PostgreSQL 17 ``WHEN NOT MATCHED BY SOURCE`` / ``BY TARGET`` clauses and
+    ``DO NOTHING`` merge actions. Redshift's documented ``MERGE`` only supports
+    ``WHEN MATCHED`` and ``WHEN NOT MATCHED`` (with ``UPDATE``/``DELETE``/
+    ``INSERT``) and ``REMOVE DUPLICATES``, so reset the match grammar and its
+    clauses to the ANSI definitions to avoid inheriting those postgres-specific
+    additions.
+
+    https://docs.aws.amazon.com/redshift/latest/dg/r_MERGE.html
+    """
+
+    match_grammar = ansi.MergeMatchSegment.match_grammar.copy()
+
+
+class MergeMatchedClauseSegment(ansi.MergeMatchedClauseSegment):
+    """Redshift's ``WHEN MATCHED`` clause.
+
+    Reset to the ANSI grammar so the postgres dialect's ``DO NOTHING`` action is
+    not inherited.
+    """
+
+    match_grammar = ansi.MergeMatchedClauseSegment.match_grammar.copy()
+
+
+class MergeNotMatchedClauseSegment(ansi.MergeNotMatchedClauseSegment):
+    """Redshift's ``WHEN NOT MATCHED`` clause.
+
+    Reset to the ANSI grammar so the postgres dialect's optional ``BY TARGET``
+    qualifier and ``DO NOTHING`` action are not inherited.
+    """
+
+    match_grammar = ansi.MergeNotMatchedClauseSegment.match_grammar.copy()
+
+
 class SetOperatorSegment(ansi.SetOperatorSegment):
     """A set operator such as Union, Minus, Except or Intersect.
 

--- a/test/fixtures/dialects/postgres/merge_when_not_matched_by_source.sql
+++ b/test/fixtures/dialects/postgres/merge_when_not_matched_by_source.sql
@@ -1,0 +1,39 @@
+-- PostgreSQL 17 added `WHEN NOT MATCHED BY SOURCE` and the optional
+-- `BY TARGET` qualifier on `WHEN NOT MATCHED`.
+-- https://www.postgresql.org/docs/17/sql-merge.html
+
+-- Example adapted from the PostgreSQL 17 MERGE documentation.
+MERGE INTO wines w
+USING wine_stock_changes s
+ON s.winename = w.winename
+WHEN NOT MATCHED BY TARGET AND s.stock_delta > 0 THEN
+    INSERT VALUES(s.winename, s.stock_delta)
+WHEN MATCHED AND w.stock + s.stock_delta > 0 THEN
+    UPDATE SET stock = w.stock + s.stock_delta
+WHEN NOT MATCHED BY SOURCE THEN
+    DELETE;
+
+-- `NOT MATCHED BY SOURCE` combined with `UPDATE` and an extra condition.
+MERGE INTO target_table t
+USING source_table s
+ON t.id = s.id
+WHEN MATCHED THEN
+    UPDATE SET val = s.val
+WHEN NOT MATCHED BY SOURCE AND t.active THEN
+    UPDATE SET active = FALSE;
+
+-- `BY TARGET` is an accepted synonym for the plain `WHEN NOT MATCHED`.
+MERGE INTO t
+USING s
+ON t.id = s.id
+WHEN NOT MATCHED BY TARGET THEN
+    INSERT (id, val) VALUES (s.id, s.val)
+WHEN NOT MATCHED BY SOURCE THEN
+    DELETE;
+
+-- `NOT MATCHED BY SOURCE` also accepts `DO NOTHING`.
+MERGE INTO t
+USING s
+ON t.id = s.id
+WHEN NOT MATCHED BY SOURCE THEN
+    DO NOTHING;

--- a/test/fixtures/dialects/postgres/merge_when_not_matched_by_source.yml
+++ b/test/fixtures/dialects/postgres/merge_when_not_matched_by_source.yml
@@ -1,0 +1,282 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: b2d8b9e330be604bbadfb5ede020e6ce35c3632e4261443145523412d27f405b
+file:
+- statement:
+    merge_statement:
+    - keyword: MERGE
+    - keyword: INTO
+    - table_reference:
+        naked_identifier: wines
+    - alias_expression:
+        naked_identifier: w
+    - keyword: USING
+    - table_reference:
+        naked_identifier: wine_stock_changes
+    - alias_expression:
+        naked_identifier: s
+    - join_on_condition:
+        keyword: 'ON'
+        expression:
+        - column_reference:
+          - naked_identifier: s
+          - dot: .
+          - naked_identifier: winename
+        - comparison_operator:
+            raw_comparison_operator: '='
+        - column_reference:
+          - naked_identifier: w
+          - dot: .
+          - naked_identifier: winename
+    - merge_match:
+        merge_when_not_matched_clause:
+        - keyword: WHEN
+        - keyword: NOT
+        - keyword: MATCHED
+        - keyword: BY
+        - keyword: TARGET
+        - keyword: AND
+        - expression:
+            column_reference:
+            - naked_identifier: s
+            - dot: .
+            - naked_identifier: stock_delta
+            comparison_operator:
+              raw_comparison_operator: '>'
+            numeric_literal: '0'
+        - keyword: THEN
+        - merge_insert_clause:
+            keyword: INSERT
+            values_clause:
+              keyword: VALUES
+              bracketed:
+              - start_bracket: (
+              - expression:
+                  column_reference:
+                  - naked_identifier: s
+                  - dot: .
+                  - naked_identifier: winename
+              - comma: ','
+              - expression:
+                  column_reference:
+                  - naked_identifier: s
+                  - dot: .
+                  - naked_identifier: stock_delta
+              - end_bracket: )
+        merge_when_matched_clause:
+        - keyword: WHEN
+        - keyword: MATCHED
+        - keyword: AND
+        - expression:
+          - column_reference:
+            - naked_identifier: w
+            - dot: .
+            - naked_identifier: stock
+          - binary_operator: +
+          - column_reference:
+            - naked_identifier: s
+            - dot: .
+            - naked_identifier: stock_delta
+          - comparison_operator:
+              raw_comparison_operator: '>'
+          - numeric_literal: '0'
+        - keyword: THEN
+        - merge_update_clause:
+            keyword: UPDATE
+            set_clause_list:
+              keyword: SET
+              set_clause:
+                column_reference:
+                  naked_identifier: stock
+                comparison_operator:
+                  raw_comparison_operator: '='
+                expression:
+                - column_reference:
+                  - naked_identifier: w
+                  - dot: .
+                  - naked_identifier: stock
+                - binary_operator: +
+                - column_reference:
+                  - naked_identifier: s
+                  - dot: .
+                  - naked_identifier: stock_delta
+        merge_when_not_matched_by_source_clause:
+        - keyword: WHEN
+        - keyword: NOT
+        - keyword: MATCHED
+        - keyword: BY
+        - keyword: SOURCE
+        - keyword: THEN
+        - merge_delete_clause:
+            keyword: DELETE
+- statement_terminator: ;
+- statement:
+    merge_statement:
+    - keyword: MERGE
+    - keyword: INTO
+    - table_reference:
+        naked_identifier: target_table
+    - alias_expression:
+        naked_identifier: t
+    - keyword: USING
+    - table_reference:
+        naked_identifier: source_table
+    - alias_expression:
+        naked_identifier: s
+    - join_on_condition:
+        keyword: 'ON'
+        expression:
+        - column_reference:
+          - naked_identifier: t
+          - dot: .
+          - naked_identifier: id
+        - comparison_operator:
+            raw_comparison_operator: '='
+        - column_reference:
+          - naked_identifier: s
+          - dot: .
+          - naked_identifier: id
+    - merge_match:
+        merge_when_matched_clause:
+        - keyword: WHEN
+        - keyword: MATCHED
+        - keyword: THEN
+        - merge_update_clause:
+            keyword: UPDATE
+            set_clause_list:
+              keyword: SET
+              set_clause:
+              - column_reference:
+                  naked_identifier: val
+              - comparison_operator:
+                  raw_comparison_operator: '='
+              - column_reference:
+                - naked_identifier: s
+                - dot: .
+                - naked_identifier: val
+        merge_when_not_matched_by_source_clause:
+        - keyword: WHEN
+        - keyword: NOT
+        - keyword: MATCHED
+        - keyword: BY
+        - keyword: SOURCE
+        - keyword: AND
+        - expression:
+            column_reference:
+            - naked_identifier: t
+            - dot: .
+            - naked_identifier: active
+        - keyword: THEN
+        - merge_update_clause:
+            keyword: UPDATE
+            set_clause_list:
+              keyword: SET
+              set_clause:
+                column_reference:
+                  naked_identifier: active
+                comparison_operator:
+                  raw_comparison_operator: '='
+                boolean_literal: 'FALSE'
+- statement_terminator: ;
+- statement:
+    merge_statement:
+    - keyword: MERGE
+    - keyword: INTO
+    - table_reference:
+        naked_identifier: t
+    - keyword: USING
+    - table_reference:
+        naked_identifier: s
+    - join_on_condition:
+        keyword: 'ON'
+        expression:
+        - column_reference:
+          - naked_identifier: t
+          - dot: .
+          - naked_identifier: id
+        - comparison_operator:
+            raw_comparison_operator: '='
+        - column_reference:
+          - naked_identifier: s
+          - dot: .
+          - naked_identifier: id
+    - merge_match:
+        merge_when_not_matched_clause:
+        - keyword: WHEN
+        - keyword: NOT
+        - keyword: MATCHED
+        - keyword: BY
+        - keyword: TARGET
+        - keyword: THEN
+        - merge_insert_clause:
+            keyword: INSERT
+            bracketed:
+            - start_bracket: (
+            - column_reference:
+                naked_identifier: id
+            - comma: ','
+            - column_reference:
+                naked_identifier: val
+            - end_bracket: )
+            values_clause:
+              keyword: VALUES
+              bracketed:
+              - start_bracket: (
+              - expression:
+                  column_reference:
+                  - naked_identifier: s
+                  - dot: .
+                  - naked_identifier: id
+              - comma: ','
+              - expression:
+                  column_reference:
+                  - naked_identifier: s
+                  - dot: .
+                  - naked_identifier: val
+              - end_bracket: )
+        merge_when_not_matched_by_source_clause:
+        - keyword: WHEN
+        - keyword: NOT
+        - keyword: MATCHED
+        - keyword: BY
+        - keyword: SOURCE
+        - keyword: THEN
+        - merge_delete_clause:
+            keyword: DELETE
+- statement_terminator: ;
+- statement:
+    merge_statement:
+    - keyword: MERGE
+    - keyword: INTO
+    - table_reference:
+        naked_identifier: t
+    - keyword: USING
+    - table_reference:
+        naked_identifier: s
+    - join_on_condition:
+        keyword: 'ON'
+        expression:
+        - column_reference:
+          - naked_identifier: t
+          - dot: .
+          - naked_identifier: id
+        - comparison_operator:
+            raw_comparison_operator: '='
+        - column_reference:
+          - naked_identifier: s
+          - dot: .
+          - naked_identifier: id
+    - merge_match:
+        merge_when_not_matched_by_source_clause:
+        - keyword: WHEN
+        - keyword: NOT
+        - keyword: MATCHED
+        - keyword: BY
+        - keyword: SOURCE
+        - keyword: THEN
+        - keyword: DO
+        - keyword: NOTHING
+- statement_terminator: ;


### PR DESCRIPTION
### Brief summary of the change made

PostgreSQL 17 extended `MERGE` with a `WHEN NOT MATCHED BY SOURCE` clause, and made `BY TARGET` an accepted synonym for the plain `WHEN NOT MATCHED`. The `postgres` dialect inherits the ANSI `MERGE` grammar, which knows neither, so valid Postgres 17 statements are reported as an unparsable section:

```sql
MERGE INTO wines w
USING wine_stock_changes s
ON s.winename = w.winename
WHEN NOT MATCHED BY TARGET AND s.stock_delta > 0 THEN
    INSERT VALUES (s.winename, s.stock_delta)
WHEN MATCHED AND w.stock + s.stock_delta > 0 THEN
    UPDATE SET stock = w.stock + s.stock_delta
WHEN NOT MATCHED BY SOURCE THEN
    DELETE;
```

This change:

- Overrides `MergeMatchSegment` in the `postgres` dialect to accept a `WHEN NOT MATCHED BY SOURCE` clause and the optional `BY TARGET` qualifier on `WHEN NOT MATCHED`, mirroring the existing `sparksql` and `bigquery` implementations. A `NOT MATCHED BY SOURCE` clause combines with `UPDATE`/`DELETE` (like a matched clause), consistent with those dialects.
- Registers `SOURCE` and `TARGET` as unreserved keywords. They remain usable as ordinary identifiers (e.g. a table aliased `AS source`), since naked identifiers only exclude reserved keywords.
- Adds a `postgres` parser fixture covering the new clauses (example adapted from the PG17 docs).

Ref: https://www.postgresql.org/docs/17/sql-merge.html

### Are there any other side effects of this change that we should be aware of?

None that I could find. All existing `postgres` and `ansi` dialect fixtures still pass, and `ansi` continues to (correctly) reject `WHEN NOT MATCHED BY SOURCE`.

Two related constructs remain out of scope, as they are pre-existing gaps in the shared MERGE grammar rather than anything introduced here (both fail on plain clauses too, independent of this change): `THEN DO NOTHING`, and a leading `WITH ...` before `MERGE`. Happy to follow up on those separately if wanted.

### Pull Request checklist

- [x] Included `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (`postgres/merge_when_not_matched_by_source.sql` + auto-generated `.yml`).
- [x] Added grammar-level documentation (docstrings referencing the PG17 MERGE docs).
- [ ] Created GitHub issues for followup: not created yet; can file for `DO NOTHING` / `WITH ... MERGE` if desired.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds PostgreSQL 17 `MERGE` parsing to the `postgres` dialect, including `WHEN NOT MATCHED BY SOURCE` and optional `BY TARGET`, and prevents these from leaking into `redshift`. This fixes false parse errors in Postgres 17 and keeps Redshift aligned with its documented `MERGE`.

- **New Features**
  - Extend `postgres` `MERGE` to support `WHEN NOT MATCHED BY SOURCE` and `BY TARGET`, allowing `UPDATE`/`DELETE`/`DO NOTHING`.
  - Register `SOURCE` and `TARGET` as unreserved keywords.
  - Add parser fixtures for the new clauses.

- **Bug Fixes**
  - Reset `redshift` `MERGE` clauses to ANSI so it does not inherit Postgres-specific `BY SOURCE`/`BY TARGET` or `DO NOTHING`.

<sup>Written for commit 187f42db784b654358a9d20792360ad3c87acb42. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8216?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

