### PR TITLE
Fix Oracle SELECT INTO record field parsing

### DIFF
--- a/src/sqlfluff/dialects/dialect_oracle.py
+++ b/src/sqlfluff/dialects/dialect_oracle.py
@@ -3856,7 +3856,13 @@ class IntoClauseSegment(BaseSegment):
 
     match_grammar = Sequence(
         "INTO",
-        Delimited(OneOf(Ref("SingleIdentifierGrammar"), Ref("BindVariableSegment"))),
+        Delimited(
+            OneOf(
+                Ref("SingleIdentifierGrammar"),
+                Ref("ObjectReferenceSegment"),
+                Ref("BindVariableSegment"),
+            )
+        ),
     )
 
 

--- a/test/fixtures/dialects/oracle/select_into_record_fields.sql
+++ b/test/fixtures/dialects/oracle/select_into_record_fields.sql
@@ -1,0 +1,16 @@
+CREATE OR REPLACE PROCEDURE test_proc(out_rec OUT SYS_REFCURSOR) IS
+  TYPE t_rec IS RECORD (a NUMBER, b NUMBER);
+  out_metrics t_rec;
+BEGIN
+  WITH cte1 AS (
+    SELECT 1 AS x FROM dual
+  )
+  SELECT
+    cte1.x,
+    cte1.x
+  INTO
+    out_metrics.a,
+    out_metrics.b
+  FROM cte1;
+END;
+/

--- a/test/fixtures/dialects/oracle/select_into_record_fields.yml
+++ b/test/fixtures/dialects/oracle/select_into_record_fields.yml
@@ -1,0 +1,110 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 5d6fc371d461be400d3e242901c3663f52e16285e742b31d3af4e596e4c57b68
+file:
+  batch:
+    statement:
+      create_procedure_statement:
+      - keyword: CREATE
+      - keyword: OR
+      - keyword: REPLACE
+      - keyword: PROCEDURE
+      - function_name:
+          function_name_identifier: test_proc
+      - function_parameter_list:
+          bracketed:
+            start_bracket: (
+            parameter: out_rec
+            keyword: OUT
+            data_type:
+              data_type_identifier: SYS_REFCURSOR
+            end_bracket: )
+      - keyword: IS
+      - declare_segment:
+        - record_type:
+          - keyword: TYPE
+          - naked_identifier: t_rec
+          - keyword: IS
+          - keyword: RECORD
+          - bracketed:
+            - start_bracket: (
+            - naked_identifier: a
+            - data_type:
+                data_type_identifier: NUMBER
+            - comma: ','
+            - naked_identifier: b
+            - data_type:
+                data_type_identifier: NUMBER
+            - end_bracket: )
+        - statement_terminator: ;
+        - naked_identifier: out_metrics
+        - data_type:
+            data_type_identifier: t_rec
+        - statement_terminator: ;
+      - begin_end_block:
+        - keyword: BEGIN
+        - statement:
+            with_compound_statement:
+              keyword: WITH
+              common_table_expression:
+                naked_identifier: cte1
+                keyword: AS
+                bracketed:
+                  start_bracket: (
+                  select_statement:
+                    select_clause:
+                      keyword: SELECT
+                      select_clause_element:
+                        numeric_literal: '1'
+                        alias_expression:
+                          alias_operator:
+                            keyword: AS
+                          naked_identifier: x
+                    from_clause:
+                      keyword: FROM
+                      from_expression:
+                        from_expression_element:
+                          table_expression:
+                            table_reference:
+                              naked_identifier: dual
+                  end_bracket: )
+              select_statement:
+                select_clause:
+                - keyword: SELECT
+                - select_clause_element:
+                    column_reference:
+                    - naked_identifier: cte1
+                    - dot: .
+                    - naked_identifier: x
+                - comma: ','
+                - select_clause_element:
+                    column_reference:
+                    - naked_identifier: cte1
+                    - dot: .
+                    - naked_identifier: x
+                into_clause:
+                - keyword: INTO
+                - object_reference:
+                  - naked_identifier: out_metrics
+                  - dot: .
+                  - naked_identifier: a
+                - comma: ','
+                - object_reference:
+                  - naked_identifier: out_metrics
+                  - dot: .
+                  - naked_identifier: b
+                from_clause:
+                  keyword: FROM
+                  from_expression:
+                    from_expression_element:
+                      table_expression:
+                        table_reference:
+                          naked_identifier: cte1
+        - statement_terminator: ;
+        - keyword: END
+      - statement_terminator: ;
+    slash_buffer_executor:
+      slash: /

