### PR TITLE
MariaDB: support IF [NOT] EXISTS on CREATE/ALTER/DROP SEQUENCE

### DIFF
--- a/src/sqlfluff/dialects/dialect_mariadb.py
+++ b/src/sqlfluff/dialects/dialect_mariadb.py
@@ -19,6 +19,7 @@ from sqlfluff.core.parser import (
     Ref,
     Sequence,
 )
+from sqlfluff.dialects import dialect_ansi as ansi
 from sqlfluff.dialects import dialect_mysql as mysql
 from sqlfluff.dialects.dialect_mariadb_keywords import (
     mariadb_reserved_keywords,
@@ -1240,4 +1241,53 @@ class CreateViewStatementSegment(mysql.CreateViewStatementSegment):
     match_grammar = mysql.CreateViewStatementSegment.match_grammar.copy(
         insert=[Ref("IfNotExistsGrammar", optional=True)],
         before=Ref("TableReferenceSegment"),
+    )
+
+
+class CreateSequenceStatementSegment(ansi.CreateSequenceStatementSegment):
+    """A `CREATE SEQUENCE` statement.
+
+    Adds MariaDB's ``IF NOT EXISTS`` clause. MySQL/ANSI do not support it, so
+    the change is confined to the MariaDB dialect.
+    https://mariadb.com/kb/en/create-sequence/
+    """
+
+    match_grammar = Sequence(
+        "CREATE",
+        "SEQUENCE",
+        Ref("IfNotExistsGrammar", optional=True),
+        Ref("SequenceReferenceSegment"),
+        AnyNumberOf(Ref("CreateSequenceOptionsSegment"), optional=True),
+    )
+
+
+class AlterSequenceStatementSegment(ansi.AlterSequenceStatementSegment):
+    """An `ALTER SEQUENCE` statement.
+
+    Adds MariaDB's ``IF EXISTS`` clause. MariaDB only.
+    https://mariadb.com/kb/en/alter-sequence/
+    """
+
+    match_grammar = Sequence(
+        "ALTER",
+        "SEQUENCE",
+        Ref("IfExistsGrammar", optional=True),
+        Ref("SequenceReferenceSegment"),
+        AnyNumberOf(Ref("AlterSequenceOptionsSegment")),
+    )
+
+
+class DropSequenceStatementSegment(ansi.DropSequenceStatementSegment):
+    """A `DROP SEQUENCE` statement.
+
+    Adds MariaDB's ``IF EXISTS`` clause and comma-separated name list.
+    MariaDB only.
+    https://mariadb.com/kb/en/drop-sequence/
+    """
+
+    match_grammar = Sequence(
+        "DROP",
+        "SEQUENCE",
+        Ref("IfExistsGrammar", optional=True),
+        Delimited(Ref("SequenceReferenceSegment")),
     )

--- a/src/sqlfluff/dialects/dialect_mariadb.py
+++ b/src/sqlfluff/dialects/dialect_mariadb.py
@@ -19,6 +19,7 @@ from sqlfluff.core.parser import (
     Ref,
     Sequence,
 )
+from sqlfluff.dialects import dialect_ansi as ansi
 from sqlfluff.dialects import dialect_mysql as mysql
 from sqlfluff.dialects.dialect_mariadb_keywords import (
     mariadb_reserved_keywords,
@@ -1052,4 +1053,53 @@ class TableOptionsSegment(mysql.TableOptionsSegment):
                 "VERSIONING",
             ),
         ),
+    )
+
+
+class CreateSequenceStatementSegment(ansi.CreateSequenceStatementSegment):
+    """A `CREATE SEQUENCE` statement.
+
+    Adds MariaDB's ``IF NOT EXISTS`` clause. MySQL/ANSI do not support it, so
+    the change is confined to the MariaDB dialect.
+    https://mariadb.com/kb/en/create-sequence/
+    """
+
+    match_grammar = Sequence(
+        "CREATE",
+        "SEQUENCE",
+        Ref("IfNotExistsGrammar", optional=True),
+        Ref("SequenceReferenceSegment"),
+        AnyNumberOf(Ref("CreateSequenceOptionsSegment"), optional=True),
+    )
+
+
+class AlterSequenceStatementSegment(ansi.AlterSequenceStatementSegment):
+    """An `ALTER SEQUENCE` statement.
+
+    Adds MariaDB's ``IF EXISTS`` clause. MariaDB only.
+    https://mariadb.com/kb/en/alter-sequence/
+    """
+
+    match_grammar = Sequence(
+        "ALTER",
+        "SEQUENCE",
+        Ref("IfExistsGrammar", optional=True),
+        Ref("SequenceReferenceSegment"),
+        AnyNumberOf(Ref("AlterSequenceOptionsSegment")),
+    )
+
+
+class DropSequenceStatementSegment(ansi.DropSequenceStatementSegment):
+    """A `DROP SEQUENCE` statement.
+
+    Adds MariaDB's ``IF EXISTS`` clause and comma-separated name list.
+    MariaDB only.
+    https://mariadb.com/kb/en/drop-sequence/
+    """
+
+    match_grammar = Sequence(
+        "DROP",
+        "SEQUENCE",
+        Ref("IfExistsGrammar", optional=True),
+        Delimited(Ref("SequenceReferenceSegment")),
     )

