### PR TITLE
fix(rust): avoid double allocation in pyo3 getters for collection fields (trim/type/escape)

### DIFF
--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/arena.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/arena.rs
@@ -52,7 +52,11 @@ enum ArenaKind {
         segment_class: Cow<'static, str>,
         segment_type: Cow<'static, str>,
         raw: String,
-        instance_types: Vec<String>,
+        /// `Arc`-wrapped so `with_instance_types`'s PyO3 caller can clone the
+        /// handle under the arena lock, drop the guard, and only then build
+        /// the Python list — never holding the lock across a Python
+        /// allocation.
+        instance_types: Arc<Vec<String>>,
         class_types: Vec<String>,
         kwargs: RawSegmentKwargs,
     },
@@ -162,7 +166,7 @@ impl Arena {
                     segment_class: segment_class.clone(),
                     segment_type: segment_type.clone(),
                     raw: raw.clone(),
-                    instance_types: instance_types.clone(),
+                    instance_types: Arc::new(instance_types.clone()),
                     class_types: class_types.clone(),
                     kwargs: segment_kwargs.clone(),
                 },
@@ -390,12 +394,13 @@ impl Arena {
         self.node_type_set(id)
     }
 
-    /// Instance types for a raw token, borrowed to avoid cloning into an
-    /// intermediate `Vec` — callers build a Python list/tuple directly.
-    pub fn with_instance_types<R>(&self, id: NodeId, f: impl FnOnce(&[String]) -> R) -> R {
+    /// Instance types for a raw token: a cheap `Arc` clone (a refcount bump,
+    /// not a deep copy) so callers can drop the arena lock before building a
+    /// Python object from it.
+    pub fn instance_types_arc(&self, id: NodeId) -> Arc<Vec<String>> {
         match &self.node(id).kind {
-            ArenaKind::Raw { instance_types, .. } => f(instance_types),
-            _ => f(&[]),
+            ArenaKind::Raw { instance_types, .. } => instance_types.clone(),
+            _ => Arc::new(Vec::new()),
         }
     }
 
@@ -419,12 +424,12 @@ impl Arena {
     }
 
     /// Characters to trim from both ends of a raw token (if set on the
-    /// token), borrowed to avoid cloning into an intermediate `Vec` —
-    /// callers build a Python list/tuple directly.
-    pub fn with_trim_chars<R>(&self, id: NodeId, f: impl FnOnce(Option<&[String]>) -> R) -> R {
+    /// token): a cheap `Arc` clone so callers can drop the arena lock before
+    /// building a Python object from it.
+    pub fn trim_chars_arc(&self, id: NodeId) -> Option<Arc<Vec<String>>> {
         match &self.node(id).kind {
-            ArenaKind::Raw { kwargs, .. } => f(kwargs.trim_chars.as_deref()),
-            _ => f(None),
+            ArenaKind::Raw { kwargs, .. } => kwargs.trim_chars.clone(),
+            _ => None,
         }
     }
 
@@ -436,19 +441,13 @@ impl Arena {
         }
     }
 
-    /// The escape `(pattern, replacement)` pairs for a raw token, borrowed to
-    /// avoid cloning into an intermediate `Vec` — callers build a Python list
-    /// directly.
-    pub fn with_escape_replacements<R>(
-        &self,
-        id: NodeId,
-        f: impl FnOnce(Option<&[(String, String)]>) -> R,
-    ) -> R {
+    /// The escape `(pattern, replacement)` pairs for a raw token: a cheap
+    /// `Arc` clone so callers can drop the arena lock before building a
+    /// Python object from it.
+    pub fn escape_replacements_arc(&self, id: NodeId) -> Option<Arc<Vec<(String, String)>>> {
         match &self.node(id).kind {
-            ArenaKind::Raw { kwargs, .. } => {
-                f(kwargs.escape_replacements.as_deref().map(Vec::as_slice))
-            }
-            _ => f(None),
+            ArenaKind::Raw { kwargs, .. } => kwargs.escape_replacements.clone(),
+            _ => None,
         }
     }
 

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/arena.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/arena.rs
@@ -89,6 +89,9 @@ struct ArenaNode {
     /// Cached `descendant_type_set` (mirrors `BaseSegment.descendant_type_set`),
     /// used by the crawler to prune subtrees.
     descendant_types: RefCell<Option<Arc<HashSet<String>>>>,
+    /// Cached `class_types` (mirrors `BaseSegment.class_types`) — computed
+    /// once per node, then handed out as a cheap `Arc` clone.
+    class_types_cache: RefCell<Option<Arc<Vec<String>>>>,
 }
 
 /// A flattened, parent-linked, id-addressable parse tree.
@@ -146,6 +149,7 @@ impl Arena {
             kind,
             cached_raw: RefCell::new(None),
             descendant_types: RefCell::new(None),
+            class_types_cache: RefCell::new(None),
         });
         self.by_uuid.insert(uuid, id);
         id
@@ -390,8 +394,16 @@ impl Arena {
         out
     }
 
-    pub fn class_types(&self, id: NodeId) -> Vec<String> {
-        self.node_type_set(id)
+    /// This node's `class_types`, cached and handed out as a cheap `Arc`
+    /// clone (mirrors `descendant_type_set`'s caching below) so callers can
+    /// drop the arena lock before building a Python object from it.
+    pub fn class_types(&self, id: NodeId) -> Arc<Vec<String>> {
+        if let Some(cached) = self.node(id).class_types_cache.borrow().as_ref() {
+            return cached.clone();
+        }
+        let rc = Arc::new(self.node_type_set(id));
+        *self.node(id).class_types_cache.borrow_mut() = Some(rc.clone());
+        rc
     }
 
     /// Instance types for a raw token: a cheap `Arc` clone (a refcount bump,

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/arena.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/arena.rs
@@ -52,10 +52,10 @@ enum ArenaKind {
         segment_class: Cow<'static, str>,
         segment_type: Cow<'static, str>,
         raw: String,
-        /// `Arc`-wrapped so `with_instance_types`'s PyO3 caller can clone the
-        /// handle under the arena lock, drop the guard, and only then build
-        /// the Python list — never holding the lock across a Python
-        /// allocation.
+        /// `Arc`-wrapped so `instance_types_arc`'s PyO3 caller
+        /// (`PyHandle::instance_types`) can clone the handle under the arena
+        /// lock, drop the guard, and only then build the Python list —
+        /// never holding the lock across a Python allocation.
         instance_types: Arc<Vec<String>>,
         class_types: Vec<String>,
         kwargs: RawSegmentKwargs,

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/arena.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/arena.rs
@@ -390,10 +390,12 @@ impl Arena {
         self.node_type_set(id)
     }
 
-    pub fn instance_types(&self, id: NodeId) -> Vec<String> {
+    /// Instance types for a raw token, borrowed to avoid cloning into an
+    /// intermediate `Vec` — callers build a Python list/tuple directly.
+    pub fn with_instance_types<R>(&self, id: NodeId, f: impl FnOnce(&[String]) -> R) -> R {
         match &self.node(id).kind {
-            ArenaKind::Raw { instance_types, .. } => instance_types.clone(),
-            _ => Vec::new(),
+            ArenaKind::Raw { instance_types, .. } => f(instance_types),
+            _ => f(&[]),
         }
     }
 
@@ -416,11 +418,13 @@ impl Arena {
         }
     }
 
-    /// Characters to trim from both ends of a raw token (if set on the token).
-    pub fn trim_chars(&self, id: NodeId) -> Option<Vec<String>> {
+    /// Characters to trim from both ends of a raw token (if set on the
+    /// token), borrowed to avoid cloning into an intermediate `Vec` —
+    /// callers build a Python list/tuple directly.
+    pub fn with_trim_chars<R>(&self, id: NodeId, f: impl FnOnce(Option<&[String]>) -> R) -> R {
         match &self.node(id).kind {
-            ArenaKind::Raw { kwargs, .. } => kwargs.trim_chars.clone(),
-            _ => None,
+            ArenaKind::Raw { kwargs, .. } => f(kwargs.trim_chars.as_deref()),
+            _ => f(None),
         }
     }
 
@@ -432,11 +436,19 @@ impl Arena {
         }
     }
 
-    /// The escape `(pattern, replacement)` pairs for a raw token.
-    pub fn escape_replacements(&self, id: NodeId) -> Option<Vec<(String, String)>> {
+    /// The escape `(pattern, replacement)` pairs for a raw token, borrowed to
+    /// avoid cloning into an intermediate `Vec` — callers build a Python list
+    /// directly.
+    pub fn with_escape_replacements<R>(
+        &self,
+        id: NodeId,
+        f: impl FnOnce(Option<&[(String, String)]>) -> R,
+    ) -> R {
         match &self.node(id).kind {
-            ArenaKind::Raw { kwargs, .. } => kwargs.escape_replacements.as_deref().cloned(),
-            _ => None,
+            ArenaKind::Raw { kwargs, .. } => {
+                f(kwargs.escape_replacements.as_deref().map(Vec::as_slice))
+            }
+            _ => f(None),
         }
     }
 

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/arena_py.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/arena_py.rs
@@ -195,7 +195,11 @@ impl PyHandle {
     fn escape_replacements<'py>(&self, py: Python<'py>) -> PyResult<Option<Bound<'py, PyList>>> {
         // Clone the `Arc` under the lock, then drop the guard before
         // building the Python list.
-        let arc = self.inner.lock().unwrap().escape_replacements_arc(self.node);
+        let arc = self
+            .inner
+            .lock()
+            .unwrap()
+            .escape_replacements_arc(self.node);
         arc.map(|pairs| pylist_of_str_pairs(py, &pairs)).transpose()
     }
 

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/arena_py.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/arena_py.rs
@@ -163,7 +163,7 @@ impl PyHandle {
         self.inner.lock().unwrap().class_types(self.node)
     }
 
-    fn instance_types<'py>(&self, py: Python<'py>) -> Bound<'py, PyList> {
+    fn instance_types<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyList>> {
         self.inner
             .lock()
             .unwrap()
@@ -175,23 +175,25 @@ impl PyHandle {
         self.inner.lock().unwrap().is_implicit(self.node)
     }
 
-    fn trim_chars<'py>(&self, py: Python<'py>) -> Option<Bound<'py, PyTuple>> {
+    fn trim_chars<'py>(&self, py: Python<'py>) -> PyResult<Option<Bound<'py, PyTuple>>> {
         self.inner
             .lock()
             .unwrap()
-            .with_trim_chars(self.node, |v| v.map(|v| pytuple_of_strs(py, v)))
+            .with_trim_chars(self.node, |v| v.map(|v| pytuple_of_strs(py, v)).transpose())
     }
 
     fn quoted_value(&self) -> Option<(String, String)> {
         self.inner.lock().unwrap().quoted_value(self.node)
     }
 
