### PR TITLE
test(ST06): pin reordering of a qualified reference with a parameterised cast

### DIFF
--- a/test/fixtures/rules/std_rule_cases/ST06.yml
+++ b/test/fixtures/rules/std_rule_cases/ST06.yml
@@ -415,3 +415,34 @@ test_pass_create_view_with_explicit_quoted_columns_clickhouse:
       TRY_CAST(e.id AS INT) AS eid,
       e.dept
     FROM employees e
+
+test_fail_fix_qualified_reference_with_parameterised_cast_snowflake:
+  # Regression test for #7192. The existing `::` cases cover simple targets
+  # (`b::int`, `'a'::varchar`); this pins the combination that was reported as
+  # unfixable: a function call wrapping a qualified reference, cast to a
+  # parameterised type.
+  configs:
+    core:
+      dialect: snowflake
+  fail_str: |
+    select
+      de.a,
+      de.ordered,
+      *,
+      case when b > 0 then 'pos' else 'non_pos' end as b_label,
+      coalesce(b, 0) as b_coalesced,
+      COALESCE(de.ordered, 0)::NUMBER(38, 4) AS ordered,
+      c
+    from tbl
+  line_numbers: [1]
+
+  fix_str: |
+    select
+      *,
+      de.a,
+      de.ordered,
+      c,
+      case when b > 0 then 'pos' else 'non_pos' end as b_label,
+      coalesce(b, 0) as b_coalesced,
+      COALESCE(de.ordered, 0)::NUMBER(38, 4) AS ordered
+    from tbl


### PR DESCRIPTION
### Brief summary of the change made

Closes #7192.

That issue reports that ST06's fixer will not reorder a calculated target combining a qualified reference with a Snowflake `::` cast. It no longer reproduces on current `main`, so this adds the regression test rather than a code change.

Worth recording what the old behaviour actually was, because it is slightly different from the report. On 3.1.1, the version named in the issue, the fixer did move the target, but sorted it in with the *simple* targets:

```sql
-- sqlfluff 3.1.1, fix --rules ST06 --dialect snowflake
select
*,
de.a,
de.ordered,
COALESCE(de.ordered, 0)::NUMBER(38, 4) AS ordered,   -- grouped with the simple targets
c,
case when b > 0 then 'pos' else 'non_pos' end as b_label,
coalesce(b, 0) as b_coalesced
from tbl;
```

On current `main` it is classified as a calculation and sorted last, which is what the rule documents:

```sql
select
*,
de.a,
de.ordered,
c,
case when b > 0 then 'pos' else 'non_pos' end as b_label,
coalesce(b, 0) as b_coalesced,
COALESCE(de.ordered, 0)::NUMBER(38, 4) AS ordered
from tbl;
```

So this was a misclassification rather than the fixer refusing to move the target.

### Why a test is worth adding

`ST06.yml` already covers `::` casts, but only simple ones: `b::int`, `2::int + 4`, `'a'::varchar`, `1::bigint`. It also has no snowflake cases at all; the configured dialects are tsql, bigquery and clickhouse.

Nothing covered the combination in the issue, which is a function call wrapping a *qualified* reference, cast to a *parameterised* type. Since the halves are covered separately but never together, the reported shape could regress without any test failing. The new case uses the exact SQL from the issue.

I was not able to identify the commit that fixed it. The behaviour changed somewhere between 3.1.1 and 4.2.2, and I did not bisect, so I would rather not guess at a cause in the commit message.

### Are there any other side effects of this change that we should be aware of?

None. This adds one case to `ST06.yml` and changes no source.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - [x] `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
- [x] Added appropriate documentation for the change.
- [ ] Created GitHub issues for any relevant followup/future enhancements if appropriate.

```
$ pytest test/rules/yaml_test_cases_test.py -k ST06
28 passed
```

`yamllint` is clean on the changed file.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a regression test in `ST06.yml` for the Snowflake dialect to pin reordering when `COALESCE(de.ordered, 0)::NUMBER(38, 4)` appears as a target. Ensures ST06 classifies it as a calculation and sorts it last; closes #7192.

<sup>Written for commit 2f1883b29c680d2928c3455199482cff5aabceaf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8276?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


### AI-assisted contribution disclosure

Flagged by the bot above. Per CONTRIBUTING: this PR was written with the help of an AI coding assistant, and I remain responsible for it.

**AI-assisted:** drafting the fixture case and this description.

**Verified by me, not taken on trust:**

- Confirmed the issue no longer reproduces on current `main` by running `sqlfluff fix --rules ST06 --dialect snowflake` against the exact SQL from the report.
- Installed sqlfluff 3.1.1, the version named in the issue, and ran the same command, which is how I found that the original behaviour was a misclassification rather than the fixer refusing to move the target. That correction is in the description above.
- Audited the existing coverage before claiming a gap: `ST06.yml` has `::` casts, but only simple ones, and no snowflake cases at all.
- Ran `pytest test/rules/yaml_test_cases_test.py -k ST06`: 28 passed. `yamllint` clean.

I did not identify the commit that fixed the underlying behaviour and said so in the description rather than guessing at one.
