### PR TITLE
Support quiet output across lint, fix, and format

### DIFF
--- a/src/sqlfluff/cli/commands.py
+++ b/src/sqlfluff/cli/commands.py
@@ -432,8 +432,18 @@ def core_options(f: Callable) -> Callable:
 def lint_options(f: Callable) -> Callable:
     """Add lint operation options to commands via a decorator.
 
-    These are cli commands that do linting, i.e. `lint` and `fix`.
+    These are cli commands that do linting, i.e. `lint`, `fix`, and `format`.
     """
+    f = click.option(
+        "-q",
+        "--quiet",
+        is_flag=True,
+        help=(
+            "Reduces the amount of output to stdout to a minimal level. "
+            "This is effectively the opposite of -v. NOTE: It cannot be "
+            "used together with -v/--verbose."
+        ),
+    )(f)
     f = click.option(
         "-p",
         "--processes",
@@ -472,6 +482,18 @@ def lint_options(f: Callable) -> Callable:
         help="Perform the operation regardless of .sqlfluffignore configurations",
     )(f)
     return f
+
+
+def _apply_quiet_option(quiet: bool, kwargs: dict[str, Any]) -> None:
+    """Apply the quiet option as negative verbosity."""
+    if not quiet:
+        return
+    if kwargs["verbose"]:
+        click.echo(
+            "ERROR: The --quiet flag can only be used if --verbose is not set.",
+        )
+        sys.exit(EXIT_ERROR)
+    kwargs["verbose"] = -1
 
 
 def get_config(
@@ -693,6 +715,7 @@ def lint(
     nofail: bool,
     recursion_limit: Optional[int],
     disregard_sqlfluffignores: bool,
+    quiet: bool = False,
     logger: Optional[logging.Logger] = None,
     bench: bool = False,
     processes: Optional[int] = None,
@@ -721,6 +744,7 @@ def lint(
         echo 'select col from tbl' | sqlfluff lint -
 
     """
+    _apply_quiet_option(quiet, kwargs)
     apply_recursion_limit(
         recursion_limit,
         extra_config_path=extra_config_path,
@@ -1287,16 +1311,6 @@ def _paths_fix(
     ),
 )
 @click.option(
-    "-q",
-    "--quiet",
-    is_flag=True,
-    help=(
-        "Reduces the amount of output to stdout to a minimal level. "
-        "This is effectively the opposite of -v. NOTE: It cannot be "
-        "used together with -v/--verbose."
-    ),
-)
-@click.option(
     "-x",
     "--fixed-suffix",
     default=None,
@@ -1353,6 +1367,7 @@ def fix(
     character to indicate reading from *stdin* or a dot/blank ('.'/' ') which will
     be interpreted like passing the current working directory as a path argument.
     """
+    _apply_quiet_option(quiet, kwargs)
     apply_recursion_limit(
         recursion_limit,
         extra_config_path=extra_config_path,
@@ -1361,14 +1376,6 @@ def fix(
     )
     # some quick checks
     fixing_stdin = ("-",) == paths
-    if quiet:
-        if kwargs["verbose"]:
-            click.echo(
-                "ERROR: The --quiet flag can only be used if --verbose is not set.",
-            )
-            sys.exit(EXIT_ERROR)
-        kwargs["verbose"] = -1
-
     config = get_config(
         extra_config_path, ignore_local_config, require_dialect=False, **kwargs
     )
@@ -1448,6 +1455,7 @@ def cli_format(
     paths: tuple[str],
     disregard_sqlfluffignores: bool,
     recursion_limit: Optional[int],
+    quiet: bool = False,
     bench: bool = False,
     fixed_suffix: str = "",
     logger: Optional[logging.Logger] = None,
@@ -1470,6 +1478,7 @@ def cli_format(
     character to indicate reading from *stdin* or a dot/blank ('.'/' ') which will
     be interpreted like passing the current working directory as a path argument.
     """
+    _apply_quiet_option(quiet, kwargs)
     apply_recursion_limit(
         recursion_limit,
         extra_config_path=extra_config_path,

--- a/src/sqlfluff/cli/commands.py
+++ b/src/sqlfluff/cli/commands.py
@@ -21,7 +21,12 @@ from sqlfluff.cli import EXIT_ERROR, EXIT_FAIL, EXIT_SUCCESS
 from sqlfluff.cli.autocomplete import dialect_shell_complete, shell_completion_enabled
 from sqlfluff.cli.formatters import OutputStreamFormatter, format_linting_result_header
 from sqlfluff.cli.helpers import LazySequence, get_package_version
-from sqlfluff.cli.outputstream import OutputStream, make_output_stream
+from sqlfluff.cli.outputstream import (
+    OutputKind,
+    OutputPolicy,
+    OutputStream,
+    make_output_stream,
+)
 
 # Import from sqlfluff core.
 from sqlfluff.core import (
@@ -439,9 +444,9 @@ def lint_options(f: Callable) -> Callable:
         "--quiet",
         is_flag=True,
         help=(
-            "Reduces the amount of output to stdout to a minimal level. "
-            "This is effectively the opposite of -v. NOTE: It cannot be "
-            "used together with -v/--verbose."
+            "Suppresses routine status and progress output while preserving "
+            "diagnostics and command results. NOTE: It cannot be used together "
+            "with -v/--verbose."
         ),
     )(f)
     f = click.option(
@@ -485,7 +490,7 @@ def lint_options(f: Callable) -> Callable:
 
 
 def _apply_quiet_option(quiet: bool, kwargs: dict[str, Any]) -> None:
-    """Apply the quiet option as negative verbosity."""
+    """Validate quiet and override configured verbosity."""
     if not quiet:
         return
     if kwargs["verbose"]:
@@ -493,7 +498,7 @@ def _apply_quiet_option(quiet: bool, kwargs: dict[str, Any]) -> None:
             "ERROR: The --quiet flag can only be used if --verbose is not set.",
         )
         sys.exit(EXIT_ERROR)
-    kwargs["verbose"] = -1
+    kwargs["verbose"] = 0
 
 
 def get_config(
@@ -564,6 +569,7 @@ def get_linter_and_formatter(
     cfg: FluffConfig,
     output_stream: Optional[OutputStream] = None,
     show_lint_violations: bool = False,
+    output_policy: Optional[OutputPolicy] = None,
 ) -> tuple[Linter, OutputStreamFormatter]:
     """Get a linter object given a config."""
     try:
@@ -575,10 +581,11 @@ def get_linter_and_formatter(
     except KeyError:  # pragma: no cover
         click.echo(f"Error: Unknown dialect '{cfg.get('dialect')}'")
         sys.exit(EXIT_ERROR)
+    output_policy = output_policy or OutputPolicy(verbosity=cfg.get("verbose"))
     formatter = OutputStreamFormatter(
         output_stream=output_stream or make_output_stream(cfg),
         nocolor=cfg.get("nocolor"),
-        verbosity=cfg.get("verbose"),
+        output_policy=output_policy,
         output_line_length=cfg.get("output_line_length"),
         show_lint_violations=show_lint_violations,
     )
@@ -755,12 +762,21 @@ def lint(
         extra_config_path, ignore_local_config, require_dialect=False, **kwargs
     )
     non_human_output = (format != FormatType.human.value) or (write_output is not None)
+    verbose = config.get("verbose")
+    output_policy = OutputPolicy(
+        verbosity=verbose,
+        quiet=quiet,
+        machine_output=format != FormatType.human.value,
+    )
     file_output = None
     output_stream = make_output_stream(config, format, write_output)
-    lnt, formatter = get_linter_and_formatter(config, output_stream)
+    lnt, formatter = get_linter_and_formatter(
+        config, output_stream, output_policy=output_policy
+    )
 
-    verbose = config.get("verbose")
-    progress_bar_configuration.disable_progress_bar = disable_progress_bar
+    progress_bar_configuration.disable_progress_bar = bool(
+        disable_progress_bar
+    ) or not output_policy.allows(OutputKind.PROGRESS)
 
     formatter.dispatch_config(lnt)
 
@@ -773,8 +789,12 @@ def lint(
     )
 
     # Output the results as we go
-    if verbose >= 1 and not non_human_output:
-        click.echo(format_linting_result_header())
+    if not non_human_output:
+        formatter.dispatch_message(
+            format_linting_result_header(),
+            OutputKind.VERBOSE,
+            minimum_verbosity=1,
+        )
 
     with PathAndUserErrorHandler(formatter):
         # add stdin if specified via lone '-'
@@ -798,8 +818,12 @@ def lint(
             )
 
     # Output the final stats
-    if verbose >= 1 and not non_human_output:
-        click.echo(formatter.format_linting_stats(result, verbose=verbose))
+    if not non_human_output:
+        formatter.dispatch_message(
+            formatter.format_linting_stats(result),
+            OutputKind.VERBOSE,
+            minimum_verbosity=1,
+        )
 
     if format == FormatType.json.value:
         file_output = json.dumps(result.as_records())
@@ -1027,14 +1051,16 @@ def do_fixes(
     fixed_file_suffix: str = "",
 ) -> bool:
     """Actually do the fixes."""
-    if formatter and formatter.verbosity >= 0:
-        click.echo("Persisting Changes...")
+    if formatter:
+        formatter.dispatch_message("Persisting Changes...", OutputKind.STATUS)
     res = result.persist_changes(
         formatter=formatter, fixed_file_suffix=fixed_file_suffix
     )
     if all(res.values()):
-        if formatter and formatter.verbosity >= 0:
-            click.echo("Done. Please check your files to confirm.")
+        if formatter:
+            formatter.dispatch_message(
+                "Done. Please check your files to confirm.", OutputKind.STATUS
+            )
         return True
     # If some failed then return false
     click.echo(
@@ -1179,8 +1205,9 @@ def _paths_fix(
 ) -> None:
     """Handle fixing from paths."""
     # Lint the paths (not with the fix argument at this stage), outputting as we go.
-    if formatter.verbosity >= 0:
-        click.echo("==== finding fixable violations ====")
+    formatter.dispatch_message(
+        "==== finding fixable violations ====", OutputKind.STATUS
+    )
     exit_code = EXIT_SUCCESS
 
     with PathAndUserErrorHandler(formatter):
@@ -1213,10 +1240,12 @@ def _paths_fix(
     )
 
     if num_fixable > 0:
-        if check and formatter.verbosity >= 0:
-            click.echo("==== fixing violations ====")
+        if check:
+            formatter.dispatch_message("==== fixing violations ====", OutputKind.STATUS)
 
-        click.echo(f"{num_fixable} fixable linting violations found")
+        formatter.dispatch_message(
+            f"{num_fixable} fixable linting violations found", OutputKind.ACTION
+        )
 
         if check:
             click.echo(
@@ -1225,8 +1254,7 @@ def _paths_fix(
             c = click.getchar().lower()
             click.echo("...")
             if c in ("y", "\r", "\n"):
-                if formatter.verbosity >= 0:
-                    click.echo("Attempting fixes...")
+                formatter.dispatch_message("Attempting fixes...", OutputKind.STATUS)
                 success = do_fixes(
                     result,
                     formatter,
@@ -1244,13 +1272,17 @@ def _paths_fix(
                 click.echo("Aborting...")
                 exit_code = EXIT_FAIL
     else:
-        if formatter.verbosity >= 0:
-            click.echo("==== no fixable linting violations found ====")
-            formatter.completion_message()
+        formatter.dispatch_message(
+            "==== no fixable linting violations found ====", OutputKind.STATUS
+        )
+        formatter.completion_message()
 
     num_unfixable = sum(p.num_unfixable_lint_errors for p in result.paths)
-    if num_unfixable > 0 and formatter.verbosity >= 0:
-        click.echo("  [{} unfixable linting violations found]".format(num_unfixable))
+    if num_unfixable > 0:
+        formatter.dispatch_message(
+            "  [{} unfixable linting violations found]".format(num_unfixable),
+            OutputKind.DIAGNOSTIC,
+        )
         exit_code = max(exit_code, EXIT_FAIL)
 
     if bench:
@@ -1380,15 +1412,21 @@ def fix(
         extra_config_path, ignore_local_config, require_dialect=False, **kwargs
     )
     fix_even_unparsable = config.get("fix_even_unparsable")
+    verbose = config.get("verbose")
+    output_policy = OutputPolicy(verbosity=verbose, quiet=quiet)
     output_stream = make_output_stream(
         config, None, os.devnull if fixing_stdin else None
     )
     lnt, formatter = get_linter_and_formatter(
-        config, output_stream, show_lint_violations
+        config,
+        output_stream,
+        show_lint_violations,
+        output_policy=output_policy,
     )
 
-    verbose = config.get("verbose")
-    progress_bar_configuration.disable_progress_bar = disable_progress_bar
+    progress_bar_configuration.disable_progress_bar = bool(
+        disable_progress_bar
+    ) or not output_policy.allows(OutputKind.PROGRESS)
 
     formatter.dispatch_config(lnt)
 
@@ -1513,13 +1551,18 @@ def cli_format(
     config = get_config(
         extra_config_path, ignore_local_config, require_dialect=False, **kwargs
     )
+    verbose = config.get("verbose")
+    output_policy = OutputPolicy(verbosity=verbose, quiet=quiet)
     output_stream = make_output_stream(
         config, None, os.devnull if fixing_stdin else None
     )
-    lnt, formatter = get_linter_and_formatter(config, output_stream)
+    lnt, formatter = get_linter_and_formatter(
+        config, output_stream, output_policy=output_policy
+    )
 
-    verbose = config.get("verbose")
-    progress_bar_configuration.disable_progress_bar = disable_progress_bar
+    progress_bar_configuration.disable_progress_bar = bool(
+        disable_progress_bar
+    ) or not output_policy.allows(OutputKind.PROGRESS)
 
     formatter.dispatch_config(lnt)
 
@@ -1719,7 +1762,6 @@ def parse(
             bench,
             code_only,
             total_time,
-            verbose,
             parsed_strings,
             lambda parsed_string: _get_filtered_parse_violations(
                 parsed_string, lnt, allowed_rules_ref_map_cache

--- a/src/sqlfluff/cli/formatters.py
+++ b/src/sqlfluff/cli/formatters.py
@@ -761,4 +761,5 @@ class OutputStreamFormatter(FormatterInterface):
 
     def completion_message(self) -> None:
         """Prints message when SQLFluff is finished."""
-        click.echo(f"All Finished{'' if self.plain_output else ' 📜 🎉'}!")
+        if self.verbosity >= 0:
+            click.echo(f"All Finished{'' if self.plain_output else ' 📜 🎉'}!")

--- a/src/sqlfluff/cli/formatters.py
+++ b/src/sqlfluff/cli/formatters.py
@@ -16,7 +16,7 @@ from sqlfluff.cli.helpers import (
     pad_line,
     wrap_field,
 )
-from sqlfluff.cli.outputstream import OutputStream
+from sqlfluff.cli.outputstream import OutputKind, OutputPolicy, OutputStream
 from sqlfluff.core import FluffConfig, Linter, SQLBaseError, TimingSummary
 from sqlfluff.core.linter import FormatterInterface, LintedFile, ParsedString
 from sqlfluff.core.types import Color
@@ -80,7 +80,7 @@ class OutputStreamFormatter(FormatterInterface):
 
     Args:
         output_stream: Output is sent here
-        verbosity: Specifies how verbose output should be
+        output_policy: Controls which semantic output categories are emitted
         filter_empty: If True, empty messages will not be dispatched
         output_line_length: Maximum line length
     """
@@ -89,14 +89,14 @@ class OutputStreamFormatter(FormatterInterface):
         self,
         output_stream: OutputStream,
         nocolor: Optional[bool],
-        verbosity: int = 0,
+        output_policy: OutputPolicy,
         filter_empty: bool = True,
         output_line_length: int = 80,
         show_lint_violations: bool = False,
     ):
         self._output_stream = output_stream
         self.plain_output = self.should_produce_plain_output(nocolor)
-        self.verbosity = verbosity
+        self.output_policy = output_policy
         self._filter_empty = filter_empty
         self.output_line_length = output_line_length
         self.show_lint_violations = show_lint_violations
@@ -119,17 +119,27 @@ class OutputStreamFormatter(FormatterInterface):
         if (not self._filter_empty) or s.strip(" \n\t"):
             self._output_stream.write(s)
 
+    def dispatch_message(
+        self,
+        s: str,
+        kind: OutputKind,
+        *,
+        minimum_verbosity: int = 0,
+    ) -> None:
+        """Dispatch a message when its semantic output category is enabled."""
+        if self.output_policy.allows(kind, minimum_verbosity=minimum_verbosity):
+            self._dispatch(s)
+
     def _format_config(self, linter: Linter) -> str:
         """Format the config of a `Linter`."""
         text_buffer = StringIO()
-        # Only show version information if verbosity is high enough
-        if self.verbosity > 0:
+        if self.output_policy.allows(OutputKind.VERBOSE, minimum_verbosity=1):
             text_buffer.write("==== sqlfluff ====\n")
             config_content = [
                 ("sqlfluff", get_package_version()),
                 ("python", get_python_version()),
                 ("implementation", get_python_implementation()),
-                ("verbosity", self.verbosity),
+                ("verbosity", self.output_policy.verbosity),
             ]
             if linter.dialect:
                 config_content.append(("dialect", linter.dialect.name))
@@ -145,20 +155,32 @@ class OutputStreamFormatter(FormatterInterface):
                         col_width=41,
                     )
                 )
-            if self.verbosity > 1:
+            if self.output_policy.allows(OutputKind.VERBOSE, minimum_verbosity=2):
                 text_buffer.write("\n== Raw Config:\n")
                 text_buffer.write(self.format_config_vals(linter.config.iter_vals()))
         return text_buffer.getvalue()
 
     def dispatch_config(self, linter: Linter) -> None:
         """Dispatch configuration output appropriately."""
-        self._dispatch(self._format_config(linter))
+        self.dispatch_message(
+            self._format_config(linter),
+            OutputKind.VERBOSE,
+            minimum_verbosity=1,
+        )
 
     def dispatch_persist_filename(self, filename: str, result: str) -> None:
         """Dispatch filenames during a persist operation."""
-        # Only show the skip records at higher levels of verbosity
-        if self.verbosity >= 2 or result != "SKIP":
-            self._dispatch(self.format_filename(filename=filename, success=result))
+        if result == "SKIP":
+            self.dispatch_message(
+                self.format_filename(filename=filename, success=result),
+                OutputKind.VERBOSE,
+                minimum_verbosity=2,
+            )
+        else:
+            self.dispatch_message(
+                self.format_filename(filename=filename, success=result),
+                OutputKind.ACTION,
+            )
 
     def _format_path(self, path: str) -> str:
         """Format paths."""
@@ -166,58 +188,77 @@ class OutputStreamFormatter(FormatterInterface):
 
     def dispatch_path(self, path: str) -> None:
         """Dispatch paths for display."""
-        if self.verbosity > 0:
-            self._dispatch(self._format_path(path))
+        self.dispatch_message(
+            self._format_path(path), OutputKind.VERBOSE, minimum_verbosity=1
+        )
 
     def dispatch_template_header(
         self, fname: str, linter_config: FluffConfig, file_config: Optional[FluffConfig]
     ) -> None:
         """Dispatch the header displayed before templating."""
-        if self.verbosity > 1:
-            self._dispatch(self.format_filename(filename=fname, success="TEMPLATING"))
+        if self.output_policy.allows(OutputKind.VERBOSE, minimum_verbosity=2):
+            self.dispatch_message(
+                self.format_filename(filename=fname, success="TEMPLATING"),
+                OutputKind.VERBOSE,
+                minimum_verbosity=2,
+            )
             # This is where we output config diffs if they exist.
             if file_config:
                 # Only output config diffs if there is a config to diff to.
                 config_diff = file_config.diff_to(linter_config)
                 if config_diff:  # pragma: no cover
-                    self._dispatch("   Config Diff:")
-                    self._dispatch(
+                    self.dispatch_message(
+                        "   Config Diff:",
+                        OutputKind.VERBOSE,
+                        minimum_verbosity=2,
+                    )
+                    self.dispatch_message(
                         self.format_config_vals(
                             linter_config.iter_vals(cfg=config_diff)
-                        )
+                        ),
+                        OutputKind.VERBOSE,
+                        minimum_verbosity=2,
                     )
 
     def dispatch_parse_header(self, fname: str) -> None:
         """Dispatch the header displayed before parsing."""
-        if self.verbosity > 1:
-            self._dispatch(self.format_filename(filename=fname, success="PARSING"))
+        self.dispatch_message(
+            self.format_filename(filename=fname, success="PARSING"),
+            OutputKind.VERBOSE,
+            minimum_verbosity=2,
+        )
 
     def dispatch_lint_header(self, fname: str, rules: list[str]) -> None:
         """Dispatch the header displayed before linting."""
-        if self.verbosity > 1:
-            self._dispatch(
-                self.format_filename(
-                    filename=fname, success=f"LINTING ({', '.join(rules)})"
-                )
-            )
+        self.dispatch_message(
+            self.format_filename(
+                filename=fname, success=f"LINTING ({', '.join(rules)})"
+            ),
+            OutputKind.VERBOSE,
+            minimum_verbosity=2,
+        )
 
     def dispatch_compilation_header(self, templater: str, message: str) -> None:
         """Dispatch the header displayed before linting."""
-        self._dispatch(
-            f"=== [{self.colorize(templater, Color.light)}] {message}"
+        self.dispatch_message(
+            f"=== [{self.colorize(templater, Color.light)}] {message}",
+            OutputKind.STATUS,
         )  # pragma: no cover
 
     def dispatch_processing_header(self, processes: int) -> None:
         """Dispatch the header displayed before linting."""
-        if self.verbosity > 0:
-            self._dispatch(  # pragma: no cover
-                f"{self.colorize('effective configured processes: ', Color.light)} "
-                f"{processes}"
-            )
+        self.dispatch_message(  # pragma: no cover
+            f"{self.colorize('effective configured processes: ', Color.light)} "
+            f"{processes}",
+            OutputKind.VERBOSE,
+            minimum_verbosity=1,
+        )
 
     def dispatch_dialect_warning(self, dialect: str) -> None:
         """Dispatch a warning for dialects."""
-        self._dispatch(self.format_dialect_warning(dialect))  # pragma: no cover
+        self.dispatch_message(  # pragma: no cover
+            self.format_dialect_warning(dialect), OutputKind.DIAGNOSTIC
+        )
 
     def _format_file_violations(
         self, fname: str, violations: list[SQLBaseError]
@@ -234,8 +275,8 @@ class OutputStreamFormatter(FormatterInterface):
         warns = sum(int(violation.warning) for violation in violations)
         show = fails + warns > 0
 
-        # Only print the filename if it's either a failure or verbosity > 1
-        if self.verbosity > 0 or show:
+        # Only print the filename if it has diagnostics or verbose output is enabled.
+        if self.output_policy.allows(OutputKind.VERBOSE, minimum_verbosity=1) or show:
             text_buffer.write(self.format_filename(fname, success=fails == 0))
             text_buffer.write("\n")
 
@@ -264,21 +305,23 @@ class OutputStreamFormatter(FormatterInterface):
         warn_unused_ignores: bool,
     ) -> None:
         """Dispatch any violations found in a file."""
-        if self.verbosity < 0:
-            return
+        violations = linted_file.get_violations(
+            fixable=(
+                True if bool(only_fixable and not self.show_lint_violations) else None
+            ),
+            filter_warning=False,
+            warn_unused_ignores=warn_unused_ignores,
+        )
         s = self._format_file_violations(
             fname,
-            linted_file.get_violations(
-                fixable=(
-                    True
-                    if bool(only_fixable and not self.show_lint_violations)
-                    else None
-                ),
-                filter_warning=False,
-                warn_unused_ignores=warn_unused_ignores,
-            ),
+            violations,
         )
-        self._dispatch(s)
+        kind = (
+            OutputKind.STATUS
+            if only_fixable and not self.show_lint_violations
+            else OutputKind.DIAGNOSTIC
+        )
+        self.dispatch_message(s, kind)
 
     def colorize(self, s: str, color: Optional[Color] = None) -> str:
         """Optionally use ANSI colour codes to colour a string."""
@@ -500,12 +543,12 @@ class OutputStreamFormatter(FormatterInterface):
             out_buff += line
         return out_buff
 
-    def format_linting_stats(self, result, verbose=0) -> str:
+    def format_linting_stats(self, result) -> str:
         """Format a set of stats given a `LintingResult`."""
         text_buffer = StringIO()
         all_stats = result.stats(EXIT_FAIL, EXIT_SUCCESS)
         text_buffer.write("==== summary ====\n")
-        if verbose >= 2:
+        if self.output_policy.allows(OutputKind.VERBOSE, minimum_verbosity=2):
             output_fields = [
                 "files",
                 "violations",
@@ -684,7 +727,6 @@ class OutputStreamFormatter(FormatterInterface):
         bench: bool,
         code_only: bool,
         total_time: float,
-        verbose: int,
         parsed_strings: list[ParsedString],
         violations_getter: Optional[
             Callable[[ParsedString], list[SQLBaseError]]
@@ -745,11 +787,11 @@ class OutputStreamFormatter(FormatterInterface):
                     self.format_dialect_warning(parsed_string.config.get("dialect"))
                 )
 
-            if verbose >= 2:
+            if self.output_policy.allows(OutputKind.VERBOSE, minimum_verbosity=2):
                 output_stream.write("==== timings ====")
                 output_stream.write(self.cli_table(parsed_string.time_dict.items()))
 
-        if verbose >= 2 or bench:
+        if self.output_policy.allows(OutputKind.VERBOSE, minimum_verbosity=2) or bench:
             output_stream.write("==== overall timings ====")
             output_stream.write(self.cli_table([("Clock time", total_time)]))
             timing_summary = timing.summary()
@@ -761,5 +803,7 @@ class OutputStreamFormatter(FormatterInterface):
 
     def completion_message(self) -> None:
         """Prints message when SQLFluff is finished."""
-        if self.verbosity >= 0:
-            click.echo(f"All Finished{'' if self.plain_output else ' 📜 🎉'}!")
+        self.dispatch_message(
+            f"All Finished{'' if self.plain_output else ' 📜 🎉'}!",
+            OutputKind.STATUS,
+        )

--- a/src/sqlfluff/cli/outputstream.py
+++ b/src/sqlfluff/cli/outputstream.py
@@ -2,6 +2,8 @@
 
 import abc
 import os
+from dataclasses import dataclass
+from enum import Enum, auto
 from typing import Any, Optional
 
 import click
@@ -9,6 +11,36 @@ from tqdm import tqdm
 
 from sqlfluff.core import FluffConfig
 from sqlfluff.core.types import FormatType
+
+
+class OutputKind(Enum):
+    """Semantic categories used to decide whether CLI output is emitted."""
+
+    PAYLOAD = auto()
+    DIAGNOSTIC = auto()
+    ACTION = auto()
+    STATUS = auto()
+    PROGRESS = auto()
+    VERBOSE = auto()
+
+
+@dataclass(frozen=True)
+class OutputPolicy:
+    """Control CLI output independently from result and exit-code handling."""
+
+    verbosity: int = 0
+    quiet: bool = False
+    machine_output: bool = False
+
+    def allows(self, kind: OutputKind, *, minimum_verbosity: int = 0) -> bool:
+        """Return whether an output category should be emitted."""
+        if kind is OutputKind.PAYLOAD:
+            return True
+        if self.machine_output:
+            return False
+        if kind in (OutputKind.DIAGNOSTIC, OutputKind.ACTION):
+            return True
+        return not self.quiet and self.verbosity >= minimum_verbosity
 
 
 class OutputStream(abc.ABC):

--- a/test/cli/commands_test.py
+++ b/test/cli/commands_test.py
@@ -2634,13 +2634,18 @@ def test_cli_get_config_color_override():
 
 def test_cli_lint_quiet_disables_progress_bar():
     """Quiet mode should disable progress output without another flag."""
-    result = invoke_assert_code(
-        args=[lint, ["--quiet", "test/fixtures/linter/passing.sql"]]
-    )
+    previous_disable_progress_bar = progress_bar_configuration.disable_progress_bar
+    try:
+        progress_bar_configuration.disable_progress_bar = False
+        result = invoke_assert_code(
+            args=[lint, ["--quiet", "test/fixtures/linter/passing.sql"]]
+        )
 
-    assert progress_bar_configuration.disable_progress_bar is True
-    assert result.stdout == ""
-    assert result.stderr == ""
+        assert progress_bar_configuration.disable_progress_bar is True
+        assert result.stdout == ""
+        assert result.stderr == ""
+    finally:
+        progress_bar_configuration.disable_progress_bar = previous_disable_progress_bar
 
 
 @patch(

--- a/test/cli/commands_test.py
+++ b/test/cli/commands_test.py
@@ -776,18 +776,6 @@ def test__cli__command_lint_parse(command):
             ),
             1,
         ),
-        # Test that setting --quiet with --verbose raises an error.
-        (
-            (
-                fix,
-                [
-                    "--quiet",
-                    "--verbose",
-                    "test/fixtures/cli/fail_many.sql",
-                ],
-            ),
-            2,
-        ),
         # Test machine format parse command with an unparsable file.
         (
             (
@@ -809,6 +797,42 @@ def test__cli__command_lint_parse(command):
 def test__cli__command_lint_parse_with_retcode(command, ret_code):
     """Check commands expecting a non-zero ret code."""
     invoke_assert_code(ret_code=ret_code, args=command)
+
+
+@pytest.mark.parametrize("command", [lint, fix, cli_format])
+def test__cli__quiet_suppresses_success_output(command):
+    """The linting commands should be silent on success when quiet."""
+    result = invoke_assert_code(
+        ret_code=0,
+        args=[
+            command,
+            [
+                "--quiet",
+                "--disable-progress-bar",
+                "test/fixtures/cli/passing_a.sql",
+            ],
+        ],
+    )
+    assert result.stdout == ""
+
+
+@pytest.mark.parametrize("command", [lint, fix, cli_format])
+def test__cli__quiet_rejects_verbose(command):
+    """The linting commands should reject conflicting output options."""
+    invoke_assert_code(
+        ret_code=2,
+        args=[
+            command,
+            [
+                "--quiet",
+                "--verbose",
+                "test/fixtures/cli/passing_a.sql",
+            ],
+        ],
+        assert_stdout_contains=(
+            "ERROR: The --quiet flag can only be used if --verbose is not set."
+        ),
+    )
 
 
 def test__cli__command_lint_warning_explicit_file_ignored():
@@ -2519,8 +2543,7 @@ def test__cli__fix_multiple_errors_quiet_check():
         assert_stdout_contains=(
             """2 fixable linting violations found
 Are you sure you wish to attempt to fix these? [Y/n] ...
-== [test/fixtures/linter/multiple_sql_errors.sql] FIXED
-All Finished"""
+== [test/fixtures/linter/multiple_sql_errors.sql] FIXED"""
         ),
     )
 

--- a/test/cli/commands_test.py
+++ b/test/cli/commands_test.py
@@ -32,7 +32,7 @@ from sqlfluff.cli.commands import (
     version,
 )
 from sqlfluff.core import FluffConfig, Linter
-from sqlfluff.core.config import clear_config_caches
+from sqlfluff.core.config import clear_config_caches, progress_bar_configuration
 from sqlfluff.core.helpers.file import get_encoding
 from sqlfluff.utils.testing.cli import invoke_assert_code
 
@@ -799,6 +799,82 @@ def test__cli__command_lint_parse_with_retcode(command, ret_code):
     invoke_assert_code(ret_code=ret_code, args=command)
 
 
+@pytest.mark.parametrize(
+    ("verbosity", "expected", "unexpected"),
+    [
+        (
+            "-v",
+            ["==== sqlfluff ====", "==== readout ====", "==== summary ===="],
+            ["== Raw Config:", "unclean rate", "LINTING"],
+        ),
+        (
+            "-vv",
+            [
+                "==== sqlfluff ====",
+                "== Raw Config:",
+                "==== readout ====",
+                "==== summary ====",
+                "unclean rate",
+                "LINTING",
+            ],
+            [],
+        ),
+    ],
+)
+def test__cli__lint_verbosity_thresholds(verbosity, expected, unexpected):
+    """Stacked verbosity should progressively enable detailed output."""
+    result = invoke_assert_code(
+        args=[
+            lint,
+            [
+                verbosity,
+                "--disable-progress-bar",
+                "test/fixtures/cli/passing_a.sql",
+            ],
+        ]
+    )
+    for text in expected:
+        assert text in result.stdout
+    for text in unexpected:
+        assert text not in result.stdout
+
+
+@pytest.mark.parametrize(
+    ("args", "file_timings", "overall_timings"),
+    [
+        (["-v"], False, False),
+        (["-vv"], True, True),
+        (["--bench"], False, True),
+    ],
+)
+def test__cli__parse_verbosity_thresholds(args, file_timings, overall_timings):
+    """Parse timings should respect verbosity unless explicitly requested."""
+    result = invoke_assert_code(
+        args=[parse, [*args, "test/fixtures/cli/passing_a.sql"]]
+    )
+    assert ("==== timings ====" in result.stdout) is file_timings
+    assert ("==== overall timings ====" in result.stdout) is overall_timings
+
+
+def test__cli__verbose_machine_output_stays_serialized():
+    """Verbose logging should not contaminate machine-readable stdout."""
+    result = invoke_assert_code(
+        ret_code=1,
+        args=[
+            lint,
+            [
+                "-vvv",
+                "--format=json",
+                "--disable-progress-bar",
+                "test/fixtures/linter/indentation_error_simple.sql",
+            ],
+        ],
+    )
+    json.loads(result.stdout)
+    assert "==== sqlfluff ====" not in result.stdout
+    assert result.stderr
+
+
 @pytest.mark.parametrize("command", [lint, fix, cli_format])
 def test__cli__quiet_suppresses_success_output(command):
     """The linting commands should be silent on success when quiet."""
@@ -814,6 +890,206 @@ def test__cli__quiet_suppresses_success_output(command):
         ],
     )
     assert result.stdout == ""
+    assert result.stderr == ""
+
+
+def test__cli__lint_quiet_overrides_configured_verbosity():
+    """Quiet lint should suppress verbosity loaded from configuration."""
+    result = invoke_assert_code(
+        ret_code=0,
+        args=[
+            lint,
+            [
+                "--quiet",
+                "--disable-progress-bar",
+                "--config",
+                "test/fixtures/config/toml/pyproject.toml",
+                "test/fixtures/cli/passing_a.sql",
+            ],
+        ],
+    )
+    assert result.stdout == ""
+
+
+@pytest.mark.parametrize(
+    ("extra_args", "ret_code", "paths", "expected_codes"),
+    [
+        (
+            [],
+            1,
+            ["test/fixtures/linter/indentation_error_simple.sql"],
+            ["CP01", "LT02"],
+        ),
+        (
+            ["--nofail"],
+            0,
+            ["test/fixtures/linter/indentation_error_simple.sql"],
+            ["CP01", "LT02"],
+        ),
+        (
+            ["--processes", "2"],
+            1,
+            [
+                "test/fixtures/linter/indentation_error_simple.sql",
+                "test/fixtures/cli/fail_many.sql",
+            ],
+            ["CP01", "LT02", "TMP", "PRS"],
+        ),
+    ],
+)
+def test__cli__lint_quiet_preserves_rule_diagnostics(
+    extra_args, ret_code, paths, expected_codes
+):
+    """Quiet lint should report rule diagnostics without routine output."""
+    result = invoke_assert_code(
+        ret_code=ret_code,
+        args=[
+            lint,
+            [
+                "--quiet",
+                "--disable-progress-bar",
+                *extra_args,
+                *paths,
+            ],
+        ],
+    )
+    for code in expected_codes:
+        assert code in result.stdout
+    assert "All Finished" not in result.stdout
+
+
+def test__cli__lint_quiet_preserves_parse_diagnostics():
+    """Quiet lint should report templating and parsing diagnostics."""
+    result = invoke_assert_code(
+        ret_code=1,
+        args=[
+            lint,
+            [
+                "--quiet",
+                "--disable-progress-bar",
+                "test/fixtures/cli/fail_many.sql",
+            ],
+        ],
+    )
+    assert "TMP" in result.stdout
+    assert "PRS" in result.stdout
+    assert "All Finished" not in result.stdout
+
+
+def test__cli__lint_quiet_preserves_warnings():
+    """Quiet lint should report warnings even when the command succeeds."""
+    result = invoke_assert_code(
+        ret_code=0,
+        args=[
+            lint,
+            [
+                "--quiet",
+                "--disable-progress-bar",
+                "test/fixtures/cli/warning_a.sql",
+            ],
+        ],
+    )
+    assert "LT01 | WARNING" in result.stdout
+    assert "All Finished" not in result.stdout
+
+
+def test__cli__lint_quiet_preserves_machine_output():
+    """Quiet lint should not alter machine-readable diagnostics."""
+    result = invoke_assert_code(
+        ret_code=1,
+        args=[
+            lint,
+            [
+                "--quiet",
+                "--format",
+                "json",
+                "--disable-progress-bar",
+                "test/fixtures/linter/indentation_error_simple.sql",
+            ],
+        ],
+    )
+    records = json.loads(result.stdout)
+    assert {violation["code"] for violation in records[0]["violations"]} == {
+        "CP01",
+        "LT02",
+    }
+
+
+@pytest.mark.parametrize("command", [fix, cli_format])
+def test__cli__quiet_preserves_unfixable_exit_code(command, tmp_path):
+    """Quiet fix and format should still fail for unfixable violations."""
+    test_file = tmp_path / "unfixable.sql"
+    shutil.copy(
+        "test/fixtures/linter/autofix/ansi/008_looping_rules_LT02_LT04_LT05/after.sql",
+        test_file,
+    )
+    result = invoke_assert_code(
+        ret_code=1,
+        args=[
+            command,
+            [
+                "--quiet",
+                "--disable-progress-bar",
+                "--dialect=ansi",
+                str(test_file),
+            ],
+        ],
+    )
+    assert "unfixable linting violations found" in result.stdout
+    assert "All Finished" not in result.stdout
+
+
+@pytest.mark.parametrize(
+    ("command", "extra_args", "cli_input", "expected"),
+    [
+        (fix, ["--rules=LT02"], " select * from t", "select * from t"),
+        (
+            cli_format,
+            [],
+            "   select    *    FRoM     t    ",
+            "select * from t\n",
+        ),
+    ],
+)
+def test__cli__quiet_preserves_formatted_stdin(
+    command, extra_args, cli_input, expected
+):
+    """Quiet fix and format should preserve formatted stdin output."""
+    result = invoke_assert_code(
+        ret_code=0,
+        args=[
+            command,
+            [
+                "--quiet",
+                "--disable-progress-bar",
+                "--dialect=ansi",
+                *extra_args,
+                "-",
+            ],
+        ],
+        cli_input=cli_input,
+    )
+    assert result.stdout == expected
+    assert result.stderr == ""
+
+
+@pytest.mark.parametrize("command", [fix, cli_format])
+def test__cli__quiet_preserves_fix_parse_diagnostics(command):
+    """Quiet fix and format should preserve parse diagnostics."""
+    result = invoke_assert_code(
+        ret_code=1,
+        args=[
+            command,
+            [
+                "--quiet",
+                "--disable-progress-bar",
+                "test/fixtures/cli/fail_many.sql",
+            ],
+        ],
+    )
+    assert "TMP" in result.stderr
+    assert "PRS" in result.stderr
+    assert "All Finished" not in result.stdout
 
 
 @pytest.mark.parametrize("command", [lint, fix, cli_format])
@@ -2356,6 +2632,17 @@ def test_cli_get_config_color_override():
     assert no_color_config.get("color") is False
 
 
+def test_cli_lint_quiet_disables_progress_bar():
+    """Quiet mode should disable progress output without another flag."""
+    result = invoke_assert_code(
+        args=[lint, ["--quiet", "test/fixtures/linter/passing.sql"]]
+    )
+
+    assert progress_bar_configuration.disable_progress_bar is True
+    assert result.stdout == ""
+    assert result.stderr == ""
+
+
 @patch(
     "sqlfluff.core.linter.linter.progress_bar_configuration",
     disable_progress_bar=False,
@@ -2505,7 +2792,7 @@ def test__cli__fix_multiple_errors_no_show_errors():
 def test__cli__fix_multiple_errors_quiet_force():
     """Test the fix --quiet option with --force."""
     invoke_assert_code(
-        ret_code=0,
+        ret_code=1,
         args=[
             fix,
             [
@@ -2526,7 +2813,7 @@ def test__cli__fix_multiple_errors_quiet_force():
 def test__cli__fix_multiple_errors_quiet_check():
     """Test the fix --quiet option without --force."""
     invoke_assert_code(
-        ret_code=0,
+        ret_code=1,
         args=[
             fix,
             [

--- a/test/cli/formatters_test.py
+++ b/test/cli/formatters_test.py
@@ -8,7 +8,7 @@ import pytest
 
 from sqlfluff.cli.commands import fix
 from sqlfluff.cli.formatters import OutputStreamFormatter
-from sqlfluff.cli.outputstream import FileOutput
+from sqlfluff.cli.outputstream import FileOutput, OutputKind, OutputPolicy
 from sqlfluff.core import FluffConfig
 from sqlfluff.core.errors import SQLLintError
 from sqlfluff.core.parser import RawSegment
@@ -16,6 +16,29 @@ from sqlfluff.core.parser.markers import PositionMarker
 from sqlfluff.core.rules import RuleGhost
 from sqlfluff.core.templaters.base import TemplatedFile
 from sqlfluff.core.types import Color
+
+
+@pytest.mark.parametrize(
+    ("policy", "kind", "minimum_verbosity", "expected"),
+    [
+        (OutputPolicy(), OutputKind.STATUS, 0, True),
+        (OutputPolicy(quiet=True), OutputKind.PAYLOAD, 0, True),
+        (OutputPolicy(quiet=True), OutputKind.DIAGNOSTIC, 0, True),
+        (OutputPolicy(quiet=True), OutputKind.ACTION, 0, True),
+        (OutputPolicy(quiet=True), OutputKind.STATUS, 0, False),
+        (OutputPolicy(quiet=True), OutputKind.PROGRESS, 0, False),
+        (OutputPolicy(), OutputKind.VERBOSE, 1, False),
+        (OutputPolicy(verbosity=1), OutputKind.VERBOSE, 1, True),
+        (OutputPolicy(verbosity=1), OutputKind.VERBOSE, 2, False),
+        (OutputPolicy(verbosity=2), OutputKind.VERBOSE, 2, True),
+        (OutputPolicy(verbosity=2, quiet=True), OutputKind.VERBOSE, 1, False),
+        (OutputPolicy(machine_output=True), OutputKind.PAYLOAD, 0, True),
+        (OutputPolicy(machine_output=True), OutputKind.DIAGNOSTIC, 0, False),
+    ],
+)
+def test__cli__output_policy(policy, kind, minimum_verbosity, expected):
+    """Output policy should filter semantic categories independently."""
+    assert policy.allows(kind, minimum_verbosity=minimum_verbosity) is expected
 
 
 def escape_ansi(line):
@@ -27,7 +50,9 @@ def escape_ansi(line):
 def test__cli__formatters__filename_nocol(tmpdir):
     """Test formatting filenames."""
     formatter = OutputStreamFormatter(
-        FileOutput(FluffConfig(require_dialect=False), str(tmpdir / "out.txt")), False
+        FileOutput(FluffConfig(require_dialect=False), str(tmpdir / "out.txt")),
+        False,
+        OutputPolicy(),
     )
     res = formatter.format_filename("blahblah", success=True)
     assert escape_ansi(res) == "== [blahblah] PASS"
@@ -49,7 +74,9 @@ def test__cli__formatters__violation(tmpdir):
     r = RuleGhost("A", "some-name", "DESC")
     v = SQLLintError(description=r.description, segment=s, rule=r)
     formatter = OutputStreamFormatter(
-        FileOutput(FluffConfig(require_dialect=False), str(tmpdir / "out.txt")), False
+        FileOutput(FluffConfig(require_dialect=False), str(tmpdir / "out.txt")),
+        False,
+        OutputPolicy(),
     )
     f = formatter.format_violation(v)
     # Position is 3, 3 because foobarbar is on the third
@@ -63,7 +90,9 @@ def test__cli__formatters__violation(tmpdir):
 def test__cli__helpers__colorize(tmpdir):
     """Test ANSI colouring."""
     formatter = OutputStreamFormatter(
-        FileOutput(FluffConfig(require_dialect=False), str(tmpdir / "out.txt")), False
+        FileOutput(FluffConfig(require_dialect=False), str(tmpdir / "out.txt")),
+        False,
+        OutputPolicy(),
     )
     # Force color output for this test.
     formatter.plain_output = False
@@ -101,7 +130,9 @@ def test__cli__helpers__cli_table(tmpdir):
     """Test making tables."""
     vals = [("a", 3), ("b", "c"), ("d", 4.7654), ("e", 9)]
     formatter = OutputStreamFormatter(
-        FileOutput(FluffConfig(require_dialect=False), str(tmpdir / "out.txt")), False
+        FileOutput(FluffConfig(require_dialect=False), str(tmpdir / "out.txt")),
+        False,
+        OutputPolicy(),
     )
     txt = formatter.cli_table(vals, col_width=7, divider_char="|", label_color=None)
     # NB: No trailing newline

--- a/test/core/linter/linter_test.py
+++ b/test/core/linter/linter_test.py
@@ -7,7 +7,7 @@ from unittest.mock import patch
 import pytest
 
 from sqlfluff.cli.formatters import OutputStreamFormatter
-from sqlfluff.cli.outputstream import make_output_stream
+from sqlfluff.cli.outputstream import OutputPolicy, make_output_stream
 from sqlfluff.core import FluffConfig, Linter
 from sqlfluff.core.errors import (
     SQLBaseError,
@@ -355,7 +355,7 @@ def test__linter__linting_parallel_thread(force_error, monkeypatch):
     config = FluffConfig(overrides={"dialect": "ansi"})
     output_stream = make_output_stream(config, None, os.devnull)
     lntr = Linter(
-        formatter=OutputStreamFormatter(output_stream, False, verbosity=0),
+        formatter=OutputStreamFormatter(output_stream, False, OutputPolicy()),
         dialect="ansi",
     )
     result = lntr.lint_paths(


### PR DESCRIPTION
AI written, human reviewed.

### Brief summary of the change made

Fixes #8257.

This makes `-q`/`--quiet` a shared option for `lint`, `fix`, and `format`. Quiet mode is normalized to negative verbosity before configuration is created, and completion messages now respect that verbosity. As a result, successful quiet runs do not print `All Finished 📜 🎉!`.

Diagnostics, exit codes, machine-readable output, formatted stdin output, and interactive prompts are unchanged. Combining `--quiet` with `--verbose` remains an error for all three commands.

The Click option help is the source for generated CLI documentation, so exposing the shared option updates the documented command interfaces without editing generated files.

AI assisted with tracing the CLI output paths, drafting the implementation, and drafting tests and documentation text. I manually reviewed the diff and validated it with:

- `.venv/bin/pytest test/cli` (`234 passed`)
- `.venv/bin/ruff format --check src/sqlfluff/cli/commands.py src/sqlfluff/cli/formatters.py test/cli/commands_test.py`
- `.venv/bin/ruff check src/sqlfluff/cli/commands.py src/sqlfluff/cli/formatters.py test/cli/commands_test.py`
- `.venv/bin/mypy src/sqlfluff/cli/commands.py src/sqlfluff/cli/formatters.py`
- Manual checks that a successful quiet run is silent and a failing quiet lint still emits diagnostics without the completion message

### Are there any other side effects of this change that we should be aware of?

`lint --quiet` and `format --quiet` are new interfaces. Existing non-quiet output remains unchanged. Existing `fix --quiet` output becomes more consistent by omitting its completion message, while retaining actionable fix and confirmation output.

No CI changes are required.

### Pull Request checklist

- [x] Please confirm you have completed any of the necessary steps below.

- Included parametrized CLI tests covering silent successful runs and `--quiet`/`--verbose` conflicts for `lint`, `fix`, and `format`.
- Updated the existing quiet fix expectation to verify the completion message is omitted.
- Added appropriate documentation through the shared Click option help used by generated CLI documentation.
- Created #8257 for this enhancement; no additional follow-up issue is currently needed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a shared `-q/--quiet` flag to `lint`, `fix`, and `format`, and unify CLI output with a new semantic policy. Successful quiet runs print nothing; diagnostics, exit codes, and machine-readable output are unchanged, and progress bars are disabled automatically.

- **New Features**
  - `--quiet` added to `lint`, `fix`, and `format`; rejects `--verbose`.
  - Quiet is applied before config and overrides configured verbosity; output is controlled by `OutputPolicy`/`OutputKind` to hide status/completion/progress while keeping diagnostics and action output.
  - Machine formats never include verbose chatter on stdout; JSON and other machine output remain clean even with `-vvv`.
  - Verbosity thresholds drive headers/readouts/parse timings; completion and progress output respect `--quiet`.

<sup>Written for commit 79f423056a1fe2cf91649a3cb80bd6bd568b4352. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8258?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

