### PR TITLE
MariaDB: support IF NOT EXISTS on CREATE VIEW

### DIFF
--- a/src/sqlfluff/dialects/dialect_mariadb.py
+++ b/src/sqlfluff/dialects/dialect_mariadb.py
@@ -1053,3 +1053,17 @@ class TableOptionsSegment(mysql.TableOptionsSegment):
             ),
         ),
     )
+
+
+class CreateViewStatementSegment(mysql.CreateViewStatementSegment):
+    """A `CREATE VIEW` statement.
+
+    Adds MariaDB's ``IF NOT EXISTS`` clause after the ``VIEW`` keyword. MySQL
+    does not support it, so the change is confined to the MariaDB dialect.
+    https://mariadb.com/kb/en/create-view/
+    """
+
+    match_grammar = mysql.CreateViewStatementSegment.match_grammar.copy(
+        insert=[Ref("IfNotExistsGrammar", optional=True)],
+        before=Ref("TableReferenceSegment"),
+    )

--- a/test/fixtures/dialects/mariadb/create_view_if_not_exists.sql
+++ b/test/fixtures/dialects/mariadb/create_view_if_not_exists.sql
@@ -1,0 +1,15 @@
+-- MariaDB supports IF NOT EXISTS on CREATE VIEW (right after the VIEW keyword).
+-- MySQL does not. https://mariadb.com/kb/en/create-view/
+
+-- CREATE VIEW [IF NOT EXISTS] view_name AS ...
+CREATE VIEW IF NOT EXISTS `v` AS SELECT 1;
+CREATE VIEW IF NOT EXISTS v2 AS SELECT `a`, `b` FROM `t`;
+CREATE VIEW IF NOT EXISTS v3 (a, b) AS SELECT 1, 2;
+CREATE ALGORITHM = MERGE VIEW IF NOT EXISTS v4 AS SELECT 1;
+CREATE DEFINER = `admin`@`localhost` SQL SECURITY INVOKER
+VIEW IF NOT EXISTS `v5` AS SELECT 1;
+CREATE VIEW IF NOT EXISTS `v6` AS SELECT `a` FROM `t` WITH CASCADED CHECK OPTION;
+
+-- Regression: the clause is optional; existing forms are unchanged.
+CREATE VIEW `v` AS SELECT 1;
+CREATE OR REPLACE VIEW `v` AS SELECT 1;

--- a/test/fixtures/dialects/mariadb/create_view_if_not_exists.yml
+++ b/test/fixtures/dialects/mariadb/create_view_if_not_exists.yml
@@ -1,0 +1,182 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: b73a2a293af5652d2e42abdcdaf2c525567aa6499a67a65394e4574c08e41fcb
+file:
+- statement:
+    create_view_statement:
+    - keyword: CREATE
+    - keyword: VIEW
+    - keyword: IF
+    - keyword: NOT
+    - keyword: EXISTS
+    - table_reference:
+        quoted_identifier: '`v`'
+    - keyword: AS
+    - select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            numeric_literal: '1'
+- statement_terminator: ;
+- statement:
+    create_view_statement:
+    - keyword: CREATE
+    - keyword: VIEW
+    - keyword: IF
+    - keyword: NOT
+    - keyword: EXISTS
+    - table_reference:
+        naked_identifier: v2
+    - keyword: AS
+    - select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            column_reference:
+              quoted_identifier: '`a`'
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+              quoted_identifier: '`b`'
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  quoted_identifier: '`t`'
+- statement_terminator: ;
+- statement:
+    create_view_statement:
+    - keyword: CREATE
+    - keyword: VIEW
+    - keyword: IF
+    - keyword: NOT
+    - keyword: EXISTS
+    - table_reference:
+        naked_identifier: v3
+    - bracketed:
+      - start_bracket: (
+      - column_reference:
+          naked_identifier: a
+      - comma: ','
+      - column_reference:
+          naked_identifier: b
+      - end_bracket: )
+    - keyword: AS
+    - select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            numeric_literal: '1'
+        - comma: ','
+        - select_clause_element:
+            numeric_literal: '2'
+- statement_terminator: ;
+- statement:
+    create_view_statement:
+    - keyword: CREATE
+    - keyword: ALGORITHM
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - keyword: MERGE
+    - keyword: VIEW
+    - keyword: IF
+    - keyword: NOT
+    - keyword: EXISTS
+    - table_reference:
+        naked_identifier: v4
+    - keyword: AS
+    - select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            numeric_literal: '1'
+- statement_terminator: ;
+- statement:
+    create_view_statement:
+    - keyword: CREATE
+    - definer_segment:
+        keyword: DEFINER
+        comparison_operator:
+          raw_comparison_operator: '='
+        role_reference:
+        - quoted_identifier: '`admin`'
+        - at_sign_literal: '@'
+        - quoted_identifier: '`localhost`'
+    - keyword: SQL
+    - keyword: SECURITY
+    - keyword: INVOKER
+    - keyword: VIEW
+    - keyword: IF
+    - keyword: NOT
+    - keyword: EXISTS
+    - table_reference:
+        quoted_identifier: '`v5`'
+    - keyword: AS
+    - select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            numeric_literal: '1'
+- statement_terminator: ;
+- statement:
+    create_view_statement:
+    - keyword: CREATE
+    - keyword: VIEW
+    - keyword: IF
+    - keyword: NOT
+    - keyword: EXISTS
+    - table_reference:
+        quoted_identifier: '`v6`'
+    - keyword: AS
+    - select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            column_reference:
+              quoted_identifier: '`a`'
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  quoted_identifier: '`t`'
+    - with_check_options:
+      - keyword: WITH
+      - keyword: CASCADED
+      - keyword: CHECK
+      - keyword: OPTION
+- statement_terminator: ;
+- statement:
+    create_view_statement:
+    - keyword: CREATE
+    - keyword: VIEW
+    - table_reference:
+        quoted_identifier: '`v`'
+    - keyword: AS
+    - select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            numeric_literal: '1'
+- statement_terminator: ;
+- statement:
+    create_view_statement:
+    - keyword: CREATE
+    - keyword: OR
+    - keyword: REPLACE
+    - keyword: VIEW
+    - table_reference:
+        quoted_identifier: '`v`'
+    - keyword: AS
+    - select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            numeric_literal: '1'
+- statement_terminator: ;


