### PR TITLE
Postgres: support VIRTUAL generated columns

### DIFF
--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -4027,7 +4027,16 @@ class ColumnConstraintSegment(ansi.ColumnConstraintSegment):
                     Ref("ExpressionSegment"),
                 ),
             ),
-            Sequence("GENERATED", "ALWAYS", "AS", Ref("ExpressionSegment"), "STORED"),
+            # GENERATED ALWAYS AS ( generation_expr ) [ STORED | VIRTUAL ]
+            # The storage keyword is optional as of Postgres 18 and defaults
+            # to VIRTUAL when omitted.
+            Sequence(
+                "GENERATED",
+                "ALWAYS",
+                "AS",
+                Ref("ExpressionSegment"),
+                OneOf("STORED", "VIRTUAL", optional=True),
+            ),
             Sequence(
                 "GENERATED",
                 OneOf("ALWAYS", Sequence("BY", "DEFAULT")),
@@ -4112,8 +4121,16 @@ class ForeignTableColumnConstraintSegment(ansi.ColumnConstraintSegment):
                     Ref("ExpressionSegment"),
                 ),
             ),
-            # GENERATED ALWAYS AS ( generation_expr ) STORED
-            Sequence("GENERATED", "ALWAYS", "AS", Ref("ExpressionSegment"), "STORED"),
+            # GENERATED ALWAYS AS ( generation_expr ) [ STORED | VIRTUAL ]
+            # The storage keyword is optional as of Postgres 18 and defaults
+            # to VIRTUAL when omitted.
+            Sequence(
+                "GENERATED",
+                "ALWAYS",
+                "AS",
+                Ref("ExpressionSegment"),
+                OneOf("STORED", "VIRTUAL", optional=True),
+            ),
         ),
     )
 

