### PR TITLE
LT15: add minimum_empty_lines_between_statements

### DIFF
--- a/src/sqlfluff/core/default_config.cfg
+++ b/src/sqlfluff/core/default_config.cfg
@@ -531,6 +531,7 @@ ignore_comment_clauses = False
 maximum_empty_lines_between_statements = 2
 maximum_empty_lines_inside_statements = 1
 maximum_empty_lines_between_batches = 1
+minimum_empty_lines_between_statements = 0
 
 [sqlfluff:rules:layout.select_targets]
 wildcard_policy = single

--- a/src/sqlfluff/rules/layout/LT15.py
+++ b/src/sqlfluff/rules/layout/LT15.py
@@ -302,13 +302,14 @@ class Rule_LT15(BaseRule):
         if not minimum:
             return None
 
-        if context.segment.is_templated:
-            return None
-
         if not self._is_gap_between_statements(context, shares_line=shares_line):
             return None
 
         if shares_line:
+            # No run to measure, so the templated check that the counter performs
+            # for the other path has to happen here instead.
+            if context.segment.is_templated:
+                return None
             blank_lines = 0
             # One extra newline ends the first statement's line; the rest are the
             # blank lines themselves.
@@ -316,6 +317,7 @@ class Rule_LT15(BaseRule):
         else:
             counted = self._count_blank_lines(context)
             if counted is None:
+                # Templated anchor: not ours to rewrite.
                 return None
             blank_lines, touched_templated = counted
             if touched_templated or blank_lines >= minimum:
@@ -333,9 +335,9 @@ class Rule_LT15(BaseRule):
         if shares_line:
             # Drop the space that separated the statements; it would otherwise be
             # left indenting the statement now starting the line.
-            for seg in context.siblings_post:
-                if seg.is_type("dedent", "indent"):
-                    continue
+            for seg in (
+                s for s in context.siblings_post if not s.is_type("dedent", "indent")
+            ):
                 if seg.is_type("whitespace"):
                     fixes.append(LintFix.delete(seg))
                 else:

--- a/src/sqlfluff/rules/layout/LT15.py
+++ b/src/sqlfluff/rules/layout/LT15.py
@@ -135,6 +135,23 @@ class Rule_LT15(BaseRule):
             )
         ]
 
+    def _effective_minimum(self) -> int:
+        """The minimum actually enforced, capped by the maximum for the same scope.
+
+        Both settings validate independently, so a minimum above the maximum is
+        accepted config. Enforcing it as written makes the two fixers undo each
+        other - the minimum inserts blank lines, the maximum deletes them back -
+        and ``sqlfluff fix`` alternates between the two results on every run
+        instead of converging, leaving file contents dependent on how many times
+        the fixer happened to run. Capping keeps the fixer convergent and leaves
+        the maximum, which is the stricter and longer-standing of the two, in
+        charge of the boundary they disagree about.
+        """
+        return min(
+            self.minimum_empty_lines_between_statements,
+            self.maximum_empty_lines_between_statements,
+        )
+
     def _in_between_statements_scope(self, context: RuleContext) -> bool:
         """Whether this position is the scope the maximum calls between-statements.
 
@@ -164,7 +181,7 @@ class Rule_LT15(BaseRule):
         Fires on the last newline of a run so the whole gap is measured once, rather
         than once per newline in it.
         """
-        minimum = self.minimum_empty_lines_between_statements
+        minimum = self._effective_minimum()
         if not minimum:
             return None
 
