### PR TITLE
docs: explain how to find layout segment types

### DIFF
--- a/docs/source/configuration/layout.rst
+++ b/docs/source/configuration/layout.rst
@@ -750,6 +750,26 @@ applies to elements of the *type* :code:`comma`, i.e. :code:`,`.
    spacing_before = touch
    line_position = trailing
 
+Finding segment types
+"""""""""""""""""""""
+
+The available types depend on the selected dialect and the SQL being parsed.
+To discover them, parse a representative query using the same dialect:
+
+.. code-block:: console
+
+   $ sqlfluff parse query.sql --dialect ansi
+   ...
+   |            select_clause:
+   ...
+   |                comma:                                        ','
+   ...
+   |            from_clause:
+
+The labels in the parse tree, such as :code:`select_clause`, :code:`comma`
+and :code:`from_clause`, are the segment types to use in
+:code:`[sqlfluff:layout:type:<type>]` section headings.
+
 Within these configurable sections there are a few key elements which are
 available:
 

--- a/docs/source/configuration/layout.rst
+++ b/docs/source/configuration/layout.rst
@@ -750,25 +750,25 @@ applies to elements of the *type* :code:`comma`, i.e. :code:`,`.
    spacing_before = touch
    line_position = trailing
 
-Finding segment types
-"""""""""""""""""""""
+.. note::
 
-The available types depend on the selected dialect and the SQL being parsed.
-To discover them, parse a representative query using the same dialect:
+    The available types depend on the selected dialect and the SQL being
+    parsed. To discover them, parse a representative query using the same
+    dialect:
 
-.. code-block:: console
+    .. code-block:: console
 
-   $ sqlfluff parse query.sql --dialect ansi
-   ...
-   |            select_clause:
-   ...
-   |                comma:                                        ','
-   ...
-   |            from_clause:
+       $ sqlfluff parse query.sql --dialect ansi
+       ...
+       |            select_clause:
+       ...
+       |                comma:                                        ','
+       ...
+       |            from_clause:
 
-The labels in the parse tree, such as :code:`select_clause`, :code:`comma`
-and :code:`from_clause`, are the segment types to use in
-:code:`[sqlfluff:layout:type:<type>]` section headings.
+    The labels in the parse tree, such as :code:`select_clause`,
+    :code:`comma` and :code:`from_clause`, are the segment types to use in
+    :code:`[sqlfluff:layout:type:<type>]` section headings.
 
 Within these configurable sections there are a few key elements which are
 available:

--- a/docsv/configuration/layout.md
+++ b/docsv/configuration/layout.md
@@ -715,6 +715,26 @@ spacing_before = touch
 line_position = trailing
 ```
 
+::: tip NOTE
+The available types depend on the selected dialect and the SQL being
+parsed. To discover them, parse a representative query using the same
+dialect:
+
+```bash
+$ sqlfluff parse query.sql --dialect ansi
+...
+|            select_clause:
+...
+|                comma:                                        ','
+...
+|            from_clause:
+```
+
+The labels in the parse tree, such as `select_clause`, `comma`
+and `from_clause`, are the segment types to use in
+`[sqlfluff:layout:type:<type>]` section headings.
+:::
+
 Within these configurable sections there are a few key elements which are
 available:
 


### PR DESCRIPTION
### Brief summary of the change made

Explain how to use `sqlfluff parse` with the configured dialect to discover segment types for `[sqlfluff:layout:type:<type>]` sections. The example connects parse-tree labels such as `select_clause`, `comma`, and `from_clause` to layout configuration.

Fixes #6601.

### Are there any other side effects of this change that we should be aware of?

No. This is a documentation-only change.

### Pull Request checklist

- [x] I confirm I have completed the necessary documentation checks.
- [x] Added appropriate documentation for the change.

## Validation

- generated documentation and Sphinx build
- codespell
- verified the shown parse labels with SQLFluff 4.3.0

## AI assistance

Codex (GPT-5) materially assisted with drafting the documentation. I manually reviewed the final diff, verified the CLI output, and ran the documentation and spelling checks.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Explains how to find layout segment types using `sqlfluff parse` for the chosen dialect and clarifies that parse-tree labels (e.g., `select_clause`, `comma`, `from_clause`) map to `[sqlfluff:layout:type:<type>]` section names. Wraps the example in a single note/admonition to avoid overshadowing the “Spacing Elements” section and mirrors the change in both Sphinx and VitePress docs.

<sup>Written for commit 51c7cec265b4b5c5cd0271e02de8476f775929c1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8299?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

