### PR TITLE
docs(CV06): clarify multiline_newline vs legacy semicolon_newline

### DIFF
--- a/src/sqlfluff/core/default_config.cfg
+++ b/src/sqlfluff/core/default_config.cfg
@@ -443,7 +443,8 @@ prefer_count_1 = False
 prefer_count_0 = False
 
 [sqlfluff:rules:convention.terminator]
-# Semi-colon formatting approach
+# Semi-colon formatting approach.
+# Use multiline_newline (not the legacy L052 name semicolon_newline).
 multiline_newline = False
 require_final_semicolon = False
 

--- a/src/sqlfluff/rules/convention/CV06.py
+++ b/src/sqlfluff/rules/convention/CV06.py
@@ -49,6 +49,19 @@ class Rule_CV06(BaseRule):
         SELECT
             a
         FROM foo;
+
+    .. note::
+
+       Configure this rule under ``[sqlfluff:rules:convention.terminator]``.
+       The option that places the terminator on its own line after a multi-line
+       statement is ``multiline_newline`` (not ``semicolon_newline``, which was
+       an older L052 name and is ignored if still present in config files):
+
+       .. code-block:: cfg
+
+          [sqlfluff:rules:convention.terminator]
+          multiline_newline = True
+          require_final_semicolon = False
     """
 
     name = "convention.terminator"

--- a/src/sqlfluff/rules/convention/__init__.py
+++ b/src/sqlfluff/rules/convention/__init__.py
@@ -32,7 +32,10 @@ def get_configs_info() -> dict[str, ConfigInfo]:
             "validation": [True, False],
             "definition": (
                 "Should semi-colons be placed on a new line after multi-line "
-                "statements?"
+                "statements? Older L052 docs and configs used the name "
+                "``semicolon_newline`` for this setting; that name is no longer "
+                "recognized — use ``multiline_newline`` under "
+                "``[sqlfluff:rules:convention.terminator]`` instead."
             ),
         },
         "require_final_semicolon": {


### PR DESCRIPTION
## Brief summary
Clarify CV06 (`L052`) configuration: the supported option is `multiline_newline` under `[sqlfluff:rules:convention.terminator]`. Older docs/configs used `semicolon_newline`, which is no longer recognized.

## Changelog & Docs
- [x] This PR does not include a changelog entry (docs/config clarification only)
- [x] Yes, these changes update the relevant docstrings / default config comments that feed the rules docs

## Testing
- `pytest test/rules/yaml_test_cases_test.py -k CV06 -q` (62 passed)
- `ruff check` on touched Python files
- Manually confirmed on current docs/main that CV06 already lists `multiline_newline`, and that `semicolon_newline` is ignored by the config loader

## AI assistance disclosure
AI tooling was used to help locate the L052→CV06 rename and draft the docstring/config wording. I reviewed the change against current CV06 behavior, ran the CV06 fixture tests, and am responsible for the final PR.

Closes #4029