### PR TITLE
fix(rust): Parser parity across Ref errors, arena-tree panics, regex case folding, and indentation config

### DIFF
--- a/sqlfluffrs/sqlfluffrs.pyi
+++ b/sqlfluffrs/sqlfluffrs.pyi
@@ -238,6 +238,13 @@ class RsParseError(Exception):
 
     pos: int
 
+MISSING_REF_PREFIX: str
+"""Sentinel prefix on an ``RsParseError`` message for an unresolvable Ref.
+
+Shared with the Rust side (``ref_grammar.rs``) so both sides of the pyo3
+boundary read the same constant instead of duplicating the literal.
+"""
+
 class RsParser:
     """Rust-based SQL parser."""
 

--- a/sqlfluffrs/sqlfluffrs_parser/src/lib.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/lib.rs
@@ -2,6 +2,7 @@ pub mod parser;
 
 // Public read API for the parse arena, consumed by the rules crate.
 pub use parser::arena::{Arena, NodeId};
+pub use parser::MISSING_REF_PREFIX;
 
 #[cfg(feature = "python")]
 pub use parser::{PyHandle, PyMatchResult, PyNode, PyParser, PyTree, RsParseError};

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/core.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/core.rs
@@ -1230,22 +1230,22 @@ impl<'a> Parser<'a> {
                 // folding, which misses that. Uses the token's precomputed
                 // raw_upper(), so this stays cheap under backtracking.
                 let raw = if case_insensitive {
-                    std::borrow::Cow::Borrowed(tok.raw_upper())
+                    tok.raw_upper()
                 } else {
-                    std::borrow::Cow::Borrowed(tok.raw())
+                    tok.raw()
                 };
 
                 // Check anti-pattern first (if present, should NOT match)
                 if let Some(ref anti) = anti_pattern {
                     vdebug!("RegexParser[table] checking anti-pattern against '{}'", raw);
-                    if anti.is_match(&raw) {
+                    if anti.is_match(raw) {
                         vdebug!("RegexParser[table] anti-pattern matched, returning Empty");
                         return Ok(MatchResult::empty_at(self.pos));
                     }
                 }
 
                 // Check main pattern
-                if pattern.is_match(&raw) {
+                if pattern.is_match(raw) {
                     let token_pos = self.pos;
 
                     vdebug!(

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/core.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/core.rs
@@ -1224,25 +1224,11 @@ impl<'a> Parser<'a> {
 
         match self.peek() {
             Some(tok) => {
-                // PYTHON PARITY: RegexParser.match evaluates against
-                // `raw_upper` (str.upper() - FULL unicode case mapping, e.g.
-                // 'straße' -> 'STRASSE', 'ﬁ' -> 'FI') when ignore_case, with
-                // the pattern also compiled case-insensitively. The regex
-                // crates only do simple case folding, under which 'ß' never
-                // matches [A-Z] - so without pre-uppercasing, unicode
-                // identifiers that Python accepts (e.g. `SELECT straße(1)` in
-                // postgres, where the lexer produces such word tokens) fail
-                // the template on the Rust side and parse structurally
-                // differently. Uppercase the comparison text exactly like
-                // Python does; Rust's str::to_uppercase applies the same
-                // unicode mappings.
-                // Use the token's cached uppercase form (RawString precomputes
-                // raw_upper at construction and returns the original &str with
-                // zero allocation when it is already uppercase) rather than
-                // recomputing to_uppercase() on every - frequently discarded,
-                // backtracked - RegexParser match attempt. raw_upper() applies
-                // the same full-unicode str::to_uppercase mapping Python's
-                // str.upper() does, so behaviour is identical.
+                // PYTHON PARITY: match against the full-unicode uppercase form
+                // when case-insensitive, like Python's str.upper() (e.g.
+                // 'straße' -> 'STRASSE') - the regex crate only does simple
+                // folding, which misses that. Uses the token's precomputed
+                // raw_upper(), so this stays cheap under backtracking.
                 let raw = if case_insensitive {
                     std::borrow::Cow::Borrowed(tok.raw_upper())
                 } else {

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/core.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/core.rs
@@ -1224,19 +1224,42 @@ impl<'a> Parser<'a> {
 
         match self.peek() {
             Some(tok) => {
-                let raw = tok.raw();
+                // PYTHON PARITY: RegexParser.match evaluates against
+                // `raw_upper` (str.upper() - FULL unicode case mapping, e.g.
+                // 'straße' -> 'STRASSE', 'ﬁ' -> 'FI') when ignore_case, with
+                // the pattern also compiled case-insensitively. The regex
+                // crates only do simple case folding, under which 'ß' never
+                // matches [A-Z] - so without pre-uppercasing, unicode
+                // identifiers that Python accepts (e.g. `SELECT straße(1)` in
+                // postgres, where the lexer produces such word tokens) fail
+                // the template on the Rust side and parse structurally
+                // differently. Uppercase the comparison text exactly like
+                // Python does; Rust's str::to_uppercase applies the same
+                // unicode mappings.
+                // Use the token's cached uppercase form (RawString precomputes
+                // raw_upper at construction and returns the original &str with
+                // zero allocation when it is already uppercase) rather than
+                // recomputing to_uppercase() on every - frequently discarded,
+                // backtracked - RegexParser match attempt. raw_upper() applies
+                // the same full-unicode str::to_uppercase mapping Python's
+                // str.upper() does, so behaviour is identical.
+                let raw = if case_insensitive {
+                    std::borrow::Cow::Borrowed(tok.raw_upper())
+                } else {
+                    std::borrow::Cow::Borrowed(tok.raw())
+                };
 
                 // Check anti-pattern first (if present, should NOT match)
                 if let Some(ref anti) = anti_pattern {
                     vdebug!("RegexParser[table] checking anti-pattern against '{}'", raw);
-                    if anti.is_match(raw) {
+                    if anti.is_match(&raw) {
                         vdebug!("RegexParser[table] anti-pattern matched, returning Empty");
                         return Ok(MatchResult::empty_at(self.pos));
                     }
                 }
 
                 // Check main pattern
-                if pattern.is_match(raw) {
+                if pattern.is_match(&raw) {
                     let token_pos = self.pos;
 
                     vdebug!(

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/mod.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/mod.rs
@@ -31,6 +31,7 @@ pub mod python;
 pub use core::Parser;
 pub use match_result::{MatchResult, MatchedClass, MetaSegment};
 pub use sqlfluffrs_types::ParseMode;
+pub use table_driven::ref_grammar::MISSING_REF_PREFIX;
 pub use types::{MetaType, Node, ParseError, ParseErrorType, RawSegmentKwargs};
 
 // Internal re-exports for submodules

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/anynumberof.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/anynumberof.rs
@@ -70,15 +70,14 @@ impl Parser<'_> {
         if has_exclude {
             if let Some(exclude_id) = self.grammar_ctx.exclude(grammar_id) {
                 self.pos = start_pos;
-                if let Ok(exclude_result) =
-                    self.parse_table_iterative_match_result(exclude_id, &frame.table_terminators)
-                {
-                    if !exclude_result.is_empty() {
-                        vdebug!("AnyNumberOf[table]: Exclude grammar matched, returning Empty");
-                        return Ok(stack.complete_frame_empty(&frame));
-                    }
-                }
+                // Try matching exclude grammar, otherwise raise RuntimeError
+                let exclude_result =
+                    self.parse_table_iterative_match_result(exclude_id, &frame.table_terminators)?;
                 self.pos = start_pos; // Reset position
+                if !exclude_result.is_empty() {
+                    vdebug!("AnyNumberOf[table]: Exclude grammar matched, returning Empty");
+                    return Ok(stack.complete_frame_empty(&frame));
+                }
             }
         }
 

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/oneof.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/oneof.rs
@@ -41,17 +41,16 @@ impl Parser<'_> {
 
         // Check exclude grammar first (before any other logic)
         if let Some(exclude_id) = self.grammar_ctx.exclude(grammar_id) {
-            // Try matching exclude grammar
-            if let Ok(exclude_result) =
-                self.parse_table_iterative_match_result(exclude_id, &frame.table_terminators)
-            {
-                if !exclude_result.is_empty() {
-                    vdebug!(
-                        "OneOf[table]: exclude grammar matched at pos {}, returning Empty",
-                        start_pos
-                    );
-                    return Ok(stack.complete_frame_empty(&frame));
-                }
+            // Try matching exclude grammar, otherwise raise RuntimeError
+            let exclude_result =
+                self.parse_table_iterative_match_result(exclude_id, &frame.table_terminators)?;
+            self.pos = start_pos;
+            if !exclude_result.is_empty() {
+                vdebug!(
+                    "OneOf[table]: exclude grammar matched at pos {}, returning Empty",
+                    start_pos
+                );
+                return Ok(stack.complete_frame_empty(&frame));
             }
             vdebug!("OneOf[table]: exclude grammar did not match, continuing");
         }

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/ref_grammar.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/ref_grammar.rs
@@ -18,11 +18,7 @@ impl Parser<'_> {
     /// Build the sentinel [`ParseError`] for an unresolvable Ref. The Python
     /// side (`rust_parser.py`) recognises the `__MISSING_REF__:` prefix and
     /// re-raises through the dialect's own `ref()`, so the resulting
-    /// RuntimeError message matches the pure-Python parser byte-for-byte
-    /// (keyword-not-found vs segment-not-found text, plus the dialect name and
-    /// contribute-guide tip). `rule_name` is the stored ref name, e.g.
-    /// `PoliciesKeywordSegment` (from a bare-string `"POLICIES"`) or a mistyped
-    /// segment ref like `TableReference`.
+    /// RuntimeError matches the pure-Python parser.
     fn missing_ref_error(rule_name: &str, pos: usize) -> ParseError {
         ParseError::with_context(format!("__MISSING_REF__:{rule_name}"), Some(pos), None)
     }

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/ref_grammar.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/ref_grammar.rs
@@ -10,17 +10,21 @@ use crate::parser::{
 #[cfg(feature = "verbose-debug")]
 use crate::vdebug;
 
+/// Sentinel prefix for an unresolvable Ref's [`ParseError`] message. The
+/// Python side (`rust_parser.py`) recognises this prefix and re-raises
+/// through the dialect's own `ref()`, so the resulting RuntimeError matches
+/// the pure-Python parser. Exported to Python via the `sqlfluffrs` module so
+/// both sides read the same constant instead of duplicating the literal.
+pub const MISSING_REF_PREFIX: &str = "__MISSING_REF__:";
+
 impl Parser<'_> {
     // ========================================================================
     // Table-Driven Ref Handlers
     // ========================================================================
 
-    /// Build the sentinel [`ParseError`] for an unresolvable Ref. The Python
-    /// side (`rust_parser.py`) recognises the `__MISSING_REF__:` prefix and
-    /// re-raises through the dialect's own `ref()`, so the resulting
-    /// RuntimeError matches the pure-Python parser.
+    /// Build the sentinel [`ParseError`] for an unresolvable Ref.
     fn missing_ref_error(rule_name: &str, pos: usize) -> ParseError {
-        ParseError::with_context(format!("__MISSING_REF__:{rule_name}"), Some(pos), None)
+        ParseError::with_context(format!("{MISSING_REF_PREFIX}{rule_name}"), Some(pos), None)
     }
 
     /// Handle Ref Initial state using table-driven approach

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/ref_grammar.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/ref_grammar.rs
@@ -63,17 +63,16 @@ impl Parser<'_> {
         let exclude_id_opt = self.grammar_ctx.exclude(grammar_id);
         if let Some(exclude_id) = exclude_id_opt {
             self.pos = start_pos;
-            if let Ok(exclude_mr) =
-                self.parse_table_iterative_match_result(exclude_id, &frame.table_terminators)
-            {
-                self.pos = start_pos;
-                if !exclude_mr.is_empty() {
-                    vdebug!(
-                        "Ref[table]: exclude grammar matched at pos {}, returning Empty",
-                        frame.pos
-                    );
-                    return Ok(stack.complete_frame_empty(&frame));
-                }
+            // Try matching exclude grammar, otherwise raise RuntimeError
+            let exclude_mr =
+                self.parse_table_iterative_match_result(exclude_id, &frame.table_terminators)?;
+            self.pos = start_pos;
+            if !exclude_mr.is_empty() {
+                vdebug!(
+                    "Ref[table]: exclude grammar matched at pos {}, returning Empty",
+                    frame.pos
+                );
+                return Ok(stack.complete_frame_empty(&frame));
             }
             vdebug!("Ref[table]: exclude grammar did not match, continuing");
         }

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/ref_grammar.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/ref_grammar.rs
@@ -15,6 +15,18 @@ impl Parser<'_> {
     // Table-Driven Ref Handlers
     // ========================================================================
 
+    /// Build the sentinel [`ParseError`] for an unresolvable Ref. The Python
+    /// side (`rust_parser.py`) recognises the `__MISSING_REF__:` prefix and
+    /// re-raises through the dialect's own `ref()`, so the resulting
+    /// RuntimeError message matches the pure-Python parser byte-for-byte
+    /// (keyword-not-found vs segment-not-found text, plus the dialect name and
+    /// contribute-guide tip). `rule_name` is the stored ref name, e.g.
+    /// `PoliciesKeywordSegment` (from a bare-string `"POLICIES"`) or a mistyped
+    /// segment ref like `TableReference`.
+    fn missing_ref_error(rule_name: &str, pos: usize) -> ParseError {
+        ParseError::with_context(format!("__MISSING_REF__:{rule_name}"), Some(pos), None)
+    }
+
     /// Handle Ref Initial state using table-driven approach
     pub(crate) fn handle_ref_initial(
         &mut self,
@@ -78,7 +90,7 @@ impl Parser<'_> {
         // `get_*_segment_grammar` match is otherwise ~20% of parse self-time.
         let child_grammar_id = match self.ref_child_cache.get(&grammar_id.0) {
             Some(&Some(id)) => GrammarId(id),
-            Some(&None) => return Ok(stack.complete_frame_empty(&frame)),
+            Some(&None) => return Err(Self::missing_ref_error(rule_name, start_pos)),
             None => {
                 // First element child if present, otherwise resolve by name.
                 // CRITICAL: For Ref grammars with an exclude, `children` contains ONLY
@@ -97,11 +109,18 @@ impl Parser<'_> {
                 match resolved {
                     Some(id) => id,
                     None => {
+                        // PYTHON PARITY: an unresolvable Ref - a keyword or
+                        // segment name the grammar references but the dialect
+                        // never registered - is a hard error in Python:
+                        // dialect.ref() raises RuntimeError the moment the branch
+                        // is matched, rather than failing the branch. Mirror that
+                        // instead of silently returning Empty (which diverged,
+                        // producing an unparsable tree where Python raised).
                         vdebug!(
-                            "Ref[table]: No element children and no dialect mapping for '{}', returning Empty",
+                            "Ref[table]: No element children and no dialect mapping for '{}', raising missing-ref error",
                             rule_name
                         );
-                        return Ok(stack.complete_frame_empty(&frame));
+                        return Err(Self::missing_ref_error(rule_name, start_pos));
                     }
                 }
             }
@@ -328,14 +347,15 @@ impl Parser<'_> {
     /// terminal parser.
     ///
     /// Mirrors the frame-based Ref handlers step for step: the
-    /// parent-max-idx guard and failed-resolution behaviour of
-    /// `handle_ref_initial` (empty result at the pre-skip position), the
-    /// leading-gap skip when the target allows gaps, the failed-child
-    /// position semantics of `handle_ref_waiting_for_child` (position and
-    /// reported extent at the post-skip position), and the result wrapping
-    /// of `handle_ref_combining` (via `build_ref_wrap`). Refs with an
-    /// exclude grammar or a non-terminal target return `Ok(None)` and take
-    /// the frame path.
+    /// parent-max-idx guard, the leading-gap skip when the target allows
+    /// gaps, the failed-child position semantics of
+    /// `handle_ref_waiting_for_child` (position and reported extent at the
+    /// post-skip position), and the result wrapping of
+    /// `handle_ref_combining` (via `build_ref_wrap`). Refs with an exclude
+    /// grammar, an unresolvable target, or a non-terminal target return
+    /// `Ok(None)` and take the frame path - for an unresolvable target that
+    /// lets `handle_ref_initial` raise its hard missing-ref error instead of
+    /// this fast path silently yielding Empty.
     pub(crate) fn try_ref_terminal_inline(
         &mut self,
         grammar_id: GrammarId,
@@ -347,8 +367,13 @@ impl Parser<'_> {
         }
         let start_pos = self.pos;
         let Some(child_id) = self.resolve_ref_target(grammar_id) else {
-            // No element child and no dialect mapping: Ref yields Empty.
-            return Ok(Some(MatchResult::empty_at(start_pos)));
+            // No element child and no dialect mapping: this is the same
+            // missing-ref condition handle_ref_initial treats as a hard
+            // error. Fall back to the frame path instead of yielding a soft
+            // Empty here, so its Err(missing_ref_error(...)) actually
+            // propagates instead of being absorbed as an ordinary
+            // non-match by the calling combinator.
+            return Ok(None);
         };
         let child_variant = self.grammar_ctx.variant(child_id);
         if !Self::is_terminal_variant(child_variant) {

--- a/sqlfluffrs/src/python.rs
+++ b/sqlfluffrs/src/python.rs
@@ -1,6 +1,8 @@
 use pyo3::prelude::*;
 use sqlfluffrs_lexer::{PyLexer, PySQLLexError};
-use sqlfluffrs_parser::{PyHandle, PyMatchResult, PyNode, PyParser, PyTree, RsParseError};
+use sqlfluffrs_parser::{
+    PyHandle, PyMatchResult, PyNode, PyParser, PyTree, RsParseError, MISSING_REF_PREFIX,
+};
 use sqlfluffrs_python::marker::PyPositionMarker;
 use sqlfluffrs_python::templater::{
     fileslice::{PyRawFileSlice, PyTemplatedFileSlice},
@@ -34,6 +36,9 @@ fn sqlfluffrs(m: &Bound<'_, PyModule>) -> PyResult<()> {
     sqlfluffrs_rules::python::register(m)?;
     // Add custom exception
     m.add("RsParseError", m.py().get_type::<RsParseError>())?;
+    // Sentinel prefix for missing-ref errors, shared with rust_parser.py so
+    // the two sides of the pyo3 boundary can't drift on the literal.
+    m.add("MISSING_REF_PREFIX", MISSING_REF_PREFIX)?;
     // TemplatedFile conversion-cache internals (weakref eviction + test
     // introspection).
     m.add_function(wrap_pyfunction!(

--- a/src/sqlfluff/core/parser/rust_parser.py
+++ b/src/sqlfluff/core/parser/rust_parser.py
@@ -151,15 +151,15 @@ try:
                 "dialect_obj"
             ).get_root_segment()
 
-            # Extract indentation config and convert boolean values only
+            # Extract indentation config for Conditional grammar evaluation.
+            # PYTHON PARITY: ParseContext.from_config coerces every value here
+            # with bool(), not just ones already typed as bool - the ini
+            # config layer can produce int 1 for a truthy setting like
+            # `indented_joins = 1`, and filtering by isinstance(v, bool)
+            # would silently drop it instead of coercing it.
             indent_config = self.config.get_section("indentation") or {}
             if indent_config:
-                # Only keep boolean config values for conditional evaluation
-                # Non-boolean values like "indent_unit": "space" are not needed
-                # for conditionals
-                indent_config = {
-                    k: v for k, v in indent_config.items() if isinstance(v, bool)
-                }
+                indent_config = {k: bool(v) for k, v in indent_config.items()}
 
             # Max parse depth (DoS mitigation); 0 disables the limit
             max_parse_depth = self.config.get("max_parse_depth")

--- a/src/sqlfluff/core/parser/rust_parser.py
+++ b/src/sqlfluff/core/parser/rust_parser.py
@@ -370,8 +370,17 @@ try:
                     )
                     if _prof is not None:
                         _prof["apply_as_tree"] = time.perf_counter() - _ts
-                except Exception:  # pragma: no cover
-                    # Non-critical: if tree building fails, rules fall back to Python
+                except (KeyboardInterrupt, SystemExit):
+                    # Never swallow interpreter control-flow exceptions.
+                    raise
+                except BaseException:  # noqa: BLE001  # pragma: no cover
+                    # Non-critical: if arena-tree building fails, rules fall back
+                    # to the Python-built tree. Deliberately `except
+                    # BaseException` (minus the control-flow exceptions above):
+                    # a Rust-side panic crosses pyo3 as PanicException, which is
+                    # a BaseException, NOT an Exception, so a bare `except
+                    # Exception` would let a panic abort the whole parse instead
+                    # of engaging this documented fallback.
                     parser_logger.warning(
                         f"Unable to apply match result in parse tree for {fname}, falling"
                         " back to Python. Please report this as a bug with the SQL that"

--- a/src/sqlfluff/core/parser/rust_parser.py
+++ b/src/sqlfluff/core/parser/rust_parser.py
@@ -110,7 +110,13 @@ def get_native_ast() -> bool:
 
 
 try:
-    from sqlfluffrs import RsMatchResult, RsParseError, RsParser, RsToken
+    from sqlfluffrs import (
+        MISSING_REF_PREFIX,
+        RsMatchResult,
+        RsParseError,
+        RsParser,
+        RsToken,
+    )
 
     _HAS_RUST_PARSER = True
 
@@ -260,13 +266,12 @@ try:
                     if _prof is not None:
                         _prof["rust_core"] = time.perf_counter() - _ts
                 except RsParseError as e:
-                    # A dangling grammar ref surfaces as a "__MISSING_REF__:<name>"
+                    # A dangling grammar ref surfaces with the MISSING_REF_PREFIX
                     # sentinel. Re-raise via the dialect's own ref() so both
                     # engines fail with the same RuntimeError.
-                    _missing_ref_prefix = "__MISSING_REF__:"
                     _rs_desc = str(e)
-                    if _rs_desc.startswith(_missing_ref_prefix):
-                        ref_name = _rs_desc[len(_missing_ref_prefix) :]
+                    if _rs_desc.startswith(MISSING_REF_PREFIX):
+                        ref_name = _rs_desc[len(MISSING_REF_PREFIX) :]
                         dialect_obj = self.config.get("dialect_obj")
                         # If ref() doesn't raise, the name exists in Python but
                         # was dropped from Rust's codegen tables - a bug.

--- a/src/sqlfluff/core/parser/rust_parser.py
+++ b/src/sqlfluff/core/parser/rust_parser.py
@@ -271,7 +271,7 @@ try:
                         # If ref() doesn't raise, the name exists in Python but
                         # was dropped from Rust's codegen tables - a bug.
                         dialect_obj.ref(ref_name)
-                        raise RuntimeError(
+                        raise RuntimeError(  # pragma: no cover
                             "Grammar refers to {!r} which is registered in "
                             "the {} dialect's Python library but missing "
                             "from its Rust parser tables. This is an "
@@ -388,7 +388,7 @@ try:
                     )
                     if _prof is not None:
                         _prof["apply_as_tree"] = time.perf_counter() - _ts
-                except (KeyboardInterrupt, SystemExit):
+                except (KeyboardInterrupt, SystemExit):  # pragma: no cover
                     # Never swallow interpreter control-flow exceptions.
                     raise
                 except BaseException:  # noqa: BLE001  # pragma: no cover

--- a/src/sqlfluff/core/parser/rust_parser.py
+++ b/src/sqlfluff/core/parser/rust_parser.py
@@ -260,6 +260,24 @@ try:
                     if _prof is not None:
                         _prof["rust_core"] = time.perf_counter() - _ts
                 except RsParseError as e:
+                    # A dangling grammar ref surfaces as a "__MISSING_REF__:<name>"
+                    # sentinel. Re-raise via the dialect's own ref() so both
+                    # engines fail with the same RuntimeError.
+                    _missing_ref_prefix = "__MISSING_REF__:"
+                    _rs_desc = str(e)
+                    if _rs_desc.startswith(_missing_ref_prefix):
+                        ref_name = _rs_desc[len(_missing_ref_prefix) :]
+                        dialect_obj = self.config.get("dialect_obj")
+                        # If ref() doesn't raise, the name exists in Python but
+                        # was dropped from Rust's codegen tables - a bug.
+                        dialect_obj.ref(ref_name)
+                        raise RuntimeError(
+                            "Grammar refers to {!r} which is registered in "
+                            "the {} dialect's Python library but missing "
+                            "from its Rust parser tables. This is an "
+                            "internal sqlfluff bug; please raise an issue "
+                            "on GitHub.".format(ref_name, dialect_obj.name)
+                        ) from e
                     # Convert Rust parse error to SQLParseError with position info
                     raise SQLParseError.from_rs_parse_error(
                         e, segments[_start_idx:_end_idx]

--- a/test/fixtures/parity/regressions.yml
+++ b/test/fixtures/parity/regressions.yml
@@ -114,12 +114,10 @@ int_typed_indentation_config:
   sql: SELECT a FROM t JOIN u USING (a)
   configs:
     indentation.indented_joins: 1
-  expect: tree
-  xfail:
-    python_vs_rust: With indentation.indented_joins set to the int 1 rather than the bool
-      True, Rust adds an extra indent/dedent pair around join_clause that Python's tree does
-      not produce.
-  pins: Int-typed vs bool indentation.indented_joins config value diverges.
+  expect: clean_tree
+  pins: RustParser's Conditional-grammar indentation config only kept values already typed
+    as bool, silently dropping int-typed truthy settings such as indented_joins = 1 (fixed
+    by coercing every indentation-section value with bool(), matching ParseContext.from_config).
 found_token_class_name:
   sql: SELECT ] FROM t
   dialect: flink

--- a/test/fixtures/parity/regressions.yml
+++ b/test/fixtures/parity/regressions.yml
@@ -52,36 +52,35 @@ bracketed_optional_content_failure_nothing_here:
 ansi_grant_all_masking_policies:
   sql: GRANT SELECT ON ALL MASKING POLICIES IN SCHEMA s TO r
   expect: error
-  xfail:
-    python_vs_rust: "Ansi grammar references the POLICIES keyword without registering it - Python's Ref raises RuntimeError the moment the branch is attempted, while Rust resolves the missing name to Empty and silently fails the branch."
-  pins: ansi grammar references the POLICIES keyword without registering it.
+  pins: ansi grammar references the POLICIES keyword (via a bare string) that it
+    never registers, so it is treated as unsupported syntax. Both engines now
+    raise the identical RuntimeError ("Grammar refers to the 'POLICIES' keyword
+    which was not found in the ansi dialect...") - Python via dialect.ref(), Rust
+    by signalling the missing ref to rust_parser.py which re-raises through the
+    same dialect.ref(). (Previously Rust silently produced an unparsable tree.)
 ansi_grant_future_masking_policies:
   sql: GRANT SELECT ON FUTURE MASKING POLICIES IN SCHEMA s TO r
   expect: error
-  xfail:
-    python_vs_rust: 'FUTURE variant of the same POLICIES keyword gap.'
-  pins: FUTURE variant of the POLICIES keyword gap.
+  pins: FUTURE variant of the same dangling POLICIES-keyword-ref gap as
+    ansi_grant_all_masking_policies; both engines raise the identical RuntimeError.
 ansi_grant_all_file_formats:
   sql: GRANT SELECT ON ALL FILE FORMATS IN SCHEMA s TO r
   expect: error
-  xfail:
-    python_vs_rust: 'Ansi grammar references the FORMATS keyword without registering it, the same dangling-ref class as the POLICIES gap.'
-  pins: ansi grammar references the FORMATS keyword without registering it.
+  pins: ansi grammar references the FORMATS keyword without registering it, the
+    same dangling-keyword-ref class as POLICIES; both engines raise the identical
+    RuntimeError.
 mysql_exchange_partition_table_reference:
   sql: ALTER TABLE t EXCHANGE PARTITION p WITH TABLE t2 WITH VALIDATION
   dialect: mysql
   expect: error
-  xfail:
-    python_vs_rust: "Mysql EXCHANGE PARTITION grammar has Ref('TableReference') - a typo for TableReferenceSegment."
-  pins: mysql EXCHANGE PARTITION dangling-ref typo (TableReference vs TableReferenceSegment).
+  pins: mysql EXCHANGE PARTITION has Ref('TableReference'), a typo for TableReferenceSegment;
+    both engines raise the identical dangling-ref RuntimeError.
 postgres_alter_foreign_table_column_keyword:
   sql: ALTER FOREIGN TABLE ft ALTER COLUMN c OPTIONS (ADD opt 'v')
   dialect: postgres
   expect: error
-  xfail:
-    python_vs_rust: 'Postgres ALTER FOREIGN TABLE ... ALTER COLUMN grammar has a dangling keyword reference.'
-  pins: "postgres ALTER FOREIGN TABLE has Ref('COLUMN') - a segment ref where the
-    COLUMN keyword was intended."
+  pins: postgres ALTER FOREIGN TABLE has Ref('COLUMN'), a segment ref where the COLUMN
+    keyword was intended; both engines raise the identical dangling-ref RuntimeError.
 parser_created_segments_drop_token_trim_chars:
   sql: SET @errmsg = 'x';
   dialect: mysql

--- a/test/fixtures/parity/regressions.yml
+++ b/test/fixtures/parity/regressions.yml
@@ -231,11 +231,10 @@ postgres_eszett_function_name:
   sql: SELECT straße(1)
   dialect: postgres
   expect: clean_tree
-  xfail:
-    python_vs_rust: Python's RegexParser matches case-insensitively against raw.upper()
-      - FULL unicode case mapping (eszett straße -> STRASSE) - while Rust's regex crate
-      only does simple case folding, under which the eszett never matches [A-Z]. The
-      word token 'straße' fails FunctionNameIdentifierSegment's template on the Rust
-      side only, so it parses as a bare column_reference there instead of a function
-      call.
-  pins: Unicode full-vs-simple case folding gap in RegexParser accept decisions.
+  pins: Python's RegexParser matches case-insensitively against raw.upper() - FULL unicode
+    case mapping (eszett straße -> STRASSE), while Rust's regex crate only does simple
+    case folding, under which the eszett never matches [A-Z] - so the word token 'straße'
+    failed FunctionNameIdentifierSegment's template on the Rust side only, parsing as
+    column_reference there instead of a function call. Fixed by pre-uppercasing the
+    comparison text for case-insensitive RegexParser matches in core.rs, matching Python's
+    raw.upper() exactly (the constructed segment still keeps the token's original casing).


### PR DESCRIPTION
This is stacked on top of https://github.com/sqlfluff/sqlfluff/pull/8198.

### Brief summary of the change made

Fixes four Python/Rust parser parity gaps, three found by the new parity test harness and one extra observation, where the Rust parser (`RustParser`) previously diverged silently from the pure-Python parser instead of matching its behaviour or errors:

1. Dangling `Ref` grammars now raise, instead of silently failing the branch. When a grammar references a keyword or segment name the dialect never registered (e.g. a bare `"POLICIES"` string, or a typo like `Ref('TableReference')`), Python's `dialect.ref()` raises a `RuntimeError` immediately. Rust previously resolved the missing name to `Empty` and quietly failed the branch, producing an unparsable tree where Python raised an error. Rust now signals the missing ref back to `rust_parser.py` via a sentinel, which re-raises through the dialect's own `ref()`.

2. Arena-tree building falls back gracefully when Rust panics. The `except Exception` around tree building was too narrow: a Rust-side panic crosses `pyo3` as `PanicException`, a `BaseException`, not an `Exception`, so it wasn't caught and would abort the whole parse instead of falling back to the documented Python-tree fallback. Now catches `BaseException` (excluding `KeyboardInterrupt`/`SystemExit`). No regression test available here.

3. `RegexParser` unicode case folding now matches Python. Python matches case-insensitively against `raw.upper()` (full Unicode case mapping, e.g. eszett `straße` -> `STRASSE`), but the Rust `regex` crate only does simple case folding, under which `ß` never matches `[A-Z]`. Words like `straße` failed a case-insensitive template on the Rust side only. Fixed by pre-uppercasing the comparison text before matching.

4. Int-typed indentation config is no longer dropped. `RustParser` filtered the indentation config section to boolean-typed values only, silently dropping int-typed truthy settings such as `indented_joins = 1`. Python's `ParseContext.from_config` coerces every value with `bool()` regardless of type; Rust now does the same.

Fixes 1, 3, and 4 are backed by parity regression fixtures in `test/fixtures/parity/regressions.yml`, converting previously-`xfail`'d cases to passing ones.

### Are there any other side effects of this change that we should be aware of?

None expected. Each change narrows an existing divergence to match Python behaviour; no new configuration or public API surface is introduced.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the Rust parser with Python for missing Ref errors, Unicode-insensitive regex, panic-safe arena-tree building, and indentation config coercion. Shares a single `MISSING_REF_PREFIX` across Rust/Python and ensures exclude probes propagate errors; converts prior parity xfails into passing tests.

- **Bug Fixes**
  - Dangling `Ref` now raises a missing-ref error; Rust returns a `MISSING_REF_PREFIX`-tagged error and `rust_parser.py` re-raises via `dialect.ref()`. The inline fast path falls back to the frame path so the error propagates, and `OneOf`/`AnyNumberOf` exclude probes no longer swallow these errors.
  - Arena-tree building now falls back cleanly on a Rust panic by catching `BaseException` (while letting `KeyboardInterrupt`/`SystemExit` through).
  - `RegexParser` case-insensitive matches use the token’s precomputed uppercased text (full Unicode mapping, e.g., `straße` -> `STRASSE`), matching Python.
  - Indentation config values are coerced with `bool()`, so int settings like `indentation.indented_joins = 1` are honored.

<sup>Written for commit ef736ca0ec03f809fbc9051e3ceffbb33a1c3873. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8244?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

