### PR TITLE
Fix AL01 loop on bracketed column aliases

### DIFF
--- a/src/sqlfluff/rules/aliasing/AL01.py
+++ b/src/sqlfluff/rules/aliasing/AL01.py
@@ -86,7 +86,12 @@ class Rule_AL01(BaseRule):
 
             elif self.aliasing != "implicit":
                 self.logger.debug("Inserting AS keyword and respacing.")
-                for identifier in context.segment.raw_segments:
+                # Anchor on the first code *child* rather than the first code
+                # raw segment. Some aliases (e.g. a bare column list like
+                # `(a, b)`) wrap their content in a `bracketed` segment, and
+                # anchoring on the nested bracket would insert the `AS` inside
+                # it, where the `alias_operator` check above can't see it.
+                for identifier in context.segment.segments:
                     if identifier.is_code:
                         break
                 else:  # pragma: no cover

--- a/test/fixtures/rules/std_rule_cases/AL01.yml
+++ b/test/fixtures/rules/std_rule_cases/AL01.yml
@@ -176,3 +176,29 @@ test_pass_alias_expression_oracle_tables:
   configs:
     core:
       dialect: oracle
+
+test_fail_bracketed_column_list_alias_5994:
+  # An alias which is only a bracketed column list has no bare identifier, so
+  # the `AS` must still be inserted as a direct child of the alias expression.
+  # https://github.com/sqlfluff/sqlfluff/issues/5994
+  fail_str: select * from (values (1, 2), (3, 4)) (a, b)
+  fix_str: select * from (values (1, 2), (3, 4)) AS (a, b)
+  configs:
+    core:
+      dialect: sparksql
+
+test_pass_bracketed_column_list_alias_5994:
+  # The fixed version of the above must be clean, i.e. the fix converges.
+  pass_str: select * from (values (1, 2), (3, 4)) AS (a, b)
+  configs:
+    core:
+      dialect: sparksql
+
+test_fail_named_bracketed_column_list_alias:
+  # Control: when the alias does have a bare identifier, the `AS` still goes
+  # before the identifier rather than before the column list.
+  fail_str: select * from (values (1, 2)) v (a, b)
+  fix_str: select * from (values (1, 2)) AS v (a, b)
+  configs:
+    core:
+      dialect: postgres


### PR DESCRIPTION
### Brief summary of the change made

Fixes #5994.

AL01 currently anchors an inserted `AS` keyword on the first code raw segment. For a bracket-only column alias such as `(a, b)`, that segment is nested inside the bracketed child, so the fix inserts `AS` where the alias-operator check cannot see it. Repeated fixing then reaches the loop limit and discards other rules’ fixes in the same run.

This change anchors on the first direct code child instead. It makes the fix converge to `AS (a, b)` while preserving placement for ordinary and named aliases.

Regression coverage includes:

- the SparkSQL reproducer from #5994;
- convergence of the fixed form;
- a named PostgreSQL alias with a column list as a control.

### Are there any other side effects of this change that we should be aware of?

None expected. The change only affects where AL01 inserts `AS` within an alias expression; existing alias forms remain unchanged in the regression suite.

### Validation

- `pytest test/rules/yaml_test_cases_test.py -k AL01 -q`: 18 passed
- `pytest test/rules/std_fix_auto_test.py -q`: 60 passed
- `ruff check src/sqlfluff/rules/aliasing/AL01.py`: passed
- `ruff format --check src/sqlfluff/rules/aliasing/AL01.py`: passed
- `mypy src/sqlfluff/rules/aliasing/AL01.py`: passed

### AI assistance disclosure

AI tools assisted with issue triage, root-cause analysis, patch drafting, and review. I validated the final diff locally with the commands and regression controls listed above.

### Pull Request checklist

- [x] Included test cases demonstrating the code change.
- [x] Verified the relevant automated tests and quality checks locally.
- [x] No documentation change is needed for this internal fixer correction.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #5994 by stopping the AL01 fix loop on bracketed column-list aliases. We now insert AS on the first direct code child of the alias expression, converging to AS (a, b) and leaving ordinary and named aliases unchanged.

<sup>Written for commit 12eee08669cf57d5c213b0c3ea672481a1bd670e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8245?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

