### PR TITLE
fix: auto-detect cached_property names and invalidate on pos_marker change

### DIFF
--- a/src/sqlfluff/core/parser/segments/base.py
+++ b/src/sqlfluff/core/parser/segments/base.py
@@ -147,6 +147,18 @@ class SegmentMetaclass(type, Matchable):
         # Populate the `_class_types` property on creation.
         added_type = class_dict.get("type", None)
         class_dict["_class_types"] = frozenset(_iter_base_types(added_type, bases))
+
+        # Auto-detect @cached_property names so _recalculate_caches()
+        # can invalidate them without a hardcoded list that drifts.
+        cached_props: set[str] = set()
+        for base in bases:
+            if hasattr(base, "_cached_property_names"):
+                cached_props.update(base._cached_property_names)
+        for key, val in class_dict.items():
+            if isinstance(val, cached_property):
+                cached_props.add(key)
+        class_dict["_cached_property_names"] = frozenset(cached_props)
+
         return cast(type["BaseSegment"], type.__new__(mcs, name, bases, class_dict))
 
 
@@ -238,7 +250,7 @@ class BaseSegment(metaclass=SegmentMetaclass):
 
     def __setattr__(self, key: str, value: Any) -> None:
         try:
-            if key == "segments":
+            if key in ("segments", "pos_marker"):
                 self._recalculate_caches()
 
         except (AttributeError, KeyError):  # pragma: no cover
@@ -770,23 +782,7 @@ class BaseSegment(metaclass=SegmentMetaclass):
     # ################ PRIVATE INSTANCE METHODS
 
     def _recalculate_caches(self) -> None:
-        for key in [
-            "is_code",
-            "is_comment",
-            "is_whitespace",
-            "raw",
-            "raw_upper",
-            "matched_length",
-            "raw_segments",
-            "raw_segments_with_ancestors",
-            "first_non_whitespace_segment_raw_upper",
-            "source_fixes",
-            "full_type_set",
-            "descendant_type_set",
-            "direct_descendant_type_set",
-            "_code_indices",
-            "_hash",
-        ]:
+        for key in self._cached_property_names:
             self.__dict__.pop(key, None)
 
     def _preface(self, ident: int, tabsize: int) -> str:

--- a/src/sqlfluff/core/parser/segments/raw.py
+++ b/src/sqlfluff/core/parser/segments/raw.py
@@ -123,6 +123,8 @@ class RawSegment(BaseSegment):
 
     def __setattr__(self, key: str, value: Any) -> None:
         """Overwrite BaseSegment's __setattr__ with BaseSegment's superclass."""
+        if key == "pos_marker":
+            self._recalculate_caches()
         super(BaseSegment, self).__setattr__(key, value)
 
     # ################ PUBLIC PROPERTIES

--- a/test/core/parser/segments/segments_base_test.py
+++ b/test/core/parser/segments/segments_base_test.py
@@ -475,6 +475,101 @@ def test__parser__raw_segment_raw_normalized():
     assert bs1.raw_normalized() == 'A".E'
 
 
