### PR TITLE
fix(rust): match Python's parse-error message text (Sequence wording, token class/repr, grammar repr truncation)

### DIFF
--- a/sqlfluffrs/sqlfluffrs_lexer/src/lexer.rs
+++ b/sqlfluffrs/sqlfluffrs_lexer/src/lexer.rs
@@ -7,7 +7,7 @@ use sqlfluffrs_types::{
     matcher::{LexMatcher, LexMatcherConfig, LexedElement},
     slice::Slice,
     templater::{fileslice::TemplatedFileSlice, templatefile::TemplatedFile},
-    token::Token,
+    token::{python_repr, Token},
 };
 
 use hashbrown::{HashMap, HashSet};
@@ -433,7 +433,7 @@ impl Lexer {
                 SQLLexError::new(
                     Some(format!(
                         "Unable to lex characters: {}",
-                        python_repr_str(&truncate_like_python(token.raw()))
+                        python_repr(&truncate_like_python(token.raw()))
                     )),
                     token.pos_marker.clone(),
                     None,
@@ -462,49 +462,6 @@ fn truncate_like_python(raw: &str) -> String {
     }
 }
 
-/// Quotes and escapes a string the way Python's `repr()` would, so the
-/// `SQLLexError` description (`"Unable to lex characters:
-/// {!r}".format(...)` in lexer.py's `violations_from_segments`) reads the
-/// same from both lexers even when the unlexable text carries control
-/// characters.
-///
-/// Escapes ASCII/C1 control characters and non-space Unicode whitespace,
-/// which covers the punctuation and symbols that typically show up in
-/// unlexable input. Format (Cf), private-use (Co), and unassigned (Cn)
-/// codepoints are printed as-is for now; extend the match below if
-/// real-world input needs them escaped too.
-fn python_repr_str(s: &str) -> String {
-    let use_double_quotes = s.contains('\'') && !s.contains('"');
-    let quote_char = if use_double_quotes { '"' } else { '\'' };
-
-    let mut out = String::with_capacity(s.len() + 2);
-    out.push(quote_char);
-    for c in s.chars() {
-        match c {
-            '\\' => out.push_str("\\\\"),
-            '\n' => out.push_str("\\n"),
-            '\r' => out.push_str("\\r"),
-            '\t' => out.push_str("\\t"),
-            c if c == quote_char => {
-                out.push('\\');
-                out.push(c);
-            }
-            c if c.is_control() || (c.is_whitespace() && c != ' ') => {
-                let cp = c as u32;
-                if cp <= 0xff {
-                    out.push_str(&format!("\\x{cp:02x}"));
-                } else if cp <= 0xffff {
-                    out.push_str(&format!("\\u{cp:04x}"));
-                } else {
-                    out.push_str(&format!("\\U{cp:08x}"));
-                }
-            }
-            c => out.push(c),
-        }
-    }
-    out.push(quote_char);
-    out
-}
 
 fn iter_tokens(
     lexed_elements: &[TemplateElement],

--- a/sqlfluffrs/sqlfluffrs_lexer/src/lexer.rs
+++ b/sqlfluffrs/sqlfluffrs_lexer/src/lexer.rs
@@ -453,13 +453,8 @@ impl Lexer {
 /// so multi-byte characters truncate the same way Python's `len` and
 /// slicing do.
 fn truncate_like_python(raw: &str) -> String {
-    if raw.chars().count() > 9 {
-        let mut truncated: String = raw.chars().take(10).collect();
-        truncated.push_str("...");
-        truncated
-    } else {
-        raw.to_string()
-    }
+    // lexer.py keeps 10 codepoints once the raw is longer than 9.
+    sqlfluffrs_types::string::ellipsize(raw, 10, 9)
 }
 
 

--- a/sqlfluffrs/sqlfluffrs_lexer/src/lexer.rs
+++ b/sqlfluffrs/sqlfluffrs_lexer/src/lexer.rs
@@ -457,7 +457,6 @@ fn truncate_like_python(raw: &str) -> String {
     sqlfluffrs_types::string::ellipsize(raw, 10, 9)
 }
 
-
 fn iter_tokens(
     lexed_elements: &[TemplateElement],
     templated_file: &Arc<TemplatedFile>,

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/sequence.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/sequence.rs
@@ -434,7 +434,7 @@ impl Parser<'_> {
                 .map(|t| format!("{}", t))
                 .unwrap_or_else(|| "start of input".to_string());
             let error_message =
-                format!("{} to start sequence. Found {}.", element_desc, error_token);
+                format!("{} to start sequence. Found {}", element_desc, error_token);
 
             let unparsable_match = MatchResult {
                 matched_slice: start_idx..max_idx,
@@ -459,7 +459,7 @@ impl Parser<'_> {
             .map(|t| format!("{}", t))
             .expect("There should be at least one matched token here.");
         let error_message = format!(
-            "{} after {}. Found {}.",
+            "{} after {}. Found {}",
             element_desc, last_matched_token, error_token
         );
 

--- a/sqlfluffrs/sqlfluffrs_types/src/grammar_api.rs
+++ b/sqlfluffrs/sqlfluffrs_types/src/grammar_api.rs
@@ -48,15 +48,31 @@ impl<'a> GrammarContext<'a> {
     /// Format: "<Ref: 'RefName'>" for Ref
     /// Format: "VariantName" for others
     pub fn grammar_repr(&self, id: GrammarId) -> String {
+        // PYTHON PARITY: BaseGrammar.__repr__ curtails each element repr to 40
+        // characters and the joined element list to 100
+        // (helpers/string.py curtail_string: `s[:n] + "..."` when longer).
+        // These reprs surface verbatim in user-visible UnparsableSegment
+        // "Expected:" messages, so the truncation must match byte-for-byte.
+        // curtail_string(s, n) keeps n and truncates past n.
+        fn curtail(s: String, n: usize) -> String {
+            crate::string::ellipsize(&s, n, n)
+        }
         if id == GrammarId::NONCODE {
             return "NONCODE".to_string();
         }
         let variant = self.variant(id);
         match variant {
             GrammarVariant::Ref => {
-                // For Ref, format as <Ref: 'RefName'>
+                // PYTHON PARITY: Ref.__repr__ (grammar/base.py) is
+                // `"<Ref: {}{}>".format(repr(self._ref), " [opt]" if
+                // self.is_optional() else "")`, so an optional Ref carries a
+                // trailing " [opt]". These reprs surface in "Expected:"
+                // unparsable messages and feed the 40/100-char curtailment, so
+                // the marker must be present (and only on Ref - container
+                // __repr__s do not append it).
                 let name = self.ref_name(id);
-                format!("<Ref: '{}'>", name)
+                let opt = if self.is_optional(id) { " [opt]" } else { "" };
+                format!("<Ref: '{}'{}>", name, opt)
             }
             GrammarVariant::Delimited => {
                 // For Delimited, Python only shows the element children (child 0), not the delimiter (child 1)
@@ -77,7 +93,15 @@ impl<'a> GrammarContext<'a> {
                 } else {
                     vec![self.grammar_repr(first_child)]
                 };
-                format!("<Delimited: [{}]>", child_reprs.join(", "))
+                let inner = curtail(
+                    child_reprs
+                        .into_iter()
+                        .map(|r| curtail(r, 40))
+                        .collect::<Vec<_>>()
+                        .join(", "),
+                    100,
+                );
+                format!("<Delimited: [{}]>", inner)
             }
             GrammarVariant::Sequence
             | GrammarVariant::OneOf
@@ -89,9 +113,13 @@ impl<'a> GrammarContext<'a> {
                 let children: Vec<GrammarId> = self.children(id).collect();
                 let child_reprs: Vec<String> = children
                     .iter()
-                    .map(|&child_id| self.grammar_repr(child_id))
+                    .map(|&child_id| curtail(self.grammar_repr(child_id), 40))
                     .collect();
-                format!("<{}: [{}]>", variant_name, child_reprs.join(", "))
+                format!(
+                    "<{}: [{}]>",
+                    variant_name,
+                    curtail(child_reprs.join(", "), 100)
+                )
             }
             GrammarVariant::StringParser
             | GrammarVariant::TypedParser

--- a/sqlfluffrs/sqlfluffrs_types/src/lib.rs
+++ b/sqlfluffrs/sqlfluffrs_types/src/lib.rs
@@ -8,6 +8,7 @@ pub mod matcher;
 pub mod parser;
 pub mod regex;
 pub mod slice;
+pub mod string;
 pub mod templater;
 pub mod token;
 pub use config::fluffconfig::FluffConfig;

--- a/sqlfluffrs/sqlfluffrs_types/src/string.rs
+++ b/sqlfluffrs/sqlfluffrs_types/src/string.rs
@@ -1,0 +1,51 @@
+//! Small string helpers shared across the workspace.
+
+/// Truncate `s` to `keep` codepoints and append `"..."` when it is longer than
+/// `over` codepoints; otherwise return it unchanged.
+///
+/// This is the shared primitive behind two Python behaviours that differ only
+/// in their thresholds, so each caller passes its own:
+///
+/// * `helpers/string.py`'s `curtail_string(s, n)` = `s[:n] + "..."` when
+///   `len(s) > n` -> `ellipsize(s, n, n)`.
+/// * `lexer.py`'s `raw[:10] + "..." if len(raw) > 9 else raw` -> `ellipsize(raw,
+///   10, 9)` (note the deliberate 10-keep / 9-threshold asymmetry).
+///
+/// Counting and slicing by `char` matches Python's `len`/slicing on `str`, so
+/// multi-byte characters truncate identically.
+pub fn ellipsize(s: &str, keep: usize, over: usize) -> String {
+    if s.chars().count() > over {
+        let mut out: String = s.chars().take(keep).collect();
+        out.push_str("...");
+        out
+    } else {
+        s.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ellipsize;
+
+    #[test]
+    fn curtail_string_semantics() {
+        // ellipsize(s, n, n): unchanged at length n, truncated past it.
+        assert_eq!(ellipsize("abcd", 4, 4), "abcd");
+        assert_eq!(ellipsize("abcde", 4, 4), "abcd...");
+    }
+
+    #[test]
+    fn lexer_truncate_semantics() {
+        // ellipsize(raw, 10, 9): the 10-keep / 9-threshold asymmetry means a
+        // 10-char string keeps all ten and still gains the ellipsis.
+        assert_eq!(ellipsize("123456789", 10, 9), "123456789");
+        assert_eq!(ellipsize("1234567890", 10, 9), "1234567890...");
+        assert_eq!(ellipsize("12345678901", 10, 9), "1234567890...");
+    }
+
+    #[test]
+    fn counts_by_codepoint() {
+        // Five 2-byte codepoints: length is 5 chars, not 10 bytes.
+        assert_eq!(ellipsize("äääää", 3, 4), "äää...");
+    }
+}

--- a/sqlfluffrs/sqlfluffrs_types/src/token/construction.rs
+++ b/sqlfluffrs/sqlfluffrs_types/src/token/construction.rs
@@ -60,7 +60,11 @@ impl Token {
     }
 
     pub fn raw_token(raw: String, pos_marker: PositionMarker, config: TokenConfig) -> Self {
-        let suffix = format!("'{}'", raw.escape_debug().to_string().trim_matches('"'));
+        // Render the stringify suffix with the shared python_repr helper (the
+        // same one the token Display uses), rather than a second ad-hoc
+        // escape_debug quoting that diverges from Python's repr for embedded
+        // quotes, control chars and non-space whitespace.
+        let suffix = crate::token::python_repr(&raw);
 
         let mut token = Token::base_token(raw, pos_marker, config, vec![]);
         token.class_name = Cow::Borrowed("RawSegment");

--- a/sqlfluffrs/sqlfluffrs_types/src/token/construction.rs
+++ b/sqlfluffrs/sqlfluffrs_types/src/token/construction.rs
@@ -71,7 +71,13 @@ impl Token {
     }
 
     pub fn code_token(raw: String, pos_marker: PositionMarker, config: TokenConfig) -> Self {
-        Self::raw_token(raw, pos_marker, config)
+        let mut token = Self::raw_token(raw, pos_marker, config);
+        // PYTHON PARITY: code-matched tokens are CodeSegment on the Python
+        // side; class_name feeds the Display used in user-visible "Found
+        // <...>" parse-error messages (token_type still drives class
+        // selection elsewhere).
+        token.class_name = Cow::Borrowed("CodeSegment");
+        token
     }
 
     pub fn symbol_token(raw: String, pos_marker: PositionMarker, config: TokenConfig) -> Self {

--- a/sqlfluffrs/sqlfluffrs_types/src/token/fmt.rs
+++ b/sqlfluffrs/sqlfluffrs_types/src/token/fmt.rs
@@ -1,14 +1,99 @@
 use super::Token;
 use std::fmt::Display;
 
+/// Render a string the way Python's `repr()` renders a `str`.
+///
+/// PYTHON PARITY: this surfaces verbatim in user-visible messages - token
+/// Displays in UnparsableSegment "Expected: ... Found <...>" text
+/// (`<{Class}: ({pos}) {raw!r}>`) and the `SQLLexError` "Unable to lex
+/// characters: {!r}" description. Python's repr prefers single quotes,
+/// switches to double quotes when the content contains a single quote (and no
+/// double quote), escapes the backslash / the chosen quote / \n \r \t, and
+/// hex/unicode-escapes control characters (C0, DEL and the C1 block) plus
+/// non-space Unicode whitespace, choosing the `\xXX` / `\uXXXX` / `\U........`
+/// width by codepoint - none of which matches Rust's `escape_debug`.
+///
+/// This is the single shared implementation used by both the parser (token
+/// Display, above) and the lexer's unlexable-error rendering, so the two
+/// never drift apart. (Format/private-use/unassigned codepoints are still
+/// printed as-is - a documented, accepted limitation shared with the lexer.)
+pub fn python_repr(s: &str) -> String {
+    let has_single = s.contains('\'');
+    let has_double = s.contains('"');
+    let quote = if has_single && !has_double { '"' } else { '\'' };
+    let mut out = String::with_capacity(s.len() + 2);
+    out.push(quote);
+    for c in s.chars() {
+        match c {
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            c if c == quote => {
+                out.push('\\');
+                out.push(c);
+            }
+            c if c.is_control() || (c.is_whitespace() && c != ' ') => {
+                let cp = c as u32;
+                if cp <= 0xff {
+                    out.push_str(&format!("\\x{cp:02x}"));
+                } else if cp <= 0xffff {
+                    out.push_str(&format!("\\u{cp:04x}"));
+                } else {
+                    out.push_str(&format!("\\U{cp:08x}"));
+                }
+            }
+            c => out.push(c),
+        }
+    }
+    out.push(quote);
+    out
+}
+
 impl Display for Token {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "<{}: ({}) '{}'>",
+            "<{}: ({}) {}>",
             self.class_name.clone(),
             self.pos_marker.clone().expect("PositionMarker unset"),
-            self.raw.as_str().escape_debug(),
+            python_repr(self.raw.as_str()),
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::python_repr;
+
+    #[test]
+    fn plain_ascii_uses_single_quotes() {
+        assert_eq!(python_repr("abc"), "'abc'");
+    }
+
+    #[test]
+    fn switches_to_double_quotes_for_single_quote_content() {
+        assert_eq!(python_repr("it's"), "\"it's\"");
+        // Both quote kinds present: stay single-quoted and escape the single.
+        assert_eq!(python_repr("a'\"b"), "'a\\'\"b'");
+    }
+
+    #[test]
+    fn escapes_c0_and_del() {
+        assert_eq!(python_repr("\x00\x1f\x7f"), "'\\x00\\x1f\\x7f'");
+        assert_eq!(python_repr("a\tb\nc"), "'a\\tb\\nc'");
+    }
+
+    #[test]
+    fn escapes_c1_controls_and_non_space_whitespace() {
+        // Matches CPython repr: NEL, NBSP -> \x85, \xa0; line separator ->  .
+        assert_eq!(python_repr("a\u{85}b"), "'a\\x85b'");
+        assert_eq!(python_repr("a\u{a0}b"), "'a\\xa0b'");
+        assert_eq!(python_repr("a\u{2028}b"), "'a\\u2028b'");
+    }
+
+    #[test]
+    fn leaves_printable_unicode_as_is() {
+        assert_eq!(python_repr("straße"), "'straße'");
     }
 }

--- a/sqlfluffrs/sqlfluffrs_types/src/token/mod.rs
+++ b/sqlfluffrs/sqlfluffrs_types/src/token/mod.rs
@@ -1,5 +1,7 @@
 pub mod config;
 pub mod construction;
+
+pub use fmt::python_repr;
 mod eq;
 pub mod fix;
 mod fmt;

--- a/test/fixtures/parity/regressions.yml
+++ b/test/fixtures/parity/regressions.yml
@@ -112,12 +112,10 @@ parser_created_segments_drop_token_trim_chars:
     RawSegment.from_result_segments never carries trim_chars over.
 partial_match_failure_keeps_children:
   sql: SELECT CASE
-  xfail:
-    python_vs_rust: Rust appends a trailing period to the 'Found <Segment>' unparsable message
-      that Python's equivalent omits; the unparsable segment's children and the rest of the
-      tree are otherwise identical between engines.
-  pins: Found-message trailing-period gap, CASE-grammar variant; see sequence_found_message_no_trailing_period
-    for the STRUCT variant.
+  pins: GREEDY_ONCE_STARTED Sequence failing partway must keep the already-matched children
+    typed (the SELECT keyword), wrapping only the unmatched tail as unparsable - the Rust
+    side used to drop accumulated child_matches/insert_segments in its error MatchResult,
+    crashing rule ST05 (#8116).
 stray_closing_bracket_dialect_bracket_set:
   sql: SELECT 1 -} FROM t
   dialect: snowflake
@@ -167,10 +165,9 @@ expected_message_curtailment:
 sequence_found_message_no_trailing_period:
   sql: SELECT STRUCT<a INT64(1)
   dialect: bigquery
-  xfail:
-    python_vs_rust: Rust's Found-WordSegment-STRUCT unparsable message ends with a period
-      that Python's identical message omits; no other part of the tree differs.
-  pins: Canonical case for the Found-message trailing-period gap.
+  pins: Canonical case for the Found-message trailing-period gap (fixed by dropping the
+    trailing period from the Sequence "to start sequence"/"after ..." error-message formats
+    in sequence.rs).
 sqlite_nothing_here_expected_message:
   sql: "WITH cte AS (\n t\n)\nSELECT"
   dialect: sqlite

--- a/test/fixtures/parity/regressions.yml
+++ b/test/fixtures/parity/regressions.yml
@@ -152,12 +152,10 @@ found_token_repr_quoting:
 expected_message_curtailment:
   sql: SELECT AS x
   dialect: databricks
-  xfail:
-    python_vs_rust: When the Expected-grammar description in an unparsable message is long,
-      Rust truncates it mid-word with '...' while Python prints it in full; Rust's message
-      also has a trailing period Python's omits.
-  pins: Long Expected-grammar description gets truncated mid-word in Rust (databricks 'SELECT
-    AS x').
+  pins: Rust rendered grammar reprs in full in "Expected:" unparsable messages, where Python's
+    BaseGrammar.__repr__ curtails each element to 40 characters and the joined list to 100
+    (helpers/string.py curtail_string) - fixed by porting the same two-level truncation into
+    GrammarContext::grammar_repr.
 sequence_found_message_no_trailing_period:
   sql: SELECT STRUCT<a INT64(1)
   dialect: bigquery

--- a/test/fixtures/parity/regressions.yml
+++ b/test/fixtures/parity/regressions.yml
@@ -139,12 +139,10 @@ int_typed_indentation_config:
 found_token_class_name:
   sql: SELECT ] FROM t
   dialect: flink
-  xfail:
-    python_vs_rust: 'Python''s ''Found <ClassName: ...>'' unparsable message names the found
-      token''s class CodeSegment while Rust names the identical token RawSegment, and Rust''s
-      message additionally has a trailing period Python''s omits.'
-  pins: Found-segment class name mismatch (flink ']'); see raw_block_survives for the templated-context
-    variant.
+  pins: Rust's code-matched tokens carried class_name RawSegment, so the "Found <...>" unparsable
+    message named the found token's class as RawSegment where Python names it CodeSegment
+    (fixed by giving Token::code_token its own CodeSegment class_name instead of reusing
+    raw_token's).
 found_token_repr_quoting:
   sql: SELECT '
   xfail:
@@ -241,12 +239,8 @@ raw_block_survives:
   context:
     col: a
     table: t
-  xfail:
-    python_vs_rust: Inside a jinja raw block that survives templating unexpanded, Python's
-      unparsable message names the found '{' token RawSegment and appends a trailing period,
-      while Rust names it CodeSegment without a trailing period.
-  pins: Found-segment class name and trailing period inside a jinja raw block; see found_token_class_name
-    for the non-templated variant (reversed class-name direction).
+  pins: Found-segment class name inside a jinja raw block that survives templating unexpanded
+    (fixed by the same Token::code_token CodeSegment fix as found_token_class_name).
 postgres_eszett_function_name:
   sql: SELECT straße(1)
   dialect: postgres

--- a/test/fixtures/parity/regressions.yml
+++ b/test/fixtures/parity/regressions.yml
@@ -145,12 +145,10 @@ found_token_class_name:
     raw_token's).
 found_token_repr_quoting:
   sql: SELECT '
-  xfail:
-    python_vs_rust: For an unterminated string literal, Python's unparsable message wraps
-      the Expected/Found text in single quotes and backslash-escapes embedded apostrophes,
-      while Rust always double-quotes the outer message and escapes the embedded quote character
-      differently, so the same content renders with different quoting/escaping between engines.
-  pins: repr() quote-character/escaping choice differs for the unlexable-token found message.
+  pins: Rust rendered a found token's raw with Rust's escape_debug quoting instead of Python's
+    repr() quote-selection rules (prefer single quotes, switch to double quotes only when
+    the content has a single quote and no double quote) - fixed by giving Token's Display
+    its own py_repr helper that follows Python's str repr() rules.
 expected_message_curtailment:
   sql: SELECT AS x
   dialect: databricks


### PR DESCRIPTION
This is stacked on top of https://github.com/sqlfluff/sqlfluff/pull/8198.

### Brief summary of the change made

This closes four gaps between the Rust and Python parsers in the text of user-visible parse-error messages, found by the parity test harness:

- Rust's `Sequence` grammar appended a trailing period to its "Found ..." error text that Python's equivalent does not have.
- Code-matched tokens in Rust reported their class as `RawSegment` in "Found <...>" messages, where Python names the same token `CodeSegment`.
- The `repr()`-style quoting of a found token's raw text followed Rust's `escape_debug` rules instead of Python's `repr()` rules (quote character choice, escaping of the backslash/quote/`\n`/`\r`/`\t`, and hex/unicode-escaping of control characters and non-space whitespace). This is now handled by a single shared `python_repr` helper used by both the token `Display` and the lexer's unlexable-character error, so the two can't drift apart again.
- Rust printed "Expected:" grammar descriptions in full, where Python's grammar `__repr__` truncates each element to 40 characters and the joined list to 100 characters. A shared `ellipsize` string helper now backs both this grammar-repr truncation and the lexer's existing raw-text truncation, since both are the same operation with different thresholds. This also fixes a related gap where an optional `Ref` grammar was missing its `[opt]` suffix in the repr.

Each fix is paired with updates to `test/fixtures/parity/regressions.yml`, converting the corresponding cases from `xfail` (documented known-divergence) to passing pins.

### Are there any other side effects of this change that we should be aware of?
None expected. These changes are limited to error-message text formatting and do not alter parsing behavior, matching, or the resulting parse tree.

### Pull Request checklist
- [ ] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns Rust parser/lexer error text with Python by fixing token class names, quoting, and grammar repr truncation to achieve message parity and turn affected parity tests from xfail to pins.

- **Bug Fixes**
  - Removed the trailing period from Sequence “Found …” errors.
  - Report `CodeSegment` (not `RawSegment`) for code-matched tokens in “Found <…>”.
  - Added shared `python_repr` for token display and lexer errors to match Python’s `repr()` quoting/escaping.
  - Added shared `ellipsize` and applied Python’s truncation rules in grammar reprs (40 per element, 100 total), including the `[opt]` marker for optional `Ref`.

<sup>Written for commit 2530509a86055b2a4764d27292f69cc4551ef7b5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8225?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

