### PR TITLE
Postgres: stop LT01 spacing array types like `int []`

### DIFF
--- a/src/sqlfluff/core/default_config.cfg
+++ b/src/sqlfluff/core/default_config.cfg
@@ -222,6 +222,9 @@ spacing_before = touch:inline
 [sqlfluff:layout:type:array_type]
 spacing_within = touch:inline
 
+[sqlfluff:layout:type:array_type_suffix]
+spacing_before = touch
+
 [sqlfluff:layout:type:typed_array_literal]
 spacing_within = touch
 

--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -1180,11 +1180,7 @@ class DatatypeSegment(ansi.DatatypeSegment):
         ),
         # array types
         OneOf(
-            AnyNumberOf(
-                Bracketed(
-                    Ref("ExpressionSegment", optional=True), bracket_type="square"
-                )
-            ),
+            AnyNumberOf(Ref("ArrayTypeSuffixSegment")),
             Ref("ArrayTypeSegment"),
             Ref("SizedArrayTypeSegment"),
             optional=True,
@@ -1197,6 +1193,20 @@ class ArrayTypeSegment(ansi.ArrayTypeSegment):
 
     type = "array_type"
     match_grammar = Ref.keyword("ARRAY")
+
+
+class ArrayTypeSuffixSegment(BaseSegment):
+    """The ``[]`` suffix that turns a scalar type into an array type.
+
+    e.g. the ``[]`` in ``int[]``. It's its own segment so that layout rule
+    LT01 keeps it touching the preceding type name rather than spacing it
+    like a standalone square bracket (see issue #5005).
+    """
+
+    type = "array_type_suffix"
+    match_grammar = Bracketed(
+        Ref("ExpressionSegment", optional=True), bracket_type="square"
+    )
 
 
 class IndexAccessMethodSegment(BaseSegment):

--- a/test/fixtures/dialects/postgres/array.yml
+++ b/test/fixtures/dialects/postgres/array.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 7da1743e6b8a4d2d629db820b6f5d6571c4b73a0011e185324a6b18ff30e46d8
+_hash: 13a1026b14253d0b8bcdd63c2099de14574103c48532a285e4528715e32a1b20
 file:
 - statement:
     select_statement:
@@ -75,17 +75,20 @@ file:
           naked_identifier: pay_by_quarter
           data_type:
             keyword: integer
-            start_square_bracket: '['
-            end_square_bracket: ']'
+            array_type_suffix:
+              start_square_bracket: '['
+              end_square_bracket: ']'
       - comma: ','
       - column_definition:
           naked_identifier: schedule
           data_type:
           - keyword: text
-          - start_square_bracket: '['
-          - end_square_bracket: ']'
-          - start_square_bracket: '['
-          - end_square_bracket: ']'
+          - array_type_suffix:
+              start_square_bracket: '['
+              end_square_bracket: ']'
+          - array_type_suffix:
+              start_square_bracket: '['
+              end_square_bracket: ']'
       - end_bracket: )
 - statement_terminator: ;
 - statement:
@@ -100,14 +103,16 @@ file:
           naked_identifier: squares
           data_type:
           - keyword: integer
-          - start_square_bracket: '['
-          - expression:
-              numeric_literal: '3'
-          - end_square_bracket: ']'
-          - start_square_bracket: '['
-          - expression:
-              numeric_literal: '3'
-          - end_square_bracket: ']'
+          - array_type_suffix:
+              start_square_bracket: '['
+              expression:
+                numeric_literal: '3'
+              end_square_bracket: ']'
+          - array_type_suffix:
+              start_square_bracket: '['
+              expression:
+                numeric_literal: '3'
+              end_square_bracket: ']'
         end_bracket: )
 - statement_terminator: ;
 - statement:
@@ -595,8 +600,9 @@ file:
                           casting_operator: '::'
                           data_type:
                             keyword: int
-                            start_square_bracket: '['
-                            end_square_bracket: ']'
+                            array_type_suffix:
+                              start_square_bracket: '['
+                              end_square_bracket: ']'
                       alias_expression:
                         alias_operator:
                           keyword: AS

