### PR TITLE
fix(clickhouse): a couple of fixes for the `CREATE DICTIONARY` statement

### DIFF
--- a/src/sqlfluff/dialects/dialect_clickhouse.py
+++ b/src/sqlfluff/dialects/dialect_clickhouse.py
@@ -1944,7 +1944,13 @@ class CreateDictionaryStatementSegment(BaseSegment):
     _dictionary_source_clause = Sequence(
         "SOURCE",
         Bracketed(
-            _dictionary_function,
+            OneOf(
+                Ref("SingleIdentifierGrammar"),
+                # NULL() is a valid SOURCE
+                # https://clickhouse.com/docs/reference/statements/create/dictionary/sources/null
+                "NULL",
+            ),
+            _dictionary_parameters,
         ),
     )
     _dictionary_layout_clause = Sequence(
@@ -1966,6 +1972,15 @@ class CreateDictionaryStatementSegment(BaseSegment):
                 Ref("NumericLiteralSegment"),
             ),
         ),
+    )
+    _dictionary_range_clause = Sequence(
+        "RANGE",
+        Bracketed(
+            "MIN",
+            Ref("SingleIdentifierGrammar"),
+            "MAX",
+            Ref("SingleIdentifierGrammar"),
+        ),
         optional=True,
     )
     _dictionary_settings_clause = Sequence(
@@ -1986,6 +2001,11 @@ class CreateDictionaryStatementSegment(BaseSegment):
         ),
         optional=True,
     )
+    _dictionary_mandatory_clauses = (
+        _dictionary_source_clause,
+        _dictionary_layout_clause,
+        _dictionary_lifetime_clause,
+    )
     match_grammar = Sequence(
         "CREATE",
         Ref("OrReplaceGrammar", optional=True),
@@ -2000,11 +2020,39 @@ class CreateDictionaryStatementSegment(BaseSegment):
         ),
         "PRIMARY",
         "KEY",
-        Delimited(Ref("SingleIdentifierGrammar")),
-        _dictionary_source_clause,
-        _dictionary_layout_clause,
-        _dictionary_lifetime_clause,
-        _dictionary_settings_clause,
+        OptionallyBracketed(Delimited(Ref("SingleIdentifierGrammar"))),
+        # The order of SOURCE, LAYOUT, LIFETIME, SETTINGS, RANGE clauses
+        # is not strictly defined. However, there is a couple of rules:
+        # 1. These clauses must be stated after the PRIMARY KEY clause.
+        # 2. These clauses must be stated before the SETTINGS clause.
+        # 3. SOURCE, LAYOUT, LIFETIME clauses are mandatory.
+        # 4. SETTINGS, RANGE clauses are optional.
+        OneOf(
+            # SOURCE, LAYOUT, LIFETIME
+            AnySetOf(
+                *_dictionary_mandatory_clauses,
+                min_times=3,
+            ),
+            # SOURCE, LAYOUT, LIFETIME, RANGE
+            AnySetOf(
+                *_dictionary_mandatory_clauses,
+                _dictionary_range_clause,
+                min_times=4,
+            ),
+            # SOURCE, LAYOUT, LIFETIME, SETTINGS
+            AnySetOf(
+                *_dictionary_mandatory_clauses,
+                _dictionary_settings_clause,
+                min_times=4,
+            ),
+            # SOURCE, LAYOUT, LIFETIME, RANGE, SETTINGS
+            AnySetOf(
+                *_dictionary_mandatory_clauses,
+                _dictionary_range_clause,
+                _dictionary_settings_clause,
+                min_times=5,
+            ),
+        ),
         Ref("CommentClauseSegment", optional=True),
     )
 

--- a/src/sqlfluff/dialects/dialect_clickhouse.py
+++ b/src/sqlfluff/dialects/dialect_clickhouse.py
@@ -2024,7 +2024,7 @@ class CreateDictionaryStatementSegment(BaseSegment):
         # The order of SOURCE, LAYOUT, LIFETIME, SETTINGS, RANGE clauses
         # is not strictly defined. However, there is a couple of rules:
         # 1. These clauses must be stated after the PRIMARY KEY clause.
