### PR TITLE
Oracle: allow record and collection fields as INTO targets

### DIFF
--- a/src/sqlfluff/dialects/dialect_oracle.py
+++ b/src/sqlfluff/dialects/dialect_oracle.py
@@ -3856,7 +3856,15 @@ class IntoClauseSegment(BaseSegment):
 
     match_grammar = Sequence(
         "INTO",
-        Delimited(OneOf(Ref("SingleIdentifierGrammar"), Ref("BindVariableSegment"))),
+        # Targets may be record or collection fields (e.g. `rec.field`), not
+        # just bare variable names.
+        Delimited(
+            OneOf(
+                Ref("SingleIdentifierGrammar"),
+                Ref("ObjectReferenceSegment"),
+                Ref("BindVariableSegment"),
+            )
+        ),
     )
 
 
@@ -3873,7 +3881,14 @@ class BulkCollectIntoClauseSegment(BaseSegment):
         "COLLECT",
         "INTO",
         ImplicitIndent,
-        Delimited(OneOf(Ref("SingleIdentifierGrammar"), Ref("BindVariableSegment"))),
+        # As above, targets may be record or collection fields.
+        Delimited(
+            OneOf(
+                Ref("SingleIdentifierGrammar"),
+                Ref("ObjectReferenceSegment"),
+                Ref("BindVariableSegment"),
+            )
+        ),
         Dedent,
     )
 

--- a/test/fixtures/dialects/oracle/returning_into.sql
+++ b/test/fixtures/dialects/oracle/returning_into.sql
@@ -152,3 +152,51 @@ BEGIN
     END LOOP;
 END;
 /
+
+-- SELECT ... INTO targeting fields of a record variable.
+CREATE OR REPLACE PROCEDURE test_proc(out_rec OUT SYS_REFCURSOR) IS
+  TYPE t_rec IS RECORD (a NUMBER, b NUMBER);
+  out_metrics t_rec;
+BEGIN
+  WITH cte1 AS (
+    SELECT 1 AS x FROM dual
+  )
+
+  SELECT
+    cte1.x,
+    cte1.x
+  INTO
+    out_metrics.a,
+    out_metrics.b
+  FROM cte1;
+END;
+/
+
+-- Record fields mixed with plain variables, and a nested field.
+DECLARE
+  TYPE inner_rec IS RECORD (c NUMBER);
+  TYPE outer_rec IS RECORD (a NUMBER, nested inner_rec);
+  rec        outer_rec;
+  plain_var  NUMBER;
+BEGIN
+  SELECT 1, 2, 3
+  INTO rec.a, plain_var, rec.nested.c
+  FROM dual;
+
+  UPDATE t1 SET id = id + 1
+  WHERE id = 1
+  RETURNING id, description INTO rec.a, rec.nested.c;
+END;
+/
+
+-- BULK COLLECT INTO targeting a record field.
+DECLARE
+  TYPE t_ids IS TABLE OF NUMBER;
+  TYPE t_holder IS RECORD (ids t_ids);
+  holder t_holder;
+BEGIN
+  SELECT id
+  BULK COLLECT INTO holder.ids
+  FROM t1;
+END;
+/

--- a/test/fixtures/dialects/oracle/returning_into.yml
+++ b/test/fixtures/dialects/oracle/returning_into.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: b69491eeb30a90ecd2d4ddeeb37ba2eea0e9d237e36fe309b6f3fc4c13b93a35
+_hash: 0e9cafeaaa324332db5ccd02859633aab9bdc7a62e27c5310a54c4af728c7ae1
 file:
 - batch:
     statement:
@@ -1282,6 +1282,292 @@ file:
             - statement_terminator: ;
             - keyword: END
             - keyword: LOOP
