### PR TITLE
Serialise source positions for violations in templated sections

### DIFF
--- a/src/sqlfluff/core/errors.py
+++ b/src/sqlfluff/core/errors.py
@@ -28,12 +28,16 @@ SerializedObject = dict[str, Union[str, int, bool, list["SerializedObject"]]]
 
 
 def _extract_position(segment: Optional["BaseSegment"]) -> dict[str, int]:
-    """If a segment is present and is a literal, return it's source length."""
+    """If a segment is present, return its source position.
+
+    For segments in templated (i.e. non-literal) sections, the source
+    position covers the templated construct (e.g. the jinja expression)
+    which generated the section.
+    """
     if segment:
         position = segment.pos_marker
         assert position
-        if position.is_literal():
-            return position.to_source_dict()
+        return position.to_source_dict()
     # An empty location is an indicator of not being able to accurately
     # represent the location.
     return {}  # pragma: no cover

--- a/test/api/simple_test.py
+++ b/test/api/simple_test.py
@@ -7,6 +7,7 @@ import pytest
 
 import sqlfluff
 from sqlfluff.api import APIParsingError
+from sqlfluff.core import FluffConfig
 from sqlfluff.core.errors import SQLFluffUserError
 
 my_bad_query = "SeLEct  *, 1, blah as  fOO  from myTable"
@@ -368,6 +369,32 @@ def test__api__lint_string():
     assert all(isinstance(elem, dict) for elem in result)
     # Check actual result
     assert result == lint_result
+
+
+def test__api__lint_string_templated_positions():
+    """Check violations in templated sections still report source positions.
+
+    https://github.com/sqlfluff/sqlfluff/issues/6450
+    """
+    sql = (
+        "SELECT\n"
+        "    {{ 'a_very_long_templated_column_name' }} AS col_a,\n"
+        "    'foo' AS col_b\n"
+        "FROM tbl\n"
+    )
+    config = FluffConfig(
+        overrides={"dialect": "ansi", "rules": "LT05", "max_line_length": 30}
+    )
+    result = sqlfluff.lint(sql, config=config)
+    assert len(result) == 1
+    violation = result[0]
+    assert violation["code"] == "LT05"
+    assert violation["start_line_no"] == 2
+    # The violation is anchored on the templated expression, but should
+    # still serialise with full source position information.
+    assert violation["start_file_pos"] == 11
+    assert violation["end_line_no"] == 2
+    assert violation["end_file_pos"] == 52
 
 
 def test__api__lint_string_specific():


### PR DESCRIPTION
### Brief summary of the change made

Fixes #6450

Violations anchored on templated (non-literal) sections were serialised without the extended position keys (`start_file_pos`, `end_line_no`, `end_line_pos`, `end_file_pos`), because `_extract_position` only returned a position for literal segments. Downstream tools (e.g. the VSCode extension) then fell back to guessing the range, highlighting large chunks of the file.

The source position of a non-literal segment is still well defined (it's the source span of the templated construct which generated it — the same span already used for `start_line_no`/`start_line_pos` on the violation), so this change serialises it in all cases.

Before, for an LT05 violation on a line containing a jinja macro call:

```json
{"start_line_no": 3, "start_line_pos": 9, "code": "LT05", ..., "fixes": [...]}
```

After:

```json
{"start_line_no": 3, "start_line_pos": 9, "code": "LT05", ..., "fixes": [...], "start_file_pos": 34, "end_line_no": 3, "end_line_pos": 86, "end_file_pos": 111}
```

Added an API test covering serialised positions for a violation anchored in a templated section.

Disclosure: this change was made with AI assistance (Devin), reviewed and tested before submission.

### Are there any other side effects of this change that we should be aware of?

JSON/YAML lint output (and `Linter.lint_string().to_dict()` consumers) will now include the extended position keys for violations in templated sections where they were previously omitted. The existing "hoist from fix" edge case in `SQLLintError.to_dict` still applies when no position is available at all.

### Pull Request checklist

- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followups/issues I identified.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Serialize full source positions for violations in templated sections so editors highlight the correct range. Updates `_extract_position` to return positions for all segments and adds an API test.

- **Bug Fixes**
  - Always serialize source positions for templated (non-literal) segments by updating _extract_position.
  - Added an API test to verify positions for a Jinja-based `LT05` violation; avoids range guessing in editors.

<sup>Written for commit c077abca78ce08174642be3cc56b1b71d5b83762. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8218?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

