### PR TITLE
fix(rules): skip CONVERT rewriting in CV11 for MySQL family dialects

### DIFF
--- a/src/sqlfluff/rules/convention/CV11.py
+++ b/src/sqlfluff/rules/convention/CV11.py
@@ -275,6 +275,14 @@ class Rule_CV11(BaseRule):
         else:  # pragma: no cover
             current_type_casting_style = None
 
+        if current_type_casting_style == "convert" and context.dialect.name in (
+            "mysql",
+            "mariadb",
+            "doris",
+            "starrocks",
+        ):
+            return None
+
         functional_context = FunctionalContext(context)
 
         # If casting style is set to consistent,


### PR DESCRIPTION
## Description
This PR resolves issue #8171 by skipping `CONVERT` rewriting in rule `CV11` for MySQL family dialects (`mysql`, `mariadb`, `doris`, `starrocks`) in `src/sqlfluff/rules/convention/CV11.py`.

## Details
- Prevents `CV11` from incorrectly swapping arguments on MySQL `CONVERT(expr, type)` calls, which use a different argument order than T-SQL.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip `CONVERT` rewriting in rule `CV11` for MySQL-family dialects to prevent invalid argument swapping. This stops false fixes on `CONVERT(expr, type)` in `mysql`, `mariadb`, `doris`, and `starrocks`.

- **Bug Fixes**
  - Add early return in `CV11._eval` when casting style is `convert` and dialect is MySQL-family, avoiding rewrite of `CONVERT(expr, type)`.

<sup>Written for commit cddf436209f232967f2af16f2123549af36f7608. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8237?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