-    fn escape_replacements<'py>(&self, py: Python<'py>) -> Option<Bound<'py, PyList>> {
+    fn escape_replacements<'py>(&self, py: Python<'py>) -> PyResult<Option<Bound<'py, PyList>>> {
         self.inner
             .lock()
             .unwrap()
             .with_escape_replacements(self.node, |pairs| {
-                pairs.map(|pairs| pylist_of_str_pairs(py, pairs))
+                pairs
+                    .map(|pairs| pylist_of_str_pairs(py, pairs))
+                    .transpose()
             })
     }
 

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/arena_py.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/arena_py.rs
@@ -17,8 +17,10 @@
 use std::sync::{Arc, Mutex};
 
 use pyo3::prelude::*;
+use pyo3::types::{PyList, PyTuple};
 
 use sqlfluffrs_python::marker::PyPositionMarker;
+use sqlfluffrs_python::pyo3_helpers::{pylist_of_str_pairs, pylist_of_strs, pytuple_of_strs};
 
 use super::arena::{Arena, NodeId};
 
@@ -161,8 +163,11 @@ impl PyHandle {
         self.inner.lock().unwrap().class_types(self.node)
     }
 
-    fn instance_types(&self) -> Vec<String> {
-        self.inner.lock().unwrap().instance_types(self.node)
+    fn instance_types<'py>(&self, py: Python<'py>) -> Bound<'py, PyList> {
+        self.inner
+            .lock()
+            .unwrap()
+            .with_instance_types(self.node, |v| pylist_of_strs(py, v))
     }
 
     /// `is_implicit` flag for Indent/Dedent metas (`None` for non-metas).
@@ -170,16 +175,24 @@ impl PyHandle {
         self.inner.lock().unwrap().is_implicit(self.node)
     }
 