--- a/src/sqlfluff/dialects/dialect_postgres_keywords.py
+++ b/src/sqlfluff/dialects/dialect_postgres_keywords.py
@@ -890,6 +890,7 @@ postgres_docs_keywords = [
     ("VERSIONING", "not-keyword"),
     ("VIEW", "non-reserved"),
     ("VIEWS", "non-reserved"),
+    ("VIRTUAL", "non-reserved"),
     ("VOLATILE", "non-reserved"),
     ("WHEN", "reserved"),
     ("WHENEVER", "not-keyword"),

--- a/test/fixtures/dialects/postgres/create_foreign_table.sql
+++ b/test/fixtures/dialects/postgres/create_foreign_table.sql
@@ -7,6 +7,8 @@ CREATE FOREIGN TABLE foreign_table (
     column_with_check_constraint float CHECK (column_with_check_constraint > 0.0),
     column_with_default_constraint timestamp DEFAULT CURRENT_TIMESTAMP,
     column_with_generated_constraint bigint GENERATED ALWAYS AS (simple_column * 2) STORED,
+    column_with_virtual_generated_constraint bigint GENERATED ALWAYS AS (simple_column * 3) VIRTUAL,
+    column_with_implicitly_virtual_generated_constraint bigint GENERATED ALWAYS AS (simple_column * 4),
     column_with_more_than_one_constraint int NOT NULL CHECK (column_with_more_than_one_constraint > 0),
     column_with_options_and_collate char(5) OPTIONS (a 'foo', b 'bar') COLLATE "es_ES",
     column_with_options_and_constraint char(5) OPTIONS (a 'foo', b 'bar') NOT NULL,

--- a/test/fixtures/dialects/postgres/create_foreign_table.yml
+++ b/test/fixtures/dialects/postgres/create_foreign_table.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: cdcbe24329fb7f0e321e4ad584f94a5d6e918340c17cc53d61af8dedc57a473d
+_hash: b6d80a45bcc90896d3537c77810bf970a7a0ab296d69c1c1b482df31450547ff
 file:
 - statement:
     create_foreign_table_statement:
@@ -110,6 +110,43 @@ file:
                 numeric_literal: '2'
               end_bracket: )
         - keyword: STORED
+      - comma: ','
+      - column_reference:
+          naked_identifier: column_with_virtual_generated_constraint
+      - data_type:
+          keyword: bigint
+      - column_constraint_segment:
+        - keyword: GENERATED
+        - keyword: ALWAYS
+        - keyword: AS
+        - expression:
+            bracketed:
+              start_bracket: (
+              expression:
+                column_reference:
+                  naked_identifier: simple_column
+                binary_operator: '*'
+                numeric_literal: '3'
+              end_bracket: )
+        - keyword: VIRTUAL
+      - comma: ','
+      - column_reference:
+          naked_identifier: column_with_implicitly_virtual_generated_constraint
+      - data_type:
+          keyword: bigint
+      - column_constraint_segment:
+        - keyword: GENERATED
+        - keyword: ALWAYS
+        - keyword: AS
+        - expression:
+            bracketed:
+              start_bracket: (
+              expression:
+                column_reference:
+                  naked_identifier: simple_column
+                binary_operator: '*'
+                numeric_literal: '4'
+              end_bracket: )
       - comma: ','
       - column_reference:
           naked_identifier: column_with_more_than_one_constraint

--- a/test/fixtures/dialects/postgres/create_table.sql
+++ b/test/fixtures/dialects/postgres/create_table.sql
@@ -370,3 +370,10 @@ CREATE TABLE myschema.user (
 CREATE TABLE my_table (
   interval  bigint
 );
+
+CREATE TABLE generated_columns (
+    simple_column integer,
+    stored_column bigint GENERATED ALWAYS AS (simple_column * 2) STORED,
+    virtual_column bigint GENERATED ALWAYS AS (simple_column * 3) VIRTUAL,
+    implicitly_virtual_column bigint GENERATED ALWAYS AS (simple_column * 4)
+);

--- a/test/fixtures/dialects/postgres/create_table.yml
+++ b/test/fixtures/dialects/postgres/create_table.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 7c8ef6046a12da5416a7f53a483423ece5bc65ab618f64ab1df1ff86aeb80b1a
+_hash: b8886382680e9fb1bffc20cd612262085bc6121a304d4b6715c99c7da52bb2b4
 file:
 - statement:
     create_table_statement:
@@ -2478,4 +2478,74 @@ file:
           data_type:
             keyword: bigint
         end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: generated_columns
+    - bracketed:
+      - start_bracket: (
+      - column_definition:
+          naked_identifier: simple_column
+          data_type:
+            keyword: integer
+      - comma: ','
+      - column_definition:
+          naked_identifier: stored_column
+          data_type:
+            keyword: bigint
+          column_constraint_segment:
+          - keyword: GENERATED
+          - keyword: ALWAYS
+          - keyword: AS
+          - expression:
+              bracketed:
+                start_bracket: (
+                expression:
+                  column_reference:
+                    naked_identifier: simple_column
+                  binary_operator: '*'
+                  numeric_literal: '2'
+                end_bracket: )
+          - keyword: STORED
+      - comma: ','
+      - column_definition:
+          naked_identifier: virtual_column
+          data_type:
+            keyword: bigint
+          column_constraint_segment:
+          - keyword: GENERATED
+          - keyword: ALWAYS
+          - keyword: AS
+          - expression:
+              bracketed:
+                start_bracket: (
+                expression:
+                  column_reference:
+                    naked_identifier: simple_column
+                  binary_operator: '*'
+                  numeric_literal: '3'
+                end_bracket: )
+          - keyword: VIRTUAL
+      - comma: ','
+      - column_definition:
+          naked_identifier: implicitly_virtual_column
+          data_type:
+            keyword: bigint
+          column_constraint_segment:
+          - keyword: GENERATED
+          - keyword: ALWAYS
+          - keyword: AS
+          - expression:
+              bracketed:
+                start_bracket: (
+                expression:
+                  column_reference:
+                    naked_identifier: simple_column
+                  binary_operator: '*'
+                  numeric_literal: '4'
+                end_bracket: )
+      - end_bracket: )
 - statement_terminator: ;


### PR DESCRIPTION
### Brief summary of the change made

Fixes #8139.

[Postgres 18](https://www.postgresql.org/docs/current/ddl-generated-columns.html) adds **virtual** generated columns. The storage keyword became optional and defaults to `VIRTUAL` when omitted:

```
GENERATED ALWAYS AS ( generation_expr ) [ STORED | VIRTUAL ]
```

Only `STORED` was accepted, so both of these were reported as unparsable:

```sql
CREATE TABLE t (
    a int,
    b int GENERATED ALWAYS AS (a * 2) STORED,   -- ok before
    c int GENERATED ALWAYS AS (a * 3) VIRTUAL,  -- PRS: unparsable
    d int GENERATED ALWAYS AS (a * 4)           -- PRS: unparsable
);
```

This accepts either keyword and makes it optional, in both `ColumnConstraintSegment` and `ForeignTableColumnConstraintSegment` — [virtual generated columns are permitted on foreign tables](https://www.postgresql.org/docs/current/sql-createforeigntable.html) too, which is the page the issue links.

`VIRTUAL` is added as **non-reserved**, matching [its classification in the Postgres grammar](https://github.com/postgres/postgres/blame/1ae87df63ff693a91fbcb968850103a5a5d8cd96/src/backend/parser/gram.y#L19246), so it stays usable as an identifier.

### Are there any other side effects of this change that we should be aware of?

The issue asks whether support can be restricted to Postgres 18 and still fail on <= 17. As far as I can tell sqlfluff doesn't version-gate dialects, and this follows the existing convention of accepting the newest syntax for a dialect — so `VIRTUAL` will now parse regardless of the server version being targeted. Happy to rework if you'd prefer a different approach.

Because `VIRTUAL` is non-reserved, existing code that uses it as an identifier is unaffected. Verified:

```sql
SELECT virtual FROM t;      -- still parses
CREATE TABLE virtual (a int);  -- still parses
```

`GENERATED ... AS IDENTITY` (both `ALWAYS` and `BY DEFAULT`) is untouched, as is the existing `STORED` form.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - [x] `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (YML regenerated with `test/generate_parse_fixture_yml.py --dialect postgres`).

Cases added to `create_table.sql` (stored / virtual / implicitly-virtual) and `create_foreign_table.sql` (virtual / implicitly-virtual). The regenerated YAML is additive — the only removed line in each is the fixture `_hash`.

Verification:

```
test/dialects/   6784 passed
test/rules/      2485 passed, 101 skipped
ruff check / ruff format / mypy   clean
```


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for Postgres 18 virtual generated columns in the Postgres dialect. Statements using GENERATED ALWAYS AS (...) with `VIRTUAL` or without a storage keyword now parse correctly, fixing #8139.

- **New Features**
  - Accept `VIRTUAL` and make the storage keyword optional in column constraints.
  - Apply the same behavior to foreign tables.
  - Mark `VIRTUAL` as non-reserved so it can still be used as an identifier.

<sup>Written for commit 6d8597f611b9907d3e67b50b2838e2abfdc59938. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8259?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

