### PR TITLE
fix(redshift): parse SELECT EXCLUDE after the full select list

### DIFF
--- a/src/sqlfluff/dialects/dialect_redshift.py
+++ b/src/sqlfluff/dialects/dialect_redshift.py
@@ -21,6 +21,7 @@ from sqlfluff.core.parser import (
     Nothing,
     OneOf,
     OptionallyBracketed,
+    ParseMode,
     Ref,
     RegexLexer,
     RegexParser,
@@ -2920,14 +2921,60 @@ class UnorderedSelectStatementSegment(ansi.UnorderedSelectStatementSegment):
     )
 
 
-class WildcardExpressionSegment(ansi.WildcardExpressionSegment):
-    """An extension of the star expression for Redshift."""
+class SelectClauseSegment(postgres.SelectClauseSegment):
+    """A Redshift `SELECT` clause.
 
-    match_grammar = ansi.WildcardExpressionSegment.match_grammar.copy(
-        insert=[
-            # Optional Exclude
-            Ref("ExcludeClauseSegment", optional=True),
-        ]
+    EXCLUDE follows the full select list:
+    https://docs.aws.amazon.com/redshift/latest/dg/r_SELECT_synopsis.html
+    https://docs.aws.amazon.com/redshift/latest/dg/r_EXCLUDE_list.html
+    """
+
+    match_grammar = Sequence(
+        "SELECT",
+        Ref("SelectClauseModifierSegment", optional=True),
+        Indent,
+        Delimited(
+            Ref("SelectClauseElementSegment"),
+            optional=True,
+            allow_trailing=True,
+            terminators=[Ref.keyword("EXCLUDE")],
+        ),
+        Ref("ExcludeClauseSegment", optional=True),
+        Dedent,
+        terminators=[
+            "INTO",
+            "FROM",
+            "WHERE",
+            Sequence("ORDER", "BY"),
+            Sequence("ON", "CONFLICT"),
+            "LIMIT",
+            "RETURNING",
+            "OVERLAPS",
+            Ref("SetOperatorSegment"),
+            Sequence("WITH", Ref.keyword("NO", optional=True), "DATA"),
+            Ref("WithCheckOptionSegment"),
+            Ref("MetaCommandQueryBufferSegment"),
+        ],
+        parse_mode=ParseMode.GREEDY_ONCE_STARTED,
+    )
+
+
+class SelectClauseElementSegment(ansi.SelectClauseElementSegment):
+    """An element in the targets of a select statement.
+
+    ``EXCLUDE`` is a select-list clause keyword in Redshift, not a column alias.
+    """
+
+    match_grammar = OneOf(
+        Ref("WildcardExpressionSegment"),
+        Sequence(
+            Ref("BaseExpressionElementGrammar"),
+            Ref(
+                "AliasExpressionSegment",
+                exclude=Ref.keyword("EXCLUDE"),
+                optional=True,
+            ),
+        ),
     )
 
 
@@ -2942,7 +2989,7 @@ class ExcludeClauseSegment(BaseSegment):
         "EXCLUDE",
         OneOf(
             Bracketed(Delimited(Ref("SingleIdentifierGrammar"))),
-            Ref("SingleIdentifierGrammar"),
+            Delimited(Ref("SingleIdentifierGrammar")),
         ),
     )
 

