### PR TITLE
feat: support custom Jinja delimiters for Snowflake CLI

### DIFF
--- a/docs/source/configuration/setting_configuration.rst
+++ b/docs/source/configuration/setting_configuration.rst
@@ -51,6 +51,13 @@ supported cfg file types):
 
     [sqlfluff:templater:jinja]
     apply_dbt_builtins = True
+    # Custom Jinja delimiters (optional, defaults shown)
+    # variable_start_string = {{
+    # variable_end_string = }}
+    # block_start_string = {%
+    # block_end_string = %}
+    # comment_start_string = {#
+    # comment_end_string = #}
 
 For the `pyproject.toml file`_, all valid sections start with
 :code:`tool.sqlfluff` and subsections are delimited by a dot. For example the
@@ -75,6 +82,13 @@ For example, a snippet from a :code:`pyproject.toml` file:
 
     [tool.sqlfluff.templater.jinja]
     apply_dbt_builtins = true
+    # Custom Jinja delimiters (optional, defaults shown)
+    # variable_start_string = "{{"
+    # variable_end_string = "}}"
+    # block_start_string = "{%"
+    # block_end_string = "%}"
+    # comment_start_string = "{#"
+    # comment_end_string = "#}"
 
     # For rule specific configuration, use dots between the names exactly
     # as you would in .sqlfluff. In the background, SQLFluff will unpack the

--- a/docs/source/configuration/templating/jinja.rst
+++ b/docs/source/configuration/templating/jinja.rst
@@ -56,6 +56,33 @@ options:
     library_path = sqlfluff_libs
     exclude_macros_from_path = my_macros_exclude
 
