### PR TITLE
Allows %TYPE column type references in TABLE returns for functions in Postgres

### DIFF
--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -1470,7 +1470,10 @@ class CreateFunctionStatementSegment(ansi.CreateFunctionStatementSegment):
                                 Ref("DatatypeSegment"),
                                 Sequence(
                                     Ref("ColumnReferenceSegment"),
-                                    OneOf(Ref("DatatypeSegment"), Ref("ColumnTypeReferenceSegment")),
+                                    OneOf(
+                                        Ref("DatatypeSegment"),
+                                        Ref("ColumnTypeReferenceSegment"),
+                                    ),
                                 ),
                             ),
                         )

--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -1470,7 +1470,7 @@ class CreateFunctionStatementSegment(ansi.CreateFunctionStatementSegment):
                                 Ref("DatatypeSegment"),
                                 Sequence(
                                     Ref("ColumnReferenceSegment"),
-                                    Ref("DatatypeSegment"),
+                                    OneOf(Ref("DatatypeSegment"), Ref("ColumnTypeReferenceSegment")),
                                 ),
                             ),
                         )

--- a/test/fixtures/dialects/postgres/create_function.sql
+++ b/test/fixtures/dialects/postgres/create_function.sql
@@ -233,3 +233,16 @@ language sql
 begin atomic
   select st_x(_pt::geometry);
 end;
+
+CREATE OR REPLACE FUNCTION time_series(
+    _from time_table.time_field % TYPE,
+    _to time_table.time_field % TYPE,
+    _buckets integer DEFAULT 200
+)
+RETURNS TABLE (pp time_table.time_field % TYPE)
+IMMUTABLE PARALLEL SAFE
+BEGIN ATOMIC
+-- ATTENTION: use integer to generate series, since with timestamps there are rounding issues
+SELECT time_bucket(_from, _from, _to, _buckets, g.ofs - 1)
+FROM generate_series(0, greatest((_buckets - 1), 1)) AS g (ofs);
+END;

--- a/test/fixtures/dialects/postgres/create_function.yml
+++ b/test/fixtures/dialects/postgres/create_function.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 8e8178a7a0e420c460c5bcc5e3f87af66585ad2e3999d077d37bdb0f0841a02c
+_hash: 5a2b2b3c8fbead6df9b71b0251fd734f8e3a21d1791166a54e69914e1e386efe
 file:
 - statement:
     create_function_statement:
@@ -1557,4 +1557,141 @@ file:
                     end_bracket: )
       - statement_terminator: ;
       - keyword: end
+- statement_terminator: ;
+- statement:
+    create_function_statement:
+    - keyword: CREATE
+    - keyword: OR
+    - keyword: REPLACE
+    - keyword: FUNCTION
+    - function_name:
+        function_name_identifier: time_series
+    - function_parameter_list:
+        bracketed:
+        - start_bracket: (
+        - parameter: _from
+        - column_type_reference:
+            column_reference:
+            - naked_identifier: time_table
+            - dot: .
+            - naked_identifier: time_field
+            binary_operator: '%'
+            keyword: TYPE
+        - comma: ','
+        - parameter: _to
+        - column_type_reference:
+            column_reference:
+            - naked_identifier: time_table
+            - dot: .
+            - naked_identifier: time_field
+            binary_operator: '%'
+            keyword: TYPE
+        - comma: ','
+        - parameter: _buckets
+        - data_type:
+            keyword: integer
+        - keyword: DEFAULT
+        - expression:
+            numeric_literal: '200'
+        - end_bracket: )
+    - keyword: RETURNS
+    - keyword: TABLE
+    - bracketed:
+        start_bracket: (
+        column_reference:
+          naked_identifier: pp
+        column_type_reference:
+          column_reference:
+          - naked_identifier: time_table
+          - dot: .
+          - naked_identifier: time_field
+          binary_operator: '%'
+          keyword: TYPE
+        end_bracket: )
+    - function_definition:
+      - keyword: IMMUTABLE
+      - keyword: PARALLEL
+      - keyword: SAFE
+      - keyword: BEGIN
+      - keyword: ATOMIC
+      - select_statement:
+          select_clause:
+            keyword: SELECT
+            select_clause_element:
+              function:
+                function_name:
+                  function_name_identifier: time_bucket
+                function_contents:
+                  bracketed:
+                  - start_bracket: (
+                  - expression:
+                      column_reference:
+                        naked_identifier: _from
+                  - comma: ','
+                  - expression:
+                      column_reference:
+                        naked_identifier: _from
+                  - comma: ','
+                  - expression:
+                      column_reference:
+                        naked_identifier: _to
+                  - comma: ','
+                  - expression:
+                      column_reference:
+                        naked_identifier: _buckets
+                  - comma: ','
+                  - expression:
+                      column_reference:
+                      - naked_identifier: g
+                      - dot: .
+                      - naked_identifier: ofs
+                      binary_operator: '-'
+                      numeric_literal: '1'
+                  - end_bracket: )
+          from_clause:
+            keyword: FROM
+            from_expression:
+              from_expression_element:
+                table_expression:
+                  function:
+                    function_name:
+                      function_name_identifier: generate_series
+                    function_contents:
+                      bracketed:
+                      - start_bracket: (
+                      - expression:
+                          numeric_literal: '0'
+                      - comma: ','
+                      - expression:
+                          function:
+                            function_name:
+                              function_name_identifier: greatest
+                            function_contents:
+                              bracketed:
+                              - start_bracket: (
+                              - expression:
+                                  bracketed:
+                                    start_bracket: (
+                                    expression:
+                                      column_reference:
+                                        naked_identifier: _buckets
+                                      binary_operator: '-'
+                                      numeric_literal: '1'
+                                    end_bracket: )
+                              - comma: ','
+                              - expression:
+                                  numeric_literal: '1'
+                              - end_bracket: )
+                      - end_bracket: )
+                alias_expression:
+                  alias_operator:
+                    keyword: AS
+                  naked_identifier: g
+                  bracketed:
+                    start_bracket: (
+                    identifier_list:
+                      naked_identifier: ofs
+                    end_bracket: )
+      - statement_terminator: ;
+      - keyword: END
 - statement_terminator: ;


### PR DESCRIPTION
### Brief summary of the change made

Allows %TYPE column type references in TABLE returns for functions in Postgres

Currently, functions with TABLE RETURNS only allow simple types like:

```sql
CREATE OR REPLACE FUNCTION time_series(
  ...
)
RETURNS TABLE (pp timestamp)
BEGIN
...
END;
```

But don't allows to use column type references (accepted by PostgreSQL) like:

```sql
CREATE OR REPLACE FUNCTION time_series(
  ...
)
RETURNS TABLE (pp time_table.time_field % TYPE)
BEGIN
...
END;
```

This PR allows this notation to be accepted by the parser.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable `%TYPE` column type references in `RETURNS TABLE` for Postgres functions to match PostgreSQL. Update the Postgres dialect to parse `table.column%TYPE` in return columns, add tests for `%TYPE` in parameters and returns, and fix fixture formatting.

<sup>Written for commit c09879dbe24ed1e465fa842443a93ec650cbec45. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8269?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