-        # 2. These clauses must be stated before the SETTINGS clause.
+        # 2. These clauses must be stated before the COMMENT clause.
         # 3. SOURCE, LAYOUT, LIFETIME clauses are mandatory.
         # 4. SETTINGS, RANGE clauses are optional.
         OneOf(

--- a/test/fixtures/dialects/clickhouse/create_dictionary.sql
+++ b/test/fixtures/dialects/clickhouse/create_dictionary.sql
@@ -15,3 +15,59 @@ LAYOUT(HASHED())
 LIFETIME(MIN 300 MAX 600)
 SETTINGS(min_idle_time = 10, max_block_size = 10000)
 COMMENT 'Country dictionary with defaults and expressions';
+
+-- https://fiddle.clickhouse.com/a82027e0-c8b1-4240-a792-e536cabb883d
+-- SOURCE, LAYOUT, LIFETIME
+CREATE DICTIONARY test_db.test_dict (
+  id UInt64,
+  id2 UInt64,
+  val String
+)
+PRIMARY KEY `id`, id2
+SOURCE(NULL())
+LAYOUT(COMPLEX_KEY_HASHED())
+LIFETIME(100);
+
+-- SOURCE, LAYOUT, LIFETIME, RANGE, COMMENT
+CREATE OR REPLACE DICTIONARY test_db.test_dict (
+  id UInt64,
+  id2 UInt64,
+  val String,
+  discount_start_date Date,
+  discount_end_date Date
+)
+PRIMARY KEY (`id`, "id2")
+LIFETIME(100)
+LAYOUT(COMPLEX_KEY_RANGE_HASHED())
+SOURCE(NULL())
+RANGE(MIN "discount_start_date" MAX discount_end_date)
+COMMENT 'comment';
+
+-- SOURCE, LAYOUT, LIFETIME, SETTINGS
+CREATE OR REPLACE DICTIONARY test_db.test_dict (
+  id UInt64,
+  id2 UInt64,
+  val String
+)
+PRIMARY KEY id, id2
+SETTINGS(min_idle_time = 10)
+LAYOUT(COMPLEX_KEY_HASHED())
+SOURCE(CLICKHOUSE(HOST 'localhost' PORT 9000 USER 'default' PASSWORD '' QUERY $$
+    SELECT 1 AS id, 1 AS id2, 'test' AS val
+$$))
+LIFETIME(100);
+
+-- SOURCE, LAYOUT, LIFETIME, RANGE, SETTINGS
+CREATE OR REPLACE DICTIONARY test_db.test_dict (
+  id UInt64,
+  id2 UInt64,
+  val String,
+  discount_start_date Date,
+  discount_end_date Date
+)
+PRIMARY KEY (id, id2)
+LIFETIME(MIN 10 MAX 100)
+LAYOUT(COMPLEX_KEY_RANGE_HASHED())
+SETTINGS(min_idle_time = 10)
+RANGE(MIN `discount_start_date` MAX `discount_end_date`)
+SOURCE(NULL());

--- a/test/fixtures/dialects/clickhouse/create_dictionary.yml
+++ b/test/fixtures/dialects/clickhouse/create_dictionary.yml
@@ -3,9 +3,9 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: e6d154272c3b76cfe94b6c47aac1aaada12c4736c349664bbf242f43b3c499f8
+_hash: fa123dc7b049b3a9d36194354afba6ad1b3e3230aec47e6657a950b1c7d9f0cc
 file:
-  statement:
+- statement:
     create_dictionary_statement:
     - keyword: CREATE
     - keyword: OR
@@ -136,4 +136,276 @@ file:
     - comment_clause:
         keyword: COMMENT
         quoted_literal: "'Country dictionary with defaults and expressions'"
-  statement_terminator: ;
+- statement_terminator: ;
+- statement:
+    create_dictionary_statement:
+    - keyword: CREATE
+    - keyword: DICTIONARY
+    - table_reference:
+      - naked_identifier: test_db
+      - dot: .
+      - naked_identifier: test_dict
+    - bracketed:
+      - start_bracket: (
+      - naked_identifier: id
+      - data_type:
+          data_type_identifier: UInt64
+      - comma: ','
+      - naked_identifier: id2
+      - data_type:
+          data_type_identifier: UInt64
+      - comma: ','
+      - naked_identifier: val
+      - data_type:
+          data_type_identifier: String
+      - end_bracket: )
+    - keyword: PRIMARY
+    - keyword: KEY
+    - quoted_identifier: '`id`'
+    - comma: ','
+    - naked_identifier: id2
+    - keyword: SOURCE
+    - bracketed:
+        start_bracket: (
+        keyword: 'NULL'
+        bracketed:
+          start_bracket: (
+          end_bracket: )
+        end_bracket: )
+    - keyword: LAYOUT
+    - bracketed:
+        start_bracket: (
+        naked_identifier: COMPLEX_KEY_HASHED
+        bracketed:
+          start_bracket: (
+          end_bracket: )
+        end_bracket: )
+    - keyword: LIFETIME
+    - bracketed:
+        start_bracket: (
+        numeric_literal: '100'
+        end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_dictionary_statement:
+    - keyword: CREATE
+    - keyword: OR
+    - keyword: REPLACE
+    - keyword: DICTIONARY
+    - table_reference:
+      - naked_identifier: test_db
+      - dot: .
+      - naked_identifier: test_dict
+    - bracketed:
+      - start_bracket: (
+      - naked_identifier: id
+      - data_type:
+          data_type_identifier: UInt64
+      - comma: ','
+      - naked_identifier: id2
+      - data_type:
+          data_type_identifier: UInt64
+      - comma: ','
+      - naked_identifier: val
+      - data_type:
+          data_type_identifier: String
+      - comma: ','
+      - naked_identifier: discount_start_date
+      - data_type:
+          data_type_identifier: Date
+      - comma: ','
+      - naked_identifier: discount_end_date
+      - data_type:
+          data_type_identifier: Date
+      - end_bracket: )
+    - keyword: PRIMARY
+    - keyword: KEY
+    - bracketed:
+      - start_bracket: (
+      - quoted_identifier: '`id`'
+      - comma: ','
+      - quoted_identifier: '"id2"'
+      - end_bracket: )
+    - keyword: LIFETIME
+    - bracketed:
+        start_bracket: (
+        numeric_literal: '100'
+        end_bracket: )
+    - keyword: LAYOUT
+    - bracketed:
+        start_bracket: (
+        naked_identifier: COMPLEX_KEY_RANGE_HASHED
+        bracketed:
+          start_bracket: (
+          end_bracket: )
+        end_bracket: )
+    - keyword: SOURCE
+    - bracketed:
+        start_bracket: (
+        keyword: 'NULL'
+        bracketed:
+          start_bracket: (
+          end_bracket: )
+        end_bracket: )
+    - keyword: RANGE
+    - bracketed:
+      - start_bracket: (
+      - keyword: MIN
+      - quoted_identifier: '"discount_start_date"'
+      - keyword: MAX
+      - naked_identifier: discount_end_date
+      - end_bracket: )
+    - comment_clause:
+        keyword: COMMENT
+        quoted_literal: "'comment'"
+- statement_terminator: ;
+- statement:
+    create_dictionary_statement:
+    - keyword: CREATE
+    - keyword: OR
+    - keyword: REPLACE
+    - keyword: DICTIONARY
+    - table_reference:
+      - naked_identifier: test_db
+      - dot: .
+      - naked_identifier: test_dict
+    - bracketed:
+      - start_bracket: (
+      - naked_identifier: id
+      - data_type:
+          data_type_identifier: UInt64
+      - comma: ','
+      - naked_identifier: id2
+      - data_type:
+          data_type_identifier: UInt64
+      - comma: ','
+      - naked_identifier: val
+      - data_type:
+          data_type_identifier: String
+      - end_bracket: )
+    - keyword: PRIMARY
+    - keyword: KEY
+    - naked_identifier: id
+    - comma: ','
+    - naked_identifier: id2
+    - keyword: SETTINGS
+    - bracketed:
+        start_bracket: (
+        naked_identifier: min_idle_time
+        comparison_operator:
+          raw_comparison_operator: '='
+        numeric_literal: '10'
+        end_bracket: )
+    - keyword: LAYOUT
+    - bracketed:
+        start_bracket: (
+        naked_identifier: COMPLEX_KEY_HASHED
+        bracketed:
+          start_bracket: (
+          end_bracket: )
+        end_bracket: )
+    - keyword: SOURCE
+    - bracketed:
+        start_bracket: (
+        naked_identifier: CLICKHOUSE
+        bracketed:
+        - start_bracket: (
+        - naked_identifier: HOST
+        - quoted_literal: "'localhost'"
+        - naked_identifier: PORT
+        - numeric_literal: '9000'
+        - naked_identifier: USER
+        - quoted_literal: "'default'"
+        - naked_identifier: PASSWORD
+        - quoted_literal: "''"
+        - naked_identifier: QUERY
+        - quoted_literal: "$$\n    SELECT 1 AS id, 1 AS id2, 'test' AS val\n$$"
+        - end_bracket: )
+        end_bracket: )
+    - keyword: LIFETIME
+    - bracketed:
+        start_bracket: (
+        numeric_literal: '100'
+        end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_dictionary_statement:
+    - keyword: CREATE
+    - keyword: OR
+    - keyword: REPLACE
+    - keyword: DICTIONARY
+    - table_reference:
+      - naked_identifier: test_db
+      - dot: .
+      - naked_identifier: test_dict
+    - bracketed:
+      - start_bracket: (
+      - naked_identifier: id
+      - data_type:
+          data_type_identifier: UInt64
+      - comma: ','
+      - naked_identifier: id2
+      - data_type:
+          data_type_identifier: UInt64
+      - comma: ','
+      - naked_identifier: val
+      - data_type:
+          data_type_identifier: String
+      - comma: ','
+      - naked_identifier: discount_start_date
+      - data_type:
+          data_type_identifier: Date
+      - comma: ','
+      - naked_identifier: discount_end_date
+      - data_type:
+          data_type_identifier: Date
+      - end_bracket: )
+    - keyword: PRIMARY
+    - keyword: KEY
+    - bracketed:
+      - start_bracket: (
+      - naked_identifier: id
+      - comma: ','
+      - naked_identifier: id2
+      - end_bracket: )
+    - keyword: LIFETIME
+    - bracketed:
+      - start_bracket: (
+      - keyword: MIN
+      - numeric_literal: '10'
+      - keyword: MAX
+      - numeric_literal: '100'
+      - end_bracket: )
+    - keyword: LAYOUT
+    - bracketed:
+        start_bracket: (
+        naked_identifier: COMPLEX_KEY_RANGE_HASHED
+        bracketed:
+          start_bracket: (
+          end_bracket: )
+        end_bracket: )
+    - keyword: SETTINGS
+    - bracketed:
+        start_bracket: (
+        naked_identifier: min_idle_time
+        comparison_operator:
+          raw_comparison_operator: '='
+        numeric_literal: '10'
+        end_bracket: )
+    - keyword: RANGE
+    - bracketed:
+      - start_bracket: (
+      - keyword: MIN
+      - quoted_identifier: '`discount_start_date`'
+      - keyword: MAX
+      - quoted_identifier: '`discount_end_date`'
+      - end_bracket: )
+    - keyword: SOURCE
+    - bracketed:
+        start_bracket: (
+        keyword: 'NULL'
+        bracketed:
+          start_bracket: (
+          end_bracket: )
+        end_bracket: )
+- statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
fixes #8297.
For full description see #8297. This PR adds a couple of fixes for the `CREATE DICTIONARY` statement in clickhouse dialect:
1. Support for bracketed PRIMARY KEY
2. Support for NULL Source type
3. Support for RANGE CLAUSE
4. Support for arbitrary order of SOURCE, LAYOUT, LIFETIME, SETTINGS, RANGE clauses.
See `How to reproduce` section in the #8297 issue for clickhouse fiddle examples, all queries are valid.

### Are there any other side effects of this change that we should be aware of?
There should not be any side effects

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
- Added appropriate documentation for the change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix ClickHouse `CREATE DICTIONARY` parsing to match ClickHouse syntax and prevent false errors (fixes #8297). Supports bracketed/unbracketed `PRIMARY KEY`, `SOURCE(NULL())`, `RANGE(MIN ... MAX ...)`, and free ordering of `SOURCE`/`LAYOUT`/`LIFETIME` with optional `RANGE`/`SETTINGS` before `COMMENT`.

<sup>Written for commit e55bc33bd09d5001a6318788a1e108d53e004f56. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8298?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

