### PR TITLE
Add rule LT16 to put GROUP BY and ORDER BY targets on separate lines

### DIFF
--- a/docsv/.vitepress/redirects.json
+++ b/docsv/.vitepress/redirects.json
@@ -57,6 +57,7 @@
   "perma/rule/LT13": "reference/rules/layout#lt13",
   "perma/rule/LT14": "reference/rules/layout#lt14",
   "perma/rule/LT15": "reference/rules/layout#lt15",
+  "perma/rule/LT16": "reference/rules/layout#lt16",
   "perma/rule/JJ01": "reference/rules/jinja#jj01",
   "perma/rule/CV01": "reference/rules/convention#cv01",
   "perma/rule/CV02": "reference/rules/convention#cv02",

--- a/src/sqlfluff/core/default_config.cfg
+++ b/src/sqlfluff/core/default_config.cfg
@@ -536,6 +536,10 @@ maximum_empty_lines_between_batches = 1
 wildcard_policy = single
 single_target_policy = same_line
 
+[sqlfluff:rules:layout.list_targets]
+group_by_policy = new_line
+order_by_policy = new_line
+
 [sqlfluff:rules:structure.subquery]
 # By default, allow subqueries in from clauses, but not join clauses
 forbid_subquery_in = join

--- a/src/sqlfluff/rules/layout/LT16.py
+++ b/src/sqlfluff/rules/layout/LT16.py
@@ -8,10 +8,12 @@ from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
 from sqlfluff.utils.functional import Segments, sp
 
 # The clauses handled by this rule, mapped from the config keyword which
-# controls them to the segment type which they're parsed as.
+# controls them to the segment types which they're parsed as. NOTE: BigQuery's
+# `GROUP AND ORDER BY` is a `GROUP BY` with an extra modifier, so it's covered
+# by the group by policy.
 CLAUSE_POLICIES = {
-    "group_by_policy": "groupby_clause",
-    "order_by_policy": "orderby_clause",
+    "group_by_policy": ("groupby_clause", "group_and_orderby_clause"),
+    "order_by_policy": ("orderby_clause",),
 }
 
 # Within these segments, the clause is part of a larger inline expression
@@ -21,7 +23,6 @@ INLINE_CONTEXTS = (
     "window_specification",
     "aggregate_order_by",
     "withingroup_clause",
-    "pipe_operator_clause",
 )
 
 
@@ -34,9 +35,13 @@ class Rule_LT16(BaseRule):
     .. note::
        By default this applies to both ``GROUP BY`` and ``ORDER BY``. Either
        can be relaxed by setting the relevant policy to ``same_line``, e.g.
-       ``order_by_policy = same_line``. ``ORDER BY`` clauses which are part
-       of a larger expression (e.g. within a window function) are never
-       affected by this rule.
+       ``order_by_policy = same_line``. BigQuery's ``GROUP AND ORDER BY``
+       follows ``group_by_policy``.
+
+    .. note::
+       ``ORDER BY`` clauses which are part of a larger expression (e.g. within
+       a window function, an aggregate function or a ``WITHIN GROUP`` clause)
+       are never affected by this rule.
 
     **Anti-pattern**
 
@@ -77,7 +82,9 @@ class Rule_LT16(BaseRule):
     name = "layout.list_targets"
     groups = ("all", "layout")
     config_keywords = ["group_by_policy", "order_by_policy"]
-    crawl_behaviour = SegmentSeekerCrawler(set(CLAUSE_POLICIES.values()))
+    crawl_behaviour = SegmentSeekerCrawler(
+        {seg_type for types in CLAUSE_POLICIES.values() for seg_type in types}
+    )
     is_fix_compatible = True
 
     def _eval(self, context: RuleContext) -> Optional[LintResult]:
@@ -132,8 +139,8 @@ class Rule_LT16(BaseRule):
     def _is_enabled(self, segment: BaseSegment) -> bool:
         """Is this rule configured to apply to this clause?"""
         return any(
-            segment.is_type(seg_type) and getattr(self, policy) == "new_line"
-            for policy, seg_type in CLAUSE_POLICIES.items()
+            segment.is_type(*seg_types) and getattr(self, policy) == "new_line"
+            for policy, seg_types in CLAUSE_POLICIES.items()
         )
 
     @staticmethod

