### PR TITLE
duckdb: parse USING SAMPLE / TABLESAMPLE

### DIFF
--- a/src/sqlfluff/dialects/dialect_duckdb.py
+++ b/src/sqlfluff/dialects/dialect_duckdb.py
@@ -129,9 +129,7 @@ duckdb_dialect.add(
             Sequence(
                 "RESERVOIR",
                 Bracketed(
-                    OneOf(
-                        Ref("SamplePercentageGrammar"), Ref("SampleRowCountGrammar")
-                    )
+                    OneOf(Ref("SamplePercentageGrammar"), Ref("SampleRowCountGrammar"))
                 ),
             ),
             # bernoulli and system are percentage-only
@@ -166,9 +164,7 @@ duckdb_dialect.add(
                 ),
             ),
         ),
-        Sequence(
-            "REPEATABLE", Bracketed(Ref("NumericLiteralSegment")), optional=True
-        ),
+        Sequence("REPEATABLE", Bracketed(Ref("NumericLiteralSegment")), optional=True),
     ),
     EqualsSegment_a=StringParser("==", ComparisonOperatorSegment),
     UnpackingOperatorSegment=TypedParser("star", SymbolSegment, "unpacking_operator"),

--- a/src/sqlfluff/dialects/dialect_duckdb.py
+++ b/src/sqlfluff/dialects/dialect_duckdb.py
@@ -75,10 +75,13 @@ duckdb_dialect.sets("unreserved_keywords").update(
         "OVERWRITE_OR_IGNORE",
         "PARQUET_VERSION",
         "PARTITION_BY",
+        "PERCENT",
         "POSITIONAL",
         "PROGRAM",
+        "RESERVOIR",
         "ROW_GROUP_SIZE",
         "ROW_GROUP_SIZE_BYTES",
+        "SAMPLE",
         "SEMI",
         "STRUCT",
         "VIRTUAL",
@@ -314,6 +317,49 @@ duckdb_dialect.patch_lexer_matchers(
         RegexLexer("equals", r"==?", CodeSegment),
     ]
 )
+
+
+class SamplingExpressionSegment(ansi.SamplingExpressionSegment):
+    """A DuckDB sampling expression.
+
+    DuckDB samples with a ``USING SAMPLE`` clause (or the ``TABLESAMPLE``
+    keyword), which accepts either a size (a percentage or a row count) or a
+    sampling method applied to a size, optionally with a repeatable seed.
+
+    https://duckdb.org/docs/stable/sql/samples
+    """
+
+    _sample_size = Sequence(
+        Ref("NumericLiteralSegment"),
+        OneOf(Ref("ModuloSegment"), "PERCENT", "ROWS", optional=True),
+    )
+    _sample_method = OneOf("RESERVOIR", "BERNOULLI", "SYSTEM")
+
+    match_grammar: Matchable = Sequence(
+        OneOf("TABLESAMPLE", Sequence("USING", "SAMPLE")),
+        OneOf(
+            # method (size), e.g. `reservoir(20%)`
+            Sequence(_sample_method, Bracketed(_sample_size)),
+            # size, optionally with a method (and seed), e.g. `10% (system, 377)`
+            Sequence(
+                _sample_size,
+                Bracketed(
+                    _sample_method,
+                    Sequence(
+                        Ref("CommaSegment"),
+                        Ref("NumericLiteralSegment"),
+                        optional=True,
+                    ),
+                    optional=True,
+                ),
+            ),
+        ),
+        Sequence(
+            "REPEATABLE",
+            Bracketed(Ref("NumericLiteralSegment")),
+            optional=True,
+        ),
+    )
 
 
 class IntervalExpressionSegment(BaseSegment):

