### PR TITLE
TSQL: don't enforce spacing before an alias column list (LT01 false positive on `AS r(c)`)

### DIFF
--- a/src/sqlfluff/core/default_config.cfg
+++ b/src/sqlfluff/core/default_config.cfg
@@ -222,7 +222,9 @@ spacing_before = touch:inline
 [sqlfluff:layout:type:alias_column_list]
 # A column list after a table alias is written both ways in the wild: the
 # T-SQL docs attach it (`AS T2(Loc)`), but the spaced form is equally valid,
-# so neither is enforced.
+# so neither is enforced. The column alias list on a VALUES clause
+# (`(VALUES (1, 2)) AS t(a, b)`) parses as the same segment, so this covers
+# that too.
 spacing_before = any
 
 [sqlfluff:layout:type:array_type]

--- a/src/sqlfluff/core/default_config.cfg
+++ b/src/sqlfluff/core/default_config.cfg
@@ -219,6 +219,12 @@ spacing_before = touch:inline
 [sqlfluff:layout:type:function_parameter_list]
 spacing_before = touch:inline
 
+[sqlfluff:layout:type:alias_column_list]
+# A column list after a table alias is written both ways in the wild: the
+# T-SQL docs attach it (`AS T2(Loc)`), but the spaced form is equally valid,
+# so neither is enforced.
+spacing_before = any
+
 [sqlfluff:layout:type:array_type]
 spacing_within = touch:inline
 

--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -2117,6 +2117,13 @@ class AliasExpressionSegment(ansi.AliasExpressionSegment):
     bracket to the alias (``AS T2(Loc)``), but the spaced form is also
     valid, so the default config enforces neither.
     https://learn.microsoft.com/en-us/sql/t-sql/xml/nodes-method-xml-data-type
