### PR TITLE
 feat(clickhouse): add support for REGEXP operator

### DIFF
--- a/src/sqlfluff/dialects/dialect_clickhouse.py
+++ b/src/sqlfluff/dialects/dialect_clickhouse.py
@@ -346,10 +346,18 @@ clickhouse_dialect.replace(
                 Ref.keyword("NOT", optional=True),
                 # REGEXP does not support the NOT keyword
                 Ref("LikeGrammar", exclude=Ref.keyword("REGEXP")),
+                Ref("Expression_A_Grammar"),
+                Sequence(
+                    "ESCAPE",
+                    Ref("Tail_Recurse_Expression_A_Grammar"),
+                    optional=True,
+                ),
             ),
-            "REGEXP",
+            Sequence(
+                "REGEXP",
+                Ref("Tail_Recurse_Expression_A_Grammar"),
+            ),
         ),
-        Ref("Tail_Recurse_Expression_A_Grammar"),
     ),
 )
 

--- a/src/sqlfluff/dialects/dialect_clickhouse.py
+++ b/src/sqlfluff/dialects/dialect_clickhouse.py
@@ -353,6 +353,7 @@ clickhouse_dialect.replace(
                     optional=True,
                 ),
             ),
+            # REGEXP does not support the ESCAPE keyword
             Sequence(
                 "REGEXP",
                 Ref("Tail_Recurse_Expression_A_Grammar"),

--- a/src/sqlfluff/dialects/dialect_clickhouse.py
+++ b/src/sqlfluff/dialects/dialect_clickhouse.py
@@ -339,6 +339,18 @@ clickhouse_dialect.replace(
             optional=True,
         ),
     ),
+    LikeGrammar=OneOf("LIKE", "ILIKE", "REGEXP"),
+    LikeExpressionGrammar=Sequence(
+        OneOf(
+            Sequence(
+                Ref.keyword("NOT", optional=True),
+                # REGEXP does not support the NOT keyword
+                Ref("LikeGrammar", exclude=Ref.keyword("REGEXP")),
+            ),
+            "REGEXP",
+        ),
+        Ref("Tail_Recurse_Expression_A_Grammar"),
+    ),
 )
 
 # Set the datetime units