--- a/src/sqlfluff/dialects/dialect_redshift.py
+++ b/src/sqlfluff/dialects/dialect_redshift.py
@@ -2928,8 +2928,9 @@ class SelectClauseSegment(postgres.SelectClauseSegment):
     https://docs.aws.amazon.com/redshift/latest/dg/r_EXCLUDE_list.html
     """
 
-    # Inherit Postgres select-clause terminators via copy(). Replace only the
-    # inner select list so EXCLUDE can terminate it without a trailing comma.
+    # Inherit Postgres terminators via copy(). EXCLUDE terminates the select
+    # list only after the first item, so `SELECT EXCLUDE` still parses as a
+    # column while `SELECT *, a, EXCLUDE x` is rejected.
     match_grammar = postgres.SelectClauseSegment.match_grammar.copy(
         insert=[
             OneOf(
@@ -2941,11 +2942,20 @@ class SelectClauseSegment(postgres.SelectClauseSegment):
                     ),
                     Ref("ExcludeClauseSegment"),
                 ),
-                Delimited(
-                    Ref("SelectClauseElementSegment"),
-                    optional=True,
-                    allow_trailing=True,
+                Sequence(
+                    Ref("SelectClauseElementSegment", optional=True),
+                    Sequence(
+                        Ref("CommaSegment"),
+                        Delimited(
+                            Ref("SelectClauseElementSegment"),
+                            optional=True,
+                            allow_trailing=True,
+                            terminators=[Ref.keyword("EXCLUDE")],
+                        ),
+                        optional=True,
+                    ),
                 ),
+                optional=True,
             ),
         ],
         before=Dedent,
@@ -2962,23 +2972,15 @@ class SelectClauseSegment(postgres.SelectClauseSegment):
 class SelectClauseElementSegment(ansi.SelectClauseElementSegment):
     """Select-list element for Redshift.
 
-    Prevent bare ``EXCLUDE`` from being treated as an implicit column alias,
-    and prevent unbracketed ``EXCLUDE col`` from being treated as an
-    expression so the select-list terminator can reject a comma before
-    ``EXCLUDE``. ``EXCLUDE(...)`` function calls and ``AS EXCLUDE`` aliases
-    remain valid.
+    Prevent bare ``EXCLUDE`` from being treated as an implicit column alias so
+    the select-clause-level ``ExcludeClauseSegment`` can match. This does not
+    restrict ``EXCLUDE(...)`` expressions or ``AS EXCLUDE`` aliases.
     """
 
     match_grammar = OneOf(
         Ref("WildcardExpressionSegment"),
         Sequence(
-            Ref(
-                "BaseExpressionElementGrammar",
-                exclude=Sequence(
-                    "EXCLUDE",
-                    Delimited(Ref("SingleIdentifierGrammar")),
-                ),
-            ),
+            Ref("BaseExpressionElementGrammar"),
             Ref(
                 "AliasExpressionSegment",
                 exclude=Ref.keyword("EXCLUDE"),

--- a/src/sqlfluff/dialects/dialect_redshift.py
+++ b/src/sqlfluff/dialects/dialect_redshift.py
@@ -2933,13 +2933,24 @@ class SelectClauseSegment(postgres.SelectClauseSegment):
         "SELECT",
         Ref("SelectClauseModifierSegment", optional=True),
         Indent,
-        Delimited(
-            Ref("SelectClauseElementSegment"),
-            optional=True,
-            allow_trailing=False,
-            terminators=[Ref.keyword("EXCLUDE")],
+        OneOf(
+            # EXCLUDE branch: terminator only here so a column named EXCLUDE can
+            # still parse via the fallback. No trailing comma before EXCLUDE.
+            Sequence(
+                Delimited(
+                    Ref("SelectClauseElementSegment"),
+                    allow_trailing=False,
+                    terminators=[Ref.keyword("EXCLUDE")],
+                ),
+                Ref("ExcludeClauseSegment"),
+            ),
+            # Postgres-compatible select list (optional / trailing commas).
+            Delimited(
+                Ref("SelectClauseElementSegment"),
+                optional=True,
+                allow_trailing=True,
+            ),
         ),
-        Ref("ExcludeClauseSegment", optional=True),
         Dedent,
         terminators=[
             "INTO",
@@ -2962,13 +2973,23 @@ class SelectClauseSegment(postgres.SelectClauseSegment):
 class SelectClauseElementSegment(ansi.SelectClauseElementSegment):
     """An element in the targets of a select statement.
 