@@ -260,7 +277,7 @@ class Rule_LT15(BaseRule):
         the gap was accepted however the minimum was configured. Here the break
         itself is missing, and the fix has to create it as well as the blank lines.
         """
-        minimum = self.minimum_empty_lines_between_statements
+        minimum = self._effective_minimum()
         if not minimum:
             return None
 

--- a/src/sqlfluff/rules/layout/LT15.py
+++ b/src/sqlfluff/rules/layout/LT15.py
@@ -83,8 +83,12 @@ class Rule_LT15(BaseRule):
         context_seg = context.segment
 
         # Terminators are only sought for the same-line minimum check; none of the
-        # maximum logic below applies to them.
+        # maximum logic below applies to them. The same outer-statement guard as
+        # the newline path applies: a semicolon delimiting inner statements of a
+        # compound or procedural body is not a gap between top-level statements.
         if context_seg.is_type("statement_terminator"):
+            if any(seg.is_type("statement") for seg in context.parent_stack):
+                return None
             return self._check_minimum_same_line(context)
 
         # A minimum only makes sense between statements, so it is checked where we
@@ -167,11 +171,6 @@ class Rule_LT15(BaseRule):
         ):
             return None
 
-        # This also covers the templated case the maximum branch guards against
-        # separately: a gap whose newlines come from a template has the template's
-        # own placeholder in it, so it is skipped here before the run is counted
-        # and templated lines can never satisfy the minimum.
-        #
         # A template block start/end sits in the gap as a placeholder meta. The
         # newlines either side of it are not a gap between two statements, so
         # padding them puts blank lines around the tag rather than between the
@@ -192,6 +191,13 @@ class Rule_LT15(BaseRule):
         run = 1
         for raw_seg in reversed(context.raw_stack):
             if raw_seg.is_type("newline"):
+                # Only block tags leave a placeholder behind. A variable or macro
+                # expanding to text containing newlines produces plain newline
+                # segments with no placeholder, so the skip above does not see it
+                # and this is the only guard against counting lines that are not
+                # in the source. The maximum branch bails on the same condition.
+                if raw_seg.is_templated:
+                    return None
                 run += 1
             elif raw_seg.is_type("whitespace"):
                 continue
@@ -239,12 +245,18 @@ class Rule_LT15(BaseRule):
             seg for seg in context.siblings_post if not seg.is_type("dedent", "indent")
         ]
         # A newline already separates the statements, so the run-based check owns
-        # this gap. Leading whitespace is skipped so a trailing space before the
-        # line break does not hide it.
+        # this gap. Whitespace and trailing comments are skipped rather than
+        # treated as the end of the search: `SELECT a; -- x` still ends its line
+        # at the newline after the comment, and stopping at the comment would
+        # report a shared line that is not shared and tear the comment off it.
         for seg in following:
-            if seg.is_type("whitespace"):
+            if seg.is_type("whitespace", "comment", "inline_comment", "block_comment"):
                 continue
             if seg.is_type("newline"):
+                return None
+            # A template tag in the gap is not a statement sharing the line, and
+            # its surrounding whitespace is not the user's to rewrite.
+            if seg.is_type("placeholder"):
                 return None
             break
 

--- a/src/sqlfluff/rules/layout/LT15.py
+++ b/src/sqlfluff/rules/layout/LT15.py
@@ -66,7 +66,12 @@ class Rule_LT15(BaseRule):
         "maximum_empty_lines_between_batches",
         "minimum_empty_lines_between_statements",
     ]
-    crawl_behaviour = SegmentSeekerCrawler(types={"newline"}, provide_raw_stack=True)
+    # Statement terminators are sought as well as newlines: a minimum between
+    # statements has to be enforceable when the statements share a line, where
+    # there is no newline to crawl at all.
+    crawl_behaviour = SegmentSeekerCrawler(
+        types={"newline", "statement_terminator"}, provide_raw_stack=True
+    )
     is_fix_compatible = True
 
     def _eval(self, context: RuleContext) -> Optional[List[LintResult]]:
@@ -76,6 +81,11 @@ class Rule_LT15(BaseRule):
         self.maximum_empty_lines_between_batches: int
         self.minimum_empty_lines_between_statements: int
         context_seg = context.segment
+
+        # Terminators are only sought for the same-line minimum check; none of the
+        # maximum logic below applies to them.
+        if context_seg.is_type("statement_terminator"):
+            return self._check_minimum_same_line(context)
 
         # A minimum only makes sense between statements, so it is checked where we
         # are not inside one. It runs first because the two cannot both fire on the
@@ -157,11 +167,33 @@ class Rule_LT15(BaseRule):
         ):
             return None
 
+        # A template block start/end sits in the gap as a placeholder meta. The
+        # newlines either side of it are not a gap between two statements, so
+        # padding them puts blank lines around the tag rather than between the
+        # statements, and the tag is not the user's line to move.
+        for seg in reversed(context.siblings_pre):
+            if seg.is_code:
+                break
+            if seg.is_type("placeholder"):
+                return None
+        for seg in context.siblings_post:
+            if seg.is_code:
+                break
+            if seg.is_type("placeholder"):
+                return None
+
         # Count the run of newlines ending at this one. Two newlines are one blank
         # line, so the blank count is one less than the run length.
         run = 1
         for raw_seg in reversed(context.raw_stack):
             if raw_seg.is_type("newline"):
+                # A templated newline is not ours to count. The maximum branch
+                # already bails on one; counting it here would let a jinja loop
+                # that emits blank lines satisfy the minimum with lines the user
+                # cannot see or edit, so the two directions would disagree about
+                # what the gap is.
+                if raw_seg.is_templated:
+                    return None
                 run += 1
             elif raw_seg.is_type("whitespace"):
                 continue
@@ -184,6 +216,67 @@ class Rule_LT15(BaseRule):
                 description=(
                     f"Expected at least {minimum} blank line(s) between statements, "
                     f"found {blank_lines}."
+                ),
+            )
+        ]
+
+    def _check_minimum_same_line(
+        self, context: RuleContext
+    ) -> Optional[List[LintResult]]:
+        """Enforce the minimum when two statements share a line.
+
+        ``_check_minimum`` measures a run of newlines, so it can only fire where a
+        newline exists. ``SELECT a; SELECT b;`` has none between the statements, so
+        the gap was accepted however the minimum was configured. Here the break
+        itself is missing, and the fix has to create it as well as the blank lines.
+        """
+        minimum = self.minimum_empty_lines_between_statements
+        if not minimum:
+            return None
+
+        if context.segment.is_templated:
+            return None
+
+        following = [
+            seg for seg in context.siblings_post if not seg.is_type("dedent", "indent")
+        ]
+        # A newline already separates the statements, so the run-based check owns
+        # this gap. Leading whitespace is skipped so a trailing space before the
+        # line break does not hide it.
+        for seg in following:
+            if seg.is_type("whitespace"):
+                continue
+            if seg.is_type("newline"):
+                return None
+            break
+
+        # Nothing but the end of the file follows, so there is no gap to pad.
+        if not any(seg.is_code for seg in following):
+            return None
+
+        # No line break at all, so every required blank line is missing and the
+        # break that ends this statement's line is missing too.
+        fixes = [
+            LintFix.create_after(
+                context.segment,
+                [NewlineSegment() for _ in range(minimum + 1)],
+            )
+        ]
+        # Drop the space that separated the statements; it would otherwise be left
+        # indenting the statement now starting the line.
+        for seg in following:
+            if seg.is_type("whitespace"):
+                fixes.append(LintFix.delete(seg))
+            else:
+                break
+
+        return [
+            LintResult(
+                anchor=context.segment,
+                fixes=fixes,
+                description=(
+                    f"Expected at least {minimum} blank line(s) between statements, "
+                    "found 0 (statements share a line)."
                 ),
             )
         ]

--- a/src/sqlfluff/rules/layout/LT15.py
+++ b/src/sqlfluff/rules/layout/LT15.py
@@ -216,19 +216,40 @@ class Rule_LT15(BaseRule):
         blank_lines = 0
         run = 1
         touched_templated = False
+        in_comment = False
+        # A multi-line block comment lexes as one block_comment segment per
+        # physical line, with its own newlines interleaved between them. Those
+        # newlines are the comment's internal formatting, not blank lines
+        # between statements, so once inside an unclosed comment body they must
+        # not accumulate toward run or be banked. A segment starts a comment
+        # (rather than continuing one seen further down) when its raw text
+        # itself opens with a comment marker; only `/* */` bodies span more
+        # than one segment, so `--`/`#` inline comments never trigger this.
+        in_open_block_comment_body = False
         for raw_seg in reversed(context.raw_stack):
+            if raw_seg.is_type("comment", "inline_comment", "block_comment"):
+                if not in_comment:
+                    # Bank the run that ended at this comment block. Further
+                    # segments of the same multi-line comment must not bank
+                    # again: they are one occupied line, not several.
+                    blank_lines += max(run - 1, 0)
+                    run = 0
+                    in_comment = True
+                in_open_block_comment_body = raw_seg.is_type(
+                    "block_comment"
+                ) and not raw_seg.raw.lstrip().startswith("/*")
+                continue
             if raw_seg.is_type("newline"):
                 if raw_seg.is_templated:
                     touched_templated = True
                     break
+                if in_open_block_comment_body:
+                    # Interior to the comment body just walked past: not a gap.
+                    continue
+                in_comment = False
                 run += 1
             elif raw_seg.is_type("whitespace"):
                 continue
-            elif raw_seg.is_type("comment", "inline_comment", "block_comment"):
-                # Bank the run that ended at this comment and keep walking: the
-                # blank lines on the far side of it are part of the same gap.
-                blank_lines += max(run - 1, 0)
-                run = 0
             else:
                 break
         return blank_lines + max(run - 1, 0), touched_templated

--- a/src/sqlfluff/rules/layout/LT15.py
+++ b/src/sqlfluff/rules/layout/LT15.py
@@ -167,6 +167,11 @@ class Rule_LT15(BaseRule):
         ):
             return None
 
+        # This also covers the templated case the maximum branch guards against
+        # separately: a gap whose newlines come from a template has the template's
+        # own placeholder in it, so it is skipped here before the run is counted
+        # and templated lines can never satisfy the minimum.
+        #
         # A template block start/end sits in the gap as a placeholder meta. The
         # newlines either side of it are not a gap between two statements, so
         # padding them puts blank lines around the tag rather than between the
@@ -187,13 +192,6 @@ class Rule_LT15(BaseRule):
         run = 1
         for raw_seg in reversed(context.raw_stack):
             if raw_seg.is_type("newline"):
-                # A templated newline is not ours to count. The maximum branch
-                # already bails on one; counting it here would let a jinja loop
-                # that emits blank lines satisfy the minimum with lines the user
-                # cannot see or edit, so the two directions would disagree about
-                # what the gap is.
-                if raw_seg.is_templated:
-                    return None
                 run += 1
             elif raw_seg.is_type("whitespace"):
                 continue

--- a/src/sqlfluff/rules/layout/LT15.py
+++ b/src/sqlfluff/rules/layout/LT15.py
@@ -1,10 +1,24 @@
 """Implementation of Rule LT15."""
 
-from typing import List, Optional
+from enum import Enum
+from typing import List, Optional, Tuple
 
 from sqlfluff.core.parser import NewlineSegment
 from sqlfluff.core.rules import BaseRule, LintFix, LintResult, RuleContext
 from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
+
+
+class _Scope(Enum):
+    """Where in the file a gap sits, which decides whose limit applies.
+
+    The three scopes are the ones the maximum has always distinguished; naming
+    them lets the minimum resolve the same way instead of keeping a second,
+    slightly different copy of the logic.
+    """
+
+    INSIDE_STATEMENT = "inside a statement"
+    BETWEEN_STATEMENTS = "between statements"
+    BETWEEN_BATCHES = "between batches"
 
 
 class Rule_LT15(BaseRule):
@@ -55,7 +69,19 @@ class Rule_LT15(BaseRule):
         SELECT b FROM tab;
 
     The minimum defaults to ``0``, which leaves the rule's existing behaviour
-    unchanged.
+    unchanged. It applies only between statements, never inside one or between
+    batches, matching the scope its name describes.
+
+    .. note::
+
+        ``minimum_empty_lines_between_statements`` is capped by
+        ``maximum_empty_lines_between_statements``. The two settings validate
+        independently, so a minimum above the maximum is accepted configuration,
+        but no file can satisfy both: the minimum inserts blank lines and the
+        maximum deletes them straight back, so ``sqlfluff fix`` alternates
+        between the two results on every run instead of converging. Where the
+        cap changes what would otherwise be reported, a warning is emitted
+        naming both values.
     """
 
     name = "layout.newlines"
@@ -80,139 +106,169 @@ class Rule_LT15(BaseRule):
         self.maximum_empty_lines_inside_statements: int
         self.maximum_empty_lines_between_batches: int
         self.minimum_empty_lines_between_statements: int
-        context_seg = context.segment
+
+        scope = self._resolve_scope(context)
 
         # Terminators are only sought for the same-line minimum check; none of the
         # maximum logic below applies to them.
-        if context_seg.is_type("statement_terminator"):
-            if not self._in_between_statements_scope(context):
+        if context.segment.is_type("statement_terminator"):
+            if scope is not _Scope.BETWEEN_STATEMENTS:
                 return None
-            return self._check_minimum_same_line(context)
+            return self._check_minimum(context, shares_line=True)
 
-        # A minimum only makes sense in the between-statements scope. It runs
-        # first because the two cannot both fire on the same gap: one wants
-        # newlines added, the other wants them removed.
-        if self._in_between_statements_scope(context):
-            minimum_result = self._check_minimum(context)
+        # The minimum runs first because the two cannot both fire on one gap: one
+        # wants newlines added, the other wants them removed.
+        if scope is _Scope.BETWEEN_STATEMENTS:
+            minimum_result = self._check_minimum(context, shares_line=False)
             if minimum_result:
                 return minimum_result
 
-        # Determine the appropriate maximum based on context
-        # Check if we're inside a statement first (highest priority)
-        if any(seg.is_type("statement") for seg in context.parent_stack):
-            # If directly inside a with_compound_statement (between CTEs or between
-            # the last CTE and the main query), use between_statements limit to avoid
-            # conflicts with LT08 which requires blank lines after CTEs.
-            if context.parent_stack and context.parent_stack[-1].is_type(
-                "with_compound_statement"
-            ):
-                maximum_empty_lines = self.maximum_empty_lines_between_statements
-            else:
-                maximum_empty_lines = self.maximum_empty_lines_inside_statements
-        # Check if we're inside a batch but not in a statement
-        elif any(seg.is_type("batch") for seg in context.parent_stack):
-            # Inside a batch (between statements in a batch)
-            maximum_empty_lines = self.maximum_empty_lines_between_statements
-        # At file level - check dialect to determine if between batches or statements
-        elif context.dialect.name == "tsql":
-            # In T-SQL at file level, we're between batches
-            maximum_empty_lines = self.maximum_empty_lines_between_batches
-        else:
-            # Default: between statements
-            maximum_empty_lines = self.maximum_empty_lines_between_statements
+        maximum_empty_lines = {
+            _Scope.INSIDE_STATEMENT: self.maximum_empty_lines_inside_statements,
+            _Scope.BETWEEN_STATEMENTS: self.maximum_empty_lines_between_statements,
+            _Scope.BETWEEN_BATCHES: self.maximum_empty_lines_between_batches,
+        }[scope]
 
