### PR TITLE
Parse round-bracketed MAP types in Athena

### DIFF
--- a/src/sqlfluff/dialects/dialect_athena.py
+++ b/src/sqlfluff/dialects/dialect_athena.py
@@ -376,17 +376,33 @@ class MapTypeSegment(BaseSegment):
 
 
 class MapTypeSchemaSegment(BaseSegment):
-    """Expression to construct the schema of a MAP datatype."""
+    """Expression to construct the schema of a MAP datatype.
+
+    Athena supports MAP<KEY_TYPE, VALUE_TYPE> in DDL and
+    MAP(KEY_TYPE, VALUE_TYPE) in queries.
+    https://docs.aws.amazon.com/athena/latest/ug/data-types.html
+    """
 
     type = "map_type_schema"
-    match_grammar = Bracketed(
-        Sequence(
-            Ref("PrimitiveTypeSegment"),
-            Ref("CommaSegment"),
-            Ref("DatatypeSegment"),
+    match_grammar = OneOf(
+        Bracketed(
+            Sequence(
+                Ref("PrimitiveTypeSegment"),
+                Ref("CommaSegment"),
+                Ref("DatatypeSegment"),
+            ),
+            bracket_pairs_set="angle_bracket_pairs",
+            bracket_type="angle",
         ),
-        bracket_pairs_set="angle_bracket_pairs",
-        bracket_type="angle",
+        Bracketed(
+            Sequence(
+                Ref("PrimitiveTypeSegment"),
+                Ref("CommaSegment"),
+                Ref("DatatypeSegment"),
+            ),
+            bracket_pairs_set="bracket_pairs",
+            bracket_type="round",
+        ),
     )
 
 

--- a/test/fixtures/dialects/athena/cast_map_round_brackets.sql
+++ b/test/fixtures/dialects/athena/cast_map_round_brackets.sql
@@ -1,0 +1,4 @@
+SELECT CAST(JSON_PARSE('{"key": "value"}') AS MAP(varchar, varchar));
+SELECT CAST(c1 AS MAP(varchar, varchar)) FROM map_table;
+SELECT CAST(c1 AS ARRAY(MAP(varchar, varchar))) FROM map_table;
+SELECT CAST(c1 AS MAP(varchar, ARRAY(integer))) FROM map_table;

--- a/test/fixtures/dialects/athena/cast_map_round_brackets.yml
+++ b/test/fixtures/dialects/athena/cast_map_round_brackets.yml
@@ -1,0 +1,169 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: b42fca762ecb71f111911a062a659992da88d027c6e21a33433f4a5bc0bc04aa
+file:
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: CAST
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  function:
+                    function_name:
+                      function_name_identifier: JSON_PARSE
+                    function_contents:
+                      bracketed:
+                        start_bracket: (
+                        expression:
+                          quoted_literal: "'{\"key\": \"value\"}'"
+                        end_bracket: )
+                keyword: AS
+                data_type:
+                  map_type:
+                    keyword: MAP
+                    map_type_schema:
+                      bracketed:
+                        start_bracket: (
+                        primitive_type:
+                          keyword: varchar
+                        comma: ','
+                        data_type:
+                          primitive_type:
+                            keyword: varchar
+                        end_bracket: )
+                end_bracket: )
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: CAST
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  column_reference:
+                    naked_identifier: c1
+                keyword: AS
+                data_type:
+                  map_type:
+                    keyword: MAP
+                    map_type_schema:
+                      bracketed:
+                        start_bracket: (
+                        primitive_type:
+                          keyword: varchar
+                        comma: ','
+                        data_type:
+                          primitive_type:
+                            keyword: varchar
+                        end_bracket: )
+                end_bracket: )
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: map_table
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: CAST
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  column_reference:
+                    naked_identifier: c1
+                keyword: AS
+                data_type:
+                  array_type:
+                    keyword: ARRAY
+                    array_type_schema:
+                      bracketed:
+                        start_bracket: (
+                        data_type:
+                          map_type:
+                            keyword: MAP
+                            map_type_schema:
+                              bracketed:
+                                start_bracket: (
+                                primitive_type:
+                                  keyword: varchar
+                                comma: ','
+                                data_type:
+                                  primitive_type:
+                                    keyword: varchar
+                                end_bracket: )
+                        end_bracket: )
+                end_bracket: )
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: map_table
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: CAST
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  column_reference:
+                    naked_identifier: c1
+                keyword: AS
+                data_type:
+                  map_type:
+                    keyword: MAP
+                    map_type_schema:
+                      bracketed:
+                        start_bracket: (
+                        primitive_type:
+                          keyword: varchar
+                        comma: ','
+                        data_type:
+                          array_type:
+                            keyword: ARRAY
+                            array_type_schema:
+                              bracketed:
+                                start_bracket: (
+                                data_type:
+                                  primitive_type:
+                                    keyword: integer
+                                end_bracket: )
+                        end_bracket: )
+                end_bracket: )
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: map_table
+- statement_terminator: ;


### PR DESCRIPTION
### Brief summary of the change made

Fixes #4749.

Athena accepts both `MAP<key_type, value_type>` and `MAP(key_type, value_type)` as type syntax, but `MapTypeSchemaSegment` currently accepts only the angle-bracket form. This makes valid casts such as `CAST(value AS MAP(varchar, varchar))` unparsable.

This change adds the round-bracket form while keeping the existing angle-bracket branch first and unchanged. The grammar now mirrors SQLFluff’s existing Trino `MapTypeSchemaSegment`, which is appropriate for Athena engine v3.

Regression fixtures cover direct casts and nested `ARRAY(MAP(...))` / `MAP(..., ARRAY(...))` forms.

### Are there any other side effects of this change that we should be aware of?

Athena queries using round-bracketed `MAP` type syntax will now parse instead of producing a `PRS` error. Existing angle-bracket DDL behavior remains unchanged.

### Validation

- Regenerated `cast_map_round_brackets.yml`: success
- Targeted new fixture: 3 passed
- All Athena parser cases: 147 passed
- `ruff check src/sqlfluff/dialects/dialect_athena.py`: passed
- `ruff format --check src/sqlfluff/dialects/dialect_athena.py`: passed
- `mypy src/sqlfluff/dialects/dialect_athena.py`: passed

### AI assistance disclosure

Claude Opus assisted with issue triage, implementation, tests, and initial review. I independently inspected the final diff, compared it against the Trino grammar, regenerated the fixture, and ran the validation listed above.

### Pull Request checklist

- [x] Included SQL and generated YAML parser fixtures.
- [x] Verified the relevant parser, lint, format, and type checks locally.
- [x] No documentation change is needed because this aligns the parser with syntax Athena already accepts.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Teach the Athena dialect to parse round-bracketed `MAP(key_type, value_type)` types in queries. This fixes unparsable casts and nested types while keeping angle-bracket `MAP<...>` support unchanged.

- **Bug Fixes**
  - Added a round-bracket branch to `MapTypeSchemaSegment` (via `OneOf`) alongside the existing angle-bracket grammar.
  - Matches Trino behavior; supports casts and nested `ARRAY(MAP(...))` and `MAP(..., ARRAY(...))`.
  - Added regression fixtures; all Athena parser tests pass.

<sup>Written for commit 3615e38648dfb730ddece33e61a6c1a227dd7fe1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8246?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