-    ``EXCLUDE`` is a select-list clause keyword in Redshift, not a column alias.
+    ``EXCLUDE`` is a select-list clause keyword in Redshift, not a column alias
+    or ``EXCLUDE (...)`` function-like expression.
     """
 
     match_grammar = OneOf(
         Ref("WildcardExpressionSegment"),
         Sequence(
-            Ref("BaseExpressionElementGrammar"),
+            Ref(
+                "BaseExpressionElementGrammar",
+                exclude=Sequence(
+                    "EXCLUDE",
+                    OneOf(
+                        Bracketed(Delimited(Ref("SingleIdentifierGrammar"))),
+                        Delimited(Ref("SingleIdentifierGrammar")),
+                    ),
+                ),
+            ),
             Ref(
                 "AliasExpressionSegment",
                 exclude=Ref.keyword("EXCLUDE"),

--- a/src/sqlfluff/dialects/dialect_redshift.py
+++ b/src/sqlfluff/dialects/dialect_redshift.py
@@ -2936,7 +2936,7 @@ class SelectClauseSegment(postgres.SelectClauseSegment):
         Delimited(
             Ref("SelectClauseElementSegment"),
             optional=True,
-            allow_trailing=True,
+            allow_trailing=False,
             terminators=[Ref.keyword("EXCLUDE")],
         ),
         Ref("ExcludeClauseSegment", optional=True),

--- a/src/sqlfluff/dialects/dialect_redshift.py
+++ b/src/sqlfluff/dialects/dialect_redshift.py
@@ -2928,26 +2928,57 @@ class SelectClauseSegment(postgres.SelectClauseSegment):
     https://docs.aws.amazon.com/redshift/latest/dg/r_EXCLUDE_list.html
     """
 