--- a/test/fixtures/dialects/postgres/create_table.yml
+++ b/test/fixtures/dialects/postgres/create_table.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 38b09e8ec8aacea1a432798cbc2b874c94fdbf2b3ab4d7eeda65bcb4b11198db
+_hash: 7c8ef6046a12da5416a7f53a483423ece5bc65ab618f64ab1df1ff86aeb80b1a
 file:
 - statement:
     create_table_statement:
@@ -81,10 +81,12 @@ file:
           naked_identifier: vector
           data_type:
           - keyword: int
-          - start_square_bracket: '['
-          - end_square_bracket: ']'
-          - start_square_bracket: '['
-          - end_square_bracket: ']'
+          - array_type_suffix:
+              start_square_bracket: '['
+              end_square_bracket: ']'
+          - array_type_suffix:
+              start_square_bracket: '['
+              end_square_bracket: ']'
         end_bracket: )
 - statement_terminator: ;
 - statement:

--- a/test/fixtures/dialects/postgres/create_view.yml
+++ b/test/fixtures/dialects/postgres/create_view.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 4de1412edb707d1fbe44f774c60d2763dc5c476ec6f59a7460a302202a30e426
+_hash: 6eb2b143abcbfdb55f08d7ddfbbacd84c5f549d36eb2aee964aee6ec58585720
 file:
 - statement:
     create_view_statement:
@@ -515,8 +515,9 @@ file:
                   casting_operator: '::'
                   data_type:
                     keyword: INTEGER
-                    start_square_bracket: '['
-                    end_square_bracket: ']'
+                    array_type_suffix:
+                      start_square_bracket: '['
+                      end_square_bracket: ']'
               alias_expression:
                 alias_operator:
                   keyword: AS
@@ -540,8 +541,9 @@ file:
                   casting_operator: '::'
                   data_type:
                     keyword: text
-                    start_square_bracket: '['
-                    end_square_bracket: ']'
+                    array_type_suffix:
+                      start_square_bracket: '['
+                      end_square_bracket: ']'
               alias_expression:
                 alias_operator:
                   keyword: AS
@@ -561,8 +563,9 @@ file:
                   casting_operator: '::'
                   data_type:
                     keyword: INTEGER
-                    start_square_bracket: '['
-                    end_square_bracket: ']'
+                    array_type_suffix:
+                      start_square_bracket: '['
+                      end_square_bracket: ']'
               alias_expression:
                 alias_operator:
                   keyword: AS

--- a/test/fixtures/dialects/postgres/datatypes.yml
+++ b/test/fixtures/dialects/postgres/datatypes.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 33dcae915e6157bf6e56ad245455ccf30b56115e604dc13b7266719d42880953
+_hash: 89842fdc15852a1b72da798ec82fdb2dea0f4c65d1ecfddca51c971133b88419
 file:
 - statement:
     create_table_statement:
@@ -651,39 +651,45 @@ file:
           naked_identifier: a
           data_type:
             keyword: integer
-            start_square_bracket: '['
-            end_square_bracket: ']'
+            array_type_suffix:
+              start_square_bracket: '['
+              end_square_bracket: ']'
       - comma: ','
       - column_definition:
           naked_identifier: b
           data_type:
           - keyword: float
-          - start_square_bracket: '['
-          - end_square_bracket: ']'
-          - start_square_bracket: '['
-          - end_square_bracket: ']'
+          - array_type_suffix:
+              start_square_bracket: '['
+              end_square_bracket: ']'
+          - array_type_suffix:
+              start_square_bracket: '['
+              end_square_bracket: ']'
       - comma: ','
       - column_definition:
           naked_identifier: c
           data_type:
             keyword: char
-            start_square_bracket: '['
-            expression:
-              numeric_literal: '1'
-            end_square_bracket: ']'
+            array_type_suffix:
+              start_square_bracket: '['
+              expression:
+                numeric_literal: '1'
+              end_square_bracket: ']'
       - comma: ','
       - column_definition:
           naked_identifier: d
           data_type:
           - keyword: jsonb
