### PR TITLE
New rule CV13: flag string literals concatenated with +

### DIFF
--- a/src/sqlfluff/rules/convention/CV13.py
+++ b/src/sqlfluff/rules/convention/CV13.py
@@ -14,6 +14,10 @@ from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
 # ``+`` *is* the concatenation operator.
 _ERRORING_DIALECTS = ("sparksql", "databricks")
 
+# Spark and Databricks also have raw string literals, written r'a', which lex to
+# their own segment type rather than to quoted_literal.
+_STRING_LITERALS = ("quoted_literal", "raw_quoted_literal")
+
 
 class Rule_CV13(BaseRule):
     """Do not use ``+`` to concatenate strings.
@@ -69,8 +73,8 @@ class Rule_CV13(BaseRule):
             if (
                 operator.is_type("binary_operator")
                 and operator.raw == "+"
-                and left.is_type("quoted_literal")
-                and right.is_type("quoted_literal")
+                and left.is_type(*_STRING_LITERALS)
+                and right.is_type(*_STRING_LITERALS)
             ):
                 results.append(
                     LintResult(

--- a/src/sqlfluff/rules/convention/CV13.py
+++ b/src/sqlfluff/rules/convention/CV13.py
@@ -1,0 +1,84 @@
+"""Implementation of Rule CV13."""
+
+from typing import Optional
+
+from sqlfluff.core.rules import BaseRule, LintResult, RuleContext
+from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
+
+# Dialects where ``+`` is not a string concatenation operator and the engine
+# rejects string operands outright rather than coercing them to numbers.
+#
+# This deliberately excludes the MySQL family (mysql, mariadb, doris,
+# starrocks), which coerces string literals to numbers instead of raising, so
+# ``'a' + 'b'`` is legal there and evaluates to 0. It also excludes tsql, where
+# ``+`` *is* the concatenation operator.
+_ERRORING_DIALECTS = ("sparksql", "databricks")
+
+
+class Rule_CV13(BaseRule):
+    """Do not use ``+`` to concatenate strings.
+
+    In most dialects ``+`` is arithmetic only, and applying it to string
+    operands is an error rather than concatenation. Spark and Databricks reject
+    it with ``DATATYPE_MISMATCH.BINARY_OP_WRONG_TYPE``, but the query still
+    parses, so the mistake is only found at runtime.
+
+    Only the unambiguous case is flagged, where both operands are string
+    literals. Deciding whether ``a + b`` concatenates or adds would require
+    knowing the types of ``a`` and ``b``, which is out of scope for a parser.
+
+    **Anti-pattern**
+
+    Using ``+`` to join two string literals.
+
+    .. code-block:: sql
+       :force:
+
+        SELECT 'a' + 'b' AS col
+        FROM foo;
+
+    **Best practice**
+
+    Use the dialect's concatenation operator, ``||``, or the ``CONCAT``
+    function.
+
+    .. code-block:: sql
+       :force:
+
+        SELECT 'a' || 'b' AS col
+        FROM foo;
+    """
+
+    name = "convention.string_concat"
+    groups = ("all", "convention")
+    crawl_behaviour = SegmentSeekerCrawler({"expression"})
+
+    def _eval(self, context: RuleContext) -> Optional[list[LintResult]]:
+        """Find ``+`` applied to two string literals."""
+        assert context.segment.is_type("expression")
+
+        if context.dialect.name not in _ERRORING_DIALECTS:
+            return None
+
+        # Whitespace, comments and meta segments are not code, so dropping them
+        # leaves the operands and operators adjacent to each other.
+        code = [seg for seg in context.segment.segments if seg.is_code]
+
+        results = []
+        for left, operator, right in zip(code, code[1:], code[2:]):
+            if (
+                operator.is_type("binary_operator")
+                and operator.raw == "+"
+                and left.is_type("quoted_literal")
+                and right.is_type("quoted_literal")
+            ):
+                results.append(
+                    LintResult(
+                        anchor=operator,
+                        description=(
+                            "Strings should be concatenated with '||', not '+'."
+                        ),
+                    )
+                )
+
+        return results or None

--- a/src/sqlfluff/rules/convention/__init__.py
+++ b/src/sqlfluff/rules/convention/__init__.py
@@ -78,6 +78,7 @@ def get_rules() -> list[type[BaseRule]]:
     from sqlfluff.rules.convention.CV10 import Rule_CV10
     from sqlfluff.rules.convention.CV11 import Rule_CV11
     from sqlfluff.rules.convention.CV12 import Rule_CV12
+    from sqlfluff.rules.convention.CV13 import Rule_CV13
 
     return [
         Rule_CV01,
@@ -92,4 +93,5 @@ def get_rules() -> list[type[BaseRule]]:
         Rule_CV10,
         Rule_CV11,
         Rule_CV12,
+        Rule_CV13,
     ]

--- a/test/fixtures/rules/std_rule_cases/CV13.yml
+++ b/test/fixtures/rules/std_rule_cases/CV13.yml
@@ -1,0 +1,84 @@
+rule: CV13
+
+test_fail_string_literals_concatenated_with_plus:
+  fail_str: |
+    SELECT 'a' + 'b' AS col
+    FROM foo
+  configs:
+    core:
+      dialect: databricks
+
+test_fail_chained_string_literals:
+  # every '+' joining two string literals is flagged, not just the first
+  fail_str: |
+    SELECT 'a' + 'b' + 'c' AS col
+    FROM foo
+  configs:
+    core:
+      dialect: databricks
+
+test_fail_sparksql:
+  fail_str: |
+    SELECT 'a' + 'b' AS col
+    FROM foo
+  configs:
+    core:
+      dialect: sparksql
+
+test_pass_pipe_concatenation:
+  pass_str: |
+    SELECT 'a' || 'b' AS col
+    FROM foo
+  configs:
+    core:
+      dialect: databricks
+
+test_pass_concat_function:
+  pass_str: |
+    SELECT CONCAT('a', 'b') AS col
+    FROM foo
+  configs:
+    core:
+      dialect: databricks
+
+test_pass_numeric_addition:
+  pass_str: |
+    SELECT 1 + 2 AS col
+    FROM foo
+  configs:
+    core:
+      dialect: databricks
+
+test_pass_column_operands_are_not_flagged:
+  # types are unknown, so this is deliberately left alone
+  pass_str: |
+    SELECT a + b AS col
+    FROM foo
+  configs:
+    core:
+      dialect: databricks
+
+test_pass_one_operand_is_a_column:
+  pass_str: |
+    SELECT 'a' + b AS col
+    FROM foo
+  configs:
+    core:
+      dialect: databricks
+
+test_pass_tsql_uses_plus_for_concatenation:
+  pass_str: |
+    SELECT 'a' + 'b' AS col
+    FROM foo
+  configs:
+    core:
+      dialect: tsql
+
+test_pass_mysql_coerces_strings_to_numbers:
+  # legal in mysql: evaluates to 0 rather than raising
+  pass_str: |
+    SELECT 'a' + 'b' AS col
+    FROM foo
+  configs:
+    core:
+      dialect: mysql

--- a/test/fixtures/rules/std_rule_cases/CV13.yml
+++ b/test/fixtures/rules/std_rule_cases/CV13.yml
@@ -82,3 +82,29 @@ test_pass_mysql_coerces_strings_to_numbers:
   configs:
     core:
       dialect: mysql
+
+test_fail_raw_string_literals:
+  # spark/databricks raw strings lex as raw_quoted_literal, not quoted_literal
+  fail_str: |
+    SELECT r'a' + r'b' AS col
+    FROM foo
+  configs:
+    core:
+      dialect: databricks
+
+test_fail_mixed_raw_and_plain_literals:
+  fail_str: |
+    SELECT r'a' + 'b' AS col
+    FROM foo
+  configs:
+    core:
+      dialect: databricks
+
+test_pass_mariadb_coerces_strings_to_numbers:
+  # same coercion as mysql, which mariadb inherits from
+  pass_str: |
+    SELECT 'a' + 'b' AS col
+    FROM foo
+  configs:
+    core:
+      dialect: mariadb


### PR DESCRIPTION
### Brief summary of the change made

Fixes #6616.

`SELECT 'a' + 'b'` parses cleanly on databricks and sparksql today, but the engine rejects it at runtime:

```
[DATATYPE_MISMATCH.BINARY_OP_WRONG_TYPE] Cannot resolve "(a + b)" due to data type mismatch:
the binary operator requires the input type ("NUMERIC" or "INTERVAL DAY TO SECOND" or
"INTERVAL YEAR TO MONTH" or "INTERVAL"), not "STRING". SQLSTATE: 42K09
```

This adds rule **CV13** (`convention.string_concat`), which flags `+` when both operands are string literals.

I followed the scoping @peterbud set out in https://github.com/sqlfluff/sqlfluff/issues/6616#issuecomment-4360180000: full detection needs semantic type analysis and is out of scope, changing `Expression_A_Grammar` globally is high risk, and a targeted rule for the clear literal cases is the pragmatic fix. So only the unambiguous shape is flagged. `a + b` and `'a' + b` are deliberately left alone, since deciding those needs the operand types.

### Dialect scope

The rule is limited to `sparksql` and `databricks`, which is where the issue was reported and where the engine errors.

Two exclusions are deliberate, and I would rather state the reasoning than have it look like an oversight:

- **tsql** is excluded because `+` *is* its concatenation operator. I checked every bundled dialect and tsql is the only one whose `ConcatSegment` resolves to `PlusSegment`; the other 27 resolve to `PipeSegment`.
- **The mysql family** (`mysql`, `mariadb`, `doris`, `starrocks`) is excluded because it coerces string literals to numbers rather than raising, so `'a' + 'b'` is legal there and evaluates to `0`. Flagging it would be a false positive.

That leaves other dialects such as postgres and snowflake, where `'a' + 'b'` is also an error, currently unflagged. Widening the list is a one-line change and I am happy to do it in this PR. I kept it narrow because I could only verify the runtime behaviour for the dialects named in the issue, and I did not want to assert error semantics for engines I had not confirmed.

### Are there any other side effects of this change that we should be aware of?

CV13 is a new rule code, so it is picked up by the `all` and `convention` groups and will start reporting on existing spark and databricks code that uses `+` between two string literals. That is the intent of the issue, and every such case is a genuine runtime error, but it is new output for those users.

No existing rule or grammar is touched, so no other dialect or rule changes behaviour.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - [x] `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
- [x] Added appropriate documentation for the change.
- [ ] Created GitHub issues for any relevant followup/future enhancements if appropriate.

`test/fixtures/rules/std_rule_cases/CV13.yml` covers 10 cases: the failing shape on databricks and sparksql, a chained `'a' + 'b' + 'c'` that flags both operators, and passes for `||`, `CONCAT(...)`, numeric addition, column operands, a mixed literal/column pair, tsql, and mysql.

```
$ pytest test/rules/ test/core/rules/
2641 passed, 104 skipped
```

`ruff check`, `ruff format`, `mypy` and `yamllint` are all clean on the changed files.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds rule CV13 (`convention.string_concat`) to flag use of `+` between two string literals (including raw strings) in `sparksql` and `databricks`, preventing runtime DATATYPE_MISMATCH errors.

- **New Features**
  - Detects `+` when both operands are string literals (`quoted_literal` or `raw_quoted_literal`).
  - Limited to `sparksql` and `databricks`.
  - Excludes `tsql` (uses `+` for concat) and MySQL family (`mysql`, `mariadb`, `doris`, `starrocks`) which coerces strings to numbers.
  - Allows `||`, `CONCAT(...)`, numeric addition, and cases with unknown types.

- **Migration**
  - Included in `all` and `convention` groups; Spark/Databricks projects may see new lint errors for `'a' + 'b'`.
  - No changes to other rules or dialects.

<sup>Written for commit 0cb13b7db86c4e1c3280ce80a02f65963e1d4ed6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8275?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


### AI-assisted contribution disclosure

Flagged by the bot above, and it is right to ask. Per CONTRIBUTING: this PR was written with the help of an AI coding assistant, and I remain responsible for it.

**AI-assisted:** drafting the rule implementation, the fixture file, and this description.

**Verified by me, not taken on trust:**

- Reproduced the reported bug first: `SELECT 'a' + 'b'` produces no violation on `databricks` and `sparksql` before the change.
- Established the dialect scope empirically rather than guessing, by walking every bundled dialect's `ConcatSegment` grammar. `tsql` is the only one of the 28 that resolves to `PlusSegment`; the other 27 resolve to `PipeSegment`. That is why `tsql` is excluded.
- Excluded the mysql family deliberately, because it coerces string literals to numbers rather than raising, so `'a' + 'b'` is legal there and evaluates to `0`. Flagging it would be a false positive.
- Scoped the rule to the literal-only case, following the direction @peterbud gave in #6616: full detection needs semantic type analysis and is out of scope, and a global `Expression_A_Grammar` change would be high risk.
- Ran `pytest test/rules/`: 2517 passed, 101 skipped. `ruff check`, `ruff format`, `mypy` and `yamllint` all clean.
- When the automated review found that `r'a' + r'b'` was being missed, I confirmed it against the parse tree (`raw_quoted_literal`, not `quoted_literal`), fixed it, and added fixtures for the raw and mixed cases.

**Known limits I would rather state than have found in review:** the dialect list is a judgement call. Postgres and snowflake also reject `'a' + 'b'` and are currently unflagged, because I could only confirm runtime behaviour for the dialects named in the issue and did not want to assert error semantics for engines I had not checked. Widening it is a one-line change if you want it broader.