--- a/test/fixtures/rules/std_rule_cases/ST03.yml
+++ b/test/fixtures/rules/std_rule_cases/ST03.yml
@@ -168,6 +168,29 @@ test_pass_cte_defined_and_used_7:
     )
     select * from final
 
+test_pass_oracle_select_into_record_fields:
+  # Issue 8250: Dotted INTO targets must not hide the following FROM clause.
+  pass_str: |
+    CREATE OR REPLACE PROCEDURE test_proc(out_rec OUT SYS_REFCURSOR) IS
+      TYPE t_rec IS RECORD (a NUMBER, b NUMBER);
+      out_metrics t_rec;
+    BEGIN
+      WITH cte1 AS (
+        SELECT 1 AS x FROM dual
+      )
+      SELECT
+        cte1.x,
+        cte1.x
+      INTO
+        out_metrics.a,
+        out_metrics.b
+      FROM cte1;
+    END;
+    /
+  configs:
+    core:
+      dialect: oracle
+
 test_snowflake_delete_cte:
   fail_str: |
     DELETE FROM MYTABLE1


### PR DESCRIPTION
 ### Brief summary of the change made

  Fixes #8250.

  Oracle `SELECT ... INTO` statements allow dotted record and collection field targets, but `IntoClauseSegment` only accepted bare identifiers or bind variables. This left dotted targets partially
  unparsable and could also cause false ST03 unused CTE violations.

  This change allows `ObjectReferenceSegment` as the longer dotted-target alternative while retaining the existing single-identifier match, preserving current parse trees for bare targets. It also adds
  an Oracle parser fixture and an ST03 regression case.

  ### Are there any other side effects of this change that we should be aware of?

  No known side effects. Existing bare `SELECT INTO` targets retain their current parse tree.

  ### Testing

  - All 300 Oracle dialect tests passed.
  - All 33 ST03 YAML cases passed.
  - The full Python suite completed with 10,589 passed and 2,533 skipped.
  - Rust workspace and Python/Rust fixture parity tests passed.
  - Ruff, mypy, pre-commit, and `git diff --check` passed.

  ### AI assistance disclosure

  Codex assisted with issue analysis, regression test preparation, and test execution. I manually reviewed the final four-file diff and the validation results, and I take responsibility
  for the contribution.

  ### Pull Request checklist

  - [x] Please confirm you have completed any of the necessary steps below.

  - Included `.sql`/`.yml` Oracle parser test cases in `test/fixtures/dialects`.
  - Included an ST03 rule test case in `test/fixtures/rules/std_rule_cases`.
  - Documentation changes are not required because this corrects existing Oracle parsing behavior.
  - No follow-up issues are currently required.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes parsing for dotted record fields in Oracle SELECT ... INTO, so targets like out_metrics.a are parsed correctly. Prevents false ST03 unused CTE errors and keeps behavior for bare targets unchanged.

- **Bug Fixes**
  - Allow `ObjectReferenceSegment` in `IntoClauseSegment` to parse dotted targets.
  - Add Oracle parser fixture and an ST03 regression test.
  - No side effects; bare `SELECT INTO` targets keep the same parse tree.

<sup>Written for commit cd6d7273018564828afe9d99e396e20c0ec630c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8253?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

