### PR TITLE
rust(fix): Resolve two codegen-determinism hazards (id-cache collisions and unsorted currency-symbol regex)

### DIFF
--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -263,8 +263,10 @@ tsql_dialect.insert_lexer_matchers(
             (
                 r"([xX]'([\da-fA-F][\da-fA-F])+'"
                 r"|0[xX][\da-fA-F]*"
-                r"|[+-]*[" + "".join(tsql_dialect.sets("currency_symbols")) + r"]"
-                r"[" + "".join(tsql_dialect.sets("currency_symbols")) + r"+-]*"
+                r"|[+-]*["
+                + "".join(sorted(tsql_dialect.sets("currency_symbols")))
+                + r"]"
+                r"[" + "".join(sorted(tsql_dialect.sets("currency_symbols"))) + r"+-]*"
                 r"(?>\d+\.\d+|\d+\.(?![\.\w])|\.\d+|\d+))"
             ),
             LiteralSegment,

--- a/test/core/parser/parity/special_cases_test.py
+++ b/test/core/parser/parity/special_cases_test.py
@@ -18,12 +18,6 @@ import pytest
 _REPO_ROOT = Path(__file__).resolve().parents[4]
 
 
-@pytest.mark.xfail(
-    reason="TableBuilder.grammar_to_id caches grammars by id() without "
-    "keeping them alive, so a GC'd grammar's slot can be inherited by an "
-    "unrelated grammar allocated at the same address.",
-    strict=True,
-)
 def test__parity__codegen_grammar_cache_pins_against_gc():
     """A grammar cached by TableBuilder must not be collectible.
 

--- a/test/core/parser/parity/special_cases_test.py
+++ b/test/core/parser/parity/special_cases_test.py
@@ -13,8 +13,6 @@ import sys
 import weakref
 from pathlib import Path
 
-import pytest
-
 _REPO_ROOT = Path(__file__).resolve().parents[4]
 
 
@@ -57,23 +55,18 @@ def test__parity__codegen_grammar_cache_pins_against_gc():
     )
 
 
-@pytest.mark.xfail(
-    reason="tsql's currency_symbols set is joined without sorting first, so "
-    "the money-literal lexer pattern's byte content varies with the "
-    "interpreter's hash seed.",
-    strict=True,
-)
 def test__parity__codegen_lexer_patterns_hash_seed_stable():
     """Dialect lexer regexes are byte-identical across interpreter hash seeds.
 
-    tsql's money-literal lexer pattern is assembled from an unordered set of
-    currency symbols via ``"".join(...)`` with no sorting, so its bytes
-    shuffle with the interpreter's hash seed - unlike every other
-    ``dialect.sets(...)``-derived pattern in the codebase, which already
-    sorts first. That makes the generated Rust lexer file (produced by
+    Regression guard: tsql's money-literal lexer pattern used to be assembled
+    from an unordered set of currency symbols via ``"".join(...)`` with no
+    sorting, so its bytes shuffled with the interpreter's hash seed - unlike
+    every other ``dialect.sets(...)``-derived pattern in the codebase, which
+    already sorts first. That made the generated Rust lexer file (produced by
     utils/rustify.py) unreproducible: rebuilding with a different hash seed
-    silently changes the checked-in output's byte content, even though the
-    character class matches exactly the same input either way.
+    silently changed the checked-in output's byte content, even though the
+    character class matched exactly the same input either way. The join is now
+    sorted; this test keeps it that way.
     """
     script = (
         "from sqlfluff.core.dialects import dialect_selector\n"

--- a/test/core/parser/parity/special_cases_test.py
+++ b/test/core/parser/parity/special_cases_test.py
@@ -1,0 +1,101 @@
+"""Parity tests that need Python-side instrumentation.
+
+Most parity coverage is data-driven (see ``cases_test.py`` and
+``test/fixtures/parity/``). The tests here can't be expressed as a plain
+SQL-plus-config case because they instrument the Python side: codegen
+object-lifetime probes, subprocess hash-seed probes.
+"""
+
+import gc
+import os
+import subprocess
+import sys
+import weakref
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+
+
+@pytest.mark.xfail(
+    reason="TableBuilder.grammar_to_id caches grammars by id() without "
+    "keeping them alive, so a GC'd grammar's slot can be inherited by an "
+    "unrelated grammar allocated at the same address.",
+    strict=True,
+)
+def test__parity__codegen_grammar_cache_pins_against_gc():
+    """A grammar cached by TableBuilder must not be collectible.
+
+    utils/build_parsers.py's TableBuilder deduplicates flattened grammars in
+    ``grammar_to_id``, keyed by Python's id() - the object's raw memory
+    address. That's only a valid cache key for as long as the object stays
+    alive: once it's garbage-collected, CPython is free to hand that same
+    address to an unrelated later grammar, which then silently inherits the
+    stale cache entry - wiring a semantically wrong subgrammar into the
+    generated Rust dialect tables (seen for real in oracle's
+    ``Ref("AttributeIndicatorSegment")`` picking up a dead
+    ``Ref("ModuloSegment")`` entry). The builder must keep every grammar it
+    caches alive for its own lifetime so no id() in ``grammar_to_id`` can
+    ever be freed and reused.
+    """
+    if str(_REPO_ROOT) not in sys.path:
+        sys.path.insert(0, str(_REPO_ROOT))
+    from sqlfluff.core.dialects import dialect_selector
+    from sqlfluff.core.parser.grammar.base import Ref
+    from utils.build_parsers import DummyParseContext, TableBuilder
+
+    dialect = dialect_selector("ansi")
+    ctx = DummyParseContext(dialect=dialect, uuid=0)
+    builder = TableBuilder()
+
+    grammar = Ref("SelectStatementSegment")
+    alive = weakref.ref(grammar)
+    builder.flatten_grammar(grammar, ctx)
+
+    del grammar
+    gc.collect()
+
+    assert alive() is not None, (
+        "TableBuilder let a cached grammar get garbage-collected - its "
+        "id() can now be reused by an unrelated grammar, silently aliasing "
+        "it to this stale GrammarId."
+    )
+
+
+@pytest.mark.xfail(
+    reason="tsql's currency_symbols set is joined without sorting first, so "
+    "the money-literal lexer pattern's byte content varies with the "
+    "interpreter's hash seed.",
+    strict=True,
+)
+def test__parity__codegen_lexer_patterns_hash_seed_stable():
+    """Dialect lexer regexes are byte-identical across interpreter hash seeds.
+
+    tsql's money-literal lexer pattern is assembled from an unordered set of
+    currency symbols via ``"".join(...)`` with no sorting, so its bytes
+    shuffle with the interpreter's hash seed - unlike every other
+    ``dialect.sets(...)``-derived pattern in the codebase, which already
+    sorts first. That makes the generated Rust lexer file (produced by
+    utils/rustify.py) unreproducible: rebuilding with a different hash seed
+    silently changes the checked-in output's byte content, even though the
+    character class matches exactly the same input either way.
+    """
+    script = (
+        "from sqlfluff.core.dialects import dialect_selector\n"
+        "d = dialect_selector('tsql')\n"
+        "for m in d.lexer_matchers:\n"
+        "    print(m.name, repr(getattr(m, 'template', None)))\n"
+    )
+    outputs = set()
+    for seed in ("0", "1", "2"):
+        env = dict(os.environ, PYTHONHASHSEED=seed, PYTHONIOENCODING="utf-8")
+        proc = subprocess.run(
+            [sys.executable, "-c", script],
+            capture_output=True,
+            env=env,
+            check=True,
+            timeout=120,
+        )
+        outputs.add(proc.stdout)
+    assert len(outputs) == 1, "lexer matcher patterns vary with the hash seed"

--- a/test/fixtures/parity/README.md
+++ b/test/fixtures/parity/README.md
@@ -79,3 +79,7 @@ Case fields:
 
 - `test/core/parser/parity/corpus_test.py` - three-way sweep of every
   dialect fixture at the same strictness.
+- `test/core/parser/parity/special_cases_test.py` - parity-adjacent checks
+  that need Python-side instrumentation rather than a plain SQL-plus-config
+  case, e.g. codegen object-lifetime and hash-seed-stability probes on
+  `utils/build_parsers.py`/`utils/build_lexers.py`.

--- a/utils/build_parsers.py
+++ b/utils/build_parsers.py
@@ -119,10 +119,15 @@ class TableBuilder:
         self.regex_to_id: Dict[str, int] = {}
         self.grammar_to_id: Dict[int, int] = {}  # Python id() -> GrammarId
 
-        # Keep references to synthetic grammars to prevent garbage collection.
-        # Python may reuse memory addresses for new objects after GC, which
-        # would cause incorrect cache hits in grammar_to_id when using id().
-        self._synthetic_grammars: List = []
+        # Keep a reference to every grammar object we cache in grammar_to_id.
+        # Python may reuse a garbage-collected object's memory address for a
+        # later, unrelated grammar; without pinning, that new grammar would
+        # silently inherit the freed object's cached GrammarId - wiring a
+        # semantically wrong subgrammar into the emitted tables. Pin every
+        # cached grammar (dialect-defined or synthetic, e.g. the OneOf
+        # _handle_delimited builds for multi-element Delimited grammars) for
+        # the builder's lifetime so no id() is ever reused while cached.
+        self._cached_grammars: List = []
         self.hint_to_id: Dict[Tuple[Tuple[str, ...], Tuple[str, ...]], int] = {}
 
     def _add_string(self, s: str) -> int:
@@ -273,6 +278,9 @@ class TableBuilder:
         # instruction will end up at the wrong index!
         grammar_id = len(self.instructions)
         self.grammar_to_id[python_id] = grammar_id
+        # Pin the object so its id() cannot be reused by a different grammar
+        # while the cache entry is live (see _cached_grammars in __init__).
+        self._cached_grammars.append(grammar)
         self.instructions.append(None)  # Reserve slot - will be replaced below
         # Reserve a slot for the segment_type offset (default: no type)
         self.segment_type_offsets.append(0xFFFFFFFF)
@@ -780,8 +788,6 @@ class TableBuilder:
                 allow_gaps=grammar.allow_gaps,
                 optional=True,  # Elements in Delimited are implicitly optional
             )
-            # Keep reference to prevent GC and id() reuse
-            self._synthetic_grammars.append(elements_oneof)
             elements_id = self.flatten_grammar(elements_oneof, parse_context)
             comment = f"Delimited({len(grammar._elements)} elements via OneOf)"
         else:


### PR DESCRIPTION
This is stacked on top of https://github.com/sqlfluff/sqlfluff/pull/8198.

### Brief summary of the change made
`utils/build_parsers.py` builds the Rust dialect tables by caching flattened grammar objects in a dict keyed by Python's `id()`. If a cached grammar got garbage collected, CPython could hand its freed memory address to a later, unrelated grammar, which then silently inherited the stale cache entry and wired the wrong subgrammar into the generated tables. This was observed for real with oracle's `AttributeIndicatorSegment` picking up a dead `ModuloSegment` entry. The fix pins every grammar placed in the cache, not just the synthetic ones, so no `id()` can be reused while its entry is live.

Separately, tsql's money-literal lexer pattern built its character class from a set of currency symbols with an unsorted `"".join(...)`, so the generated regex string's byte order depended on the interpreter's hash seed, unlike every other `dialect.sets(...)`-derived pattern in the codebase, which already sorts first. That made the checked-in generated Rust lexer output non-reproducible across rebuilds. The join is now sorted.

Both are regression-guarded with new tests in `test/core/parser/parity/special_cases_test.py`, added to the parity test suite for cases that need Python-side instrumentation (object-lifetime and subprocess hash-seed probes) rather than a plain SQL-plus-config case.

### Are there any other side effects of this change that we should be aware of?
None expected. Both fixes only affect the codegen path (`utils/build_parsers.py`, `utils/build_lexers.py` regex assembly) and should make generated output deterministic without changing what it matches.


### Pull Request checklist
- [ ] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix two codegen nondeterminism issues so the generated Rust parser/lexer output is reproducible. No behavior change to what the parser or lexer matches.

- **Bug Fixes**
  - Parser codegen: In `utils/build_parsers.py`, `TableBuilder` now pins every cached grammar to prevent `id()` reuse after GC, replacing `_synthetic_grammars` with `_cached_grammars` and appending in `flatten_grammar`.
  - Lexer codegen (T-SQL): Sort `currency_symbols` when building the money-literal regex in `src/sqlfluff/dialects/dialect_tsql.py` to make the pattern stable across hash seeds.
  - Tests: Add `test/core/parser/parity/special_cases_test.py` to guard object-lifetime and hash-seed stability; update `test/fixtures/parity/README.md`.

<sup>Written for commit 4de8bae62d9777e452549f69ffe3d092840ad2ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8226?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