+      - statement_terminator: ;
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      create_procedure_statement:
+      - keyword: CREATE
+      - keyword: OR
+      - keyword: REPLACE
+      - keyword: PROCEDURE
+      - function_name:
+          function_name_identifier: test_proc
+      - function_parameter_list:
+          bracketed:
+            start_bracket: (
+            parameter: out_rec
+            keyword: OUT
+            data_type:
+              data_type_identifier: SYS_REFCURSOR
+            end_bracket: )
+      - keyword: IS
+      - declare_segment:
+        - record_type:
+          - keyword: TYPE
+          - naked_identifier: t_rec
+          - keyword: IS
+          - keyword: RECORD
+          - bracketed:
+            - start_bracket: (
+            - naked_identifier: a
+            - data_type:
+                data_type_identifier: NUMBER
+            - comma: ','
+            - naked_identifier: b
+            - data_type:
+                data_type_identifier: NUMBER
+            - end_bracket: )
+        - statement_terminator: ;
+        - naked_identifier: out_metrics
+        - data_type:
+            data_type_identifier: t_rec
+        - statement_terminator: ;
+      - begin_end_block:
+        - keyword: BEGIN
+        - statement:
+            with_compound_statement:
+              keyword: WITH
+              common_table_expression:
+                naked_identifier: cte1
+                keyword: AS
+                bracketed:
+                  start_bracket: (
+                  select_statement:
+                    select_clause:
+                      keyword: SELECT
+                      select_clause_element:
+                        numeric_literal: '1'
+                        alias_expression:
+                          alias_operator:
+                            keyword: AS
+                          naked_identifier: x
+                    from_clause:
+                      keyword: FROM
+                      from_expression:
+                        from_expression_element:
+                          table_expression:
+                            table_reference:
+                              naked_identifier: dual
+                  end_bracket: )
+              select_statement:
+                select_clause:
+                - keyword: SELECT
+                - select_clause_element:
+                    column_reference:
+                    - naked_identifier: cte1
+                    - dot: .
+                    - naked_identifier: x
+                - comma: ','
+                - select_clause_element:
+                    column_reference:
+                    - naked_identifier: cte1
+                    - dot: .
+                    - naked_identifier: x
+                into_clause:
+                - keyword: INTO
+                - object_reference:
+                  - naked_identifier: out_metrics
+                  - dot: .
+                  - naked_identifier: a
+                - comma: ','
+                - object_reference:
+                  - naked_identifier: out_metrics
+                  - dot: .
+                  - naked_identifier: b
+                from_clause:
+                  keyword: FROM
+                  from_expression:
+                    from_expression_element:
+                      table_expression:
+                        table_reference:
+                          naked_identifier: cte1
+        - statement_terminator: ;
+        - keyword: END
+      - statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      begin_end_block:
+      - declare_segment:
+        - keyword: DECLARE
+        - record_type:
+          - keyword: TYPE
+          - naked_identifier: inner_rec
+          - keyword: IS
+          - keyword: RECORD
+          - bracketed:
+              start_bracket: (
+              naked_identifier: c
+              data_type:
+                data_type_identifier: NUMBER
+              end_bracket: )
+        - statement_terminator: ;
+        - record_type:
+          - keyword: TYPE
+          - naked_identifier: outer_rec
+          - keyword: IS
+          - keyword: RECORD
+          - bracketed:
+            - start_bracket: (
+            - naked_identifier: a
+            - data_type:
+                data_type_identifier: NUMBER
+            - comma: ','
+            - naked_identifier: nested
+            - data_type:
+                data_type_identifier: inner_rec
+            - end_bracket: )
+        - statement_terminator: ;
+        - naked_identifier: rec
+        - data_type:
+            data_type_identifier: outer_rec
+        - statement_terminator: ;
+        - naked_identifier: plain_var
+        - data_type:
+            data_type_identifier: NUMBER
+        - statement_terminator: ;
+      - keyword: BEGIN
+      - statement:
+          select_statement:
+            select_clause:
+            - keyword: SELECT
+            - select_clause_element:
+                numeric_literal: '1'
+            - comma: ','
+            - select_clause_element:
+                numeric_literal: '2'
+            - comma: ','
+            - select_clause_element:
+                numeric_literal: '3'
+            into_clause:
+            - keyword: INTO
+            - object_reference:
+              - naked_identifier: rec
+              - dot: .
+              - naked_identifier: a
+            - comma: ','
+            - naked_identifier: plain_var
+            - comma: ','
+            - object_reference:
+              - naked_identifier: rec
+              - dot: .
+              - naked_identifier: nested
+              - dot: .
+              - naked_identifier: c
+            from_clause:
+              keyword: FROM
+              from_expression:
+                from_expression_element:
+                  table_expression:
+                    table_reference:
+                      naked_identifier: dual
+      - statement_terminator: ;
+      - statement:
+          update_statement:
+            keyword: UPDATE
+            table_reference:
+              naked_identifier: t1
+            set_clause_list:
+              keyword: SET
+              set_clause:
+                column_reference:
+                  naked_identifier: id
+                comparison_operator:
+                  raw_comparison_operator: '='
+                expression:
+                  column_reference:
+                    naked_identifier: id
+                  binary_operator: +
+                  numeric_literal: '1'
+            where_clause:
+              keyword: WHERE
+              expression:
+                column_reference:
+                  naked_identifier: id
+                comparison_operator:
+                  raw_comparison_operator: '='
+                numeric_literal: '1'
+            returning_clause:
+            - keyword: RETURNING
+            - naked_identifier: id
+            - comma: ','
+            - naked_identifier: description
+            - into_clause:
+              - keyword: INTO
+              - object_reference:
+                - naked_identifier: rec
+                - dot: .
+                - naked_identifier: a
+              - comma: ','
+              - object_reference:
+                - naked_identifier: rec
+                - dot: .
+                - naked_identifier: nested
+                - dot: .
+                - naked_identifier: c
+      - statement_terminator: ;
+      - keyword: END
+    statement_terminator: ;
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      begin_end_block:
+      - declare_segment:
+        - keyword: DECLARE
+        - collection_type:
+          - keyword: TYPE
+          - naked_identifier: t_ids
+          - keyword: IS
+          - keyword: TABLE
+          - keyword: OF
+          - data_type:
+              data_type_identifier: NUMBER
+        - statement_terminator: ;
+        - record_type:
+          - keyword: TYPE
+          - naked_identifier: t_holder
+          - keyword: IS
+          - keyword: RECORD
+          - bracketed:
+              start_bracket: (
+              naked_identifier: ids
+              data_type:
+                data_type_identifier: t_ids
+              end_bracket: )
+        - statement_terminator: ;
+        - naked_identifier: holder
+        - data_type:
+            data_type_identifier: t_holder
+        - statement_terminator: ;
+      - keyword: BEGIN
+      - statement:
+          select_statement:
+            select_clause:
+              keyword: SELECT
+              select_clause_element:
+                column_reference:
+                  naked_identifier: id
+            bulk_collect_into_clause:
+            - keyword: BULK
+            - keyword: COLLECT
+            - keyword: INTO
+            - object_reference:
+              - naked_identifier: holder
+              - dot: .
+              - naked_identifier: ids
+            from_clause:
+              keyword: FROM
+              from_expression:
+                from_expression_element:
+                  table_expression:
+                    table_reference:
+                      naked_identifier: t1
       - statement_terminator: ;
       - keyword: END
     statement_terminator: ;