+def test__parser__base_segments_cached_property_names_autodetected():
+    """Test that _cached_property_names is auto-detected by the metaclass."""
+    # BaseSegment should have all its @cached_property fields detected.
+    expected_base = {
+        "_hash",
+        "is_code",
+        "_code_indices",
+        "is_comment",
+        "is_whitespace",
+        "raw",
+        "descendant_type_set",
+        "direct_descendant_type_set",
+        "raw_upper",
+        "raw_segments",
+        "raw_segments_with_ancestors",
+        "source_fixes",
+        "first_non_whitespace_segment_raw_upper",
+        "is_templated",
+    }
+    assert BaseSegment._cached_property_names == expected_base
+
+    # RawSegment inherits BaseSegment's cached props and adds its own.
+    assert "representation" in RawSegment._cached_property_names
+    assert RawSegment._cached_property_names == expected_base | {"representation"}
+
+    # Stale names from the old hardcoded list should NOT be present.
+    assert "matched_length" not in BaseSegment._cached_property_names
+    assert "full_type_set" not in BaseSegment._cached_property_names
+
+
+def test__parser__base_segments_recalculate_caches_clears_all():
+    """Test that _recalculate_caches clears every @cached_property."""
+    template = TemplatedFile.from_string("foobar")
+    rs = RawSegment("foobar", PositionMarker(slice(0, 6), slice(0, 6), template))
+    bs = BaseSegment([rs])
+
+    # Populate caches by accessing them.
+    bs.is_code
+    bs.raw
+    bs._hash
+    assert "_hash" in bs.__dict__
+    assert "raw" in bs.__dict__
+    assert "is_code" in bs.__dict__
+
+    # Clear them.
+    bs._recalculate_caches()
+    assert "_hash" not in bs.__dict__
+    assert "raw" not in bs.__dict__
+    assert "is_code" not in bs.__dict__
+
+
+def test__parser__base_segments_pos_marker_invalidation(raw_seg):
+    """Test that reassigning pos_marker invalidates pos-dependent caches.
+
+    Regression test for issue #3855: _hash and is_templated both read
+    pos_marker, but only `segments` reassignment triggered cache
+    invalidation. After fixing, pos_marker reassignment should also
+    clear caches so stale values are not retained.
+    """
+    template = TemplatedFile.from_string("foobar")
+    seg = RawSegment("foobar", PositionMarker(slice(0, 6), slice(0, 6), template))
+
+    # Populate _hash cache.
+    old_hash = seg._hash
+    assert "_hash" in seg.__dict__
+
+    # Reassign pos_marker to a different source slice.
+    seg.pos_marker = PositionMarker(slice(6, 12), slice(6, 12), template)
+
+    # _hash should have been invalidated and recomputed with new slice.
+    assert "_hash" not in seg.__dict__
+    new_hash = seg._hash
+    assert new_hash != old_hash
+
+
+def test__parser__base_segments_copy_pos_marker_invalidation(raw_seg):
+    """Test that copy() + pos_marker reassignment doesn't keep stale caches.
+
+    This is the real-world path in _position_segments: copy inherits
+    cached values from the original, then pos_marker is reassigned.
+    The stale cache must be cleared.
+    """
+    template = TemplatedFile.from_string("foobar")
+    seg = RawSegment("foobar", PositionMarker(slice(0, 6), slice(0, 6), template))
+    original_hash = seg._hash
+
+    copied = seg.copy()
+    # copy() transfers cached values via __dict__.update.
+    assert copied._hash == original_hash
+
+    # Reassign pos_marker (as _position_segments does).
+    copied.pos_marker = PositionMarker(slice(6, 12), slice(6, 12), template)
+    assert copied._hash != original_hash
+
+
 def test__parser__base_segments_structural_simplify_with_position():
     """Test structural_simplify with 3-element tuple (with position)."""
     # This covers lines 603 and 614 in base.py


### PR DESCRIPTION
### Brief summary of the change made

Fixes #3855.

The hardcoded cache invalidation list in `_recalculate_caches()` had drifted: it included stale names (`matched_length`, `raw_segments_with_ancestors`, `full_type_set`) and missed `is_templated`. Separately, `pos_marker` reassignment didn't trigger cache invalidation, leaving `_hash` and `is_templated` stale after `_position_segments` during fixing.

- Auto-detect `@cached_property` names in `SegmentMetaclass` at class definition time
- Replace hardcoded list with the dynamic set
- Add `pos_marker` to `__setattr__` triggers in `BaseSegment` and `RawSegment`

### Are there any other side effects of this change that we should be aware of?

No user-facing behavior change. `is_templated` and `representation` are now correctly invalidated (previously missed). The three stale names were already no-ops to pop.

### AI assistance disclosure

AI assisted with investigation, patch drafting, and test writing. Final diff validated locally.

### Pull Request checklist

- [x] Included test cases in `test/core/parser/segments/segments_base_test.py` (4 new tests)
- [x] Verified tests: 50 segment tests, 125 linter tests, 2504 rule tests passed
- [x] No documentation change needed — internal correctness fix

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-detect cached property names and invalidate caches on `pos_marker` changes to prevent stale values during fixing. This replaces the drifting hardcoded list and keeps `_hash`, `is_templated`, and `representation` correct.

- **Bug Fixes**
  - Detect `@cached_property` names in `SegmentMetaclass` and use them in `_recalculate_caches()` instead of a hardcoded list.
  - Invalidate caches when `pos_marker` changes (`BaseSegment` and `RawSegment`) and when `segments` changes (`BaseSegment`).

<sup>Written for commit 27040e8e6099b0b18290a9c6f583ac2b048bd103. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8273?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

