### PR TITLE
BigQuery: only parse date parts in date part functions

### DIFF
--- a/src/sqlfluff/dialects/dialect_bigquery.py
+++ b/src/sqlfluff/dialects/dialect_bigquery.py
@@ -345,8 +345,6 @@ bigquery_dialect.replace(
         )
     ),
     FunctionContentsExpressionGrammar=OneOf(
-        Ref("DatetimeUnitSegment"),
-        Ref("DatePartWeekSegment"),
         Sequence(
             Ref("ExpressionSegment"),
             Sequence(OneOf("IGNORE", "RESPECT"), "NULLS", optional=True),

--- a/src/sqlfluff/dialects/dialect_bigquery.py
+++ b/src/sqlfluff/dialects/dialect_bigquery.py
@@ -1188,15 +1188,39 @@ class FunctionNameSegment(ansi.FunctionNameSegment):
     )
 
 
+class DatePartFunctionNameSegment(ansi.DatePartFunctionNameSegment):
+    """Date part function name, allowing an optional SAFE. prefix.
+
+    BigQuery allows date part functions to be SAFE-qualified (e.g.
+    ``SAFE.DATE_TRUNC(some_date, YEAR)``) and the date part argument
+    should still parse as a date part rather than a column reference.
+    https://cloud.google.com/bigquery/docs/reference/standard-sql/functions-reference#safe_prefix
+    """
+
+    match_grammar: Matchable = Sequence(
+        Sequence("SAFE", Ref("DotSegment"), optional=True),
+        Ref("DatePartFunctionName"),
+    )
+
+
 class DateTimeFunctionContentsSegment(ansi.DateTimeFunctionContentsSegment):
-    """Datetime function contents segment."""
+    """Datetime function contents segment.
+
+    Each argument is either a date part or an expression: matching
+    them one argument at a time (rather than via the generic
+    ``FunctionContentsGrammar``, which contains its own delimited list)
+    ensures date parts are always preferred over column references for
+    every argument.
+    """
 
     match_grammar = Sequence(
         Bracketed(
             Delimited(
-                Ref("DatetimeUnitSegment"),
-                Ref("DatePartWeekSegment"),
-                Ref("FunctionContentsGrammar"),
+                OneOf(
+                    Ref("DatetimeUnitSegment"),
+                    Ref("DatePartWeekSegment"),
+                    Ref("FunctionContentsExpressionGrammar"),
+                ),
             ),
         )
     )

--- a/test/fixtures/dialects/bigquery/parameters.yml
+++ b/test/fixtures/dialects/bigquery/parameters.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 8c54cfecb9e82789d21a903c1597a099d07f8d290574d9b70d891d49a51329a5
+_hash: 7577d3b4ebea648adc117297efba03042cef3fc329305a836f645f6e5a3a1176
 file:
 - statement:
     select_statement:
@@ -92,12 +92,14 @@ file:
               function_name_identifier: parse_date
             function_contents:
               bracketed:
-                start_bracket: (
-                expression:
+              - start_bracket: (
+              - expression:
                   quoted_literal: '"%Y%m"'
-                comma: ','
-                date_part: year
-                end_bracket: )
+              - comma: ','
+              - expression:
+                  column_reference:
+                    naked_identifier: year
+              - end_bracket: )
 - statement_terminator: ;
 - statement:
     select_statement:

--- a/test/fixtures/dialects/bigquery/select_function_datepart_column.sql
+++ b/test/fixtures/dialects/bigquery/select_function_datepart_column.sql
@@ -1,0 +1,12 @@
+-- Columns named after date parts should parse as column references in
+-- functions which don't take date part arguments.
+-- https://github.com/sqlfluff/sqlfluff/issues/5015
+SELECT REGEXP_EXTRACT(year, r"[0-9]{4}")
+FROM some_table;
+
+-- Date part functions should still parse date parts.
+SELECT
+    EXTRACT(YEAR FROM some_date),
+    DATE_TRUNC(some_date, WEEK(MONDAY)),
+    DATE_DIFF(date_a, date_b, DAY)
+FROM some_table;

--- a/test/fixtures/dialects/bigquery/select_function_datepart_column.sql
+++ b/test/fixtures/dialects/bigquery/select_function_datepart_column.sql
@@ -10,3 +10,12 @@ SELECT
     DATE_TRUNC(some_date, WEEK(MONDAY)),
     DATE_DIFF(date_a, date_b, DAY)
 FROM some_table;
+
+-- SAFE-qualified date part functions should also parse date parts.
+SELECT
+    SAFE.DATE_TRUNC(some_date, YEAR),
+    SAFE.DATETIME_TRUNC(some_datetime, MINUTE),
+    SAFE.TIMESTAMP_TRUNC(some_timestamp, HOUR),
+    SAFE.DATE_DIFF(date_a, date_b, DAY),
+    SAFE.LAST_DAY(some_date, MONTH)
+FROM some_table;

--- a/test/fixtures/dialects/bigquery/select_function_datepart_column.yml
+++ b/test/fixtures/dialects/bigquery/select_function_datepart_column.yml
@@ -1,0 +1,95 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: fdb2153cb6f02dcbe7f107d39f28eee9f9d2c08edbc58edd0b0738319e53efb3
+file:
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: REGEXP_EXTRACT
+            function_contents:
+              bracketed:
+              - start_bracket: (
+              - expression:
+                  column_reference:
+                    naked_identifier: year
+              - comma: ','
+              - expression:
+                  quoted_literal: r"[0-9]{4}"
+              - end_bracket: )
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: some_table
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: EXTRACT
+            function_contents:
+              bracketed:
+                start_bracket: (
+                date_part: YEAR
+                keyword: FROM
+                expression:
+                  column_reference:
+                    naked_identifier: some_date
+                end_bracket: )
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: DATE_TRUNC
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  column_reference:
+                    naked_identifier: some_date
+                comma: ','
+                date_part_week:
+                  keyword: WEEK
+                  bracketed:
+                    start_bracket: (
+                    keyword: MONDAY
+                    end_bracket: )
+                end_bracket: )
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: DATE_DIFF
+            function_contents:
+              bracketed:
+              - start_bracket: (
+              - expression:
+                  column_reference:
+                    naked_identifier: date_a
+              - comma: ','
+              - expression:
+                  column_reference:
+                    naked_identifier: date_b
+              - comma: ','
+              - date_part: DAY
+              - end_bracket: )
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: some_table
+- statement_terminator: ;

