### PR TITLE
test(ST11): pin the UNNEST + deeply nested struct case from #6997

### DIFF
--- a/test/fixtures/rules/std_rule_cases/ST11.yml
+++ b/test/fixtures/rules/std_rule_cases/ST11.yml
@@ -216,6 +216,30 @@ test_pass_table_expression_function_6558:
     core:
       dialect: bigquery
 
+test_pass_unnest_deeply_nested_struct_6997:
+  # An UNNEST alias referenced only through several levels of struct access is
+  # still a reference. The UNNEST chain and deep struct access are each covered
+  # above; this pins the combination reported in issue #6997.
+  pass_str: |
+    WITH test_table AS (
+        SELECT
+            1 AS id,
+            ARRAY<
+                STRUCT<repeated_structs STRUCT<nested_struct STRUCT<generic_field STRING>>>
+            >[
+                STRUCT(STRUCT(STRUCT('abc' AS generic_field)))
+            ] AS generic_array
+    )
+
+    SELECT
+        test_table.id,
+        g.repeated_structs.nested_struct.generic_field
+    FROM test_table
+    LEFT JOIN UNNEST(test_table.generic_array) AS g
+  configs:
+    core:
+      dialect: bigquery
+
 test_mysql_identifier_with_backticks_should_not_except:
   pass_str: |
     SELECT `f`.`bar`, `g`.`baz` FROM `foo` AS `f` LEFT JOIN `foobar` AS `g`;


### PR DESCRIPTION
### Brief summary of the change made

Closes #6997.

That issue reports an ST11 false positive on a BigQuery `UNNEST` alias that is only ever referenced through several levels of struct access:

```sql
select test_table.id, g.repeated_structs.nested_struct.generic_field
from test_table
left join unnest(test_table.generic_array) as g
```

It no longer reproduces on `main`. #7795 fixed the underlying struct/nested-field reference handling back in April, and the earlier attempt at #6997 (#7007) was closed while still WIP, so the issue just stayed open.

`ST11.yml` already covers the two halves separately:

- `test_pass_table_expression_function_6558`: an `UNNEST` chain
- `test_pass_deeply_nested_struct_field_access`: deep struct access, but on a plain `LEFT JOIN b`

Nothing covered the combination, which is the shape #6997 actually reported. This adds it, so the issue can be closed against a test rather than against a manual check.

The case has teeth: it fails on `f32ab9fb7~1` (the commit before #7795) and passes on `main`.

```text
$ git checkout f32ab9fb7~1 -- src/sqlfluff/rules/structure/ST11.py
$ pytest test/rules/yaml_test_cases_test.py -k "ST11 and 6997"
FAILED test/rules/yaml_test_cases_test.py::test__rule_test_case[ST11_test_pass_unnest_deeply_nested_struct_6997]

$ git checkout HEAD -- src/sqlfluff/rules/structure/ST11.py
$ pytest test/rules/yaml_test_cases_test.py -k ST11
33 passed
```

Test-only, no rule or dialect code touched.

### Are there any other side effects of this change that we should be aware of?

No. One `pass_str` case added to `test/fixtures/rules/std_rule_cases/ST11.yml`; the full ST11 suite is green (33 passed).

### Pull Request checklist

- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes:
  - the change *is* the test case: `test_pass_unnest_deeply_nested_struct_6997`.
- Added appropriate documentation for the change: n/a, no behavior change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate: n/a.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a BigQuery ST11 test for an UNNEST alias referenced only through deep struct access. This pins the fix from #7795 and closes #6997; test-only change with no rule or dialect updates.

<sup>Written for commit 2307cfb90890199930961fc73f2f45d653a65ef4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8240?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

