### PR TITLE
fix(postgres): support VIRTUAL and optional storage mode in GENERATED ALWAYS AS

### DIFF
--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -4027,7 +4027,13 @@ class ColumnConstraintSegment(ansi.ColumnConstraintSegment):
                     Ref("ExpressionSegment"),
                 ),
             ),
-            Sequence("GENERATED", "ALWAYS", "AS", Ref("ExpressionSegment"), "STORED"),
+            Sequence(
+                "GENERATED",
+                "ALWAYS",
+                "AS",
+                Ref("ExpressionSegment"),
+                OneOf("STORED", "VIRTUAL", optional=True),
+            ),
             Sequence(
                 "GENERATED",
                 OneOf("ALWAYS", Sequence("BY", "DEFAULT")),
@@ -4112,8 +4118,14 @@ class ForeignTableColumnConstraintSegment(ansi.ColumnConstraintSegment):
                     Ref("ExpressionSegment"),
                 ),
             ),
-            # GENERATED ALWAYS AS ( generation_expr ) STORED
-            Sequence("GENERATED", "ALWAYS", "AS", Ref("ExpressionSegment"), "STORED"),
+            # GENERATED ALWAYS AS ( generation_expr ) [ STORED | VIRTUAL ]
+            Sequence(
+                "GENERATED",
+                "ALWAYS",
+                "AS",
+                Ref("ExpressionSegment"),
+                OneOf("STORED", "VIRTUAL", optional=True),
+            ),
         ),
     )
 


### PR DESCRIPTION
## Description
This PR resolves issue #8139 by supporting `VIRTUAL` and optional storage clauses in Postgres `GENERATED ALWAYS AS (...)` column constraints in `src/sqlfluff/dialects/dialect_postgres.py`.

## Details
- Adds support for Postgres 18 virtual generated columns (e.g. `GENERATED ALWAYS AS (...) VIRTUAL` or omitted storage mode).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add support for Postgres 18 virtual generated columns by allowing VIRTUAL and optional storage in GENERATED ALWAYS AS constraints. Fixes parsing for columns defined without STORED or with VIRTUAL in both regular and foreign tables.

- **Bug Fixes**
  - Postgres dialect now accepts GENERATED ALWAYS AS (...) with STORED, VIRTUAL, or omitted storage for column and foreign table constraints.

<sup>Written for commit de2a5ade3cd6b418e1e15aac3ba852631579fbe2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8238?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