--- a/src/sqlfluff/rules/layout/LT16.py
+++ b/src/sqlfluff/rules/layout/LT16.py
@@ -1,0 +1,182 @@
+"""Implementation of Rule LT16."""
+
+from typing import Optional
+
+from sqlfluff.core.parser import BaseSegment, NewlineSegment
+from sqlfluff.core.rules import BaseRule, LintFix, LintResult, RuleContext
+from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
+from sqlfluff.utils.functional import Segments, sp
+
+# The clauses handled by this rule, mapped from the config keyword which
+# controls them to the segment type which they're parsed as.
+CLAUSE_POLICIES = {
+    "group_by_policy": "groupby_clause",
+    "order_by_policy": "orderby_clause",
+}
+
+# Within these segments, the clause is part of a larger inline expression
+# (e.g. the `ORDER BY` of a window function or an aggregate function), and
+# so shouldn't be split over several lines.
+INLINE_CONTEXTS = (
+    "window_specification",
+    "aggregate_order_by",
+    "withingroup_clause",
+    "pipe_operator_clause",
+)
+
+
+class Rule_LT16(BaseRule):
+    """List targets should be on a new line unless there is only one target.
+
+    This is the equivalent of :sqlfluff:ref:`LT09` for the other lists of
+    targets in a statement, so that they're all laid out consistently.
+
+    .. note::
+       By default this applies to both ``GROUP BY`` and ``ORDER BY``. Either
+       can be relaxed by setting the relevant policy to ``same_line``, e.g.
+       ``order_by_policy = same_line``. ``ORDER BY`` clauses which are part
+       of a larger expression (e.g. within a window function) are never
+       affected by this rule.
+
+    **Anti-pattern**
+
+    Multiple targets on the same line.
+
+    .. code-block:: sql
+
+        select
+            a,
+            b
+        from fct
+        group by a, b;
+
+    **Best practice**
+
+    Multiple targets each on their own line.
+
+    .. code-block:: sql
+
+        select
+            a,
+            b
+        from fct
+        group by
+            a,
+            b;
+
+        -- A single target may still share a line with the keyword.
+
+        select
+            a,
+            b
+        from fct
+        group by a;
+
+    """
+
+    name = "layout.list_targets"
+    groups = ("all", "layout")
+    config_keywords = ["group_by_policy", "order_by_policy"]
+    crawl_behaviour = SegmentSeekerCrawler(set(CLAUSE_POLICIES.values()))
+    is_fix_compatible = True
+
+    def _eval(self, context: RuleContext) -> Optional[LintResult]:
+        self.group_by_policy: str
+        self.order_by_policy: str
+        if not self._is_enabled(context.segment):
+            return None
+        # Skip clauses which are only part of a larger inline expression.
+        if any(parent.is_type(*INLINE_CONTEXTS) for parent in context.parent_stack):
+            return None
+
+        fixes: list[LintFix] = []
+        segment = context.segment
+        children = segment.segments
+        clause_raws = Segments(segment).raw_segments
+        for target_idx in self._list_target_idxs(segment):
+            target = children[target_idx]
+            target_initial_code = (
+                Segments(target).raw_segments.first(sp.is_code()).get()
+            )
+            assert target_initial_code
+            # Find where the previous target ended. We ignore commas here so
+            # that leading comma layouts aren't broken up unnecessarily.
+            previous_code = (
+                clause_raws.select(
+                    select_if=sp.and_(sp.is_code(), sp.not_(sp.raw_is(","))),
+                    stop_seg=target_initial_code,
+                )
+                .last()
+                .get()
+            )
+            assert previous_code
+            assert previous_code.pos_marker and target_initial_code.pos_marker
+            # If this target doesn't start on the line that the previous one
+            # (or the keyword) ended on, then there's nothing to do.
+            if (
+                previous_code.pos_marker.working_line_no
+                != target_initial_code.pos_marker.working_line_no
+            ):
+                continue
+
+            fixes.extend(
+                LintFix.delete(ws)
+                for ws in self._preceding_whitespace(children, target_idx)
+            )
+            fixes.append(LintFix.create_before(target, [NewlineSegment()]))
+
+        if fixes:
+            return LintResult(anchor=segment, fixes=fixes)
+        return None
+
+    def _is_enabled(self, segment: BaseSegment) -> bool:
+        """Is this rule configured to apply to this clause?"""
+        return any(
+            segment.is_type(seg_type) and getattr(self, policy) == "new_line"
+            for policy, seg_type in CLAUSE_POLICIES.items()
+        )
+
+    @staticmethod
+    def _list_target_idxs(segment: BaseSegment) -> list[int]:
+        """Get the indices of the children which start each list target.
+
+        Returns an empty list if there aren't multiple targets to lay out,
+        e.g. for ``GROUP BY ALL`` or a single ``ORDER BY`` target. Note that
+        only the commas at the top level of the clause count, so the contents
+        of e.g. ``GROUP BY ROLLUP(a, b)`` are left alone.
+        """
+        children = segment.segments
+        comma_idxs = [idx for idx, seg in enumerate(children) if seg.is_type("comma")]
+        if not comma_idxs:
+            return []
+
+        target_idxs = []
+        # The first target starts after the introducing keywords (e.g. the
+        # `GROUP BY` of `GROUP BY a, b`, or the `ORDER BY ALL` of some
+        # dialects). Any other keywords are part of a target.
+        for idx, seg in enumerate(children):
+            if seg.is_code and not seg.is_type("keyword"):
+                target_idxs.append(idx)
+                break
+        # Every other target starts at the first code after a comma.
+        for comma_idx in comma_idxs:
+            for idx in range(comma_idx + 1, len(children)):
+                if children[idx].is_code:
+                    target_idxs.append(idx)
+                    break
+        return sorted(set(target_idxs))
+
+    @staticmethod
+    def _preceding_whitespace(
+        children: tuple[BaseSegment, ...], target_idx: int
+    ) -> list[BaseSegment]:
+        """Get the whitespace to remove before a target we're moving."""
+        whitespace = []
+        for seg in reversed(children[:target_idx]):
+            if seg.is_type("whitespace"):
+                whitespace.append(seg)
+            elif not (seg.is_type("comma") or seg.is_meta):
+                # Anything else (including comments) means we've reached the
+                # end of the previous target.
+                break
+        return whitespace

