### PR TITLE
MariaDB: support IF EXISTS on ALTER TABLE (table level and DROP PARTITION)

### DIFF
--- a/src/sqlfluff/dialects/dialect_mariadb.py
+++ b/src/sqlfluff/dialects/dialect_mariadb.py
@@ -575,13 +575,17 @@ class AlterTableConstraintSegment(mysql.TableConstraintSegment):
 class AlterTableStatementSegment(mysql.AlterTableStatementSegment):
     """An `ALTER TABLE` statement.
 
-    Overriding MySQL to add MariaDB's ``IF [NOT] EXISTS`` conditional clauses on
-    the ``ADD`` / ``DROP`` / ``CHANGE`` / ``MODIFY`` / ``ALTER {INDEX|KEY}``
-    actions. The ``ADD`` index/constraint clauses pick up ``IF NOT EXISTS`` via
-    the ALTER-only `AlterTableConstraintSegment`; the remaining actions are
-    handled here. Every added clause is strictly optional, so previously valid
-    statements parse identically. MySQL does not support these clauses, so the
-    change is confined to the MariaDB dialect.
+    Overriding MySQL to add MariaDB extensions:
+    - Table-level ``IF EXISTS`` (between ``TABLE`` and table reference)
+    - Column-level ``IF [NOT] EXISTS`` on ``ADD`` / ``DROP`` / ``CHANGE`` /
+      ``MODIFY`` / ``ALTER {INDEX|KEY}`` actions (the ``ADD`` index/constraint
+      clauses pick up ``IF NOT EXISTS`` via the ALTER-only
+      `AlterTableConstraintSegment`; the remaining actions are handled here)
+    - Partition-level ``DROP PARTITION IF EXISTS`` with comma-separated name list
+
+    Every added clause is strictly optional, so previously valid statements parse
+    identically. MySQL does not support these clauses, so the change is confined
+    to the MariaDB dialect.
 
     https://mariadb.com/docs/server/reference/sql-statements/data-definition/alter/alter-table
     """