+
+    The same segment carries the column alias list on a VALUES clause
+    (``(VALUES (1, 2)) AS t(a, b)``), so its spacing is unenforced as well.
+
+    Apart from that column list this mirrors ``ansi.AliasExpressionSegment``.
+    Changes to the ANSI grammar no longer reach T-SQL on their own, so they
+    have to be applied here too.
     """
 
     match_grammar: Matchable = Sequence(

--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -2108,6 +2108,38 @@ class EqualAliasOperatorSegment(BaseSegment):
     match_grammar: Matchable = Sequence(Ref("RawEqualsSegment"))
 
 
+class AliasExpressionSegment(ansi.AliasExpressionSegment):
+    """A reference to an object with an `AS` clause.
+
+    T-SQL wraps the optional column list after a table alias
+    (``... .nodes('/rows/row') AS r(c)``) in an ``alias_column_list``
+    segment so that its spacing is configurable: the docs attach the
+    bracket to the alias (``AS T2(Loc)``), but the spaced form is also
+    valid, so the default config enforces neither.
+    https://learn.microsoft.com/en-us/sql/t-sql/xml/nodes-method-xml-data-type
+    """
+
+    match_grammar: Matchable = Sequence(
+        Indent,
+        Ref("AsAliasOperatorSegment", optional=True),
+        OneOf(
+            Sequence(
+                Ref("SingleIdentifierGrammar"),
+                Ref("AliasColumnListSegment", optional=True),
+            ),
+            Ref("SingleQuotedIdentifierSegment"),
+        ),
+        Dedent,
+    )
+
+
+class AliasColumnListSegment(BaseSegment):
+    """The bracketed column list following a table alias: ``AS r(c)``."""
+
+    type = "alias_column_list"
+    match_grammar: Matchable = Bracketed(Ref("SingleIdentifierListSegment"))
+
+
 class SelectClauseModifierSegment(BaseSegment):
     """Things that come after SELECT but before the columns."""
 

--- a/test/fixtures/dialects/tsql/datatype_methods.yml
+++ b/test/fixtures/dialects/tsql/datatype_methods.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 11c659de66b99a66717b06502719fc73d6298c843a998e3ccd226c7ec38e7330
+_hash: 9104490326dbbd14e1313c426b22577fb58ef1ed3cfd49f3c3c5c84b7a6b1d58
 file:
   batch:
   - statement:
@@ -383,11 +383,12 @@ file:
                   alias_operator:
                     keyword: AS
                   naked_identifier: na
-                  bracketed:
-                    start_bracket: (
-                    identifier_list:
-                      naked_identifier: Loc
-                    end_bracket: )
+                  alias_column_list:
+                    bracketed:
+                      start_bracket: (
+                      identifier_list:
+                        naked_identifier: Loc
+                      end_bracket: )
   - statement_terminator: ;
   - statement:
       select_statement:
@@ -425,11 +426,12 @@ file:
                         end_bracket: )
               alias_expression:
                 naked_identifier: T
-                bracketed:
-                  start_bracket: (
-                  identifier_list:
-                    naked_identifier: c
-                  end_bracket: )
+                alias_column_list:
+                  bracketed:
+                    start_bracket: (
+                    identifier_list:
+                      naked_identifier: c
+                    end_bracket: )
   - statement_terminator: ;
   - go_statement:
       keyword: GO

--- a/test/fixtures/dialects/tsql/merge.yml
+++ b/test/fixtures/dialects/tsql/merge.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: f91f474bfec6523b98ddd6be79b122aaab65c0456c9f9534712f7e281c42d982
+_hash: b58b2dc54b9924461421e859beb4956f272b76acfde0bf3eb6d4c410965551df
 file:
 - batch:
     statement:
@@ -492,13 +492,14 @@ file:
           alias_operator:
             keyword: as
           naked_identifier: src
-          bracketed:
-            start_bracket: (
-            identifier_list:
-            - naked_identifier: UnitMeasureCode
-            - comma: ','
-            - naked_identifier: Name
-            end_bracket: )
+          alias_column_list:
+            bracketed:
+              start_bracket: (
+              identifier_list:
+              - naked_identifier: UnitMeasureCode
+              - comma: ','
+              - naked_identifier: Name
+              end_bracket: )
       - join_on_condition:
           keyword: 'ON'
           bracketed:
@@ -672,13 +673,14 @@ file:
           alias_operator:
             keyword: as
           naked_identifier: src
-          bracketed:
-            start_bracket: (
-            identifier_list:
-            - naked_identifier: ProductID
-            - comma: ','
-            - naked_identifier: OrderQty
-            end_bracket: )
+          alias_column_list:
+            bracketed:
+              start_bracket: (
+              identifier_list:
+              - naked_identifier: ProductID
+              - comma: ','
+              - naked_identifier: OrderQty
+              end_bracket: )
       - join_on_condition:
           keyword: 'ON'
           bracketed:
@@ -878,13 +880,14 @@ file:
           alias_operator:
             keyword: AS
           naked_identifier: src
-          bracketed:
-            start_bracket: (
-            identifier_list:
-            - naked_identifier: ProductID
-            - comma: ','
-            - naked_identifier: OrderQty
-            end_bracket: )
+          alias_column_list:
+            bracketed:
+              start_bracket: (
+              identifier_list:
+              - naked_identifier: ProductID
+              - comma: ','
+              - naked_identifier: OrderQty
+              end_bracket: )
       - join_on_condition:
           keyword: 'ON'
           expression:
@@ -1133,13 +1136,14 @@ file:
           alias_operator:
             keyword: as
           naked_identifier: src
-          bracketed:
-            start_bracket: (
-            identifier_list:
-            - naked_identifier: UnitMeasureCode
-            - comma: ','
-            - naked_identifier: Name
-            end_bracket: )
+          alias_column_list:
+            bracketed:
+              start_bracket: (
+              identifier_list:
+              - naked_identifier: UnitMeasureCode
+              - comma: ','
+              - naked_identifier: Name
+              end_bracket: )
       - join_on_condition:
           keyword: 'ON'
           bracketed:
@@ -1332,13 +1336,14 @@ file:
           alias_operator:
             keyword: AS
           naked_identifier: src
-          bracketed:
-            start_bracket: (
-            identifier_list:
-            - naked_identifier: ProductID
-            - comma: ','
-            - naked_identifier: OrderQty
-            end_bracket: )
+          alias_column_list:
+            bracketed:
+              start_bracket: (
+              identifier_list:
+              - naked_identifier: ProductID
+              - comma: ','
+              - naked_identifier: OrderQty
+              end_bracket: )
       - join_on_condition:
           keyword: 'ON'
           expression:

--- a/test/fixtures/dialects/tsql/openrowset.yml
+++ b/test/fixtures/dialects/tsql/openrowset.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 52a7a08a72ad411173d5547e1d0f83859d89af746bc0edb9875e6aca8e6729db
+_hash: bc8ffc29f25fd7c55c09689285b98d24444ff151228be78b03f3b99139849fc5
 file:
 - batch:
     statement:
@@ -440,13 +440,14 @@ file:
                 alias_operator:
                   keyword: AS
                 naked_identifier: Document
-                bracketed:
-                  start_bracket: (
-                  identifier_list:
-                  - naked_identifier: column1
-                  - comma: ','
-                  - naked_identifier: column2
-                  end_bracket: )
+                alias_column_list:
+                  bracketed:
+                    start_bracket: (
+                    identifier_list:
+                    - naked_identifier: column1
+                    - comma: ','
+                    - naked_identifier: column2
+                    end_bracket: )
     statement_terminator: ;
     go_statement:
       keyword: GO

--- a/test/fixtures/dialects/tsql/table_alias_column_list.sql
+++ b/test/fixtures/dialects/tsql/table_alias_column_list.sql
@@ -10,3 +10,8 @@ FROM @x.nodes('/Root/row') AS t (c);
 SELECT na.Loc.query('.')
 FROM SomeTable
 CROSS APPLY SomeXMLColumn.nodes('/root/Location') na(Loc, Other);
+
+-- The VALUES clause column alias list goes through the same segment, which
+-- is what the ANSI grammar named this slot for in the first place.
+SELECT a, b
+FROM (VALUES (1, 2), (3, 4)) AS t(a, b);

--- a/test/fixtures/dialects/tsql/table_alias_column_list.sql
+++ b/test/fixtures/dialects/tsql/table_alias_column_list.sql
@@ -1,0 +1,12 @@
+-- Column list aliases on table-valued expressions (issue #6733).
+SELECT r.c.value('column[1]', 'varchar(10)') AS [Value]
+FROM @xml.nodes('/rows/row') AS r(c);
+
+-- The spaced form parses identically.
+SELECT t.c.query('.')
+FROM @x.nodes('/Root/row') AS t (c);
+
+-- Multi-column list, without AS.
+SELECT na.Loc.query('.')
+FROM SomeTable
+CROSS APPLY SomeXMLColumn.nodes('/root/Location') na(Loc, Other);

--- a/test/fixtures/dialects/tsql/table_alias_column_list.yml
+++ b/test/fixtures/dialects/tsql/table_alias_column_list.yml
@@ -1,0 +1,157 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: c104e28cada4d3b23aaddcf2b47ef3235bb370ac0f6a7cbd039be4f508f4b337
+file:
+  batch:
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            column_reference:
+            - naked_identifier: r
+            - dot: .
+            - naked_identifier: c
+            - datatype_method:
+                dot: .
+                datatype_method_name_identifier: value
+                function_contents:
+                  bracketed:
+                  - start_bracket: (
+                  - expression:
+                      quoted_literal: "'column[1]'"
+                  - comma: ','
+                  - expression:
+                      quoted_literal: "'varchar(10)'"
+                  - end_bracket: )
+            alias_expression:
+              alias_operator:
+                keyword: AS
+              quoted_identifier: '[Value]'
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  parameter: '@xml'
+                  datatype_method:
+                    dot: .
+                    datatype_method_name_identifier: nodes
+                    function_contents:
+                      bracketed:
+                        start_bracket: (
+                        expression:
+                          quoted_literal: "'/rows/row'"
+                        end_bracket: )
+              alias_expression:
+                alias_operator:
+                  keyword: AS
+                naked_identifier: r
+                alias_column_list:
+                  bracketed:
+                    start_bracket: (
+                    identifier_list:
+                      naked_identifier: c
+                    end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            column_reference:
+            - naked_identifier: t
+            - dot: .
+            - naked_identifier: c
+            - datatype_method:
+                dot: .
+                datatype_method_name_identifier: query
+                function_contents:
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                      quoted_literal: "'.'"
+                    end_bracket: )
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  parameter: '@x'
+                  datatype_method:
+                    dot: .
+                    datatype_method_name_identifier: nodes
+                    function_contents:
+                      bracketed:
+                        start_bracket: (
+                        expression:
+                          quoted_literal: "'/Root/row'"
+                        end_bracket: )
+              alias_expression:
+                alias_operator:
+                  keyword: AS
+                naked_identifier: t
+                alias_column_list:
+                  bracketed:
+                    start_bracket: (
+                    identifier_list:
+                      naked_identifier: c
+                    end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            column_reference:
+            - naked_identifier: na
+            - dot: .
+            - naked_identifier: Loc
+            - datatype_method:
+                dot: .
+                datatype_method_name_identifier: query
+                function_contents:
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                      quoted_literal: "'.'"
+                    end_bracket: )
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: SomeTable
+            join_clause:
+            - keyword: CROSS
+            - keyword: APPLY
+            - from_expression_element:
+                table_expression:
+                  table_reference:
+                    naked_identifier: SomeXMLColumn
+                    datatype_method:
+                      dot: .
+                      datatype_method_name_identifier: nodes
+                      function_contents:
+                        bracketed:
+                          start_bracket: (
+                          expression:
+                            quoted_literal: "'/root/Location'"
+                          end_bracket: )
+                alias_expression:
+                  naked_identifier: na
+                  alias_column_list:
+                    bracketed:
+                      start_bracket: (
+                      identifier_list:
+                      - naked_identifier: Loc
+                      - comma: ','
+                      - naked_identifier: Other
+                      end_bracket: )
+  - statement_terminator: ;

--- a/test/fixtures/dialects/tsql/table_alias_column_list.yml
+++ b/test/fixtures/dialects/tsql/table_alias_column_list.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: c104e28cada4d3b23aaddcf2b47ef3235bb370ac0f6a7cbd039be4f508f4b337
+_hash: cc3f95239586771b10b7cbb66c3f127be06cd0d04a9bec1b9572060dc71a1461
 file:
   batch:
   - statement:
@@ -154,4 +154,51 @@ file:
                       - comma: ','
                       - naked_identifier: Other
                       end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            column_reference:
+              naked_identifier: a
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+              naked_identifier: b
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              bracketed:
+                start_bracket: (
+                table_expression:
+                  values_clause:
+                  - keyword: VALUES
+                  - bracketed:
+                    - start_bracket: (
+                    - integer_literal: '1'
+                    - comma: ','
+                    - integer_literal: '2'
+                    - end_bracket: )
+                  - comma: ','
+                  - bracketed:
+                    - start_bracket: (
+                    - integer_literal: '3'
+                    - comma: ','
+                    - integer_literal: '4'
+                    - end_bracket: )
+                end_bracket: )
+              alias_expression:
+                alias_operator:
+                  keyword: AS
+                naked_identifier: t
+                alias_column_list:
+                  bracketed:
+                    start_bracket: (
+                    identifier_list:
+                    - naked_identifier: a
+                    - comma: ','
+                    - naked_identifier: b
+                    end_bracket: )
   - statement_terminator: ;

--- a/test/fixtures/rules/std_rule_cases/LT01-brackets.yml
+++ b/test/fixtures/rules/std_rule_cases/LT01-brackets.yml
@@ -117,3 +117,38 @@ test_pass_duckdb_array_literal_not_touched:
   configs:
     core:
       dialect: duckdb
+
+# A column list after a T-SQL table alias is written both ways, so neither
+# is enforced. The docs attach it (`AS T2(Loc)`), which used to be flagged.
+# https://github.com/sqlfluff/sqlfluff/issues/6733
+test_pass_tsql_alias_column_list_touching:
+  pass_str: |
+    SELECT r.c.value('column[1]', 'varchar(10)') AS [Value]
+    FROM @xml.nodes('/rows/row') AS r(c);
+  configs:
+    core:
+      dialect: tsql
+
+test_pass_tsql_alias_column_list_spaced:
+  pass_str: |
+    SELECT r.c.value('column[1]', 'varchar(10)') AS [Value]
+    FROM @xml.nodes('/rows/row') AS r (c);
+  configs:
+    core:
+      dialect: tsql
+
+# Either style can still be enforced by configuring the segment.
+test_fail_tsql_alias_column_list_spaced_when_touch_configured:
+  fail_str: |
+    SELECT r.c.value('column[1]', 'varchar(10)') AS [Value]
+    FROM @xml.nodes('/rows/row') AS r (c);
+  fix_str: |
+    SELECT r.c.value('column[1]', 'varchar(10)') AS [Value]
+    FROM @xml.nodes('/rows/row') AS r(c);
+  configs:
+    core:
+      dialect: tsql
+    layout:
+      type:
+        alias_column_list:
+          spacing_before: touch

--- a/test/fixtures/rules/std_rule_cases/LT01-brackets.yml
+++ b/test/fixtures/rules/std_rule_cases/LT01-brackets.yml
@@ -138,6 +138,16 @@ test_pass_tsql_alias_column_list_spaced:
       dialect: tsql
 
 # Either style can still be enforced by configuring the segment.
+# The VALUES clause column alias list is the same segment, so it is not
+# enforced either. Pinned because the config comment says so.
+test_pass_tsql_values_alias_column_list_touching:
+  pass_str: |
+    SELECT a, b
+    FROM (VALUES (1, 2), (3, 4)) AS t(a, b);
+  configs:
+    core:
+      dialect: tsql
+
 test_fail_tsql_alias_column_list_spaced_when_touch_configured:
   fail_str: |
     SELECT r.c.value('column[1]', 'varchar(10)') AS [Value]


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

### Brief summary of the change made

Closes #6733.

That issue covered RF05, AL05 and LT01, plus `sqlfluff fix` corrupting the script. The RF05 half was #8088 (merged), and AL05 and the corruption no longer reproduce on main. This is the last part still reproducing, so it closes the issue rather than making progress on it.

LT01 required a space between a table alias and its column list, so the form the T-SQL docs use throughout was flagged:

```sql
select
    r.c.value('column[1]', 'varchar(10)') as [Value]
from @xml.nodes('/rows/row') as r(c);
```

```
L:3 P:34  LT01  Expected single whitespace between naked identifier and start bracket '('.
```

and `sqlfluff fix` rewrote it to `as r (c)`.

Both spacings are valid T-SQL, and the documentation uses both. Every SQL example in the [`nodes()` reference](https://learn.microsoft.com/en-us/sql/t-sql/xml/nodes-method-xml-data-type) attaches the bracket to the alias (`AS T2(Loc)`, `T(c)`, `A2(B)`, `AS T1(Locations)`), while the [FROM syntax notation](https://learn.microsoft.com/en-us/sql/t-sql/queries/from-transact-sql) writes it spaced, as `[ ( column_alias [ , ...n ] ) ]`. So neither form is wrong, and the rule shouldn't mandate either.

The column list previously parsed as a bare `bracketed` directly under `alias_expression`, which layout config can't target without also catching every other bracket. This wraps it in an `alias_column_list` segment and sets `spacing_before = any`.

I went with `any` rather than `touch:inline` deliberately. `touch` would fix the reported false positive but flip the mandate, and `sqlfluff fix` would then rewrite the spaced form that the rule has been *requiring* until now, which is churn for existing T-SQL users beyond the reported bug. With `any`, neither spacing is enforced by default and either can be required by configuring the segment (covered by a test case). Happy to switch it to `touch:inline` if you'd prefer the opinionated default, since it's a one-line config change.

### Are there any other side effects of this change that we should be aware of?

The extra AST level is the main one. `alias_expression -> bracketed` becomes `alias_expression -> alias_column_list -> bracketed`, which changes three existing tsql fixtures (`datatype_methods`, `merge`, `openrowset`). I checked for code that reaches into an alias for its column list and found none: nothing in `src/` matches `identifier_list` outside the dialect files, and the alias-name lookups in `core/dialects/common.py` and `utils/analysis/query.py` read the identifier child, which is unaffected.

Scope is tsql only; the ansi `AliasExpressionSegment` is untouched, so other dialects keep the existing parse and spacing behaviour. The analogous `cte_column_list` is also unchanged, so it still requires a space, which felt out of scope here.

Full `test/rules` and `test/dialects` pass (9331 passed, 101 skipped), plus ruff and mypy clean.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - [x] `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`: four cases in `LT01-brackets.yml`, covering both spacings passing on a table alias, the VALUES-clause column alias list, and the touching style being enforced when configured.
  - [x] `.sql`/`.yml` parser test cases in `test/fixtures/dialects`: new `tsql/table_alias_column_list.sql`, plus regenerated fixtures.
  - [ ] Full autofix test cases in `test/fixtures/linter/autofix`.
  - [ ] Other.
- [x] Added appropriate documentation for the change. The new config entry is commented in `default_config.cfg`, and it appears in the layout docs automatically.
- [ ] Created GitHub issues for any relevant followup/future enhancements if appropriate.