-          - start_square_bracket: '['
-          - expression:
-              numeric_literal: '3'
-          - end_square_bracket: ']'
-          - start_square_bracket: '['
-          - expression:
-              numeric_literal: '5'
-          - end_square_bracket: ']'
+          - array_type_suffix:
+              start_square_bracket: '['
+              expression:
+                numeric_literal: '3'
+              end_square_bracket: ']'
+          - array_type_suffix:
+              start_square_bracket: '['
+              expression:
+                numeric_literal: '5'
+              end_square_bracket: ']'
       - comma: ','
       - column_definition:
           naked_identifier: e

--- a/test/fixtures/dialects/postgres/variadic.yml
+++ b/test/fixtures/dialects/postgres/variadic.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 92b2cf467675139e3bc7ac853e3792c534f91964fa86bc59d627204c88e096a4
+_hash: 30641e531ae5e59117438fdac37eee5d5c60f04f52ad7ded0a49982cfd6c10af
 file:
 - statement:
     create_function_statement:
@@ -18,8 +18,9 @@ file:
           parameter: arr
           data_type:
             keyword: numeric
-            start_square_bracket: '['
-            end_square_bracket: ']'
+            array_type_suffix:
+              start_square_bracket: '['
+              end_square_bracket: ']'
           end_bracket: )
     - keyword: RETURNS
     - data_type:
@@ -85,8 +86,9 @@ file:
                     casting_operator: '::'
                     data_type:
                       keyword: numeric
-                      start_square_bracket: '['
-                      end_square_bracket: ']'
+                      array_type_suffix:
+                        start_square_bracket: '['
+                        end_square_bracket: ']'
                 end_bracket: )
 - statement_terminator: ;
 - statement:

--- a/test/fixtures/rules/std_rule_cases/LT01-brackets.yml
+++ b/test/fixtures/rules/std_rule_cases/LT01-brackets.yml
@@ -90,3 +90,30 @@ test_fail_mysql_index_prefix_length:
   configs:
     core:
       dialect: mysql
+
+# An array type suffix `[]` should touch the type name rather than being
+# spaced like a standalone square bracket.
+# https://github.com/sqlfluff/sqlfluff/issues/5005
+test_pass_postgres_array_data_type:
+  pass_str: |
+    CREATE TABLE t (a int[], b text[][]);
+  configs:
+    core:
+      dialect: postgres
+
+test_fail_postgres_array_data_type_extra_space:
+  fail_str: |
+    CREATE TABLE t (a int []);
+  fix_str: |
+    CREATE TABLE t (a int[]);
+  configs:
+    core:
+      dialect: postgres
+
+# A bare array literal still keeps the space after the preceding keyword.
+test_pass_duckdb_array_literal_not_touched:
+  pass_str: |
+    SELECT [1, 2, 3] AS a;
+  configs:
+    core:
+      dialect: duckdb


### PR DESCRIPTION
### Brief summary of the change made

fixes #5005

LT01 was turning `int[]` into `int []`. The array `[]` suffix parsed as a plain square bracket sitting inside the data type, so layout spaced it like any other bracket. I pulled it into its own `array_type_suffix` segment and set that segment to touch the preceding type name, so `int[]` is left alone and a stray `int []` gets fixed back to `int[]`.

### Are there any other side effects of this change that we should be aware of?

The suffix hangs off the postgres datatype, so duckdb, greenplum and materialize inherit the fix. Only the postgres parse fixtures regenerated. Bare array literals like `SELECT [1, 2, 3]` keep their leading space, and there's a test pinning that so it can't regress. Dialects that don't actually have `[]` array types (they parse `CAST(x AS int[])` as an empty array literal, not a real array type) are left untouched on purpose.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- [x] Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix LT01 spacing for Postgres array types so `int[]` stays tight and `int []` is autofixed to `int[]`. Adds a dedicated suffix node and layout rule to prevent bracket spacing.

- **Bug Fixes**
  - Introduced `array_type_suffix` in Postgres grammar so `[]` touches the type.
  - Added `spacing_before = touch` for `array_type_suffix` in default layout.
  - Updated Postgres parse fixtures and LT01 tests; array literals (e.g., `SELECT [1, 2, 3]`) keep their space.
  - DuckDB, Greenplum, and Materialize inherit the fix.

<sup>Written for commit 6481b488eb03e2c0073ebaccb044974e50e92cf6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8222?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