-    fn trim_chars(&self) -> Option<Vec<String>> {
-        self.inner.lock().unwrap().trim_chars(self.node)
+    fn trim_chars<'py>(&self, py: Python<'py>) -> Option<Bound<'py, PyTuple>> {
+        self.inner
+            .lock()
+            .unwrap()
+            .with_trim_chars(self.node, |v| v.map(|v| pytuple_of_strs(py, v)))
     }
 
     fn quoted_value(&self) -> Option<(String, String)> {
         self.inner.lock().unwrap().quoted_value(self.node)
     }
 
-    fn escape_replacements(&self) -> Option<Vec<(String, String)>> {
-        self.inner.lock().unwrap().escape_replacements(self.node)
+    fn escape_replacements<'py>(&self, py: Python<'py>) -> Option<Bound<'py, PyList>> {
+        self.inner
+            .lock()
+            .unwrap()
+            .with_escape_replacements(self.node, |pairs| {
+                pairs.map(|pairs| pylist_of_str_pairs(py, pairs))
+            })
     }
 
     #[getter]
@@ -187,14 +200,9 @@ impl PyHandle {
         self.inner.lock().unwrap().segment_class(self.node)
     }
 
-    fn descendant_type_set(&self) -> Vec<String> {
-        self.inner
-            .lock()
-            .unwrap()
-            .descendant_type_set(self.node)
-            .iter()
-            .cloned()
-            .collect()
+    fn descendant_type_set<'py>(&self, py: Python<'py>) -> Bound<'py, PyList> {
+        let set = self.inner.lock().unwrap().descendant_type_set(self.node);
+        PyList::new(py, set.iter().map(String::as_str)).unwrap()
     }
 
     #[getter]

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/arena_py.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/arena_py.rs
@@ -20,7 +20,9 @@ use pyo3::prelude::*;
 use pyo3::types::{PyList, PyTuple};
 
 use sqlfluffrs_python::marker::PyPositionMarker;
-use sqlfluffrs_python::pyo3_helpers::{pylist_of_str_pairs, pylist_of_strs, pytuple_of_strs};
+use sqlfluffrs_python::pyo3_helpers::{
+    pylist_of_str_pairs, pylist_of_strs, pylist_of_strs_iter, pytuple_of_strs,
+};
 
 use super::arena::{Arena, NodeId};
 
@@ -202,9 +204,9 @@ impl PyHandle {
         self.inner.lock().unwrap().segment_class(self.node)
     }
 
-    fn descendant_type_set<'py>(&self, py: Python<'py>) -> Bound<'py, PyList> {
+    fn descendant_type_set<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyList>> {
         let set = self.inner.lock().unwrap().descendant_type_set(self.node);
-        PyList::new(py, set.iter().map(String::as_str)).unwrap()
+        pylist_of_strs_iter(py, set.iter().map(String::as_str))
     }
 
     #[getter]

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/arena_py.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/arena_py.rs
@@ -166,10 +166,11 @@ impl PyHandle {
     }
 
     fn instance_types<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyList>> {
-        self.inner
-            .lock()
-            .unwrap()
-            .with_instance_types(self.node, |v| pylist_of_strs(py, v))
+        // Clone the `Arc` under the lock (a refcount bump), then drop the
+        // guard before building the Python list — the arena lock is never
+        // held across a Python allocation.
+        let arc = self.inner.lock().unwrap().instance_types_arc(self.node);
+        pylist_of_strs(py, &arc)
     }
 
     /// `is_implicit` flag for Indent/Dedent metas (`None` for non-metas).
@@ -178,10 +179,10 @@ impl PyHandle {
     }
 
     fn trim_chars<'py>(&self, py: Python<'py>) -> PyResult<Option<Bound<'py, PyTuple>>> {
-        self.inner
-            .lock()
-            .unwrap()
-            .with_trim_chars(self.node, |v| v.map(|v| pytuple_of_strs(py, v)).transpose())
+        // Clone the `Arc` under the lock, then drop the guard before
+        // building the Python tuple.
+        let arc = self.inner.lock().unwrap().trim_chars_arc(self.node);
+        arc.map(|v| pytuple_of_strs(py, &v)).transpose()
     }
 
     fn quoted_value(&self) -> Option<(String, String)> {
@@ -189,14 +190,10 @@ impl PyHandle {
     }
 
     fn escape_replacements<'py>(&self, py: Python<'py>) -> PyResult<Option<Bound<'py, PyList>>> {
-        self.inner
-            .lock()
-            .unwrap()
-            .with_escape_replacements(self.node, |pairs| {
-                pairs
-                    .map(|pairs| pylist_of_str_pairs(py, pairs))
-                    .transpose()
-            })
+        // Clone the `Arc` under the lock, then drop the guard before
+        // building the Python list.
+        let arc = self.inner.lock().unwrap().escape_replacements_arc(self.node);
+        arc.map(|pairs| pylist_of_str_pairs(py, &pairs)).transpose()
     }
 
     #[getter]

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/arena_py.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/arena_py.rs
@@ -161,8 +161,11 @@ impl PyHandle {
         seg_type.iter().any(|t| a.is_type(self.node, t))
     }
 
