### PR TITLE
fix(clickhouse): add REGEXP to LikeGrammar in ClickHouse dialect

### DIFF
--- a/src/sqlfluff/dialects/dialect_clickhouse.py
+++ b/src/sqlfluff/dialects/dialect_clickhouse.py
@@ -118,6 +118,7 @@ clickhouse_dialect.replace(
         # Add Lambda Function
         Ref("LambdaFunctionSegment"),
     ),
+    LikeGrammar=OneOf("LIKE", "ILIKE", "RLIKE", "REGEXP"),
     ComparisonOperatorGrammar=OneOf(
         Ref("EqualsSegment"),
         Ref("DoubleEqualsSegment"),


### PR DESCRIPTION
## Description
This PR resolves issue #8234 by adding `REGEXP` to `LikeGrammar` in ClickHouse dialect (`src/sqlfluff/dialects/dialect_clickhouse.py`).

## Details
- Allows ClickHouse queries using `REGEXP` operator (e.g. `select 'a' regexp '[a-z]'`) to parse without syntax errors.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add REGEXP to the ClickHouse `LikeGrammar` so queries using the REGEXP operator parse without errors. This enables expressions like: select 'a' regexp '[a-z]' in the ClickHouse dialect.

<sup>Written for commit 265d5b04c55fd8d28d4b2df5f24952fb365bb67c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8236?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