-        if len(context.raw_stack) < maximum_empty_lines:  # pragma: no cover
+        counted = self._count_blank_lines(context)
+        if counted is None or counted[0] <= maximum_empty_lines:
             return None
-
-        for raw_seg in context.raw_stack[-maximum_empty_lines - 1 :]:
-            if raw_seg.is_templated or not raw_seg.is_type("newline"):
-                return None
 
         return [
             LintResult(
-                anchor=context_seg,
-                fixes=[LintFix.delete(context_seg)],
+                anchor=context.segment,
+                fixes=[LintFix.delete(context.segment)],
             )
         ]
 
-    def _effective_minimum(self) -> int:
-        """The minimum actually enforced, capped by the maximum for the same scope.
+    def _resolve_scope(self, context: RuleContext) -> _Scope:
+        """Which of the three scopes this position sits in.
 
-        Both settings validate independently, so a minimum above the maximum is
-        accepted config. Enforcing it as written makes the two fixers undo each
-        other - the minimum inserts blank lines, the maximum deletes them back -
-        and ``sqlfluff fix`` alternates between the two results on every run
-        instead of converging, leaving file contents dependent on how many times
-        the fixer happened to run. Capping keeps the fixer convergent and leaves
-        the maximum, which is the stricter and longer-standing of the two, in
-        charge of the boundary they disagree about.
+        Shared by the maximum's limit selection and the minimum's gate so the two
+        cannot drift apart. Batches are detected structurally rather than by
+        dialect name: the previous ``dialect.name == "tsql"`` test missed Oracle,
+        which also has batch grammar, so a file-level gap there was measured
+        against the between-statements maximum instead of the between-batches
+        one. Testing for the node itself also means a dialect that gains batch
+        grammar later needs no change here.
+        """
+        if any(seg.is_type("statement") for seg in context.parent_stack):
+            # Directly inside a with_compound_statement (between CTEs, or between
+            # the last CTE and the main query) uses the between-statements limit
+            # to avoid conflicting with LT08, which requires blank lines
+            # after CTEs.
+            if context.parent_stack[-1].is_type("with_compound_statement"):
+                return _Scope.BETWEEN_STATEMENTS
+            return _Scope.INSIDE_STATEMENT
+
+        if any(seg.is_type("batch") for seg in context.parent_stack):
+            return _Scope.BETWEEN_STATEMENTS
+
+        # File level: a gap out here separates batches in the dialects that have
+        # them, and statements everywhere else.
+        if any(
+            seg.is_type("batch")
+            for seg in (*context.siblings_pre, *context.siblings_post)
+        ):
+            return _Scope.BETWEEN_BATCHES
+        return _Scope.BETWEEN_STATEMENTS
+
+    def _count_blank_lines(self, context: RuleContext) -> Optional[Tuple[int, bool]]:
+        """Blank lines in the run of newlines ending at the current segment.
+
+        Both directions measure the gap with this, so they cannot disagree about
+        what "two blank lines" means. Two consecutive newlines bound one blank
+        line, hence the run length less one. Whitespace does not break the run,
+        so a line of spaces still counts as blank.
+
+        A templated newline ends the run rather than being counted: those lines
+        are not in the source, so neither direction may add or remove them, and
+        neither should let them stand in for lines the user wrote. Counting only
+        as far as the nearest one leaves both directions measuring the same set
+        of editable lines.
+
+        Returns the count and whether the run was cut short by templated output.
+        The maximum only ever deletes an editable newline, so the count alone is
+        enough for it. The minimum has to add lines, and padding a gap whose
+        rendered form already contains lines the source does not would be
+        guessing at the result, so it declines those gaps entirely.
+
+        Returns ``None`` when the anchor itself is templated, since there is then
+        nothing editable to anchor a fix to.
+        """
+        if context.segment.is_templated:
+            return None
+
+        run = 1
+        touched_templated = False
+        for raw_seg in reversed(context.raw_stack):
+            if raw_seg.is_type("newline"):
+                if raw_seg.is_templated:
+                    touched_templated = True
+                    break
+                run += 1
+            elif raw_seg.is_type("whitespace"):
+                continue
+            else:
+                break
+        return run - 1, touched_templated
+
+    def _effective_minimum(self) -> int:
+        """The minimum actually enforced, capped by the maximum for the scope.
+
+        See the note in the class docstring: uncapped, the two fixers undo each
+        other and ``fix`` never converges.
         """
         return min(
             self.minimum_empty_lines_between_statements,
             self.maximum_empty_lines_between_statements,
         )
 
-    def _in_between_statements_scope(self, context: RuleContext) -> bool:
-        """Whether this position is the scope the maximum calls between-statements.
+    def _is_gap_between_statements(
+        self, context: RuleContext, *, shares_line: bool
+    ) -> bool:
+        """Whether the position is a gap with a statement on each side.
 
-        The maximum resolves three scopes and picks a limit for each: inside a
-        statement, between statements within a batch, and between batches at file
-        level. ``minimum_empty_lines_between_statements`` names exactly one of
-        them, so it has to be resolved the same way rather than firing anywhere
-        outside a statement.
+        A gap needs a statement on both sides, tested on the statement type
+        rather than on any code. Without the preceding test, a file opening with
+        a blank line or a comment reads as a gap before its first statement and
+        gets padded. Without the following test, a batch delimiter (T-SQL ``GO``,
+        Oracle ``/``) reads as the next statement and the rule demands a blank
+        line in front of it; those are ``go_statement`` and
+        ``slash_buffer_executor``, and they end a batch rather than starting one.
         """
-        if any(seg.is_type("statement") for seg in context.parent_stack):
-            return False
-        if any(seg.is_type("batch") for seg in context.parent_stack):
-            return True
-        # File level. Dialects with batch grammar (T-SQL, Oracle) wrap their
-        # statements in batch nodes, so a gap out here separates batches, which
-        # is the maximum's third scope and not this setting's business. Tested
-        # structurally rather than by dialect name so a dialect that gains batch
-        # grammar later is handled without a code change.
-        return not any(
-            seg.is_type("batch")
-            for seg in (*context.siblings_pre, *context.siblings_post)
-        )
-
-    def _check_minimum(self, context: RuleContext) -> Optional[List[LintResult]]:
-        """Require at least ``minimum_empty_lines_between_statements`` blank lines.
-
-        Fires on the last newline of a run so the whole gap is measured once, rather
-        than once per newline in it.
-        """
-        minimum = self._effective_minimum()
-        if not minimum:
-            return None
-
-        # Only act on the last newline of the run; otherwise the same gap would be
-        # reported several times over. Whitespace is skipped both here and in the
-        # backward walk below, so a line of spaces still counts as blank.
         following = [
             seg
             for seg in context.siblings_post
             if not seg.is_type("dedent", "indent", "whitespace")
         ]
-        if following and following[0].is_type("newline"):
-            return None
 
-        # A gap needs a statement on both sides, tested on the statement type
-        # rather than on any code. Without the preceding check, a file that opens
-        # with a blank line or a comment is treated as a gap before its first
-        # statement and padded. Without the following check, a batch delimiter
-        # (T-SQL `GO`, Oracle `/`) reads as the next statement and the rule
-        # demands a blank line in front of it; those are `go_statement` and
-        # `slash_buffer_executor`, not statements, and they end a batch rather
-        # than starting one.
+        if shares_line:
+            # Whitespace and trailing comments are skipped rather than treated as
+            # the end of the search: `SELECT a; -- x` still ends its line at the
+            # newline after the comment, so stopping at the comment would report a
+            # shared line that is not shared and tear the comment off it.
+            for seg in following:
+                if seg.is_type("comment", "inline_comment", "block_comment"):
+                    continue
+                # A newline already separates the statements, so the run-based
+                # path owns this gap.
+                if seg.is_type("newline"):
+                    return False
+                # A template tag in the gap is not a statement sharing the line,
+                # and its surrounding whitespace is not the user's to rewrite.
+                if seg.is_type("placeholder"):
+                    return False
+                break
+        else:
+            # Only act on the last newline of the run, or the same gap is
+            # reported once per newline in it.
+            if following and following[0].is_type("newline"):
+                return False
+
         if not any(seg.is_type("statement") for seg in context.siblings_pre):
-            return None
-
-        # Skip when no further statement follows, so there is no gap to pad, and
-        # when the newline is templated, since that is not ours to rewrite.
-        if context.segment.is_templated or not any(
-            seg.is_type("statement") for seg in context.siblings_post
-        ):
-            return None
+            return False
+        if not any(seg.is_type("statement") for seg in following):
+            return False
 
         # A template block start/end sits in the gap as a placeholder meta. The
         # newlines either side of it are not a gap between two statements, so