-    fn class_types(&self) -> Vec<String> {
-        self.inner.lock().unwrap().class_types(self.node)
+    fn class_types<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyList>> {
+        // Clone the cached `Arc` under the lock, then drop the guard before
+        // building the Python list.
+        let arc = self.inner.lock().unwrap().class_types(self.node);
+        pylist_of_strs(py, &arc)
     }
 
     fn instance_types<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyList>> {

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/match_result.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/match_result.rs
@@ -615,7 +615,7 @@ impl MatchResult {
                         instance_types,
                         &raw_class_ct,
                         RawSegmentKwargs {
-                            trim_chars: match_class.segment_kwargs.trim_chars,
+                            trim_chars: match_class.segment_kwargs.trim_chars.map(Arc::new),
                             quoted_value,
                             escape_replacements,
                         },

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/python.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/python.rs
@@ -1,7 +1,7 @@
 use hashbrown::HashMap;
 use pyo3::exceptions::PyException;
 use pyo3::prelude::*;
-use pyo3::types::{PyDict, PyList};
+use pyo3::types::{PyDict, PyList, PyTuple};
 
 use crate::parser::MetaSegment;
 
@@ -9,6 +9,7 @@ use super::match_result::MatchResult;
 use super::types::NodeTupleValue;
 use super::{Node, ParseError, Parser};
 use sqlfluffrs_dialects::Dialect;
+use sqlfluffrs_python::pyo3_helpers::{pylist_of_str_pairs, pylist_of_strs, pytuple_of_strs};
 use sqlfluffrs_python::token::PyToken;
 use sqlfluffrs_types::Token;
 use std::str::FromStr;
@@ -99,22 +100,22 @@ impl PyNode {
     }
 
     /// Get instance_types (for Raw nodes)
-    fn instance_types(&self) -> Option<Vec<String>> {
+    fn instance_types<'py>(&self, py: Python<'py>) -> Option<Bound<'py, PyList>> {
         match &self.0 {
-            Node::Raw { instance_types, .. } => Some(instance_types.clone()),
+            Node::Raw { instance_types, .. } => Some(pylist_of_strs(py, instance_types)),
             _ => None,
         }
     }
 
     /// Get class_types — mirrors Python's class_types property.
-    fn class_types(&self) -> Option<Vec<String>> {
+    fn class_types<'py>(&self, py: Python<'py>) -> Option<Bound<'py, PyList>> {
         match &self.0 {
-            Node::Raw { class_types, .. } => Some(class_types.clone()),
+            Node::Raw { class_types, .. } => Some(pylist_of_strs(py, class_types)),
             Node::Segment { class_types, .. } => {
                 if class_types.is_empty() {
                     None
                 } else {
-                    Some(class_types.clone())
+                    Some(pylist_of_strs(py, class_types))
                 }
             }
             _ => None,
@@ -288,20 +289,22 @@ impl PyMatchResult {
 
     /// Get instance_types (semantic type markers like "keyword", "star")
     #[getter]
-    fn instance_types(&self) -> Option<Vec<String>> {
+    fn instance_types<'py>(&self, py: Python<'py>) -> Option<Bound<'py, PyList>> {
         self.0
             .matched_class
             .as_ref()
-            .and_then(|s| s.segment_kwargs.instance_types.clone())
+            .and_then(|s| s.segment_kwargs.instance_types.as_ref())
+            .map(|v| pylist_of_strs(py, v))
     }
 
     /// Get trim_chars for the segment
     #[getter]
-    fn trim_chars(&self) -> Option<Vec<String>> {
+    fn trim_chars<'py>(&self, py: Python<'py>) -> Option<Bound<'py, PyTuple>> {
         self.0
             .matched_class
             .as_ref()
-            .and_then(|s| s.segment_kwargs.trim_chars.clone())
+            .and_then(|s| s.segment_kwargs.trim_chars.as_ref())
+            .map(|v| pytuple_of_strs(py, v))
     }
 
     /// Get casefold mode (for case-insensitive matching)
@@ -343,11 +346,12 @@ impl PyMatchResult {
 
     /// Get escape_replacements for escape sequence handling
     #[getter]
-    fn escape_replacements(&self) -> Option<Vec<(String, String)>> {
+    fn escape_replacements<'py>(&self, py: Python<'py>) -> Option<Bound<'py, PyList>> {
         self.0
             .matched_class
             .as_ref()
-            .and_then(|s| s.segment_kwargs.escape_replacements.as_deref().cloned())
+            .and_then(|s| s.segment_kwargs.escape_replacements.as_deref())
+            .map(|pairs| pylist_of_str_pairs(py, pairs))
     }
 
     /// Get insert_segments (meta segments like Indent/Dedent to insert)

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/python.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/python.rs
@@ -100,25 +100,25 @@ impl PyNode {
     }
 
     /// Get instance_types (for Raw nodes)
-    fn instance_types<'py>(&self, py: Python<'py>) -> Option<Bound<'py, PyList>> {
+    fn instance_types<'py>(&self, py: Python<'py>) -> PyResult<Option<Bound<'py, PyList>>> {
         match &self.0 {
-            Node::Raw { instance_types, .. } => Some(pylist_of_strs(py, instance_types)),
-            _ => None,
+            Node::Raw { instance_types, .. } => Ok(Some(pylist_of_strs(py, instance_types)?)),
+            _ => Ok(None),
         }
     }
 
     /// Get class_types — mirrors Python's class_types property.
-    fn class_types<'py>(&self, py: Python<'py>) -> Option<Bound<'py, PyList>> {
+    fn class_types<'py>(&self, py: Python<'py>) -> PyResult<Option<Bound<'py, PyList>>> {
         match &self.0 {
-            Node::Raw { class_types, .. } => Some(pylist_of_strs(py, class_types)),
+            Node::Raw { class_types, .. } => Ok(Some(pylist_of_strs(py, class_types)?)),
             Node::Segment { class_types, .. } => {
                 if class_types.is_empty() {
-                    None
+                    Ok(None)
                 } else {
-                    Some(pylist_of_strs(py, class_types))
+                    Ok(Some(pylist_of_strs(py, class_types)?))
                 }
             }
-            _ => None,
+            _ => Ok(None),
         }
     }
 
@@ -289,22 +289,24 @@ impl PyMatchResult {
 
     /// Get instance_types (semantic type markers like "keyword", "star")
     #[getter]
-    fn instance_types<'py>(&self, py: Python<'py>) -> Option<Bound<'py, PyList>> {
+    fn instance_types<'py>(&self, py: Python<'py>) -> PyResult<Option<Bound<'py, PyList>>> {
         self.0
             .matched_class
             .as_ref()
             .and_then(|s| s.segment_kwargs.instance_types.as_ref())
             .map(|v| pylist_of_strs(py, v))
+            .transpose()
     }
 
     /// Get trim_chars for the segment
     #[getter]
-    fn trim_chars<'py>(&self, py: Python<'py>) -> Option<Bound<'py, PyTuple>> {
+    fn trim_chars<'py>(&self, py: Python<'py>) -> PyResult<Option<Bound<'py, PyTuple>>> {
         self.0
             .matched_class
             .as_ref()
             .and_then(|s| s.segment_kwargs.trim_chars.as_ref())
             .map(|v| pytuple_of_strs(py, v))
+            .transpose()
     }
 
     /// Get casefold mode (for case-insensitive matching)
