### PR TITLE
RF07: compare identifiers by dialect-normalized name

### DIFF
--- a/src/sqlfluff/rules/references/RF07.py
+++ b/src/sqlfluff/rules/references/RF07.py
@@ -1,23 +1,9 @@
 """Implementation of Rule RF07."""
 
 from sqlfluff.core.dialects.common import qualification
-from sqlfluff.core.parser import BaseSegment
 from sqlfluff.core.rules import BaseRule, EvalResultType, LintResult, RuleContext
 from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
 from sqlfluff.utils.analysis.select import get_select_statement_info
-
-
-def _identifier_key(identifier: BaseSegment) -> tuple[bool, str]:
-    """Return a comparison key of quoting style and normalized name.
-
-    Unquoted identifiers fold case according to the dialect, so they compare
-    case-insensitively with each other. A quoted identifier keeps its exact
-    spelling and only compares equal to another quoted identifier with the
-    same spelling, mirroring ANSI quoted identifier semantics.
-    """
-    if identifier.is_type("quoted_identifier"):
-        return (True, identifier.raw_normalized())
-    return (False, identifier.raw_normalized())
 
 
 class Rule_RF07(BaseRule):
@@ -85,10 +71,11 @@ class Rule_RF07(BaseRule):
         if not select_info or len(select_info.table_aliases) <= 1:
             return None
 