--- a/test/fixtures/dialects/mariadb/sequence_if_exists.sql
+++ b/test/fixtures/dialects/mariadb/sequence_if_exists.sql
@@ -1,0 +1,23 @@
+-- MariaDB supports IF [NOT] EXISTS on CREATE/ALTER/DROP SEQUENCE, and a
+-- comma-separated name list on DROP SEQUENCE. ANSI/MySQL do not.
+-- https://mariadb.com/kb/en/create-sequence/
+-- https://mariadb.com/kb/en/alter-sequence/
+-- https://mariadb.com/kb/en/drop-sequence/
+
+-- CREATE SEQUENCE [IF NOT EXISTS]
+CREATE SEQUENCE IF NOT EXISTS `s1`;
+CREATE SEQUENCE IF NOT EXISTS s2 START WITH 100 INCREMENT BY 10;
+
+-- ALTER SEQUENCE [IF EXISTS]
+ALTER SEQUENCE IF EXISTS `s1` INCREMENT BY 5;
+
+-- DROP SEQUENCE [IF EXISTS] name[, name ...]
+DROP SEQUENCE IF EXISTS `s1`;
+DROP SEQUENCE IF EXISTS s1, s2, s3;
+
+-- Regression: the clauses are optional; bare forms and the DROP list are
+-- unchanged.
+CREATE SEQUENCE `s1`;
+ALTER SEQUENCE `s1` INCREMENT BY 5;
+DROP SEQUENCE `s1`;
+DROP SEQUENCE s1, s2;

--- a/test/fixtures/dialects/mariadb/sequence_if_exists.yml
+++ b/test/fixtures/dialects/mariadb/sequence_if_exists.yml
@@ -1,0 +1,107 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 1edbf0259b8b5246ac80397cc37c19d563ccded9eb0e67ba224b8e2e6e7aa5f5
+file:
+- statement:
+    create_sequence_statement:
+    - keyword: CREATE
+    - keyword: SEQUENCE
+    - keyword: IF
+    - keyword: NOT
+    - keyword: EXISTS
+    - sequence_reference:
+        quoted_identifier: '`s1`'
+- statement_terminator: ;
+- statement:
+    create_sequence_statement:
+    - keyword: CREATE
+    - keyword: SEQUENCE
+    - keyword: IF
+    - keyword: NOT
+    - keyword: EXISTS
+    - sequence_reference:
+        naked_identifier: s2
+    - create_sequence_options_segment:
+      - keyword: START
+      - keyword: WITH
+      - numeric_literal: '100'
+    - create_sequence_options_segment:
+      - keyword: INCREMENT
+      - keyword: BY
+      - numeric_literal: '10'
+- statement_terminator: ;
+- statement:
+    alter_sequence_statement:
+    - keyword: ALTER
+    - keyword: SEQUENCE
+    - keyword: IF
+    - keyword: EXISTS
+    - sequence_reference:
+        quoted_identifier: '`s1`'
+    - alter_sequence_options_segment:
+      - keyword: INCREMENT
+      - keyword: BY
+      - numeric_literal: '5'
+- statement_terminator: ;
+- statement:
+    drop_sequence_statement:
+    - keyword: DROP
+    - keyword: SEQUENCE
+    - keyword: IF
+    - keyword: EXISTS
+    - sequence_reference:
+        quoted_identifier: '`s1`'
+- statement_terminator: ;
+- statement:
+    drop_sequence_statement:
+    - keyword: DROP
+    - keyword: SEQUENCE
+    - keyword: IF
+    - keyword: EXISTS
+    - sequence_reference:
+        naked_identifier: s1
+    - comma: ','
+    - sequence_reference:
+        naked_identifier: s2
+    - comma: ','
+    - sequence_reference:
+        naked_identifier: s3
+- statement_terminator: ;
+- statement:
+    create_sequence_statement:
+    - keyword: CREATE
+    - keyword: SEQUENCE
+    - sequence_reference:
+        quoted_identifier: '`s1`'
+- statement_terminator: ;
+- statement:
+    alter_sequence_statement:
+    - keyword: ALTER
+    - keyword: SEQUENCE
+    - sequence_reference:
+        quoted_identifier: '`s1`'
+    - alter_sequence_options_segment:
+      - keyword: INCREMENT
+      - keyword: BY
+      - numeric_literal: '5'
+- statement_terminator: ;
+- statement:
+    drop_sequence_statement:
+    - keyword: DROP
+    - keyword: SEQUENCE
+    - sequence_reference:
+        quoted_identifier: '`s1`'
+- statement_terminator: ;
+- statement:
+    drop_sequence_statement:
+    - keyword: DROP
+    - keyword: SEQUENCE
+    - sequence_reference:
+        naked_identifier: s1
+    - comma: ','
+    - sequence_reference:
+        naked_identifier: s2
+- statement_terminator: ;


