### PR TITLE
Fix T-SQL alignment after leading commas

### DIFF
--- a/src/sqlfluff/utils/reflow/respace.py
+++ b/src/sqlfluff/utils/reflow/respace.py
@@ -454,6 +454,9 @@ def _determine_aligned_inline_spacing(
                 and sibling.pos_marker
                 and seg.pos_marker.working_loc == sibling.pos_marker.working_loc
                 and last_code
+                and last_code.pos_marker
+                and _pos_line(last_code.pos_marker, use_source_positions)
+                == _pos_line(sibling.pos_marker, use_source_positions)
             ):
                 if use_source_positions:
                     end_pm = last_code.pos_marker.end_point_marker()

--- a/src/sqlfluff/utils/reflow/respace.py
+++ b/src/sqlfluff/utils/reflow/respace.py
@@ -455,8 +455,14 @@ def _determine_aligned_inline_spacing(
                 and seg.pos_marker.working_loc == sibling.pos_marker.working_loc
                 and last_code
                 and last_code.pos_marker
-                and _pos_line(last_code.pos_marker, use_source_positions)
-                == _pos_line(sibling.pos_marker, use_source_positions)
+                and (
+                    _pos_line(last_code.pos_marker, use_source_positions)
+                    == _pos_line(sibling.pos_marker, use_source_positions)
+                    or _pos_line(
+                        last_code.pos_marker.end_point_marker(), use_source_positions
+                    )
+                    == _pos_line(sibling.pos_marker, use_source_positions)
+                )
             ):
                 if use_source_positions:
                     end_pm = last_code.pos_marker.end_point_marker()

--- a/test/rules/std_LT01_alignment_test.py
+++ b/test/rules/std_LT01_alignment_test.py
@@ -46,3 +46,35 @@ align_scope = bracketed
     )
 
     assert sqlfluff.fix(sql, config=config) == expected
+
+
+def test_lt01_alignment_uses_multiline_segment_endpoint() -> None:
+    """A multiline segment ending beside an alias should set the baseline."""
+    sql = (
+        "SELECT\n"
+        "    'alpha\n"
+        "a_long_tail' AS first_column,\n"
+        "    c AS second_column\n"
+        "FROM foo\n"
+    )
+    expected = (
+        "SELECT\n"
+        "    'alpha\n"
+        "a_long_tail' AS first_column,\n"
+        "    c        AS second_column\n"
+        "FROM foo\n"
+    )
+    config = FluffConfig.from_string(
+        """
+[sqlfluff]
+dialect = ansi
+rules = LT01
+
+[sqlfluff:layout:type:alias_expression]
+spacing_before = align
+align_within = select_clause
+align_scope = bracketed
+"""
+    )
+
+    assert sqlfluff.fix(sql, config=config) == expected

--- a/test/rules/std_LT01_alignment_test.py
+++ b/test/rules/std_LT01_alignment_test.py
@@ -1,0 +1,48 @@
+"""Tests for LT01 alignment."""
+
+import sqlfluff
+from sqlfluff.core.config import FluffConfig
+
+
+def test_lt01_alignment_ignores_code_on_previous_line() -> None:
+    """Leading commas should not inherit alignment from the previous line."""
+    sql = (
+        "SELECT\n"
+        "    FirstCol = 'Some Value'\n"
+        "    , SecondCol = 'Some other value'\n"
+        "    , ThirdCol = 'yet another val'\n"
+        "    , t.NonaliasedCol\n"
+        "FROM TestTable AS t\n"
+        ";\n"
+    )
+    expected = (
+        "SELECT\n"
+        "    FirstCol    = 'Some Value'\n"
+        "    , SecondCol = 'Some other value'\n"
+        "    , ThirdCol  = 'yet another val'\n"
+        "    , t.NonaliasedCol\n"
+        "FROM TestTable AS t\n"
+        ";\n"
+    )
+    config = FluffConfig.from_string(
+        """
+[sqlfluff]
+dialect = tsql
+rules = LT01
+
+[sqlfluff:layout:type:comma]
+line_position = leading
+
+[sqlfluff:layout:type:alias_operator]
+spacing_before = align
+align_within = select_clause
+align_scope = bracketed
+
+[sqlfluff:layout:type:alias_expression]
+spacing_before = align
+align_within = select_clause
+align_scope = bracketed
+"""
+    )
+
+    assert sqlfluff.fix(sql, config=config) == expected


### PR DESCRIPTION
### Brief summary of the change made

Fixes #8256.

Alignment spacing now ignores code from a previous line when calculating the inline alignment baseline. This prevents a leading comma from receiving an extra space when T-SQL assignment-style aliases and alias operators are both aligned.

A regression test covers the reported leading-comma configuration and verifies the exact fixed SQL.

### Are there any other side effects of this change that we should be aware of?

No expected behavior change for same-line alignment. Segments without preceding code on their own line no longer contribute a stale previous-line endpoint to the alignment width.

### Pull Request checklist

- [x] Included an automated regression test.
- [x] Ran focused LT01 tests: 204 passed.
- [x] Ran Ruff check and format check on changed files.
- [x] Ran git diff --check.

### AI assistance disclosure

AI assistance was used to inspect the alignment implementation and draft the focused fix and regression test. I manually reproduced the issue, reviewed the patch, verified the exact corrected output with zero LT01 violations, and ran the tests and quality checks listed above.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix T‑SQL leading‑comma alignment in `sqlfluff` `LT01` by ignoring previous‑line code when computing inline alignment, preventing extra space after leading commas with aligned alias operators/expressions. Also align multiline segment endpoints by using a segment’s end marker as the baseline when it ends beside an alias; regression tests cover both scenarios.

<sup>Written for commit a94fd13edf2826854ae3b1a5d58277f226a2356b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8265?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