@@ -346,12 +348,13 @@ impl PyMatchResult {
 
     /// Get escape_replacements for escape sequence handling
     #[getter]
-    fn escape_replacements<'py>(&self, py: Python<'py>) -> Option<Bound<'py, PyList>> {
+    fn escape_replacements<'py>(&self, py: Python<'py>) -> PyResult<Option<Bound<'py, PyList>>> {
         self.0
             .matched_class
             .as_ref()
             .and_then(|s| s.segment_kwargs.escape_replacements.as_deref())
             .map(|pairs| pylist_of_str_pairs(py, pairs))
+            .transpose()
     }
 
     /// Get insert_segments (meta segments like Indent/Dedent to insert)

--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/types.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/types.rs
@@ -32,7 +32,10 @@ pub enum MetaType {
 /// Additional segment properties for Raw segments
 #[derive(Debug, Clone, PartialEq, Default)]
 pub struct RawSegmentKwargs {
-    pub trim_chars: Option<Vec<String>>,
+    /// `Arc`-wrapped, like `escape_replacements` below, so PyO3 getters on the
+    /// arena-backed `RsHandle` can clone the handle under the arena lock and
+    /// build the Python tuple only after dropping the guard.
+    pub trim_chars: Option<std::sync::Arc<Vec<String>>>,
     pub quoted_value: Option<(String, String)>,
     pub escape_replacements: Option<std::sync::Arc<Vec<(String, String)>>>,
 }

--- a/sqlfluffrs/sqlfluffrs_python/src/lib.rs
+++ b/sqlfluffrs/sqlfluffrs_python/src/lib.rs
@@ -3,6 +3,7 @@
 
 pub mod config;
 pub mod marker;
+pub mod pyo3_helpers;
 pub mod slice;
 pub mod templater;
 pub mod token;

--- a/sqlfluffrs/sqlfluffrs_python/src/pyo3_helpers.rs
+++ b/sqlfluffrs/sqlfluffrs_python/src/pyo3_helpers.rs
@@ -1,0 +1,29 @@
+//! Small shared converters for building PyO3 containers from Rust collections.
+//!
+//! Centralised here so the string-list and escape-pair conversions used across
+//! `sqlfluffrs_python::token` and the `sqlfluffrs_parser` PyO3 bindings stay in
+//! sync instead of being copy-pasted at each call site.
+
+use pyo3::prelude::*;
+use pyo3::types::{PyList, PyTuple};
+
+/// Build a `PyList` of Python strings from a slice of owned `String`s.
+pub fn pylist_of_strs<'py>(py: Python<'py>, items: &[String]) -> Bound<'py, PyList> {
+    PyList::new(py, items.iter().map(String::as_str)).unwrap()
+}
+
+/// Build a `PyTuple` of Python strings from a slice of owned `String`s.
+pub fn pytuple_of_strs<'py>(py: Python<'py>, items: &[String]) -> Bound<'py, PyTuple> {
+    PyTuple::new(py, items.iter().map(String::as_str)).unwrap()
+}
+
+/// Build a `PyList` of `(str, str)` tuples from a slice of string pairs.
+pub fn pylist_of_str_pairs<'py>(py: Python<'py>, pairs: &[(String, String)]) -> Bound<'py, PyList> {
+    PyList::new(
+        py,
+        pairs
+            .iter()
+            .map(|(a, b)| PyTuple::new(py, [a.as_str(), b.as_str()]).unwrap()),
+    )
+    .unwrap()
+}

--- a/sqlfluffrs/sqlfluffrs_python/src/pyo3_helpers.rs
+++ b/sqlfluffrs/sqlfluffrs_python/src/pyo3_helpers.rs
@@ -8,22 +8,25 @@ use pyo3::prelude::*;
 use pyo3::types::{PyList, PyTuple};
 
 /// Build a `PyList` of Python strings from a slice of owned `String`s.
-pub fn pylist_of_strs<'py>(py: Python<'py>, items: &[String]) -> Bound<'py, PyList> {
-    PyList::new(py, items.iter().map(String::as_str)).unwrap()
+pub fn pylist_of_strs<'py>(py: Python<'py>, items: &[String]) -> PyResult<Bound<'py, PyList>> {
+    PyList::new(py, items.iter().map(String::as_str))
 }
 
 /// Build a `PyTuple` of Python strings from a slice of owned `String`s.
-pub fn pytuple_of_strs<'py>(py: Python<'py>, items: &[String]) -> Bound<'py, PyTuple> {
-    PyTuple::new(py, items.iter().map(String::as_str)).unwrap()
+pub fn pytuple_of_strs<'py>(py: Python<'py>, items: &[String]) -> PyResult<Bound<'py, PyTuple>> {
+    PyTuple::new(py, items.iter().map(String::as_str))
 }
 
 /// Build a `PyList` of `(str, str)` tuples from a slice of string pairs.
-pub fn pylist_of_str_pairs<'py>(py: Python<'py>, pairs: &[(String, String)]) -> Bound<'py, PyList> {
+pub fn pylist_of_str_pairs<'py>(
+    py: Python<'py>,
+    pairs: &[(String, String)],
+) -> PyResult<Bound<'py, PyList>> {
     PyList::new(
         py,
         pairs
             .iter()
-            .map(|(a, b)| PyTuple::new(py, [a.as_str(), b.as_str()]).unwrap()),
+            .map(|(a, b)| PyTuple::new(py, [a.as_str(), b.as_str()]))
+            .collect::<PyResult<Vec<_>>>()?,
     )
-    .unwrap()
 }

--- a/sqlfluffrs/sqlfluffrs_python/src/pyo3_helpers.rs
+++ b/sqlfluffrs/sqlfluffrs_python/src/pyo3_helpers.rs
@@ -5,11 +5,27 @@
 //! sync instead of being copy-pasted at each call site.
 
 use pyo3::prelude::*;
-use pyo3::types::{PyList, PyTuple};
+use pyo3::types::{PyFrozenSet, PyList, PyTuple};
 
 /// Build a `PyList` of Python strings from a slice of owned `String`s.
 pub fn pylist_of_strs<'py>(py: Python<'py>, items: &[String]) -> PyResult<Bound<'py, PyList>> {
     PyList::new(py, items.iter().map(String::as_str))
