### PR TITLE
Give CV06 placement violations accurate descriptions

### DIFF
--- a/src/sqlfluff/rules/convention/CV06.py
+++ b/src/sqlfluff/rules/convention/CV06.py
@@ -245,6 +245,9 @@ class Rule_CV06(BaseRule):
         return LintResult(
             anchor=info.anchor_segment,
             fixes=fixes,
+            description=(
+                "Semi-colon should not be preceded by whitespace or newlines."
+            ),
         )
 
     def _handle_semicolon_newline(
@@ -301,6 +304,9 @@ class Rule_CV06(BaseRule):
         return LintResult(
             anchor=anchor_segment,
             fixes=fixes,
+            description=(
+                "Semi-colon should be on a new line after a multi-line statement."
+            ),
         )
 
     def _create_semicolon_and_delete_whitespace(

--- a/test/rules/std_LT12_CV06_test.py
+++ b/test/rules/std_LT12_CV06_test.py
@@ -24,3 +24,46 @@ def test__rules__std_LT12_and_CV06_interaction() -> None:
 
     # Check file is fixed.
     assert linted_file.fix_string()[0] == "SELECT foo FROM bar;\n"
+
+
+def _lint_cv06(sql: str, **rule_config: object) -> list:
+    """Lint a string with only CV06 enabled and return its violations."""
+    cfg = FluffConfig(overrides={"dialect": "ansi", "rules": "CV06"})
+    for key, val in rule_config.items():
+        cfg.set_value(config_path=["rules", "convention.terminator", key], val=val)
+    return Linter(config=cfg).lint_string(sql).violations
+
+
+def test__rules__std_CV06_description_semicolon_newline() -> None:
+    """Placement violations should not claim the semi-colon is missing.
+
+    The statement here already ends with a semi-colon; the only problem is that
+    ``multiline_newline`` requires it on its own line. Reporting "Statements must
+    end with a semi-colon." for this case is misleading (see issue #5987).
+    """
+    violations = _lint_cv06("SELECT a\nFROM foo;\n", multiline_newline=True)
+
+    assert [v.rule.code for v in violations] == ["CV06"]
+    assert (
+        violations[0].description
+        == "Semi-colon should be on a new line after a multi-line statement."
+    )
+
+
+def test__rules__std_CV06_description_semicolon_spacing() -> None:
+    """A semi-colon separated from its statement is a spacing violation."""
+    violations = _lint_cv06("SELECT a\nFROM foo\n;\n")
+
+    assert [v.rule.code for v in violations] == ["CV06"]
+    assert (
+        violations[0].description
+        == "Semi-colon should not be preceded by whitespace or newlines."
+    )
+
+
+def test__rules__std_CV06_description_missing_semicolon_unchanged() -> None:
+    """A genuinely missing semi-colon keeps the original description."""
+    violations = _lint_cv06("SELECT a\nFROM foo\n", require_final_semicolon=True)
+
+    assert [v.rule.code for v in violations] == ["CV06"]
+    assert violations[0].description == "Statements must end with a semi-colon."


### PR DESCRIPTION
### Brief summary of the change made

CV06 raised every violation with the rule docstring — *"Statements must end with a semi-colon."* — including the two branches where the semi-colon **is** present and only its position is wrong. None of the rule's nine `LintResult` call sites set a `description`, so a statement that plainly ends in `;` gets reported as missing one.

That is actively misleading, and it has already cost someone a bug report: #5987 reports "false positives" from `multiline_newline = true` on lines that end with `;`. Having reproduced it, the linting behaviour there is **correct** — with `multiline_newline = true` a multi-line statement is supposed to carry its semi-colon on its own line. What was wrong was the message explaining why.

This makes progress on #5987 by fixing the message rather than the behaviour:

| Situation | Before | After |
|---|---|---|
| `;` separated from the statement by whitespace/newlines | Statements must end with a semi-colon. | Semi-colon should not be preceded by whitespace or newlines. |
| multi-line statement, `;` not on its own line | Statements must end with a semi-colon. | Semi-colon should be on a new line after a multi-line statement. |
| `;` genuinely missing | Statements must end with a semi-colon. | *(unchanged)* |

### Are there any other side effects of this change that we should be aware of?

Linting behaviour, violation positions and autofixes are all unchanged — only the `description` text of two branches differs. No existing test asserted the old wording, so nothing needed updating: the full `test/rules` suite passes unchanged at **2506 passed, 101 skipped**.

Anyone matching CV06 output by message text would see the new strings, which is the intended point of the change.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - **Other**: three cases added to `test/rules/std_LT12_CV06_test.py`, one per branch above — including one asserting that a genuinely missing semi-colon keeps the original wording.

  These are Python tests rather than `.yml` rule cases because the `violations:` block in the YAML harness compares the full `to_dict()` of each violation, including every autofix; asserting a description that way would have been long and brittle. Happy to move them if you'd prefer.
- [x] Added appropriate documentation for the change — none needed; the rule docstring still describes the rule's purpose and is unchanged.
- [x] Created GitHub issues for any relevant followup/future enhancements if appropriate — none identified.

---

AI disclosure, per CONTRIBUTING: this change was drafted with AI assistance. The wording of the two descriptions and the tests were AI-drafted. I manually validated the change by reproducing #5987 locally, confirming from `CV06.py` that `semicolon_newline = self.multiline_newline if not info.is_one_line else False` makes the reported behaviour intentional, verifying each of the three branches emits the intended message, and running the full `test/rules` suite plus `ruff`, `ruff-format` and `mypy` on the changed files.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update CV06 to show accurate messages for semicolon placement instead of claiming a missing semi-colon when one is present. Behavior and autofixes are unchanged; tests added; clarifies confusion from #5987.

- **Bug Fixes**
  - If whitespace/newlines precede the semi-colon: Semi-colon should not be preceded by whitespace or newlines.
  - For multi-line statements requiring their own line: Semi-colon should be on a new line after a multi-line statement.
  - Genuinely missing semi-colon message remains: Statements must end with a semi-colon.

<sup>Written for commit f188e90a8a895d79358d2dac547f030f93cffe8f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8268?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

