### PR TITLE
Redshift: allow array accessors within SUPER paths in the FROM clause

### DIFF
--- a/src/sqlfluff/dialects/dialect_redshift.py
+++ b/src/sqlfluff/dialects/dialect_redshift.py
@@ -2615,6 +2615,29 @@ class LockTableStatementSegment(BaseSegment):
     )
 
 
+class TableReferenceSegment(ansi.TableReferenceSegment):
+    """A reference to a table, CTE, subquery or alias.
+
+    Overridden to allow indexing into SUPER arrays part way through the
+    reference, e.g. ``a.topic[0].extension``. Redshift supports navigating
+    into a SUPER column in the FROM clause, and the array accessor may appear
+    on any element of the path.
+
+    https://docs.aws.amazon.com/redshift/latest/dg/query-super.html
+    """
+
+    match_grammar: Matchable = Delimited(
+        Sequence(
+            Ref("SingleIdentifierGrammar"),
+            Ref("ArrayAccessorSegment", optional=True),
+            allow_gaps=False,
+        ),
+        delimiter=Ref("ObjectReferenceDelimiterGrammar"),
+        terminators=[Ref("ObjectReferenceTerminatorGrammar")],
+        allow_gaps=False,
+    )
+
+
 class TableExpressionSegment(ansi.TableExpressionSegment):
     """The main table expression e.g. within a FROM clause.
 

--- a/test/fixtures/dialects/redshift/super_array_accessor.sql
+++ b/test/fixtures/dialects/redshift/super_array_accessor.sql
@@ -1,0 +1,13 @@
+-- Navigating into a SUPER column in the FROM clause, where the path
+-- indexes into an array part way through.
+-- https://docs.aws.amazon.com/redshift/latest/dg/query-super.html
+SELECT raw_data.resource_id
+FROM raw_data
+LEFT JOIN raw_data.topic[0].extension AS topic_extension_array ON TRUE;
+
+SELECT c.c_name
+FROM customer_orders_lineitem AS c, c.c_orders[0] AS o;
+
+SELECT t.id
+FROM mytable AS t
+LEFT JOIN t.array_a[0].array_b[1] AS nested ON TRUE;

--- a/test/fixtures/dialects/redshift/super_array_accessor.yml
+++ b/test/fixtures/dialects/redshift/super_array_accessor.yml
@@ -1,0 +1,132 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: f6cb8ebe4bc3537ba5410297db261c9923318ddcbfe5ba54d0f7eb68405e5b1e
+file:
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          column_reference:
+          - naked_identifier: raw_data
+          - dot: .
+          - naked_identifier: resource_id
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: raw_data
+          join_clause:
+          - keyword: LEFT
+          - keyword: JOIN
+          - from_expression_element:
+              table_expression:
+                table_reference:
+                - naked_identifier: raw_data
+                - dot: .
+                - naked_identifier: topic
+                - array_accessor:
+                    start_square_bracket: '['
+                    numeric_literal: '0'
+                    end_square_bracket: ']'
+                - dot: .
+                - naked_identifier: extension
+              alias_expression:
+                alias_operator:
+                  keyword: AS
+                naked_identifier: topic_extension_array
+          - join_on_condition:
+              keyword: 'ON'
+              expression:
+                boolean_literal: 'TRUE'
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          column_reference:
+          - naked_identifier: c
+          - dot: .
+          - naked_identifier: c_name
+      from_clause:
+      - keyword: FROM
+      - from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: customer_orders_lineitem
+            alias_expression:
+              alias_operator:
+                keyword: AS
+              naked_identifier: c
+      - comma: ','
+      - from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+              - naked_identifier: c
+              - dot: .
+              - naked_identifier: c_orders
+              - array_accessor:
+                  start_square_bracket: '['
+                  numeric_literal: '0'
+                  end_square_bracket: ']'
+            alias_expression:
+              alias_operator:
+                keyword: AS
+              naked_identifier: o
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          column_reference:
+          - naked_identifier: t
+          - dot: .
+          - naked_identifier: id
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: mytable
+            alias_expression:
+              alias_operator:
+                keyword: AS
+              naked_identifier: t
+          join_clause:
+          - keyword: LEFT
+          - keyword: JOIN
+          - from_expression_element:
+              table_expression:
+                table_reference:
+                - naked_identifier: t
+                - dot: .
+                - naked_identifier: array_a
+                - array_accessor:
+                    start_square_bracket: '['
+                    numeric_literal: '0'
+                    end_square_bracket: ']'
+                - dot: .
+                - naked_identifier: array_b
+                - array_accessor:
+                    start_square_bracket: '['
+                    numeric_literal: '1'
+                    end_square_bracket: ']'
+              alias_expression:
+                alias_operator:
+                  keyword: AS
+                naked_identifier: nested
+          - join_on_condition:
+              keyword: 'ON'
+              expression:
+                boolean_literal: 'TRUE'
+- statement_terminator: ;


### PR DESCRIPTION
### Brief summary of the change made

Fixes #2935.

Redshift lets you navigate into a `SUPER` column in the `FROM` clause, and the path may index into an array part way through. The example from the issue is still unparsable on `main`:

```sql
SELECT 1
FROM raw_data AS a
LEFT JOIN a.topic[0].extension AS t ON TRUE
```
```
L: 3 | P: 18 | PRS | Found unparsable section: '[0].extension AS t ON TRUE'
```

`ObjectReferenceTerminatorGrammar` includes `StartSquareBracketSegment`, so the reference deliberately stops at the opening bracket. That is right for a column reference, where the accessor is picked up afterwards by the expression grammar, but in a table expression there is nothing left to pick it up and the rest of the path falls out as an unparsable section.

The Redshift dialect already has an `ArrayAccessorSegment`, and `TableExpressionSegment` is already overridden there for `ObjectUnpivotSegment` and `ArrayUnnestSegment`. This change follows the same shape: it overrides `TableReferenceSegment` so that each element of the path may carry an optional array accessor.

`a.topic[0].extension` now parses as a `table_reference` with the `array_accessor` in place, and the existing `AT`-style unnesting (`t.array_a AS value_a AT idx`, covered by `array_unnest.sql`) is unaffected.

### Are there any other side effects of this change that we should be aware of?

The override is confined to `dialect_redshift.py`, and no dialect loads Redshift as its base, so nothing outside Redshift can see it. Within Redshift it widens `table_reference` to accept `[...]` in places real SQL would not put it — the same trade-off the dialect already makes elsewhere, and it does not make any previously valid statement parse differently. All 80 existing Redshift fixtures regenerate byte-identical; the only new YAML is the one added here.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - [x] `.sql`/`.yml` parser test cases in `test/fixtures/dialects` — `redshift/super_array_accessor.sql`, covering the case from the issue, an accessor in a comma join, and two accessors in one path. The YAML is generated with the script. On `main` this fixture fails (`test__dialect__base_parse_struct[redshift-super_array_accessor.sql...]`); with the change it passes.
- [x] Added appropriate documentation for the change — the new segment carries a docstring linking the Redshift `SUPER` querying page.
- [x] Created GitHub issues for any relevant followup/future enhancements if appropriate — none.

Ran locally on `d19152f`: `test/dialects/dialects_test.py -k redshift` (240 passed).

---

*Disclosure per the AI-assisted contributions section of `CONTRIBUTING.md`: I used an AI assistant to help locate the terminator that ends the reference and to draft this description. I reproduced the parse failure myself, reduced it to the three-line case above, confirmed the new fixture fails before the change and passes after it, and checked that the other 80 Redshift fixtures regenerate unchanged.*


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow array accessors inside Redshift SUPER paths in FROM/JOIN table references (e.g., a.topic[0].extension) to fix parse failures. This enables navigating into SUPER arrays mid-path without affecting existing unnest syntax.

- Bug Fixes
  - Overrode `TableReferenceSegment` in Redshift to allow an optional array accessor (`[...]`) after each identifier in a table path.
  - Added parser fixtures for joins and multiple accessors; change is scoped to Redshift and does not alter existing statements or `AT`-style unnesting.

<sup>Written for commit b4353c22d8ab62bfc9080a9357a81a8db685acec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8272?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