-        # Comparison keys of the aliases declared in this SELECT: case variants
-        # of unquoted identifiers match, quoted identifiers match exactly.
+        # Normalized names of the aliases declared in this SELECT.
+        # raw_normalized() applies the dialect's identifier case folding, so
+        # names which the dialect treats as the same column compare equal.
         alias_names = {
-            _identifier_key(identifier)
+            identifier.raw_normalized()
             for element in select_statement.recursive_crawl(
                 "select_clause_element", no_recursive_seg_type="select_statement"
             )
@@ -113,7 +100,7 @@ class Rule_RF07(BaseRule):
                 identifier = next(reference.recursive_crawl("identifier"), None)
                 if identifier is None:  # pragma: no cover
                     continue
-                if _identifier_key(identifier) in alias_names:
+                if identifier.raw_normalized() in alias_names:
                     results.append(
                         LintResult(
                             anchor=reference,

--- a/test/fixtures/rules/std_rule_cases/RF07.yml
+++ b/test/fixtures/rules/std_rule_cases/RF07.yml
@@ -75,16 +75,50 @@ test_fail_quoted_alias_quoted_reference:
       references.window_alias:
         force_enable: true
 
-test_pass_quoted_alias_unquoted_reference:
-  # A quoted alias preserves its case, so it is not the same identifier
-  # as an unquoted (case-folded) reference.
-  pass_str: |
+test_fail_quoted_alias_unquoted_reference:
+  # An unquoted reference folds to the dialect's case, and ansi folds to upper,
+  # so PARTITION BY id resolves to the same name as the quoted alias "ID".
+  # SQL:2016 5.4 makes a regular identifier equivalent to a delimited
+  # identifier holding its case-folded spelling.
+  fail_str: |
     SELECT
         t1.col1 AS "ID",
         SUM(t2.v) OVER (PARTITION BY id ORDER BY t1.ts) AS s
     FROM t1
     JOIN t2 ON t1.col1 = t2.id
   configs:
+    rules:
+      references.window_alias:
+        force_enable: true
+
+test_pass_quoted_alias_case_differs_from_folded_reference:
+  # In ansi an unquoted id folds to ID, which is not the quoted alias "id",
+  # so these are two different columns and there is nothing to flag.
+  pass_str: |
+    SELECT
+        t1.col1 AS "id",
+        SUM(t2.v) OVER (PARTITION BY id ORDER BY t1.ts) AS s
+    FROM t1
+    JOIN t2 ON t1.col1 = t2.id
+  configs:
+    core:
+      dialect: ansi
+    rules:
+      references.window_alias:
+        force_enable: true
+
+test_fail_quoted_alias_unquoted_reference_lowercase_dialect:
+  # postgres folds unquoted identifiers to lower, so here it is the quoted
+  # alias "id" that collides, the mirror image of the ansi case above.
+  fail_str: |
+    SELECT
+        t1.col1 AS "id",
+        SUM(t2.v) OVER (PARTITION BY id ORDER BY t1.ts) AS s
+    FROM t1
+    JOIN t2 ON t1.col1 = t2.id
+  configs:
+    core:
+      dialect: postgres
     rules:
       references.window_alias:
         force_enable: true


### PR DESCRIPTION
### Brief summary of the change made

`RF07` compares select aliases against window-clause references through a helper whose two branches are identical:

```python
def _identifier_key(identifier: BaseSegment) -> tuple[bool, str]:
    if identifier.is_type("quoted_identifier"):
        return (True, identifier.raw_normalized())
    return (False, identifier.raw_normalized())
```

Both arms compute the same string, so the only thing the helper contributes is the `is_quoted` flag — and that flag means a quoted identifier can never compare equal to an unquoted one.

That is a layer too many, because `raw_normalized()` already handles case sensitivity per dialect. It case-folds only when the segment defines a `casefold`, and the dialects set that on `quoted_identifier` exactly when their quoted identifiers really are case-insensitive (`athena`, `duckdb`, `sqlite`, `teradata`, `trino`, `vertica`) and leave it off where they are not (`ansi`, `postgres`, …). So the normalized name is already the dialect's own notion of identifier identity, and the extra flag suppresses genuine matches:

```sql
-- ansi folds unquoted identifiers to upper, so `id` here IS the alias "ID"
SELECT
    t1.col1 AS "ID",
    SUM(t2.v) OVER (PARTITION BY id ORDER BY t1.ts) AS s
FROM t1
JOIN t2 ON t1.col1 = t2.id
```

`PARTITION BY id` folds to `ID` and resolves to `t2.id`, not to the alias — precisely what RF07 exists to flag — but it is silently accepted today. SQL:2016 5.4 spells this equivalence out: a regular identifier is equivalent to a delimited identifier holding its case-folded spelling. `postgres` shows the mirror image, where it is `AS "id"` that collides with `PARTITION BY id`.

This drops the helper and compares `raw_normalized()` directly, which is what the neighbouring rules already do (`RF02` builds `{alias.segment.raw_normalized() ...}`, `ST07` compares `seg.raw_normalized()`).

### Are there any other side effects of this change that we should be aware of?

The rule now reports two shapes it previously missed, in both folding directions. I checked the change does not simply match more of everything — a 6-case probe across `ansi` and `postgres` confirms every combination lands where SQL identifier equivalence says it should, with all three must-not-flag controls still clean:

| dialect | alias | window ref | flagged before | flagged after | same column? |
| --- | --- | --- | --- | --- | --- |
| ansi | `"ID"` | `id` | no | **yes** | yes, `id` folds to `ID` |
| ansi | `"id"` | `id` | no | no | no, `id` folds to `ID` |
| postgres | `"id"` | `id` | no | **yes** | yes, `id` folds to `id` |
| postgres | `"ID"` | `id` | no | no | no, `id` folds to `id` |
| ansi | `ID` | `id` | yes | yes | yes |
| ansi | `"ID"` | `"id"` | no | no | no, both quoted |

One existing fixture changes expectation. `test_pass_quoted_alias_unquoted_reference` asserted that ansi `AS "ID"` with `PARTITION BY id` should pass, reasoning that "a quoted alias preserves its case, so it is not the same identifier as an unquoted (case-folded) reference". Preserving the case is what makes them the *same* identifier here, since the unquoted reference folds up onto it. I have inverted that case and kept its intent as a new pass case using `"id"`, where the folded reference genuinely does not match, plus a `postgres` fail case for the lower-folding direction.

RF07 is opt-in via `force_enable`, so no default behaviour changes.

### Testing

`RF07.yml` goes from 14 cases to 16. Both new fail cases fail without the source change:

```console
$ python -m pytest test/rules/yaml_test_cases_test.py -k RF07
16 passed, 2309 deselected

# with only src/sqlfluff/rules/references/RF07.py reverted
FAILED ...[RF07_test_fail_quoted_alias_unquoted_reference] - No RF07 failures found in query which should fail.
FAILED ...[RF07_test_fail_quoted_alias_unquoted_reference_lowercase_dialect] - No RF07 failures found in query which should fail.
2 failed, 14 passed
```

Wider suite and linting, on Windows with Python 3.13:

```console
$ python -m pytest test/rules
2487 passed, 101 skipped

$ python -m ruff check src/sqlfluff/rules/references/RF07.py     # All checks passed!
$ python -m ruff format --check src/sqlfluff/rules/references/RF07.py   # 1 file already formatted
$ python -m yamllint test/fixtures/rules/std_rule_cases/RF07.yml # clean
$ python -m mypy src/sqlfluff/rules/references/RF07.py           # Success: no issues found
```


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
RF07 now compares identifiers by the dialect-normalized name to detect alias/window-reference collisions across quoted and unquoted forms. This fixes missed cases (e.g., `ansi` folds to upper, `postgres` to lower) while keeping the rule opt-in.

- **Bug Fixes**
  - Flags alias vs. window-clause collisions when names normalize to the same value per dialect.
  - Expands RF07 cases to cover both folding directions; no default behavior change (`force_enable` required).

- **Refactors**
  - Removed `_identifier_key`; compare `raw_normalized()` directly, consistent with `RF02` and `ST07`.

<sup>Written for commit 4dd8588e72d23b68ebd56b073433505b740a1999. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8254?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

