### PR TITLE
Stop CV12 deleting the WHERE clause when the join is templated

### DIFF
--- a/src/sqlfluff/rules/convention/CV12.py
+++ b/src/sqlfluff/rules/convention/CV12.py
@@ -142,6 +142,24 @@ class Rule_CV12(BaseRule):
 
             if not where_clause_simplifable:
                 yield LintResult(anchor=join_clause)
+            elif join_clause.pos_marker and not join_clause.pos_marker.is_literal():
+                # The join clause overlaps templated code (e.g. a Jinja
+                # expression for the joined table). Any replacement of the
+                # join clause would be discarded by the linter as unsafe,
+                # but the paired WHERE clause rewrite would still apply,
+                # silently deleting the condition. Flag the issue without
+                # a fix and leave the WHERE clause untouched. Anchor on a
+                # literal segment where possible so the violation isn't
+                # filtered out along with the templated section.
+                anchor = next(
+                    (
+                        seg
+                        for seg in join_clause.recursive_crawl_all()
+                        if seg.pos_marker and seg.pos_marker.is_literal() and seg.raw
+                    ),
+                    join_clause,
+                )
+                yield LintResult(anchor=anchor)
             else:
                 this_join_clause_subexpressions = set()
                 for subexpr_idx, subexpr_segments in enumerate(subexpressions):

--- a/test/fixtures/rules/std_rule_cases/CV12.yml
+++ b/test/fixtures/rules/std_rule_cases/CV12.yml
@@ -155,3 +155,21 @@ test_pass_left_join_unnest_where_unaliased:
       UNNEST(t.purchases)
     WHERE
       t.user_id != 1
+
+test_fail_templated_join_no_fix:
+  # If the join clause overlaps templated code, replacing it would
+  # be discarded as unsafe while the WHERE rewrite still applied,
+  # silently deleting the join condition. The violation should
+  # still be flagged, but without a fix.
+  # https://github.com/sqlfluff/sqlfluff/issues/8230
+  fail_str: |
+    select a.id, b.id as b_id
+    from table_a as a
+    left join {{ ref('table_b') }} as b
+    where a.region = b.region
+  configs:
+    core:
+      templater: jinja
+    templater:
+      jinja:
+        apply_dbt_builtins: true


### PR DESCRIPTION
### Brief summary of the change made

Fixes #8230

When the joined table reference comes from a Jinja expression, CV12 emits two paired fixes: one replacing the whole `join_clause` with a version carrying the new `ON` condition, and one rewriting (or deleting) the `WHERE` clause. The join clause replacement overlaps templated source, so the linter discards it as unsafe — but the WHERE rewrite is still applied on its own, silently deleting the join condition:

```sql
select a.id, b.id as b_id
from table_a as a
left join {{ ref('table_b') }} as b
where a.region = b.region
```

`sqlfluff fix --rules CV12` on the above dropped the `where` line and added no `on` clause.

This change adds a guard in `Rule_CV12`: if the join clause's position marker isn't literal (i.e. it overlaps templated code), the rule yields the lint result without a fix and leaves the WHERE subexpressions unconsumed, so the WHERE clause is untouched. The result is anchored on the first literal segment inside the join clause so the violation isn't filtered out by `remove_templated_errors` along with the templated section — the issue is still reported, just marked unfixable.

Added a `.yml` regression case with the Jinja `ref()` repro from the issue; the test harness asserts that a `fail_str` without a `fix_str` leaves the SQL unmodified, which fails on current main and passes with this change.

### Are there any other side effects of this change that we should be aware of?

Templated joins that previously received the (discarded) fix now report the violation as unfixable instead. Non-templated joins are unaffected.

### Pull Request checklist

- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followups/issues I identified.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent CV12 from deleting the WHERE clause when the join is templated (e.g., Jinja). If the join clause overlaps templated code, the rule now flags the violation as unfixable and leaves WHERE unchanged.

- **Bug Fixes**
  - Added a guard in `Rule_CV12`: when the join clause is non-literal, skip join/WHERE rewrites and anchor the violation on the first literal segment to avoid filtering.
  - Added a regression test in `CV12.yml` for a Jinja `ref()` join to ensure the SQL remains unchanged while the issue is reported.

<sup>Written for commit 87c69a2454817fe2f68a462926920bb08055266a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8251?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

