### PR TITLE
CV12: don't fix join conditions when the join clause is templated

### DIFF
--- a/src/sqlfluff/rules/convention/CV12.py
+++ b/src/sqlfluff/rules/convention/CV12.py
@@ -140,6 +140,18 @@ class Rule_CV12(BaseRule):
                 # Join condition is present, no error reported.
                 continue
 
+            if join_clause.is_templated:
+                # Moving a condition into an ON clause rewrites the whole join
+                # clause. If that clause contains templated code, the resulting
+                # patch can't be mapped back onto the source file and is
+                # silently dropped - but the WHERE clause rewrite below is
+                # literal, so it still applies. The net effect is that the join
+                # condition is deleted rather than moved, silently changing the
+                # meaning of the query. Flag the violation, but don't offer a
+                # fix we can't apply safely.
+                yield LintResult(anchor=join_clause)
+                continue
+
             if not where_clause_simplifable:
                 yield LintResult(anchor=join_clause)
             else:

--- a/test/fixtures/rules/std_rule_cases/CV12.yml
+++ b/test/fixtures/rules/std_rule_cases/CV12.yml
@@ -155,3 +155,52 @@ test_pass_left_join_unnest_where_unaliased:
       UNNEST(t.purchases)
     WHERE
       t.user_id != 1
+
+test_pass_templated_join_clause_not_fixed:
+  # https://github.com/sqlfluff/sqlfluff/issues/8230
+  # Moving the condition into an ON clause rewrites the whole join clause. When
+  # that clause is templated the resulting patch can't be mapped back to the
+  # source and is dropped, but the (literal) WHERE rewrite still applied - which
+  # deleted the join condition altogether.
+  pass_str: |
+    select a.id, b.id as b_id
+    from table_a as a
+    left join {{ ref('table_b') }} as b
+    where a.region = b.region
+  configs:
+    core:
+      dialect: snowflake
+      templater: jinja
+
+test_pass_templated_join_clause_keeps_other_filters:
+  # The join condition used to disappear while the unrelated filter survived,
+  # so the fix looked successful but silently changed the query's meaning.
+  pass_str: |
+    select a.id
+    from table_a as a
+    left join {{ ref('table_b') }} as b
+    where a.region = b.region and a.x = 1
+  configs:
+    core:
+      dialect: snowflake
+      templater: jinja
+
+test_fail_templated_join_alongside_literal_join:
+  # Only the non-templated join is rewritten; the templated join's condition
+  # stays put in the WHERE clause.
+  fail_str: |
+    select a.id
+    from table_a as a
+    left join {{ ref('table_b') }} as b
+    left join table_c as c
+    where a.region = b.region and a.k = c.k
+  fix_str: |
+    select a.id
+    from table_a as a
+    left join {{ ref('table_b') }} as b
+    left join table_c as c ON a.k = c.k
+    where a.region = b.region
+  configs:
+    core:
+      dialect: snowflake
+      templater: jinja


### PR DESCRIPTION
### Brief summary of the change made

Fixes #8230.

Moving a `WHERE` condition into an `ON` clause is emitted as **two independent fixes**: one replacing the `join_clause`, and one rewriting the `where_clause`.

When the join clause contains templated code, its patch cannot be mapped back onto the source file and is discarded — but the `WHERE` rewrite is literal, so it still applies. The join condition is therefore **deleted rather than moved**, silently changing the meaning of the query.

Reproduction (`--dialect snowflake --templater jinja`):

```sql
-- before
select a.id, b.id as b_id
from table_a as a
left join {{ ref('table_b') }} as b
where a.region = b.region
```
```sql
-- after `sqlfluff fix --rules CV12`  (condition gone, no ON added)
select a.id, b.id as b_id
from table_a as a
left join {{ ref('table_b') }} as b
```

The variant with an additional unrelated filter is easier to miss in review, because the fix still *looks* successful:

```sql
-- before
where a.region = b.region and a.x = 1
-- after: the join condition silently vanished
where a.x = 1
```

The linter debug log shows the two patches, one of which is dropped:

```
Appending end_point Patch: 'left join table_c as c' > 'left join table_c as c ON a.k = c.k'
Appending end_point Patch: '\nwhere a.region = b.region and a.k = c.k' > ''
```

**Fix:** skip offering the fix when the join clause is templated, following the existing precedent in `ST10` (`if lhs.is_templated or rhs.is_templated: continue`). The `LintResult` is still yielded rather than skipped outright, so the violation is reported wherever templated violations are surfaced (e.g. placeholder templaters that `_is_semantically_literal_templated` treats as literal).

### Are there any other side effects of this change that we should be aware of?

Scope is limited to join clauses that are *themselves* templated:

| case | behaviour |
|---|---|
| plain join | unchanged — still auto-fixed |
| templated table in `FROM` only | unchanged — still auto-fixed |
| templated join clause | no longer fixed (previously corrupted the SQL) |
| templated join **+** literal join in the same statement | literal join still fixed; only the templated one is left alone |

That last case is covered by `test_fail_templated_join_alongside_literal_join`, which asserts the non-templated join still gets its `ON` clause while the templated join's condition stays in the `WHERE`.

Users relying on the previous behaviour were receiving silently incorrect SQL, so there is no valid behaviour being removed.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - [x] `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
- [x] Added appropriate documentation for the change.

Three cases added to `test/fixtures/rules/std_rule_cases/CV12.yml`. Verified they fail without the rule change and pass with it:

```
# with the fix
28 passed, 2298 deselected

# with only CV12.py reverted
FAILED CV12_test_pass_templated_join_clause_not_fixed
FAILED CV12_test_pass_templated_join_clause_keeps_other_filters
FAILED CV12_test_fail_templated_join_alongside_literal_join
3 failed, 25 passed
```

Full suite: `test/rules/` → **2488 passed, 101 skipped**. `ruff check`, `ruff format --diff` and `mypy` all clean on the changed file.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #8230. Stop `CV12` from auto-fixing join conditions when the join clause contains templated code (e.g., Jinja) to prevent conditions being deleted instead of moved.

- **Bug Fixes**
  - If the join clause is templated, emit a violation but don’t generate a fix.
  - Preserve existing behavior for non-templated joins and templated `FROM` only; in mixed statements, only literal joins are fixed.
  - Added three rule cases covering templated join clauses and mixed joins.

<sup>Written for commit 54b5f6e4470e717019f387c5329b41005d6af01e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8255?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

