### PR TITLE
Migrate deprecated rules:max_line_length into the core section

### DIFF
--- a/src/sqlfluff/core/config/file.py
+++ b/src/sqlfluff/core/config/file.py
@@ -17,7 +17,7 @@ from functools import cache
 from typing import Optional
 
 from sqlfluff.core.config.ini import load_ini_string
-from sqlfluff.core.config.toml import load_toml_file_config
+from sqlfluff.core.config.toml import PYPROJECT_FILENAME, load_toml_file_config
 from sqlfluff.core.config.validate import validate_config_dict
 from sqlfluff.core.helpers.string import (
     split_comma_separated_string,
@@ -38,7 +38,7 @@ OPAQUE_SECTION_KEY_PATH = ("templater", "jinja", "context")
 def _load_raw_file_as_dict(filepath: str) -> ConfigMappingType:
     """Loads the raw dict object from file without interpolation."""
     filename = os.path.basename(filepath)
-    if filename == "pyproject.toml":
+    if filename == PYPROJECT_FILENAME:
         return load_toml_file_config(filepath)
     # If it's not a pyproject file, assume that it's an ini file.
     with open(filepath, mode="r") as file:

--- a/src/sqlfluff/core/config/removed.py
+++ b/src/sqlfluff/core/config/removed.py
@@ -1,10 +1,12 @@
 """Records of deprecated and removed config variables."""
 
 import logging
+import os.path
 from dataclasses import dataclass
 from typing import Callable, Optional, Union
 
 from sqlfluff.core.config.ini import coerce_value
+from sqlfluff.core.config.toml import PYPROJECT_FILENAME
 from sqlfluff.core.errors import SQLFluffUserError
 from sqlfluff.core.helpers.dict import (
     NestedStringDict,
@@ -234,10 +236,13 @@ def validate_config_dict_for_removed(
     # it, and that differs between the two config formats: ``pyproject.toml``
     # nests the root section as ``[tool.sqlfluff.core]`` while ini style files
     # put the same keys at the root of ``[sqlfluff]``.
+    # NOTE: This mirrors ``_load_raw_file_as_dict`` exactly, filename and all:
+    # a ``.toml`` suffix is not enough, because any file which isn't named
+    # ``pyproject.toml`` is loaded as ini and so takes the ini spelling.
     # NOTE: ``logging_reference`` is typed as a string but callers also pass
     # path objects (it is otherwise only ever interpolated into a message),
-    # so coerce before inspecting the suffix.
-    toml_source = str(logging_reference).lower().endswith(".toml")
+    # so coerce before inspecting it.
+    toml_source = os.path.basename(str(logging_reference)) == PYPROJECT_FILENAME
 
     # Iterate through a copy of the config keys, so we can safely mutate
     # the underlying dict.

--- a/src/sqlfluff/core/config/removed.py
+++ b/src/sqlfluff/core/config/removed.py
@@ -56,20 +56,23 @@ class _RemovedConfig:
         """Format the old key in a way similar to a config file."""
         return ":".join(self.old_path)
 
-    @property
-    def formatted_new_key(self) -> str:
-        """Format the new key (assuming it exists) in a way similar to a config file.
+    def formatted_new_key(self, *, toml: bool = False) -> str:
+        """Format the new key (assuming it exists) as the user has to write it.
 
-        NOTE: ``core`` is the internal name of the root ``[sqlfluff]`` section
-        and is never written by users, so it is stripped here. Without that,
-        a warning would quote a path (e.g. ``core:max_line_length``) which is
-        silently ignored if it is copied into a config file.
+        NOTE: ``core`` is the internal name of the root ``[sqlfluff]`` section,
+        and the two config formats spell it differently. In ini style configs
+        (``.sqlfluff``, ``setup.cfg``, ``tox.ini``) those keys sit at the root
+        of ``[sqlfluff]``, so the ``core`` element is stripped: quoting
+        ``core:max_line_length`` would send people to a section that does not
+        exist and leave the setting ignored. In ``pyproject.toml`` the same
+        setting lives under ``[tool.sqlfluff.core]``, so there ``core`` is part
+        of what the user must write and is kept.
         """
         assert self.new_path, (
             "`formatted_new_key` can only be called if a `new_path` is set."
         )
         path = self.new_path
-        if len(path) > 1 and path[0] == "core":
+        if not toml and len(path) > 1 and path[0] == "core":
             path = path[1:]
         return ":".join(path)
 
@@ -227,6 +230,15 @@ def validate_config_dict_for_removed(
     # NOTE: During recursion, this should be set explicitly.
     root_config_ref = root_config_ref or config
 
+    # The warnings below quote the migrated key the way the user has to write
+    # it, and that differs between the two config formats: ``pyproject.toml``
+    # nests the root section as ``[tool.sqlfluff.core]`` while ini style files
+    # put the same keys at the root of ``[sqlfluff]``.
+    # NOTE: ``logging_reference`` is typed as a string but callers also pass
+    # path objects (it is otherwise only ever interpolated into a message),
+    # so coerce before inspecting the suffix.
+    toml_source = str(logging_reference).lower().endswith(".toml")
+
     # Iterate through a copy of the config keys, so we can safely mutate
     # the underlying dict.
     for key in list(config.keys()):
@@ -277,7 +289,8 @@ def validate_config_dict_for_removed(
                 f"\nWARNING: Config file {logging_reference} set a deprecated "
                 f"config value `{removed_value.formatted_old_key}` (which can be "
                 "migrated) but ALSO set the value it would be migrated to. The new "
-                f"value (`{removed_value.formatted_new_key}`) takes precedence. "
+                f"value (`{removed_value.formatted_new_key(toml=toml_source)}`) "
+                "takes precedence. "
                 "Please update your configuration to remove this warning. "
                 f"\n\n{removed_value.warning}\n\n"
                 "See https://docs.sqlfluff.com/en/stable/perma/"
@@ -302,7 +315,7 @@ def validate_config_dict_for_removed(
             f"\nWARNING: Config file {logging_reference} set a deprecated config "
             f"value `{removed_value.formatted_old_key}`. This will be "
             "removed in a later release. This has been mapped to "
-            f"`{removed_value.formatted_new_key}` set to a value of "
+            f"`{removed_value.formatted_new_key(toml=toml_source)}` set to a value of "
             f"{new_value!r} for this run. "
             "Please update your configuration to remove this warning. "
             f"\n\n{removed_value.warning}\n\n"

--- a/src/sqlfluff/core/config/removed.py
+++ b/src/sqlfluff/core/config/removed.py
@@ -83,7 +83,7 @@ REMOVED_CONFIGS = [
             "The max_line_length config has moved "
             "from sqlfluff:rules to the root sqlfluff level."
         ),
-        ("max_line_length",),
+        ("core", "max_line_length"),
         (lambda x: x),
     ),
     _RemovedConfig(

--- a/src/sqlfluff/core/config/removed.py
+++ b/src/sqlfluff/core/config/removed.py
@@ -58,11 +58,20 @@ class _RemovedConfig:
 
     @property
     def formatted_new_key(self) -> str:
-        """Format the new key (assuming it exists) in a way similar to a config file."""
+        """Format the new key (assuming it exists) in a way similar to a config file.
+
+        NOTE: ``core`` is the internal name of the root ``[sqlfluff]`` section
+        and is never written by users, so it is stripped here. Without that,
+        a warning would quote a path (e.g. ``core:max_line_length``) which is
+        silently ignored if it is copied into a config file.
+        """
         assert self.new_path, (
             "`formatted_new_key` can only be called if a `new_path` is set."
         )
-        return ":".join(self.new_path)
+        path = self.new_path
+        if len(path) > 1 and path[0] == "core":
+            path = path[1:]
+        return ":".join(path)
 
 
 RemovedConfigMapType = dict[str, Union[_RemovedConfig, "RemovedConfigMapType"]]

--- a/src/sqlfluff/core/config/toml.py
+++ b/src/sqlfluff/core/config/toml.py
@@ -19,6 +19,13 @@ from sqlfluff.core.types import ConfigMappingType
 
 T = TypeVar("T")
 
+# The only filename which is parsed as toml. Anything else, whatever its
+# extension, is parsed as ini. Both the loader (`_load_raw_file_as_dict`)
+# and the migration warnings key off this, so they have to agree: a warning
+# which quotes the toml spelling for a file loaded as ini sends the user to a
+# section they cannot set.
+PYPROJECT_FILENAME = "pyproject.toml"
+
 
 def _condense_rule_record(record: NestedDictRecord[T]) -> NestedDictRecord[T]:
     """Helper function to condense the rule section of a toml config."""

--- a/test/core/config/fluffconfig_test.py
+++ b/test/core/config/fluffconfig_test.py
@@ -226,6 +226,14 @@ def test__config__from_string():
     assert cfg.get("dialect") == "mysql"
 
 
+def test__config__deprecated_max_line_length_is_applied():
+    """A deprecated `sqlfluff:rules:max_line_length` should still take effect."""
+    cfg = FluffConfig.from_string(
+        "[sqlfluff]\ndialect = ansi\n\n[sqlfluff:rules]\nmax_line_length = 30\n"
+    )
+    assert cfg.get("max_line_length") == 30
+
+
 def test__config_missing_dialect():
     """Verify an exception is thrown if no dialect was specified."""
     with pytest.raises(SQLFluffUserError) as e:

--- a/test/core/config/validate_test.py
+++ b/test/core/config/validate_test.py
@@ -128,6 +128,11 @@ def test__validate_configs_removed_new_key_display():
         (".sqlfluff", "`max_line_length`"),
         ("setup.cfg", "`max_line_length`"),
         ("/some/path/pyproject.toml", "`core:max_line_length`"),
+        # Only `pyproject.toml` is loaded as toml. Any other name is read as
+        # ini whatever its extension, so it takes the ini spelling.
+        ("/some/path/custom.toml", "`max_line_length`"),
+        ("/some/path/Pyproject.TOML", "`max_line_length`"),
+        ("<config string>", "`max_line_length`"),
     ],
 )
 def test__validate_configs_removed_warning_is_source_aware(
@@ -137,7 +142,8 @@ def test__validate_configs_removed_warning_is_source_aware(
 
     An ini config takes `max_line_length` at the root of `[sqlfluff]`, but a
     `pyproject.toml` needs it under `[tool.sqlfluff.core]`, so a single
-    spelling cannot be correct for both.
+    spelling cannot be correct for both. The format is decided by filename in
+    `_load_raw_file_as_dict`, so the warning has to key off the same thing.
     """
     config = records_to_nested_dict([(("rules", "max_line_length"), 800)])
     with caplog.at_level(logging.WARNING, logger="sqlfluff.config"):

--- a/test/core/config/validate_test.py
+++ b/test/core/config/validate_test.py
@@ -103,6 +103,20 @@ def test__validate_configs_max_line_length_precedence():
     assert config == {"core": {"dialect": "ansi", "max_line_length": 50}}
 
 
+def test__validate_configs_removed_new_key_display():
+    """A migrated key should be quoted the way a user would write it.
+
+    `core` is the internal name of the root `[sqlfluff]` section, so a warning
+    naming `core:max_line_length` would send people to a section that does not
+    exist and leave the setting ignored.
+    """
+    record = next(
+        k for k in REMOVED_CONFIGS if k.old_path == ("rules", "max_line_length")
+    )
+    assert record.new_path == ("core", "max_line_length")
+    assert record.formatted_new_key == "max_line_length"
+
+
 @pytest.mark.parametrize(
     "old_value,expected",
     [

--- a/test/core/config/validate_test.py
+++ b/test/core/config/validate_test.py
@@ -71,6 +71,38 @@ def test__validate_configs_precedence_same_file():
     assert config == {"layout": {"type": {"binary_operator": {"line_position": "foo"}}}}
 
 
+def test__validate_configs_max_line_length_migration():
+    """Test migration of the deprecated `rules:max_line_length` config.
+
+    The replacement value is resolved from the `core` section, so the
+    migrated value must land there rather than at the root of the config.
+    """
+    old_key = ("rules", "max_line_length")
+    new_key = ("core", "max_line_length")
+    # Confirm this key is still translated (guards against the test drifting).
+    assert any(
+        k.old_path == old_key and k.new_path == new_key for k in REMOVED_CONFIGS
+    ), (
+        "This test depends on this key still being removed. Update the test to "
+        "one that is if this one isn't."
+    )
+    # NOTE: A `core` section is present, as it would be for any config loaded
+    # from a file (the `[sqlfluff]` section is loaded as `core`).
+    config = {"core": {"dialect": "ansi"}, "rules": {"max_line_length": 30}}
+    validate_config_dict_for_removed(config, "<test>")
+    assert config == {"core": {"dialect": "ansi", "max_line_length": 30}}
+
+
+def test__validate_configs_max_line_length_precedence():
+    """The new `max_line_length` value should win over the deprecated one."""
+    config = {
+        "core": {"dialect": "ansi", "max_line_length": 50},
+        "rules": {"max_line_length": 30},
+    }
+    validate_config_dict_for_removed(config, "<test>")
+    assert config == {"core": {"dialect": "ansi", "max_line_length": 50}}
+
+
 @pytest.mark.parametrize(
     "old_value,expected",
     [

--- a/test/core/config/validate_test.py
+++ b/test/core/config/validate_test.py
@@ -1,5 +1,7 @@
 """Tests for the config validation routines."""
 
+import logging
+
 import pytest
 
 from sqlfluff.core.config.removed import (
@@ -106,15 +108,43 @@ def test__validate_configs_max_line_length_precedence():
 def test__validate_configs_removed_new_key_display():
     """A migrated key should be quoted the way a user would write it.
 
-    `core` is the internal name of the root `[sqlfluff]` section, so a warning
-    naming `core:max_line_length` would send people to a section that does not
-    exist and leave the setting ignored.
+    `core` is the internal name of the root `[sqlfluff]` section. In ini style
+    configs a warning naming `core:max_line_length` would send people to a
+    section that does not exist and leave the setting ignored, while in
+    `pyproject.toml` the same setting really does live under
+    `[tool.sqlfluff.core]` and the prefix must stay.
     """
     record = next(
         k for k in REMOVED_CONFIGS if k.old_path == ("rules", "max_line_length")
     )
     assert record.new_path == ("core", "max_line_length")
-    assert record.formatted_new_key == "max_line_length"
+    assert record.formatted_new_key() == "max_line_length"
+    assert record.formatted_new_key(toml=True) == "core:max_line_length"
+
+
+@pytest.mark.parametrize(
+    "logging_reference,expected",
+    [
+        (".sqlfluff", "`max_line_length`"),
+        ("setup.cfg", "`max_line_length`"),
+        ("/some/path/pyproject.toml", "`core:max_line_length`"),
+    ],
+)
+def test__validate_configs_removed_warning_is_source_aware(
+    logging_reference, expected, caplog
+):
+    """The migration warning quotes the key for the format being read.
+
+    An ini config takes `max_line_length` at the root of `[sqlfluff]`, but a
+    `pyproject.toml` needs it under `[tool.sqlfluff.core]`, so a single
+    spelling cannot be correct for both.
+    """
+    config = records_to_nested_dict([(("rules", "max_line_length"), 800)])
+    with caplog.at_level(logging.WARNING, logger="sqlfluff.config"):
+        validate_config_dict_for_removed(config, logging_reference)
+    assert expected in caplog.text
+    # The functional migration is unaffected by how the warning is rendered.
+    assert config == {"core": {"max_line_length": 800}}
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Brief summary of the change made

Fixes #4237.

`sqlfluff:rules:max_line_length` was moved to the root `sqlfluff` level, and `REMOVED_CONFIGS` carries a migration record for it. The warning is printed, but the value never takes effect:

```
WARNING: Config file .sqlfluff set a deprecated config value `rules:max_line_length`.
This has been mapped to `max_line_length` set to a value of 30 for this run.
```
...and `LT05` still uses the default of 80.

The cause is the `new_path` of that record, `("max_line_length",)`, which points at the root of the config dict. `max_line_length` is resolved from the `core` section (the `[sqlfluff]` section of a config file is loaded as `core`), so the migrated value lands beside `core` instead of inside it:

```python
>>> load_config_file_as_dict(".sqlfluff")   # [sqlfluff:rules] max_line_length = 30
{'core': {'dialect': 'ansi'}, 'max_line_length': 30}
>>> FluffConfig.from_path(".").get("max_line_length")
80
```

This is the only record in `REMOVED_CONFIGS` whose `new_path` targets the root; every other one names its section (`("indentation", ...)`, `("layout", "type", ...)`, `("core", "recurse")`) and works. The change points this one at `("core", "max_line_length")` as well.

### Are there any other side effects of this change that we should be aware of?

Yes, one, and I think it is a fix rather than a regression. `validate_config_dict_for_removed` checks whether the new key is already set, in order to warn that the new value takes precedence. That lookup used the same root path, where a value never appeared, so for this key the branch was unreachable and setting both keys silently produced neither warning nor the expected precedence. It now behaves like the other migrated keys:

```
WARNING: ... set a deprecated config value `rules:max_line_length` (which can be migrated)
but ALSO set the value it would be migrated to. The new value (`core:max_line_length`)
takes precedence.
```

The one cosmetic consequence is that the warning now names the new key as `core:max_line_length`, while a user writes it as `max_line_length` under `[sqlfluff]`. I left it alone rather than adding a display-only field for a single key, but I am happy to add one if you would prefer the message to match what people type.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - [x] Other: three tests, all of which fail on `main` and pass with the change.
    - `test__validate_configs_max_line_length_migration` — the migrated value lands in `core`, using the dict shape produced by an actual config file.
    - `test__validate_configs_max_line_length_precedence` — an explicitly set `core` value wins over the deprecated one.
    - `test__config__deprecated_max_line_length_is_applied` — end to end through `FluffConfig.from_string`, the value a user would actually write.
- [x] Added appropriate documentation for the change — none needed; the documented behaviour is what this restores.
- [x] Created GitHub issues for any relevant followup/future enhancements if appropriate — none.

Ran locally on `d19152f`: `test/core/config` (111 passed), `test/core` (903 passed), `test/cli` (229 passed), and `test/rules -k LT05` (65 passed).

---

*Disclosure per the AI-assisted contributions section of `CONTRIBUTING.md`: I used an AI assistant to help locate the cause and draft the tests and this description. I reproduced the bug myself from the config in the issue, confirmed the three tests fail before the change and pass after it, and ran the test selections listed above.*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix migration of deprecated `sqlfluff:rules:max_line_length` to `core:max_line_length`, and make warnings quote the key correctly for the source config. `LT05` now uses the migrated value, and precedence warnings behave as expected.

- **Bug Fixes**
  - Map the removed config to `("core", "max_line_length")` so the value takes effect.
  - Render the migrated key as `max_line_length` for ini configs and `core:max_line_length` for `pyproject.toml`, keyed off the filename (`pyproject.toml`) to match how configs are loaded and avoid bad guidance for custom `.toml` names.
  - Trigger the correct precedence warning when both deprecated and new keys are present.

<sup>Written for commit 49a33765ae3c80728190f8edae0276cbc5746837. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8271?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