+Custom Jinja Delimiters
+"""""""""""""""""""""""
+
+By default, Jinja uses ``{{ }}`` for variables, ``{% %}`` for blocks, and
+``{# #}`` for comments. Some tools use different delimiters — for example,
+`Snowflake CLI <https://docs.snowflake.com/en/developer-guide/snowflake-cli/project-definitions/use-sql-variables>`_
+uses ``<% varname %>`` for variable substitution.
+
+SQLFluff exposes Jinja's delimiter config options so you can lint files
+that use non-standard delimiters:
+
+.. code-block:: cfg
+
+    [sqlfluff:templater:jinja]
+    variable_start_string = <%
+    variable_end_string = %>
+
+All six Jinja delimiter options are supported:
+
+- ``variable_start_string`` / ``variable_end_string`` (default: ``{{ }}``)
+- ``block_start_string`` / ``block_end_string`` (default: ``{% %}``)
+- ``comment_start_string`` / ``comment_end_string`` (default: ``{# #}``)
+
+Each can be set independently. Unset options fall back to Jinja defaults.
+
+.. code-block:: cfg
+
     [sqlfluff:templater:jinja:context]
     my_list = ['a', 'b', 'c']
     MY_LIST = ("d", "e", "f")

--- a/docsv/configuration/index.md
+++ b/docsv/configuration/index.md
@@ -33,6 +33,13 @@ unwrap_wrapped_queries = True
 
 [sqlfluff:templater:jinja]
 apply_dbt_builtins = True
+# Custom Jinja delimiters (optional, defaults shown)
+# variable_start_string = {{
+# variable_end_string = }}
+# block_start_string = {%
+# block_end_string = %}
+# comment_start_string = {#
+# comment_end_string = #}
 ```
 
 For the [pyproject.toml file](https://www.python.org/dev/peps/pep-0518/), all valid sections start with `tool.sqlfluff` and subsections are delimited by a dot. For example the *jinjacontext* section will be indicated in the section started with `[tool.sqlfluff.jinjacontext]`.
@@ -54,6 +61,13 @@ unwrap_wrapped_queries = true
 
 [tool.sqlfluff.templater.jinja]
 apply_dbt_builtins = true
+# Custom Jinja delimiters (optional, defaults shown)
+# variable_start_string = "{{"
+# variable_end_string = "}}"
+# block_start_string = "{%"
+# block_end_string = "%}"
+# comment_start_string = "{#"
+# comment_end_string = "#}"
 
 # For rule specific configuration, use dots between the names exactly
 # as you would in .sqlfluff. In the background, SQLFluff will unpack the

--- a/docsv/configuration/templating/jinja.md
+++ b/docsv/configuration/templating/jinja.md
@@ -41,6 +41,30 @@ my_where_dict = {"field_1": 1, "field_2": 2}
 a_macro_def = {% macro my_macro(n) %}{{ n }} + {{ n * 2 }}{% endmacro %}
 ```
 
+## Custom Jinja Delimiters
+
+By default, Jinja uses `{{ }}` for variables, `{% %}` for blocks, and
+`{# #}` for comments. Some tools use different delimiters — for example,
+[Snowflake CLI](https://docs.snowflake.com/en/developer-guide/snowflake-cli/project-definitions/use-sql-variables)
+uses `<% varname %>` for variable substitution.
+
+SQLFluff exposes Jinja's delimiter config options so you can lint files
+that use non-standard delimiters:
+
+```ini
+[sqlfluff:templater:jinja]
+variable_start_string = <%
+variable_end_string = %>
+```
+
+All six Jinja delimiter options are supported:
+
+- `variable_start_string` / `variable_end_string` (default: `{{ }}`)
+- `block_start_string` / `block_end_string` (default: `{% %}`)
+- `comment_start_string` / `comment_end_string` (default: `{# #}`)
+
+Each can be set independently. Unset options fall back to Jinja defaults.
+
 ## Complex Jinja Variable Templating
 
 Apart from the Generic variable templating that is supported for all

--- a/src/sqlfluff/core/templaters/jinja.py
+++ b/src/sqlfluff/core/templaters/jinja.py
@@ -397,6 +397,29 @@ class JinjaTemplater(PythonTemplater):
                 line_pos=pos,
             )
 
+    def _get_jinja_env_kwargs(self, config: Optional[FluffConfig]) -> dict[str, str]:
+        """Read optional Jinja delimiter overrides from config.
+
+        Returns a dict of kwargs to splat into SandboxedEnvironment.
+        All keys are optional; absent keys fall back to Jinja defaults
+        (``{{ }}`` for variables, ``{% %}`` for blocks).
+        """
+        kwargs: dict[str, str] = {}
+        if not config:
+            return kwargs
+        for key in (
+            "variable_start_string",
+            "variable_end_string",
+            "block_start_string",
+            "block_end_string",
+            "comment_start_string",
+            "comment_end_string",
+        ):
+            val = config.get_section((self.templater_selector, self.name, key))
+            if val is not None:
+                kwargs[key] = val
+        return kwargs
+
     def _get_jinja_env(self, config: Optional[FluffConfig] = None) -> Environment:
         """Get a properly configured jinja environment.
 
@@ -457,6 +480,7 @@ class JinjaTemplater(PythonTemplater):
             autoescape=False,
             extensions=extensions,
             loader=loader,