--- a/src/sqlfluff/dialects/dialect_duckdb.py
+++ b/src/sqlfluff/dialects/dialect_duckdb.py
@@ -112,6 +112,64 @@ duckdb_dialect.sets("datetime_units").update(
 duckdb_dialect.add(
     LambdaArrowSegment=StringParser("->", SymbolSegment, type="lambda_arrow"),
     OrIgnoreGrammar=Sequence("OR", "IGNORE"),
+    # DuckDB sampling. A percentage (`10%` / `10 PERCENT`) as opposed to a fixed
+    # row count (a bare number, or `10 ROWS`). Only reservoir sampling supports a
+    # fixed row count; bernoulli and system sampling are percentage-only. Shared
+    # by the table-level `TABLESAMPLE` and the query-level `USING SAMPLE` clauses.
+    # https://duckdb.org/docs/stable/sql/samples
+    SamplePercentageGrammar=Sequence(
+        Ref("NumericLiteralSegment"), OneOf(Ref("ModuloSegment"), "PERCENT")
+    ),
+    SampleRowCountGrammar=Sequence(
+        Ref("NumericLiteralSegment"), Ref.keyword("ROWS", optional=True)
+    ),
+    SampleExpressionGrammar=Sequence(
+        OneOf(
+            # reservoir takes a percentage or a fixed row count
+            Sequence(
+                "RESERVOIR",
+                Bracketed(
+                    OneOf(
+                        Ref("SamplePercentageGrammar"), Ref("SampleRowCountGrammar")
+                    )
+                ),
+            ),
+            # bernoulli and system are percentage-only
+            Sequence(
+                OneOf("BERNOULLI", "SYSTEM"),
+                Bracketed(Ref("SamplePercentageGrammar")),
+            ),
+            # a percentage, optionally with any method (and seed)
+            Sequence(
+                Ref("SamplePercentageGrammar"),
+                Bracketed(
+                    OneOf("RESERVOIR", "BERNOULLI", "SYSTEM"),
+                    Sequence(
+                        Ref("CommaSegment"),
+                        Ref("NumericLiteralSegment"),
+                        optional=True,
+                    ),
+                    optional=True,
+                ),
+            ),
+            # a fixed row count, optionally with reservoir (and seed)
+            Sequence(
+                Ref("SampleRowCountGrammar"),
+                Bracketed(
+                    "RESERVOIR",
+                    Sequence(
+                        Ref("CommaSegment"),
+                        Ref("NumericLiteralSegment"),
+                        optional=True,
+                    ),
+                    optional=True,
+                ),
+            ),
+        ),
+        Sequence(
+            "REPEATABLE", Bracketed(Ref("NumericLiteralSegment")), optional=True
+        ),
+    ),
     EqualsSegment_a=StringParser("==", ComparisonOperatorSegment),
     UnpackingOperatorSegment=TypedParser("star", SymbolSegment, "unpacking_operator"),
     # DuckDB math operators
@@ -320,55 +378,36 @@ duckdb_dialect.patch_lexer_matchers(
 
 
 class SamplingExpressionSegment(ansi.SamplingExpressionSegment):
-    """A DuckDB sampling expression.
+    """A DuckDB ``TABLESAMPLE`` expression.
 
-    DuckDB samples with a ``USING SAMPLE`` clause (or the ``TABLESAMPLE``
-    keyword), which accepts either a size (a percentage or a row count) or a
-    sampling method applied to a size, optionally with a repeatable seed.
+    ``TABLESAMPLE`` is the table-level form: it samples an individual table in
+    the ``FROM`` clause (before joins). The query-level ``USING SAMPLE`` form is
+    handled by ``UsingSampleClauseSegment``.
 
     https://duckdb.org/docs/stable/sql/samples
     """
 
-    # A percentage (`10%` or `10 PERCENT`) as opposed to a fixed row count (a
-    # bare number, or `10 ROWS`). Only reservoir sampling supports a fixed row
-    # count; bernoulli and system sampling are percentage-only.
-    _percentage = Sequence(
-        Ref("NumericLiteralSegment"),
-        OneOf(Ref("ModuloSegment"), "PERCENT"),
-    )
-    _row_count = Sequence(
-        Ref("NumericLiteralSegment"),
-        Ref.keyword("ROWS", optional=True),
-    )
-    _seed = Sequence(Ref("CommaSegment"), Ref("NumericLiteralSegment"), optional=True)
-
     match_grammar: Matchable = Sequence(
-        OneOf("TABLESAMPLE", Sequence("USING", "SAMPLE")),
-        OneOf(
-            # reservoir takes a percentage or a fixed row count
-            Sequence("RESERVOIR", Bracketed(OneOf(_percentage, _row_count))),
-            # bernoulli and system are percentage-only
-            Sequence(OneOf("BERNOULLI", "SYSTEM"), Bracketed(_percentage)),
-            # a percentage, optionally with any method (and seed),
-            # e.g. `10% (system, 377)`
-            Sequence(
-                _percentage,
-                Bracketed(
-                    OneOf("RESERVOIR", "BERNOULLI", "SYSTEM"), _seed, optional=True
-                ),
-            ),
-            # a fixed row count, optionally with reservoir (and seed),
-            # e.g. `10 ROWS (reservoir, 354)`
-            Sequence(
-                _row_count,
-                Bracketed("RESERVOIR", _seed, optional=True),
-            ),
-        ),
-        Sequence(
-            "REPEATABLE",
-            Bracketed(Ref("NumericLiteralSegment")),
-            optional=True,
-        ),
+        "TABLESAMPLE",
+        Ref("SampleExpressionGrammar"),
+    )
+
+
+class UsingSampleClauseSegment(BaseSegment):
+    """A DuckDB query-level ``USING SAMPLE`` clause.
+
+    Unlike ``TABLESAMPLE``, ``USING SAMPLE`` samples the result of the whole
+    ``FROM`` clause (after joins), so it trails the query rather than attaching
+    to a single table.
+
+    https://duckdb.org/docs/stable/sql/samples
+    """
+
+    type = "sample_expression"
+    match_grammar: Matchable = Sequence(
+        "USING",
+        "SAMPLE",
+        Ref("SampleExpressionGrammar"),
     )
 
 
@@ -850,6 +889,9 @@ class SelectStatementSegment(ansi.SelectStatementSegment):
             Ref("WithCheckOptionSegment"),
             Ref("MetaCommandQueryBufferSegment"),
         ],
+    ).copy(
+        # `USING SAMPLE` is query-level, so it trails the whole statement.
+        insert=[Ref("UsingSampleClauseSegment", optional=True)],
     )
 
 

--- a/src/sqlfluff/dialects/dialect_duckdb.py
+++ b/src/sqlfluff/dialects/dialect_duckdb.py
@@ -329,29 +329,39 @@ class SamplingExpressionSegment(ansi.SamplingExpressionSegment):
     https://duckdb.org/docs/stable/sql/samples
     """
 
-    _sample_size = Sequence(
+    # A percentage (`10%` or `10 PERCENT`) as opposed to a fixed row count (a
+    # bare number, or `10 ROWS`). Only reservoir sampling supports a fixed row
+    # count; bernoulli and system sampling are percentage-only.
+    _percentage = Sequence(
         Ref("NumericLiteralSegment"),
-        OneOf(Ref("ModuloSegment"), "PERCENT", "ROWS", optional=True),
+        OneOf(Ref("ModuloSegment"), "PERCENT"),
     )
-    _sample_method = OneOf("RESERVOIR", "BERNOULLI", "SYSTEM")
+    _row_count = Sequence(
+        Ref("NumericLiteralSegment"),
+        Ref.keyword("ROWS", optional=True),
+    )
+    _seed = Sequence(Ref("CommaSegment"), Ref("NumericLiteralSegment"), optional=True)
 
     match_grammar: Matchable = Sequence(
         OneOf("TABLESAMPLE", Sequence("USING", "SAMPLE")),
         OneOf(
-            # method (size), e.g. `reservoir(20%)`
-            Sequence(_sample_method, Bracketed(_sample_size)),
-            # size, optionally with a method (and seed), e.g. `10% (system, 377)`
+            # reservoir takes a percentage or a fixed row count
+            Sequence("RESERVOIR", Bracketed(OneOf(_percentage, _row_count))),
+            # bernoulli and system are percentage-only
+            Sequence(OneOf("BERNOULLI", "SYSTEM"), Bracketed(_percentage)),
+            # a percentage, optionally with any method (and seed),
+            # e.g. `10% (system, 377)`
             Sequence(
-                _sample_size,
+                _percentage,
                 Bracketed(
-                    _sample_method,
-                    Sequence(
-                        Ref("CommaSegment"),
-                        Ref("NumericLiteralSegment"),
-                        optional=True,
-                    ),
-                    optional=True,
+                    OneOf("RESERVOIR", "BERNOULLI", "SYSTEM"), _seed, optional=True
                 ),
+            ),
+            # a fixed row count, optionally with reservoir (and seed),
+            # e.g. `10 ROWS (reservoir, 354)`
+            Sequence(
+                _row_count,
+                Bracketed("RESERVOIR", _seed, optional=True),
             ),
         ),
         Sequence(

--- a/src/sqlfluff/dialects/dialect_duckdb.py
+++ b/src/sqlfluff/dialects/dialect_duckdb.py
@@ -919,6 +919,9 @@ class UnorderedSelectStatementSegment(ansi.UnorderedSelectStatementSegment):
         Ref("HavingClauseSegment", optional=True),
         Ref("NamedWindowSegment", optional=True),
         Ref("QualifyClauseSegment", optional=True),
+        # `USING SAMPLE` is query-level, so it also trails a `SELECT` that is a
+        # branch of a set expression (e.g. one side of a `UNION`).
+        Ref("UsingSampleClauseSegment", optional=True),
         terminators=[
             Ref("SetOperatorSegment"),
             Ref("OrderByClauseSegment"),

--- a/test/fixtures/dialects/duckdb/using_sample.sql
+++ b/test/fixtures/dialects/duckdb/using_sample.sql
@@ -1,5 +1,8 @@
--- DuckDB `USING SAMPLE` / `TABLESAMPLE` table sampling.
--- https://duckdb.org/docs/stable/sql/samples
+-- DuckDB sampling. https://duckdb.org/docs/stable/sql/samples
+--
+-- `USING SAMPLE` is a query-level clause: it samples the result of the whole
+-- FROM clause (after joins), so it trails the query. `TABLESAMPLE` is the
+-- table-level form: it samples an individual table (before joins).
 
 -- Percentage samples.
 SELECT * FROM addresses USING SAMPLE 10%;
@@ -25,11 +28,21 @@ SELECT * FROM addresses USING SAMPLE 20% (system, 377);
 -- A fixed row count with an explicit method (and optional seed) -- reservoir only.
 SELECT * FROM addresses USING SAMPLE 10 ROWS (reservoir, 354);
 
--- `TABLESAMPLE` is an accepted synonym.
+-- `USING SAMPLE` samples after joins, so it trails the whole query.
+SELECT *
+FROM tbl, tbl2
+WHERE tbl.i = tbl2.i
+USING SAMPLE reservoir(20%);
+
+SELECT city, count(*)
+FROM addresses
+GROUP BY city
+ORDER BY city
+USING SAMPLE 10%;
+
+-- `TABLESAMPLE` samples before joins, so it attaches to a table in FROM.
 SELECT * FROM addresses TABLESAMPLE 10%;
 SELECT * FROM addresses TABLESAMPLE bernoulli(10%);
-
--- Sampling combined with a join (the sample applies to the sampled table).
 SELECT *
-FROM addresses USING SAMPLE 10%
-JOIN cities USING (city_id);
+FROM tbl TABLESAMPLE reservoir(20%), tbl2
+WHERE tbl.i = tbl2.i;

--- a/test/fixtures/dialects/duckdb/using_sample.sql
+++ b/test/fixtures/dialects/duckdb/using_sample.sql
@@ -5,21 +5,29 @@
 SELECT * FROM addresses USING SAMPLE 10%;
 SELECT * FROM addresses USING SAMPLE 10 PERCENT;
 
--- Fixed-size (row count) sample.
+-- Fixed row-count samples (a bare number, or `ROWS`). Only reservoir sampling
+-- supports a fixed number of rows.
+SELECT * FROM addresses USING SAMPLE 5;
 SELECT * FROM addresses USING SAMPLE 100 ROWS;
 
--- Sampling method applied to a size.
+-- A sampling method applied to a size. `reservoir` accepts a percentage or a
+-- row count; `bernoulli` and `system` are percentage-only.
 SELECT * FROM addresses USING SAMPLE reservoir(20%);
+SELECT * FROM addresses USING SAMPLE reservoir(500 ROWS);
 SELECT * FROM addresses USING SAMPLE bernoulli(10%);
-SELECT * FROM addresses USING SAMPLE reservoir(500 ROWS) REPEATABLE (100);
+SELECT * FROM addresses USING SAMPLE system(20%);
+SELECT * FROM addresses USING SAMPLE reservoir(50 ROWS) REPEATABLE (100);
 
--- Size with an explicit method and seed.
-SELECT * FROM addresses USING SAMPLE 10% (system, 377);
+-- A percentage with an explicit method (and optional seed) -- any method.
+SELECT * FROM addresses USING SAMPLE 10 PERCENT (bernoulli);
+SELECT * FROM addresses USING SAMPLE 20% (system, 377);
+
+-- A fixed row count with an explicit method (and optional seed) -- reservoir only.
 SELECT * FROM addresses USING SAMPLE 10 ROWS (reservoir, 354);
 
 -- `TABLESAMPLE` is an accepted synonym.
 SELECT * FROM addresses TABLESAMPLE 10%;
-SELECT * FROM addresses TABLESAMPLE bernoulli(10);
+SELECT * FROM addresses TABLESAMPLE bernoulli(10%);
 
 -- Sampling combined with a join (the sample applies to the sampled table).
 SELECT *

--- a/test/fixtures/dialects/duckdb/using_sample.sql
+++ b/test/fixtures/dialects/duckdb/using_sample.sql
@@ -46,3 +46,18 @@ SELECT * FROM addresses TABLESAMPLE bernoulli(10%);
 SELECT *
 FROM tbl TABLESAMPLE reservoir(20%), tbl2
 WHERE tbl.i = tbl2.i;
+
+-- `USING SAMPLE` also trails a `SELECT` that is a branch of a set expression,
+-- so it can sample either (or both) sides of a `UNION`.
+SELECT * FROM tbl USING SAMPLE 10%
+UNION ALL
+SELECT * FROM other;
+
+SELECT * FROM tbl
+UNION ALL
+SELECT * FROM other USING SAMPLE 10%;
+
+SELECT * FROM a USING SAMPLE 5 ROWS
+UNION
+SELECT * FROM b USING SAMPLE 10%
+ORDER BY 1;

--- a/test/fixtures/dialects/duckdb/using_sample.sql
+++ b/test/fixtures/dialects/duckdb/using_sample.sql
@@ -1,0 +1,27 @@
+-- DuckDB `USING SAMPLE` / `TABLESAMPLE` table sampling.
+-- https://duckdb.org/docs/stable/sql/samples
+
+-- Percentage samples.
+SELECT * FROM addresses USING SAMPLE 10%;
+SELECT * FROM addresses USING SAMPLE 10 PERCENT;
+
+-- Fixed-size (row count) sample.
+SELECT * FROM addresses USING SAMPLE 100 ROWS;
+
+-- Sampling method applied to a size.
+SELECT * FROM addresses USING SAMPLE reservoir(20%);
+SELECT * FROM addresses USING SAMPLE bernoulli(10%);
+SELECT * FROM addresses USING SAMPLE reservoir(500 ROWS) REPEATABLE (100);
+
+-- Size with an explicit method and seed.
+SELECT * FROM addresses USING SAMPLE 10% (system, 377);
+SELECT * FROM addresses USING SAMPLE 10 ROWS (reservoir, 354);
+
+-- `TABLESAMPLE` is an accepted synonym.
+SELECT * FROM addresses TABLESAMPLE 10%;
+SELECT * FROM addresses TABLESAMPLE bernoulli(10);
+
+-- Sampling combined with a join (the sample applies to the sampled table).
+SELECT *
+FROM addresses USING SAMPLE 10%
+JOIN cities USING (city_id);

--- a/test/fixtures/dialects/duckdb/using_sample.yml
+++ b/test/fixtures/dialects/duckdb/using_sample.yml
@@ -1,0 +1,279 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: bd47ec9f744514e4ab3a1f4d324b1b8f3406cd871baa37e7c810bf4a4f29f2c0
+file:
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: addresses
+            sample_expression:
+            - keyword: USING
+            - keyword: SAMPLE
+            - numeric_literal: '10'
+            - binary_operator: '%'
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: addresses
+            sample_expression:
+            - keyword: USING
+            - keyword: SAMPLE
+            - numeric_literal: '10'
+            - keyword: PERCENT
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: addresses
+            sample_expression:
+            - keyword: USING
+            - keyword: SAMPLE
+            - numeric_literal: '100'
+            - keyword: ROWS
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: addresses
+            sample_expression:
+            - keyword: USING
+            - keyword: SAMPLE
+            - keyword: reservoir
+            - bracketed:
+                start_bracket: (
+                numeric_literal: '20'
+                binary_operator: '%'
+                end_bracket: )
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: addresses
+            sample_expression:
+            - keyword: USING
+            - keyword: SAMPLE
+            - keyword: bernoulli
+            - bracketed:
+                start_bracket: (
+                numeric_literal: '10'
+                binary_operator: '%'
+                end_bracket: )
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: addresses
+            sample_expression:
+            - keyword: USING
+            - keyword: SAMPLE
+            - keyword: reservoir
+            - bracketed:
+                start_bracket: (
+                numeric_literal: '500'
+                keyword: ROWS
+                end_bracket: )
+            - keyword: REPEATABLE
+            - bracketed:
+                start_bracket: (
+                numeric_literal: '100'
+                end_bracket: )
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: addresses
+            sample_expression:
+            - keyword: USING
+            - keyword: SAMPLE
+            - numeric_literal: '10'
+            - binary_operator: '%'
+            - bracketed:
+                start_bracket: (
+                keyword: system
+                comma: ','
+                numeric_literal: '377'
+                end_bracket: )
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: addresses
+            sample_expression:
+            - keyword: USING
+            - keyword: SAMPLE
+            - numeric_literal: '10'
+            - keyword: ROWS
+            - bracketed:
+                start_bracket: (
+                keyword: reservoir
+                comma: ','
+                numeric_literal: '354'
+                end_bracket: )
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: addresses
+            sample_expression:
+              keyword: TABLESAMPLE
+              numeric_literal: '10'
+              binary_operator: '%'
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: addresses
+            sample_expression:
+            - keyword: TABLESAMPLE
+            - keyword: bernoulli
+            - bracketed:
+                start_bracket: (
+                numeric_literal: '10'
+                end_bracket: )
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: addresses
+            sample_expression:
+            - keyword: USING
+            - keyword: SAMPLE
+            - numeric_literal: '10'
+            - binary_operator: '%'
+          join_clause:
+          - keyword: JOIN
+          - from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: cities
+          - keyword: USING
+          - bracketed:
+              start_bracket: (
+              naked_identifier: city_id
+              end_bracket: )
+- statement_terminator: ;

--- a/test/fixtures/dialects/duckdb/using_sample.yml
+++ b/test/fixtures/dialects/duckdb/using_sample.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: f335e72bbe584654b2cfc28681e64d20ed7f44fe6508ece50bee56082d17bc63
+_hash: a036d8a9066af01b34bb9a7b82efa88c90f0369ac84d53be6857737cac3e6872
 file:
 - statement:
     select_statement:
@@ -467,4 +467,129 @@ file:
           - naked_identifier: tbl2
           - dot: .
           - naked_identifier: i
+- statement_terminator: ;
+- statement:
+    set_expression:
+    - select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: tbl
+        sample_expression:
+        - keyword: USING
+        - keyword: SAMPLE
+        - numeric_literal: '10'
+        - binary_operator: '%'
+    - set_operator:
+      - keyword: UNION
+      - keyword: ALL
+    - select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: other
+- statement_terminator: ;
+- statement:
+    set_expression:
+    - select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: tbl
+    - set_operator:
+      - keyword: UNION
+      - keyword: ALL
+    - select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: other
+        sample_expression:
+        - keyword: USING
+        - keyword: SAMPLE
+        - numeric_literal: '10'
+        - binary_operator: '%'
+- statement_terminator: ;
+- statement:
+    set_expression:
+    - select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: a
+        sample_expression:
+        - keyword: USING
+        - keyword: SAMPLE
+        - numeric_literal: '5'
+        - keyword: ROWS
+    - set_operator:
+        keyword: UNION
+    - select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: b
+        sample_expression:
+        - keyword: USING
+        - keyword: SAMPLE
+        - numeric_literal: '10'
+        - binary_operator: '%'
+    - orderby_clause:
+      - keyword: ORDER
+      - keyword: BY
+      - numeric_literal: '1'
 - statement_terminator: ;

--- a/test/fixtures/dialects/duckdb/using_sample.yml
+++ b/test/fixtures/dialects/duckdb/using_sample.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: bd47ec9f744514e4ab3a1f4d324b1b8f3406cd871baa37e7c810bf4a4f29f2c0
+_hash: 7a54755ae6a5464999a5b952abf567933ea14e95f7d9d7a697cf8cb49ce4902b
 file:
 - statement:
     select_statement:
@@ -46,6 +46,26 @@ file:
             - keyword: SAMPLE
             - numeric_literal: '10'
             - keyword: PERCENT
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: addresses
+            sample_expression:
+            - keyword: USING
+            - keyword: SAMPLE
+            - numeric_literal: '5'
 - statement_terminator: ;
 - statement:
     select_statement:
@@ -111,6 +131,31 @@ file:
             sample_expression:
             - keyword: USING
             - keyword: SAMPLE
+            - keyword: reservoir
+            - bracketed:
+                start_bracket: (
+                numeric_literal: '500'
+                keyword: ROWS
+                end_bracket: )
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: addresses
+            sample_expression:
+            - keyword: USING
+            - keyword: SAMPLE
             - keyword: bernoulli
             - bracketed:
                 start_bracket: (
@@ -136,10 +181,35 @@ file:
             sample_expression:
             - keyword: USING
             - keyword: SAMPLE
+            - keyword: system
+            - bracketed:
+                start_bracket: (
+                numeric_literal: '20'
+                binary_operator: '%'
+                end_bracket: )
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: addresses
+            sample_expression:
+            - keyword: USING
+            - keyword: SAMPLE
             - keyword: reservoir
             - bracketed:
                 start_bracket: (
-                numeric_literal: '500'
+                numeric_literal: '50'
                 keyword: ROWS
                 end_bracket: )
             - keyword: REPEATABLE
@@ -167,6 +237,31 @@ file:
             - keyword: USING
             - keyword: SAMPLE
             - numeric_literal: '10'
+            - keyword: PERCENT
+            - bracketed:
+                start_bracket: (
+                keyword: bernoulli
+                end_bracket: )
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: addresses
+            sample_expression:
+            - keyword: USING
+            - keyword: SAMPLE
+            - numeric_literal: '20'
             - binary_operator: '%'
             - bracketed:
                 start_bracket: (
@@ -243,6 +338,7 @@ file:
             - bracketed:
                 start_bracket: (
                 numeric_literal: '10'
+                binary_operator: '%'
                 end_bracket: )
 - statement_terminator: ;
 - statement:

--- a/test/fixtures/dialects/duckdb/using_sample.yml
+++ b/test/fixtures/dialects/duckdb/using_sample.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 7a54755ae6a5464999a5b952abf567933ea14e95f7d9d7a697cf8cb49ce4902b
+_hash: f335e72bbe584654b2cfc28681e64d20ed7f44fe6508ece50bee56082d17bc63
 file:
 - statement:
     select_statement:
@@ -20,11 +20,11 @@ file:
             table_expression:
               table_reference:
                 naked_identifier: addresses
-            sample_expression:
-            - keyword: USING
-            - keyword: SAMPLE
-            - numeric_literal: '10'
-            - binary_operator: '%'
+      sample_expression:
+      - keyword: USING
+      - keyword: SAMPLE
+      - numeric_literal: '10'
+      - binary_operator: '%'
 - statement_terminator: ;
 - statement:
     select_statement:
@@ -41,11 +41,11 @@ file:
             table_expression:
               table_reference:
                 naked_identifier: addresses
-            sample_expression:
-            - keyword: USING
-            - keyword: SAMPLE
-            - numeric_literal: '10'
-            - keyword: PERCENT
+      sample_expression:
+      - keyword: USING
+      - keyword: SAMPLE
+      - numeric_literal: '10'
+      - keyword: PERCENT
 - statement_terminator: ;
 - statement:
     select_statement:
@@ -62,10 +62,10 @@ file:
             table_expression:
               table_reference:
                 naked_identifier: addresses
-            sample_expression:
-            - keyword: USING
-            - keyword: SAMPLE
-            - numeric_literal: '5'
+      sample_expression:
+      - keyword: USING
+      - keyword: SAMPLE
+      - numeric_literal: '5'
 - statement_terminator: ;
 - statement:
     select_statement:
@@ -82,11 +82,11 @@ file:
             table_expression:
               table_reference:
                 naked_identifier: addresses
-            sample_expression:
-            - keyword: USING
-            - keyword: SAMPLE
-            - numeric_literal: '100'
-            - keyword: ROWS
+      sample_expression:
+      - keyword: USING
+      - keyword: SAMPLE
+      - numeric_literal: '100'
+      - keyword: ROWS
 - statement_terminator: ;
 - statement:
     select_statement:
@@ -103,24 +103,261 @@ file:
             table_expression:
               table_reference:
                 naked_identifier: addresses
-            sample_expression:
-            - keyword: USING
-            - keyword: SAMPLE
-            - keyword: reservoir
-            - bracketed:
+      sample_expression:
+      - keyword: USING
+      - keyword: SAMPLE
+      - keyword: reservoir
+      - bracketed:
+          start_bracket: (
+          numeric_literal: '20'
+          binary_operator: '%'
+          end_bracket: )
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: addresses
+      sample_expression:
+      - keyword: USING
+      - keyword: SAMPLE
+      - keyword: reservoir
+      - bracketed:
+          start_bracket: (
+          numeric_literal: '500'
+          keyword: ROWS
+          end_bracket: )
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: addresses
+      sample_expression:
+      - keyword: USING
+      - keyword: SAMPLE
+      - keyword: bernoulli
+      - bracketed:
+          start_bracket: (
+          numeric_literal: '10'
+          binary_operator: '%'
+          end_bracket: )
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: addresses
+      sample_expression:
+      - keyword: USING
+      - keyword: SAMPLE
+      - keyword: system
+      - bracketed:
+          start_bracket: (
+          numeric_literal: '20'
+          binary_operator: '%'
+          end_bracket: )
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: addresses
+      sample_expression:
+      - keyword: USING
+      - keyword: SAMPLE
+      - keyword: reservoir
+      - bracketed:
+          start_bracket: (
+          numeric_literal: '50'
+          keyword: ROWS
+          end_bracket: )
+      - keyword: REPEATABLE
+      - bracketed:
+          start_bracket: (
+          numeric_literal: '100'
+          end_bracket: )
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: addresses
+      sample_expression:
+      - keyword: USING
+      - keyword: SAMPLE
+      - numeric_literal: '10'
+      - keyword: PERCENT
+      - bracketed:
+          start_bracket: (
+          keyword: bernoulli
+          end_bracket: )
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: addresses
+      sample_expression:
+      - keyword: USING
+      - keyword: SAMPLE
+      - numeric_literal: '20'
+      - binary_operator: '%'
+      - bracketed:
+          start_bracket: (
+          keyword: system
+          comma: ','
+          numeric_literal: '377'
+          end_bracket: )
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: addresses
+      sample_expression:
+      - keyword: USING
+      - keyword: SAMPLE
+      - numeric_literal: '10'
+      - keyword: ROWS
+      - bracketed:
+          start_bracket: (
+          keyword: reservoir
+          comma: ','
+          numeric_literal: '354'
+          end_bracket: )
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+      - keyword: FROM
+      - from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: tbl
+      - comma: ','
+      - from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: tbl2
+      where_clause:
+        keyword: WHERE
+        expression:
+        - column_reference:
+          - naked_identifier: tbl
+          - dot: .
+          - naked_identifier: i
+        - comparison_operator:
+            raw_comparison_operator: '='
+        - column_reference:
+          - naked_identifier: tbl2
+          - dot: .
+          - naked_identifier: i
+      sample_expression:
+      - keyword: USING
+      - keyword: SAMPLE
+      - keyword: reservoir
+      - bracketed:
+          start_bracket: (
+          numeric_literal: '20'
+          binary_operator: '%'
+          end_bracket: )
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            naked_identifier: city
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: count
+            function_contents:
+              bracketed:
                 start_bracket: (
-                numeric_literal: '20'
-                binary_operator: '%'
+                star: '*'
                 end_bracket: )
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-        keyword: SELECT
-        select_clause_element:
-          wildcard_expression:
-            wildcard_identifier:
-              star: '*'
       from_clause:
         keyword: FROM
         from_expression:
@@ -128,174 +365,21 @@ file:
             table_expression:
               table_reference:
                 naked_identifier: addresses
-            sample_expression:
-            - keyword: USING
-            - keyword: SAMPLE
-            - keyword: reservoir
-            - bracketed:
-                start_bracket: (
-                numeric_literal: '500'
-                keyword: ROWS
-                end_bracket: )
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-        keyword: SELECT
-        select_clause_element:
-          wildcard_expression:
-            wildcard_identifier:
-              star: '*'
-      from_clause:
-        keyword: FROM
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: addresses
-            sample_expression:
-            - keyword: USING
-            - keyword: SAMPLE
-            - keyword: bernoulli
-            - bracketed:
-                start_bracket: (
-                numeric_literal: '10'
-                binary_operator: '%'
-                end_bracket: )
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-        keyword: SELECT
-        select_clause_element:
-          wildcard_expression:
-            wildcard_identifier:
-              star: '*'
-      from_clause:
-        keyword: FROM
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: addresses
-            sample_expression:
-            - keyword: USING
-            - keyword: SAMPLE
-            - keyword: system
-            - bracketed:
-                start_bracket: (
-                numeric_literal: '20'
-                binary_operator: '%'
-                end_bracket: )
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-        keyword: SELECT
-        select_clause_element:
-          wildcard_expression:
-            wildcard_identifier:
-              star: '*'
-      from_clause:
-        keyword: FROM
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: addresses
-            sample_expression:
-            - keyword: USING
-            - keyword: SAMPLE
-            - keyword: reservoir
-            - bracketed:
-                start_bracket: (
-                numeric_literal: '50'
-                keyword: ROWS
-                end_bracket: )
-            - keyword: REPEATABLE
-            - bracketed:
-                start_bracket: (
-                numeric_literal: '100'
-                end_bracket: )
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-        keyword: SELECT
-        select_clause_element:
-          wildcard_expression:
-            wildcard_identifier:
-              star: '*'
-      from_clause:
-        keyword: FROM
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: addresses
-            sample_expression:
-            - keyword: USING
-            - keyword: SAMPLE
-            - numeric_literal: '10'
-            - keyword: PERCENT
-            - bracketed:
-                start_bracket: (
-                keyword: bernoulli
-                end_bracket: )
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-        keyword: SELECT
-        select_clause_element:
-          wildcard_expression:
-            wildcard_identifier:
-              star: '*'
-      from_clause:
-        keyword: FROM
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: addresses
-            sample_expression:
-            - keyword: USING
-            - keyword: SAMPLE
-            - numeric_literal: '20'
-            - binary_operator: '%'
-            - bracketed:
-                start_bracket: (
-                keyword: system
-                comma: ','
-                numeric_literal: '377'
-                end_bracket: )
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-        keyword: SELECT
-        select_clause_element:
-          wildcard_expression:
-            wildcard_identifier:
-              star: '*'
-      from_clause:
-        keyword: FROM
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: addresses
-            sample_expression:
-            - keyword: USING
-            - keyword: SAMPLE
-            - numeric_literal: '10'
-            - keyword: ROWS
-            - bracketed:
-                start_bracket: (
-                keyword: reservoir
-                comma: ','
-                numeric_literal: '354'
-                end_bracket: )
+      groupby_clause:
+      - keyword: GROUP
+      - keyword: BY
+      - column_reference:
+          naked_identifier: city
+      orderby_clause:
+      - keyword: ORDER
+      - keyword: BY
+      - column_reference:
+          naked_identifier: city
+      sample_expression:
+      - keyword: USING
+      - keyword: SAMPLE
+      - numeric_literal: '10'
+      - binary_operator: '%'
 - statement_terminator: ;
 - statement:
     select_statement:
@@ -350,26 +434,37 @@ file:
             wildcard_identifier:
               star: '*'
       from_clause:
-        keyword: FROM
-        from_expression:
+      - keyword: FROM
+      - from_expression:
           from_expression_element:
             table_expression:
               table_reference:
-                naked_identifier: addresses
+                naked_identifier: tbl
             sample_expression:
-            - keyword: USING
-            - keyword: SAMPLE
-            - numeric_literal: '10'
-            - binary_operator: '%'
-          join_clause:
-          - keyword: JOIN
-          - from_expression_element:
-              table_expression:
-                table_reference:
-                  naked_identifier: cities
-          - keyword: USING
-          - bracketed:
-              start_bracket: (
-              naked_identifier: city_id
-              end_bracket: )
+            - keyword: TABLESAMPLE
+            - keyword: reservoir
+            - bracketed:
+                start_bracket: (
+                numeric_literal: '20'
+                binary_operator: '%'
+                end_bracket: )
+      - comma: ','
+      - from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: tbl2
+      where_clause:
+        keyword: WHERE
+        expression:
+        - column_reference:
+          - naked_identifier: tbl
+          - dot: .
+          - naked_identifier: i
+        - comparison_operator:
+            raw_comparison_operator: '='
+        - column_reference:
+          - naked_identifier: tbl2
+          - dot: .
+          - naked_identifier: i
 - statement_terminator: ;


### PR DESCRIPTION
### Brief summary of the change made

DuckDB samples a table with a `USING SAMPLE` clause (or the `TABLESAMPLE` keyword), which the `duckdb` dialect did not model, so valid statements such as `SELECT * FROM t USING SAMPLE 10%` were reported as an unparsable section.

This adds a DuckDB `SamplingExpressionSegment` override covering the documented forms:

- a size: a percentage (`10%`, `10 PERCENT`) or a row count (`100 ROWS`)
- a sampling method applied to a size: `reservoir(20%)`, `bernoulli(10%)`, `system(10%)`
- a size with an explicit method and optional seed: `10% (system, 377)`, `10 ROWS (reservoir, 354)`
- an optional `REPEATABLE (seed)`
- the `TABLESAMPLE` keyword as an accepted synonym

`SAMPLE`, `PERCENT` and `RESERVOIR` are registered as unreserved keywords so they remain usable as ordinary identifiers.

Ref: https://duckdb.org/docs/stable/sql/samples

### Are there any other side effects of this change that we should be aware of?

None found. The clause hooks into the existing optional `SamplingExpressionSegment` on the from-expression element, so `%` (modulo) and `JOIN ... USING (col)` are unaffected, and `sample`/`percent`/`reservoir` remain valid identifiers. A query-level trailing `USING SAMPLE` (after `WHERE`/`GROUP BY`) is a separate placement and intentionally left for a follow-up.

### Pull Request checklist

- [x] Included `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (`duckdb/using_sample.sql` + auto-generated `.yml`).
- [x] Added grammar-level documentation (docstring referencing the DuckDB sampling docs).

---

Disclosure: this change was written with AI assistance (Claude Code). I've reviewed the diff and reasoning and verified it against the test suite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds DuckDB `USING SAMPLE` (query-level) and `TABLESAMPLE` (table-level) parsing in the `duckdb` dialect, including on SELECT branches inside set expressions. Fixes unparsable sampling queries and applies `ruff` formatting.

- **New Features**
  - Parse sizes: `10%`, `10 PERCENT`, `100 ROWS`.
  - Parse methods: `reservoir(20%)`, `bernoulli(10%)`, `system(10%)`, and size with method and seed: `10% (system, 377)`.
  - Treat `USING SAMPLE` as a trailing query-level clause; also allowed on SELECTs inside set expressions (`UNION`, etc.). `TABLESAMPLE` attaches to individual tables.
  - Support `REPEATABLE (seed)` and register `SAMPLE`, `PERCENT`, `RESERVOIR` as unreserved keywords.

- **Bug Fixes**
  - Enforce DuckDB rules: row counts only with `reservoir`; `bernoulli` and `system` accept percentages only.

<sup>Written for commit 35e67b46a71000cc9c7336c063b20f7ee5e08b6d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8229?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

