### PR TITLE
fix: pass sync=True to GhApi in release script

### DIFF
--- a/util.py
+++ b/util.py
@@ -121,6 +121,7 @@ def release(new_version_num):
         owner=os.environ["GITHUB_REPOSITORY_OWNER"],
         repo="sqlfluff",
         token=os.environ["GITHUB_TOKEN"],
+        sync=True,
     )
     try:
         releases = api.repos.list_releases(per_page=100)


### PR DESCRIPTION
## Summary
- The "Prepare release" step of the release PR workflow (`create-release-pull-request.yaml`) has been failing with `TypeError: 'coroutine' object is not iterable` — see [run 30920741825](https://github.com/sqlfluff/sqlfluff/actions/runs/30920741825).
- Root cause: `ghapi` 2.0 (an unpinned dependency) made `GhApi` async by default, so generated endpoint calls like `api.repos.list_releases(...)` now return coroutines instead of results.
- Fix: pass `sync=True` when constructing `GhApi` in `util.py`, which keeps generated endpoint calls blocking, matching how the rest of the script uses the result (iterating/indexing directly).

## Test plan
- [x] Verified locally against the live GitHub API (unauthenticated) that `GhApi(..., sync=True).repos.list_releases(...)` returns a real list and can be iterated/indexed, whereas without `sync=True` it returns an unawaited coroutine, reproducing the CI failure.
- [ ] Re-run the "Create release pull request" workflow for 4.3.0 to confirm the "Prepare release" step now succeeds end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the release workflow by instantiating `GhApi` with `sync=True` so API calls remain blocking. This avoids coroutines from `ghapi` 2.0’s async default and resolves the "TypeError: 'coroutine' object is not iterable" in the "Prepare release" step.

<sup>Written for commit 21c5ed809aa31719b3019f36d939c156b424ba58. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8281?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