+            **self._get_jinja_env_kwargs(config),
         )
 
     def _get_macros_path(
@@ -769,6 +793,7 @@ class JinjaTemplater(PythonTemplater):
         if (
             in_str
             and not re.search(r"\{[{%#]", in_str)
+            and not self._get_jinja_env_kwargs(config)
             and not self._get_macros_path(config, "load_macros_from_path")
             and not config.get_section((self.templater_selector, self.name, "macros"))
             and not config.get("library_path")
@@ -872,7 +897,7 @@ class JinjaTemplater(PythonTemplater):
 
         templater_logger.info("Slicing File Template")
         templater_logger.debug("    Raw String: %r", raw_str[:80])
-        analyzer = self._get_jinja_analyzer(raw_str, self._get_jinja_env())
+        analyzer = self._get_jinja_analyzer(raw_str, self._get_jinja_env(config))
         tracer = analyzer.analyze(render_func)
         trace = tracer.trace(append_to_templated=append_to_templated)
         return trace.raw_sliced, trace.sliced_file, trace.templated_str
@@ -970,6 +995,7 @@ class JinjaTemplater(PythonTemplater):
         in_str: str,
         render_func: Callable[[str], str],
         uncovered_slices: set[int],
+        config: Optional[FluffConfig] = None,
         append_to_templated: str = "",
     ) -> Iterator[tuple[list[RawFileSlice], list[TemplatedFileSlice], str]]:
         """Address uncovered slices by tweaking the template to hit them.
@@ -982,10 +1008,13 @@ class JinjaTemplater(PythonTemplater):
                 slices we'll attempt to hit by modifying the template. NOTE: These are
                 indices in the _sequence of slices_, not _character indices_ in the
                 raw source file.
+            config (:obj:`FluffConfig`, optional): Config so the analyzer uses the
+                configured Jinja delimiters when building variants.
             append_to_templated (:obj:`str`, optional): Optional string to append
                 to the templated file.
         """
-        analyzer = self._get_jinja_analyzer(in_str, self._get_jinja_env())
+        env = self._get_jinja_env(config)
+        analyzer = self._get_jinja_analyzer(in_str, env)
         tracer_copy = analyzer.analyze(render_func)
 
         max_variants_generated = 10
@@ -1016,7 +1045,10 @@ class JinjaTemplater(PythonTemplater):
                     # hardcoded value that hits the target slice in the template
                     # (here that is options[0]).
                     new_value = "True" if options[0] == branch + 1 else "False"
-                    new_source = f"{{% {raw_file_slice.tag} {new_value} %}}"
+                    new_source = (
+                        f"{env.block_start_string} {raw_file_slice.tag} "
+                        f"{new_value} {env.block_end_string}"
+                    )
                     tracer_trace.raw_slice_info[
                         raw_file_slice
                     ].alternate_code = new_source
@@ -1040,9 +1072,7 @@ class JinjaTemplater(PythonTemplater):
             # those.
             variant_raw_str = "".join(variant_key)
             if variant_raw_str not in variants:
-                analyzer = self._get_jinja_analyzer(
-                    variant_raw_str, self._get_jinja_env()
-                )
+                analyzer = self._get_jinja_analyzer(variant_raw_str, env)
                 tracer_trace = analyzer.analyze(render_func)
                 try:
                     trace = tracer_trace.trace(
@@ -1153,7 +1183,7 @@ class JinjaTemplater(PythonTemplater):
         _, _, render_func = self.construct_render_func(fname=fname, config=config)
 
         for raw_sliced, sliced_file, templated_str in self._handle_unreached_code(
-            in_str, render_func, uncovered_literal_idxs
+            in_str, render_func, uncovered_literal_idxs, config=config
         ):
             yield (
                 TemplatedFile(

--- a/src/sqlfluff/core/templaters/slicers/tracer.py
+++ b/src/sqlfluff/core/templaters/slicers/tracer.py
@@ -274,13 +274,32 @@ class JinjaTagConfiguration:
 class JinjaAnalyzer:
     """Analyzes a Jinja template to prepare for tracing."""
 
-    re_open_tag = regex.compile(r"^\s*({[{%])[\+\-]?\s*")
-    re_close_tag = regex.compile(r"\s*[\+\-]?([}%]})\s*$")
-
     def __init__(self, raw_str: str, env: Environment) -> None:
         # Input
         self.raw_str: str = raw_str
         self.env = env
+        open_alts = sorted(
+            {
+                env.variable_start_string,
+                env.block_start_string,
+                env.comment_start_string,
+            },
+            key=len,
+            reverse=True,
+        )
+        close_alts = sorted(
+            {
+                env.variable_end_string,
+                env.block_end_string,
+                env.comment_end_string,
+            },
+            key=len,
+            reverse=True,
+        )
+        open_pat = "|".join(regex.escape(s) for s in open_alts)
+        close_pat = "|".join(regex.escape(s) for s in close_alts)
+        self.re_open_tag = regex.compile(rf"^\s*({open_pat})[\+\-]?\s*")
+        self.re_close_tag = regex.compile(rf"\s*[\+\-]?({close_pat})\s*$")
 
         # Output
         self.raw_sliced: list[RawFileSlice] = []

--- a/src/sqlfluff/rules/jinja/JJ01.py
+++ b/src/sqlfluff/rules/jinja/JJ01.py
@@ -44,41 +44,41 @@ class Rule_JJ01(BaseRule):
     is_fix_compatible = True
 
     @staticmethod
-    def _get_whitespace_ends(s: str) -> tuple[str, str, str, str, str]:
+    def _get_whitespace_ends(
+        s: str, open_delim: str, close_delim: str
+    ) -> tuple[str, str, str, str, str]:
         """Remove tag ends and partition off any whitespace ends.
 
         This function assumes that we've already trimmed the string
         to just the tag, and will raise an AssertionError if not.
-        >>> Rule_JJ01._get_whitespace_ends('  {{not_trimmed}}   ')
+        >>> Rule_JJ01._get_whitespace_ends('  {{not_trimmed}}   ', '{{', '}}')
         Traceback (most recent call last):
             ...
         AssertionError
 
         In essence it divides up a tag into the end tokens, any
         leading or trailing whitespace and the inner content
-        >>> Rule_JJ01._get_whitespace_ends('{{ my_content }}')
+        >>> Rule_JJ01._get_whitespace_ends('{{ my_content }}', '{{', '}}')
         ('{{', ' ', 'my_content', ' ', '}}')
 
         It also works with block tags and more complicated content
         and end markers.
-        >>> Rule_JJ01._get_whitespace_ends('{%+if a + b is True     -%}')
+        >>> Rule_JJ01._get_whitespace_ends('{%+if a + b is True     -%}', '{%', '%}')
         ('{%+', '', 'if a + b is True', '     ', '-%}')
         """
-        assert s[0] == "{" and s[-1] == "}"
-        # Jinja tags all have a length of two. We can use slicing
-        # to remove them easily.
-        main = s[2:-2]
-        pre = s[:2]
-        post = s[-2:]
-        # Optionally Jinja tags may also have plus of minus notation
-        # https://jinja2docs.readthedocs.io/en/stable/templates.html#whitespace-control
+        assert s.startswith(open_delim) and s.endswith(close_delim)
+        pre_len = len(open_delim)
+        post_len = len(close_delim)
+        main = s[pre_len:-post_len]
+        pre = s[:pre_len]
+        post = s[-post_len:]
         modifier_chars = ["+", "-"]
         if main and main[0] in modifier_chars:
             main = main[1:]
-            pre = s[:3]
+            pre = s[: pre_len + 1]
         if main and main[-1] in modifier_chars:
             main = main[:-1]
-            post = s[-3:]
+            post = s[-(post_len + 1) :]
         inner = main.strip()
         pos = main.find(inner)
         return pre, main[:pos], inner, main[pos + len(inner) :], post
@@ -133,6 +133,31 @@ class Rule_JJ01(BaseRule):
             self.logger.debug(f"Detected non-jinja templater: {_templater_class.name}")
             return []
 
+        # Read the configured Jinja delimiters so we can match tags
+        # that use custom delimiters (e.g. Snowflake CLI's <% var %>).
+        delimiters = set()
+        for key in (
+            "variable_start_string",
+            "block_start_string",
+            "comment_start_string",
+        ):
+            val = context.config.get_section(("templater", "jinja", key))
+            if val:
+                delimiters.add(val)
+        # Default Jinja delimiters
+        open_delims = delimiters or {"{{", "{%", "{#"}
+        close_delims = set()
+        for key in (
+            "variable_end_string",
+            "block_end_string",
+            "comment_end_string",
+        ):
+            val = context.config.get_section(("templater", "jinja", key))
+            if val:
+                close_delims.add(val)
+        if not close_delims:
+            close_delims = {"}}", "%}", "#}"}
+
         results = []
         # Work through the templated slices
         for raw_slice in context.templated_file.raw_sliced:
@@ -141,7 +166,23 @@ class Rule_JJ01(BaseRule):
                 continue
 
             stripped = raw_slice.raw.strip()
-            if not stripped or stripped[0] != "{" or stripped[-1] != "}":
+            if not stripped:
+                continue  # pragma: no cover
+
+            # Match against any of the configured opening/closing delimiters
+            open_delim = None
+            close_delim = None
+            for d in open_delims:
+                if stripped.startswith(d):
+                    open_delim = d
+                    break
+            if open_delim:
+                for d in close_delims:
+                    if stripped.endswith(d):
+                        close_delim = d
+                        break
+
+            if not open_delim or not close_delim:
                 continue  # pragma: no cover
 
             self.logger.debug(
@@ -151,7 +192,7 @@ class Rule_JJ01(BaseRule):
             # Partition and Position
             src_idx = raw_slice.source_idx
             tag_pre, ws_pre, inner, ws_post, tag_post = self._get_whitespace_ends(
-                stripped
+                stripped, open_delim, close_delim
             )
             position = raw_slice.raw.find(stripped[0])
 

--- a/src/sqlfluff/rules/jinja/JJ01.py
+++ b/src/sqlfluff/rules/jinja/JJ01.py
@@ -135,28 +135,26 @@ class Rule_JJ01(BaseRule):
 
         # Read the configured Jinja delimiters so we can match tags
         # that use custom delimiters (e.g. Snowflake CLI's <% var %>).
-        delimiters = set()
-        for key in (
-            "variable_start_string",
-            "block_start_string",
-            "comment_start_string",
-        ):
-            val = context.config.get_section(("templater", "jinja", key))
-            if val:
-                delimiters.add(val)
-        # Default Jinja delimiters
-        open_delims = delimiters or {"{{", "{%", "{#"}
-        close_delims = set()
-        for key in (
-            "variable_end_string",
-            "block_end_string",
-            "comment_end_string",
-        ):
-            val = context.config.get_section(("templater", "jinja", key))
-            if val:
-                close_delims.add(val)
-        if not close_delims:
-            close_delims = {"}}", "%}", "#}"}
+        # Build (open, close) pairs, preserving Jinja defaults for any
+        # option that isn't explicitly overridden. This lets custom
+        # variable delimiters coexist with default block/comment tags.
+        default_pairs = {
+            "variable": ("{{", "}}"),
+            "block": ("{%", "%}"),
+            "comment": ("{#", "#}"),
+        }
+        delim_pairs: list[tuple[str, str]] = []
+        for kind, (d_open, d_close) in default_pairs.items():
+            open_val = context.config.get_section(
+                ("templater", "jinja", f"{kind}_start_string")
+            )
+            close_val = context.config.get_section(
+                ("templater", "jinja", f"{kind}_end_string")
+            )
+            delim_pairs.append((open_val or d_open, close_val or d_close))
+        # Match longest open delimiters first so a shorter prefix (e.g. "<")
+        # can't shadow a longer one (e.g. "<%") that also starts the tag.
+        delim_pairs.sort(key=lambda p: len(p[0]), reverse=True)
 
         results = []
         # Work through the templated slices
@@ -169,18 +167,14 @@ class Rule_JJ01(BaseRule):
             if not stripped:
                 continue  # pragma: no cover
 
-            # Match against any of the configured opening/closing delimiters
+            # Match the tag against a delimiter pair (open and close together)
             open_delim = None
             close_delim = None
-            for d in open_delims:
-                if stripped.startswith(d):
-                    open_delim = d
+            for d_open, d_close in delim_pairs:
+                if stripped.startswith(d_open) and stripped.endswith(d_close):
+                    open_delim = d_open
+                    close_delim = d_close
                     break
-            if open_delim:
-                for d in close_delims:
-                    if stripped.endswith(d):
-                        close_delim = d
-                        break
 
             if not open_delim or not close_delim:
                 continue  # pragma: no cover

--- a/test/core/templaters/jinja_test.py
+++ b/test/core/templaters/jinja_test.py
@@ -2087,10 +2087,7 @@ def test__templater_jinja_dotted_context_config():
 
 
 def test__templater_jinja_custom_variable_delimiters():
-    """Test custom variable delimiters (e.g. Snowflake CLI <% var %>).
-
-    See issue #7598: Snowflake CLI uses <% varname %> instead of {{ varname }}.
-    """
+    """Test custom variable delimiters (e.g. Snowflake CLI <% var %>)."""
     config = FluffConfig.from_string(
         "[sqlfluff]\n"
         "dialect = snowflake\n"
@@ -2107,10 +2104,7 @@ def test__templater_jinja_custom_variable_delimiters():
 
 
 def test__templater_jinja_custom_block_delimiters():
-    """Test custom block delimiters for control flow.
-
-    See issue #7598: users may want to override {% %} delimiters too.
-    """
+    """Test custom block delimiters for control flow."""
     config = FluffConfig.from_string(
         "[sqlfluff]\n"
         "dialect = ansi\n"
@@ -2129,13 +2123,7 @@ def test__templater_jinja_custom_block_delimiters():
 
 
 def test__templater_jinja_custom_block_delimiters_variants():
-    """Test that variant generation respects custom block delimiters.
-
-    See issue #7598: variant generation in _handle_unreached_code() must
-    use the configured delimiters when building override tags, otherwise
-    custom-delimiter templates with unreached conditional branches
-    produce invalid variants.
-    """
+    """Test variant generation respects custom block delimiters."""
     config = FluffConfig.from_string(
         "[sqlfluff]\n"
         "dialect = ansi\n"
@@ -2151,12 +2139,7 @@ def test__templater_jinja_custom_block_delimiters_variants():
     variants = list(
         t.process_with_variants(in_str=instr, fname="test.sql", config=config)
     )
-    # First variant: flag is False, so SELECT 2
     assert str(variants[0][0]) == "SELECT 2"
-    # A variant should be generated that forces the unreached True branch,
-    # producing SELECT 1. This proves the override tag used the configured
-    # <% %> delimiters — if it had used default {% %}, the variant would
-    # fail to parse and no SELECT 1 variant would appear.
     variant_outputs = {str(v[0]) for v in variants}
     assert "SELECT 1" in variant_outputs
     assert "SELECT 2" in variant_outputs

--- a/test/core/templaters/jinja_test.py
+++ b/test/core/templaters/jinja_test.py
@@ -2084,3 +2084,79 @@ def test__templater_jinja_dotted_context_config():
 
     # The template should render with the nested values
     assert str(outstr) == "SELECT * FROM `myproject.prod_test.table`"
+
+
+def test__templater_jinja_custom_variable_delimiters():
+    """Test custom variable delimiters (e.g. Snowflake CLI <% var %>).
+
+    See issue #7598: Snowflake CLI uses <% varname %> instead of {{ varname }}.
+    """
+    config = FluffConfig.from_string(
+        "[sqlfluff]\n"
+        "dialect = snowflake\n"
+        "templater = jinja\n"
+        "[sqlfluff:templater:jinja]\n"
+        "variable_start_string = <%\n"
+        "variable_end_string = %>\n"
+    )
+    t = JinjaTemplater(override_context=dict(table_name="my_table", identifier="42"))
+    instr = "SELECT * FROM <% table_name %> WHERE id = <% identifier %>\n"
+    outstr, vs = t.process(in_str=instr, fname="test.sql", config=config)
+    assert str(outstr) == "SELECT * FROM my_table WHERE id = 42\n"
+    assert len(vs) == 0
+
+
+def test__templater_jinja_custom_block_delimiters():
+    """Test custom block delimiters for control flow.
+
+    See issue #7598: users may want to override {% %} delimiters too.
+    """
+    config = FluffConfig.from_string(
+        "[sqlfluff]\n"
+        "dialect = ansi\n"
+        "templater = jinja\n"
+        "[sqlfluff:templater:jinja]\n"
+        "block_start_string = <%\n"
+        "block_end_string = %>\n"
+        "variable_start_string = <<\n"
+        "variable_end_string = >>\n"
+    )
+    t = JinjaTemplater(override_context=dict(cols=["a", "b", "c"]))
+    instr = "<% for c in cols %> << c >><% if not loop.last %>, <% endif %><% endfor %>"
+    outstr, vs = t.process(in_str=instr, fname="test.sql", config=config)
+    assert str(outstr) == " a,  b,  c"
+    assert len(vs) == 0
+
+
+def test__templater_jinja_custom_block_delimiters_variants():
+    """Test that variant generation respects custom block delimiters.
+
+    See issue #7598: variant generation in _handle_unreached_code() must
+    use the configured delimiters when building override tags, otherwise
+    custom-delimiter templates with unreached conditional branches
+    produce invalid variants.
+    """
+    config = FluffConfig.from_string(
+        "[sqlfluff]\n"
+        "dialect = ansi\n"
+        "templater = jinja\n"
+        "[sqlfluff:templater:jinja]\n"
+        "block_start_string = <%\n"
+        "block_end_string = %>\n"
+        "variable_start_string = <<\n"
+        "variable_end_string = >>\n"
+    )
+    t = JinjaTemplater(override_context=dict(flag=False))
+    instr = "<% if flag %>SELECT 1<% else %>SELECT 2<% endif %>"
+    variants = list(
+        t.process_with_variants(in_str=instr, fname="test.sql", config=config)
+    )
+    # First variant: flag is False, so SELECT 2
+    assert str(variants[0][0]) == "SELECT 2"
+    # A variant should be generated that forces the unreached True branch,
+    # producing SELECT 1. This proves the override tag used the configured
+    # <% %> delimiters — if it had used default {% %}, the variant would
+    # fail to parse and no SELECT 1 variant would appear.
+    variant_outputs = {str(v[0]) for v in variants}
+    assert "SELECT 1" in variant_outputs
+    assert "SELECT 2" in variant_outputs

--- a/test/rules/std_JJ01_test.py
+++ b/test/rules/std_JJ01_test.py
@@ -40,3 +40,23 @@ def test_lint_jj01_pickled_config():
     # Check we successfully got the right results.
     assert len(linting_errors) == 1
     assert linting_errors[0].check_tuple() == ("JJ01", 3, 15)
+
+
+def test_lint_jj01_custom_delimiters():
+    """Test JJ01 works with custom Jinja delimiters."""
+    sql = "SELECT * FROM <%foo%>"
+    config = FluffConfig.from_string(
+        "[sqlfluff]\n"
+        "dialect = ansi\n"
+        "rules = JJ01\n"
+        "templater = jinja\n"
+        "[sqlfluff:templater:jinja]\n"
+        "variable_start_string = <%\n"
+        "variable_end_string = %>\n"
+        "[sqlfluff:templater:jinja:context]\n"
+        "foo = bar\n"
+    )
+    linter = Linter(config=config)
+    result = linter.lint_string(sql)
+    assert len(result.violations) == 1
+    assert result.violations[0].check_tuple()[0] == "JJ01"

--- a/test/rules/std_JJ01_test.py
+++ b/test/rules/std_JJ01_test.py
@@ -80,3 +80,40 @@ def test_lint_jj01_mixed_custom_and_default_delimiters():
     result = linter.lint_string(sql)
     jj01 = [v for v in result.violations if v.rule_code() == "JJ01"]
     assert len(jj01) == 3
+
+
+def test_lint_jj01_custom_block_delimiters():
+    """Custom block delimiters are matched as pairs."""
+    sql = "((if true))SELECT 1((endif))\n"
+    config = FluffConfig.from_string(
+        "[sqlfluff]\n"
+        "dialect = ansi\n"
+        "rules = JJ01\n"
+        "templater = jinja\n"
+        "[sqlfluff:templater:jinja]\n"
+        "block_start_string = ((\n"
+        "block_end_string = ))\n"
+    )
+    linter = Linter(config=config)
+    result = linter.lint_string(sql)
+    jj01 = [v for v in result.violations if v.rule_code() == "JJ01"]
+    assert len(jj01) == 2
+
+
+def test_lint_jj01_partial_delimiter_override():
+    """Only overriding the start string keeps the default end string."""
+    sql = "SELECT <<foo}} FROM tbl\n"
+    config = FluffConfig.from_string(
+        "[sqlfluff]\n"
+        "dialect = ansi\n"
+        "rules = JJ01\n"
+        "templater = jinja\n"
+        "[sqlfluff:templater:jinja]\n"
+        "variable_start_string = <<\n"
+        "[sqlfluff:templater:jinja:context]\n"
+        "foo = bar\n"
+    )
+    linter = Linter(config=config)
+    result = linter.lint_string(sql)
+    jj01 = [v for v in result.violations if v.rule_code() == "JJ01"]
+    assert len(jj01) == 1

--- a/test/rules/std_JJ01_test.py
+++ b/test/rules/std_JJ01_test.py
@@ -60,3 +60,23 @@ def test_lint_jj01_custom_delimiters():
     result = linter.lint_string(sql)
     assert len(result.violations) == 1
     assert result.violations[0].check_tuple()[0] == "JJ01"
+
+
+def test_lint_jj01_mixed_custom_and_default_delimiters():
+    """Custom variable delimiters coexist with default block delimiters."""
+    sql = "{%if true%}SELECT <%foo%> AS x{%endif%}\n"
+    config = FluffConfig.from_string(
+        "[sqlfluff]\n"
+        "dialect = ansi\n"
+        "rules = JJ01\n"
+        "templater = jinja\n"
+        "[sqlfluff:templater:jinja]\n"
+        "variable_start_string = <%\n"
+        "variable_end_string = %>\n"
+        "[sqlfluff:templater:jinja:context]\n"
+        "foo = bar\n"
+    )
+    linter = Linter(config=config)
+    result = linter.lint_string(sql)
+    jj01 = [v for v in result.violations if v.rule_code() == "JJ01"]
+    assert len(jj01) == 3


### PR DESCRIPTION
## Summary

Fixes #7598.

Snowflake CLI uses `<% varname %>` instead of `{{ varname }}` for variable substitution. SQLFluff's Jinja templater hardcoded the standard delimiters, so files using Snowflake CLI templating couldn't be linted.

This PR exposes Jinja's delimiter config options via `[sqlfluff:templater:jinja]`:

- `variable_start_string` / `variable_end_string`
- `block_start_string` / `block_end_string`
- `comment_start_string` / `comment_end_string`

Usage:
```ini
[sqlfluff:templater:jinja]
variable_start_string = <%
variable_end_string = %>
```

### Changes

- `_get_jinja_env_kwargs()` reads delimiter overrides from config
- `SandboxedEnvironment` receives the overrides
- `JinjaAnalyzer` builds its open/close tag regexes from the env's configured delimiters instead of hardcoded `{{ }}` / `{% %}` / `{# #}`
- `slice_file()` passes `config` to `_get_jinja_env()` so the analyzer gets the right delimiters
- Fast path skips when custom delimiters are configured (zero overhead for standard Jinja)

### AI assistance disclosure

AI assisted with investigation, patch drafting, and test writing. Final diff validated locally.

#### Pull Request checklist

- [x] Tests added in `test/core/templaters/jinja_test.py` (2 new tests)
- [x] All 223 templater tests pass
- [x] 10103 tests pass (1 pre-existing failure unrelated to this change)
- [x] pre-commit clean (mypy, ruff, codespell, yamllint, doc8)
- [x] No documentation change needed — config options are standard Jinja parameters

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for custom Jinja delimiters so projects using Snowflake CLI-style `<% %>` tags can be linted. Previously only `{{ }}`, `{% %}`, and `{# #}` were recognized; now all six delimiter options are configurable and templating, slicing, variant generation, and rule `JJ01` honor them. Custom delimiters coexist with the defaults, and the fast path is skipped when they're set.

- New Features
  - Adds `variable_start_string`, `variable_end_string`, `block_start_string`, `block_end_string`, `comment_start_string`, `comment_end_string` under `[sqlfluff:templater:jinja]`.

- Refactors
  - Passes delimiter overrides to the Jinja `SandboxedEnvironment` and skips the fast path when overrides are present.
  - Builds tag detection from environment delimiters; `JinjaAnalyzer`, slicing, variant generation, and rule `JJ01` use them, matching tags as (open, close) pairs so custom variable delimiters don't hide default block tags.
  - Documents delimiter configuration in both Sphinx docs and `docsv` VitePress docs.

<sup>Written for commit 19a2d894c0198b505e5f7f4126c8458826f5c1dd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8277?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

