### PR TITLE
Databricks: Aligned INSERT statement with documentation, adding missing forms

### DIFF
--- a/src/sqlfluff/dialects/dialect_databricks.py
+++ b/src/sqlfluff/dialects/dialect_databricks.py
@@ -1590,6 +1590,90 @@ class LimitClauseSegment(sparksql.LimitClauseSegment):
     )
 
 
+class InsertStatementSegment(sparksql.InsertStatementSegment):
+    """An `INSERT [TABLE]` statement for Databricks SQL.
+
+    The Databricks docs define three distinct forms:
+
+    Form 1 — standard insert, ``OVERWRITE`` or ``INTO``:
+        ``INSERT [WITH SCHEMA EVOLUTION] { OVERWRITE | INTO } [TABLE] table_name
+        [PARTITION clause] [( column_name [, ...] ) | BY NAME] query``
+
+    Form 2 — selective replace, ``INTO`` only:
+        ``INSERT [WITH SCHEMA EVOLUTION] INTO [TABLE] table_name
+        [BY NAME] [REPLACE WHERE predicate | REPLACE USING (col [, ...])] query``
+
+    Form 3 — replace-on, ``INTO`` only:
+        ``INSERT [WITH SCHEMA EVOLUTION] INTO [TABLE] table_name [target_alias]
+        [BY NAME] REPLACE ON boolean_expression { (query) [source_alias] | query }``
+
+    https://docs.databricks.com/aws/en/sql/language-manual/sql-ref-syntax-dml-insert-into
+    """
+
+    type = "insert_statement"
+
+    match_grammar = Sequence(
+        "INSERT",
+        # WITH SCHEMA EVOLUTION: Databricks Runtime 18.1+
+        Sequence("WITH", "SCHEMA", "EVOLUTION", optional=True),
+        OneOf(
+            # Forms 2 & 3: INTO only (OVERWRITE is not allowed with REPLACE)
+            Sequence(
+                "INTO",
+                Ref.keyword("TABLE", optional=True),
+                Ref("TableReferenceSegment"),
+                OneOf(
+                    # Form 3: REPLACE ON with optional target_alias and BY NAME.
+                    # target_alias requires the AS keyword here to avoid ambiguity
+                    # with the REPLACE/BY unreserved keywords being consumed as a
+                    # bare identifier alias.
+                    Sequence(
+                        Sequence(
+                            "AS",
+                            Ref("SingleIdentifierGrammar"),
+                            optional=True,
+                        ),
+                        Sequence("BY", "NAME", optional=True),
+                        "REPLACE",
+                        "ON",
+                        Ref("ExpressionSegment"),
+                        Ref("SelectableGrammar"),
+                    ),
+                    # Form 2: [BY NAME] REPLACE WHERE predicate | REPLACE USING (cols)
+                    Sequence(
+                        Sequence("BY", "NAME", optional=True),
+                        "REPLACE",
+                        OneOf(
+                            Sequence(
+                                Ref("WhereClauseSegment"),
+                                Ref("InsertSourceGrammar"),
+                            ),
+                            Sequence(
+                                "USING",
+                                Ref("BracketedColumnReferenceListGrammar"),
+                                Ref("InsertSourceGrammar"),
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+            # Form 1: { INTO | OVERWRITE } with optional PARTITION and column list
+            Sequence(
+                OneOf("INTO", "OVERWRITE"),
+                Ref.keyword("TABLE", optional=True),
+                Ref("TableReferenceSegment"),
+                Ref("PartitionSpecGrammar", optional=True),
+                OneOf(
+                    Ref("BracketedColumnReferenceListGrammar"),
+                    Sequence("BY", "NAME"),
+                    optional=True,
+                ),
+                Ref("InsertSourceGrammar"),
+            ),
+        ),
+    )
+
+
 class MergeInsertClauseSegment(sparksql.MergeInsertClauseSegment):
     """`INSERT` clause within the `MERGE` statement.
 

--- a/src/sqlfluff/dialects/dialect_databricks.py
+++ b/src/sqlfluff/dialects/dialect_databricks.py
@@ -1624,12 +1624,9 @@ class InsertStatementSegment(sparksql.InsertStatementSegment):
                 Ref("TableReferenceSegment"),
                 OneOf(
                     # Form 3: REPLACE ON with optional target_alias and BY NAME.
-                    # target_alias requires the AS keyword here to avoid ambiguity
-                    # with the REPLACE/BY unreserved keywords being consumed as a
-                    # bare identifier alias.
                     Sequence(
                         Sequence(
-                            "AS",
+                            Ref.keyword("AS", optional=True),
                             Ref("SingleIdentifierGrammar"),
                             optional=True,
                         ),
@@ -1638,6 +1635,11 @@ class InsertStatementSegment(sparksql.InsertStatementSegment):
                         "ON",
                         Ref("ExpressionSegment"),
                         Ref("SelectableGrammar"),
+                        Sequence(
+                            Ref.keyword("AS", optional=True),
+                            Ref("SingleIdentifierGrammar"),
+                            optional=True,
+                        ),
                     ),
                     # Form 2: [BY NAME] REPLACE WHERE predicate | REPLACE USING (cols)
                     Sequence(

--- a/test/fixtures/dialects/databricks/insert_into.sql
+++ b/test/fixtures/dialects/databricks/insert_into.sql
@@ -1,0 +1,122 @@
+-- Standard INSERT INTO
+INSERT INTO students VALUES ('Amy Smith', '123 Park Ave', 111111);
+
+-- INSERT INTO with column list
+INSERT INTO students (name, address, student_id)
+VALUES ('Amy Smith', '123 Park Ave', 111111);
+
+-- INSERT INTO with BY NAME
+INSERT INTO target BY NAME
+SELECT named_struct('a', 1, 'b', 2) AS s, 0 AS n, 'data' AS text;
+
+-- INSERT OVERWRITE
+INSERT OVERWRITE students VALUES ('Ashua Hill', '456 Erica Ct', 111111);
+
+-- INSERT OVERWRITE with PARTITION
+INSERT OVERWRITE students PARTITION (student_id = 111111)
+SELECT name, address FROM persons WHERE name = 'Amy Smith';
+
+-- INSERT INTO with PARTITION and BY NAME
+INSERT INTO students PARTITION (student_id = 222222) BY NAME
+SELECT address, name FROM persons WHERE name = 'Dora Williams';
+
+-- INSERT INTO with REPLACE WHERE (no BY NAME)
+INSERT INTO sales
+REPLACE WHERE tx_date BETWEEN '2022-10-01' AND '2022-10-31'
+VALUES (DATE '2022-10-01', 1237), (DATE '2022-10-02', 2378);
+
+-- INSERT INTO with BY NAME and REPLACE WHERE (Databricks-specific combination)
+INSERT INTO sales BY NAME
+REPLACE WHERE tx_date BETWEEN '2022-10-01' AND '2022-10-31'
+SELECT * FROM (
+    (
+        VALUES (1237, DATE '2022-10-01'), (2378, DATE '2022-10-02')
+    ) AS (amount, tx_date)
+);
+
+-- INSERT INTO with REPLACE USING (no BY NAME)
+INSERT INTO TABLE students
+REPLACE USING (country)
+SELECT * FROM new_students;
+
+-- INSERT INTO with BY NAME and REPLACE USING (Databricks Runtime 18.1+)
+INSERT INTO TABLE students BY NAME
+REPLACE USING (country)
+SELECT * FROM (
+    VALUES ('US', 'Sophie'), ('UK', 'Oliver')
+) AS t(country, name);
+
+-- INSERT INTO with REPLACE ON
+INSERT INTO TABLE students AS t
+REPLACE ON t.name = s.name
+SELECT * FROM people;
+
+-- INSERT INTO with BY NAME and REPLACE ON (Databricks Runtime 18.1+)
+INSERT INTO TABLE students AS t BY NAME
+REPLACE ON t.name = s.name
+SELECT * FROM (
+    VALUES ('query', 'Bob'), ('query', 'Charlie')
+) AS s(row_origin, name);
+
+-- INSERT WITH SCHEMA EVOLUTION
+INSERT WITH SCHEMA EVOLUTION INTO TABLE students
+SELECT * FROM new_students;
+
+-- INSERT WITH SCHEMA EVOLUTION and BY NAME
+INSERT WITH SCHEMA EVOLUTION INTO TABLE target BY NAME
+SELECT named_struct('a', 1, 'b', 2) AS s, 0 AS n;
+
+-- INSERT WITH SCHEMA EVOLUTION and BY NAME REPLACE WHERE
+INSERT WITH SCHEMA EVOLUTION INTO sales BY NAME
+REPLACE WHERE tx_date BETWEEN '2022-10-01' AND '2022-10-31'
+SELECT amount, tx_date FROM new_sales;
+
+-- INSERT OVERWRITE with BY NAME
+INSERT OVERWRITE students BY NAME
+SELECT address, name, student_id FROM persons;
+
+-- Regression: INSERT INTO TABLE with column list and SELECT
+INSERT INTO TABLE students (name, address, student_id)
+SELECT name, address, student_id FROM persons;
+
+-- Regression: INSERT using TABLE as source
+INSERT INTO students TABLE visiting_students;
+
+INSERT OVERWRITE students TABLE visiting_students;
+
+-- Regression: INSERT using FROM source
+INSERT INTO students
+FROM persons
+SELECT name, address
+WHERE qualified = TRUE;
+
+-- Regression: PARTITION with explicit column list (both INTO and OVERWRITE)
+INSERT INTO students PARTITION (student_id = 11215017) (address, name)
+VALUES ('Hangzhou, China', 'Kent Yao Jr.');
+
+INSERT OVERWRITE students PARTITION (student_id = 11215017) (address, name)
+VALUES ('Hangzhou, China', 'Kent Yao Jr.');
+
+-- Regression: OVERWRITE with PARTITION and BY NAME
+INSERT OVERWRITE students PARTITION (student_id = 222222) BY NAME
+SELECT address, name FROM persons;
+
+-- Regression: INSERT OVERWRITE TABLE with PARTITION and VALUES
+INSERT OVERWRITE TABLE students PARTITION (student_id = 333333)
+VALUES ('Bob Jones', '789 Main St');
+
+-- WITH SCHEMA EVOLUTION and OVERWRITE (Form 1)
+INSERT WITH SCHEMA EVOLUTION OVERWRITE students
+SELECT * FROM new_students;
+
+-- WITH SCHEMA EVOLUTION and REPLACE USING
+INSERT WITH SCHEMA EVOLUTION INTO TABLE students BY NAME
+REPLACE USING (country)
+SELECT * FROM new_students;
+
+-- WITH SCHEMA EVOLUTION and REPLACE ON with alias and BY NAME (most complex form)
+INSERT WITH SCHEMA EVOLUTION INTO TABLE students AS t BY NAME
+REPLACE ON t.name = s.name
+SELECT * FROM (
+    VALUES ('Alice', 'US'), ('Bob', 'UK')
+) AS s(name, country);

--- a/test/fixtures/dialects/databricks/insert_into.sql
+++ b/test/fixtures/dialects/databricks/insert_into.sql
@@ -51,12 +51,27 @@ INSERT INTO TABLE students AS t
 REPLACE ON t.name = s.name
 SELECT * FROM people;
 
+-- INSERT INTO with REPLACE ON and implicit target alias (no AS)
+INSERT INTO TABLE students t
+REPLACE ON t.name = s.name
+SELECT * FROM people;
+
 -- INSERT INTO with BY NAME and REPLACE ON (Databricks Runtime 18.1+)
 INSERT INTO TABLE students AS t BY NAME
 REPLACE ON t.name = s.name
 SELECT * FROM (
     VALUES ('query', 'Bob'), ('query', 'Charlie')
 ) AS s(row_origin, name);
+
+-- INSERT INTO with REPLACE ON and source alias
+INSERT INTO TABLE students AS t
+REPLACE ON t.name = s.name
+SELECT * FROM people AS s;
+
+-- INSERT INTO with REPLACE ON and implicit source alias (no AS)
+INSERT INTO TABLE students t
+REPLACE ON t.name = s.name
+SELECT * FROM people s;
 
 -- INSERT WITH SCHEMA EVOLUTION
 INSERT WITH SCHEMA EVOLUTION INTO TABLE students

--- a/test/fixtures/dialects/databricks/insert_into.yml
+++ b/test/fixtures/dialects/databricks/insert_into.yml
@@ -1,0 +1,1000 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 40797554fad1786db2735acdf98e689af307af7b98a14e5d9f66bf5c23118069
+file:
+- statement:
+    insert_statement:
+    - keyword: INSERT
+    - keyword: INTO
+    - table_reference:
+        naked_identifier: students
+    - values_clause:
+        keyword: VALUES
+        bracketed:
+        - start_bracket: (
+        - expression:
+            quoted_literal: "'Amy Smith'"
+        - comma: ','
+        - expression:
+            quoted_literal: "'123 Park Ave'"
+        - comma: ','
+        - expression:
+            numeric_literal: '111111'
+        - end_bracket: )
+- statement_terminator: ;
+- statement:
+    insert_statement:
+    - keyword: INSERT
+    - keyword: INTO
+    - table_reference:
+        naked_identifier: students
+    - bracketed:
+      - start_bracket: (
+      - column_reference:
+          naked_identifier: name
+      - comma: ','
+      - column_reference:
+          naked_identifier: address
+      - comma: ','
+      - column_reference:
+          naked_identifier: student_id
+      - end_bracket: )
+    - values_clause:
+        keyword: VALUES
+        bracketed:
+        - start_bracket: (
+        - expression:
+            quoted_literal: "'Amy Smith'"
+        - comma: ','
+        - expression:
+            quoted_literal: "'123 Park Ave'"
+        - comma: ','
+        - expression:
+            numeric_literal: '111111'
+        - end_bracket: )
+- statement_terminator: ;
+- statement:
+    insert_statement:
+    - keyword: INSERT
+    - keyword: INTO
+    - table_reference:
+        naked_identifier: target
+    - keyword: BY
+    - keyword: NAME
+    - select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            function:
+              function_name:
+                function_name_identifier: named_struct
+              function_contents:
+                bracketed:
+                - start_bracket: (
+                - expression:
+                    quoted_literal: "'a'"
+                - comma: ','
+                - expression:
+                    numeric_literal: '1'
+                - comma: ','
+                - expression:
+                    quoted_literal: "'b'"
+                - comma: ','
+                - expression:
+                    numeric_literal: '2'
+                - end_bracket: )
+            alias_expression:
+              alias_operator:
+                keyword: AS
+              naked_identifier: s
+        - comma: ','
+        - select_clause_element:
+            numeric_literal: '0'
+            alias_expression:
+              alias_operator:
+                keyword: AS
+              naked_identifier: n
+        - comma: ','
+        - select_clause_element:
+            quoted_literal: "'data'"
+            alias_expression:
+              alias_operator:
+                keyword: AS
+              naked_identifier: text
+- statement_terminator: ;
+- statement:
+    insert_statement:
+    - keyword: INSERT
+    - keyword: OVERWRITE
+    - table_reference:
+        naked_identifier: students
+    - values_clause:
+        keyword: VALUES
+        bracketed:
+        - start_bracket: (
+        - expression:
+            quoted_literal: "'Ashua Hill'"
+        - comma: ','
+        - expression:
+            quoted_literal: "'456 Erica Ct'"
+        - comma: ','
+        - expression:
+            numeric_literal: '111111'
+        - end_bracket: )
+- statement_terminator: ;
+- statement:
+    insert_statement:
+    - keyword: INSERT
+    - keyword: OVERWRITE
+    - table_reference:
+        naked_identifier: students
+    - keyword: PARTITION
+    - bracketed:
+        start_bracket: (
+        column_reference:
+          naked_identifier: student_id
+        comparison_operator:
+          raw_comparison_operator: '='
+        numeric_literal: '111111'
+        end_bracket: )
+    - select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            column_reference:
+              naked_identifier: name
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+              naked_identifier: address
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: persons
+        where_clause:
+          keyword: WHERE
+          expression:
+            column_reference:
+              naked_identifier: name
+            comparison_operator:
+              raw_comparison_operator: '='
+            quoted_literal: "'Amy Smith'"
+- statement_terminator: ;
+- statement:
+    insert_statement:
+    - keyword: INSERT
+    - keyword: INTO
+    - table_reference:
+        naked_identifier: students
+    - keyword: PARTITION
+    - bracketed:
+        start_bracket: (
+        column_reference:
+          naked_identifier: student_id
+        comparison_operator:
+          raw_comparison_operator: '='
+        numeric_literal: '222222'
+        end_bracket: )
+    - keyword: BY
+    - keyword: NAME
+    - select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            column_reference:
+              naked_identifier: address
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+              naked_identifier: name
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: persons
+        where_clause:
+          keyword: WHERE
+          expression:
+            column_reference:
+              naked_identifier: name
+            comparison_operator:
+              raw_comparison_operator: '='
+            quoted_literal: "'Dora Williams'"
+- statement_terminator: ;
+- statement:
+    insert_statement:
+    - keyword: INSERT
+    - keyword: INTO
+    - table_reference:
+        naked_identifier: sales
+    - keyword: REPLACE
+    - where_clause:
+        keyword: WHERE
+        expression:
+        - column_reference:
+            naked_identifier: tx_date
+        - keyword: BETWEEN
+        - quoted_literal: "'2022-10-01'"
+        - keyword: AND
+        - quoted_literal: "'2022-10-31'"
+    - values_clause:
+      - keyword: VALUES
+      - bracketed:
+        - start_bracket: (
+        - expression:
+            keyword: DATE
+            date_constructor_literal: "'2022-10-01'"
+        - comma: ','
+        - expression:
+            numeric_literal: '1237'
+        - end_bracket: )
+      - comma: ','
+      - bracketed:
+        - start_bracket: (
+        - expression:
+            keyword: DATE
+            date_constructor_literal: "'2022-10-02'"
+        - comma: ','
+        - expression:
+            numeric_literal: '2378'
+        - end_bracket: )
+- statement_terminator: ;
+- statement:
+    insert_statement:
+    - keyword: INSERT
+    - keyword: INTO
+    - table_reference:
+        naked_identifier: sales
+    - keyword: BY
+    - keyword: NAME
+    - keyword: REPLACE
+    - where_clause:
+        keyword: WHERE
+        expression:
+        - column_reference:
+            naked_identifier: tx_date
+        - keyword: BETWEEN
+        - quoted_literal: "'2022-10-01'"
+        - keyword: AND
+        - quoted_literal: "'2022-10-31'"
+    - select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+        from_clause:
+          keyword: FROM
+          from_expression:
+            bracketed:
+              start_bracket: (
+              from_expression_element:
+                bracketed:
+                  start_bracket: (
+                  table_expression:
+                    values_clause:
+                    - keyword: VALUES
+                    - bracketed:
+                      - start_bracket: (
+                      - expression:
+                          numeric_literal: '1237'
+                      - comma: ','
+                      - expression:
+                          keyword: DATE
+                          date_constructor_literal: "'2022-10-01'"
+                      - end_bracket: )
+                    - comma: ','
+                    - bracketed:
+                      - start_bracket: (
+                      - expression:
+                          numeric_literal: '2378'
+                      - comma: ','
+                      - expression:
+                          keyword: DATE
+                          date_constructor_literal: "'2022-10-02'"
+                      - end_bracket: )
+                  end_bracket: )
+                alias_expression:
+                  alias_operator:
+                    keyword: AS
+                  bracketed:
+                    start_bracket: (
+                    identifier_list:
+                    - naked_identifier: amount
+                    - comma: ','
+                    - naked_identifier: tx_date
+                    end_bracket: )
+              end_bracket: )
+- statement_terminator: ;
+- statement:
+    insert_statement:
+    - keyword: INSERT
+    - keyword: INTO
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: students
+    - keyword: REPLACE
+    - keyword: USING
+    - bracketed:
+        start_bracket: (
+        column_reference:
+          naked_identifier: country
+        end_bracket: )
+    - select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: new_students
+- statement_terminator: ;
+- statement:
+    insert_statement:
+    - keyword: INSERT
+    - keyword: INTO
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: students
+    - keyword: BY
+    - keyword: NAME
+    - keyword: REPLACE
+    - keyword: USING
+    - bracketed:
+        start_bracket: (
+        column_reference:
+          naked_identifier: country
+        end_bracket: )
+    - select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              bracketed:
+                start_bracket: (
+                table_expression:
+                  values_clause:
+                  - keyword: VALUES
+                  - bracketed:
+                    - start_bracket: (
+                    - expression:
+                        quoted_literal: "'US'"
+                    - comma: ','
+                    - expression:
+                        quoted_literal: "'Sophie'"
+                    - end_bracket: )
+                  - comma: ','
+                  - bracketed:
+                    - start_bracket: (
+                    - expression:
+                        quoted_literal: "'UK'"
+                    - comma: ','
+                    - expression:
+                        quoted_literal: "'Oliver'"
+                    - end_bracket: )
+                end_bracket: )
+              alias_expression:
+                alias_operator:
+                  keyword: AS
+                naked_identifier: t
+                bracketed:
+                  start_bracket: (
+                  identifier_list:
+                  - naked_identifier: country
+                  - comma: ','
+                  - naked_identifier: name
+                  end_bracket: )
+- statement_terminator: ;
+- statement:
+    insert_statement:
+    - keyword: INSERT
+    - keyword: INTO
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: students
+    - keyword: AS
+    - naked_identifier: t
+    - keyword: REPLACE
+    - keyword: 'ON'
+    - expression:
+      - column_reference:
+        - naked_identifier: t
+        - dot: .
+        - naked_identifier: name
+      - comparison_operator:
+          raw_comparison_operator: '='
+      - column_reference:
+        - naked_identifier: s
+        - dot: .
+        - naked_identifier: name
+    - select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: people
+- statement_terminator: ;
+- statement:
+    insert_statement:
+    - keyword: INSERT
+    - keyword: INTO
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: students
+    - keyword: AS
+    - naked_identifier: t
+    - keyword: BY
+    - keyword: NAME
+    - keyword: REPLACE
+    - keyword: 'ON'
+    - expression:
+      - column_reference:
+        - naked_identifier: t
+        - dot: .
+        - naked_identifier: name
+      - comparison_operator:
+          raw_comparison_operator: '='
+      - column_reference:
+        - naked_identifier: s
+        - dot: .
+        - naked_identifier: name
+    - select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              bracketed:
+                start_bracket: (
+                table_expression:
+                  values_clause:
+                  - keyword: VALUES
+                  - bracketed:
+                    - start_bracket: (
+                    - expression:
+                        quoted_literal: "'query'"
+                    - comma: ','
+                    - expression:
+                        quoted_literal: "'Bob'"
+                    - end_bracket: )
+                  - comma: ','
+                  - bracketed:
+                    - start_bracket: (
+                    - expression:
+                        quoted_literal: "'query'"
+                    - comma: ','
+                    - expression:
+                        quoted_literal: "'Charlie'"
+                    - end_bracket: )
+                end_bracket: )
+              alias_expression:
+                alias_operator:
+                  keyword: AS
+                naked_identifier: s
+                bracketed:
+                  start_bracket: (
+                  identifier_list:
+                  - naked_identifier: row_origin
+                  - comma: ','
+                  - naked_identifier: name
+                  end_bracket: )
+- statement_terminator: ;
+- statement:
+    insert_statement:
+    - keyword: INSERT
+    - keyword: WITH
+    - keyword: SCHEMA
+    - keyword: EVOLUTION
+    - keyword: INTO
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: students
+    - select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: new_students
+- statement_terminator: ;
+- statement:
+    insert_statement:
+    - keyword: INSERT
+    - keyword: WITH
+    - keyword: SCHEMA
+    - keyword: EVOLUTION
+    - keyword: INTO
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: target
+    - keyword: BY
+    - keyword: NAME
+    - select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            function:
+              function_name:
+                function_name_identifier: named_struct
+              function_contents:
+                bracketed:
+                - start_bracket: (
+                - expression:
+                    quoted_literal: "'a'"
+                - comma: ','
+                - expression:
+                    numeric_literal: '1'
+                - comma: ','
+                - expression:
+                    quoted_literal: "'b'"
+                - comma: ','
+                - expression:
+                    numeric_literal: '2'
+                - end_bracket: )
+            alias_expression:
+              alias_operator:
+                keyword: AS
+              naked_identifier: s
+        - comma: ','
+        - select_clause_element:
+            numeric_literal: '0'
+            alias_expression:
+              alias_operator:
+                keyword: AS
+              naked_identifier: n
+- statement_terminator: ;
+- statement:
+    insert_statement:
+    - keyword: INSERT
+    - keyword: WITH
+    - keyword: SCHEMA
+    - keyword: EVOLUTION
+    - keyword: INTO
+    - table_reference:
+        naked_identifier: sales
+    - keyword: BY
+    - keyword: NAME
+    - keyword: REPLACE
+    - where_clause:
+        keyword: WHERE
+        expression:
+        - column_reference:
+            naked_identifier: tx_date
+        - keyword: BETWEEN
+        - quoted_literal: "'2022-10-01'"
+        - keyword: AND
+        - quoted_literal: "'2022-10-31'"
+    - select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            column_reference:
+              naked_identifier: amount
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+              naked_identifier: tx_date
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: new_sales
+- statement_terminator: ;
+- statement:
+    insert_statement:
+    - keyword: INSERT
+    - keyword: OVERWRITE
+    - table_reference:
+        naked_identifier: students
+    - keyword: BY
+    - keyword: NAME
+    - select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            column_reference:
+              naked_identifier: address
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+              naked_identifier: name
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+              naked_identifier: student_id
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: persons
+- statement_terminator: ;
+- statement:
+    insert_statement:
+    - keyword: INSERT
+    - keyword: INTO
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: students
+    - bracketed:
+      - start_bracket: (
+      - column_reference:
+          naked_identifier: name
+      - comma: ','
+      - column_reference:
+          naked_identifier: address
+      - comma: ','
+      - column_reference:
+          naked_identifier: student_id
+      - end_bracket: )
+    - select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            column_reference:
+              naked_identifier: name
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+              naked_identifier: address
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+              naked_identifier: student_id
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: persons
+- statement_terminator: ;
+- statement:
+    insert_statement:
+    - keyword: INSERT
+    - keyword: INTO
+    - table_reference:
+        naked_identifier: students
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: visiting_students
+- statement_terminator: ;
+- statement:
+    insert_statement:
+    - keyword: INSERT
+    - keyword: OVERWRITE
+    - table_reference:
+        naked_identifier: students
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: visiting_students
+- statement_terminator: ;
+- statement:
+    insert_statement:
+    - keyword: INSERT
+    - keyword: INTO
+    - table_reference:
+        naked_identifier: students
+    - keyword: FROM
+    - table_reference:
+        naked_identifier: persons
+    - keyword: SELECT
+    - column_reference:
+        naked_identifier: name
+    - comma: ','
+    - column_reference:
+        naked_identifier: address
+    - where_clause:
+        keyword: WHERE
+        expression:
+          column_reference:
+            naked_identifier: qualified
+          comparison_operator:
+            raw_comparison_operator: '='
+          boolean_literal: 'TRUE'
+- statement_terminator: ;
+- statement:
+    insert_statement:
+    - keyword: INSERT
+    - keyword: INTO
+    - table_reference:
+        naked_identifier: students
+    - keyword: PARTITION
+    - bracketed:
+        start_bracket: (
+        column_reference:
+          naked_identifier: student_id
+        comparison_operator:
+          raw_comparison_operator: '='
+        numeric_literal: '11215017'
+        end_bracket: )
+    - bracketed:
+      - start_bracket: (
+      - column_reference:
+          naked_identifier: address
+      - comma: ','
+      - column_reference:
+          naked_identifier: name
+      - end_bracket: )
+    - values_clause:
+        keyword: VALUES
+        bracketed:
+        - start_bracket: (
+        - expression:
+            quoted_literal: "'Hangzhou, China'"
+        - comma: ','
+        - expression:
+            quoted_literal: "'Kent Yao Jr.'"
+        - end_bracket: )
+- statement_terminator: ;
+- statement:
+    insert_statement:
+    - keyword: INSERT
+    - keyword: OVERWRITE
+    - table_reference:
+        naked_identifier: students
+    - keyword: PARTITION
+    - bracketed:
+        start_bracket: (
+        column_reference:
+          naked_identifier: student_id
+        comparison_operator:
+          raw_comparison_operator: '='
+        numeric_literal: '11215017'
+        end_bracket: )
+    - bracketed:
+      - start_bracket: (
+      - column_reference:
+          naked_identifier: address
+      - comma: ','
+      - column_reference:
+          naked_identifier: name
+      - end_bracket: )
+    - values_clause:
+        keyword: VALUES
+        bracketed:
+        - start_bracket: (
+        - expression:
+            quoted_literal: "'Hangzhou, China'"
+        - comma: ','
+        - expression:
+            quoted_literal: "'Kent Yao Jr.'"
+        - end_bracket: )
+- statement_terminator: ;
+- statement:
+    insert_statement:
+    - keyword: INSERT
+    - keyword: OVERWRITE
+    - table_reference:
+        naked_identifier: students
+    - keyword: PARTITION
+    - bracketed:
+        start_bracket: (
+        column_reference:
+          naked_identifier: student_id
+        comparison_operator:
+          raw_comparison_operator: '='
+        numeric_literal: '222222'
+        end_bracket: )
+    - keyword: BY
+    - keyword: NAME
+    - select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            column_reference:
+              naked_identifier: address
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+              naked_identifier: name
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: persons
+- statement_terminator: ;
+- statement:
+    insert_statement:
+    - keyword: INSERT
+    - keyword: OVERWRITE
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: students
+    - keyword: PARTITION
+    - bracketed:
+        start_bracket: (
+        column_reference:
+          naked_identifier: student_id
+        comparison_operator:
+          raw_comparison_operator: '='
+        numeric_literal: '333333'
+        end_bracket: )
+    - values_clause:
+        keyword: VALUES
+        bracketed:
+        - start_bracket: (
+        - expression:
+            quoted_literal: "'Bob Jones'"
+        - comma: ','
+        - expression:
+            quoted_literal: "'789 Main St'"
+        - end_bracket: )
+- statement_terminator: ;
+- statement:
+    insert_statement:
+    - keyword: INSERT
+    - keyword: WITH
+    - keyword: SCHEMA
+    - keyword: EVOLUTION
+    - keyword: OVERWRITE
+    - table_reference:
+        naked_identifier: students
+    - select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: new_students
+- statement_terminator: ;
+- statement:
+    insert_statement:
+    - keyword: INSERT
+    - keyword: WITH
+    - keyword: SCHEMA
+    - keyword: EVOLUTION
+    - keyword: INTO
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: students
+    - keyword: BY
+    - keyword: NAME
+    - keyword: REPLACE
+    - keyword: USING
+    - bracketed:
+        start_bracket: (
+        column_reference:
+          naked_identifier: country
+        end_bracket: )
+    - select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: new_students
+- statement_terminator: ;
+- statement:
+    insert_statement:
+    - keyword: INSERT
+    - keyword: WITH
+    - keyword: SCHEMA
+    - keyword: EVOLUTION
+    - keyword: INTO
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: students
+    - keyword: AS
+    - naked_identifier: t
+    - keyword: BY
+    - keyword: NAME
+    - keyword: REPLACE
+    - keyword: 'ON'
+    - expression:
+      - column_reference:
+        - naked_identifier: t
+        - dot: .
+        - naked_identifier: name
+      - comparison_operator:
+          raw_comparison_operator: '='
+      - column_reference:
+        - naked_identifier: s
+        - dot: .
+        - naked_identifier: name
+    - select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              bracketed:
+                start_bracket: (
+                table_expression:
+                  values_clause:
+                  - keyword: VALUES
+                  - bracketed:
+                    - start_bracket: (
+                    - expression:
+                        quoted_literal: "'Alice'"
+                    - comma: ','
+                    - expression:
+                        quoted_literal: "'US'"
+                    - end_bracket: )
+                  - comma: ','
+                  - bracketed:
+                    - start_bracket: (
+                    - expression:
+                        quoted_literal: "'Bob'"
+                    - comma: ','
+                    - expression:
+                        quoted_literal: "'UK'"
+                    - end_bracket: )
+                end_bracket: )
+              alias_expression:
+                alias_operator:
+                  keyword: AS
+                naked_identifier: s
+                bracketed:
+                  start_bracket: (
+                  identifier_list:
+                  - naked_identifier: name
+                  - comma: ','
+                  - naked_identifier: country
+                  end_bracket: )
+- statement_terminator: ;

--- a/test/fixtures/dialects/databricks/insert_into.yml
+++ b/test/fixtures/dialects/databricks/insert_into.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 40797554fad1786db2735acdf98e689af307af7b98a14e5d9f66bf5c23118069
+_hash: a6ba1c9d4ce5a70a12a4591fab65d8ab1d28008fc0c736759af6016752c5a742
 file:
 - statement:
     insert_statement:
@@ -450,6 +450,42 @@ file:
     - keyword: TABLE
     - table_reference:
         naked_identifier: students
+    - naked_identifier: t
+    - keyword: REPLACE
+    - keyword: 'ON'
+    - expression:
+      - column_reference:
+        - naked_identifier: t
+        - dot: .
+        - naked_identifier: name
+      - comparison_operator:
+          raw_comparison_operator: '='
+      - column_reference:
+        - naked_identifier: s
+        - dot: .
+        - naked_identifier: name
+    - select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: people
+- statement_terminator: ;
+- statement:
+    insert_statement:
+    - keyword: INSERT
+    - keyword: INTO
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: students
     - keyword: AS
     - naked_identifier: t
     - keyword: BY
@@ -512,6 +548,85 @@ file:
                   - comma: ','
                   - naked_identifier: name
                   end_bracket: )
+- statement_terminator: ;
+- statement:
+    insert_statement:
+    - keyword: INSERT
+    - keyword: INTO
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: students
+    - keyword: AS
+    - naked_identifier: t
+    - keyword: REPLACE
+    - keyword: 'ON'
+    - expression:
+      - column_reference:
+        - naked_identifier: t
+        - dot: .
+        - naked_identifier: name
+      - comparison_operator:
+          raw_comparison_operator: '='
+      - column_reference:
+        - naked_identifier: s
+        - dot: .
+        - naked_identifier: name
+    - select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: people
+              alias_expression:
+                alias_operator:
+                  keyword: AS
+                naked_identifier: s
+- statement_terminator: ;
+- statement:
+    insert_statement:
+    - keyword: INSERT
+    - keyword: INTO
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: students
+    - naked_identifier: t
+    - keyword: REPLACE
+    - keyword: 'ON'
+    - expression:
+      - column_reference:
+        - naked_identifier: t
+        - dot: .
+        - naked_identifier: name
+      - comparison_operator:
+          raw_comparison_operator: '='
+      - column_reference:
+        - naked_identifier: s
+        - dot: .
+        - naked_identifier: name
+    - select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: people
+              alias_expression:
+                naked_identifier: s
 - statement_terminator: ;
 - statement:
     insert_statement:


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
Override InsertStatementSegment in the Databricks dialect to correctly support all three documented INSERT forms, including BY NAME combined with REPLACE WHERE/REPLACE USING/REPLACE ON, the WITH SCHEMA EVOLUTION prefix, and the correct restriction that OVERWRITE is not valid with REPLACE forms.
Documentation of Databricks: [INSERT](https://docs.databricks.com/gcp/en/sql/language-manual/sql-ref-syntax-dml-insert-into)
Documentation of SparkSQL: [INSERT TABLE](https://spark.apache.org/docs/4.2.0/sql-ref-syntax-dml-insert-table.html)


### Are there any other side effects of this change that we should be aware of?
The INSERT implementation in Databricks is replacing the one in SparkSQL, meaning that changes to SparkSQL don't automatically flow to Databricks. This is however intended, as the implementations are different.

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Overrides the Databricks `InsertStatementSegment` to match Databricks SQL docs, adding the missing INSERT forms and enforcing dialect rules (e.g., no OVERWRITE with REPLACE). This replaces the SparkSQL behavior for INSERT in the Databricks dialect and includes full parser tests.

- **New Features**
  - Support Form 1: INTO/OVERWRITE with optional PARTITION and column list/“BY NAME”.
  - Support Form 2: INTO with BY NAME and REPLACE WHERE or REPLACE USING (...).
  - Support Form 3: INTO with REPLACE ON, including target alias (AS or implicit) and source alias.
  - Accepts the WITH SCHEMA EVOLUTION prefix across forms and disallows OVERWRITE with REPLACE.
  - Adds Databricks fixtures and regression cases, including `TABLE` and `FROM` sources.

<sup>Written for commit 88b905410e8cbdd5fd105f12c06cd7393161e750. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8264?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