-    # Keep the Postgres select-clause structure and terminators; only attach
-    # EXCLUDE after the delimited select list.
+    # Inherit Postgres select-clause terminators via copy(). Replace only the
+    # inner select list so EXCLUDE can terminate it without a trailing comma.
     match_grammar = postgres.SelectClauseSegment.match_grammar.copy(
-        insert=[Ref("ExcludeClauseSegment", optional=True)],
+        insert=[
+            OneOf(
+                Sequence(
+                    Delimited(
+                        Ref("SelectClauseElementSegment"),
+                        allow_trailing=False,
+                        terminators=[Ref.keyword("EXCLUDE")],
+                    ),
+                    Ref("ExcludeClauseSegment"),
+                ),
+                Delimited(
+                    Ref("SelectClauseElementSegment"),
+                    optional=True,
+                    allow_trailing=True,
+                ),
+            ),
+        ],
         before=Dedent,
+        remove=[
+            Delimited(
+                Ref("SelectClauseElementSegment"),
+                optional=True,
+                allow_trailing=True,
+            ),
+        ],
     )
 
 
 class SelectClauseElementSegment(ansi.SelectClauseElementSegment):
     """Select-list element for Redshift.
 
-    Prevent bare ``EXCLUDE`` from being treated as an implicit column alias so
-    the select-clause-level ``ExcludeClauseSegment`` can match. This does not
-    restrict ``EXCLUDE(...)`` expressions or ``AS EXCLUDE`` aliases.
+    Prevent bare ``EXCLUDE`` from being treated as an implicit column alias,
+    and prevent unbracketed ``EXCLUDE col`` from being treated as an
+    expression so the select-list terminator can reject a comma before
+    ``EXCLUDE``. ``EXCLUDE(...)`` function calls and ``AS EXCLUDE`` aliases
+    remain valid.
     """
 
     match_grammar = OneOf(
         Ref("WildcardExpressionSegment"),
         Sequence(
-            Ref("BaseExpressionElementGrammar"),
+            Ref(
+                "BaseExpressionElementGrammar",
+                exclude=Sequence(
+                    "EXCLUDE",
+                    Delimited(Ref("SingleIdentifierGrammar")),
+                ),
+            ),
             Ref(
                 "AliasExpressionSegment",
                 exclude=Ref.keyword("EXCLUDE"),

--- a/src/sqlfluff/dialects/dialect_redshift.py
+++ b/src/sqlfluff/dialects/dialect_redshift.py
@@ -21,7 +21,6 @@ from sqlfluff.core.parser import (
     Nothing,
     OneOf,
     OptionallyBracketed,
-    ParseMode,
     Ref,
     RegexLexer,
     RegexParser,
@@ -2924,72 +2923,31 @@ class UnorderedSelectStatementSegment(ansi.UnorderedSelectStatementSegment):
 class SelectClauseSegment(postgres.SelectClauseSegment):
     """A Redshift `SELECT` clause.
 
-    EXCLUDE follows the full select list:
+    EXCLUDE follows the full select list (not a wildcard/item suffix):
     https://docs.aws.amazon.com/redshift/latest/dg/r_SELECT_synopsis.html
     https://docs.aws.amazon.com/redshift/latest/dg/r_EXCLUDE_list.html
     """
 
-    match_grammar = Sequence(
-        "SELECT",
-        Ref("SelectClauseModifierSegment", optional=True),
-        Indent,
-        OneOf(
-            # EXCLUDE branch: terminator only here so a column named EXCLUDE can
-            # still parse via the fallback. No trailing comma before EXCLUDE.
-            Sequence(
-                Delimited(
-                    Ref("SelectClauseElementSegment"),
-                    allow_trailing=False,
-                    terminators=[Ref.keyword("EXCLUDE")],
-                ),
-                Ref("ExcludeClauseSegment"),
-            ),
-            # Postgres-compatible select list (optional / trailing commas).
-            Delimited(
-                Ref("SelectClauseElementSegment"),
-                optional=True,
-                allow_trailing=True,
-            ),
-        ),
-        Dedent,
-        terminators=[
-            "INTO",
-            "FROM",
-            "WHERE",
-            Sequence("ORDER", "BY"),
-            Sequence("ON", "CONFLICT"),
-            "LIMIT",
-            "RETURNING",
-            "OVERLAPS",
-            Ref("SetOperatorSegment"),
-            Sequence("WITH", Ref.keyword("NO", optional=True), "DATA"),
-            Ref("WithCheckOptionSegment"),
-            Ref("MetaCommandQueryBufferSegment"),
-        ],
-        parse_mode=ParseMode.GREEDY_ONCE_STARTED,
+    # Keep the Postgres select-clause structure and terminators; only attach
+    # EXCLUDE after the delimited select list.
+    match_grammar = postgres.SelectClauseSegment.match_grammar.copy(
+        insert=[Ref("ExcludeClauseSegment", optional=True)],
+        before=Dedent,
     )
 
 
 class SelectClauseElementSegment(ansi.SelectClauseElementSegment):
-    """An element in the targets of a select statement.
+    """Select-list element for Redshift.
 
-    ``EXCLUDE`` is a select-list clause keyword in Redshift, not a column alias
-    or ``EXCLUDE (...)`` function-like expression.
+    Prevent bare ``EXCLUDE`` from being treated as an implicit column alias so
+    the select-clause-level ``ExcludeClauseSegment`` can match. This does not
+    restrict ``EXCLUDE(...)`` expressions or ``AS EXCLUDE`` aliases.
     """
 
     match_grammar = OneOf(
         Ref("WildcardExpressionSegment"),
         Sequence(
-            Ref(
-                "BaseExpressionElementGrammar",
-                exclude=Sequence(
-                    "EXCLUDE",
-                    OneOf(
-                        Bracketed(Delimited(Ref("SingleIdentifierGrammar"))),
-                        Delimited(Ref("SingleIdentifierGrammar")),
-                    ),
-                ),
-            ),
+            Ref("BaseExpressionElementGrammar"),
             Ref(
                 "AliasExpressionSegment",
                 exclude=Ref.keyword("EXCLUDE"),

--- a/test/dialects/redshift_test.py
+++ b/test/dialects/redshift_test.py
@@ -29,6 +29,10 @@ def _violations(sql: str) -> list:
             "SELECT col1, EXCLUDE col2 FROM tbl;",
             id="comma_before_unbracketed_exclude_no_star",
         ),
+        pytest.param(
+            "SELECT col1, EXCLUDE (col2) FROM tbl;",
+            id="comma_before_bracketed_exclude",
+        ),
     ],
 )
 def test_select_exclude_rejects_comma_before_clause(sql: str) -> None:

--- a/test/dialects/redshift_test.py
+++ b/test/dialects/redshift_test.py
@@ -1,0 +1,36 @@
+"""Redshift dialect-specific parser rejection tests.
+
+Positive/valid-SQL cases belong in the SQL/YAML parse fixtures under
+test/fixtures/dialects/redshift/ per project convention.
+"""
+
+import pytest
+
+from sqlfluff.core import Linter
+
+
+def _violations(sql: str) -> list:
+    """Return all parse errors, including unparsable nodes in the tree."""
+    parsed = Linter(dialect="redshift").parse_string(sql)
+    violations: list = list(parsed.violations)
+    if parsed.tree:
+        violations += list(parsed.tree.recursive_crawl("unparsable"))
+    return violations
+
+
+@pytest.mark.parametrize(
+    "sql",
+    [
+        pytest.param(
+            "SELECT *, a, EXCLUDE x FROM tbl;",
+            id="comma_before_unbracketed_exclude",
+        ),
+        pytest.param(
+            "SELECT col1, EXCLUDE col2 FROM tbl;",
+            id="comma_before_unbracketed_exclude_no_star",
+        ),
+    ],
+)
+def test_select_exclude_rejects_comma_before_clause(sql: str) -> None:
+    """A comma before SELECT EXCLUDE must not parse as a select item."""
+    assert _violations(sql), f"Expected violations but got none for:\n{sql}"

--- a/test/fixtures/dialects/redshift/select_exclude.sql
+++ b/test/fixtures/dialects/redshift/select_exclude.sql
@@ -5,3 +5,11 @@ SELECT * EXCLUDE col1, col2 FROM table1;
 SELECT * EXCLUDE (col1) FROM table1;
 
 SELECT * EXCLUDE (col1, col2) FROM table1;
+
+SELECT *, NULL AS example EXCLUDE (col1, col2) FROM table1;
+
+SELECT *, 1 EXCLUDE (col1) FROM table1;
+
+SELECT col1, col2, col3 EXCLUDE (col2) FROM table1;
+
+SELECT a.col1, b.* EXCLUDE (col2, col3) FROM table1 AS a, table2 AS b;

--- a/test/fixtures/dialects/redshift/select_exclude.sql
+++ b/test/fixtures/dialects/redshift/select_exclude.sql
@@ -13,3 +13,11 @@ SELECT *, 1 EXCLUDE (col1) FROM table1;
 SELECT col1, col2, col3 EXCLUDE (col2) FROM table1;
 
 SELECT a.col1, b.* EXCLUDE (col2, col3) FROM table1 AS a, table2 AS b;
+
+SELECT EXCLUDE FROM table1;
+
+SELECT EXCLUDE, col1 FROM table1;
+
+SELECT "EXCLUDE" FROM table1;
+
+SELECT a, b, FROM table1;

--- a/test/fixtures/dialects/redshift/select_exclude.sql
+++ b/test/fixtures/dialects/redshift/select_exclude.sql
@@ -20,4 +20,10 @@ SELECT EXCLUDE, col1 FROM table1;
 
 SELECT "EXCLUDE" FROM table1;
 
+SELECT EXCLUDE(col1) FROM table1;
+
+SELECT schema.EXCLUDE(col1) FROM table1;
+
+SELECT 1 AS EXCLUDE FROM table1;
+
 SELECT a, b, FROM table1;

--- a/test/fixtures/dialects/redshift/select_exclude.sql
+++ b/test/fixtures/dialects/redshift/select_exclude.sql
@@ -10,6 +10,8 @@ SELECT *, NULL AS example EXCLUDE (col1, col2) FROM table1;
 
 SELECT *, 1 EXCLUDE (col1) FROM table1;
 
+SELECT *, a EXCLUDE x FROM tbl;
+
 SELECT col1, col2, col3 EXCLUDE (col2) FROM table1;
 
 SELECT a.col1, b.* EXCLUDE (col2, col3) FROM table1 AS a, table2 AS b;

--- a/test/fixtures/dialects/redshift/select_exclude.yml
+++ b/test/fixtures/dialects/redshift/select_exclude.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 8af0225139de47a1091714a9eae65f90fbfeec65fd6829606cdf0315f1cb4530
+_hash: 6457b9499f4cfb1515222fee55dd11c07eabdb5877ec3b2cd712658fed0941d1
 file:
 - statement:
     select_statement:
@@ -263,6 +263,72 @@ file:
         select_clause_element:
           column_reference:
             quoted_identifier: '"EXCLUDE"'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: table1
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: EXCLUDE
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  column_reference:
+                    naked_identifier: col1
+                end_bracket: )
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: table1
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          function:
+            function_name:
+              naked_identifier: schema
+              dot: .
+              function_name_identifier: EXCLUDE
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  column_reference:
+                    naked_identifier: col1
+                end_bracket: )
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: table1
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          numeric_literal: '1'
+          alias_expression:
+            alias_operator:
+              keyword: AS
+            naked_identifier: EXCLUDE
       from_clause:
         keyword: FROM
         from_expression:

--- a/test/fixtures/dialects/redshift/select_exclude.yml
+++ b/test/fixtures/dialects/redshift/select_exclude.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: b61864bab6f6dd814161d79c2f2ef70ee4636b50df919e7d3223c5ebe56cd4d9
+_hash: 8af0225139de47a1091714a9eae65f90fbfeec65fd6829606cdf0315f1cb4530
 file:
 - statement:
     select_statement:
@@ -221,4 +221,73 @@ file:
               alias_operator:
                 keyword: AS
               naked_identifier: b
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          column_reference:
+            naked_identifier: EXCLUDE
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: table1
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            naked_identifier: EXCLUDE
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            naked_identifier: col1
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: table1
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          column_reference:
+            quoted_identifier: '"EXCLUDE"'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: table1
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            naked_identifier: a
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            naked_identifier: b
+      - comma: ','
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: table1
 - statement_terminator: ;

--- a/test/fixtures/dialects/redshift/select_exclude.yml
+++ b/test/fixtures/dialects/redshift/select_exclude.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 6457b9499f4cfb1515222fee55dd11c07eabdb5877ec3b2cd712658fed0941d1
+_hash: f598ac2950dca0d8a6a498056cbcea0569b39e71756285f4852725960e56b2d8
 file:
 - statement:
     select_statement:
@@ -146,6 +146,29 @@ file:
             table_expression:
               table_reference:
                 naked_identifier: table1
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            naked_identifier: a
+      - select_exclude_clause:
+          keyword: EXCLUDE
+          naked_identifier: x
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: tbl
 - statement_terminator: ;
 - statement:
     select_statement:

--- a/test/fixtures/dialects/redshift/select_exclude.yml
+++ b/test/fixtures/dialects/redshift/select_exclude.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: ccfe5628326043e2977dbfdf0721ccb5be8f8449f571dcb4fbb46d8e92aa9eb8
+_hash: b61864bab6f6dd814161d79c2f2ef70ee4636b50df919e7d3223c5ebe56cd4d9
 file:
 - statement:
     select_statement:
@@ -13,9 +13,76 @@ file:
           wildcard_expression:
             wildcard_identifier:
               star: '*'
-            select_exclude_clause:
-              keyword: EXCLUDE
-              naked_identifier: col1
+        select_exclude_clause:
+          keyword: EXCLUDE
+          naked_identifier: col1
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: table1
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+        select_exclude_clause:
+        - keyword: EXCLUDE
+        - naked_identifier: col1
+        - comma: ','
+        - naked_identifier: col2
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: table1
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+        select_exclude_clause:
+          keyword: EXCLUDE
+          bracketed:
+            start_bracket: (
+            naked_identifier: col1
+            end_bracket: )
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: table1
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+        select_exclude_clause:
+          keyword: EXCLUDE
+          bracketed:
+          - start_bracket: (
+          - naked_identifier: col1
+          - comma: ','
+          - naked_identifier: col2
+          - end_bracket: )
       from_clause:
         keyword: FROM
         from_expression:
@@ -32,13 +99,75 @@ file:
           wildcard_expression:
             wildcard_identifier:
               star: '*'
-            select_exclude_clause:
-              keyword: EXCLUDE
-              naked_identifier: col1
+      - comma: ','
+      - select_clause_element:
+          null_literal: 'NULL'
+          alias_expression:
+            alias_operator:
+              keyword: AS
+            naked_identifier: example
+      - select_exclude_clause:
+          keyword: EXCLUDE
+          bracketed:
+          - start_bracket: (
+          - naked_identifier: col1
+          - comma: ','
+          - naked_identifier: col2
+          - end_bracket: )
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: table1
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      - comma: ','
+      - select_clause_element:
+          numeric_literal: '1'
+      - select_exclude_clause:
+          keyword: EXCLUDE
+          bracketed:
+            start_bracket: (
+            naked_identifier: col1
+            end_bracket: )
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: table1
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            naked_identifier: col1
       - comma: ','
       - select_clause_element:
           column_reference:
             naked_identifier: col2
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            naked_identifier: col3
+      - select_exclude_clause:
+          keyword: EXCLUDE
+          bracketed:
+            start_bracket: (
+            naked_identifier: col2
+            end_bracket: )
       from_clause:
         keyword: FROM
         from_expression:
@@ -50,46 +179,46 @@ file:
 - statement:
     select_statement:
       select_clause:
-        keyword: SELECT
-        select_clause_element:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+          - naked_identifier: a
+          - dot: .
+          - naked_identifier: col1
+      - comma: ','
+      - select_clause_element:
           wildcard_expression:
             wildcard_identifier:
+              naked_identifier: b
+              dot: .
               star: '*'
-            select_exclude_clause:
-              keyword: EXCLUDE
-              bracketed:
-                start_bracket: (
-                naked_identifier: col1
-                end_bracket: )
+      - select_exclude_clause:
+          keyword: EXCLUDE
+          bracketed:
+          - start_bracket: (
+          - naked_identifier: col2
+          - comma: ','
+          - naked_identifier: col3
+          - end_bracket: )
       from_clause:
-        keyword: FROM
-        from_expression:
+      - keyword: FROM
+      - from_expression:
           from_expression_element:
             table_expression:
               table_reference:
                 naked_identifier: table1
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-        keyword: SELECT
-        select_clause_element:
-          wildcard_expression:
-            wildcard_identifier:
-              star: '*'
-            select_exclude_clause:
-              keyword: EXCLUDE
-              bracketed:
-              - start_bracket: (
-              - naked_identifier: col1
-              - comma: ','
-              - naked_identifier: col2
-              - end_bracket: )
-      from_clause:
-        keyword: FROM
-        from_expression:
+            alias_expression:
+              alias_operator:
+                keyword: AS
+              naked_identifier: a
+      - comma: ','
+      - from_expression:
           from_expression_element:
             table_expression:
               table_reference:
-                naked_identifier: table1
+                naked_identifier: table2
+            alias_expression:
+              alias_operator:
+                keyword: AS
+              naked_identifier: b
 - statement_terminator: ;


### PR DESCRIPTION
## Brief summary
Fix Redshift parsing of `EXCLUDE` when it follows a non-wildcard select list (e.g. `SELECT *, NULL AS example EXCLUDE (col1, col2)`).

## Changelog & Docs
- [ ] This PR does not include a changelog entry (bug fix for dialect parsing)
- [ ] Docs not required (behavior aligned with existing vendor syntax)

## Testing
- Extended `test/fixtures/dialects/redshift/select_exclude.sql`
- Regenerated YAML via `python test/generate_parse_fixture_yml.py -d redshift -f 'select_exclude*'`
- Verified against AWS Redshift SELECT / EXCLUDE docs and the alias-ambiguity case called out on #8043

## Approach
Per review on #8043: attach a single optional `ExcludeClauseSegment` after the delimited select list via Postgres `SelectClauseSegment.copy`; stop bare `EXCLUDE` being treated as an implicit alias; keep EXCLUDE off wildcard expressions. `EXCLUDE(...)` expressions and `AS EXCLUDE` remain valid.

Closes #7899