### PR DESCRIPTION
### Brief summary of the change made

Fixes #8250.

PL/SQL `SELECT ... INTO` and `BULK COLLECT INTO` accept fields of a record or collection variable as targets, e.g. `INTO rec.a, rec.b`. Only `SingleIdentifierGrammar` and `BindVariableSegment` were accepted, so everything from the first `.` onward — **including the trailing `FROM` clause** — collapsed into a single `unparsable` segment:

```
into_clause:
    keyword:          'into'
    naked_identifier: 'out_metrics'
unparsable:           !! Expected: 'Nothing here.'
    dot:              '.'
    word:             'a'
    ...
    word:             'from'
    word:             'cte1'
```

That produced the confusing knock-on failure in the issue title: with the `FROM` clause buried inside `unparsable` rather than parsed as a `table_reference`, ST03's usage detection (`recursive_crawl("table_reference")`) never saw the reference, so it reported a genuinely-used CTE as unused.

This accepts `ObjectReferenceSegment` in both clauses.

### Are there any other side effects of this change that we should be aware of?

`SingleIdentifierGrammar` is deliberately kept **ahead** of `ObjectReferenceSegment` in the `OneOf`. `ObjectReferenceSegment` would also match a bare name, and putting it first re-shaped every existing plain target from a bare `naked_identifier` into a wrapped `object_reference` — 11 fixture files, 125 deleted lines. With the current ordering the plain forms parse exactly as before and **the regenerated fixtures show no churn at all**; the only files that change are the ones I added cases to.

I used `ObjectReferenceSegment` rather than `ColumnReferenceSegment` on purpose: INTO targets are PL/SQL variables, not columns, and `column_reference` is crawled by a number of rules (RF02, AL07, AM03, …) that would then see them as column references.

No dialect inherits from `oracle`, so the change is contained.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - [x] `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (YML regenerated with `test/generate_parse_fixture_yml.py --dialect oracle`).

Cases added to `returning_into.sql`: the issue's procedure, a nested record field (`rec.nested.c`), record fields mixed with plain variables, and `BULK COLLECT INTO` a record field.

Verified against a standalone reproduction script, run with only the dialect file reverted and then restored:

```
unpatched:  5 FAIL / 2 PASS
patched:    7 PASS
```

The two that pass while unpatched are deliberate regression guards (plain variable and plain `BULK COLLECT` targets), so a fix that over-reached would fail them.

```
test/dialects/ -k oracle    315 passed
test/rules/                 2485 passed, 101 skipped
ruff check / ruff format / mypy   clean
```


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow record and collection field references (e.g., rec.a) as targets in Oracle SELECT ... INTO and BULK COLLECT INTO. Fixes parsing that swallowed the FROM clause and prevented accurate table/CTE usage detection.

- **Bug Fixes**
  - Support `rec.field` (including nested) in both `INTO` clauses by accepting object references.
  - Keep `SingleIdentifierGrammar` before object refs to preserve existing parse trees and fixtures.
  - Use object references instead of column references so rules don’t misinterpret variables as columns.
  - Add tests for record fields, nested fields, mixed targets, and BULK COLLECT INTO; no other dialects affected.

<sup>Written for commit 13925114290c162897f83da68b61f10d1034fcbb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8260?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