--- a/src/sqlfluff/rules/layout/__init__.py
+++ b/src/sqlfluff/rules/layout/__init__.py
@@ -50,10 +50,10 @@ def get_configs_info() -> dict[str, ConfigInfo]:
         "group_by_policy": {
             "validation": ["same_line", "new_line"],
             "definition": (
-                "Treatment of ``GROUP BY`` targets. ``new_line`` (default) "
-                "requires each target to be on its own line, unless there is "
-                "only one. ``same_line`` allows several targets to share a "
-                "line."
+                "Treatment of ``GROUP BY`` targets (including BigQuery's "
+                "``GROUP AND ORDER BY``). ``new_line`` (default) requires "
+                "each target to be on its own line, unless there is only "
+                "one. ``same_line`` allows several targets to share a line."
             ),
         },
         "order_by_policy": {

--- a/src/sqlfluff/rules/layout/__init__.py
+++ b/src/sqlfluff/rules/layout/__init__.py
@@ -47,6 +47,24 @@ def get_configs_info() -> dict[str, ConfigInfo]:
             "validation": ["single", "multiple"],
             "definition": "Treatment of wildcards. Defaults to ``single``.",
         },
+        "group_by_policy": {
+            "validation": ["same_line", "new_line"],
+            "definition": (
+                "Treatment of ``GROUP BY`` targets. ``new_line`` (default) "
+                "requires each target to be on its own line, unless there is "
+                "only one. ``same_line`` allows several targets to share a "
+                "line."
+            ),
+        },
+        "order_by_policy": {
+            "validation": ["same_line", "new_line"],
+            "definition": (
+                "Treatment of ``ORDER BY`` targets. ``new_line`` (default) "
+                "requires each target to be on its own line, unless there is "
+                "only one. ``same_line`` allows several targets to share a "
+                "line."
+            ),
+        },
         "single_target_policy": {
             "validation": ["same_line", "new_line"],
             "definition": (
@@ -82,6 +100,7 @@ def get_rules() -> list[type[BaseRule]]:
     from sqlfluff.rules.layout.LT13 import Rule_LT13
     from sqlfluff.rules.layout.LT14 import Rule_LT14
     from sqlfluff.rules.layout.LT15 import Rule_LT15
+    from sqlfluff.rules.layout.LT16 import Rule_LT16
 
     return [
         Rule_LT01,
@@ -99,4 +118,5 @@ def get_rules() -> list[type[BaseRule]]:
         Rule_LT13,
         Rule_LT14,
         Rule_LT15,
+        Rule_LT16,
     ]

--- a/test/fixtures/rules/std_rule_cases/LT16.yml
+++ b/test/fixtures/rules/std_rule_cases/LT16.yml
@@ -1,0 +1,242 @@
+rule: LT16
+
+test_pass_single_group_by_target:
+  pass_str: |
+    select a
+    from t
+    group by a
+
+test_pass_group_by_targets_on_separate_lines:
+  pass_str: |
+    select
+        a,
+        b
+    from t
+    group by
+        a,
+        b
+
+test_fail_group_by_targets_on_one_line:
+  fail_str: |
+    select
+        a,
+        b
+    from t
+    group by
+        a, b
+  fix_str: |
+    select
+        a,
+        b
+    from t
+    group by
+        a,
+    b
+
+test_fail_group_by_targets_on_keyword_line:
+  fail_str: |
+    select
+        a,
+        b
+    from t
+    group by a, b
+  fix_str: |
+    select
+        a,
+        b
+    from t
+    group by
+    a,
+    b
+
+test_fail_order_by_targets_on_keyword_line:
+  fail_str: |
+    select
+        a,
+        b
+    from t
+    order by a desc, b nulls last
+  fix_str: |
+    select
+        a,
+        b
+    from t
+    order by
+    a desc,
+    b nulls last
+
+test_pass_single_order_by_target:
+  pass_str: |
+    select a
+    from t
+    order by a desc
+
+test_pass_group_by_policy_same_line:
+  pass_str: |
+    select
+        a,
+        b
+    from t
+    group by a, b
+  configs:
+    rules:
+      layout.list_targets:
+        group_by_policy: same_line
+
+test_fail_order_by_only_when_group_by_disabled:
+  fail_str: |
+    select
+        a,
+        b
+    from t
+    group by a, b
+    order by a, b
+  fix_str: |
+    select
+        a,
+        b
+    from t
+    group by a, b
+    order by
+    a,
+    b
+  configs:
+    rules:
+      layout.list_targets:
+        group_by_policy: same_line
+
+test_pass_order_by_policy_same_line:
+  pass_str: |
+    select
+        a,
+        b
+    from t
+    order by a, b
+  configs:
+    rules:
+      layout.list_targets:
+        order_by_policy: same_line
+
+test_pass_group_by_all:
+  pass_str: |
+    select
+        a,
+        b
+    from t
+    group by all
+
+test_pass_group_by_rollup:
+  # Only the targets at the top level of the clause are split up.
+  pass_str: |
+    select
+        a,
+        b
+    from t
+    group by
+        rollup(a, b)
+
+test_fail_group_by_rollup_with_further_targets:
+  fail_str: |
+    select
+        a,
+        b,
+        c
+    from t
+    group by
+        rollup(a, b), c
+  fix_str: |
+    select
+        a,
+        b,
+        c
+    from t
+    group by
+        rollup(a, b),
+    c
+
+test_pass_group_by_grouping_sets:
+  pass_str: |
+    select
+        a,
+        b
+    from t
+    group by
+        grouping sets ((a, b), (a))
+
+test_pass_order_by_in_window_function:
+  pass_str: |
+    select
+        row_number() over (partition by a, b order by c, d) as rn
+    from t
+
+test_pass_order_by_in_aggregate:
+  pass_str: |
+    select
+        array_agg(x order by a, b) as ag
+    from t
+
+test_pass_leading_commas:
+  # The targets are already on separate lines, so there's nothing to do.
+  pass_str: |
+    select
+        a
+        , b
+    from t
+    group by
+        a
+        , b
+
+test_fail_multiline_target:
+  fail_str: |
+    select
+        a,
+        b
+    from t
+    group by
+        case
+            when a > 1 then a
+            else b
+        end, b
+  fix_str: |
+    select
+        a,
+        b
+    from t
+    group by
+        case
+            when a > 1 then a
+            else b
+        end,
+    b
+
+test_pass_comment_between_targets:
+  pass_str: |
+    select
+        a,
+        b
+    from t
+    group by
+        a,  -- the first target
+        b
+
+test_fail_subquery_group_by:
+  fail_str: |
+    select *
+    from (
+        select
+            a,
+            b
+        from t
+        group by a, b
+    ) as x
+  fix_str: |
+    select *
+    from (
+        select
+            a,
+            b
+        from t
+        group by
+    a,
+    b
+    ) as x

--- a/test/fixtures/rules/std_rule_cases/LT16.yml
+++ b/test/fixtures/rules/std_rule_cases/LT16.yml
@@ -163,6 +163,56 @@ test_pass_group_by_grouping_sets:
     group by
         grouping sets ((a, b), (a))
 
+test_fail_bigquery_pipe_group_and_order_by:
+  # `GROUP AND ORDER BY` is a `GROUP BY` with a modifier, so it follows
+  # `group_by_policy`.
+  fail_str: |
+    FROM Produce
+    |> AGGREGATE SUM(sales) AS total_sales
+       GROUP AND ORDER BY category, item DESC;
+  fix_str: |
+    FROM Produce
+    |> AGGREGATE SUM(sales) AS total_sales
+       GROUP AND ORDER BY
+    category,
+    item DESC;
+  configs:
+    core:
+      dialect: bigquery
+
+test_pass_bigquery_pipe_group_and_order_by_same_line_policy:
+  pass_str: |
+    FROM Produce
+    |> AGGREGATE SUM(sales) AS total_sales
+       GROUP AND ORDER BY category, item DESC;
+  configs:
+    core:
+      dialect: bigquery
+    rules:
+      layout.list_targets:
+        group_by_policy: same_line
+
+test_fail_bigquery_pipe_group_by_and_order_by:
+  # Pipe operators are statement level operations, so the lists in them are
+  # split up just like any other.
+  fail_str: |
+    FROM Produce
+    |> AGGREGATE SUM(sales) AS total_sales
+       GROUP BY category, item
+    |> ORDER BY category, item DESC;
+  fix_str: |
+    FROM Produce
+    |> AGGREGATE SUM(sales) AS total_sales
+       GROUP BY
+    category,
+    item
+    |> ORDER BY
+    category,
+    item DESC;
+  configs:
+    core:
+      dialect: bigquery
+
 test_pass_order_by_in_window_function:
   pass_str: |
     select

--- a/test/fixtures/rules/std_rule_cases/LT16_LT02.yml
+++ b/test/fixtures/rules/std_rule_cases/LT16_LT02.yml
@@ -1,0 +1,59 @@
+rule: LT16, LT02
+
+# LT16 only inserts the line breaks between targets. The indentation of the
+# targets it moves is then handled by LT02, so these cases check that the two
+# rules combine to give a sensible layout.
+
+test_group_by_targets_indented_after_split:
+  fail_str: |
+    select
+        a,
+        b
+    from t
+    group by a, b
+  fix_str: |
+    select
+        a,
+        b
+    from t
+    group by
+        a,
+        b
+
+test_order_by_targets_indented_after_split:
+  fail_str: |
+    select
+        a,
+        b
+    from t
+    order by a desc, b nulls last
+  fix_str: |
+    select
+        a,
+        b
+    from t
+    order by
+        a desc,
+        b nulls last
+
+test_group_by_targets_indented_in_subquery:
+  fail_str: |
+    select *
+    from (
+        select
+            a,
+            b
+        from t
+        group by a, b
+    ) as x
+  fix_str: |
+    select *
+    from (
+        select
+            a,
+            b
+        from t
+        group by
+            a,
+            b
+    ) as x


### PR DESCRIPTION
### Brief summary of the change made

Fixes #7842.

`LT09` puts each select target on its own line, but there's no equivalent for the other target lists in a statement, so a formatted query ends up inconsistent:

```sql
select
    a,
    b
from fct
group by
    a, b;
```

This adds **`LT16` (`layout.list_targets`)**, which applies the same treatment to `GROUP BY` and `ORDER BY`. Where a clause has more than one target, each one starts on a new line:

```sql
select
    a,
    b
from fct
group by
    a,
    b;
```

Details:

- Only the commas at the **top level** of the clause count, so `GROUP BY ROLLUP(a, b)`, `GROUPING SETS (...)` and `GROUP BY ALL` are left alone.
- `ORDER BY` clauses which form part of a larger inline expression are skipped: window specifications, aggregate `ORDER BY` and `WITHIN GROUP`. This reuses the same exclusion set already configured for `orderby_clause` in `[sqlfluff:layout:type:orderby_clause] keyword_line_position_exclusions`.
- A single target may still share a line with the keyword (`group by a`), mirroring `LT09`'s default `single_target_policy = same_line`.
- Like `LT09`, the rule only inserts the line breaks; the indentation of the targets it moves is left to `LT02`.

Each clause has its own policy so they can be adopted independently:

```ini
[sqlfluff:rules:layout.list_targets]
group_by_policy = new_line
order_by_policy = new_line
```

The mapping in `CLAUSE_POLICIES` is the single place to extend if other list clauses (e.g. `DISTRIBUTE BY`/`SORT BY`) turn out to be wanted later.

### Are there any other side effects of this change that we should be aware of?

**Both policies default to `new_line`, so this changes formatting for existing users** who have `GROUP BY a, b` or `ORDER BY a, b` on a single line. That felt like the point of the issue — consistency with `LT09`, which is already default-on for select targets — but I'm very happy to flip the defaults to `same_line` and make it opt-in if maintainers would rather not change existing output in a minor release. It's a one-line change in `default_config.cfg`.

Beyond that:

- No existing test or fixture in the repo needed changing.
- Verified against the whole `test/fixtures/dialects` corpus for all 28 dialects: no rule exceptions, every LT16 violation resolved in a single `fix` pass with none remaining (i.e. no oscillation), and the whitespace-normalised content of every file was identical before and after, so no SQL is lost or reordered.
- The docs examples in `gettingstarted.rst` / `basic-usage.md` contain no `GROUP BY`, so their expected lint output is unaffected.

### Pull Request checklist

- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - [x] `.yml` rule test cases in `test/fixtures/rules/std_rule_cases` — `LT16.yml` (19 cases) plus `LT16_LT02.yml` (3 combo cases showing the final indented layout). 100% statement coverage of the new rule.
  - [ ] `.sql`/`.yml` parser test cases in `test/fixtures/dialects` — n/a, no grammar change.
  - [ ] Full autofix test cases in `test/fixtures/linter/autofix`.
  - [x] Other — manual verification across all dialect fixtures, described above.
- [x] Added appropriate documentation for the change — rule docstring (picked up by the rules reference), config definitions in `rules/layout/__init__.py`, defaults in `default_config.cfg`, and a `docsv` permalink redirect entry for `LT16`.
- [x] Created GitHub issues for any relevant followup/future enhancements if appropriate — nothing outstanding; other list clauses can be added to `CLAUSE_POLICIES` if requested.

### AI assistance disclosure

Per `CONTRIBUTING.md`: this change was authored with AI assistance (Claude Code). The rule implementation, the test cases and this description were AI-drafted.

Validation that was actually run, rather than asserted:

- Full test suite: 10607 passed, 0 failed (2527 skips are all "Rust parser not available"). The only failures in my environment are the 4 in `diff_quality_plugin_test.py`, which fail identically on a clean checkout here — a local `diff-cover` driver-detection issue, not related to this change.
- `ruff format`, `ruff check`, `mypy` and `yamllint` clean on the changed files.
- The cross-dialect fixture sweep described above.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `LT16` (`layout.list_targets`) to put each GROUP BY and ORDER BY target on its own line when there are multiple, matching `LT09`. Also handles BigQuery pipe syntax, including `GROUP AND ORDER BY` and top‑level `|> ORDER BY`.

- **New Features**
  - Split each top-level target in GROUP BY and ORDER BY onto a new line when multiple targets are present.
  - Skip inline ORDER BY in window specs, aggregate ORDER BY, and WITHIN GROUP; leave ROLLUP/GROUPING SETS/ALL unchanged.
  - BigQuery: `GROUP AND ORDER BY` follows `group_by_policy`; top-level `|> ORDER BY` clauses are split.
  - A single target can stay on the keyword line; indentation remains handled by `LT02`.
  - Independent policies: `group_by_policy` and `order_by_policy`.

- **Migration**
  - Defaults are `new_line` for both policies; single-line target lists will reflow.
  - Opt out per clause via config: `group_by_policy = same_line` or `order_by_policy = same_line`.

<sup>Written for commit 8997ffdc5ab926f4c856dcb930cb6bfc4967469d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8249?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

