### PR TITLE
fix(rust): match Rust parser bracket matching to Python's behaviour on crossed, unclosed, and dialect-specific brackets

### DIFF
--- a/sqlfluffrs/sqlfluffrs_lexer/src/lexer.rs
+++ b/sqlfluffrs/sqlfluffrs_lexer/src/lexer.rs
@@ -224,7 +224,13 @@ impl SQLLexError {
 /// MATCH_RECOGNIZE exclude bracket `{-`/`-}`, added to that same set).
 const DEFAULT_BRACKET_PAIRS: &[(&str, &str, &str, &str, bool)] = &[
     ("(", ")", "start_bracket", "end_bracket", true),
-    ("[", "]", "start_square_bracket", "end_square_bracket", false),
+    (
+        "[",
+        "]",
+        "start_square_bracket",
+        "end_square_bracket",
+        false,
+    ),
     ("{", "}", "start_curly_bracket", "end_curly_bracket", false),
 ];
 

--- a/sqlfluffrs/sqlfluffrs_lexer/src/lexer.rs
+++ b/sqlfluffrs/sqlfluffrs_lexer/src/lexer.rs
@@ -217,10 +217,22 @@ impl SQLLexError {
     }
 }
 
+/// The universal ASCII bracket pairs every dialect has (round/square/curly),
+/// used unless a dialect-specific set is supplied via [`Lexer::with_bracket_pairs`].
+/// PYTHON PARITY: matches `Dialect`'s base `bracket_pairs` set
+/// (dialect_ansi.py) before any dialect-specific additions (e.g. snowflake's
+/// MATCH_RECOGNIZE exclude bracket `{-`/`-}`, added to that same set).
+const DEFAULT_BRACKET_PAIRS: &[(&str, &str, &str, &str, bool)] = &[
+    ("(", ")", "start_bracket", "end_bracket", true),
+    ("[", "]", "start_square_bracket", "end_square_bracket", false),
+    ("{", "}", "start_curly_bracket", "end_curly_bracket", false),
+];
+
 #[derive(Clone)]
 pub struct Lexer {
     last_resort_lexer: LexMatcher,
     matchers: Vec<LexMatcher>,
+    bracket_pairs: Vec<(&'static str, &'static str, &'static str, &'static str, bool)>,
 }
 
 impl Lexer {
@@ -239,7 +251,19 @@ impl Lexer {
         Self {
             last_resort_lexer,
             matchers,
+            bracket_pairs: DEFAULT_BRACKET_PAIRS.to_vec(),
         }
+    }
+
+    /// Override the bracket-pairs set used for `matching_bracket_idx`
+    /// pre-computation, e.g. with a dialect's full `bracket_pairs` set
+    /// (round/square/curly plus any dialect-specific additions).
+    pub fn with_bracket_pairs(
+        mut self,
+        bracket_pairs: Vec<(&'static str, &'static str, &'static str, &'static str, bool)>,
+    ) -> Self {
+        self.bracket_pairs = bracket_pairs;
+        self
     }
 
     pub fn lex_string<'a>(&'a self, mut input: &'a str) -> Vec<LexedElement<'a>> {
@@ -359,7 +383,7 @@ impl Lexer {
             self.elements_to_tokens(&templated_buffer, &template, template_blocks_indent);
 
         // OPTIMIZATION: Pre-compute bracket pairs for O(1) lookup during parsing
-        Self::compute_bracket_pairs(&mut tokens);
+        self.compute_bracket_pairs(&mut tokens);
 
         let violations = Lexer::violations_from_tokens(&tokens);
         (tokens, violations)
@@ -367,9 +391,15 @@ impl Lexer {
 
     /// Pre-compute matching bracket indices for all bracket tokens.
     /// This allows O(1) bracket lookup during parsing instead of O(n) scanning.
-    fn compute_bracket_pairs(tokens: &mut [Token]) {
-        // Stack to track opening brackets: (index, bracket_char)
-        let mut bracket_stack: Vec<(usize, char)> = Vec::new();
+    ///
+    /// PYTHON PARITY: bracket identity is by raw text against `self.bracket_pairs`
+    /// (a dialect's full `bracket_pairs` set - see `Dialect::get_bracket_pairs`),
+    /// not a hardcoded ASCII trio, so dialect-specific brackets (e.g. snowflake's
+    /// MATCH_RECOGNIZE exclude bracket `{-`/`-}`) are tracked identically to
+    /// round/square/curly.
+    fn compute_bracket_pairs(&self, tokens: &mut [Token]) {
+        // Stack to track opening brackets: (index, bracket-pair-type index)
+        let mut bracket_stack: Vec<(usize, usize)> = Vec::new();
 
         for idx in 0..tokens.len() {
             // Only code tokens can be brackets. Skipping non-code tokens (notably
@@ -382,28 +412,26 @@ impl Lexer {
             let raw = tokens[idx].raw();
 
             // Check if this is an opening bracket
-            if let Some(open_char) = match raw {
-                "(" => Some('('),
-                "[" => Some('['),
-                "{" => Some('{'),
-                _ => None,
-            } {
-                bracket_stack.push((idx, open_char));
+            if let Some(pair_idx) = self
+                .bracket_pairs
+                .iter()
+                .position(|(open, _, _, _, _)| *open == raw)
+            {
+                bracket_stack.push((idx, pair_idx));
             }
             // Check if this is a closing bracket
-            else if let Some(expected_open) = match raw {
-                ")" => Some('('),
-                "]" => Some('['),
-                "}" => Some('{'),
-                _ => None,
-            } {
+            else if let Some(expected_idx) = self
+                .bracket_pairs
+                .iter()
+                .position(|(_, close, _, _, _)| *close == raw)
+            {
                 // Only the most-recently-opened bracket (the top of the stack)
                 // may be closed next, per LIFO nesting discipline. This matches
                 // Python's resolve_bracket (match_algorithms.py), which recurses
                 // into a freshly-opened bracket and only returns once that
                 // specific bracket is resolved.
-                if let Some(&(open_idx, top_char)) = bracket_stack.last() {
-                    if top_char == expected_open {
+                if let Some(&(open_idx, top_idx)) = bracket_stack.last() {
+                    if top_idx == expected_idx {
                         bracket_stack.pop();
                         // Set bidirectional pointers
                         tokens[open_idx].matching_bracket_idx = Some(idx);
@@ -951,7 +979,10 @@ pub mod python {
                 panic!("Lexer does not support setting both `config` and `dialect`.")
             }
             let dialect = cfg_dialect.unwrap_or_else(|| in_dialect.expect("Dialect not defined"));
-            Self(Lexer::new(None, dialect.get_lexers().to_vec()))
+            Self(
+                Lexer::new(None, dialect.get_lexers().to_vec())
+                    .with_bracket_pairs(dialect.get_bracket_pairs().clone()),
+            )
         }
 
         #[pyo3(signature = (input, template_blocks_indent = true))]

--- a/sqlfluffrs/sqlfluffrs_lexer/src/lexer.rs
+++ b/sqlfluffrs/sqlfluffrs_lexer/src/lexer.rs
@@ -222,6 +222,8 @@ impl SQLLexError {
 /// PYTHON PARITY: matches `Dialect`'s base `bracket_pairs` set
 /// (dialect_ansi.py) before any dialect-specific additions (e.g. snowflake's
 /// MATCH_RECOGNIZE exclude bracket `{-`/`-}`, added to that same set).
+/// The last `bool` in each tuple is `persists`: `true` wraps the matched
+/// span in a `BracketedSegment` node, `false` leaves the children inline.
 const DEFAULT_BRACKET_PAIRS: &[(&str, &str, &str, &str, bool)] = &[
     ("(", ")", "start_bracket", "end_bracket", true),
     (

--- a/sqlfluffrs/sqlfluffrs_lexer/src/lexer.rs
+++ b/sqlfluffrs/sqlfluffrs_lexer/src/lexer.rs
@@ -4,7 +4,7 @@ use log::debug;
 
 use sqlfluffrs_types::{
     marker::PositionMarker,
-    matcher::{LexMatcher, LexMatcherConfig, LexedElement},
+    matcher::{BracketPairEntry, LexMatcher, LexMatcherConfig, LexedElement},
     slice::Slice,
     templater::{fileslice::TemplatedFileSlice, templatefile::TemplatedFile},
     token::{python_repr, Token},
@@ -238,7 +238,7 @@ const DEFAULT_BRACKET_PAIRS: &[(&str, &str, &str, &str, bool)] = &[
 pub struct Lexer {
     last_resort_lexer: LexMatcher,
     matchers: Vec<LexMatcher>,
-    bracket_pairs: Vec<(&'static str, &'static str, &'static str, &'static str, bool)>,
+    bracket_pairs: Vec<BracketPairEntry>,
 }
 
 impl Lexer {
@@ -264,10 +264,7 @@ impl Lexer {
     /// Override the bracket-pairs set used for `matching_bracket_idx`
     /// pre-computation, e.g. with a dialect's full `bracket_pairs` set
     /// (round/square/curly plus any dialect-specific additions).
-    pub fn with_bracket_pairs(
-        mut self,
-        bracket_pairs: Vec<(&'static str, &'static str, &'static str, &'static str, bool)>,
-    ) -> Self {
+    pub fn with_bracket_pairs(mut self, bracket_pairs: Vec<BracketPairEntry>) -> Self {
         self.bracket_pairs = bracket_pairs;
         self
     }

--- a/sqlfluffrs/sqlfluffrs_lexer/src/lexer.rs
+++ b/sqlfluffrs/sqlfluffrs_lexer/src/lexer.rs
@@ -4,7 +4,7 @@ use log::debug;
 
 use sqlfluffrs_types::{
     marker::PositionMarker,
-    matcher::{BracketPairEntry, LexMatcher, LexMatcherConfig, LexedElement},
+    matcher::{BracketPairEntry, BracketPairSet, LexMatcher, LexMatcherConfig, LexedElement},
     slice::Slice,
     templater::{fileslice::TemplatedFileSlice, templatefile::TemplatedFile},
     token::{python_repr, Token},
@@ -219,28 +219,38 @@ impl SQLLexError {
 
 /// The universal ASCII bracket pairs every dialect has (round/square/curly),
 /// used unless a dialect-specific set is supplied via [`Lexer::with_bracket_pairs`].
-/// PYTHON PARITY: matches `Dialect`'s base `bracket_pairs` set
-/// (dialect_ansi.py) before any dialect-specific additions (e.g. snowflake's
-/// MATCH_RECOGNIZE exclude bracket `{-`/`-}`, added to that same set).
-/// The last `bool` in each tuple is `persists`: `true` wraps the matched
-/// span in a `BracketedSegment` node, `false` leaves the children inline.
-const DEFAULT_BRACKET_PAIRS: &[(&str, &str, &str, &str, bool)] = &[
-    ("(", ")", "start_bracket", "end_bracket", true),
-    (
-        "[",
-        "]",
-        "start_square_bracket",
-        "end_square_bracket",
-        false,
-    ),
-    ("{", "}", "start_curly_bracket", "end_curly_bracket", false),
+/// PYTHON PARITY: matches `Dialect`'s base `bracket_pairs` set (dialect_ansi.py)
+/// before any dialect-specific additions. `persists` is whether the matched
+/// span is kept as a structured `BracketedSegment` node vs flattened inline.
+const DEFAULT_BRACKET_PAIRS: &[BracketPairEntry] = &[
+    BracketPairEntry {
+        open: "(",
+        close: ")",
+        start_type: "start_bracket",
+        end_type: "end_bracket",
+        persists: true,
+    },
+    BracketPairEntry {
+        open: "[",
+        close: "]",
+        start_type: "start_square_bracket",
+        end_type: "end_square_bracket",
+        persists: false,
+    },
+    BracketPairEntry {
+        open: "{",
+        close: "}",
+        start_type: "start_curly_bracket",
+        end_type: "end_curly_bracket",
+        persists: false,
+    },
 ];
 
 #[derive(Clone)]
 pub struct Lexer {
     last_resort_lexer: LexMatcher,
     matchers: Vec<LexMatcher>,
-    bracket_pairs: Vec<BracketPairEntry>,
+    bracket_pairs: BracketPairSet,
 }
 
 impl Lexer {
@@ -259,14 +269,14 @@ impl Lexer {
         Self {
             last_resort_lexer,
             matchers,
-            bracket_pairs: DEFAULT_BRACKET_PAIRS.to_vec(),
+            bracket_pairs: BracketPairSet(DEFAULT_BRACKET_PAIRS.to_vec()),
         }
     }
 
     /// Override the bracket-pairs set used for `matching_bracket_idx`
     /// pre-computation, e.g. with a dialect's full `bracket_pairs` set
     /// (round/square/curly plus any dialect-specific additions).
-    pub fn with_bracket_pairs(mut self, bracket_pairs: Vec<BracketPairEntry>) -> Self {
+    pub fn with_bracket_pairs(mut self, bracket_pairs: BracketPairSet) -> Self {
         self.bracket_pairs = bracket_pairs;
         self
     }
@@ -394,68 +404,12 @@ impl Lexer {
         (tokens, violations)
     }
 
-    /// Pre-compute matching bracket indices for all bracket tokens.
-    /// This allows O(1) bracket lookup during parsing instead of O(n) scanning.
-    ///
-    /// PYTHON PARITY: bracket identity is by raw text against `self.bracket_pairs`
-    /// (a dialect's full `bracket_pairs` set - see `Dialect::get_bracket_pairs`),
-    /// not a hardcoded ASCII trio, so dialect-specific brackets (e.g. snowflake's
-    /// MATCH_RECOGNIZE exclude bracket `{-`/`-}`) are tracked identically to
-    /// round/square/curly.
+    /// Pre-compute matching bracket indices for all bracket tokens, for O(1)
+    /// lookup during parsing instead of O(n) scanning. Bracket identity is by
+    /// raw text against `self.bracket_pairs` (a dialect's full set - see
+    /// `Dialect::get_bracket_pairs` - not a hardcoded ASCII trio).
     fn compute_bracket_pairs(&self, tokens: &mut [Token]) {
-        // Stack to track opening brackets: (index, bracket-pair-type index)
-        let mut bracket_stack: Vec<(usize, usize)> = Vec::new();
-
-        for idx in 0..tokens.len() {
-            // Only code tokens can be brackets. Skipping non-code tokens (notably
-            // comments) prevents bracket characters inside a block/inline comment -
-            // e.g. `min(` / `)` - from being paired with real brackets in the SQL.
-            if !tokens[idx].is_code() {
-                continue;
-            }
-
-            let raw = tokens[idx].raw();
-
-            // Check if this is an opening bracket
-            if let Some(pair_idx) = self
-                .bracket_pairs
-                .iter()
-                .position(|(open, _, _, _, _)| *open == raw)
-            {
-                bracket_stack.push((idx, pair_idx));
-            }
-            // Check if this is a closing bracket
-            else if let Some(expected_idx) = self
-                .bracket_pairs
-                .iter()
-                .position(|(_, close, _, _, _)| *close == raw)
-            {
-                // Only the most-recently-opened bracket (the top of the stack)
-                // may be closed next, per LIFO nesting discipline. This matches
-                // Python's resolve_bracket (match_algorithms.py), which recurses
-                // into a freshly-opened bracket and only returns once that
-                // specific bracket is resolved.
-                if let Some(&(open_idx, top_idx)) = bracket_stack.last() {
-                    if top_idx == expected_idx {
-                        bracket_stack.pop();
-                        // Set bidirectional pointers
-                        tokens[open_idx].matching_bracket_idx = Some(idx);
-                        tokens[idx].matching_bracket_idx = Some(open_idx);
-                    } else {
-                        // A type mismatch (e.g. `a[(1]`) is what Python's
-                        // resolve_bracket raises on, unwinding through every
-                        // enclosing bracket's own call. Clear the whole stack
-                        // to match that: every bracket still open at this
-                        // point stays unresolved, so none of them can later
-                        // pair with a closer that follows.
-                        bracket_stack.clear();
-                    }
-                }
-                // If the stack is empty, there's no open bracket at all -
-                // leave as None (syntax error).
-            }
-        }
-        // Any remaining opening brackets on the stack are unmatched - leave as None
+        self.bracket_pairs.compute_matching_indices(tokens);
     }
 
     fn violations_from_tokens(tokens: &[Token]) -> Vec<SQLLexError> {

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/core.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/core.rs
@@ -1758,7 +1758,10 @@ impl<'a> Parser<'a> {
                     if nested_match {
                         inner_child_matches.push(Arc::new(nested_bracket));
                     }
-                } else if bracket_pairs.iter().any(|(_, close, _, _, _)| *close == inner_raw) {
+                } else if bracket_pairs
+                    .iter()
+                    .any(|(_, close, _, _, _)| *close == inner_raw)
+                {
                     // PYTHON PARITY: a closing bracket of a *different* type than
                     // the one we opened is a crossed bracket. Our own
                     // `close_bracket` is handled above and same-type nested

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/core.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/core.rs
@@ -1616,17 +1616,13 @@ impl<'a> Parser<'a> {
             if let Some(tok) = self.peek() {
                 let tok_raw = tok.raw().to_owned();
 
-                // Handle bracket openers - match entire bracketed section with
-                // nested brackets. Recognise openers by the dialect's full
-                // bracket_pairs set (round/square/curly plus any dialect-specific
-                // brackets, e.g. snowflake's exclude `{-`), matching Python's
-                // resolve_bracket rather than a hardcoded ASCII trio.
+                // Handle bracket openers - match the entire bracketed section,
+                // recursing into any nested brackets (Python parity: resolve_bracket).
                 let opener_persists = self
                     .dialect
                     .get_bracket_pairs()
-                    .iter()
-                    .find(|(open, _, _, _, _)| *open == tok_raw)
-                    .map(|(_, _, _, _, persists)| *persists);
+                    .find_by_open(&tok_raw)
+                    .map(|p| p.persists);
                 if let Some(persists) = opener_persists {
                     let bracket_match =
                         self.match_bracket_recursively(tok_raw.as_str(), persists, true)?;
@@ -1701,19 +1697,14 @@ impl<'a> Parser<'a> {
         persists: bool,
         nested_match: bool,
     ) -> Result<MatchResult, ParseError> {
-        // PYTHON PARITY: recognise brackets - and their leaf segment types - by
-        // the dialect's full bracket_pairs set (round → start_bracket, square →
-        // start_square_bracket, curly → start_curly_bracket, plus any dialect-
-        // specific brackets, e.g. snowflake's exclude `{-`/`-}` →
-        // start_exclude_bracket), mirroring resolve_bracket, rather than a
-        // hardcoded ASCII trio. `get_bracket_pairs` returns a `&'static` slice,
-        // so it can be held across the `&mut self` calls in the scan loop below.
+        // `get_bracket_pairs` returns a `&'static` reference, so it can be held
+        // across the `&mut self` calls in the scan loop below.
         let bracket_pairs = self.dialect.get_bracket_pairs();
-        let (close_bracket, start_bracket_type, end_bracket_type) = bracket_pairs
-            .iter()
-            .find(|(open, _, _, _, _)| *open == open_bracket)
-            .map(|(_, close, start_ty, end_ty, _)| (*close, *start_ty, *end_ty))
+        let opener = bracket_pairs
+            .find_by_open(open_bracket)
             .expect("match_bracket_recursively called with an unregistered opener");
+        let (close_bracket, start_bracket_type, end_bracket_type) =
+            (opener.close, opener.start_type, opener.end_type);
 
         let bracket_start = self.pos;
 
@@ -1745,10 +1736,8 @@ impl<'a> Parser<'a> {
                     // Found our closing bracket
                     closed = true;
                     break;
-                } else if let Some(nested_persists) = bracket_pairs
-                    .iter()
-                    .find(|(open, _, _, _, _)| *open == inner_raw)
-                    .map(|(_, _, _, _, persists)| *persists)
+                } else if let Some(nested_persists) =
+                    bracket_pairs.find_by_open(&inner_raw).map(|p| p.persists)
                 {
                     // Found a nested bracket (any registered opener) - recurse,
                     // carrying its own dialect persists flag.
@@ -1758,18 +1747,10 @@ impl<'a> Parser<'a> {
                     if nested_match {
                         inner_child_matches.push(Arc::new(nested_bracket));
                     }
-                } else if bracket_pairs
-                    .iter()
-                    .any(|(_, close, _, _, _)| *close == inner_raw)
-                {
-                    // PYTHON PARITY: a closing bracket of a *different* type than
-                    // the one we opened is a crossed bracket. Our own
-                    // `close_bracket` is handled above and same-type nested
-                    // openers are recursed (consuming their own closer), so
-                    // reaching here means a wrong-type closer of any registered
-                    // pair (round/square/curly or a dialect-specific one).
-                    // Python's `resolve_bracket` (match_algorithms.py) raises
-                    // rather than swallowing it as content, so mirror that.
+                } else if bracket_pairs.is_close(&inner_raw) {
+                    // A closing bracket of a different type than the one we
+                    // opened is a crossed bracket (Python's resolve_bracket
+                    // raises here rather than swallowing it as content).
                     return Err(ParseError::with_context(
                         format!(
                             "Found unexpected end bracket!, was expecting <StringParser: '{}'>, but got <StringParser: '{}'>",

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/core.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/core.rs
@@ -1619,7 +1619,7 @@ impl<'a> Parser<'a> {
                 // Handle bracket openers - match entire bracketed section with nested brackets
                 if tok_raw == "(" || tok_raw == "[" || tok_raw == "{" {
                     let bracket_match =
-                        self.match_bracket_recursively(tok_raw.as_str(), tok_raw == "(", true);
+                        self.match_bracket_recursively(tok_raw.as_str(), tok_raw == "(", true)?;
                     child_matches.push(bracket_match);
                 } else {
                     // Regular token - just bump, it'll be part of the raw content
@@ -1675,12 +1675,22 @@ impl<'a> Parser<'a> {
     /// `resolve_bracket`: when true, directly-nested brackets are attached as
     /// structured children; the recursive call passes false, so deeper brackets
     /// are consumed but flattened to raw siblings (pure-Python parity).
+    ///
+    /// PYTHON PARITY: `resolve_bracket` (match_algorithms.py) always raises
+    /// `SQLParseError("Couldn't find closing bracket for opening bracket.")`
+    /// when a bracket it opened is never closed before running out of
+    /// segments - unconditionally, regardless of any enclosing grammar's
+    /// parse_mode. This mirrors that: reaching the end of input without
+    /// finding `close_bracket` is an error, not a silent partial match: a
+    /// crossed opening bracket of a *different* type (e.g. an unclosed `{`
+    /// found while scanning for `)`) must abort here rather than being
+    /// swallowed into the match as if it had closed cleanly.
     fn match_bracket_recursively(
         &mut self,
         open_bracket: &str,
         persists: bool,
         nested_match: bool,
-    ) -> MatchResult {
+    ) -> Result<MatchResult, ParseError> {
         // Python parity: bracket leaf type depends on the bracket char
         // (`[`→square, `{`→curly); only `(` uses the plain bracket type.
         let (close_bracket, start_bracket_type, end_bracket_type) = match open_bracket {
@@ -1711,22 +1721,43 @@ impl<'a> Parser<'a> {
         let mut inner_child_matches: Vec<Arc<MatchResult>> = vec![Arc::new(open_bracket_match)];
 
         // Match everything until matching close bracket, recursively handling nested brackets
+        let mut closed = false;
         while !self.is_at_end() {
             if let Some(inner_tok) = self.peek() {
                 let inner_raw = inner_tok.raw().to_owned();
 
                 if inner_raw == close_bracket {
                     // Found our closing bracket
+                    closed = true;
                     break;
                 } else if inner_raw == "(" || inner_raw == "[" || inner_raw == "{" {
                     // Found a nested bracket - recursively match it
                     let nested_persists = inner_raw == "(";
                     let nested_bracket =
-                        self.match_bracket_recursively(inner_raw.as_str(), nested_persists, false);
+                        self.match_bracket_recursively(inner_raw.as_str(), nested_persists, false)?;
                     // Only attach directly-nested brackets; deeper ones flatten.
                     if nested_match {
                         inner_child_matches.push(Arc::new(nested_bracket));
                     }
+                } else if inner_raw == ")" || inner_raw == "]" || inner_raw == "}" {
+                    // PYTHON PARITY: a closing bracket of a *different* type than
+                    // the one we opened is a crossed bracket. Our own
+                    // `close_bracket` is handled above and same-type nested
+                    // openers are recursed (consuming their own closer), so
+                    // reaching here means a wrong-type ASCII closer. Python's
+                    // `resolve_bracket` (match_algorithms.py) raises rather than
+                    // swallowing it as content, so mirror that exactly instead
+                    // of bumping past it. (Scoped to the universal ASCII closers
+                    // so dialect-specific brackets like snowflake's `-}` keep
+                    // their current handling.)
+                    return Err(ParseError::with_context(
+                        format!(
+                            "Found unexpected end bracket!, was expecting <StringParser: '{}'>, but got <StringParser: '{}'>",
+                            close_bracket, inner_raw
+                        ),
+                        Some(self.pos),
+                        None,
+                    ));
                 } else {
                     // Regular token - just bump
                     self.bump();
@@ -1736,13 +1767,17 @@ impl<'a> Parser<'a> {
             }
         }
 
+        if !closed {
+            return Err(ParseError::with_context(
+                "Couldn't find closing bracket for opening bracket.".to_string(),
+                Some(bracket_start),
+                None,
+            ));
+        }
+
         // Record closing bracket position with SymbolSegment class
-        let bracket_end = if !self.is_at_end() {
-            self.bump(); // consume the close bracket
-            self.pos
-        } else {
-            self.pos
-        };
+        self.bump(); // consume the close bracket
+        let bracket_end = self.pos;
 
         let close_bracket_match = MatchResult {
             matched_slice: bracket_end - 1..bracket_end,
@@ -1758,6 +1793,11 @@ impl<'a> Parser<'a> {
         };
         inner_child_matches.push(Arc::new(close_bracket_match));
 
-        MatchResult::bracketed(bracket_start, bracket_end, inner_child_matches, persists)
+        Ok(MatchResult::bracketed(
+            bracket_start,
+            bracket_end,
+            inner_child_matches,
+            persists,
+        ))
     }
 }

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/core.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/core.rs
@@ -1616,10 +1616,20 @@ impl<'a> Parser<'a> {
             if let Some(tok) = self.peek() {
                 let tok_raw = tok.raw().to_owned();
 
-                // Handle bracket openers - match entire bracketed section with nested brackets
-                if tok_raw == "(" || tok_raw == "[" || tok_raw == "{" {
+                // Handle bracket openers - match entire bracketed section with
+                // nested brackets. Recognise openers by the dialect's full
+                // bracket_pairs set (round/square/curly plus any dialect-specific
+                // brackets, e.g. snowflake's exclude `{-`), matching Python's
+                // resolve_bracket rather than a hardcoded ASCII trio.
+                let opener_persists = self
+                    .dialect
+                    .get_bracket_pairs()
+                    .iter()
+                    .find(|(open, _, _, _, _)| *open == tok_raw)
+                    .map(|(_, _, _, _, persists)| *persists);
+                if let Some(persists) = opener_persists {
                     let bracket_match =
-                        self.match_bracket_recursively(tok_raw.as_str(), tok_raw == "(", true)?;
+                        self.match_bracket_recursively(tok_raw.as_str(), persists, true)?;
                     child_matches.push(bracket_match);
                 } else {
                     // Regular token - just bump, it'll be part of the raw content
@@ -1691,14 +1701,19 @@ impl<'a> Parser<'a> {
         persists: bool,
         nested_match: bool,
     ) -> Result<MatchResult, ParseError> {
-        // Python parity: bracket leaf type depends on the bracket char
-        // (`[`→square, `{`→curly); only `(` uses the plain bracket type.
-        let (close_bracket, start_bracket_type, end_bracket_type) = match open_bracket {
-            "(" => (")", "start_bracket", "end_bracket"),
-            "[" => ("]", "start_square_bracket", "end_square_bracket"),
-            "{" => ("}", "start_curly_bracket", "end_curly_bracket"),
-            _ => unreachable!(),
-        };
+        // PYTHON PARITY: recognise brackets - and their leaf segment types - by
+        // the dialect's full bracket_pairs set (round → start_bracket, square →
+        // start_square_bracket, curly → start_curly_bracket, plus any dialect-
+        // specific brackets, e.g. snowflake's exclude `{-`/`-}` →
+        // start_exclude_bracket), mirroring resolve_bracket, rather than a
+        // hardcoded ASCII trio. `get_bracket_pairs` returns a `&'static` slice,
+        // so it can be held across the `&mut self` calls in the scan loop below.
+        let bracket_pairs = self.dialect.get_bracket_pairs();
+        let (close_bracket, start_bracket_type, end_bracket_type) = bracket_pairs
+            .iter()
+            .find(|(open, _, _, _, _)| *open == open_bracket)
+            .map(|(_, close, start_ty, end_ty, _)| (*close, *start_ty, *end_ty))
+            .expect("match_bracket_recursively called with an unregistered opener");
 
         let bracket_start = self.pos;
 
@@ -1730,26 +1745,28 @@ impl<'a> Parser<'a> {
                     // Found our closing bracket
                     closed = true;
                     break;
-                } else if inner_raw == "(" || inner_raw == "[" || inner_raw == "{" {
-                    // Found a nested bracket - recursively match it
-                    let nested_persists = inner_raw == "(";
+                } else if let Some(nested_persists) = bracket_pairs
+                    .iter()
+                    .find(|(open, _, _, _, _)| *open == inner_raw)
+                    .map(|(_, _, _, _, persists)| *persists)
+                {
+                    // Found a nested bracket (any registered opener) - recurse,
+                    // carrying its own dialect persists flag.
                     let nested_bracket =
                         self.match_bracket_recursively(inner_raw.as_str(), nested_persists, false)?;
                     // Only attach directly-nested brackets; deeper ones flatten.
                     if nested_match {
                         inner_child_matches.push(Arc::new(nested_bracket));
                     }
-                } else if inner_raw == ")" || inner_raw == "]" || inner_raw == "}" {
+                } else if bracket_pairs.iter().any(|(_, close, _, _, _)| *close == inner_raw) {
                     // PYTHON PARITY: a closing bracket of a *different* type than
                     // the one we opened is a crossed bracket. Our own
                     // `close_bracket` is handled above and same-type nested
                     // openers are recursed (consuming their own closer), so
-                    // reaching here means a wrong-type ASCII closer. Python's
-                    // `resolve_bracket` (match_algorithms.py) raises rather than
-                    // swallowing it as content, so mirror that exactly instead
-                    // of bumping past it. (Scoped to the universal ASCII closers
-                    // so dialect-specific brackets like snowflake's `-}` keep
-                    // their current handling.)
+                    // reaching here means a wrong-type closer of any registered
+                    // pair (round/square/curly or a dialect-specific one).
+                    // Python's `resolve_bracket` (match_algorithms.py) raises
+                    // rather than swallowing it as content, so mirror that.
                     return Err(ParseError::with_context(
                         format!(
                             "Found unexpected end bracket!, was expecting <StringParser: '{}'>, but got <StringParser: '{}'>",

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/core.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/core.rs
@@ -1682,15 +1682,8 @@ impl<'a> Parser<'a> {
     /// structured children; the recursive call passes false, so deeper brackets
     /// are consumed but flattened to raw siblings (pure-Python parity).
     ///
-    /// PYTHON PARITY: `resolve_bracket` (match_algorithms.py) always raises
-    /// `SQLParseError("Couldn't find closing bracket for opening bracket.")`
-    /// when a bracket it opened is never closed before running out of
-    /// segments - unconditionally, regardless of any enclosing grammar's
-    /// parse_mode. This mirrors that: reaching the end of input without
-    /// finding `close_bracket` is an error, not a silent partial match: a
-    /// crossed opening bracket of a *different* type (e.g. an unclosed `{`
-    /// found while scanning for `)`) must abort here rather than being
-    /// swallowed into the match as if it had closed cleanly.
+    /// Reaching end of input without finding `close_bracket` is always an
+    /// error, regardless of parse_mode - never a silent partial match.
     fn match_bracket_recursively(
         &mut self,
         open_bracket: &str,

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/frame.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/frame.rs
@@ -152,13 +152,6 @@ pub struct BracketedState {
     pub parse_mode_override: Option<ParseMode>,
     /// Store child matches here until sequence is complete.
     pub child_matches: Vec<Arc<MatchResult>>,
-    /// `child_matches.len()` once the opening bracket has been recorded and
-    /// before any content element has been attempted. Content-failure error
-    /// messages (see `handle_bracketed_content_result`) compare against this
-    /// baseline - rather than `child_matches.is_empty()` - to tell "nothing
-    /// in the content grammar has matched yet" apart from "the opening
-    /// bracket is already in `child_matches`, but no content has".
-    pub content_start_len: usize,
 }
 
 /// Working state for a `Sequence` frame (see [`FrameContext::Sequence`]).

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/frame.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/frame.rs
@@ -152,6 +152,13 @@ pub struct BracketedState {
     pub parse_mode_override: Option<ParseMode>,
     /// Store child matches here until sequence is complete.
     pub child_matches: Vec<Arc<MatchResult>>,
+    /// `child_matches.len()` once the opening bracket has been recorded and
+    /// before any content element has been attempted. Content-failure error
+    /// messages (see `handle_bracketed_content_result`) compare against this
+    /// baseline - rather than `child_matches.is_empty()` - to tell "nothing
+    /// in the content grammar has matched yet" apart from "the opening
+    /// bracket is already in `child_matches`, but no content has".
+    pub content_start_len: usize,
 }
 
 /// Working state for a `Sequence` frame (see [`FrameContext::Sequence`]).

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/helpers.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/helpers.rs
@@ -201,15 +201,20 @@ impl<'a> Parser<'a> {
             return None;
         }
 
-        // Validate the token at matching_idx is actually the expected closing bracket
+        // Validate the token at matching_idx is actually the expected closing bracket.
+        // PYTHON PARITY: recognise the opener by the dialect's full bracket_pairs
+        // set (round/square/curly plus any dialect-specific brackets, e.g.
+        // snowflake's exclude `{-`/`-}`), not a hardcoded ASCII trio - otherwise
+        // exclude-bracket opens never validate and bracket_max_idx silently
+        // becomes None, losing the closing-bracket boundary entirely.
         let close_tok = self.tokens.get(matching_idx)?;
         let open_raw = open_tok.raw();
-        let expected_close = match open_raw {
-            "(" => ")",
-            "[" => "]",
-            "{" => "}",
-            _ => return None, // Not an opening bracket
-        };
+        let expected_close = self
+            .dialect
+            .get_bracket_pairs()
+            .iter()
+            .find(|(open, _, _, _, _)| *open == open_raw)
+            .map(|(_, close, _, _, _)| *close)?;
 
         if close_tok.raw() == expected_close {
             Some(matching_idx)

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/helpers.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/helpers.rs
@@ -201,20 +201,16 @@ impl<'a> Parser<'a> {
             return None;
         }
 
-        // Validate the token at matching_idx is actually the expected closing bracket.
-        // PYTHON PARITY: recognise the opener by the dialect's full bracket_pairs
-        // set (round/square/curly plus any dialect-specific brackets, e.g.
-        // snowflake's exclude `{-`/`-}`), not a hardcoded ASCII trio - otherwise
-        // exclude-bracket opens never validate and bracket_max_idx silently
-        // becomes None, losing the closing-bracket boundary entirely.
+        // Validate the token at matching_idx is actually the expected closing
+        // bracket, recognising the opener via the dialect's full bracket_pairs
+        // set (not a hardcoded ASCII trio) so dialect-specific brackets validate too.
         let close_tok = self.tokens.get(matching_idx)?;
         let open_raw = open_tok.raw();
         let expected_close = self
             .dialect
             .get_bracket_pairs()
-            .iter()
-            .find(|(open, _, _, _, _)| *open == open_raw)
-            .map(|(_, close, _, _, _)| *close)?;
+            .find_by_open(open_raw)
+            .map(|p| p.close)?;
 
         if close_tok.raw() == expected_close {
             Some(matching_idx)

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/helpers.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/helpers.rs
@@ -201,9 +201,7 @@ impl<'a> Parser<'a> {
             return None;
         }
 
-        // Validate the token at matching_idx is actually the expected closing
-        // bracket, recognising the opener via the dialect's full bracket_pairs
-        // set (not a hardcoded ASCII trio) so dialect-specific brackets validate too.
+        // Validate the token at matching_idx is actually the expected closing bracket.
         let close_tok = self.tokens.get(matching_idx)?;
         let open_raw = open_tok.raw();
         let expected_close = self

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/python.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/python.rs
@@ -662,12 +662,16 @@ fn compute_bracket_pairs(tokens: &mut [Token], bracket_pairs: &[(&str, &str, &st
         let raw = tokens[idx].raw();
 
         // Check if this is an opening bracket
-        if let Some(pair_idx) = bracket_pairs.iter().position(|(open, _, _, _, _)| *open == raw) {
+        if let Some(pair_idx) = bracket_pairs
+            .iter()
+            .position(|(open, _, _, _, _)| *open == raw)
+        {
             bracket_stack.push((idx, pair_idx));
         }
         // Check if this is a closing bracket
-        else if let Some(expected_idx) =
-            bracket_pairs.iter().position(|(_, close, _, _, _)| *close == raw)
+        else if let Some(expected_idx) = bracket_pairs
+            .iter()
+            .position(|(_, close, _, _, _)| *close == raw)
         {
             // Only the most-recently-opened bracket (the top of the stack) may
             // be closed next, per LIFO nesting discipline. See the sibling

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/python.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/python.rs
@@ -514,7 +514,7 @@ impl PyParser {
         // Compute bracket pairs for the tokens.
         // When tokens come from Python (lexed by Python lexer), matching_bracket_idx is None.
         // We need to compute it for the Bracketed grammar to work correctly.
-        compute_bracket_pairs(&mut rust_tokens);
+        compute_bracket_pairs(&mut rust_tokens, self.dialect.get_bracket_pairs());
 
         // Create parser
         let mut parser = Parser::new_with_max_parse_depth(
@@ -555,7 +555,7 @@ impl PyParser {
         let mut rust_tokens: Vec<Token> = tokens.into_iter().map(|t| t.into()).collect();
 
         // Compute bracket pairs for the tokens.
-        compute_bracket_pairs(&mut rust_tokens);
+        compute_bracket_pairs(&mut rust_tokens, self.dialect.get_bracket_pairs());
 
         // Create parser
         let mut parser = Parser::new_with_max_parse_depth(
@@ -601,7 +601,7 @@ impl PyParser {
         let mut rust_tokens: Vec<Token> = tokens.into_iter().map(|t| t.into()).collect();
 
         // Compute bracket pairs for the tokens.
-        compute_bracket_pairs(&mut rust_tokens);
+        compute_bracket_pairs(&mut rust_tokens, self.dialect.get_bracket_pairs());
 
         // Create parser with grammar counting enabled
         let mut parser = Parser::new_with_max_parse_depth(
@@ -647,9 +647,9 @@ impl PyParser {
 ///
 /// This is necessary when tokens come from Python (via PyToken -> Token conversion)
 /// because the Python lexer doesn't compute these indices.
-fn compute_bracket_pairs(tokens: &mut [Token]) {
-    // Stack to track opening brackets: (index, bracket_char)
-    let mut bracket_stack: Vec<(usize, char)> = Vec::new();
+fn compute_bracket_pairs(tokens: &mut [Token], bracket_pairs: &[(&str, &str, &str, &str, bool)]) {
+    // Stack to track opening brackets: (index, bracket-pair-type index)
+    let mut bracket_stack: Vec<(usize, usize)> = Vec::new();
 
     for idx in 0..tokens.len() {
         // Only code tokens can be brackets. Skipping non-code tokens (notably
@@ -662,28 +662,24 @@ fn compute_bracket_pairs(tokens: &mut [Token]) {
         let raw = tokens[idx].raw();
 
         // Check if this is an opening bracket
-        if let Some(open_char) = match raw {
-            "(" => Some('('),
-            "[" => Some('['),
-            "{" => Some('{'),
-            _ => None,
-        } {
-            bracket_stack.push((idx, open_char));
+        if let Some(pair_idx) = bracket_pairs.iter().position(|(open, _, _, _, _)| *open == raw) {
+            bracket_stack.push((idx, pair_idx));
         }
         // Check if this is a closing bracket
-        else if let Some(expected_open) = match raw {
-            ")" => Some('('),
-            "]" => Some('['),
-            "}" => Some('{'),
-            _ => None,
-        } {
+        else if let Some(expected_idx) =
+            bracket_pairs.iter().position(|(_, close, _, _, _)| *close == raw)
+        {
             // Only the most-recently-opened bracket (the top of the stack) may
             // be closed next, per LIFO nesting discipline. See the sibling
             // implementation in sqlfluffrs_lexer/src/lexer.rs::compute_bracket_pairs
             // for the full rationale (Python parity with resolve_bracket in
-            // match_algorithms.py).
-            if let Some(&(open_idx, top_char)) = bracket_stack.last() {
-                if top_char == expected_open {
+            // match_algorithms.py). Bracket identity is by raw text against the
+            // dialect's full `bracket_pairs` set (see `Dialect::get_bracket_pairs`),
+            // not a hardcoded ASCII trio, so dialect-specific brackets (e.g.
+            // snowflake's MATCH_RECOGNIZE exclude bracket `{-`/`-}`) are tracked
+            // identically to round/square/curly.
+            if let Some(&(open_idx, top_idx)) = bracket_stack.last() {
+                if top_idx == expected_idx {
                     bracket_stack.pop();
                     // Set bidirectional pointers
                     tokens[open_idx].matching_bracket_idx = Some(idx);

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/python.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/python.rs
@@ -514,7 +514,9 @@ impl PyParser {
         // Compute bracket pairs for the tokens.
         // When tokens come from Python (lexed by Python lexer), matching_bracket_idx is None.
         // We need to compute it for the Bracketed grammar to work correctly.
-        compute_bracket_pairs(&mut rust_tokens, self.dialect.get_bracket_pairs());
+        self.dialect
+            .get_bracket_pairs()
+            .compute_matching_indices(&mut rust_tokens);
 
         // Create parser
         let mut parser = Parser::new_with_max_parse_depth(
@@ -555,7 +557,9 @@ impl PyParser {
         let mut rust_tokens: Vec<Token> = tokens.into_iter().map(|t| t.into()).collect();
 
         // Compute bracket pairs for the tokens.
-        compute_bracket_pairs(&mut rust_tokens, self.dialect.get_bracket_pairs());
+        self.dialect
+            .get_bracket_pairs()
+            .compute_matching_indices(&mut rust_tokens);
 
         // Create parser
         let mut parser = Parser::new_with_max_parse_depth(
@@ -601,7 +605,9 @@ impl PyParser {
         let mut rust_tokens: Vec<Token> = tokens.into_iter().map(|t| t.into()).collect();
 
         // Compute bracket pairs for the tokens.
-        compute_bracket_pairs(&mut rust_tokens, self.dialect.get_bracket_pairs());
+        self.dialect
+            .get_bracket_pairs()
+            .compute_matching_indices(&mut rust_tokens);
 
         // Create parser with grammar counting enabled
         let mut parser = Parser::new_with_max_parse_depth(
@@ -637,68 +643,4 @@ impl PyParser {
 
         Ok((PyMatchResult(match_result), grammar_counts))
     }
-}
-
-/// Compute matching bracket indices for all bracket tokens.
-///
-/// This function sets `matching_bracket_idx` on each opening and closing bracket
-/// to point to its matching counterpart. This is used by the parser's
-/// `find_matching_bracket` function for O(1) bracket pair lookup.
-///
-/// This is necessary when tokens come from Python (via PyToken -> Token conversion)
-/// because the Python lexer doesn't compute these indices.
-fn compute_bracket_pairs(tokens: &mut [Token], bracket_pairs: &[(&str, &str, &str, &str, bool)]) {
-    // Stack to track opening brackets: (index, bracket-pair-type index)
-    let mut bracket_stack: Vec<(usize, usize)> = Vec::new();
-
-    for idx in 0..tokens.len() {
-        // Only code tokens can be brackets. Skipping non-code tokens (notably
-        // comments) prevents bracket characters inside a block/inline comment -
-        // e.g. `min(` / `)` - from being paired with real brackets in the SQL.
-        if !tokens[idx].is_code() {
-            continue;
-        }
-
-        let raw = tokens[idx].raw();
-
-        // Check if this is an opening bracket
-        if let Some(pair_idx) = bracket_pairs
-            .iter()
-            .position(|(open, _, _, _, _)| *open == raw)
-        {
-            bracket_stack.push((idx, pair_idx));
-        }
-        // Check if this is a closing bracket
-        else if let Some(expected_idx) = bracket_pairs
-            .iter()
-            .position(|(_, close, _, _, _)| *close == raw)
-        {
-            // Only the most-recently-opened bracket (the top of the stack) may
-            // be closed next, per LIFO nesting discipline. See the sibling
-            // implementation in sqlfluffrs_lexer/src/lexer.rs::compute_bracket_pairs
-            // for the full rationale (Python parity with resolve_bracket in
-            // match_algorithms.py). Bracket identity is by raw text against the
-            // dialect's full `bracket_pairs` set (see `Dialect::get_bracket_pairs`),
-            // not a hardcoded ASCII trio, so dialect-specific brackets (e.g.
-            // snowflake's MATCH_RECOGNIZE exclude bracket `{-`/`-}`) are tracked
-            // identically to round/square/curly.
-            if let Some(&(open_idx, top_idx)) = bracket_stack.last() {
-                if top_idx == expected_idx {
-                    bracket_stack.pop();
-                    // Set bidirectional pointers
-                    tokens[open_idx].matching_bracket_idx = Some(idx);
-                    tokens[idx].matching_bracket_idx = Some(open_idx);
-                } else {
-                    // A type mismatch is what Python's resolve_bracket raises
-                    // on, unwinding through every enclosing bracket's own
-                    // call. Clear the whole stack to match that: every
-                    // bracket still open at this point stays unresolved, so
-                    // none of them can later pair with a closer that follows.
-                    bracket_stack.clear();
-                }
-            }
-            // If the stack is empty, there's no open bracket at all - leave as None.
-        }
-    }
-    // Any remaining opening brackets on the stack are unmatched - leave as None
 }

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/bracketed.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/bracketed.rs
@@ -139,6 +139,7 @@ impl Parser<'_> {
             content_idx,
             parse_mode_override,
             child_matches,
+            content_start_len,
             ..
         }) = &mut frame.context
         else {
@@ -167,6 +168,7 @@ impl Parser<'_> {
         );
 
         child_matches.push(Arc::clone(child_match));
+        *content_start_len = child_matches.len();
         let content_start_idx = *child_end_pos;
         // Compute bracket_max_idx from the opening bracket's token position
         let computed_bracket_max_idx = if !child_match.matched_slice.is_empty() {
@@ -306,6 +308,7 @@ impl Parser<'_> {
             content_idx,
             parse_mode_override,
             child_matches,
+            content_start_len,
             ..
         }) = &mut frame.context
         else {
@@ -349,9 +352,27 @@ impl Parser<'_> {
                 self.tokens.len()
             );
 
+        // PYTHON PARITY: only an *optional* content element is allowed to fail
+        // and have the loop carry on to the next one unaffected (Python's
+        // Sequence.match: `if elem.is_optional(): continue`). A *required*
+        // element failing (empty match) must stop the content sequence right
+        // here, exactly like Python returns immediately from that failed
+        // element - not march on and let a later element match at the same,
+        // still-unclaimed position (e.g. tsql's Bracketed(Expression, "AS",
+        // Datatype) content: if "AS" is missing, DatatypeSegment must not be
+        // allowed to try matching where "AS" was expected). Falling through
+        // (rather than returning here) lets the closing-bracket gap-check
+        // below turn this into the same "to start sequence"/"after X"
+        // unparsable Python would produce.
+        let current_required_failed = child_is_empty
+            && !self
+                .grammar_ctx
+                .inst(content_ids[*content_idx])
+                .is_optional();
+
         // CRITICAL: Check if there are more content elements to parse
         // Continue parsing even if current element returned Empty (optional elements)
-        if *content_idx + 1 < content_ids.len() {
+        if !current_required_failed && *content_idx + 1 < content_ids.len() {
             // More content elements remain - parse the next one
             *content_idx += 1;
 
@@ -460,16 +481,69 @@ impl Parser<'_> {
                         // with matched_class set, so only create the unparsable
                         // child when there's actually code left to wrap.
                         if unparsable_stop > check_pos {
+                            // PYTHON PARITY: this loop marches through every content
+                            // element regardless of success (see the comment above),
+                            // so this gap can mean two different things Python's
+                            // Sequence.match (grammar/sequence.py) tells apart by
+                            // message: either a *required* content element genuinely
+                            // failed to match (in which case Python names the
+                            // expected grammar and found token - "to start
+                            // sequence" if nothing had matched yet, "after X" if
+                            // something had), or every required element matched
+                            // fine and this is real trailing content the grammar
+                            // has nothing left to claim (Python's generic "Nothing
+                            // here." GREEDY-leftover fallback). Crucially, a failed
+                            // *optional* element is NOT a failure Python reports:
+                            // `Sequence.match` does `if elem.is_optional(): continue`
+                            // and falls through to the same "Nothing here." leftover,
+                            // so gate on `current_required_failed` (a REQUIRED empty
+                            // match), not merely `child_is_empty`, or an optional
+                            // element's failure wrongly produces the specific message.
+                            // `child_matches.len() == *content_start_len` checks
+                            // whether any *content* element (as opposed to the
+                            // opening bracket, which is always in `child_matches`
+                            // by this point) has matched yet.
+                            let specific_message = if current_required_failed {
+                                content_ids.get(*content_idx).map(|&gid| {
+                                    let element_desc = self.grammar_ctx.grammar_repr(gid);
+                                    let error_token = self
+                                        .tokens
+                                        .get(check_pos)
+                                        .map(|t| format!("{}", t))
+                                        .unwrap_or_else(|| "end of input".to_string());
+                                    if child_matches.len() == *content_start_len {
+                                        format!(
+                                            "{} to start sequence. Found {}",
+                                            element_desc, error_token
+                                        )
+                                    } else {
+                                        let last_matched_token = self
+                                            .tokens
+                                            .get(check_pos.saturating_sub(1))
+                                            .map(|t| format!("{}", t))
+                                            .unwrap_or_else(|| "start of input".to_string());
+                                        format!(
+                                            "{} after {}. Found {}",
+                                            element_desc, last_matched_token, error_token
+                                        )
+                                    }
+                                })
+                            } else {
+                                None
+                            };
+                            let error_message =
+                                specific_message.unwrap_or_else(|| "Nothing here.".to_string());
+
                             vdebug!(
-                                    "Bracketed[table] GREEDY mode: Creating unparsable section for tokens {}..{} (content ended at {}, closing bracket at {})",
-                                    check_pos, unparsable_stop, check_pos, expected_close_pos
+                                    "Bracketed[table] GREEDY mode: Creating unparsable section for tokens {}..{} (content ended at {}, closing bracket at {}): {}",
+                                    check_pos, unparsable_stop, check_pos, expected_close_pos, error_message
                                 );
 
                             // Create an UnparsableSegment for the tokens we couldn't parse
                             let unparsable_match = MatchResult {
                                 matched_slice: check_pos..unparsable_stop,
                                 matched_class: Some(MatchedClass::unparsable(
-                                    "Nothing here.",
+                                    &error_message,
                                     unparsable_stop,
                                 )),
                                 ..Default::default()
@@ -669,6 +743,7 @@ fn initialize_bracketed_frame(
         content_idx: 0,
         parse_mode_override: None, // Will be set when creating content frames
         child_matches: Vec::new(),
+        content_start_len: 0, // Set once the opening bracket is recorded
     });
     frame.table_terminators = SmallVec::from_slice(all_terminators);
     stack.push(frame);

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/bracketed.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/bracketed.rs
@@ -139,7 +139,6 @@ impl Parser<'_> {
             content_idx,
             parse_mode_override,
             child_matches,
-            content_start_len,
             ..
         }) = &mut frame.context
         else {
@@ -168,7 +167,6 @@ impl Parser<'_> {
         );
 
         child_matches.push(Arc::clone(child_match));
-        *content_start_len = child_matches.len();
         let content_start_idx = *child_end_pos;
         // Compute bracket_max_idx from the opening bracket's token position
         let computed_bracket_max_idx = if !child_match.matched_slice.is_empty() {
@@ -308,7 +306,6 @@ impl Parser<'_> {
             content_idx,
             parse_mode_override,
             child_matches,
-            content_start_len,
             ..
         }) = &mut frame.context
         else {
@@ -453,6 +450,51 @@ impl Parser<'_> {
             // STRICT mode check: All content elements must end at the closing bracket position
             // This check should only happen AFTER all content elements have been processed.
             let check_pos = self.skip_start_index_forward_to_code(self.pos, self.tokens.len());
+
+            // PYTHON PARITY: a *required* content element that failed (empty
+            // match) means the content Sequence never completed. When that
+            // happens *after* earlier content already matched (a genuine
+            // partial match), a STRICT Bracketed must fail (return Empty)
+            // rather than match the closing bracket over the partial content -
+            // even when the failure lands exactly on the closing bracket, so
+            // the gap check below would otherwise fall through to MatchingClose
+            // and fabricate a partial match (e.g. tsql CAST(5), whose
+            // Bracketed(Expression, "AS", Datatype) would otherwise succeed
+            // with just the expression). Python's STRICT Sequence.match returns
+            // no match there.
+            //
+            // Crucially this is gated on content having actually matched
+            // (`last_matched_end > content_start`): a required element failing
+            // with *nothing* consumed is just an empty bracket - `()` - which
+            // is valid (e.g. tsql's `dbo.f()` table hint bracket
+            // Bracketed(TableHintSegment, ...) on empty parens), and Python
+            // accepts it, so we must not fail those.
+            // Content starts at the end of the opening bracket, which is always
+            // the first recorded child match.
+            let content_start = child_matches
+                .first()
+                .map(|m| m.matched_slice.end)
+                .unwrap_or(check_pos);
+            let last_matched_end = child_matches
+                .iter()
+                .map(|m| m.matched_slice.end)
+                .max()
+                .unwrap_or(content_start);
+            if current_required_failed
+                && parse_mode == ParseMode::Strict
+                && last_matched_end > content_start
+            {
+                vdebug!(
+                    "Bracketed[table] STRICT mode: required content element failed after a partial match, returning Empty. frame_id={}, frame.pos={}",
+                    frame.frame_id, frame.pos
+                );
+                self.pos = frame.pos;
+                frame.end_pos = Some(frame.pos);
+                frame.state = FrameState::Combining;
+                stack.push(frame);
+                return Ok(TableFrameResult::Done);
+            }
+
             if let Some(expected_close_pos) = *bracket_max_idx {
                 if check_pos != expected_close_pos {
                     if parse_mode == ParseMode::Strict {
@@ -499,32 +541,55 @@ impl Parser<'_> {
                             // so gate on `current_required_failed` (a REQUIRED empty
                             // match), not merely `child_is_empty`, or an optional
                             // element's failure wrongly produces the specific message.
-                            // `child_matches.len() == *content_start_len` checks
-                            // whether any *content* element (as opposed to the
-                            // opening bracket, which is always in `child_matches`
-                            // by this point) has matched yet.
                             let specific_message = if current_required_failed {
                                 content_ids.get(*content_idx).map(|&gid| {
                                     let element_desc = self.grammar_ctx.grammar_repr(gid);
-                                    let error_token = self
-                                        .tokens
-                                        .get(check_pos)
-                                        .map(|t| format!("{}", t))
-                                        .unwrap_or_else(|| "end of input".to_string());
-                                    if child_matches.len() == *content_start_len {
+                                    // The found-token fallback string differs by
+                                    // branch, exactly as sequence.rs does it: the
+                                    // "to start sequence" branch falls back to
+                                    // "start of input" (nothing consumed yet), the
+                                    // "after X" branch to "end of input".
+                                    let found_token = |fallback: &str| {
+                                        self.tokens
+                                            .get(check_pos)
+                                            .map(|t| format!("{}", t))
+                                            .unwrap_or_else(|| fallback.to_string())
+                                    };
+                                    // PYTHON PARITY: Python's Sequence.match keys
+                                    // "to start sequence" vs "after X" on whether
+                                    // any token was consumed (matched_idx ==
+                                    // start_idx), not on a child *count* - an
+                                    // insert-only match (zero-length Indent/
+                                    // Conditional) bumps the count but not the
+                                    // position. `content_start` is where content
+                                    // began (end of the opening bracket, always
+                                    // the first recorded child match);
+                                    // `last_matched_end` is the furthest content
+                                    // match so far (Python's matched_idx).
+                                    if last_matched_end <= content_start {
                                         format!(
                                             "{} to start sequence. Found {}",
-                                            element_desc, error_token
+                                            element_desc,
+                                            found_token("start of input")
                                         )
                                     } else {
+                                        // The "after X" token is the last
+                                        // *matched* token (Python's
+                                        // segments[matched_idx - 1]), not
+                                        // tokens[check_pos - 1]: check_pos was
+                                        // skipped forward over any gap and would
+                                        // otherwise name the intervening
+                                        // whitespace.
                                         let last_matched_token = self
                                             .tokens
-                                            .get(check_pos.saturating_sub(1))
+                                            .get(last_matched_end.saturating_sub(1))
                                             .map(|t| format!("{}", t))
                                             .unwrap_or_else(|| "start of input".to_string());
                                         format!(
                                             "{} after {}. Found {}",
-                                            element_desc, last_matched_token, error_token
+                                            element_desc,
+                                            last_matched_token,
+                                            found_token("end of input")
                                         )
                                     }
                                 })
@@ -743,7 +808,6 @@ fn initialize_bracketed_frame(
         content_idx: 0,
         parse_mode_override: None, // Will be set when creating content frames
         child_matches: Vec::new(),
-        content_start_len: 0, // Set once the opening bracket is recorded
     });
     frame.table_terminators = SmallVec::from_slice(all_terminators);
     stack.push(frame);

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/bracketed.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/bracketed.rs
@@ -349,18 +349,11 @@ impl Parser<'_> {
                 self.tokens.len()
             );
 
-        // PYTHON PARITY: only an *optional* content element is allowed to fail
-        // and have the loop carry on to the next one unaffected (Python's
-        // Sequence.match: `if elem.is_optional(): continue`). A *required*
-        // element failing (empty match) must stop the content sequence right
-        // here, exactly like Python returns immediately from that failed
-        // element - not march on and let a later element match at the same,
-        // still-unclaimed position (e.g. tsql's Bracketed(Expression, "AS",
-        // Datatype) content: if "AS" is missing, DatatypeSegment must not be
-        // allowed to try matching where "AS" was expected). Falling through
-        // (rather than returning here) lets the closing-bracket gap-check
-        // below turn this into the same "to start sequence"/"after X"
-        // unparsable Python would produce.
+        // Only an optional element may fail and let the loop advance to the
+        // next one; a required element failing must stop advancing here (not
+        // let a later element match at its still-unclaimed position), but we
+        // fall through rather than return so the gap-check below still
+        // produces the right unparsable span.
         let current_required_failed = child_is_empty
             && !self
                 .grammar_ctx
@@ -451,26 +444,13 @@ impl Parser<'_> {
             // This check should only happen AFTER all content elements have been processed.
             let check_pos = self.skip_start_index_forward_to_code(self.pos, self.tokens.len());
 
-            // PYTHON PARITY: a *required* content element that failed (empty
-            // match) means the content Sequence never completed. When that
-            // happens *after* earlier content already matched (a genuine
-            // partial match), a STRICT Bracketed must fail (return Empty)
-            // rather than match the closing bracket over the partial content -
-            // even when the failure lands exactly on the closing bracket, so
-            // the gap check below would otherwise fall through to MatchingClose
-            // and fabricate a partial match (e.g. tsql CAST(5), whose
-            // Bracketed(Expression, "AS", Datatype) would otherwise succeed
-            // with just the expression). Python's STRICT Sequence.match returns
-            // no match there.
-            //
-            // Crucially this is gated on content having actually matched
-            // (`last_matched_end > content_start`): a required element failing
-            // with *nothing* consumed is just an empty bracket - `()` - which
-            // is valid (e.g. tsql's `dbo.f()` table hint bracket
-            // Bracketed(TableHintSegment, ...) on empty parens), and Python
-            // accepts it, so we must not fail those.
-            // Content starts at the end of the opening bracket, which is always
-            // the first recorded child match.
+            // A required element failing after some content already matched
+            // is a genuine partial match: STRICT must fail here rather than
+            // let the gap check below match the closing bracket over it.
+            // Gated on `last_matched_end > content_start` so a required
+            // element failing with nothing consumed - an empty bracket `()` -
+            // still succeeds. Content starts at the end of the opening
+            // bracket, always the first recorded child match.
             let content_start = child_matches
                 .first()
                 .map(|m| m.matched_slice.end)
@@ -523,49 +503,29 @@ impl Parser<'_> {
                         // with matched_class set, so only create the unparsable
                         // child when there's actually code left to wrap.
                         if unparsable_stop > check_pos {
-                            // PYTHON PARITY: this loop marches through every content
-                            // element regardless of success (see the comment above),
-                            // so this gap can mean two different things Python's
-                            // Sequence.match (grammar/sequence.py) tells apart by
-                            // message: either a *required* content element genuinely
-                            // failed to match (in which case Python names the
-                            // expected grammar and found token - "to start
-                            // sequence" if nothing had matched yet, "after X" if
-                            // something had), or every required element matched
-                            // fine and this is real trailing content the grammar
-                            // has nothing left to claim (Python's generic "Nothing
-                            // here." GREEDY-leftover fallback). Crucially, a failed
-                            // *optional* element is NOT a failure Python reports:
-                            // `Sequence.match` does `if elem.is_optional(): continue`
-                            // and falls through to the same "Nothing here." leftover,
-                            // so gate on `current_required_failed` (a REQUIRED empty
-                            // match), not merely `child_is_empty`, or an optional
-                            // element's failure wrongly produces the specific message.
+                            // This gap means one of two things: a required
+                            // element genuinely failed (message names the
+                            // expected grammar and found token), or every
+                            // required element matched and this is just
+                            // trailing content ("Nothing here."). Gate on
+                            // `current_required_failed`, not `child_is_empty`,
+                            // so a failed *optional* element gets the generic
+                            // message, not the specific one.
                             let specific_message = if current_required_failed {
                                 content_ids.get(*content_idx).map(|&gid| {
                                     let element_desc = self.grammar_ctx.grammar_repr(gid);
-                                    // The found-token fallback string differs by
-                                    // branch, exactly as sequence.rs does it: the
-                                    // "to start sequence" branch falls back to
-                                    // "start of input" (nothing consumed yet), the
-                                    // "after X" branch to "end of input".
+                                    // Fallback when check_pos is out of range: "start
+                                    // of input" for the "to start sequence" branch,
+                                    // "end of input" for the "after X" branch.
                                     let found_token = |fallback: &str| {
                                         self.tokens
                                             .get(check_pos)
                                             .map(|t| format!("{}", t))
                                             .unwrap_or_else(|| fallback.to_string())
                                     };
-                                    // PYTHON PARITY: Python's Sequence.match keys
-                                    // "to start sequence" vs "after X" on whether
-                                    // any token was consumed (matched_idx ==
-                                    // start_idx), not on a child *count* - an
-                                    // insert-only match (zero-length Indent/
-                                    // Conditional) bumps the count but not the
-                                    // position. `content_start` is where content
-                                    // began (end of the opening bracket, always
-                                    // the first recorded child match);
-                                    // `last_matched_end` is the furthest content
-                                    // match so far (Python's matched_idx).
+                                    // Branch on whether any position was consumed,
+                                    // not child count: a zero-length insert-only
+                                    // match bumps the count but not the position.
                                     if last_matched_end <= content_start {
                                         format!(
                                             "{} to start sequence. Found {}",
@@ -573,13 +533,10 @@ impl Parser<'_> {
                                             found_token("start of input")
                                         )
                                     } else {
-                                        // The "after X" token is the last
-                                        // *matched* token (Python's
-                                        // segments[matched_idx - 1]), not
-                                        // tokens[check_pos - 1]: check_pos was
-                                        // skipped forward over any gap and would
-                                        // otherwise name the intervening
-                                        // whitespace.
+                                        // Use the last matched token, not
+                                        // tokens[check_pos - 1]: check_pos skipped
+                                        // forward over any gap and would otherwise
+                                        // name the intervening whitespace.
                                         let last_matched_token = self
                                             .tokens
                                             .get(last_matched_end.saturating_sub(1))

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/match_algorithms.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/match_algorithms.rs
@@ -74,12 +74,12 @@ fn try_match_grammar(
 /// `open_idx` is eventually accounted for.
 enum BracketScanResult {
     /// A closer of the wrong type was found. `idx` is its position,
-    /// `actual_close` its raw text, and `expected_open` the type of the
+    /// `actual_close` its raw text, and `expected_open` the raw text of the
     /// innermost still-open bracket it should have closed instead.
     Mismatch {
         idx: usize,
         actual_close: String,
-        expected_open: char,
+        expected_open: String,
     },
     /// Nothing closed it before `tokens.len()`. `idx` is the innermost
     /// still-open bracket at that point, i.e. the one Python's recursive
@@ -104,37 +104,39 @@ enum BracketScanResult {
 /// (`resolve_bracket`, match_algorithms.py): "Couldn't find closing bracket
 /// for opening bracket" (genuinely unclosed) vs. "Found unexpected end
 /// bracket!, was expecting X, but got Y" (closed by the wrong type).
+///
+/// `bracket_pairs` is the dialect's full bracket-pairs set (see
+/// `Dialect::get_bracket_pairs`) so dialect-specific brackets (e.g.
+/// snowflake's MATCH_RECOGNIZE exclude bracket `{-`/`-}`) are recognised
+/// identically to round/square/curly, not just the universal ASCII trio.
 fn find_mismatched_closing_bracket(
     tokens: &[Token],
     from_idx: usize,
     open_idx: usize,
+    bracket_pairs: &[(&str, &str, &str, &str, bool)],
 ) -> BracketScanResult {
     let mut idx = from_idx;
     let mut innermost_idx = open_idx;
-    let mut open_char = tokens[open_idx]
-        .raw()
-        .chars()
-        .next()
-        .expect("bracket raw is non-empty");
+    let mut open_raw = tokens[open_idx].raw().to_string();
     while idx < tokens.len() {
         let raw = tokens[idx].raw();
-        match raw {
-            "(" | "[" | "{" => match tokens[idx].matching_bracket_idx {
+        if bracket_pairs.iter().any(|(open, _, _, _, _)| *open == raw) {
+            match tokens[idx].matching_bracket_idx {
                 Some(matching_idx) => idx = matching_idx + 1,
                 None => {
                     innermost_idx = idx;
-                    open_char = raw.chars().next().expect("bracket raw is non-empty");
+                    open_raw = raw.to_string();
                     idx += 1;
                 }
-            },
-            ")" | "]" | "}" => {
-                return BracketScanResult::Mismatch {
-                    idx,
-                    actual_close: raw.to_string(),
-                    expected_open: open_char,
-                };
             }
-            _ => idx += 1,
+        } else if bracket_pairs.iter().any(|(_, close, _, _, _)| *close == raw) {
+            return BracketScanResult::Mismatch {
+                idx,
+                actual_close: raw.to_string(),
+                expected_open: open_raw,
+            };
+        } else {
+            idx += 1;
         }
     }
     BracketScanResult::Unclosed { idx: innermost_idx }
@@ -199,6 +201,7 @@ impl Parser<'_> {
     ) -> Result<(usize, usize), ParseError> {
         let tokens = self.tokens;
         let tokens_len = tokens.len();
+        let bracket_pairs: &[(&str, &str, &str, &str, bool)] = self.dialect.get_bracket_pairs();
 
         if start_idx >= tokens_len {
             return Ok((tokens_len, tokens_len));
@@ -233,7 +236,7 @@ impl Parser<'_> {
         while i < max_idx {
             let token = &tokens[i];
             let raw = token.raw();
-            if raw == "(" || raw == "[" || raw == "{" {
+            if bracket_pairs.iter().any(|(open, _, _, _, _)| *open == raw) {
                 if let Some(matching_idx) = token.matching_bracket_idx {
                     vdebug!(
                         "[GREEDY_MATCH_TABLE] greedy_match: skipping bracket at {} to {}",
@@ -249,18 +252,23 @@ impl Parser<'_> {
                     // message for the true unclosed-to-EOF case. Either way,
                     // blame the innermost still-open bracket, matching
                     // resolve_bracket's own recursive call.
-                    match find_mismatched_closing_bracket(tokens, i + 1, i) {
+                    match find_mismatched_closing_bracket(tokens, i + 1, i, bracket_pairs) {
                         BracketScanResult::Mismatch {
                             idx: mismatch_idx,
                             actual_close,
                             expected_open,
                         } => {
-                            let expected_close = match expected_open {
-                                '(' => ")",
-                                '[' => "]",
-                                '{' => "}",
-                                _ => unreachable!("expected_open is always a bracket character"),
-                            };
+                            // `expected_open` is always the raw of a token that
+                            // matched a registered opener in
+                            // find_mismatched_closing_bracket, so this lookup
+                            // cannot miss; fall back to the opener text rather
+                            // than panicking (AGENTS.md: no `.expect()` in
+                            // production) if that invariant ever changes.
+                            let expected_close = bracket_pairs
+                                .iter()
+                                .find(|(open, _, _, _, _)| *open == expected_open)
+                                .map(|(_, close, _, _, _)| *close)
+                                .unwrap_or(expected_open.as_str());
                             vdebug!(
                                 "[GREEDY_MATCH_TABLE] greedy_match: mismatched closing bracket '{}' at {} for opening bracket at {} (expected '{}')",
                                 actual_close, mismatch_idx, i, expected_close
@@ -297,7 +305,7 @@ impl Parser<'_> {
             // bracket! Return no match": abort the terminator search and
             // claim everything through max_idx, rather than scan past the
             // stray bracket to a later terminator like `FROM` or `UNION`.
-            if raw == ")" || raw == "]" || raw == "}" {
+            if bracket_pairs.iter().any(|(_, close, _, _, _)| *close == raw) {
                 vdebug!(
                     "[GREEDY_MATCH_TABLE] greedy_match: unexpected closing bracket at {} — aborting terminator search, claiming through {}",
                     i, max_idx

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/match_algorithms.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/match_algorithms.rs
@@ -257,12 +257,9 @@ impl Parser<'_> {
                             actual_close,
                             expected_open,
                         } => {
-                            // `expected_open` is always the raw of a token that
-                            // matched a registered opener in
-                            // find_mismatched_closing_bracket, so this lookup
-                            // cannot miss; fall back to the opener text rather
-                            // than panicking (AGENTS.md: no `.expect()` in
-                            // production) if that invariant ever changes.
+                            // Lookup can't miss (expected_open is always a
+                            // registered opener), but fall back to the opener
+                            // text rather than panicking.
                             let expected_close = bracket_pairs
                                 .find_by_open(&expected_open)
                                 .map(|p| p.close)

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/match_algorithms.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/match_algorithms.rs
@@ -129,7 +129,10 @@ fn find_mismatched_closing_bracket(
                     idx += 1;
                 }
             }
-        } else if bracket_pairs.iter().any(|(_, close, _, _, _)| *close == raw) {
+        } else if bracket_pairs
+            .iter()
+            .any(|(_, close, _, _, _)| *close == raw)
+        {
             return BracketScanResult::Mismatch {
                 idx,
                 actual_close: raw.to_string(),
@@ -305,7 +308,10 @@ impl Parser<'_> {
             // bracket! Return no match": abort the terminator search and
             // claim everything through max_idx, rather than scan past the
             // stray bracket to a later terminator like `FROM` or `UNION`.
-            if bracket_pairs.iter().any(|(_, close, _, _, _)| *close == raw) {
+            if bracket_pairs
+                .iter()
+                .any(|(_, close, _, _, _)| *close == raw)
+            {
                 vdebug!(
                     "[GREEDY_MATCH_TABLE] greedy_match: unexpected closing bracket at {} — aborting terminator search, claiming through {}",
                     i, max_idx

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/match_algorithms.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/match_algorithms.rs
@@ -1,4 +1,4 @@
-use sqlfluffrs_types::{GrammarId, GrammarVariant, Token};
+use sqlfluffrs_types::{BracketPairSet, GrammarId, GrammarVariant, Token};
 
 use crate::parser::{ParseError, Parser};
 
@@ -106,21 +106,20 @@ enum BracketScanResult {
 /// bracket!, was expecting X, but got Y" (closed by the wrong type).
 ///
 /// `bracket_pairs` is the dialect's full bracket-pairs set (see
-/// `Dialect::get_bracket_pairs`) so dialect-specific brackets (e.g.
-/// snowflake's MATCH_RECOGNIZE exclude bracket `{-`/`-}`) are recognised
+/// `Dialect::get_bracket_pairs`), so dialect-specific brackets are recognised
 /// identically to round/square/curly, not just the universal ASCII trio.
 fn find_mismatched_closing_bracket(
     tokens: &[Token],
     from_idx: usize,
     open_idx: usize,
-    bracket_pairs: &[(&str, &str, &str, &str, bool)],
+    bracket_pairs: &BracketPairSet,
 ) -> BracketScanResult {
     let mut idx = from_idx;
     let mut innermost_idx = open_idx;
     let mut open_raw = tokens[open_idx].raw().to_string();
     while idx < tokens.len() {
         let raw = tokens[idx].raw();
-        if bracket_pairs.iter().any(|(open, _, _, _, _)| *open == raw) {
+        if bracket_pairs.is_open(raw) {
             match tokens[idx].matching_bracket_idx {
                 Some(matching_idx) => idx = matching_idx + 1,
                 None => {
@@ -129,10 +128,7 @@ fn find_mismatched_closing_bracket(
                     idx += 1;
                 }
             }
-        } else if bracket_pairs
-            .iter()
-            .any(|(_, close, _, _, _)| *close == raw)
-        {
+        } else if bracket_pairs.is_close(raw) {
             return BracketScanResult::Mismatch {
                 idx,
                 actual_close: raw.to_string(),
@@ -204,7 +200,7 @@ impl Parser<'_> {
     ) -> Result<(usize, usize), ParseError> {
         let tokens = self.tokens;
         let tokens_len = tokens.len();
-        let bracket_pairs: &[(&str, &str, &str, &str, bool)] = self.dialect.get_bracket_pairs();
+        let bracket_pairs = self.dialect.get_bracket_pairs();
 
         if start_idx >= tokens_len {
             return Ok((tokens_len, tokens_len));
@@ -239,7 +235,7 @@ impl Parser<'_> {
         while i < max_idx {
             let token = &tokens[i];
             let raw = token.raw();
-            if bracket_pairs.iter().any(|(open, _, _, _, _)| *open == raw) {
+            if bracket_pairs.is_open(raw) {
                 if let Some(matching_idx) = token.matching_bracket_idx {
                     vdebug!(
                         "[GREEDY_MATCH_TABLE] greedy_match: skipping bracket at {} to {}",
@@ -268,9 +264,8 @@ impl Parser<'_> {
                             // than panicking (AGENTS.md: no `.expect()` in
                             // production) if that invariant ever changes.
                             let expected_close = bracket_pairs
-                                .iter()
-                                .find(|(open, _, _, _, _)| *open == expected_open)
-                                .map(|(_, close, _, _, _)| *close)
+                                .find_by_open(&expected_open)
+                                .map(|p| p.close)
                                 .unwrap_or(expected_open.as_str());
                             vdebug!(
                                 "[GREEDY_MATCH_TABLE] greedy_match: mismatched closing bracket '{}' at {} for opening bracket at {} (expected '{}')",
@@ -308,10 +303,7 @@ impl Parser<'_> {
             // bracket! Return no match": abort the terminator search and
             // claim everything through max_idx, rather than scan past the
             // stray bracket to a later terminator like `FROM` or `UNION`.
-            if bracket_pairs
-                .iter()
-                .any(|(_, close, _, _, _)| *close == raw)
-            {
+            if bracket_pairs.is_close(raw) {
                 vdebug!(
                     "[GREEDY_MATCH_TABLE] greedy_match: unexpected closing bracket at {} — aborting terminator search, claiming through {}",
                     i, max_idx

--- a/sqlfluffrs/sqlfluffrs_types/src/lib.rs
+++ b/sqlfluffrs/sqlfluffrs_types/src/lib.rs
@@ -18,7 +18,7 @@ pub use grammar_tables::{
     ChildrenIter, GrammarInstExt, GrammarTables, SimpleHintData, TableMemoryStats, TerminatorsIter,
 };
 pub use marker::PositionMarker;
-pub use matcher::{BracketPairEntry, LexMatcher, LexMatcherConfig};
+pub use matcher::{BracketPairEntry, BracketPairSet, LexMatcher, LexMatcherConfig};
 pub use parser::{ParseMode, RootGrammar, SimpleHint};
 pub use regex::{RegexMode, RegexModeGroup};
 pub use slice::Slice;

--- a/sqlfluffrs/sqlfluffrs_types/src/lib.rs
+++ b/sqlfluffrs/sqlfluffrs_types/src/lib.rs
@@ -18,7 +18,7 @@ pub use grammar_tables::{
     ChildrenIter, GrammarInstExt, GrammarTables, SimpleHintData, TableMemoryStats, TerminatorsIter,
 };
 pub use marker::PositionMarker;
-pub use matcher::{LexMatcher, LexMatcherConfig};
+pub use matcher::{BracketPairEntry, LexMatcher, LexMatcherConfig};
 pub use parser::{ParseMode, RootGrammar, SimpleHint};
 pub use regex::{RegexMode, RegexModeGroup};
 pub use slice::Slice;

--- a/sqlfluffrs/sqlfluffrs_types/src/matcher.rs
+++ b/sqlfluffrs/sqlfluffrs_types/src/matcher.rs
@@ -12,6 +12,11 @@ use crate::{token::CaseFold, PositionMarker, RegexModeGroup, Token, TokenConfig}
 /// Function pointer type for token generation: one of `Token::{kind}_token`.
 pub type TokenGenerator = fn(String, PositionMarker, TokenConfig) -> Token;
 
+/// A single bracket pair: (open raw text, close raw text, start-bracket
+/// segment type, end-bracket segment type, persists). See
+/// `utils/build_lexers.py::generate_bracket_pairs` for how these are derived.
+pub type BracketPairEntry = (&'static str, &'static str, &'static str, &'static str, bool);
+
 #[derive(Debug, Clone)]
 pub enum LexerMode {
     String(String),                           // Match a literal string

--- a/sqlfluffrs/sqlfluffrs_types/src/matcher.rs
+++ b/sqlfluffrs/sqlfluffrs_types/src/matcher.rs
@@ -12,10 +12,83 @@ use crate::{token::CaseFold, PositionMarker, RegexModeGroup, Token, TokenConfig}
 /// Function pointer type for token generation: one of `Token::{kind}_token`.
 pub type TokenGenerator = fn(String, PositionMarker, TokenConfig) -> Token;
 
-/// A single bracket pair: (open raw text, close raw text, start-bracket
-/// segment type, end-bracket segment type, persists). See
+/// A single bracket pair recognised by a dialect. See
 /// `utils/build_lexers.py::generate_bracket_pairs` for how these are derived.
-pub type BracketPairEntry = (&'static str, &'static str, &'static str, &'static str, bool);
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BracketPairEntry {
+    pub open: &'static str,
+    pub close: &'static str,
+    pub start_type: &'static str,
+    pub end_type: &'static str,
+    pub persists: bool,
+}
+
+/// A dialect's full set of recognised bracket pairs (round/square/curly plus
+/// any dialect-specific additions, e.g. snowflake's exclude `{-`/`-}`).
+#[derive(Debug, Clone, Default)]
+pub struct BracketPairSet(pub Vec<BracketPairEntry>);
+
+impl BracketPairSet {
+    pub fn find_by_open(&self, raw: &str) -> Option<&BracketPairEntry> {
+        self.0.iter().find(|p| p.open == raw)
+    }
+
+    pub fn is_open(&self, raw: &str) -> bool {
+        self.0.iter().any(|p| p.open == raw)
+    }
+
+    pub fn is_close(&self, raw: &str) -> bool {
+        self.0.iter().any(|p| p.close == raw)
+    }
+
+    pub fn position_by_open(&self, raw: &str) -> Option<usize> {
+        self.0.iter().position(|p| p.open == raw)
+    }
+
+    pub fn position_by_close(&self, raw: &str) -> Option<usize> {
+        self.0.iter().position(|p| p.close == raw)
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = &BracketPairEntry> {
+        self.0.iter()
+    }
+
+    /// Pre-compute `matching_bracket_idx` for every bracket token via LIFO
+    /// nesting order (Python parity: `resolve_bracket`, match_algorithms.py).
+    /// Only code tokens are considered, so bracket characters inside a
+    /// comment can't pair with real brackets in the SQL.
+    pub fn compute_matching_indices(&self, tokens: &mut [Token]) {
+        let mut bracket_stack: Vec<(usize, usize)> = Vec::new();
+
+        for idx in 0..tokens.len() {
+            if !tokens[idx].is_code() {
+                continue;
+            }
+
+            let raw = tokens[idx].raw();
+
+            if let Some(pair_idx) = self.position_by_open(raw) {
+                bracket_stack.push((idx, pair_idx));
+            } else if let Some(expected_idx) = self.position_by_close(raw) {
+                // Only the most-recently-opened bracket may be closed next
+                // (LIFO), matching `resolve_bracket`'s own recursion.
+                if let Some(&(open_idx, top_idx)) = bracket_stack.last() {
+                    if top_idx == expected_idx {
+                        bracket_stack.pop();
+                        tokens[open_idx].matching_bracket_idx = Some(idx);
+                        tokens[idx].matching_bracket_idx = Some(open_idx);
+                    } else {
+                        // Type mismatch: unwind the whole stack, as Python's
+                        // resolve_bracket does when it raises.
+                        bracket_stack.clear();
+                    }
+                }
+                // Empty stack: a stray closer with no open bracket - leave as None.
+            }
+        }
+        // Any remaining openers on the stack are unmatched - leave as None.
+    }
+}
 
 #[derive(Debug, Clone)]
 pub enum LexerMode {

--- a/sqlfluffrs/sqlfluffrs_types/src/matcher.rs
+++ b/sqlfluffrs/sqlfluffrs_types/src/matcher.rs
@@ -61,6 +61,8 @@ impl BracketPairSet {
         let mut bracket_stack: Vec<(usize, usize)> = Vec::new();
 
         for idx in 0..tokens.len() {
+            tokens[idx].matching_bracket_idx = None;
+
             if !tokens[idx].is_code() {
                 continue;
             }

--- a/sqlfluffrs/src/test_harness.rs
+++ b/sqlfluffrs/src/test_harness.rs
@@ -80,7 +80,8 @@ impl FixtureTest {
         let dialect = Dialect::from_str(self.dialect.as_str()).expect("Invalid dialect");
 
         let input = LexInput::String(sql_content.clone());
-        let lexer = Lexer::new(None, Dialect::get_lexers(&dialect).clone());
+        let lexer = Lexer::new(None, Dialect::get_lexers(&dialect).clone())
+            .with_bracket_pairs(Dialect::get_bracket_pairs(&dialect).clone());
         let (tokens, lex_errors) = lexer.lex(input, false);
 
         if !lex_errors.is_empty() {
@@ -216,6 +217,37 @@ mod tests {
     use super::*;
 
     #[test]
+    fn dialect_specific_brackets_pair_only_when_supplied() {
+        // Snowflake's MATCH_RECOGNIZE exclude brackets `{-`/`-}` are a
+        // dialect-specific pair absent from the lexer's ASCII-trio default. A
+        // lexer built for a dialect must therefore be given that dialect's
+        // bracket set (as the pyo3 PyLexer ctor does); otherwise `{-`/`-}` are
+        // lexed as ordinary tokens and never paired, and the parser then treats
+        // them as unbalanced.
+        let dialect = Dialect::Snowflake;
+        let sql = "PATTERN ({- A -} B)";
+        let find = |tokens: &[sqlfluffrs_types::Token], raw: &str| {
+            tokens
+                .iter()
+                .position(|t| t.raw() == raw)
+                .unwrap_or_else(|| panic!("no {raw:?} token"))
+        };
+
+        // With the dialect's bracket pairs, `{-` and `-}` pair up.
+        let lexer = Lexer::new(None, Dialect::get_lexers(&dialect).clone())
+            .with_bracket_pairs(Dialect::get_bracket_pairs(&dialect).clone());
+        let (tokens, _) = lexer.lex(LexInput::String(sql.to_string()), false);
+        let (open, close) = (find(&tokens, "{-"), find(&tokens, "-}"));
+        assert_eq!(tokens[open].matching_bracket_idx, Some(close));
+        assert_eq!(tokens[close].matching_bracket_idx, Some(open));
+
+        // With the ASCII-only default the exclude brackets stay unpaired.
+        let default_lexer = Lexer::new(None, Dialect::get_lexers(&dialect).clone());
+        let (tokens, _) = default_lexer.lex(LexInput::String(sql.to_string()), false);
+        assert_eq!(tokens[find(&tokens, "{-")].matching_bracket_idx, None);
+    }
+
+    #[test]
     fn test_discover_ansi_fixtures() {
         let fixtures_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
             .parent()
@@ -271,7 +303,8 @@ mod tests {
         let sql = "SELECT 1";
         let input = LexInput::String(sql.to_string());
         let dialect = Dialect::Ansi;
-        let lexer = Lexer::new(None, Dialect::get_lexers(&dialect).clone());
+        let lexer = Lexer::new(None, Dialect::get_lexers(&dialect).clone())
+            .with_bracket_pairs(Dialect::get_bracket_pairs(&dialect).clone());
         let (tokens, _errors) = lexer.lex(input, false);
 
         let mut parser = Parser::new(&tokens, dialect, hashbrown::HashMap::new());
@@ -290,7 +323,8 @@ mod tests {
         let sql = "SELECT a, b, c FROM table1 WHERE a = 1 AND b = 2 ORDER BY c";
         let input = LexInput::String(sql.to_string());
         let dialect = Dialect::Ansi;
-        let lexer = Lexer::new(None, Dialect::get_lexers(&dialect).clone());
+        let lexer = Lexer::new(None, Dialect::get_lexers(&dialect).clone())
+            .with_bracket_pairs(Dialect::get_bracket_pairs(&dialect).clone());
         let (tokens, _errors) = lexer.lex(input, false);
 
         let mut parser = Parser::new(&tokens, dialect, hashbrown::HashMap::new());
@@ -315,7 +349,8 @@ mod whitespace_tests {
         let sql = "SELECT x FROM foo AS t";
         let input = LexInput::String(sql.to_string());
         let dialect = Dialect::Ansi;
-        let lexer = Lexer::new(None, Dialect::get_lexers(&dialect).clone());
+        let lexer = Lexer::new(None, Dialect::get_lexers(&dialect).clone())
+            .with_bracket_pairs(Dialect::get_bracket_pairs(&dialect).clone());
         let (tokens, _errors) = lexer.lex(input, false);
 
         println!("\n=== TOKENS ===");
@@ -349,7 +384,8 @@ mod whitespace_tests {
         let sql = "SELECT a (x) AS y";
         let input = LexInput::String(sql.to_string());
         let dialect = Dialect::Ansi;
-        let lexer = Lexer::new(None, Dialect::get_lexers(&dialect).clone());
+        let lexer = Lexer::new(None, Dialect::get_lexers(&dialect).clone())
+            .with_bracket_pairs(Dialect::get_bracket_pairs(&dialect).clone());
         let (tokens, _errors) = lexer.lex(input, false);
 
         println!("\n=== TOKENS ===");

--- a/sqlfluffrs/src/test_harness.rs
+++ b/sqlfluffrs/src/test_harness.rs
@@ -218,12 +218,9 @@ mod tests {
 
     #[test]
     fn dialect_specific_brackets_pair_only_when_supplied() {
-        // Snowflake's MATCH_RECOGNIZE exclude brackets `{-`/`-}` are a
-        // dialect-specific pair absent from the lexer's ASCII-trio default. A
-        // lexer built for a dialect must therefore be given that dialect's
-        // bracket set (as the pyo3 PyLexer ctor does); otherwise `{-`/`-}` are
-        // lexed as ordinary tokens and never paired, and the parser then treats
-        // them as unbalanced.
+        // Snowflake's `{-`/`-}` brackets are absent from the lexer's default
+        // set, so a dialect's own bracket set must be supplied or they're
+        // lexed as ordinary tokens and never paired.
         let dialect = Dialect::Snowflake;
         let sql = "PATTERN ({- A -} B)";
         let find = |tokens: &[sqlfluffrs_types::Token], raw: &str| {

--- a/test/core/parser/rust_parser_test.py
+++ b/test/core/parser/rust_parser_test.py
@@ -678,32 +678,18 @@ def test__rust_parser__vs_python_stray_closing_bracket_terminator():
 
 
 @pytest.mark.skipif(not _HAS_RUST_PARSER, reason="Rust parser not available")
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "Known gap: greedy_match's stray-closing-bracket check "
-        "(sqlfluffrs_parser/src/parser/table_driven/match_algorithms.rs) "
-        "recognises brackets by a hardcoded raw-text match on '(', '[', "
-        "'{' and ')', ']', '}'. Python's equivalent, next_ex_bracket_match "
-        "(src/sqlfluff/core/parser/match_algorithms.py:469-529), instead "
-        "looks up the active dialect's bracket_pairs set, so it also "
-        "recognises dialect-specific bracket tokens such as Snowflake's "
-        "MATCH_RECOGNIZE exclude brackets '{-'/'-}' "
-        "(dialect_snowflake.py:128-130). On a stray '-}', Python aborts the "
-        "terminator search and claims the rest as unparsable, while Rust's "
-        "hardcoded check doesn't recognise '-}' as a bracket at all and "
-        "keeps scanning, finding the following FROM as a normal terminator. "
-        "Fixing it means threading the dialect's bracket set through "
-        "greedy_match instead of hardcoding ASCII brackets."
-    ),
-)
 def test__rust_parser__vs_python_stray_closing_bracket_hardcoded_set():
-    """RustParser's greedy_match only recognises a hardcoded ASCII bracket set.
+    """greedy_match recognises a dialect's full bracket_pairs set, not just ASCII.
 
     Snowflake's MATCH_RECOGNIZE exclude brackets ('{-'/'-}') are part of the
-    dialect's bracket_pairs set, so Python treats a stray '-}' the same way
-    as a stray ')'. RustParser's hardcoded check doesn't recognise '-}' as a
-    bracket, so it keeps scanning past it instead of aborting.
+    dialect's bracket_pairs set, so Python treats a stray '-}' the same way as
+    a stray ')'. greedy_match now threads the active dialect's bracket set
+    (Dialect::get_bracket_pairs) through its stray-closing-bracket check
+    instead of hardcoding '(', '[', '{' / ')', ']', '}', so RustParser aborts
+    the terminator search on a stray '-}' exactly like Python's
+    next_ex_bracket_match rather than scanning past it to the following FROM.
+    (The equivalent SQL is also pinned in
+    test/fixtures/parity/regressions.yml::stray_closing_bracket_dialect_bracket_set.)
     """
     rust_result, python_result = _compare_parser_vs_rust(
         "SELECT 1 -} FROM t", dialect="snowflake"

--- a/test/fixtures/parity/regressions.yml
+++ b/test/fixtures/parity/regressions.yml
@@ -32,18 +32,17 @@ bracketed_required_content_fails_at_close_bracket:
   sql: select CAST(5);
   dialect: tsql
   expect: tree
-  xfail:
-    python_vs_rust: "A STRICT Bracketed whose required content element fails
-      exactly at the closing bracket (no trailing gap) still succeeds on the
-      Rust side with partial content. CastFunctionContents is
-      Bracketed(Expression, \"AS\", Datatype): on CAST(5) Expression matches
-      '5', the required \"AS\" fails at ')', and bracketed.rs - because check_pos
-      equals the closing-bracket position - skips the content-failure handling
-      and matches the close bracket anyway, fabricating a function node with
-      just the expression. Python's STRICT Sequence rejects the CAST and falls
-      back to a column_reference with the rest unparsable."
-  pins: tsql CAST(5)-without-AS partial-match-at-close-bracket gap in
-    bracketed.rs's STRICT required-content handling.
+  pins: A STRICT Bracketed must fail (return empty) when a required content
+    element fails *after earlier content already matched* - a genuine partial
+    match - even when that failure lands exactly on the closing bracket, rather
+    than matching the close bracket over the partial content. CastFunctionContents
+    is Bracketed(Expression, "AS", Datatype); on CAST(5) Expression matches '5',
+    the required "AS" fails at ')', and Rust used to fabricate a function node
+    with just the expression where Python rejects the CAST and falls back to a
+    column_reference with the rest unparsable. The fix is gated on content having
+    actually matched (last_matched_end > content_start) so a required element
+    failing with nothing consumed - a valid empty bracket `()`, e.g. a tsql table
+    hint bracket on empty parens - is left untouched.
 bracketed_optional_content_failure_nothing_here:
   sql: SELECT SUM(a) OVER (1 2 3) FROM t
   expect: tree

--- a/test/fixtures/parity/regressions.yml
+++ b/test/fixtures/parity/regressions.yml
@@ -5,35 +5,21 @@ anything_dialect_exclude_bracket:
   sql: CREATE TABLE t (c VARCHAR({- 1 -}) AS y)
   dialect: snowflake
   expect: tree
-  xfail:
-    python_vs_rust: "The Anything-grammar bracket path (core.rs
-      match_bracket_recursively, reached here via snowflake's
-      Bracketed(Anything()) column-datatype params) recognises the dialect's
-      exclude bracket '{-'/'-}' as a bracket pair, but two things differ from
-      Python's resolve_bracket: the leaf segments are typed
-      exclude_bracket_open/exclude_bracket_close where Python types them
-      start_exclude_bracket/end_exclude_bracket, and Rust does not wrap the
-      pair in its own nested `bracketed` node with indent/dedent metas - it
-      emits the two bracket tokens and their content as flat siblings of the
-      outer bracket instead."
   pins: Dialect-specific bracket (snowflake's exclude bracket '{-'/'-}')
     reached via the Anything-grammar bracket path (core.rs
-    match_bracket_recursively) - leaf typing and nested-node wrapping gap;
-    see anything_dialect_exclude_bracket_unclosed for the crossed/unclosed
+    match_bracket_recursively) - was a leaf typing and nested-node wrapping
+    gap, fixed alongside the dialect bracket-pairs work; see
+    anything_dialect_exclude_bracket_unclosed for the crossed/unclosed
     variant of the same path.
 anything_dialect_exclude_bracket_unclosed:
   sql: CREATE TABLE t (c NUMBER({- x) AS y)
   dialect: snowflake
-  xfail:
-    python_vs_rust: "For this crossed/unclosed dialect exclude bracket, Python's
-      resolve_bracket raises SQLParseError (\"Found unexpected end bracket!,
-      was expecting <StringParser: '-}'>, but got <StringParser: ')'>\"), but
-      core.rs's match_bracket_recursively does not detect the crossed
-      bracket and returns a fabricated tree instead."
+  expect: error
   pins: Crossed/unclosed variant of anything_dialect_exclude_bracket - Rust
-    does not raise where Python does. Unlike anything_crossed_ascii_bracket_raises,
-    this is scoped to snowflake's dialect-specific '{-'/'-}' exclude bracket, not
-    a universal ASCII closer, so it is not covered by the crossed-ASCII-closer fix.
+    now raises like Python does, fixed alongside the crossed-bracket
+    detection work. Unlike anything_crossed_ascii_bracket_raises, this is
+    scoped to snowflake's dialect-specific '{-'/'-}' exclude bracket, not a
+    universal ASCII closer.
 anything_crossed_ascii_bracket_raises:
   sql: CREATE TABLE t (col VARCHAR(x ( y ] z )))
   expect: error
@@ -113,13 +99,18 @@ partial_match_failure_keeps_children:
 stray_closing_bracket_dialect_bracket_set:
   sql: SELECT 1 -} FROM t
   dialect: snowflake
-  xfail:
-    python_vs_rust: 'Rust''s unparsable-recovery region for the unmatched dialect-specific
-      closing bracket (snowflake''s exclude-bracket ''-}'') does not stop at the bracket:
-      it keeps consuming subsequent tokens (FROM, the table reference) as raw words inside
-      the same unparsable segment, where Python recovers immediately after the stray bracket
-      and parses the FROM clause normally.'
-  pins: Dialect-specific stray closing bracket (snowflake '-}') recovery never closes.
+  expect: tree
+  pins: 'Rust''s bracket-matching (the lexer''s matching_bracket_idx pre-computation
+    in sqlfluffrs_lexer and sqlfluffrs_parser/python.rs, plus greedy_match''s
+    stray-closing-bracket abort in match_algorithms.rs) only recognised the
+    universal round/square/curly brackets by hardcoded ASCII text, so it missed
+    dialect-specific entries in a dialect''s bracket_pairs set - here snowflake''s
+    MATCH_RECOGNIZE exclude bracket ''{-''/''-}'' - and kept scanning past the stray
+    ''-}'' instead of aborting the terminator search there like Python''s
+    next_ex_bracket_match/resolve_bracket do. Fixed by generating each dialect''s
+    full bracket_pairs set (Dialect::get_bracket_pairs, from utils/build_lexers.py)
+    and threading it through both the lexer''s bracket pre-computation and
+    greedy_match''s bracket checks, instead of a hardcoded three-pair list.'
 int_typed_indentation_config:
   sql: SELECT a FROM t JOIN u USING (a)
   configs:

--- a/test/fixtures/parity/regressions.yml
+++ b/test/fixtures/parity/regressions.yml
@@ -19,9 +19,8 @@ anything_dialect_exclude_bracket:
   pins: Dialect-specific bracket (snowflake's exclude bracket '{-'/'-}')
     reached via the Anything-grammar bracket path (core.rs
     match_bracket_recursively) - leaf typing and nested-node wrapping gap;
-    see anything_dialect_exclude_bracket_unclosed and
-    anything_crossed_ascii_bracket_raises for the crossed/unclosed variants of
-    the same path.
+    see anything_dialect_exclude_bracket_unclosed for the crossed/unclosed
+    variant of the same path.
 anything_dialect_exclude_bracket_unclosed:
   sql: CREATE TABLE t (c NUMBER({- x) AS y)
   dialect: snowflake
@@ -32,18 +31,17 @@ anything_dialect_exclude_bracket_unclosed:
       core.rs's match_bracket_recursively does not detect the crossed
       bracket and returns a fabricated tree instead."
   pins: Crossed/unclosed variant of anything_dialect_exclude_bracket - Rust
-    does not raise where Python does.
+    does not raise where Python does. Unlike anything_crossed_ascii_bracket_raises,
+    this is scoped to snowflake's dialect-specific '{-'/'-}' exclude bracket, not
+    a universal ASCII closer, so it is not covered by the crossed-ASCII-closer fix.
 anything_crossed_ascii_bracket_raises:
   sql: CREATE TABLE t (col VARCHAR(x ( y ] z )))
   expect: error
-  xfail:
-    python_vs_rust: "Python's resolve_bracket raises SQLParseError (\"Found
-      unexpected end bracket!, was expecting <StringParser: ')'>, but got
-      <StringParser: ']'>\") for a wrong-type ASCII closing bracket crossed
-      inside an Anything() region, but core.rs's match_bracket_recursively
-      does not raise on the crossed bracket and returns a tree instead."
-  pins: ASCII-bracket variant of the same crossed-bracket detection gap as
-    anything_dialect_exclude_bracket_unclosed.
+  pins: "ASCII-bracket variant of the crossed-bracket detection gap fixed alongside
+    materialize_curly_cross_silent_recovery - core.rs's match_bracket_recursively
+    now raises on any wrong-type ASCII closing bracket crossed inside an Anything()
+    region, matching Python's resolve_bracket SQLParseError (\"Found unexpected end
+    bracket!, was expecting <StringParser: ')'>, but got <StringParser: ']'>\")."
 bracketed_required_content_fails_at_close_bracket:
   sql: select CAST(5);
   dialect: tsql
@@ -171,12 +169,14 @@ sqlite_nothing_here_expected_message:
 materialize_curly_cross_silent_recovery:
   sql: COPY t FROM STDIN (FORMAT {-
   dialect: materialize
-  xfail:
-    python_vs_rust: For an unclosed regular bracket followed by an unclosed curly bracket
-      (materialize's COPY ... (FORMAT {- ), Python raises SQLParseError (couldn't find closing
-      bracket for opening bracket), while Rust silently recovers, producing a full tree with
-      the stray '(' and '{' folded into a trailing unparsable segment instead of raising.
-  pins: Crossed bracket-type recovery for materialize COPY ... FORMAT { syntax.
+  expect: error
+  pins: The Rust Anything() grammar (core.rs match_bracket_recursively, used for the
+    COPY ... options content) reached end-of-input inside an unresolved nested bracket
+    of a different type (materialize's COPY FORMAT '{' crossed with the outer, also
+    unclosed, '(') and silently treated wherever it stopped as the closing bracket,
+    instead of raising like Python's resolve_bracket does whenever a bracket it opened
+    is never closed - fixed by making match_bracket_recursively return an error in that
+    case instead of a fabricated match.
 tsql_cast_structure:
   sql: select CAST(0X0 uniqueidentifier);
   dialect: tsql
@@ -195,14 +195,13 @@ materialize_webhook_overlapping_matches:
   sql: "(\n ) ( );\nCREATE SOURCE my_webhook_source IN CLUSTER my_cluster FROM WEBHOOK\n BODY\
     \ FORMAT JSON\n (\n (\n my_webhook_share"
   dialect: materialize
-  xfail:
-    python_vs_rust: 'On this heavily cross-bracketed materialize webhook fragment, Python
-      raises a clean SQLParseError (couldn''t find closing bracket for opening bracket, at
-      line 6, position 2), while Rust raises an internal ValueError (segment skip ahead error:
-      an outer match contains overlapping child matches, this MatchResult was wrongly constructed),
-      indicating a genuine invariant violation in the Rust matcher rather than a parse error.'
-  pins: Rust match-invariant crash on deeply crossed/nested unmatched brackets (materialize
-    webhook fixture).
+  expect: error
+  pins: 'Same root cause as materialize_curly_cross_silent_recovery - core.rs''s
+    match_bracket_recursively silently fabricated a close for deeply crossed/unmatched
+    brackets instead of raising, and downstream the resulting malformed match ended up
+    with overlapping child matches, tripping the Python-side builder''s invariant check
+    (ValueError). Fixed by the same change: an unresolved bracket now raises immediately
+    instead of ever reaching the builder.'
 depth_guard_error_position:
   sql: SELECT CASE WHEN 1 THEN CASE WHEN 1 THEN CASE WHEN 1 THEN CASE WHEN 1 THEN CASE WHEN
     1 THEN CASE WHEN 1 THEN CASE WHEN 1 THEN CASE WHEN 1 THEN CASE WHEN 1 THEN CASE WHEN 1

--- a/test/fixtures/parity/regressions.yml
+++ b/test/fixtures/parity/regressions.yml
@@ -63,11 +63,9 @@ bracketed_required_content_fails_at_close_bracket:
 bracketed_optional_content_failure_nothing_here:
   sql: SELECT SUM(a) OVER (1 2 3) FROM t
   expect: tree
-  pins: Bracketed content-failure message for a failed *optional* content
-    element (window function's WindowSpecificationSegment, optional=True,
-    parse_mode=GREEDY, failing on '1 2 3') - both engines fall back to the
-    generic "Nothing here." GREEDY-leftover message rather than the
-    required-element-specific "<elem> to start sequence/after X" wording.
+  pins: Bracketed content-failure message must match Python's Sequence.match -
+    a failed *optional* content element yields "Nothing here.", not the specific
+    "<elem> to start sequence/after X" message reserved for required failures.
 ansi_grant_all_masking_policies:
   sql: GRANT SELECT ON ALL MASKING POLICIES IN SCHEMA s TO r
   expect: error
@@ -163,11 +161,13 @@ sequence_found_message_no_trailing_period:
 sqlite_nothing_here_expected_message:
   sql: "WITH cte AS (\n t\n)\nSELECT"
   dialect: sqlite
-  xfail:
-    python_vs_rust: Where a CTE definition's body fails to start a SelectableGrammar, Python's
-      unparsable message names the specific expected grammar and found token, while Rust falls
-      back to the generic placeholder message 'Nothing here.'
-  pins: Generic vs specific fallback message for an empty CTE body (sqlite).
+  expect: tree
+  pins: Bracketed content matching (bracketed.rs) always blamed a content/closing-bracket
+    gap on the generic GREEDY-leftover fallback ('Nothing here.'), even when the gap was
+    actually caused by the sole content element (here, SelectableGrammar inside the CTE's
+    parens) failing to match at all - fixed by tracking how many child matches existed
+    before content parsing began, so a content element that never got off the ground is
+    reported with Python's specific "to start sequence"/"after X" message instead.
 materialize_curly_cross_silent_recovery:
   sql: COPY t FROM STDIN (FORMAT {-
   dialect: materialize
@@ -180,12 +180,17 @@ materialize_curly_cross_silent_recovery:
 tsql_cast_structure:
   sql: select CAST(0X0 uniqueidentifier);
   dialect: tsql
-  xfail:
-    python_vs_rust: 'Rust does not recognise tsql''s AS-less CAST(literal type) shorthand
-      cast syntax: Python parses it as a function call with a binary_literal argument and
-      a data_type, while Rust parses only CAST as a bare column reference and folds the remainder
-      of the statement into an unparsable segment.'
-  pins: tsql CAST(literal type) shorthand (no AS) grammar gap.
+  expect: tree
+  pins: 'CastFunctionContentsSegment requires "AS" between the expression and the
+    data_type (Bracketed(ExpressionSegment, "AS", DatatypeSegment)), and this SQL
+    omits it, so the reference (Python) correctly rejects the CAST call and falls
+    back to a bare column_reference with the rest unparsable. bracketed.rs''s content
+    loop used to march on to the next content element even after a required
+    (non-optional) one failed to match, so with "AS" missing it let DatatypeSegment
+    try - and succeed - matching "uniqueidentifier" in the position "AS" should have
+    occupied, fabricating a function call Python never accepts. Fixed by stopping the
+    content loop the moment a required element fails, exactly like Python''s
+    Sequence.match.'
 materialize_webhook_overlapping_matches:
   sql: "(\n ) ( );\nCREATE SOURCE my_webhook_source IN CLUSTER my_cluster FROM WEBHOOK\n BODY\
     \ FORMAT JSON\n (\n (\n my_webhook_share"

--- a/utils/build_dialects.py
+++ b/utils/build_dialects.py
@@ -19,6 +19,7 @@ def generate_use():
     print()
     print("use sqlfluffrs_types::RootGrammar;")
     print("use sqlfluffrs_types::LexMatcher;")
+    print("use sqlfluffrs_types::BracketPairEntry;")
     print("use std::str::FromStr;")
 
 
@@ -95,7 +96,7 @@ impl Dialect {{
         }}
     }}
 
-    pub fn get_bracket_pairs(&self) -> &'static Vec<(&'static str, &'static str, &'static str, &'static str, bool)> {{
+    pub fn get_bracket_pairs(&self) -> &'static Vec<BracketPairEntry> {{
         match self {{
             {dialect_bracket_pairs},
         }}

--- a/utils/build_dialects.py
+++ b/utils/build_dialects.py
@@ -13,7 +13,8 @@ def generate_use():
         print(
             f"use crate::dialect::{dialect.label.lower()}::matcher::{{"
             f"{dialect.label.upper()}_KEYWORDS, "
-            f"{dialect.label.upper()}_LEXERS}};"
+            f"{dialect.label.upper()}_LEXERS, "
+            f"{dialect.label.upper()}_BRACKET_PAIRS}};"
         )
     print()
     print("use sqlfluffrs_types::RootGrammar;")
@@ -35,6 +36,12 @@ def generate_dialect_enum():
     dialect_reserved_keywords = ",\n            ".join(
         [
             f"Dialect::{d.label.capitalize()} => &{d.label.upper()}_KEYWORDS"
+            for d in dialect_readout()
+        ]
+    )
+    dialect_bracket_pairs = ",\n            ".join(
+        [
+            f"Dialect::{d.label.capitalize()} => &{d.label.upper()}_BRACKET_PAIRS"
             for d in dialect_readout()
         ]
     )
@@ -85,6 +92,12 @@ impl Dialect {{
     pub fn get_lexers(&self) -> &'static Vec<LexMatcher> {{
         match self {{
             {dialect_match},
+        }}
+    }}
+
+    pub fn get_bracket_pairs(&self) -> &'static Vec<(&'static str, &'static str, &'static str, &'static str, bool)> {{
+        match self {{
+            {dialect_bracket_pairs},
         }}
     }}
 

--- a/utils/build_dialects.py
+++ b/utils/build_dialects.py
@@ -19,7 +19,7 @@ def generate_use():
     print()
     print("use sqlfluffrs_types::RootGrammar;")
     print("use sqlfluffrs_types::LexMatcher;")
-    print("use sqlfluffrs_types::BracketPairEntry;")
+    print("use sqlfluffrs_types::BracketPairSet;")
     print("use std::str::FromStr;")
 
 
@@ -96,7 +96,7 @@ impl Dialect {{
         }}
     }}
 
-    pub fn get_bracket_pairs(&self) -> &'static Vec<BracketPairEntry> {{
+    pub fn get_bracket_pairs(&self) -> &'static BracketPairSet {{
         match self {{
             {dialect_bracket_pairs},
         }}

--- a/utils/build_lexers.py
+++ b/utils/build_lexers.py
@@ -16,6 +16,7 @@ def generate_use():
     print("use sqlfluffrs_types::{LexMatcher, LexMatcherConfig};")
     print("use sqlfluffrs_types::{Token, RegexModeGroup};")
     print("use sqlfluffrs_types::token::CaseFold;")
+    print("use sqlfluffrs_types::BracketPairEntry;")
 
 
 def segment_to_token_name(s: str):
@@ -57,7 +58,7 @@ def generate_bracket_pairs(dialect: str):
     loaded_dialect = dialect_selector(dialect)
     print(
         f"pub static {dialect.upper()}_BRACKET_PAIRS:"
-        " Lazy<Vec<(&'static str, &'static str, &'static str, &'static str, bool)>>"
+        " Lazy<Vec<BracketPairEntry>>"
         " = Lazy::new(|| { vec!["
     )
     for _bracket_type, start_ref, end_ref, persists in sorted(

--- a/utils/build_lexers.py
+++ b/utils/build_lexers.py
@@ -39,6 +39,46 @@ def generate_lexer(dialect: str):
     print("]});")
 
 
+def generate_bracket_pairs(dialect: str):
+    """Generate the bracket pairs as (open, close, start, end, persists).
+
+    Each tuple is (open raw text, close raw text, start-bracket segment type,
+    end-bracket segment type, persists). Used by the Rust lexer/parser's
+    bracket-matching (`matching_bracket_idx` pre-computation, the parser's
+    stray-closing-bracket detection, and the Anything-grammar bracket recursion
+    in core.rs), so dialect-specific brackets - e.g. snowflake's exclude bracket
+    `{-`/`-}` (types start_exclude_bracket / end_exclude_bracket, persists=True),
+    added to the same `bracket_pairs` set as round/square/curly - are recognised,
+    typed and structurally preserved identically to the universal three rather
+    than by a hardcoded ASCII trio. `persists` (round/exclude are True; square/
+    curly are False) is whether the matched span is kept as a structured
+    `bracketed` node vs flattened to raw siblings.
+    """
+    loaded_dialect = dialect_selector(dialect)
+    print(
+        f"pub static {dialect.upper()}_BRACKET_PAIRS:"
+        " Lazy<Vec<(&'static str, &'static str, &'static str, &'static str, bool)>>"
+        " = Lazy::new(|| { vec!["
+    )
+    for _bracket_type, start_ref, end_ref, persists in sorted(
+        loaded_dialect.bracket_sets("bracket_pairs")
+    ):
+        start_seg = loaded_dialect.ref(start_ref)
+        end_seg = loaded_dialect.ref(end_ref)
+        start_template = start_seg.template
+        end_template = end_seg.template
+        # The segment type the parser assigns to the matched bracket, e.g.
+        # "start_bracket" / "start_exclude_bracket" (matches Python's
+        # StartBracketSegment / StartExcludeBracketSegment instance_types).
+        start_type = (start_seg._instance_types or (start_seg.raw_class.type,))[0]
+        end_type = (end_seg._instance_types or (end_seg.raw_class.type,))[0]
+        print(
+            f'    ("{start_template}", "{end_template}", '
+            f'"{start_type}", "{end_type}", {str(bool(persists)).lower()}),'
+        )
+    print("]});")
+
+
 def generate_reserved_keyword_list(dialect: str):
     """Generate the keywords for a dialects."""
     loaded_dialect = dialect_selector(dialect)
@@ -245,5 +285,7 @@ if __name__ == "__main__":
     generate_reserved_keyword_list(args.dialect)
     print()
     generate_lexer(args.dialect)
+    print()
+    generate_bracket_pairs(args.dialect)
     print()
     generate_extract_nested_block_comments(args.dialect)

--- a/utils/build_lexers.py
+++ b/utils/build_lexers.py
@@ -41,19 +41,12 @@ def generate_lexer(dialect: str):
 
 
 def generate_bracket_pairs(dialect: str):
-    """Generate the bracket pairs as (open, close, start, end, persists).
+    """Generate the dialect's BracketPairEntry set.
 
-    Each tuple is (open raw text, close raw text, start-bracket segment type,
-    end-bracket segment type, persists). Used by the Rust lexer/parser's
-    bracket-matching (`matching_bracket_idx` pre-computation, the parser's
-    stray-closing-bracket detection, and the Anything-grammar bracket recursion
-    in core.rs), so dialect-specific brackets - e.g. snowflake's exclude bracket
-    `{-`/`-}` (types start_exclude_bracket / end_exclude_bracket, persists=True),
-    added to the same `bracket_pairs` set as round/square/curly - are recognised,
-    typed and structurally preserved identically to the universal three rather
-    than by a hardcoded ASCII trio. `persists` (round/exclude are True; square/
-    curly are False) is whether the matched span is kept as a structured
-    `bracketed` node vs flattened to raw siblings.
+    Used by the Rust lexer/parser for bracket matching, stray-closing-bracket
+    detection, and Anything-grammar bracket recursion. `persists` is whether
+    the matched span is kept as a structured `bracketed` node vs flattened
+    to raw siblings.
     """
     loaded_dialect = dialect_selector(dialect)
     print(

--- a/utils/build_lexers.py
+++ b/utils/build_lexers.py
@@ -16,7 +16,7 @@ def generate_use():
     print("use sqlfluffrs_types::{LexMatcher, LexMatcherConfig};")
     print("use sqlfluffrs_types::{Token, RegexModeGroup};")
     print("use sqlfluffrs_types::token::CaseFold;")
-    print("use sqlfluffrs_types::BracketPairEntry;")
+    print("use sqlfluffrs_types::{BracketPairEntry, BracketPairSet};")
 
 
 def segment_to_token_name(s: str):
@@ -58,8 +58,8 @@ def generate_bracket_pairs(dialect: str):
     loaded_dialect = dialect_selector(dialect)
     print(
         f"pub static {dialect.upper()}_BRACKET_PAIRS:"
-        " Lazy<Vec<BracketPairEntry>>"
-        " = Lazy::new(|| { vec!["
+        " Lazy<BracketPairSet>"
+        " = Lazy::new(|| { BracketPairSet(vec!["
     )
     for _bracket_type, start_ref, end_ref, persists in sorted(
         loaded_dialect.bracket_sets("bracket_pairs")
@@ -74,10 +74,11 @@ def generate_bracket_pairs(dialect: str):
         start_type = (start_seg._instance_types or (start_seg.raw_class.type,))[0]
         end_type = (end_seg._instance_types or (end_seg.raw_class.type,))[0]
         print(
-            f'    ("{start_template}", "{end_template}", '
-            f'"{start_type}", "{end_type}", {str(bool(persists)).lower()}),'
+            f'    BracketPairEntry {{ open: "{start_template}", '
+            f'close: "{end_template}", start_type: "{start_type}", '
+            f'end_type: "{end_type}", persists: {str(bool(persists)).lower()} }},'
         )
-    print("]});")
+    print("]) });")
 
 
 def generate_reserved_keyword_list(dialect: str):


### PR DESCRIPTION
This is stacked on top of https://github.com/sqlfluff/sqlfluff/pull/8198.

### Brief summary of the change made
This closes several bracket matching gaps between the Rust parser and Python's reference implementation, all previously tracked as `xfail` cases in the parity test suite.

- The `Anything()` grammar's bracket-recursion path (`match_bracket_recursively`) now raises a parse error instead of silently producing a fabricated tree when it hits a crossed bracket (a closing bracket of the wrong type) or runs out of input before finding its closing bracket, matching Python's `resolve_bracket`.
- Bracket recognition in that same path, and in the parser's top-level bracket handling, is no longer limited to a hardcoded set of `(`, `[`, `{`. It's now driven by each dialect's actual bracket pairs (generated from the dialect definitions), so dialect-specific brackets such as Snowflake's exclude bracket `{-`/`-}` are recognised, typed, and structurally preserved the same way Python does.
- `Bracketed` content matching now distinguishes a failed *optional* content element (which Python lets the sequence continue past) from a failed *required* one (which should stop the sequence there). This fixes cases where a required element's failure was previously masked, including one where a STRICT bracket would incorrectly succeed with a partial match if the failure happened to land exactly at the closing bracket.
- The error messages produced for these content-failure cases (naming the expected grammar/token and whether it is "to start sequence" or "after X") are now derived the same way Python derives them, rather than falling back to a generic message.

Supporting changes: dialect bracket pairs are generated into the Rust dialect tables (`build_dialects.py` / `build_lexers.py`) alongside the existing lexer generation, and several previously `xfail`'d parity fixtures in `test/fixtures/parity/regressions.yml` are now passing and documented as such.

### Are there any other side effects of this change that we should be aware of?

Bracket-opener detection for the `Anything()` grammar path is now a lookup against the dialect's bracket set rather than a fixed ASCII check, so any dialect that defines additional bracket-like pairs will pick them up automatically through this path.


### Pull Request checklist
- [ ] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns Rust bracket behavior with Python across all dialects. Uses each dialect’s `bracket_pairs`, raises on crossed/unclosed brackets, and fixes `Bracketed` content handling and error messages.

- **Bug Fixes**
  - Dialect-aware brackets end-to-end: lexer precomputes `matching_bracket_idx` using each dialect’s `bracket_pairs`; parser/`greedy_match` detect opens/closes via `Dialect::get_bracket_pairs` (e.g., Snowflake `{-`/`-}`); stray dialect closers now abort terminator search.
  - `Anything()` recursion now errors on crossed or unclosed brackets instead of fabricating a match.
  - `Bracketed` content: stop on required failures; STRICT no longer accepts partial matches at the close; optional failures produce “Nothing here.”; error text mirrors Python (“to start sequence”/“after X” with correct found-token fallbacks), without rejecting valid empty parens.
  - Reset stale `matching_bracket_idx` before recomputing bracket pairs to avoid carrying incorrect links between runs.

- **Refactors**
  - Introduced `BracketPairEntry` and `BracketPairSet` with shared lookups (`compute_matching_indices`, `is_open`/`is_close`). Generate per‑dialect `bracket_pairs` in `utils/build_lexers.py`, expose via `Dialect::get_bracket_pairs`; lexer has an ASCII default with `persists` flags and can be overridden via `Lexer::with_bracket_pairs`; the Python bridge now uses it.
  - Bracket leaf types and persistence now match Python; tests and the harness updated to supply dialect bracket pairs.

<sup>Written for commit 5033156f9819ed1b0afad3eb924e37975cca2ec5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8243?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

