### PR TITLE
Respect DBT_POPULATE_CACHE in dbt templater

### DIFF
--- a/docs/source/configuration/templating/dbt.rst
+++ b/docs/source/configuration/templating/dbt.rst
@@ -91,6 +91,7 @@ You can set the dbt project directory, profiles directory and profile with:
     profile = <dbt profile>
     target = <dbt target>
     dbt_skip_compilation_error = <True or False, default is True>
+    populate_relations_cache = <True or False, default is True>
 
 .. note::
 
@@ -101,6 +102,11 @@ You can set the dbt project directory, profiles directory and profile with:
     ``profiles_dir`` can be set by ``DBT_ENGINE_PROFILES_DIR`` or
     ``DBT_PROFILES_DIR``, and ``profile`` can be set by ``DBT_ENGINE_PROFILE``
     or ``DBT_PROFILE``.
+
+    The dbt templater also supports dbt's ``DBT_POPULATE_CACHE`` environment
+    variable. Set ``DBT_POPULATE_CACHE=False`` or
+    ``populate_relations_cache = False`` to skip the eager relation-cache
+    warm-up before linting.
 
 .. note::
 

--- a/plugins/sqlfluff-templater-dbt/sqlfluff_templater_dbt/templater.py
+++ b/plugins/sqlfluff-templater-dbt/sqlfluff_templater_dbt/templater.py
@@ -185,6 +185,7 @@ class DbtTemplater(JinjaTemplater):
         self.profiles_dir = None
         self.working_dir = os.getcwd()
         self.dbt_skip_compilation_error = True
+        self.populate_relations_cache = True
         super().__init__(override_context=override_context)
 
     def config_pairs(self):
@@ -459,6 +460,40 @@ class DbtTemplater(JinjaTemplater):
             default=True,
         )
 
+    @staticmethod
+    def _coerce_bool(value: Any, name: str) -> bool:
+        """Coerce a config or environment variable value to a boolean."""
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, int) and value in {0, 1}:
+            return bool(value)
+        if isinstance(value, str):
+            cleaned_value = value.strip().lower()
+            if cleaned_value in {"1", "true", "yes", "on"}:
+                return True
+            if cleaned_value in {"0", "false", "no", "off"}:
+                return False
+        raise SQLFluffUserError(
+            f"Expected `{name}` to be a boolean value, but got {value!r}."
+        )
+
+    def _get_populate_relations_cache(self) -> bool:
+        """Get whether to eagerly populate dbt's relations cache."""
+        assert self.sqlfluff_config
+        config_value = self.sqlfluff_config.get(
+            val="populate_relations_cache",
+            section=(self.templater_selector, self.name),
+            default=None,
+        )
+        if config_value is not None:
+            return self._coerce_bool(config_value, "populate_relations_cache")
+
+        env_value = os.getenv("DBT_POPULATE_CACHE")
+        if env_value is not None:
+            return self._coerce_bool(env_value, "DBT_POPULATE_CACHE")
+
+        return True
+
     def sequence_files(
         self, fnames: list[str], config=None, formatter=None
     ) -> Iterator[str]:
@@ -562,6 +597,7 @@ class DbtTemplater(JinjaTemplater):
         self.project_dir = self._get_project_dir()
         self.profiles_dir = self._get_profiles_dir()
         self.dbt_skip_compilation_error = self._get_dbt_skip_compilation_error()
+        self.populate_relations_cache = self._get_populate_relations_cache()
         fname_absolute_path = os.path.abspath(fname) if fname != "stdin" else fname
 
         # NOTE: dbt exceptions are caught and handled safely for pickling by the outer
@@ -889,8 +925,9 @@ class DbtTemplater(JinjaTemplater):
 
                 adapter.set_macro_resolver(self.dbt_manifest)
                 adapter.set_macro_context_generator(generate_runtime_macro_context)
-                adapter.set_relations_cache(self.dbt_manifest.nodes.values())
-            else:
+                if self.populate_relations_cache:
+                    adapter.set_relations_cache(self.dbt_manifest.nodes.values())
+            elif self.populate_relations_cache:
                 adapter.set_relations_cache(self.dbt_manifest)
 
         yield

--- a/plugins/sqlfluff-templater-dbt/test/templater_test.py
+++ b/plugins/sqlfluff-templater-dbt/test/templater_test.py
@@ -813,6 +813,82 @@ def test__target_path_from_env(dbt_templater, monkeypatch):
     assert dbt_templater._get_target_path() == "engine_target"
 
 
