### PR TITLE
New rule RF08: flag CLUSTER BY columns the table does not define

### DIFF
--- a/src/sqlfluff/rules/references/RF08.py
+++ b/src/sqlfluff/rules/references/RF08.py
@@ -27,7 +27,7 @@ class Rule_RF08(BaseRule):
 
     Only ``CREATE TABLE`` statements that declare their columns explicitly are
     checked. A ``CREATE TABLE ... AS SELECT`` takes its columns from the query,
-    so there is no local list to compare against and it is left alone.
+    so it is left alone even when it also carries a column list.
 
     **Anti-pattern**
 
@@ -64,6 +64,17 @@ class Rule_RF08(BaseRule):
 
         cluster_clauses = list(context.segment.recursive_crawl(*_CLUSTER_CLAUSES))
         if not cluster_clauses:
+            return None
+
+        # A statement with a query takes its columns from that query, so an
+        # explicit column list is not necessarily the whole story and comparing
+        # against it can flag a column the SELECT does provide. Skip any CTAS,
+        # with or without a column list.
+        if any(
+            context.segment.recursive_crawl(
+                "select_statement", "with_compound_statement"
+            )
+        ):
             return None
 
         defined = {

--- a/src/sqlfluff/rules/references/RF08.py
+++ b/src/sqlfluff/rules/references/RF08.py
@@ -14,9 +14,8 @@ _IDENTIFIERS = ("naked_identifier", "quoted_identifier")
 
 def _name_of(segment: BaseSegment) -> Optional[str]:
     """The identifier a column definition or reference introduces, case folded."""
-    for part in segment.recursive_crawl(*_IDENTIFIERS):
-        return part.raw.strip('"`[]').upper()
-    return None
+    part = next(segment.recursive_crawl(*_IDENTIFIERS), None)
+    return part.raw.strip('"`[]').upper() if part else None
 
 
 class Rule_RF08(BaseRule):

--- a/src/sqlfluff/rules/references/RF08.py
+++ b/src/sqlfluff/rules/references/RF08.py
@@ -1,0 +1,95 @@
+"""Implementation of Rule RF08."""
+
+from typing import Optional
+
+from sqlfluff.core.parser import BaseSegment
+from sqlfluff.core.rules import BaseRule, LintResult, RuleContext
+from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
+
+# Databricks and Spark parse this as `table_cluster_by_clause`; BigQuery uses
+# `cluster_by_segment`. The contents are the same shape in both.
+_CLUSTER_CLAUSES = ("table_cluster_by_clause", "cluster_by_segment")
+_IDENTIFIERS = ("naked_identifier", "quoted_identifier")
+
+
+def _name_of(segment: BaseSegment) -> Optional[str]:
+    """The identifier a column definition or reference introduces, case folded."""
+    for part in segment.recursive_crawl(*_IDENTIFIERS):
+        return part.raw.strip('"`[]').upper()
+    return None
+
+
+class Rule_RF08(BaseRule):
+    """``CLUSTER BY`` should only reference columns defined by the table.
+
+    A clustering column that is not in the table definition is accepted by the
+    parser but rejected by the engine when the statement runs, so a typo here
+    survives linting and fails at execution time.
+
+    Only ``CREATE TABLE`` statements that declare their columns explicitly are
+    checked. A ``CREATE TABLE ... AS SELECT`` takes its columns from the query,
+    so there is no local list to compare against and it is left alone.
+
+    **Anti-pattern**
+
+    ``CLUSTER BY`` names a column the table does not have.
+
+    .. code-block:: sql
+       :force:
+
+        CREATE TABLE my_table (
+            col1 STRING
+        )
+        CLUSTER BY (col2);
+
+    **Best practice**
+
+    Cluster by a column the table defines.
+
+    .. code-block:: sql
+       :force:
+
+        CREATE TABLE my_table (
+            col1 STRING
+        )
+        CLUSTER BY (col1);
+    """
+
+    name = "references.cluster_by"
+    groups = ("all", "references")
+    crawl_behaviour = SegmentSeekerCrawler({"create_table_statement"})
+
+    def _eval(self, context: RuleContext) -> Optional[list[LintResult]]:
+        """Compare the clustering columns against the defined ones."""
+        assert context.segment.is_type("create_table_statement")
+
+        cluster_clauses = list(context.segment.recursive_crawl(*_CLUSTER_CLAUSES))
+        if not cluster_clauses:
+            return None
+
+        defined = {
+            name
+            for definition in context.segment.recursive_crawl("column_definition")
+            if (name := _name_of(definition)) is not None
+        }
+        # No explicit column list means CTAS or CREATE TABLE LIKE, where the
+        # columns come from elsewhere and cannot be checked here.
+        if not defined:
+            return None
+
+        results = []
+        for clause in cluster_clauses:
+            for reference in clause.recursive_crawl("column_reference"):
+                name = _name_of(reference)
+                if name is not None and name not in defined:
+                    results.append(
+                        LintResult(
+                            anchor=reference,
+                            description=(
+                                f"Column '{reference.raw}' in CLUSTER BY is not "
+                                "defined by this table."
+                            ),
+                        )
+                    )
+
+        return results or None

--- a/src/sqlfluff/rules/references/__init__.py
+++ b/src/sqlfluff/rules/references/__init__.py
@@ -74,6 +74,7 @@ def get_rules() -> list[type[BaseRule]]:
     from sqlfluff.rules.references.RF05 import Rule_RF05
     from sqlfluff.rules.references.RF06 import Rule_RF06
     from sqlfluff.rules.references.RF07 import Rule_RF07
+    from sqlfluff.rules.references.RF08 import Rule_RF08
 
     return [
         Rule_RF01,
@@ -83,4 +84,5 @@ def get_rules() -> list[type[BaseRule]]:
         Rule_RF05,
         Rule_RF06,
         Rule_RF07,
+        Rule_RF08,
     ]

--- a/test/fixtures/rules/std_rule_cases/RF08.yml
+++ b/test/fixtures/rules/std_rule_cases/RF08.yml
@@ -100,3 +100,55 @@ test_pass_bigquery_defined_column:
   configs:
     core:
       dialect: bigquery
+
+test_pass_ctas_with_an_explicit_column_list:
+  # the query supplies columns too, so the local list is not the whole story
+  pass_str: |
+    CREATE TABLE t (
+        col1 STRING
+    )
+    CLUSTER BY (col2)
+    AS SELECT col2 FROM other
+  configs:
+    core:
+      dialect: databricks
+
+test_pass_backtick_quoted_identifiers:
+  pass_str: |
+    CREATE TABLE t (
+        `col1` STRING
+    )
+    CLUSTER BY (`col1`)
+  configs:
+    core:
+      dialect: databricks
+
+test_pass_double_quoted_identifiers:
+  pass_str: |
+    CREATE TABLE t (
+        "col1" STRING
+    )
+    CLUSTER BY ("col1")
+  configs:
+    core:
+      dialect: databricks
+
+test_fail_backtick_quoted_undefined_column:
+  # quoting must not hide a genuine typo
+  fail_str: |
+    CREATE TABLE t (
+        `col1` STRING
+    )
+    CLUSTER BY (`col2`)
+  configs:
+    core:
+      dialect: databricks
+
+test_pass_create_table_like_has_no_local_columns:
+  # the columns come from the source table, so there is nothing to compare to
+  pass_str: |
+    CREATE TABLE t LIKE other
+    CLUSTER BY (col1)
+  configs:
+    core:
+      dialect: databricks

--- a/test/fixtures/rules/std_rule_cases/RF08.yml
+++ b/test/fixtures/rules/std_rule_cases/RF08.yml
@@ -1,0 +1,102 @@
+rule: RF08
+
+test_fail_cluster_by_undefined_column_databricks:
+  fail_str: |
+    CREATE TABLE my_catalog.my_schema.my_table (
+        col1 STRING
+    )
+    CLUSTER BY (col2)
+  configs:
+    core:
+      dialect: databricks
+
+test_fail_cluster_by_undefined_column_sparksql:
+  fail_str: |
+    CREATE TABLE my_table (
+        col1 STRING
+    )
+    CLUSTER BY (col2)
+  configs:
+    core:
+      dialect: sparksql
+
+test_fail_cluster_by_undefined_column_bigquery:
+  fail_str: |
+    CREATE TABLE my_table (
+        col1 STRING
+    )
+    CLUSTER BY (col2)
+  configs:
+    core:
+      dialect: bigquery
+
+test_fail_second_of_two_cluster_columns_undefined:
+  fail_str: |
+    CREATE TABLE my_table (
+        col1 STRING,
+        col2 STRING
+    )
+    CLUSTER BY (col1, col3)
+  configs:
+    core:
+      dialect: databricks
+
+test_pass_cluster_by_defined_column:
+  pass_str: |
+    CREATE TABLE my_catalog.my_schema.my_table (
+        col1 STRING
+    )
+    CLUSTER BY (col1)
+  configs:
+    core:
+      dialect: databricks
+
+test_pass_cluster_by_multiple_defined_columns:
+  pass_str: |
+    CREATE TABLE my_table (
+        col1 STRING,
+        col2 BIGINT
+    )
+    CLUSTER BY (col1, col2)
+  configs:
+    core:
+      dialect: databricks
+
+test_pass_cluster_by_is_case_insensitive:
+  pass_str: |
+    CREATE TABLE my_table (
+        MyCol STRING
+    )
+    CLUSTER BY (mycol)
+  configs:
+    core:
+      dialect: databricks
+
+test_pass_no_cluster_by_clause:
+  pass_str: |
+    CREATE TABLE my_table (
+        col1 STRING
+    )
+  configs:
+    core:
+      dialect: databricks
+
+test_pass_ctas_has_no_local_column_list:
+  # columns come from the query, so there is nothing to compare against
+  pass_str: |
+    CREATE TABLE my_table
+    CLUSTER BY (col1)
+    AS SELECT col1 FROM other_table
+  configs:
+    core:
+      dialect: databricks
+
+test_pass_bigquery_defined_column:
+  pass_str: |
+    CREATE TABLE my_table (
+        col1 STRING
+    )
+    CLUSTER BY (col1)
+  configs:
+    core:
+      dialect: bigquery

--- a/test/fixtures/rules/std_rule_cases/RF08.yml
+++ b/test/fixtures/rules/std_rule_cases/RF08.yml
@@ -152,3 +152,48 @@ test_pass_create_table_like_has_no_local_columns:
   configs:
     core:
       dialect: databricks
+
+test_pass_backtick_quoted_reference_matches_bare_definition:
+  # _name_of strips the quoting before comparing, so the two spellings match
+  pass_str: |
+    CREATE TABLE my_table (
+        col_a INT,
+        col_b INT
+    )
+    CLUSTER BY (`col_a`, col_b);
+  configs:
+    core:
+      dialect: databricks
+
+test_pass_backtick_quoted_definition_matches_bare_reference:
+  # and the same in the other direction, since either side may be quoted
+  pass_str: |
+    CREATE TABLE my_table (
+        `col_a` INT,
+        col_b INT
+    )
+    CLUSTER BY (col_a);
+  configs:
+    core:
+      dialect: databricks
+
+test_pass_both_sides_backtick_quoted:
+  pass_str: |
+    CREATE TABLE my_table (
+        `col_a` INT
+    )
+    CLUSTER BY (`col_a`);
+  configs:
+    core:
+      dialect: databricks
+
+test_fail_backtick_quoted_column_is_still_undefined:
+  # stripping the quotes must not turn an undefined column into a match
+  fail_str: |
+    CREATE TABLE my_table (
+        col_a INT
+    )
+    CLUSTER BY (`col_typo`);
+  configs:
+    core:
+      dialect: databricks


### PR DESCRIPTION
### Brief summary of the change made

Fixes #6631.

A `CLUSTER BY` column that the table does not define parses cleanly today, so the typo in the issue survives linting and only fails when the statement runs:

```sql
CREATE TABLE my_catalog.my_schema.my_table (
    col1 STRING
)
CLUSTER BY (col2);   -- col2 does not exist
```

```
$ sqlfluff lint t.sql --dialect databricks
All Finished!
```

This adds rule **RF08** (`references.cluster_by`), which compares the identifiers in the `CLUSTER BY` list against the ones introduced by the column definitions in the same statement:

```
L:   4 | P:  13 | RF08 | Column 'col2' in CLUSTER BY is not defined by this table.
```

The check is entirely local to the `CREATE TABLE` statement, so it needs no schema knowledge and no cross-file resolution.

### Dialect coverage

Databricks and Spark parse the clause as `table_cluster_by_clause`; BigQuery parses it as `cluster_by_segment`. Both are handled, and there are fixtures for all three dialects. Hive does not parse this form of the statement at all, so it is not affected.

### Deliberately not flagged

`CREATE TABLE ... AS SELECT` is skipped. Its columns come from the query rather than a local list, so there is nothing in the statement to compare against and flagging it would be a false positive:

```sql
CREATE TABLE my_table
CLUSTER BY (col1)
AS SELECT col1 FROM other_table   -- passes
```

Comparison is case insensitive and strips quoting, so `MyCol` in the definition matches `mycol` in the clustering list.

### Are there any other side effects of this change that we should be aware of?

RF08 is a new rule code, so it is picked up by the `all` and `references` groups and will start reporting on existing code that clusters by a column the table does not declare. That is the point of the issue, and every such case is a genuine runtime failure, but it is new output for those users.

No existing rule, grammar or dialect is touched.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - [x] `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
- [x] Added appropriate documentation for the change.
- [ ] Created GitHub issues for any relevant followup/future enhancements if appropriate.

`test/fixtures/rules/std_rule_cases/RF08.yml` has 10 cases: failures on databricks, sparksql and bigquery, a failure where only the second of two clustering columns is undefined, and passes for a valid column, multiple valid columns, mixed case, no `CLUSTER BY` at all, CTAS, and BigQuery with a valid column.

```
$ pytest test/rules/
2518 passed, 101 skipped
```

`ruff check`, `ruff format`, `mypy` and `yamllint` are clean on the changed files.

### AI-assisted contribution disclosure

Per CONTRIBUTING: this PR was written with the help of an AI coding assistant, and I remain responsible for it.

**AI-assisted:** drafting the rule, the fixtures and this description.

**Verified by me:** reproduced the issue first on databricks; confirmed from the parse trees that Databricks/Spark and BigQuery use different segment names for the clause, which is why both are handled rather than assuming one shape; checked that Hive does not parse the statement form at all; and confirmed the CTAS case passes rather than assuming it. Ran the full `test/rules/` suite (2518 passed) plus ruff, mypy and yamllint.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Flags CLUSTER BY columns not defined in the same CREATE TABLE so typos fail at lint time. Previously these parsed and passed linting; now RF08 (`references.cluster_by`) reports them and is enabled in `all` and `references`.

- Compares CLUSTER BY identifiers to columns defined in the statement; no schema lookups.
- Skips `CREATE TABLE ... AS SELECT` and `CREATE TABLE LIKE ...` (with or without a column list) to avoid false positives.
- Case-insensitive and tolerant of backtick/double-quoted names; quoting cannot mask undefined columns.
- Supports Databricks/Spark (`table_cluster_by_clause`) and BigQuery (`cluster_by_segment`).
- Users may see new findings where CLUSTER BY references an undefined column.

<sup>Written for commit 9c814f4013c42c2e8deeb71375725d5cd3f9d757. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8280?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