@@ -590,6 +594,7 @@ class AlterTableStatementSegment(mysql.AlterTableStatementSegment):
     match_grammar = Sequence(
         "ALTER",
         "TABLE",
+        Ref("IfExistsGrammar", optional=True),
         Ref("TableReferenceSegment"),
         Delimited(
             OneOf(
@@ -755,27 +760,43 @@ class AlterTableStatementSegment(mysql.AlterTableStatementSegment):
         ),
         Sequence(
             OneOf(
-                "ADD",
-                "DROP",
-                "DISCARD",
-                "IMPORT",
-                "TRUNCATE",
-                "COALESCE",
-                "REORGANIZE",
-                "EXCHANGE",
-                "ANALYZE",
-                "CHECK",
-                "OPTIMIZE",
-                "REBUILD",
-                "REPAIR",
-                "REMOVE",
-            ),
-            OneOf("PARTITION", "PARTITIONING"),
-            OneOf(
-                Ref("SingleIdentifierGrammar"),
-                Ref("NumericLiteralSegment"),
-                "ALL",
-                Bracketed(Delimited(Ref("ObjectReferenceSegment"))),
+                # MariaDB: DROP PARTITION [IF EXISTS] p1[, p2 ...]
+                # `IF EXISTS` and the comma-separated name list are MariaDB
+                # extensions kept on the DROP verb only, so ADD/TRUNCATE/etc.
+                # do not pick up the conditional. Only ``PARTITION`` is valid
+                # here (``DROP PARTITIONING`` is not MariaDB syntax; removing
+                # partitioning uses ``REMOVE PARTITIONING``).
+                Sequence(
+                    "DROP",
+                    "PARTITION",
+                    Ref("IfExistsGrammar", optional=True),
+                    Delimited(Ref("SingleIdentifierGrammar")),
+                ),
+                # All other partition actions (unchanged behaviour).
+                Sequence(
+                    OneOf(
+                        "ADD",
+                        "DISCARD",
+                        "IMPORT",
+                        "TRUNCATE",
+                        "COALESCE",
+                        "REORGANIZE",
+                        "EXCHANGE",
+                        "ANALYZE",
+                        "CHECK",
+                        "OPTIMIZE",
+                        "REBUILD",
+                        "REPAIR",
+                        "REMOVE",
+                    ),
+                    OneOf("PARTITION", "PARTITIONING"),
+                    OneOf(
+                        Ref("SingleIdentifierGrammar"),
+                        Ref("NumericLiteralSegment"),
+                        "ALL",
+                        Bracketed(Delimited(Ref("ObjectReferenceSegment"))),
+                    ),
+                ),
             ),
             Ref.keyword("TABLESPACE", optional=True),
             Sequence(

--- a/test/fixtures/dialects/mariadb/alter_table_if_exists.sql
+++ b/test/fixtures/dialects/mariadb/alter_table_if_exists.sql
@@ -1,0 +1,25 @@
+-- MariaDB allows a table-level IF EXISTS on ALTER TABLE, and IF EXISTS on
+-- DROP PARTITION. MySQL does not.
+-- https://mariadb.com/docs/server/reference/sql-statements/data-definition/alter/alter-table
+
+-- ALTER TABLE [IF EXISTS] tbl_name
+ALTER TABLE IF EXISTS `t` ADD COLUMN `c` INT;
+ALTER TABLE IF EXISTS `t` DROP COLUMN IF EXISTS `c`;
+ALTER TABLE IF EXISTS `t` RENAME TO `t2`;
+
+-- Regression: the clause is optional, so the bare form is unchanged.
+ALTER TABLE `t` ADD COLUMN `c` INT;
+
+-- DROP PARTITION [IF EXISTS] p1[, p2 ...]
+ALTER TABLE `t` DROP PARTITION IF EXISTS `p1`;
+ALTER TABLE `t` DROP PARTITION IF EXISTS `p1`, `p2`, `p3`;
+
+-- Regression: DROP PARTITION without the clause, and a comma-separated list,
+-- must still parse. Other partition verbs are unchanged.
+ALTER TABLE `t` DROP PARTITION `p1`;
+ALTER TABLE `t` DROP PARTITION `p1`, `p2`;
+ALTER TABLE `t` TRUNCATE PARTITION `p1`;
+ALTER TABLE `t` COALESCE PARTITION 2;
+
+-- Unquoted identifiers (real-world form)
+ALTER TABLE orders DROP PARTITION IF EXISTS p1, p2;

--- a/test/fixtures/dialects/mariadb/alter_table_if_exists.yml
+++ b/test/fixtures/dialects/mariadb/alter_table_if_exists.yml
@@ -1,0 +1,147 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: c76e8491815fecbd53ab63d0360aa67d4d2fdf86d9b40b3e9d33b57cb1475efe
+file:
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - keyword: IF
+    - keyword: EXISTS
+    - table_reference:
+        quoted_identifier: '`t`'
+    - keyword: ADD
+    - keyword: COLUMN
+    - column_definition:
+        quoted_identifier: '`c`'
+        data_type:
+          data_type_identifier: INT
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - keyword: IF
+    - keyword: EXISTS
+    - table_reference:
+        quoted_identifier: '`t`'
+    - keyword: DROP
+    - keyword: COLUMN
+    - keyword: IF
+    - keyword: EXISTS
+    - column_reference:
+        quoted_identifier: '`c`'
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - keyword: IF
+    - keyword: EXISTS
+    - table_reference:
+        quoted_identifier: '`t`'
+    - keyword: RENAME
+    - keyword: TO
+    - table_reference:
+        quoted_identifier: '`t2`'
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        quoted_identifier: '`t`'
+    - keyword: ADD
+    - keyword: COLUMN
+    - column_definition:
+        quoted_identifier: '`c`'
+        data_type:
+          data_type_identifier: INT
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        quoted_identifier: '`t`'
+    - keyword: DROP
+    - keyword: PARTITION
+    - keyword: IF
+    - keyword: EXISTS
+    - quoted_identifier: '`p1`'
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        quoted_identifier: '`t`'
+    - keyword: DROP
+    - keyword: PARTITION
+    - keyword: IF
+    - keyword: EXISTS
+    - quoted_identifier: '`p1`'
+    - comma: ','
+    - quoted_identifier: '`p2`'
+    - comma: ','
+    - quoted_identifier: '`p3`'
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        quoted_identifier: '`t`'
+    - keyword: DROP
+    - keyword: PARTITION
+    - quoted_identifier: '`p1`'
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        quoted_identifier: '`t`'
+    - keyword: DROP
+    - keyword: PARTITION
+    - quoted_identifier: '`p1`'
+    - comma: ','
+    - quoted_identifier: '`p2`'
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        quoted_identifier: '`t`'
+    - keyword: TRUNCATE
+    - keyword: PARTITION
+    - quoted_identifier: '`p1`'
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        quoted_identifier: '`t`'
+    - keyword: COALESCE
+    - keyword: PARTITION
+    - numeric_literal: '2'
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: orders
+    - keyword: DROP
+    - keyword: PARTITION
+    - keyword: IF
+    - keyword: EXISTS
+    - naked_identifier: p1
+    - comma: ','
+    - naked_identifier: p2
+- statement_terminator: ;


### PR DESCRIPTION
### Brief summary of the change made

MariaDB extends `ALTER TABLE` with `IF EXISTS` conditional clauses that MySQL
does not support. This adds the two remaining `ALTER TABLE`-level conditionals
that were still raising `PRS: Found unparsable section`:

- **Table level:** `ALTER TABLE [IF EXISTS] tbl_name ...`
- **Partition drop:** `ALTER TABLE ... DROP PARTITION [IF EXISTS] p1[, p2, ...]`

This is a follow-up to #8174 (which added `IF [NOT] EXISTS` on the
`ADD`/`DROP`/`CHANGE`/`MODIFY`/`ALTER {INDEX|KEY}` actions) and follows the same
approach: the grammar lives entirely in the `mariadb` dialect by overriding
`AlterTableStatementSegment`, and every added token is optional, so previously
valid statements parse identically.

The `DROP PARTITION` branch was also given a comma-separated partition name list
(`DROP PARTITION p1, p2`), which is valid MariaDB but previously failed to parse.

References: https://mariadb.com/docs/server/reference/sql-statements/data-definition/alter/alter-table

### Are there any other side effects of this change that we should be aware of?

- None expected. All added grammar is optional, and the changes are confined to
  `dialect_mariadb.py`; `dialect_mysql.py` and `dialect_ansi.py` are untouched,
  so MySQL/ANSI parsing is unchanged.
- No over-acceptance: `IF EXISTS` on partitions is scoped to the `DROP PARTITION`
  branch only, so `ADD PARTITION IF EXISTS` / `TRUNCATE PARTITION IF EXISTS`
  (not valid MariaDB) still correctly report as unparsable, and non-`DROP`
  partition verbs are unchanged.
- Intentional narrowing: the dedicated `DROP PARTITION` branch accepts only a
  comma-separated list of partition names (per MariaDB's documented
  `DROP PARTITION partition_names` syntax). The previous shared grammar also
  accepted `ALL`, a numeric literal, and a bracketed list on `DROP PARTITION` —
  none of which are valid MariaDB for `DROP PARTITION` — so those now correctly
  report as unparsable. `ALL` remains valid on the other partition verbs
  (`TRUNCATE`/`ANALYZE`/`CHECK`/`OPTIMIZE`/`REBUILD`/`REPAIR PARTITION`).
- No Rust regeneration was run (`tox -e generate-rs` / `utils/rustify.py build`);
  the generated Rust files are not checked into source control.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects`
    (`test/fixtures/dialects/mariadb/alter_table_if_exists.sql` and its
    auto-generated `.yml`).
- Added appropriate documentation for the change (updated the
  `AlterTableStatementSegment` docstring).
- Created GitHub issues for any relevant followup/future enhancements if appropriate.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds MariaDB support for `ALTER TABLE IF EXISTS` and `DROP PARTITION IF EXISTS`, including comma-separated partition names. Tightens `DROP PARTITION` parsing to match MariaDB-only syntax while leaving MySQL/ANSI unchanged.

- **New Features**
  - Table-level `ALTER TABLE IF EXISTS tbl_name ...`.
  - `DROP PARTITION IF EXISTS p1[, p2 ...]` with comma-separated names; previously failed to parse.
  - Invalid `DROP PARTITION` forms (`ALL`, numeric, bracketed list) and `DROP PARTITIONING` are now rejected in `mariadb`.

<sup>Written for commit 0d2ee66671a8a6e048b2f0e54618e7508728067f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8287?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


### AI assistance disclosure

Per the project's AI-assisted contribution guide: this contribution was prepared with AI assistance (Claude Code).

- **AI-assisted:** drafting the `dialect_mariadb.py` grammar changes, the `.sql`/`.yml` parser fixtures, and this PR description.
- **Manually validated by me:** every added syntax form was checked against the official MariaDB documentation linked above (not invented); the fixtures were regenerated and reviewed; and the full suite was run locally and in CI — `pytest test/dialects/dialects_test.py -k mariadb`, `mypy`, `ruff`, and the `ymlchecks` fixture check — all passing. The change is confined to the `mariadb` dialect; `dialect_mysql.py` and `dialect_ansi.py` are untouched.

I take responsibility for the correctness, tests, and maintainability of this PR.