+@pytest.mark.parametrize(
+    ("env_value", "expected"),
+    [("false", False), ("0", False), ("true", True), ("1", True)],
+)
+def test__populate_relations_cache_from_env(
+    dbt_templater, monkeypatch, env_value, expected
+):
+    """Test possibility to skip relation cache population from a dbt env var."""
+    dbt_templater.sqlfluff_config = FluffConfig(
+        configs={"core": {"dialect": "ansi"}, "templater": {"dbt": {}}}
+    )
+    monkeypatch.setenv("DBT_POPULATE_CACHE", env_value)
+
+    assert dbt_templater._get_populate_relations_cache() is expected
+
+
+def test__populate_relations_cache_config_precedence(dbt_templater, monkeypatch):
+    """Test SQLFluff config takes precedence over DBT_POPULATE_CACHE."""
+    monkeypatch.setenv("DBT_POPULATE_CACHE", "false")
+    dbt_templater.sqlfluff_config = FluffConfig(
+        configs={
+            "core": {"dialect": "ansi"},
+            "templater": {"dbt": {"populate_relations_cache": True}},
+        }
+    )
+
+    assert dbt_templater._get_populate_relations_cache() is True
+
+
+def test__populate_relations_cache_from_config(dbt_templater, monkeypatch):
+    """Test possibility to skip relation cache population from SQLFluff config."""
+    monkeypatch.delenv("DBT_POPULATE_CACHE", raising=False)
+    dbt_templater.sqlfluff_config = FluffConfig(
+        configs={
+            "core": {"dialect": "ansi"},
+            "templater": {"dbt": {"populate_relations_cache": False}},
+        }
+    )
+
+    assert dbt_templater._get_populate_relations_cache() is False
+
+
+def test__populate_relations_cache_invalid_env(dbt_templater, monkeypatch):
+    """Test invalid DBT_POPULATE_CACHE values raise a helpful error."""
+    monkeypatch.setenv("DBT_POPULATE_CACHE", "definitely")
+    dbt_templater.sqlfluff_config = FluffConfig(
+        configs={"core": {"dialect": "ansi"}, "templater": {"dbt": {}}}
+    )
+
+    with pytest.raises(SQLFluffUserError, match="DBT_POPULATE_CACHE"):
+        dbt_templater._get_populate_relations_cache()
+
+
+def test__connection_skips_relations_cache_when_disabled(dbt_templater):
+    """Test that disabling relation cache population skips the dbt warm-up call."""
+    pytest.importorskip("dbt")
+    DbtTemplater.adapters.clear()
+    adapter = mock.Mock()
+    manifest = mock.Mock()
+
+    dbt_templater.project_dir = "test-project"
+    dbt_templater.populate_relations_cache = False
+    dbt_templater.__dict__["dbt_config"] = object()
+    dbt_templater.__dict__["dbt_manifest"] = manifest
+    dbt_templater.__dict__["dbt_version_tuple"] = (1, 8)
+
+    with mock.patch("dbt.adapters.factory.get_adapter", return_value=adapter):
+        with dbt_templater.connection():
+            pass
+
+    adapter.acquire_connection.assert_called_once_with("master")
+    adapter.set_macro_resolver.assert_called_once_with(manifest)
+    adapter.set_relations_cache.assert_not_called()
+    manifest.nodes.values.assert_not_called()
+
+
 def test__project_dir_does_not_exist_error(dbt_templater):
     """Test an error is logged if the given dbt project directory doesn't exist."""
     dbt_templater.sqlfluff_config = FluffConfig(


### PR DESCRIPTION
### Brief summary of the change made
Fixes #8239.

The dbt templater now honours `DBT_POPULATE_CACHE` and a new `[sqlfluff:templater:dbt]` `populate_relations_cache` option before calling dbt's eager `set_relations_cache()` warm-up. The default remains `True` to preserve existing behaviour, while `DBT_POPULATE_CACHE=false` or `populate_relations_cache = False` skips the eager relation-cache population.

AI assistance was used for implementation and PR text. Local validation performed:

- `uvx tox -e dbt180 -- plugins/sqlfluff-templater-dbt/test/templater_test.py -k 'populate_relations_cache or connection_skips_relations_cache_when_disabled'`
- `.tox/dbt180/bin/python -m ruff check plugins/sqlfluff-templater-dbt/sqlfluff_templater_dbt/templater.py plugins/sqlfluff-templater-dbt/test/templater_test.py`
- `.tox/dbt180/bin/python -m ruff format --check plugins/sqlfluff-templater-dbt/sqlfluff_templater_dbt/templater.py plugins/sqlfluff-templater-dbt/test/templater_test.py`
- `git diff --check`

Note: I also ran the full `plugins/sqlfluff-templater-dbt/test/templater_test.py` file in `dbt180`; tests requiring a live local Postgres instance failed with `connection refused`/cursor errors, while the non-database targeted regression tests passed.

### Are there any other side effects of this change that we should be aware of?

Users who opt out of eager relation-cache population may pay lazy dbt relation lookups only if their templating actually needs relation cache data.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the `dbt` templater respect `DBT_POPULATE_CACHE` and a new `populate_relations_cache` option to control eager relation-cache warm-up. Default stays enabled; disabling skips the warm-up and can reduce unnecessary DB hits during linting.

- **New Features**
  - Added `populate_relations_cache` in `[sqlfluff:templater:dbt]` (default `True`).
  - Support `DBT_POPULATE_CACHE`; `sqlfluff` config takes precedence.
  - Only warm up relations cache when enabled.
  - Added unit tests and documentation.

- **Migration**
  - To disable eager cache population: set `DBT_POPULATE_CACHE=false` or `populate_relations_cache = False` in `[sqlfluff:templater:dbt]`.

<sup>Written for commit baa8f3af9e7c414e83aaddf77e4dc12e7d0095e0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8286?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