+}
+
+/// Build a `PyList` of Python strings from any iterator of borrowed `&str`s.
+pub fn pylist_of_strs_iter<'py, 'a>(
+    py: Python<'py>,
+    items: impl IntoIterator<Item = &'a str>,
+) -> PyResult<Bound<'py, PyList>> {
+    PyList::new(py, items)
+}
+
+/// Build a `PyFrozenSet` of Python strings from any iterator of borrowed `&str`s.
+pub fn pyfrozenset_of_strs<'py, 'a>(
+    py: Python<'py>,
+    items: impl IntoIterator<Item = &'a str>,
+) -> PyResult<Bound<'py, PyFrozenSet>> {
+    PyFrozenSet::new(py, items)
 }
 
 /// Build a `PyTuple` of Python strings from a slice of owned `String`s.

--- a/sqlfluffrs/sqlfluffrs_python/src/pyo3_helpers.rs
+++ b/sqlfluffrs/sqlfluffrs_python/src/pyo3_helpers.rs
@@ -1,8 +1,9 @@
 //! Small shared converters for building PyO3 containers from Rust collections.
 //!
-//! Centralised here so the string-list and escape-pair conversions used across
-//! `sqlfluffrs_python::token` and the `sqlfluffrs_parser` PyO3 bindings stay in
-//! sync instead of being copy-pasted at each call site.
+//! Centralised here so the string-list, string-set, and escape-pair
+//! conversions used across `sqlfluffrs_python::token` and the
+//! `sqlfluffrs_parser` PyO3 bindings stay in sync instead of being
+//! copy-pasted at each call site.
 
 use pyo3::prelude::*;
 use pyo3::types::{PyFrozenSet, PyList, PyTuple};

--- a/sqlfluffrs/sqlfluffrs_python/src/token.rs
+++ b/sqlfluffrs/sqlfluffrs_python/src/token.rs
@@ -231,13 +231,19 @@ impl PyToken {
     }
 
     #[getter]
-    pub fn trim_start(&self) -> Option<Vec<String>> {
-        self.0.trim_start.clone()
+    pub fn trim_start<'py>(&self, py: Python<'py>) -> Option<Bound<'py, PyTuple>> {
+        self.0
+            .trim_start
+            .as_ref()
+            .map(|v| PyTuple::new(py, v.iter().map(String::as_str)).unwrap())
     }
 
     #[getter]
-    pub fn trim_chars(&self) -> Option<Vec<String>> {
-        self.0.trim_chars.clone()
+    pub fn trim_chars<'py>(&self, py: Python<'py>) -> Option<Bound<'py, PyTuple>> {
+        self.0
+            .trim_chars
+            .as_ref()
+            .map(|v| PyTuple::new(py, v.iter().map(String::as_str)).unwrap())
     }
 
     #[pyo3(signature = (raw_only = false))]

--- a/sqlfluffrs/sqlfluffrs_python/src/token.rs
+++ b/sqlfluffrs/sqlfluffrs_python/src/token.rs
@@ -11,7 +11,9 @@ use pyo3::{
 use uuid::Uuid;
 
 use crate::marker::{PyPositionMarker, PySqlFluffPositionMarker};
-use crate::pyo3_helpers::{pyfrozenset_of_strs, pylist_of_str_pairs, pylist_of_strs, pytuple_of_strs};
+use crate::pyo3_helpers::{
+    pyfrozenset_of_strs, pylist_of_str_pairs, pylist_of_strs, pytuple_of_strs,
+};
 use sqlfluffrs_types::token::fix::SourceFix;
 use sqlfluffrs_types::{
     regex::RegexModeGroup,

--- a/sqlfluffrs/sqlfluffrs_python/src/token.rs
+++ b/sqlfluffrs/sqlfluffrs_python/src/token.rs
@@ -6,11 +6,12 @@ use std::{
 use hashbrown::HashSet;
 use pyo3::{
     prelude::*,
-    types::{PyDict, PyString, PyTuple, PyType},
+    types::{PyDict, PyFrozenSet, PyList, PyString, PyTuple, PyType},
 };
 use uuid::Uuid;
 
 use crate::marker::{PyPositionMarker, PySqlFluffPositionMarker};
+use crate::pyo3_helpers::{pylist_of_str_pairs, pylist_of_strs, pytuple_of_strs};
 use sqlfluffrs_types::token::fix::SourceFix;
 use sqlfluffrs_types::{
     regex::RegexModeGroup,
@@ -232,18 +233,12 @@ impl PyToken {
 
     #[getter]
     pub fn trim_start<'py>(&self, py: Python<'py>) -> Option<Bound<'py, PyTuple>> {
-        self.0
-            .trim_start
-            .as_ref()
-            .map(|v| PyTuple::new(py, v.iter().map(String::as_str)).unwrap())
+        self.0.trim_start.as_ref().map(|v| pytuple_of_strs(py, v))
     }
 
     #[getter]
     pub fn trim_chars<'py>(&self, py: Python<'py>) -> Option<Bound<'py, PyTuple>> {
-        self.0
-            .trim_chars
-            .as_ref()
-            .map(|v| PyTuple::new(py, v.iter().map(String::as_str)).unwrap())
+        self.0.trim_chars.as_ref().map(|v| pytuple_of_strs(py, v))
     }
 
     #[pyo3(signature = (raw_only = false))]
@@ -280,13 +275,21 @@ impl PyToken {
     }
 
     #[getter]
-    pub fn class_types(&self) -> HashSet<String> {
-        self.0.class_types()
+    pub fn class_types<'py>(&self, py: Python<'py>) -> Bound<'py, PyFrozenSet> {
+        PyFrozenSet::new(
+            py,
+            self.0
+                .instance_types
+                .iter()
+                .map(String::as_str)
+                .chain(self.0.class_types.iter().map(String::as_str)),
+        )
+        .unwrap()
     }
 
     #[getter]
-    pub fn instance_types(&self) -> Vec<String> {
-        self.0.instance_types.clone()
+    pub fn instance_types<'py>(&self, py: Python<'py>) -> Bound<'py, PyList> {
+        pylist_of_strs(py, &self.0.instance_types)
     }
 
     #[getter]
@@ -450,8 +453,10 @@ impl PyToken {
     }
 
     #[getter]
