### PR TITLE
fix: preserve CV12 predicates with templated joins

### DIFF
--- a/src/sqlfluff/rules/convention/CV12.py
+++ b/src/sqlfluff/rules/convention/CV12.py
@@ -15,7 +15,6 @@ from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
 from sqlfluff.core.rules.fix import LintFix
 from sqlfluff.dialects.dialect_ansi import (
     ExpressionSegment,
-    JoinClauseSegment,
     JoinOnConditionSegment,
 )
 
@@ -208,20 +207,12 @@ class Rule_CV12(BaseRule):
                             join_on_expression,
                         )
                     )
-                    join_clause_segment = JoinClauseSegment(
-                        (
-                            *join_clause.segments,
-                            WhitespaceSegment(),
-                            join_on,
-                        )
-                    )
-
                     yield LintResult(
                         anchor=join_clause,
                         fixes=[
-                            LintFix.replace(
-                                join_clause,
-                                edit_segments=[join_clause_segment],
+                            LintFix.create_after(
+                                join_table_reference,
+                                edit_segments=[WhitespaceSegment(), join_on],
                             )
                         ],
                     )

--- a/test/fixtures/rules/std_rule_cases/CV12.yml
+++ b/test/fixtures/rules/std_rule_cases/CV12.yml
@@ -155,3 +155,18 @@ test_pass_left_join_unnest_where_unaliased:
       UNNEST(t.purchases)
     WHERE
       t.user_id != 1
+
+test_fail_templated_join_table:
+  fail_str: |
+    select a.id, b.id as b_id
+    from table_a as a
+    left join {{ ref('table_b') }} as b
+    where a.region = b.region
+  fix_str: |
+    select a.id, b.id as b_id
+    from table_a as a
+    left join {{ ref('table_b') }} as b ON a.region = b.region
+  configs:
+    core:
+      dialect: snowflake
+      templater: jinja


### PR DESCRIPTION
### Brief summary of the change made

Fixes #8230.

CV12 previously replaced the entire `join_clause` when moving a predicate from `WHERE` to `JOIN ... ON ...`. If the joined table came from a Jinja expression, SQLFluff discarded that replacement as unsafe because it overlapped templated source. The separate cleanup fix still deleted the `WHERE` clause, so `sqlfluff fix` could silently remove the predicate.

This changes the JOIN fix to insert the generated `ON` condition after the joined table element instead of replacing the whole join clause. The insertion point is outside the templated table expression, so the JOIN addition and WHERE cleanup are both applied.

A YAML regression covers the Snowflake/Jinja `ref()` case from the issue.

### Are there any other side effects of this change that we should be aware of?

The generated SQL and rule selection are unchanged for non-templated joins. The edit is narrower: it preserves the existing join segments and inserts only the whitespace and `JoinOnConditionSegment` already generated by CV12.

### Validation

- `python -m pytest test/rules/yaml_test_cases_test.py -k CV12 -vv` — 26 passed
- `ruff check src/sqlfluff/rules/convention/CV12.py`
- `ruff format --check src/sqlfluff/rules/convention/CV12.py`
- `yamllint -c .yamllint test/fixtures/rules/std_rule_cases/CV12.yml`
- `git diff --check`
- Reproduced the original destructive fix before the change and verified the exact CLI case now produces `JOIN ... ON ...` without losing the predicate

### AI-assisted contribution disclosure

AI assistance was used to inspect the rule/fix flow, identify why the templated JOIN replacement was discarded, and prepare the focused code and test changes. I manually reproduced the issue on current `main`, reviewed the final two-file diff, ran the complete CV12 test matrix and quality checks listed above, and verified the exact CLI output after the fix.

### Pull Request checklist

- [x] Included a `.yml` rule test case demonstrating the regression and fix.
- [x] No documentation change is needed because this restores the documented CV12 behavior.
- [x] The linked issue covers the defect; no follow-up issue is currently needed.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves CV12 predicates with templated joins by inserting the generated JOIN ON after the joined table. Prevents WHERE predicate loss on Snowflake/Jinja ref() joins.

- **Bug Fixes**
  - Insert the ON condition after the join table reference instead of replacing the whole join clause.
  - Works with templated joins (e.g., Jinja ref()), so both the JOIN addition and WHERE cleanup apply.
  - Adds a regression test covering Snowflake with Jinja ref().

<sup>Written for commit a63237c0c43c55aea2259185af7561d8771a8769. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8232?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