@@ -222,60 +278,25 @@ class Rule_LT15(BaseRule):
             if seg.is_code:
                 break
             if seg.is_type("placeholder"):
-                return None
+                return False
         for seg in context.siblings_post:
             if seg.is_code:
                 break
             if seg.is_type("placeholder"):
-                return None
+                return False
 
-        # Count the run of newlines ending at this one. Two newlines are one blank
-        # line, so the blank count is one less than the run length.
-        run = 1
-        for raw_seg in reversed(context.raw_stack):
-            if raw_seg.is_type("newline"):
-                # Only block tags leave a placeholder behind. A variable or macro
-                # expanding to text containing newlines produces plain newline
-                # segments with no placeholder, so the skip above does not see it
-                # and this is the only guard against counting lines that are not
-                # in the source. The maximum branch bails on the same condition.
-                if raw_seg.is_templated:
-                    return None
-                run += 1
-            elif raw_seg.is_type("whitespace"):
-                continue
-            else:
-                break
-        blank_lines = run - 1
+        return True
 
-        if blank_lines >= minimum:
-            return None
-
-        return [
-            LintResult(
-                anchor=context.segment,
-                fixes=[
-                    LintFix.create_after(
-                        context.segment,
-                        [NewlineSegment() for _ in range(minimum - blank_lines)],
-                    )
-                ],
-                description=(
-                    f"Expected at least {minimum} blank line(s) between statements, "
-                    f"found {blank_lines}."
-                ),
-            )
-        ]
-
-    def _check_minimum_same_line(
-        self, context: RuleContext
+    def _check_minimum(
+        self, context: RuleContext, *, shares_line: bool
     ) -> Optional[List[LintResult]]:
-        """Enforce the minimum when two statements share a line.
+        """Require at least ``minimum_empty_lines_between_statements`` blank lines.
 
-        ``_check_minimum`` measures a run of newlines, so it can only fire where a
-        newline exists. ``SELECT a; SELECT b;`` has none between the statements, so
-        the gap was accepted however the minimum was configured. Here the break
-        itself is missing, and the fix has to create it as well as the blank lines.
+        Handles both shapes a too-small gap can take. Usually there is a run of
+        newlines to measure and pad. When the statements share a line
+        (``SELECT a; SELECT b;``) there is no newline to crawl at all, so the run
+        cannot be measured, the gap is zero by definition, and the fix has to
+        create the line break as well as the blank lines.
         """
         minimum = self._effective_minimum()
         if not minimum:
@@ -284,53 +305,76 @@ class Rule_LT15(BaseRule):
         if context.segment.is_templated:
             return None
 
-        following = [
-            seg for seg in context.siblings_post if not seg.is_type("dedent", "indent")
-        ]
-        # A newline already separates the statements, so the run-based check owns
-        # this gap. Whitespace and trailing comments are skipped rather than
-        # treated as the end of the search: `SELECT a; -- x` still ends its line
-        # at the newline after the comment, and stopping at the comment would
-        # report a shared line that is not shared and tear the comment off it.
-        for seg in following:
-            if seg.is_type("whitespace", "comment", "inline_comment", "block_comment"):
-                continue
-            if seg.is_type("newline"):
-                return None
-            # A template tag in the gap is not a statement sharing the line, and
-            # its surrounding whitespace is not the user's to rewrite.
-            if seg.is_type("placeholder"):
-                return None
-            break
-
-        # No further statement follows, so there is no gap to pad. A batch
-        # delimiter is not a statement and does not open one.
-        if not any(seg.is_type("statement") for seg in following):
+        if not self._is_gap_between_statements(context, shares_line=shares_line):
             return None
 
-        # No line break at all, so every required blank line is missing and the
-        # break that ends this statement's line is missing too.
+        if shares_line:
+            blank_lines = 0
+            # One extra newline ends the first statement's line; the rest are the
+            # blank lines themselves.
+            newlines_to_add = minimum + 1
+        else:
+            counted = self._count_blank_lines(context)
+            if counted is None:
+                return None
+            blank_lines, touched_templated = counted
+            if touched_templated or blank_lines >= minimum:
+                return None
+            newlines_to_add = minimum - blank_lines
+
+        self._warn_if_capped()
+
         fixes = [
             LintFix.create_after(
                 context.segment,
-                [NewlineSegment() for _ in range(minimum + 1)],
+                [NewlineSegment() for _ in range(newlines_to_add)],
             )
         ]
-        # Drop the space that separated the statements; it would otherwise be left
-        # indenting the statement now starting the line.
-        for seg in following:
-            if seg.is_type("whitespace"):
-                fixes.append(LintFix.delete(seg))
-            else:
-                break
+        if shares_line:
+            # Drop the space that separated the statements; it would otherwise be
+            # left indenting the statement now starting the line.
+            for seg in context.siblings_post:
+                if seg.is_type("dedent", "indent"):
+                    continue
+                if seg.is_type("whitespace"):
+                    fixes.append(LintFix.delete(seg))
+                else:
+                    break
+
+        description = (
+            f"Expected at least {minimum} blank line(s) between statements, "
+            f"found {blank_lines}."
+        )
+        if shares_line:
+            description = (
+                f"Expected at least {minimum} blank line(s) between statements, "
+                "found 0 (statements share a line)."
+            )
 
         return [
             LintResult(
                 anchor=context.segment,
                 fixes=fixes,
-                description=(
-                    f"Expected at least {minimum} blank line(s) between statements, "
-                    "found 0 (statements share a line)."
-                ),
+                description=description,
             )
         ]
+
+    def _warn_if_capped(self) -> None:
+        """Tell the user when the cap is what decided the reported gap.
+
+        Only fires where it changes an actual result, so a contradictory config
+        that never meets two statements stays quiet.
+        """
+        configured = self.minimum_empty_lines_between_statements
+        maximum = self.maximum_empty_lines_between_statements
+        if configured > maximum:
+            self.logger.warning(
+                "minimum_empty_lines_between_statements (%s) is greater than "
+                "maximum_empty_lines_between_statements (%s); enforcing %s. No "
+                "file can satisfy both, and applying the minimum as configured "
+                "would leave `sqlfluff fix` alternating between the two results "
+                "instead of converging.",
+                configured,
+                maximum,
+                maximum,
+            )

--- a/src/sqlfluff/rules/layout/LT15.py
+++ b/src/sqlfluff/rules/layout/LT15.py
@@ -129,9 +129,18 @@ class Rule_LT15(BaseRule):
             _Scope.BETWEEN_BATCHES: self.maximum_empty_lines_between_batches,
         }[scope]
 
-        counted = self._count_blank_lines(context)
-        if counted is None or counted[0] <= maximum_empty_lines:
+        # The maximum keeps its original windowed eligibility test rather than
+        # reusing `_count_blank_lines`. The two are not interchangeable: the
+        # counter skips whitespace and counts the editable newlines ahead of a
+        # templated one, where this check suppresses the violation outright for
+        # both. Sharing it silently widened a long-standing rule, so the shared
+        # helper stays with the minimum and this stays as it shipped.
+        if len(context.raw_stack) < maximum_empty_lines:  # pragma: no cover
             return None
+
+        for raw_seg in context.raw_stack[-maximum_empty_lines - 1 :]:
+            if raw_seg.is_templated or not raw_seg.is_type("newline"):
+                return None
 
         return [
             LintResult(
@@ -264,6 +273,16 @@ class Rule_LT15(BaseRule):
             # reported once per newline in it.
             if following and following[0].is_type("newline"):
                 return False
+            # A comment splits the gap into two runs of newlines, and both would
+            # otherwise qualify: each has a statement behind it and a statement
+            # ahead of it, so one gap gets padded twice. The run that ends at the
+            # next statement is the gap's anchor, so a run that reaches a comment
+            # first is not.
+            for seg in following:
+                if seg.is_type("comment", "inline_comment", "block_comment"):
+                    return False
+                if seg.is_type("statement"):
+                    break
 
         if not any(seg.is_type("statement") for seg in context.siblings_pre):
             return False

--- a/src/sqlfluff/rules/layout/LT15.py
+++ b/src/sqlfluff/rules/layout/LT15.py
@@ -207,6 +207,13 @@ class Rule_LT15(BaseRule):
         if context.segment.is_templated:
             return None
 
+        # Walk back to the statement that opens the gap, counting blank lines.
+        # A comment does not end the gap: `SELECT a;`, a blank line, a comment,
+        # then `SELECT b;` is one gap that already has its blank line, and
+        # stopping at the comment would hide it and pad the gap a second time.
+        # A comment does occupy a line, though, so it ends the current run of
+        # blank lines rather than being counted as one.
+        blank_lines = 0
         run = 1
         touched_templated = False
         for raw_seg in reversed(context.raw_stack):
@@ -217,9 +224,14 @@ class Rule_LT15(BaseRule):
                 run += 1
             elif raw_seg.is_type("whitespace"):
                 continue
+            elif raw_seg.is_type("comment", "inline_comment", "block_comment"):
+                # Bank the run that ended at this comment and keep walking: the
+                # blank lines on the far side of it are part of the same gap.
+                blank_lines += max(run - 1, 0)
+                run = 0
             else:
                 break
-        return run - 1, touched_templated
+        return blank_lines + max(run - 1, 0), touched_templated
 
     def _effective_minimum(self) -> int:
         """The minimum actually enforced, capped by the maximum for the scope.

--- a/src/sqlfluff/rules/layout/LT15.py
+++ b/src/sqlfluff/rules/layout/LT15.py
@@ -2,6 +2,7 @@
 
 from typing import List, Optional
 
+from sqlfluff.core.parser import NewlineSegment
 from sqlfluff.core.rules import BaseRule, LintFix, LintResult, RuleContext
 from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
 
@@ -37,6 +38,24 @@ class Rule_LT15(BaseRule):
         LIMIT 5
         ;
 
+    A minimum can also be required between statements. With
+    ``minimum_empty_lines_between_statements = 1``, this is an anti-pattern:
+
+    .. code-block:: sql
+
+        SELECT a FROM tab;
+        SELECT b FROM tab;
+
+    and this is the best practice:
+
+    .. code-block:: sql
+
+        SELECT a FROM tab;
+
+        SELECT b FROM tab;
+
+    The minimum defaults to ``0``, which leaves the rule's existing behaviour
+    unchanged.
     """
 
     name = "layout.newlines"
@@ -45,6 +64,7 @@ class Rule_LT15(BaseRule):
         "maximum_empty_lines_between_statements",
         "maximum_empty_lines_inside_statements",
         "maximum_empty_lines_between_batches",
+        "minimum_empty_lines_between_statements",
     ]
     crawl_behaviour = SegmentSeekerCrawler(types={"newline"}, provide_raw_stack=True)
     is_fix_compatible = True
@@ -54,7 +74,16 @@ class Rule_LT15(BaseRule):
         self.maximum_empty_lines_between_statements: int
         self.maximum_empty_lines_inside_statements: int
         self.maximum_empty_lines_between_batches: int
+        self.minimum_empty_lines_between_statements: int
         context_seg = context.segment
+
+        # A minimum only makes sense between statements, so it is checked where we
+        # are not inside one. It runs first because the two cannot both fire on the
+        # same gap: one wants newlines added, the other wants them removed.
+        if not any(seg.is_type("statement") for seg in context.parent_stack):
+            minimum_result = self._check_minimum(context)
+            if minimum_result:
+                return minimum_result
 
         # Determine the appropriate maximum based on context
         # Check if we're inside a statement first (highest priority)
@@ -91,5 +120,64 @@ class Rule_LT15(BaseRule):
             LintResult(
                 anchor=context_seg,
                 fixes=[LintFix.delete(context_seg)],
+            )
+        ]
+
+    def _check_minimum(self, context: RuleContext) -> Optional[List[LintResult]]:
+        """Require at least ``minimum_empty_lines_between_statements`` blank lines.
+
+        Fires on the last newline of a run so the whole gap is measured once, rather
+        than once per newline in it.
+        """
+        minimum = self.minimum_empty_lines_between_statements
+        if not minimum:
+            return None
+
+        # Only act on the last newline of the run; otherwise the same gap would be
+        # reported several times over. Whitespace is skipped both here and in the
+        # backward walk below, so a line of spaces still counts as blank.
+        following = [
+            seg
+            for seg in context.siblings_post
+            if not seg.is_type("dedent", "indent", "whitespace")
+        ]
+        if following and following[0].is_type("newline"):
+            return None
+
+        # Skip when nothing but the end of the file follows, so there is no gap to
+        # pad, and when the newline is templated, since that is not ours to rewrite.
+        if context.segment.is_templated or not any(
+            seg.is_code for seg in context.siblings_post
+        ):
+            return None
+
+        # Count the run of newlines ending at this one. Two newlines are one blank
+        # line, so the blank count is one less than the run length.
+        run = 1
+        for raw_seg in reversed(context.raw_stack):
+            if raw_seg.is_type("newline"):
+                run += 1
+            elif raw_seg.is_type("whitespace"):
+                continue
+            else:
+                break
+        blank_lines = run - 1
+
+        if blank_lines >= minimum:
+            return None
+
+        return [
+            LintResult(
+                anchor=context.segment,
+                fixes=[
+                    LintFix.create_after(
+                        context.segment,
+                        [NewlineSegment() for _ in range(minimum - blank_lines)],
+                    )
+                ],
+                description=(
+                    f"Expected at least {minimum} blank line(s) between statements, "
+                    f"found {blank_lines}."
+                ),
             )
         ]

--- a/src/sqlfluff/rules/layout/LT15.py
+++ b/src/sqlfluff/rules/layout/LT15.py
@@ -83,18 +83,16 @@ class Rule_LT15(BaseRule):
         context_seg = context.segment
 
         # Terminators are only sought for the same-line minimum check; none of the
-        # maximum logic below applies to them. The same outer-statement guard as
-        # the newline path applies: a semicolon delimiting inner statements of a
-        # compound or procedural body is not a gap between top-level statements.
+        # maximum logic below applies to them.
         if context_seg.is_type("statement_terminator"):
-            if any(seg.is_type("statement") for seg in context.parent_stack):
+            if not self._in_between_statements_scope(context):
                 return None
             return self._check_minimum_same_line(context)
 
-        # A minimum only makes sense between statements, so it is checked where we
-        # are not inside one. It runs first because the two cannot both fire on the
-        # same gap: one wants newlines added, the other wants them removed.
-        if not any(seg.is_type("statement") for seg in context.parent_stack):
+        # A minimum only makes sense in the between-statements scope. It runs
+        # first because the two cannot both fire on the same gap: one wants
+        # newlines added, the other wants them removed.
+        if self._in_between_statements_scope(context):
             minimum_result = self._check_minimum(context)
             if minimum_result:
                 return minimum_result
@@ -137,6 +135,29 @@ class Rule_LT15(BaseRule):
             )
         ]
 
+    def _in_between_statements_scope(self, context: RuleContext) -> bool:
+        """Whether this position is the scope the maximum calls between-statements.
+
+        The maximum resolves three scopes and picks a limit for each: inside a
+        statement, between statements within a batch, and between batches at file
+        level. ``minimum_empty_lines_between_statements`` names exactly one of
+        them, so it has to be resolved the same way rather than firing anywhere
+        outside a statement.
+        """
+        if any(seg.is_type("statement") for seg in context.parent_stack):
+            return False
+        if any(seg.is_type("batch") for seg in context.parent_stack):
+            return True
+        # File level. Dialects with batch grammar (T-SQL, Oracle) wrap their
+        # statements in batch nodes, so a gap out here separates batches, which
+        # is the maximum's third scope and not this setting's business. Tested
+        # structurally rather than by dialect name so a dialect that gains batch
+        # grammar later is handled without a code change.
+        return not any(
+            seg.is_type("batch")
+            for seg in (*context.siblings_pre, *context.siblings_post)
+        )
+
     def _check_minimum(self, context: RuleContext) -> Optional[List[LintResult]]:
         """Require at least ``minimum_empty_lines_between_statements`` blank lines.
 
@@ -158,16 +179,21 @@ class Rule_LT15(BaseRule):
         if following and following[0].is_type("newline"):
             return None
 
-        # A gap needs a statement on both sides. Without the preceding check, a
-        # file that opens with a blank line or a comment is treated as a gap
-        # before its first statement and padded, which is a false positive.
-        if not any(seg.is_code for seg in context.siblings_pre):
+        # A gap needs a statement on both sides, tested on the statement type
+        # rather than on any code. Without the preceding check, a file that opens
+        # with a blank line or a comment is treated as a gap before its first
+        # statement and padded. Without the following check, a batch delimiter
+        # (T-SQL `GO`, Oracle `/`) reads as the next statement and the rule
+        # demands a blank line in front of it; those are `go_statement` and
+        # `slash_buffer_executor`, not statements, and they end a batch rather
+        # than starting one.
+        if not any(seg.is_type("statement") for seg in context.siblings_pre):
             return None
 
-        # Skip when nothing but the end of the file follows, so there is no gap to
-        # pad, and when the newline is templated, since that is not ours to rewrite.
+        # Skip when no further statement follows, so there is no gap to pad, and
+        # when the newline is templated, since that is not ours to rewrite.
         if context.segment.is_templated or not any(
-            seg.is_code for seg in context.siblings_post
+            seg.is_type("statement") for seg in context.siblings_post
         ):
             return None
 
@@ -260,8 +286,9 @@ class Rule_LT15(BaseRule):
                 return None
             break
 
-        # Nothing but the end of the file follows, so there is no gap to pad.
-        if not any(seg.is_code for seg in following):
+        # No further statement follows, so there is no gap to pad. A batch
+        # delimiter is not a statement and does not open one.
+        if not any(seg.is_type("statement") for seg in following):
             return None
 
         # No line break at all, so every required blank line is missing and the

--- a/src/sqlfluff/rules/layout/LT15.py
+++ b/src/sqlfluff/rules/layout/LT15.py
@@ -144,6 +144,12 @@ class Rule_LT15(BaseRule):
         if following and following[0].is_type("newline"):
             return None
 
+        # A gap needs a statement on both sides. Without the preceding check, a
+        # file that opens with a blank line or a comment is treated as a gap
+        # before its first statement and padded, which is a false positive.
+        if not any(seg.is_code for seg in context.siblings_pre):
+            return None
+
         # Skip when nothing but the end of the file follows, so there is no gap to
         # pad, and when the newline is templated, since that is not ours to rewrite.
         if context.segment.is_templated or not any(

--- a/src/sqlfluff/rules/layout/__init__.py
+++ b/src/sqlfluff/rules/layout/__init__.py
@@ -36,6 +36,13 @@ def get_configs_info() -> dict[str, ConfigInfo]:
                 "The maximum number of empty lines allowed inside statements."
             ),
         },