### PR DESCRIPTION
### Brief summary of the change made

MariaDB supports `IF [NOT] EXISTS` conditional clauses on sequence DDL that ANSI
and MySQL do not. These statements previously raised
`PRS: Found unparsable section`; this adds:

- `CREATE SEQUENCE [IF NOT EXISTS] name`
- `ALTER SEQUENCE [IF EXISTS] name`
- `DROP SEQUENCE [IF EXISTS] name[, name ...]`

The sequence statements are defined only in the ANSI dialect and inherited
unchanged by MariaDB, so the three segments are overridden in the `mariadb`
dialect by subclassing the ANSI segments and inserting the optional conditional
right after the `SEQUENCE` keyword (MariaDB's documented position). `DROP
SEQUENCE` also gains a comma-separated name list, which is valid MariaDB.

Every added token is optional, so previously valid statements parse identically.

This is part of a small series filling remaining MariaDB `IF [NOT] EXISTS` gaps
(companion to the ALTER TABLE work).

References:
- https://mariadb.com/kb/en/create-sequence/
- https://mariadb.com/kb/en/alter-sequence/
- https://mariadb.com/kb/en/drop-sequence/

### Are there any other side effects of this change that we should be aware of?

- None expected. The changes are confined to `dialect_mariadb.py` (which now
  imports `dialect_ansi` only to subclass its sequence segments); `dialect_ansi.py`
  and `dialect_mysql.py` are unmodified, so ANSI/MySQL parsing is unchanged and
  still rejects `IF [NOT] EXISTS` on sequences.
- Scope is limited to the `IF [NOT] EXISTS` clause plus the `DROP SEQUENCE`
  comma-separated name list. `CREATE OR REPLACE SEQUENCE` and
  `CREATE/DROP TEMPORARY SEQUENCE` are separate MariaDB features and are
  intentionally left for a follow-up.
- No Rust regeneration was run (`tox -e generate-rs` / `utils/rustify.py build`);
  the generated Rust files are not checked into source control.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes:
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects`
    (`test/fixtures/dialects/mariadb/sequence_if_exists.sql` and its
    auto-generated `.yml`).
- Added appropriate documentation for the change (docstrings on the new
  overrides linking the MariaDB KB pages).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds MariaDB support for `IF [NOT] EXISTS` in `CREATE/ALTER/DROP SEQUENCE` and a comma-separated name list in `DROP SEQUENCE`, fixing parse errors and matching MariaDB syntax. Changes are limited to `dialect_mariadb`; ANSI/MySQL parsing is unchanged.

- **New Features**
  - `CREATE SEQUENCE [IF NOT EXISTS] name`
  - `ALTER SEQUENCE [IF EXISTS] name`
  - `DROP SEQUENCE [IF EXISTS] name[, name ...]`

<sup>Written for commit 056c899865d48618ebaaf12d876bd14f3d3486fd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8288?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

### AI assistance disclosure

Per the project's AI-assisted contribution guide: this contribution was prepared with AI assistance (Claude Code).

- **AI-assisted:** drafting the `dialect_mariadb.py` grammar changes, the `.sql`/`.yml` parser fixtures, and this PR description.
- **Manually validated by me:** every added syntax form was checked against the official MariaDB documentation linked above (not invented); the fixtures were regenerated and reviewed; and the full suite was run locally and in CI — `pytest test/dialects/dialects_test.py -k mariadb`, `mypy`, `ruff`, and the `ymlchecks` fixture check — all passing. The change is confined to the `mariadb` dialect; `dialect_mysql.py` and `dialect_ansi.py` are untouched.

I take responsibility for the correctness, tests, and maintainability of this PR.