--- a/test/fixtures/dialects/clickhouse/like_expression.sql
+++ b/test/fixtures/dialects/clickhouse/like_expression.sql
@@ -131,7 +131,7 @@ FROM (
 
 SELECT name
 FROM system.columns
-WHERE database LIKE 'sY%' ESCAPE '|';
+WHERE database ILIKE 'sY%' ESCAPE '|';
 
 
 -- NOT ILIKE ESCAPE

--- a/test/fixtures/dialects/clickhouse/like_expression.sql
+++ b/test/fixtures/dialects/clickhouse/like_expression.sql
@@ -14,6 +14,7 @@ SELECT name
 FROM system.columns
 WHERE database REGEXP '^sys.*$';
 
+
 -- LIKE
 SELECT 'string' LIKE 's%';
 
@@ -30,6 +31,7 @@ SELECT name
 FROM system.columns
 WHERE database LIKE 'sys%';
 
+
 -- NOT LIKE
 SELECT 'string' NOT LIKE 's%';
 
@@ -45,6 +47,7 @@ FROM (
 SELECT name
 FROM system.columns
 WHERE database NOT LIKE 'sys%';
+
 
 -- ILIKE
 SELECT 'string' ILIKE 'S%';
@@ -78,3 +81,71 @@ FROM (
 SELECT name
 FROM system.columns
 WHERE database NOT ILIKE 'sYs%';
+
+
+-- LIKE ESCAPE
+SELECT 'test%value' LIKE 'test|%%' ESCAPE '|';
+
+SELECT
+CASE
+    WHEN field = 0 THEN 'false'
+    ELSE 'true'
+END
+FROM (
+   SELECT CAST(('string' LIKE 's%' ESCAPE '|') AS String) LIKE '%0%' ESCAPE '|' AS field
+) AS foo;
+
+SELECT name
+FROM system.columns
+WHERE database LIKE 'sy%' ESCAPE '|';
+
+
+-- NOT LIKE ESCAPE
+SELECT 'test%value' NOT LIKE 'est|%%' ESCAPE '|';
+
+SELECT
+CASE
+    WHEN field = 0 THEN 'false'
+    ELSE 'true'
+END
+FROM (
+   SELECT CAST(('string' LIKE 's%' ESCAPE '|') AS String) NOT LIKE '%0%' ESCAPE '|' AS field
+) AS foo;
+
+SELECT name
+FROM system.columns
+WHERE database NOT LIKE 'sy%' ESCAPE '|';
+
+
+-- ILIKE ESCAPE
+SELECT 'test%value' ILIKE 'Test|%%' ESCAPE '|';
+
+SELECT
+CASE
+    WHEN field = 0 THEN 'false'
+    ELSE 'true'
+END
+FROM (
+   SELECT CAST(('string' ILIKE 'S%' ESCAPE '|') AS String) LIKE '%0%' ESCAPE '|' AS field
+) AS foo;
+
+SELECT name
+FROM system.columns
+WHERE database LIKE 'sY%' ESCAPE '|';
+
+
+-- NOT ILIKE ESCAPE
+SELECT 'test%value' NOT ILIKE 'Est|%%' ESCAPE '|';
+
+SELECT
+CASE
+    WHEN field = 0 THEN 'false'
+    ELSE 'true'
+END
+FROM (
+   SELECT CAST(('string' NOT ILIKE 'S%' ESCAPE '|') AS String) LIKE '%0%' ESCAPE '|' AS field
+) AS foo;
+
+SELECT name
+FROM system.columns
+WHERE database NOT ILIKE 'sY%' ESCAPE '|';

--- a/test/fixtures/dialects/clickhouse/like_expression.sql
+++ b/test/fixtures/dialects/clickhouse/like_expression.sql
@@ -1,0 +1,80 @@
+-- REGEXP
+SELECT 'string' REGEXP '[a-zAZ]';
+
+SELECT
+CASE
+    WHEN field = 0 THEN 'false'
+    ELSE 'true'
+END
+FROM (
+   SELECT CAST(('string' REGEXP '[0-9]') AS String) REGEXP '[0123]' AS field
+) AS foo;
+
+SELECT name
+FROM system.columns
+WHERE database REGEXP '^sys.*$';
+
+-- LIKE
+SELECT 'string' LIKE 's%';
+
+SELECT
+CASE
+    WHEN field = 0 THEN 'false'
+    ELSE 'true'
+END
+FROM (
+   SELECT CAST(('string' LIKE 's%') AS String) LIKE '%0%' AS field
+) AS foo;
+
+SELECT name
+FROM system.columns
+WHERE database LIKE 'sys%';
+
+-- NOT LIKE
+SELECT 'string' NOT LIKE 's%';
+
+SELECT
+CASE
+    WHEN field = 0 THEN 'false'
+    ELSE 'true'
+END
+FROM (
+   SELECT CAST(('string' LIKE 's%') AS String) NOT LIKE '%0%' AS field
+) AS foo;
+
+SELECT name
+FROM system.columns
+WHERE database NOT LIKE 'sys%';
+
+-- ILIKE
+SELECT 'string' ILIKE 'S%';
+
+SELECT
+CASE
+    WHEN field = 0 THEN 'false'
+    ELSE 'true'
+END
+FROM (
+   SELECT CAST(('string' ILIKE 'S%') AS String) LIKE '%0%' AS field
+) AS foo;
+
+SELECT name
+FROM system.columns
+WHERE database ILIKE 'sYs%';
+
+
+-- NOT ILIKE
+SELECT 'string' NOT ILIKE 'S%';
+
+SELECT
+CASE
+    WHEN field = 0 THEN 'false'
+    ELSE 'true'
+END
+FROM (
+   SELECT CAST(('string' NOT ILIKE 'S%') AS String) LIKE '%0%' AS field
+) AS foo;
+
+SELECT name
+FROM system.columns
+WHERE database NOT ILIKE 'sYs%';

--- a/test/fixtures/dialects/clickhouse/like_expression.yml
+++ b/test/fixtures/dialects/clickhouse/like_expression.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: a9ba8b8a57868d3ffbfb5e7c581984c63ba54f585d0f5b87567579db412ccf1b
+_hash: 04a8a5c49540ba60f2db5a72c8a7a32ce80d9ad3f6e12d54c0dabd4e01507ee5
 file:
 - statement:
     select_statement:
@@ -510,4 +510,442 @@ file:
         - keyword: NOT
         - keyword: ILIKE
         - quoted_literal: "'sYs%'"
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+          - quoted_literal: "'test%value'"
+          - keyword: LIKE
+          - quoted_literal: "'test|%%'"
+          - keyword: ESCAPE
+          - quoted_literal: "'|'"
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+            case_expression:
+            - keyword: CASE
+            - when_clause:
+              - keyword: WHEN
+              - expression:
+                  column_reference:
+                    naked_identifier: field
+                  comparison_operator:
+                    raw_comparison_operator: '='
+                  numeric_literal: '0'
+              - keyword: THEN
+              - expression:
+                  quoted_literal: "'false'"
+            - else_clause:
+                keyword: ELSE
+                expression:
+                  quoted_literal: "'true'"
+            - keyword: END
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              bracketed:
+                start_bracket: (
+                select_statement:
+                  select_clause:
+                    keyword: SELECT
+                    select_clause_element:
+                      expression:
+                      - function:
+                          function_name:
+                            function_name_identifier: CAST
+                          function_contents:
+                            bracketed:
+                              start_bracket: (
+                              expression:
+                                bracketed:
+                                  start_bracket: (
+                                  expression:
+                                  - quoted_literal: "'string'"
+                                  - keyword: LIKE
+                                  - quoted_literal: "'s%'"
+                                  - keyword: ESCAPE
+                                  - quoted_literal: "'|'"
+                                  end_bracket: )
+                              keyword: AS
+                              data_type:
+                                data_type_identifier: String
+                              end_bracket: )
+                      - keyword: LIKE
+                      - quoted_literal: "'%0%'"
+                      - keyword: ESCAPE
+                      - quoted_literal: "'|'"
+                      alias_expression:
+                        alias_operator:
+                          keyword: AS
+                        naked_identifier: field
+                end_bracket: )
+            alias_expression:
+              alias_operator:
+                keyword: AS
+              naked_identifier: foo
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          column_reference:
+            naked_identifier: name
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+              - naked_identifier: system
+              - dot: .
+              - naked_identifier: columns
+      where_clause:
+        keyword: WHERE
+        expression:
+        - column_reference:
+            naked_identifier: database
+        - keyword: LIKE
+        - quoted_literal: "'sy%'"
+        - keyword: ESCAPE
+        - quoted_literal: "'|'"
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+          - quoted_literal: "'test%value'"
+          - keyword: NOT
+          - keyword: LIKE
+          - quoted_literal: "'est|%%'"
+          - keyword: ESCAPE
+          - quoted_literal: "'|'"
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+            case_expression:
+            - keyword: CASE
+            - when_clause:
+              - keyword: WHEN
+              - expression:
+                  column_reference:
+                    naked_identifier: field
+                  comparison_operator:
+                    raw_comparison_operator: '='
+                  numeric_literal: '0'
+              - keyword: THEN
+              - expression:
+                  quoted_literal: "'false'"
+            - else_clause:
+                keyword: ELSE
+                expression:
+                  quoted_literal: "'true'"
+            - keyword: END
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              bracketed:
+                start_bracket: (
+                select_statement:
+                  select_clause:
+                    keyword: SELECT
+                    select_clause_element:
+                      expression:
+                      - function:
+                          function_name:
+                            function_name_identifier: CAST
+                          function_contents:
+                            bracketed:
+                              start_bracket: (
+                              expression:
+                                bracketed:
+                                  start_bracket: (
+                                  expression:
+                                  - quoted_literal: "'string'"
+                                  - keyword: LIKE
+                                  - quoted_literal: "'s%'"
+                                  - keyword: ESCAPE
+                                  - quoted_literal: "'|'"
+                                  end_bracket: )
+                              keyword: AS
+                              data_type:
+                                data_type_identifier: String
+                              end_bracket: )
+                      - keyword: NOT
+                      - keyword: LIKE
+                      - quoted_literal: "'%0%'"
+                      - keyword: ESCAPE
+                      - quoted_literal: "'|'"
+                      alias_expression:
+                        alias_operator:
+                          keyword: AS
+                        naked_identifier: field
+                end_bracket: )
+            alias_expression:
+              alias_operator:
+                keyword: AS
+              naked_identifier: foo
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          column_reference:
+            naked_identifier: name
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+              - naked_identifier: system
+              - dot: .
+              - naked_identifier: columns
+      where_clause:
+        keyword: WHERE
+        expression:
+        - column_reference:
+            naked_identifier: database
+        - keyword: NOT
+        - keyword: LIKE
+        - quoted_literal: "'sy%'"
+        - keyword: ESCAPE
+        - quoted_literal: "'|'"
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+          - quoted_literal: "'test%value'"
+          - keyword: ILIKE
+          - quoted_literal: "'Test|%%'"
+          - keyword: ESCAPE
+          - quoted_literal: "'|'"
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+            case_expression:
+            - keyword: CASE
+            - when_clause:
+              - keyword: WHEN
+              - expression:
+                  column_reference:
+                    naked_identifier: field
+                  comparison_operator:
+                    raw_comparison_operator: '='
+                  numeric_literal: '0'
+              - keyword: THEN
+              - expression:
+                  quoted_literal: "'false'"
+            - else_clause:
+                keyword: ELSE
+                expression:
+                  quoted_literal: "'true'"
+            - keyword: END
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              bracketed:
+                start_bracket: (
+                select_statement:
+                  select_clause:
+                    keyword: SELECT
+                    select_clause_element:
+                      expression:
+                      - function:
+                          function_name:
+                            function_name_identifier: CAST
+                          function_contents:
+                            bracketed:
+                              start_bracket: (
+                              expression:
+                                bracketed:
+                                  start_bracket: (
+                                  expression:
+                                  - quoted_literal: "'string'"
+                                  - keyword: ILIKE
+                                  - quoted_literal: "'S%'"
+                                  - keyword: ESCAPE
+                                  - quoted_literal: "'|'"
+                                  end_bracket: )
+                              keyword: AS
+                              data_type:
+                                data_type_identifier: String
+                              end_bracket: )
+                      - keyword: LIKE
+                      - quoted_literal: "'%0%'"
+                      - keyword: ESCAPE
+                      - quoted_literal: "'|'"
+                      alias_expression:
+                        alias_operator:
+                          keyword: AS
+                        naked_identifier: field
+                end_bracket: )
+            alias_expression:
+              alias_operator:
+                keyword: AS
+              naked_identifier: foo
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          column_reference:
+            naked_identifier: name
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+              - naked_identifier: system
+              - dot: .
+              - naked_identifier: columns
+      where_clause:
+        keyword: WHERE
+        expression:
+        - column_reference:
+            naked_identifier: database
+        - keyword: LIKE
+        - quoted_literal: "'sY%'"
+        - keyword: ESCAPE
+        - quoted_literal: "'|'"
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+          - quoted_literal: "'test%value'"
+          - keyword: NOT
+          - keyword: ILIKE
+          - quoted_literal: "'Est|%%'"
+          - keyword: ESCAPE
+          - quoted_literal: "'|'"
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+            case_expression:
+            - keyword: CASE
+            - when_clause:
+              - keyword: WHEN
+              - expression:
+                  column_reference:
+                    naked_identifier: field
+                  comparison_operator:
+                    raw_comparison_operator: '='
+                  numeric_literal: '0'
+              - keyword: THEN
+              - expression:
+                  quoted_literal: "'false'"
+            - else_clause:
+                keyword: ELSE
+                expression:
+                  quoted_literal: "'true'"
+            - keyword: END
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              bracketed:
+                start_bracket: (
+                select_statement:
+                  select_clause:
+                    keyword: SELECT
+                    select_clause_element:
+                      expression:
+                      - function:
+                          function_name:
+                            function_name_identifier: CAST
+                          function_contents:
+                            bracketed:
+                              start_bracket: (
+                              expression:
+                                bracketed:
+                                  start_bracket: (
+                                  expression:
+                                  - quoted_literal: "'string'"
+                                  - keyword: NOT
+                                  - keyword: ILIKE
+                                  - quoted_literal: "'S%'"
+                                  - keyword: ESCAPE
+                                  - quoted_literal: "'|'"
+                                  end_bracket: )
+                              keyword: AS
+                              data_type:
+                                data_type_identifier: String
+                              end_bracket: )
+                      - keyword: LIKE
+                      - quoted_literal: "'%0%'"
+                      - keyword: ESCAPE
+                      - quoted_literal: "'|'"
+                      alias_expression:
+                        alias_operator:
+                          keyword: AS
+                        naked_identifier: field
+                end_bracket: )
+            alias_expression:
+              alias_operator:
+                keyword: AS
+              naked_identifier: foo
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          column_reference:
+            naked_identifier: name
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+              - naked_identifier: system
+              - dot: .
+              - naked_identifier: columns
+      where_clause:
+        keyword: WHERE
+        expression:
+        - column_reference:
+            naked_identifier: database
+        - keyword: NOT
+        - keyword: ILIKE
+        - quoted_literal: "'sY%'"
+        - keyword: ESCAPE
+        - quoted_literal: "'|'"
 - statement_terminator: ;

--- a/test/fixtures/dialects/clickhouse/like_expression.yml
+++ b/test/fixtures/dialects/clickhouse/like_expression.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 04a8a5c49540ba60f2db5a72c8a7a32ce80d9ad3f6e12d54c0dabd4e01507ee5
+_hash: 85bcd210e44a1117d3f40f10f6c5a96f7dd033bae482b289bb990428fa2278cc
 file:
 - statement:
     select_statement:
@@ -833,7 +833,7 @@ file:
         expression:
         - column_reference:
             naked_identifier: database
-        - keyword: LIKE
+        - keyword: ILIKE
         - quoted_literal: "'sY%'"
         - keyword: ESCAPE
         - quoted_literal: "'|'"

--- a/test/fixtures/dialects/clickhouse/like_expression.yml
+++ b/test/fixtures/dialects/clickhouse/like_expression.yml
@@ -1,0 +1,513 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: a9ba8b8a57868d3ffbfb5e7c581984c63ba54f585d0f5b87567579db412ccf1b
+file:
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+          - quoted_literal: "'string'"
+          - keyword: REGEXP
+          - quoted_literal: "'[a-zAZ]'"
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+            case_expression:
+            - keyword: CASE
+            - when_clause:
+              - keyword: WHEN
+              - expression:
+                  column_reference:
+                    naked_identifier: field
+                  comparison_operator:
+                    raw_comparison_operator: '='
+                  numeric_literal: '0'
+              - keyword: THEN
+              - expression:
+                  quoted_literal: "'false'"
+            - else_clause:
+                keyword: ELSE
+                expression:
+                  quoted_literal: "'true'"
+            - keyword: END
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              bracketed:
+                start_bracket: (
+                select_statement:
+                  select_clause:
+                    keyword: SELECT
+                    select_clause_element:
+                      expression:
+                        function:
+                          function_name:
+                            function_name_identifier: CAST
+                          function_contents:
+                            bracketed:
+                              start_bracket: (
+                              expression:
+                                bracketed:
+                                  start_bracket: (
+                                  expression:
+                                  - quoted_literal: "'string'"
+                                  - keyword: REGEXP
+                                  - quoted_literal: "'[0-9]'"
+                                  end_bracket: )
+                              keyword: AS
+                              data_type:
+                                data_type_identifier: String
+                              end_bracket: )
+                        keyword: REGEXP
+                        quoted_literal: "'[0123]'"
+                      alias_expression:
+                        alias_operator:
+                          keyword: AS
+                        naked_identifier: field
+                end_bracket: )
+            alias_expression:
+              alias_operator:
+                keyword: AS
+              naked_identifier: foo
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          column_reference:
+            naked_identifier: name
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+              - naked_identifier: system
+              - dot: .
+              - naked_identifier: columns
+      where_clause:
+        keyword: WHERE
+        expression:
+          column_reference:
+            naked_identifier: database
+          keyword: REGEXP
+          quoted_literal: "'^sys.*$'"
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+          - quoted_literal: "'string'"
+          - keyword: LIKE
+          - quoted_literal: "'s%'"
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+            case_expression:
+            - keyword: CASE
+            - when_clause:
+              - keyword: WHEN
+              - expression:
+                  column_reference:
+                    naked_identifier: field
+                  comparison_operator:
+                    raw_comparison_operator: '='
+                  numeric_literal: '0'
+              - keyword: THEN
+              - expression:
+                  quoted_literal: "'false'"
+            - else_clause:
+                keyword: ELSE
+                expression:
+                  quoted_literal: "'true'"
+            - keyword: END
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              bracketed:
+                start_bracket: (
+                select_statement:
+                  select_clause:
+                    keyword: SELECT
+                    select_clause_element:
+                      expression:
+                        function:
+                          function_name:
+                            function_name_identifier: CAST
+                          function_contents:
+                            bracketed:
+                              start_bracket: (
+                              expression:
+                                bracketed:
+                                  start_bracket: (
+                                  expression:
+                                  - quoted_literal: "'string'"
+                                  - keyword: LIKE
+                                  - quoted_literal: "'s%'"
+                                  end_bracket: )
+                              keyword: AS
+                              data_type:
+                                data_type_identifier: String
+                              end_bracket: )
+                        keyword: LIKE
+                        quoted_literal: "'%0%'"
+                      alias_expression:
+                        alias_operator:
+                          keyword: AS
+                        naked_identifier: field
+                end_bracket: )
+            alias_expression:
+              alias_operator:
+                keyword: AS
+              naked_identifier: foo
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          column_reference:
+            naked_identifier: name
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+              - naked_identifier: system
+              - dot: .
+              - naked_identifier: columns
+      where_clause:
+        keyword: WHERE
+        expression:
+          column_reference:
+            naked_identifier: database
+          keyword: LIKE
+          quoted_literal: "'sys%'"
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+          - quoted_literal: "'string'"
+          - keyword: NOT
+          - keyword: LIKE
+          - quoted_literal: "'s%'"
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+            case_expression:
+            - keyword: CASE
+            - when_clause:
+              - keyword: WHEN
+              - expression:
+                  column_reference:
+                    naked_identifier: field
+                  comparison_operator:
+                    raw_comparison_operator: '='
+                  numeric_literal: '0'
+              - keyword: THEN
+              - expression:
+                  quoted_literal: "'false'"
+            - else_clause:
+                keyword: ELSE
+                expression:
+                  quoted_literal: "'true'"
+            - keyword: END
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              bracketed:
+                start_bracket: (
+                select_statement:
+                  select_clause:
+                    keyword: SELECT
+                    select_clause_element:
+                      expression:
+                      - function:
+                          function_name:
+                            function_name_identifier: CAST
+                          function_contents:
+                            bracketed:
+                              start_bracket: (
+                              expression:
+                                bracketed:
+                                  start_bracket: (
+                                  expression:
+                                  - quoted_literal: "'string'"
+                                  - keyword: LIKE
+                                  - quoted_literal: "'s%'"
+                                  end_bracket: )
+                              keyword: AS
+                              data_type:
+                                data_type_identifier: String
+                              end_bracket: )
+                      - keyword: NOT
+                      - keyword: LIKE
+                      - quoted_literal: "'%0%'"
+                      alias_expression:
+                        alias_operator:
+                          keyword: AS
+                        naked_identifier: field
+                end_bracket: )
+            alias_expression:
+              alias_operator:
+                keyword: AS
+              naked_identifier: foo
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          column_reference:
+            naked_identifier: name
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+              - naked_identifier: system
+              - dot: .
+              - naked_identifier: columns
+      where_clause:
+        keyword: WHERE
+        expression:
+        - column_reference:
+            naked_identifier: database
+        - keyword: NOT
+        - keyword: LIKE
+        - quoted_literal: "'sys%'"
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+          - quoted_literal: "'string'"
+          - keyword: ILIKE
+          - quoted_literal: "'S%'"
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+            case_expression:
+            - keyword: CASE
+            - when_clause:
+              - keyword: WHEN
+              - expression:
+                  column_reference:
+                    naked_identifier: field
+                  comparison_operator:
+                    raw_comparison_operator: '='
+                  numeric_literal: '0'
+              - keyword: THEN
+              - expression:
+                  quoted_literal: "'false'"
+            - else_clause:
+                keyword: ELSE
+                expression:
+                  quoted_literal: "'true'"
+            - keyword: END
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              bracketed:
+                start_bracket: (
+                select_statement:
+                  select_clause:
+                    keyword: SELECT
+                    select_clause_element:
+                      expression:
+                        function:
+                          function_name:
+                            function_name_identifier: CAST
+                          function_contents:
+                            bracketed:
+                              start_bracket: (
+                              expression:
+                                bracketed:
+                                  start_bracket: (
+                                  expression:
+                                  - quoted_literal: "'string'"
+                                  - keyword: ILIKE
+                                  - quoted_literal: "'S%'"
+                                  end_bracket: )
+                              keyword: AS
+                              data_type:
+                                data_type_identifier: String
+                              end_bracket: )
+                        keyword: LIKE
+                        quoted_literal: "'%0%'"
+                      alias_expression:
+                        alias_operator:
+                          keyword: AS
+                        naked_identifier: field
+                end_bracket: )
+            alias_expression:
+              alias_operator:
+                keyword: AS
+              naked_identifier: foo
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          column_reference:
+            naked_identifier: name
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+              - naked_identifier: system
+              - dot: .
+              - naked_identifier: columns
+      where_clause:
+        keyword: WHERE
+        expression:
+          column_reference:
+            naked_identifier: database
+          keyword: ILIKE
+          quoted_literal: "'sYs%'"
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+          - quoted_literal: "'string'"
+          - keyword: NOT
+          - keyword: ILIKE
+          - quoted_literal: "'S%'"
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+            case_expression:
+            - keyword: CASE
+            - when_clause:
+              - keyword: WHEN
+              - expression:
+                  column_reference:
+                    naked_identifier: field
+                  comparison_operator:
+                    raw_comparison_operator: '='
+                  numeric_literal: '0'
+              - keyword: THEN
+              - expression:
+                  quoted_literal: "'false'"
+            - else_clause:
+                keyword: ELSE
+                expression:
+                  quoted_literal: "'true'"
+            - keyword: END
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              bracketed:
+                start_bracket: (
+                select_statement:
+                  select_clause:
+                    keyword: SELECT
+                    select_clause_element:
+                      expression:
+                        function:
+                          function_name:
+                            function_name_identifier: CAST
+                          function_contents:
+                            bracketed:
+                              start_bracket: (
+                              expression:
+                                bracketed:
+                                  start_bracket: (
+                                  expression:
+                                  - quoted_literal: "'string'"
+                                  - keyword: NOT
+                                  - keyword: ILIKE
+                                  - quoted_literal: "'S%'"
+                                  end_bracket: )
+                              keyword: AS
+                              data_type:
+                                data_type_identifier: String
+                              end_bracket: )
+                        keyword: LIKE
+                        quoted_literal: "'%0%'"
+                      alias_expression:
+                        alias_operator:
+                          keyword: AS
+                        naked_identifier: field
+                end_bracket: )
+            alias_expression:
+              alias_operator:
+                keyword: AS
+              naked_identifier: foo
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          column_reference:
+            naked_identifier: name
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+              - naked_identifier: system
+              - dot: .
+              - naked_identifier: columns
+      where_clause:
+        keyword: WHERE
+        expression:
+        - column_reference:
+            naked_identifier: database
+        - keyword: NOT
+        - keyword: ILIKE
+        - quoted_literal: "'sYs%'"
+- statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
fixes #8234.
ClickHouse has an alternative syntax for the [match](https://clickhouse.com/docs/reference/functions/regular-functions/string-search-functions#match) function:
```
match(haystack, pattern) <=> haystack REGEXP pattern
```
for instance:
```sql
SELECT match('Hello World', 'Hello.*');
```
is the same as
```sql
SELECT 'Hello World' REGEXP 'Hello.*';
```
here is a working example:
https://fiddle.clickhouse.com/f50091d0-99ae-458f-95f5-e15db3d91f8d

```REGEXP``` behaves similarly to ```LIKE``` and ```ILIKE```

this PR introduces custom ```LikeGrammar``` and ```LikeExpressionGrammar```, previously these grammars were inherited from ansi dialect.:
1. support for ```REGEXP``` is added (but not for ```NOT REGEXP``` - this syntax is invalid)
2. support for ```RLIKE``` is dropped - ```RLIKE``` is not supported in ClickHouse

### Are there any other side effects of this change that we should be aware of?
* support for ```RLIKE``` is dropped

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
- Added appropriate documentation for the change.




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add REGEXP operator support to the ClickHouse dialect and align LIKE/ILIKE parsing with ClickHouse, including ESCAPE support (26.6+). Fixes #8234.

- **New Features**
  - Parse "expr REGEXP pattern" as an alternative to match(haystack, pattern); "NOT REGEXP" is invalid per ClickHouse.
  - Support ESCAPE with LIKE, ILIKE, NOT LIKE, and NOT ILIKE.

- **Migration**
  - Replace RLIKE with REGEXP or match(...).

<sup>Written for commit 1508805a369f8ff8cafc44c3e702d00cbd2343f7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8235?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->