### PR DESCRIPTION
### Brief summary of the change made

MariaDB supports `IF NOT EXISTS` on `CREATE VIEW`, which MySQL does not.
`CREATE VIEW IF NOT EXISTS view_name AS ...` previously raised
`PRS: Found unparsable section`; this adds the optional clause.

The MySQL `CreateViewStatementSegment` is overridden in the `mariadb` dialect to
insert an optional `IF NOT EXISTS` right after the `VIEW` keyword (MariaDB's
documented position), reusing the existing `.copy(insert=..., before=...)` idiom.
The clause is optional, so previously valid statements parse identically, and the
`AS <select>` body remains required.

This is part of a small series filling remaining MariaDB `IF [NOT] EXISTS` gaps.

Reference: https://mariadb.com/kb/en/create-view/

### Are there any other side effects of this change that we should be aware of?

- None expected. The change is confined to `dialect_mariadb.py`; `dialect_ansi.py`
  and `dialect_mysql.py` are unmodified, so MySQL/ANSI parsing is unchanged and
  still rejects `IF NOT EXISTS` on `CREATE VIEW`. `ALGORITHM`, `DEFINER`,
  `SQL SECURITY`, the column list and `WITH CHECK OPTION` are all preserved and
  exercised in combination with `IF NOT EXISTS` in the fixture. `OR REPLACE` is
  also preserved and covered standalone (regression line).
- MariaDB documents `OR REPLACE` and `IF NOT EXISTS` as **mutually exclusive**,
  so `CREATE OR REPLACE VIEW IF NOT EXISTS ...` is not valid MariaDB and is
  intentionally not added as a (must-parse) fixture. As elsewhere in sqlfluff,
  both clauses are kept individually optional and the mutual exclusion is not
  enforced at the grammar level.
- No Rust regeneration was run (`tox -e generate-rs` / `utils/rustify.py build`);
  the generated Rust files are not checked into source control.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes:
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects`
    (`test/fixtures/dialects/mariadb/create_view_if_not_exists.sql` and its
    auto-generated `.yml`).
- Added appropriate documentation for the change (docstring on the new override
  linking the MariaDB KB page).


### AI assistance disclosure

Per the project's AI-assisted contribution guide: this contribution was prepared with AI assistance (Claude Code).

- **AI-assisted:** drafting the `dialect_mariadb.py` grammar changes, the `.sql`/`.yml` parser fixtures, and this PR description.
- **Manually validated by me:** every added syntax form was checked against the official MariaDB documentation linked above (not invented); the fixtures were regenerated and reviewed; and the full suite was run locally and in CI — `pytest test/dialects/dialects_test.py -k mariadb`, `mypy`, `ruff`, and the `ymlchecks` fixture check — all passing. The change is confined to the `mariadb` dialect; `dialect_mysql.py` and `dialect_ansi.py` are untouched.

I take responsibility for the correctness, tests, and maintainability of this PR.