--- a/test/fixtures/dialects/bigquery/select_function_datepart_column.yml
+++ b/test/fixtures/dialects/bigquery/select_function_datepart_column.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: fdb2153cb6f02dcbe7f107d39f28eee9f9d2c08edbc58edd0b0738319e53efb3
+_hash: 0e73811db854c30e3eb3b9edf34bf6240c2cc4f6f08d4834e7ce4ae38867b6e9
 file:
 - statement:
     select_statement:
@@ -85,6 +85,101 @@ file:
               - comma: ','
               - date_part: DAY
               - end_bracket: )
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: some_table
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          function:
+            function_name:
+              keyword: SAFE
+              dot: .
+              function_name_identifier: DATE_TRUNC
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  column_reference:
+                    naked_identifier: some_date
+                comma: ','
+                date_part: YEAR
+                end_bracket: )
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              keyword: SAFE
+              dot: .
+              function_name_identifier: DATETIME_TRUNC
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  column_reference:
+                    naked_identifier: some_datetime
+                comma: ','
+                date_part: MINUTE
+                end_bracket: )
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              keyword: SAFE
+              dot: .
+              function_name_identifier: TIMESTAMP_TRUNC
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  column_reference:
+                    naked_identifier: some_timestamp
+                comma: ','
+                date_part: HOUR
+                end_bracket: )
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              keyword: SAFE
+              dot: .
+              function_name_identifier: DATE_DIFF
+            function_contents:
+              bracketed:
+              - start_bracket: (
+              - expression:
+                  column_reference:
+                    naked_identifier: date_a
+              - comma: ','
+              - expression:
+                  column_reference:
+                    naked_identifier: date_b
+              - comma: ','
+              - date_part: DAY
+              - end_bracket: )
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              keyword: SAFE
+              dot: .
+              function_name_identifier: LAST_DAY
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  column_reference:
+                    naked_identifier: some_date
+                comma: ','
+                date_part: MONTH
+                end_bracket: )
       from_clause:
         keyword: FROM
         from_expression:

--- a/test/fixtures/dialects/bigquery/select_safe_function.yml
+++ b/test/fixtures/dialects/bigquery/select_safe_function.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: fc26094109f498162ebd6326dce20aca48378060b1ad46e1c9d0a719ed828f76
+_hash: 3c74dce55852bf1ff8eb6fb334aa01f3d4a24cf0f533e1844ef7cd0bff7c7b98
 file:
   statement:
     select_statement:
@@ -50,7 +50,9 @@ file:
             function_contents:
               bracketed:
               - start_bracket: (
-              - date_part: DAY
+              - expression:
+                  column_reference:
+                    naked_identifier: DAY
               - comma: ','
               - expression:
                   numeric_literal:


### PR DESCRIPTION
### Brief summary of the change made

Fixes #5015

In the BigQuery dialect, `FunctionContentsExpressionGrammar` included `DatetimeUnitSegment` and `DatePartWeekSegment`, so *any* function argument matching a date part keyword (`year`, `day`, etc.) was parsed as a `date_part` rather than a column reference. This caused CP01 (keyword capitalisation) to fire on column names like `year`:

```sql
SELECT REGEXP_EXTRACT(year, r"[0-9]{4}") FROM some_table
-- L: 1 | P: 23 | CP01 | Keywords must be consistently upper case.
```

Functions which genuinely take date part arguments (`EXTRACT`, `DATE_TRUNC`, `DATE_DIFF`, `LAST_DAY`, ...) are already routed through `DateTimeFunctionContentsSegment` via the `date_part_function_name` set, so the generic grammar doesn't need to match date parts. This change removes the two references from the generic grammar.

Two existing fixtures change as a result, both for the better:
- `parameters.yml`: `parse_date("%Y%m", year)` now parses `year` as an identifier — the fixture's own comment says `-- this should parse year as an identifier`.
- `select_safe_function.yml`: `SAFE.DATEADD(DAY, ...)` now parses `DAY` as a column reference (`DATEADD` isn't a BigQuery date part function).

Added a parser fixture covering the reported case plus checks that `EXTRACT`/`DATE_TRUNC`/`DATE_DIFF` still parse date parts.

Disclosure: this change was made with AI assistance (Devin), reviewed and tested before submission.

### Are there any other side effects of this change that we should be aware of?

Arguments named after date parts in non-date-part functions now parse as column references instead of `date_part` segments, which may shift results for rules that treat keywords/identifiers differently (as intended here).

### Pull Request checklist

- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followups/issues I identified.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix BigQuery parsing so date part keywords are only recognized in date-part functions, including `SAFE.`-qualified ones (Fixes #5015). Prevents CP01 false positives on columns named like year or day in non-date-part functions.

- **Bug Fixes**
  - Route `SAFE.`-qualified date-part functions through `DateTimeFunctionContentsSegment` and match each argument as a date part or expression to prefer date parts where valid.
  - Non-date-part functions now treat columns named like date parts as identifiers (e.g., `REGEXP_EXTRACT(year, ...)`, `SAFE.DATEADD(DAY, ...)`).
  - Updated fixtures and added parser tests, including coverage for `SAFE.DATE_TRUNC`, `SAFE.DATETIME_TRUNC`, `SAFE.TIMESTAMP_TRUNC`, `SAFE.DATE_DIFF`, and `SAFE.LAST_DAY`.

<sup>Written for commit 1ccd442fdd408ac2e8ebb5623f310081ec03803b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8219?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