-    pub fn escape_replacements(&self) -> Option<Vec<(String, String)>> {
-        self.0.escape_replacements().cloned()
+    pub fn escape_replacements<'py>(&self, py: Python<'py>) -> Option<Bound<'py, PyList>> {
+        self.0
+            .escape_replacements()
+            .map(|pairs| pylist_of_str_pairs(py, pairs))
     }
 
     pub fn set_parent(&self, parent: &Bound<'_, PyAny>, idx: usize) -> PyResult<()> {

--- a/sqlfluffrs/sqlfluffrs_python/src/token.rs
+++ b/sqlfluffrs/sqlfluffrs_python/src/token.rs
@@ -11,7 +11,7 @@ use pyo3::{
 use uuid::Uuid;
 
 use crate::marker::{PyPositionMarker, PySqlFluffPositionMarker};
-use crate::pyo3_helpers::{pylist_of_str_pairs, pylist_of_strs, pytuple_of_strs};
+use crate::pyo3_helpers::{pyfrozenset_of_strs, pylist_of_str_pairs, pylist_of_strs, pytuple_of_strs};
 use sqlfluffrs_types::token::fix::SourceFix;
 use sqlfluffrs_types::{
     regex::RegexModeGroup,
@@ -283,8 +283,8 @@ impl PyToken {
     }
 
     #[getter]
-    pub fn class_types<'py>(&self, py: Python<'py>) -> Bound<'py, PyFrozenSet> {
-        PyFrozenSet::new(
+    pub fn class_types<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyFrozenSet>> {
+        pyfrozenset_of_strs(
             py,
             self.0
                 .instance_types
@@ -292,7 +292,6 @@ impl PyToken {
                 .map(String::as_str)
                 .chain(self.0.class_types.iter().map(String::as_str)),
         )
-        .unwrap()
     }
 
     #[getter]

--- a/sqlfluffrs/sqlfluffrs_python/src/token.rs
+++ b/sqlfluffrs/sqlfluffrs_python/src/token.rs
@@ -232,13 +232,21 @@ impl PyToken {
     }
 
     #[getter]
-    pub fn trim_start<'py>(&self, py: Python<'py>) -> Option<Bound<'py, PyTuple>> {
-        self.0.trim_start.as_ref().map(|v| pytuple_of_strs(py, v))
+    pub fn trim_start<'py>(&self, py: Python<'py>) -> PyResult<Option<Bound<'py, PyTuple>>> {
+        self.0
+            .trim_start
+            .as_ref()
+            .map(|v| pytuple_of_strs(py, v))
+            .transpose()
     }
 
     #[getter]
-    pub fn trim_chars<'py>(&self, py: Python<'py>) -> Option<Bound<'py, PyTuple>> {
-        self.0.trim_chars.as_ref().map(|v| pytuple_of_strs(py, v))
+    pub fn trim_chars<'py>(&self, py: Python<'py>) -> PyResult<Option<Bound<'py, PyTuple>>> {
+        self.0
+            .trim_chars
+            .as_ref()
+            .map(|v| pytuple_of_strs(py, v))
+            .transpose()
     }
 
     #[pyo3(signature = (raw_only = false))]
@@ -288,7 +296,7 @@ impl PyToken {
     }
 
     #[getter]
-    pub fn instance_types<'py>(&self, py: Python<'py>) -> Bound<'py, PyList> {
+    pub fn instance_types<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyList>> {
         pylist_of_strs(py, &self.0.instance_types)
     }
 
@@ -453,10 +461,14 @@ impl PyToken {
     }
 
     #[getter]
-    pub fn escape_replacements<'py>(&self, py: Python<'py>) -> Option<Bound<'py, PyList>> {
+    pub fn escape_replacements<'py>(
+        &self,
+        py: Python<'py>,
+    ) -> PyResult<Option<Bound<'py, PyList>>> {
         self.0
             .escape_replacements()
             .map(|pairs| pylist_of_str_pairs(py, pairs))