+        "minimum_empty_lines_between_statements": {
+            "validation": range(1000),
+            "definition": (
+                "The minimum number of empty lines required between statements. "
+                "Defaults to 0, which does not require any."
+            ),
+        },
         "maximum_empty_lines_between_batches": {
             "validation": range(1000),
             "definition": (

--- a/test/fixtures/rules/std_rule_cases/LT15.yml
+++ b/test/fixtures/rules/std_rule_cases/LT15.yml
@@ -573,3 +573,49 @@ test_pass_minimum_equal_to_maximum_is_satisfiable:
       layout.newlines:
         minimum_empty_lines_between_statements: 2
         maximum_empty_lines_between_statements: 2
+
+test_fail_oracle_file_level_gap_uses_the_between_batches_maximum:
+  # oracle has batch grammar like t-sql, but the scope test was
+  # `dialect.name == "tsql"`, so a file-level gap here was measured against the
+  # between-statements maximum instead. resolving the scope structurally fixes
+  # it: with between_batches = 1 these three blank lines are a violation, where
+  # before the rule reported the file clean.
+  fail_str: |
+    SELECT a FROM tab;
+    /
+
+
+
+    SELECT b FROM tab;
+    /
+  fix_str: |
+    SELECT a FROM tab;
+    /
+
+    SELECT b FROM tab;
+    /
+  configs:
+    core:
+      dialect: oracle
+    rules:
+      layout.newlines:
+        maximum_empty_lines_between_batches: 1
+        maximum_empty_lines_between_statements: 4
+
+test_pass_oracle_inside_batch_still_uses_the_between_statements_maximum:
+  # the control for the case above: a gap inside a batch is not a batch
+  # boundary, so the larger between-statements allowance still applies
+  pass_str: |
+    SELECT a FROM tab;
+
+
+    SELECT b FROM tab;
+    /
+  configs:
+    core:
+      dialect: oracle
+    rules:
+      layout.newlines:
+        maximum_empty_lines_between_batches: 1
+        maximum_empty_lines_between_statements: 4
+

--- a/test/fixtures/rules/std_rule_cases/LT15.yml
+++ b/test/fixtures/rules/std_rule_cases/LT15.yml
@@ -585,7 +585,6 @@ test_fail_oracle_file_level_gap_uses_the_between_batches_maximum:
     /
 
 
-
     SELECT b FROM tab;
     /
   fix_str: |
@@ -618,4 +617,13 @@ test_pass_oracle_inside_batch_still_uses_the_between_statements_maximum:
       layout.newlines:
         maximum_empty_lines_between_batches: 1
         maximum_empty_lines_between_statements: 4
-
+test_pass_minimum_ignores_a_templated_anchor_newline:
+  # the newline the rule anchors on is itself templated, so there is no source
+  # line to attach a fix to and the gap is declined rather than padded
+  pass_str: 'SELECT a FROM tab;{{ "\n" }}SELECT b FROM tab;'
+  configs:
+    core:
+      templater: jinja
+    rules:
+      layout.newlines:
+        minimum_empty_lines_between_statements: 1

--- a/test/fixtures/rules/std_rule_cases/LT15.yml
+++ b/test/fixtures/rules/std_rule_cases/LT15.yml
@@ -423,3 +423,51 @@ test_pass_minimum_ignores_templated_terminator:
     rules:
       layout.newlines:
         minimum_empty_lines_between_statements: 1
+
+test_pass_minimum_trailing_comment_does_not_hide_the_newline:
+  # the statements are already on separate lines; stopping the scan at the
+  # comment reported a shared line and tore the comment off its statement
+  pass_str: |
+    SELECT a FROM tab; -- x
+
+    SELECT b FROM tab;
+  configs:
+    rules:
+      layout.newlines:
+        minimum_empty_lines_between_statements: 1
+
+test_pass_minimum_ignores_templated_newlines_in_the_run:
+  # a jinja expression expanding to newlines leaves no placeholder behind, so
+  # the placeholder skip cannot see it; without the is_templated guard those
+  # lines are counted as part of the gap even though they are not in the source
+  pass_str: "SELECT a FROM tab;{{ \"\\n\\n\" }}\nSELECT b FROM tab;"
+  configs:
+    core:
+      templater: jinja
+    rules:
+      layout.newlines:
+        minimum_empty_lines_between_statements: 3
+
+test_pass_minimum_ignores_semicolons_inside_a_compound_statement:
+  # a semicolon delimiting inner statements of a procedural body is not a gap
+  # between top-level statements
+  pass_str: |
+    CREATE PROCEDURE p AS BEGIN SELECT 1; SELECT 2; END;
+  configs:
+    core:
+      dialect: tsql
+    rules:
+      layout.newlines:
+        minimum_empty_lines_between_statements: 1
+
+test_pass_minimum_ignores_a_template_tag_between_same_line_statements:
+  # the tag is not a statement sharing the line, and the whitespace either side
+  # of it is the template's, not the user's, so it must not be rewritten
+  pass_str: |
+    SELECT a FROM tab; {% if true %}{% endif %} SELECT b FROM tab;
+  configs:
+    core:
+      templater: jinja
+    rules:
+      layout.newlines:
+        minimum_empty_lines_between_statements: 1

--- a/test/fixtures/rules/std_rule_cases/LT15.yml
+++ b/test/fixtures/rules/std_rule_cases/LT15.yml
@@ -471,3 +471,70 @@ test_pass_minimum_ignores_a_template_tag_between_same_line_statements:
     rules:
       layout.newlines:
         minimum_empty_lines_between_statements: 1
+
+test_pass_minimum_does_not_apply_between_batches_tsql:
+  # the maximum resolves three scopes and only the middle one is "between
+  # statements"; a file-level gap in a batch dialect separates batches, which
+  # maximum_empty_lines_between_batches governs, not this setting
+  pass_str: |
+    SELECT 1;
+
+    SELECT 2;
+    GO
+    SELECT 3;
+  configs:
+    core:
+      dialect: tsql
+    rules:
+      layout.newlines:
+        minimum_empty_lines_between_statements: 1
+
+test_fail_minimum_applies_between_statements_inside_a_batch_tsql:
+  # inside a batch it is still a gap between statements, so it still applies
+  fail_str: |
+    SELECT 1;
+    SELECT 2;
+    GO
+  fix_str: |
+    SELECT 1;
+
+    SELECT 2;
+    GO
+  configs:
+    core:
+      dialect: tsql
+    rules:
+      layout.newlines:
+        minimum_empty_lines_between_statements: 1
+
+test_pass_minimum_does_not_apply_between_batches_oracle:
+  # oracle has the same batch grammar, delimited by '/'
+  pass_str: |
+    SELECT 1 FROM dual;
+
+    SELECT 2 FROM dual;
+    /
+    SELECT 3 FROM dual;
+  configs:
+    core:
+      dialect: oracle
+    rules:
+      layout.newlines:
+        minimum_empty_lines_between_statements: 1
+
+test_fail_minimum_applies_between_statements_inside_a_batch_oracle:
+  fail_str: |
+    SELECT 1 FROM dual;
+    SELECT 2 FROM dual;
+    /
+  fix_str: |
+    SELECT 1 FROM dual;
+
+    SELECT 2 FROM dual;
+    /
+  configs:
+    core:
+      dialect: oracle
+    rules:
+      layout.newlines:
+        minimum_empty_lines_between_statements: 1

--- a/test/fixtures/rules/std_rule_cases/LT15.yml
+++ b/test/fixtures/rules/std_rule_cases/LT15.yml
@@ -673,3 +673,55 @@ test_pass_minimum_counts_a_blank_line_before_an_intervening_comment:
     rules:
       layout.newlines:
         minimum_empty_lines_between_statements: 1
+
+test_fail_minimum_ignores_blank_lines_internal_to_a_multiline_comment:
+  # a multi-line /* */ comment lexes as one block_comment segment per physical
+  # line, with its own newlines between them. those newlines are part of the
+  # comment's own text, not a gap between statements, so a blank line inside
+  # the comment must not count toward the minimum even though the statements
+  # themselves are not separated by any real blank line
+  fail_str: |
+    SELECT a FROM tab;
+    /* line1
+
+    line2 */
+    SELECT b FROM tab;
+  fix_str: |
+    SELECT a FROM tab;
+    /* line1
+
+    line2 */
+
+    SELECT b FROM tab;
+  configs:
+    rules:
+      layout.newlines:
+        minimum_empty_lines_between_statements: 1
+
+test_pass_minimum_still_counts_a_blank_line_between_two_separate_comments:
+  # two adjacent -- comments with a real blank line between them: this must
+  # stay satisfied, since the blank line is a genuine gap, not comment-internal
+  pass_str: |
+    SELECT a FROM tab;
+    -- comment 1
+
+    -- comment 2
+    SELECT b FROM tab;
+  configs:
+    rules:
+      layout.newlines:
+        minimum_empty_lines_between_statements: 1
+
+test_pass_minimum_still_counts_a_blank_line_before_a_multiline_comment:
+  # a real blank line before a multi-line /* */ comment must still satisfy the
+  # minimum; only newlines inside the comment's own body are excluded
+  pass_str: |
+    SELECT a FROM tab;
+
+    /* line1
+    line2 */
+    SELECT b FROM tab;
+  configs:
+    rules:
+      layout.newlines:
+        minimum_empty_lines_between_statements: 1

--- a/test/fixtures/rules/std_rule_cases/LT15.yml
+++ b/test/fixtures/rules/std_rule_cases/LT15.yml
@@ -673,4 +673,3 @@ test_pass_minimum_counts_a_blank_line_before_an_intervening_comment:
     rules:
       layout.newlines:
         minimum_empty_lines_between_statements: 1
-

--- a/test/fixtures/rules/std_rule_cases/LT15.yml
+++ b/test/fixtures/rules/std_rule_cases/LT15.yml
@@ -410,3 +410,16 @@ test_pass_minimum_ignores_template_block_tags:
     rules:
       layout.newlines:
         minimum_empty_lines_between_statements: 1
+
+test_pass_minimum_ignores_templated_terminator:
+  # the terminator itself comes from the template, so the break after it is not
+  # the user's line to insert
+  pass_str: |
+    {% set semi = ";" %}
+    SELECT a FROM tab{{ semi }} SELECT b FROM tab;
+  configs:
+    core:
+      templater: jinja
+    rules:
+      layout.newlines:
+        minimum_empty_lines_between_statements: 1

--- a/test/fixtures/rules/std_rule_cases/LT15.yml
+++ b/test/fixtures/rules/std_rule_cases/LT15.yml
@@ -659,3 +659,18 @@ test_fail_minimum_pads_a_comment_separated_gap_once:
     rules:
       layout.newlines:
         minimum_empty_lines_between_statements: 1
+
+test_pass_minimum_counts_a_blank_line_before_an_intervening_comment:
+  # the gap spans the comment, so a blank line on the far side of it already
+  # satisfies the minimum. stopping the count at the comment hid that and
+  # padded the same gap a second time
+  pass_str: |
+    SELECT a FROM tab;
+
+    -- a note
+    SELECT b FROM tab;
+  configs:
+    rules:
+      layout.newlines:
+        minimum_empty_lines_between_statements: 1
+

--- a/test/fixtures/rules/std_rule_cases/LT15.yml
+++ b/test/fixtures/rules/std_rule_cases/LT15.yml
@@ -538,3 +538,39 @@ test_fail_minimum_applies_between_statements_inside_a_batch_oracle:
     rules:
       layout.newlines:
         minimum_empty_lines_between_statements: 1
+
+test_pass_minimum_above_maximum_is_capped_not_oscillating:
+  # both settings validate independently, so a minimum above the maximum is
+  # accepted config. enforced as written the two fixers undo each other and
+  # `fix` alternates between 2 and 5 blank lines on every run without ever
+  # converging. the minimum is capped by the maximum so the file settles.
+  fail_str: |
+    SELECT a FROM tab;
+    SELECT b FROM tab;
+  fix_str: |
+    SELECT a FROM tab;
+
+
+    SELECT b FROM tab;
+  configs:
+    rules:
+      layout.newlines:
+        minimum_empty_lines_between_statements: 5
+        maximum_empty_lines_between_statements: 2
+
+test_pass_minimum_equal_to_maximum_is_satisfiable:
+  # the boundary case: exactly at the maximum must still be reachable
+  fail_str: |
+    SELECT a FROM tab;
+    SELECT b FROM tab;
+  fix_str: |
+    SELECT a FROM tab;
+
+
+    SELECT b FROM tab;
+  configs:
+    rules:
+      layout.newlines:
+        minimum_empty_lines_between_statements: 2
+        maximum_empty_lines_between_statements: 2
+

--- a/test/fixtures/rules/std_rule_cases/LT15.yml
+++ b/test/fixtures/rules/std_rule_cases/LT15.yml
@@ -725,3 +725,19 @@ test_pass_minimum_still_counts_a_blank_line_before_a_multiline_comment:
     rules:
       layout.newlines:
         minimum_empty_lines_between_statements: 1
+
+test_pass_minimum_counts_a_blank_line_after_an_intervening_comment:
+  # the third permutation cubic traced alongside the other two: the blank
+  # line sits after the comment (immediately before the next statement)
+  # rather than before it. pads_a_comment_separated_gap_once pins zero blank
+  # lines either side, and counts_a_blank_line_before_an_intervening_comment
+  # pins one before; this is the one nothing else covers.
+  pass_str: |
+    SELECT a FROM tab;
+    -- a note
+
+    SELECT b FROM tab;
+  configs:
+    rules:
+      layout.newlines:
+        minimum_empty_lines_between_statements: 1

--- a/test/fixtures/rules/std_rule_cases/LT15.yml
+++ b/test/fixtures/rules/std_rule_cases/LT15.yml
@@ -351,3 +351,62 @@ test_fail_minimum_pads_a_whitespace_only_gap:
     rules:
       layout.newlines:
         minimum_empty_lines_between_statements: 2
+
+test_fail_minimum_statements_sharing_a_line:
+  # the run-based check can only fire where a newline exists, so two statements
+  # on one line used to be accepted whatever the minimum was set to
+  fail_str: SELECT a FROM tab; SELECT b FROM tab;
+  fix_str: |-
+    SELECT a FROM tab;
+
+    SELECT b FROM tab;
+  configs:
+    rules:
+      layout.newlines:
+        minimum_empty_lines_between_statements: 1
+
+test_fail_minimum_two_statements_sharing_a_line_higher_minimum:
+  fail_str: SELECT a FROM tab; SELECT b FROM tab;
+  fix_str: |-
+    SELECT a FROM tab;
+
+
+    SELECT b FROM tab;
+  configs:
+    rules:
+      layout.newlines:
+        minimum_empty_lines_between_statements: 2
+
+test_pass_minimum_zero_leaves_shared_line_alone:
+  # the default must stay a no-op, so a shared line is not touched
+  pass_str: SELECT a FROM tab; SELECT b FROM tab;
+  configs:
+    rules:
+      layout.newlines:
+        minimum_empty_lines_between_statements: 0
+
+test_pass_minimum_trailing_terminator_at_end_of_file:
+  # nothing follows the last terminator, so there is no gap to pad
+  pass_str: |
+    SELECT a FROM tab;
+
+    SELECT b FROM tab;
+  configs:
+    rules:
+      layout.newlines:
+        minimum_empty_lines_between_statements: 1
+
+test_pass_minimum_ignores_template_block_tags:
+  # the newlines around a jinja block tag are not a gap between two statements;
+  # padding them would put blank lines around the tag instead
+  pass_str: |
+    SELECT a FROM tab;
+    {% for _ in range(2) %}
+    {% endfor %}
+    SELECT b FROM tab;
+  configs:
+    core:
+      templater: jinja
+    rules:
+      layout.newlines:
+        minimum_empty_lines_between_statements: 1

--- a/test/fixtures/rules/std_rule_cases/LT15.yml
+++ b/test/fixtures/rules/std_rule_cases/LT15.yml
@@ -325,3 +325,29 @@ test_pass_minimum_counts_a_whitespace_only_line_as_blank:
     rules:
       layout.newlines:
         minimum_empty_lines_between_statements: 1
+
+test_pass_minimum_ignores_leading_blank_line:
+  # no statement precedes the gap, so there is nothing to separate
+  pass_str: "\nSELECT a FROM tab;\n"
+  configs:
+    rules:
+      layout.newlines:
+        minimum_empty_lines_between_statements: 1
+
+test_pass_minimum_ignores_leading_comment:
+  pass_str: |
+    -- a header comment
+    SELECT a FROM tab;
+  configs:
+    rules:
+      layout.newlines:
+        minimum_empty_lines_between_statements: 1
+
+test_fail_minimum_pads_a_whitespace_only_gap:
+  # the whitespace-only line counts as one blank, so one more is inserted
+  fail_str: "SELECT a FROM tab;\n   \nSELECT b FROM tab;\n"
+  fix_str: "SELECT a FROM tab;\n   \n\nSELECT b FROM tab;\n"
+  configs:
+    rules:
+      layout.newlines:
+        minimum_empty_lines_between_statements: 2

--- a/test/fixtures/rules/std_rule_cases/LT15.yml
+++ b/test/fixtures/rules/std_rule_cases/LT15.yml
@@ -263,3 +263,65 @@ test_fail_extra_blank_in_cte_body:
     rules:
       layout.newlines:
         maximum_empty_lines_inside_statements: 0
+
+test_fail_minimum_blank_lines_between_statements:
+  # issue #6840: a minimum, mirroring maximum_empty_lines_between_statements
+  fail_str: |
+    SELECT a FROM tab;
+    SELECT b FROM tab;
+  fix_str: |
+    SELECT a FROM tab;
+
+    SELECT b FROM tab;
+  configs:
+    rules:
+      layout.newlines:
+        minimum_empty_lines_between_statements: 1
+
+test_fail_minimum_of_two_blank_lines:
+  fail_str: |
+    SELECT a FROM tab;
+
+    SELECT b FROM tab;
+  fix_str: |
+    SELECT a FROM tab;
+
+
+    SELECT b FROM tab;
+  configs:
+    rules:
+      layout.newlines:
+        minimum_empty_lines_between_statements: 2
+
+test_pass_minimum_already_satisfied:
+  pass_str: |
+    SELECT a FROM tab;
+
+    SELECT b FROM tab;
+  configs:
+    rules:
+      layout.newlines:
+        minimum_empty_lines_between_statements: 1
+
+test_pass_minimum_defaults_to_zero:
+  # unset means unchanged behaviour for everyone already using this rule
+  pass_str: |
+    SELECT a FROM tab;
+    SELECT b FROM tab;
+
+test_pass_minimum_ignores_end_of_file:
+  # no statement follows, so there is no gap to pad
+  pass_str: |
+    SELECT a FROM tab;
+  configs:
+    rules:
+      layout.newlines:
+        minimum_empty_lines_between_statements: 1
+
+test_pass_minimum_counts_a_whitespace_only_line_as_blank:
+  # a line of spaces is still a blank line, so the run walk steps over whitespace
+  pass_str: "SELECT a FROM tab;\n   \nSELECT b FROM tab;\n"
+  configs:
+    rules:
+      layout.newlines:
+        minimum_empty_lines_between_statements: 1

--- a/test/fixtures/rules/std_rule_cases/LT15.yml
+++ b/test/fixtures/rules/std_rule_cases/LT15.yml
@@ -539,7 +539,7 @@ test_fail_minimum_applies_between_statements_inside_a_batch_oracle:
       layout.newlines:
         minimum_empty_lines_between_statements: 1
 
-test_pass_minimum_above_maximum_is_capped_not_oscillating:
+test_fail_minimum_above_maximum_is_capped_not_oscillating:
   # both settings validate independently, so a minimum above the maximum is
   # accepted config. enforced as written the two fixers undo each other and
   # `fix` alternates between 2 and 5 blank lines on every run without ever
@@ -558,7 +558,7 @@ test_pass_minimum_above_maximum_is_capped_not_oscillating:
         minimum_empty_lines_between_statements: 5
         maximum_empty_lines_between_statements: 2
 
-test_pass_minimum_equal_to_maximum_is_satisfiable:
+test_fail_minimum_equal_to_maximum_is_satisfiable:
   # the boundary case: exactly at the maximum must still be reachable
   fail_str: |
     SELECT a FROM tab;
@@ -617,6 +617,7 @@ test_pass_oracle_inside_batch_still_uses_the_between_statements_maximum:
       layout.newlines:
         maximum_empty_lines_between_batches: 1
         maximum_empty_lines_between_statements: 4
+
 test_pass_minimum_ignores_a_templated_anchor_newline:
   # the newline the rule anchors on is itself templated, so there is no source
   # line to attach a fix to and the gap is declined rather than padded
@@ -624,6 +625,37 @@ test_pass_minimum_ignores_a_templated_anchor_newline:
   configs:
     core:
       templater: jinja
+    rules:
+      layout.newlines:
+        minimum_empty_lines_between_statements: 1
+
+test_fail_maximum_reports_only_the_final_newline_of_a_whitespace_broken_run:
+  # the maximum's windowed eligibility test suppresses the violation when the
+  # run is not purely newlines. sharing the minimum's counter here silently
+  # widened the rule, so this pins the shipped behaviour: a whitespace-only
+  # line inside the run leaves only the final newline reported
+  fail_str: "SELECT a FROM tab;\n   \n\n\nSELECT b FROM tab;\n"
+  fix_str: "SELECT a FROM tab;\n   \n\nSELECT b FROM tab;\n"
+  configs:
+    rules:
+      layout.newlines:
+        maximum_empty_lines_between_statements: 1
+        minimum_empty_lines_between_statements: 0
+
+test_fail_minimum_pads_a_comment_separated_gap_once:
+  # a comment splits the gap into two runs of newlines and both used to
+  # qualify, so one gap was padded twice. only the run that ends at the next
+  # statement is the anchor
+  fail_str: |
+    SELECT a FROM tab;
+    -- a note
+    SELECT b FROM tab;
+  fix_str: |
+    SELECT a FROM tab;
+    -- a note
+
+    SELECT b FROM tab;
+  configs:
     rules:
       layout.newlines:
         minimum_empty_lines_between_statements: 1

--- a/test/fixtures/rules/std_rule_cases/LT15.yml
+++ b/test/fixtures/rules/std_rule_cases/LT15.yml
@@ -573,4 +573,3 @@ test_pass_minimum_equal_to_maximum_is_satisfiable:
       layout.newlines:
         minimum_empty_lines_between_statements: 2
         maximum_empty_lines_between_statements: 2
-


### PR DESCRIPTION
### Brief summary of the change made

Fixes #6840.

`LT15` can cap the blank lines between statements but cannot require any, so there is no way to stop statements being run together:

```sql
SELECT a FROM tab;
SELECT b FROM tab;
SELECT c FROM tab;
```

This adds `minimum_empty_lines_between_statements`, the mirror of the existing `maximum_empty_lines_between_statements`. With it set to `1`:

```
L:   1 | P:  19 | LT15 | Expected at least 1 blank line(s) between statements, found 0.
L:   2 | P:  19 | LT15 | Expected at least 1 blank line(s) between statements, found 0.
```

and `sqlfluff fix` inserts the blank lines.

**It defaults to `0`, so nothing changes for anyone already using this rule.** There is a test pinning that.

### Design notes

A few things were less obvious than the symmetry suggests, so recording the choices:

- **Only checked outside a statement.** That is where "between statements" is meaningful, and it keeps the option away from the `with_compound_statement` branch, which exists to avoid conflicting with LT08's blank-line-after-CTE requirement.
- **Runs before the maximum**, so the two cannot both act on one gap: one wants newlines added, the other wants them removed.
- **Fires on the last newline of a run**, located with `context.siblings_post` (the same approach LT09 uses). Reporting on every newline in a gap would produce one violation per line.
- **Whitespace is stepped over in both directions**, so a line containing only spaces still counts as a blank line. This one came out of a test: the forward lookahead originally skipped only indent/dedent, so a `\n   \n` gap was measured from the wrong newline and reported "found 0" on an already-correct file.
- **Templated newlines and EOF are skipped.** There is nothing to pad before the end of the file, and templated whitespace is not ours to rewrite.

### Are there any other side effects of this change that we should be aware of?

None at the default. The option is opt-in and the existing maximum behaviour is untouched, which the pre-existing LT15 cases cover.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - [x] `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
- [x] Added appropriate documentation for the change.
- [ ] Created GitHub issues for any relevant followup/future enhancements if appropriate.

Six cases added: a failing pair fixed to one blank line, a minimum of two, an already-satisfied file, the default-of-zero no-op, end-of-file, and the whitespace-only line. The rule docstring and `default_config.cfg` are updated too.

```
$ pytest test/rules/
2514 passed, 101 skipped
```

`LT15.py` is at 100% statement coverage, and `ruff check`, `ruff format`, `mypy` and `yamllint` are clean on the changed files.

### AI-assisted contribution disclosure

Per CONTRIBUTING: this PR was written with the help of an AI coding assistant, and I remain responsible for it.

**AI-assisted:** drafting the implementation, the fixtures and this description.

**Verified by me:** confirmed the gap exists and that the default is a genuine no-op by linting with no config present, rather than assuming; checked the fix output byte by byte; found and fixed the whitespace-lookahead bug from a failing fixture rather than adjusting the test; and checked `LT15.py` reaches 100% coverage, since the repo gates on it, folding one unreachable branch into an adjacent condition instead of writing a test for a path that cannot happen.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `minimum_empty_lines_between_statements` to LT15 to require blank lines between top‑level statements; previously LT15 could only cap blanks. Defaults to 0 (no change unless configured) and runs before and is capped by the maximum so fixes converge; logs a warning when the cap changes a reported result.

- Scope: Only between statements (including inside batches), never inside statements or between batches. Detects batches structurally (covers T‑SQL and Oracle). Treats `GO` and `/` as non‑statements.
- Same-line statements: Enforced by seeking `statement_terminator` (“SELECT …; SELECT …”). Inserts a newline plus required blanks, preserves trailing comments, and ignores inner semicolons in procedural bodies.
- Templates: Counts only editable newlines. Skips templated newlines and templated terminators. Declines gaps touching template block placeholders and does not rewrite template‑owned whitespace.
- Counting/anchoring: Shares one blank‑line counter for the minimum; the maximum keeps its original windowed eligibility to avoid widening behavior. When a comment splits a gap, anchors only the run ending at the next statement and counts across the intervening comment so existing blanks aren’t hidden. Newlines inside a multi‑line `/* */` comment are the comment’s own text, not blanks, and don’t satisfy the minimum.
- Config/tests: Adds `minimum_empty_lines_between_statements = 0` to default config and rule metadata. Tests pin the default no‑op, same‑line enforcement, batch and template edge cases, all blank‑line‑around‑comment permutations, and convergence when min > max.

<sup>Written for commit 6815500c3154672f044100bcb58ff5ced7f387db. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8282?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