+            .transpose()
     }
 
     pub fn set_parent(&self, parent: &Bound<'_, PyAny>, idx: usize) -> PyResult<()> {

--- a/test/core/parser/rust_parser_test.py
+++ b/test/core/parser/rust_parser_test.py
@@ -443,6 +443,55 @@ def test__rust_parser__rs_node_class_types_match_python():
     assert checked_gzip, "expected a quoted 'GZIP' compression value in the parse"
 
 
+@pytest.mark.skipif(not _HAS_RUST_PARSER, reason="Rust parser not available")
+def test__rust_parser__rs_token_getters_return_expected_container_types():
+    """RsToken collection getters return the expected Python container types.
+
+    Pins the container types (`tuple`/`frozenset`/`list`) that PR #8247's
+    direct-to-Python-object builders produce, so a future change to
+    `pyo3_helpers` can't silently swap e.g. `trim_chars` back to a `list`
+    or `class_types` back to a plain `set`.
+    """
+    from sqlfluff.core import FluffConfig
+    from sqlfluff.core.parser import Lexer
+
+    config = FluffConfig(overrides={"dialect": "mysql"})
+    segments, _ = Lexer(config=config).lex("SET @errmsg = 'it''s';")
+    tokens = {
+        s.raw: s._rstoken for s in segments if getattr(s, "_rstoken", None) is not None
+    }
+
+    at_sign_token = tokens["@errmsg"]
+    assert isinstance(at_sign_token.trim_chars, tuple)
+    assert at_sign_token.trim_chars == ("@",)
+    assert isinstance(at_sign_token.class_types, frozenset)
+    assert isinstance(at_sign_token.instance_types, list)
+
+    quoted_token = tokens["'it''s'"]
+    assert isinstance(quoted_token.escape_replacements, list)
+    assert quoted_token.escape_replacements
+
+
+@pytest.mark.skipif(not _HAS_RUST_PARSER, reason="Rust parser not available")
+def test__rust_parser__rs_handle_getters_return_expected_container_types():
+    """RsHandle collection getters return the expected Python container types.
+
+    Companion to the `RsToken` check above: covers the arena-side getters
+    (`descendant_type_set`, `class_types`) that build their `PyList` directly
+    rather than through the shared `pyo3_helpers` builders.
+    """
+    from sqlfluff.core import FluffConfig
+    from sqlfluff.core.parser import Lexer
+
+    config = FluffConfig(overrides={"dialect": "ansi", "use_rust_parser": True})
+    segments, _ = Lexer(config=config).lex("SELECT a FROM my_table\n")
+    tree = RustParser(config=config).parse(segments, fname="t.sql")
+
+    root = tree._rs_tree.root
+    assert isinstance(root.descendant_type_set(), list)
+    assert isinstance(root.class_types(), list)
+
+
 # ---------------------------------------------------------------------------
 # Per-stage profiling
 # ---------------------------------------------------------------------------

--- a/test/core/parser/rust_parser_test.py
+++ b/test/core/parser/rust_parser_test.py
@@ -476,9 +476,8 @@ def test__rust_parser__rs_token_getters_return_expected_container_types():
 def test__rust_parser__rs_handle_getters_return_expected_container_types():
     """RsHandle collection getters return the expected Python container types.
 
-    Companion to the `RsToken` check above: covers the arena-side getters
-    (`descendant_type_set`, `class_types`) that build their `PyList` directly
-    rather than through the shared `pyo3_helpers` builders.
+    Covers `descendant_type_set` and `class_types`, both cached behind an `Arc`,
+    and two `RsHandle` getters which now use the shared helpers.
     """
     from sqlfluff.core import FluffConfig
     from sqlfluff.core.parser import Lexer

--- a/test/core/parser/rust_parser_test.py
+++ b/test/core/parser/rust_parser_test.py
@@ -492,6 +492,58 @@ def test__rust_parser__rs_handle_getters_return_expected_container_types():
     assert isinstance(root.class_types(), list)
 
 
+@pytest.mark.skipif(not _HAS_RUST_PARSER, reason="Rust parser not available")
+def test__rust_parser__rs_match_result_getters_return_expected_container_types():
+    """RsMatchResult collection getters return the expected container types.
+
+    Companion to the two checks above: covers `instance_types`, `trim_chars`,
+    and `escape_replacements` on the raw `RsMatchResult` returned by
+    `RsParser.parse_match_result_from_tokens`, before it's ever turned into a
+    tree. BigQuery's single-quoted literal grammar sets all three via
+    grammar-configured kwargs (as opposed to lexer-level kwargs, which are
+    deliberately not carried onto a fresh parser match), giving a real case
+    for each getter in one parse.
+
+    Note: `RsNode` (`PyNode` in Rust) has no corresponding check — no
+    `#[pymethod]` anywhere in the Rust workspace ever constructs and returns
+    one to Python, so it cannot be reached or tested from here.
+    """
+    from sqlfluff.core import FluffConfig
+    from sqlfluff.core.parser import Lexer
+
+    config = FluffConfig(overrides={"dialect": "bigquery"})
+    segments, _ = Lexer(config=config).lex("SELECT 'abc'")
+    tokens = [
+        s._rstoken
+        for s in segments
+        if getattr(s, "_rstoken", None) is not None and s.is_code
+    ]
+
+    rs_match = RsParser(
+        dialect="bigquery", indent_config={}
+    ).parse_match_result_from_tokens(tokens)
+
+    def flatten(match):
+        yield match
+        for child in match.child_matches:
+            yield from flatten(child)
+
+    keyword_match = next(
+        m for m in flatten(rs_match) if m.matched_class == "KeywordSegment"
+    )
+    assert isinstance(keyword_match.instance_types, list)
+    assert "keyword" in keyword_match.instance_types
+
+    literal_match = next(
+        m for m in flatten(rs_match) if m.matched_class == "LiteralSegment"
+    )
+    assert isinstance(literal_match.instance_types, list)
+    assert isinstance(literal_match.trim_chars, tuple)
+    assert literal_match.trim_chars == ("'",)
+    assert isinstance(literal_match.escape_replacements, list)
+    assert literal_match.escape_replacements
+
+
 # ---------------------------------------------------------------------------
 # Per-stage profiling
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Originated [here](https://github.com/sqlfluff/sqlfluff/pull/8224#discussion_r3670201506), I looked a bit further and applied it to other call sites as well.

<!--Thanks for adding this feature!-->                                                                                                                                                                                            

<!--Please give the Pull Request a meaningful title for the release notes-->                                                                                                                                                      

### Brief summary of the change made
Several pyo3 getters (`trim_start`, `trim_chars`, type sets, escape replacements) were cloning their underlying Rust collections into an intermediate `Vec` before converting to a Python object, allocating twice per call. This adds a shared helper (`pyo3_helpers.rs`) to convert directly into a `PyTuple`/Python object, and updates the getters in `arena.rs`, `arena_py.rs`, `python.rs`, and `token.rs` to use it, cutting the redundant allocation.

### Are there any other side effects of this change that we should be aware of?
`trim_start`/`trim_chars` now return as a `PyTuple` instead of `Vec<String>` on the Python side; any callers relying on list-specific mutation of these values would need updating (tuples are immutable).

### Pull Request checklist                                                                                                                                                                                                        
- [ ] Please confirm you have completed any of the necessary steps below.                                                                                                                                                         
                                                                                                                                                                                                                                    
- Included test cases to demonstrate any code changes, which may be one or more of the following:                                                                                                                                 
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.                                                                                                                                                               
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).                                                                                        
  - Full autofix test cases in `test/fixtures/linter/autofix`.                                                                                                                                                                    
  - Other.                                                                                                                                                                                                                        
- Added appropriate documentation for the change.                                                                                                                                                                                 
- Created GitHub issues for any relevant followup/future enhancements if appropriate.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Build Python lists/tuples/frozensets directly from cached Rust data in `pyo3` getters to remove double allocations and avoid holding locks during Python allocation. Standardizes shared builders to return `PyResult`, fixes unwrap panics, and caches `class_types`.

- **Refactors**
  - Added `sqlfluffrs_python::pyo3_helpers` (`pylist_of_strs`, `pylist_of_strs_iter`, `pyfrozenset_of_strs`, `pylist_of_str_pairs`, `pytuple_of_strs`) returning `PyResult`.
  - Store `instance_types` and `trim_chars` as `Arc<Vec<_>>`; cache `class_types` as `Arc<Vec<_>>`; expose `*_arc` getters for `trim_chars` and `escape_replacements`. `descendant_type_set` builds a `PyList` from an iterator.
  - Updated getters in `arena_py.rs`, `python.rs` (`PyNode`, `PyMatchResult`), and `token.rs` to return `PyList`/`PyTuple`/`PyFrozenSet` and propagate `PyResult`; no locks are held across Python allocations. Added tests pinning container types for `RsToken`, `RsHandle`, and `RsMatchResult`. Updated docs.

- **Migration**
  - `trim_start` and `trim_chars` now return Python tuples.
  - `class_types` on `PyToken` now returns a `frozenset` (was a mutable set).

<sup>Written for commit 1fb699e47cc2efccd0959bb985ebf92178bc501c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8247?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



