### PR TITLE
docs(vitepress): rework the version picker and warn on stale docs

### DIFF
--- a/docsv/.vitepress/config.ts
+++ b/docsv/.vitepress/config.ts
@@ -1,5 +1,6 @@
-import { readFileSync } from 'node:fs'
-import { join } from 'node:path'
+import { existsSync, readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { defineConfig } from 'vitepress'
 import type { DefaultTheme, HeadConfig } from 'vitepress'
 
@@ -8,7 +9,7 @@ import sidebarRules from './sidebar-rules.json'
 import sidebarCli from './sidebar-cli.json'
 import sidebarApi from './sidebar-api.json'
 import sidebarDialects from './sidebar-dialects.json'
-import { normalizeBase, withDocsBase } from './path-utils'
+import { manifestPath, normalizeBase, withDocsBase } from './path-utils'
 import { DESIGN_SOURCE, assertDesignPackage } from '../scripts/sync-design.mjs'
 
 const GUIDE: DefaultTheme.NavItemWithLink[] = [
@@ -108,6 +109,53 @@ if (noIndex) {
     head.push(['meta', { name: 'robots', content: 'noindex,nofollow' }])
 }
 
+/**
+ * Serve the versions manifest during local development.
+ *
+ * In production `scripts/assemble-site.py` writes the manifest at the language
+ * root, one level above this build's base, so that every published version reads
+ * the same file. The dev server only serves `public/` beneath its own base, which
+ * puts that path out of reach: the request 404s, and the version picker correctly
+ * degrades to a static label. That made the picker and the version notice
+ * impossible to work on locally, so this serves `dev-versions.json` at the same
+ * path the deployed site uses.
+ *
+ * The fixture is read per request, so editing it to try a different set of
+ * versions only needs a browser reload. Deleting it exercises the degraded path.
+ * The release entries it names are not built locally, so following one of those
+ * links in dev lands on the dev server's own 404.
+ *
+ * A versioned base is required for any of this to appear, since the picker takes
+ * the current version from the base:
+ *
+ *   SQLFLUFF_DOCS_BASE=/en/latest/ pnpm docs:dev
+ *
+ * `apply: 'serve'` keeps this out of production builds, and registering the
+ * middleware directly in `configureServer` runs it ahead of Vite's own base
+ * handling, which would otherwise reject the path first.
+ */
+const devVersionsFixture = join(dirname(fileURLToPath(import.meta.url)), 'dev-versions.json')
+
+const serveDevVersions = {
+    name: 'sqlfluff-dev-versions',
+    apply: 'serve' as const,
+    configureServer(server: { middlewares: { use: (path: string, fn: unknown) => void } }) {
+        server.middlewares.use(
+            manifestPath(docsBase),
+            (_req: unknown, res: { statusCode: number; setHeader: (k: string, v: string) => void; end: (body?: string) => void }) => {
+                if (!existsSync(devVersionsFixture)) {
+                    res.statusCode = 404
+                    res.end()
+                    return
+                }
+
+                res.setHeader('Content-Type', 'application/json')
+                res.end(readFileSync(devVersionsFixture, 'utf-8'))
+            }
+        )
+    },
+}
+
 export default defineConfig({
     title: 'SQLFluff',
     description: 'The SQL Linter for Humans',
@@ -190,5 +238,9 @@ export default defineConfig({
             dark: 'github-dark'
         },
         lineNumbers: false
+    },
+
+    vite: {
+        plugins: [serveDevVersions]
     }
 })

--- a/docsv/.vitepress/dev-versions.json
+++ b/docsv/.vitepress/dev-versions.json
@@ -1,0 +1,66 @@
+{
+  "_comment": "Local development fixture for the version picker and version notice. Served only by the dev server; the deployed manifest is written by scripts/assemble-site.py. Edit freely to try other states, or delete to see how the picker degrades when no manifest is reachable.",
+  "default": "latest",
+  "latest": "latest",
+  "stable": "3.4.2",
+  "versions": [
+    {
+      "key": "latest",
+      "label": "latest",
+      "title": "Latest (main)",
+      "path": "/en/latest/",
+      "kind": "channel",
+      "builder": "vitepress",
+      "prerelease": false
+    },
+    {
+      "key": "stable",
+      "label": "stable",
+      "title": "Stable (3.4.2)",
+      "path": "/en/stable/",
+      "kind": "channel",
+      "builder": "vitepress",
+      "prerelease": false
+    },
+    {
+      "key": "3.4.2",
+      "label": "3.4.2",
+      "title": "3.4.2",
+      "path": "/en/3.4.2/",
+      "kind": "release",
+      "builder": "vitepress",
+      "prerelease": false,
+      "published_at": "2026-07-14"
+    },
+    {
+      "key": "3.4.1",
+      "label": "3.4.1",
+      "title": "3.4.1",
+      "path": "/en/3.4.1/",
+      "kind": "release",
+      "builder": "vitepress",
+      "prerelease": false,
+      "published_at": "2026-06-02"
+    },
+    {
+      "key": "3.4.0",
+      "label": "3.4.0",
+      "title": "3.4.0",
+      "path": "/en/3.4.0/",
+      "kind": "release",
+      "builder": "vitepress",
+      "prerelease": false,
+      "published_at": "2026-05-11"
+    },
+    {
+      "key": "3.3.1",
+      "label": "3.3.1",
+      "title": "3.3.1",
+      "path": "/en/3.3.1/",
+      "kind": "release",
+      "builder": "vitepress",
+      "prerelease": false,
+      "published_at": "2026-03-20"
+    }
+  ]
+}

--- a/docsv/.vitepress/theme/ThemeLayout.vue
+++ b/docsv/.vitepress/theme/ThemeLayout.vue
@@ -8,12 +8,12 @@ import VersionPicker from './VersionPicker.vue'
 <template>
   <DefaultTheme.Layout>
     <template #nav-bar-content-after>
-      <VersionPicker :show-label="false" :inline="true" />
+      <VersionPicker />
       <ThemeSwitcher />
     </template>
 
     <template #nav-screen-content-after>
-      <VersionPicker class="version-picker--mobile" />
+      <VersionPicker variant="list" :show-label="true" class="version-picker--mobile" />
       <ThemeSwitcher class="theme-switcher--mobile" />
     </template>
 

--- a/docsv/.vitepress/theme/ThemeLayout.vue
+++ b/docsv/.vitepress/theme/ThemeLayout.vue
@@ -2,11 +2,19 @@
 import DefaultTheme from 'vitepress/theme'
 import NotFound from './NotFound.vue'
 import ThemeSwitcher from './ThemeSwitcher.vue'
+import VersionBanner from './VersionBanner.vue'
 import VersionPicker from './VersionPicker.vue'
 </script>
 
 <template>
   <DefaultTheme.Layout>
+    <!-- Above the nav bar rather than inside the article, so the notice reaches
+         the home page and the 404 page as well as prose, and so it does not
+         narrow to the reading column. -->
+    <template #layout-top>
+      <VersionBanner />
+    </template>
+
     <template #nav-bar-content-after>
       <VersionPicker />
       <ThemeSwitcher />

--- a/docsv/.vitepress/theme/VersionBanner.vue
+++ b/docsv/.vitepress/theme/VersionBanner.vue
@@ -1,0 +1,151 @@
+<script setup lang="ts">
+/**
+ * A notice shown when the reader is not on the documentation they probably
+ * want.
+ *
+ * Most readers arrive from a search engine, which favours whichever version has
+ * accumulated links rather than the current one. They cannot act on that unless
+ * they are told, so this states the version being read and offers the same page
+ * in the recommended one. `useVersions` owns the decision about when a notice is
+ * warranted.
+ *
+ * The manifest is fetched after mount — a build cannot know at compile time
+ * which versions were published after it — so this appears slightly after first
+ * paint and shifts the page down on the versions which need it. Reserving the
+ * space on every version would trade a shift on old builds for wasted space on
+ * the current one.
+ */
+import { onUnmounted, ref, watch } from 'vue'
+import { useVersions, versionHref } from './versions'
+
+const { notice, pagePath } = useVersions()
+
+const banner = ref<HTMLElement>()
+let observer: ResizeObserver | undefined
+
+/**
+ * The nav bar, sidebar, content and nav screen all offset themselves by
+ * `--vp-layout-top-height`, and the default theme reserves a z-index layer above
+ * the nav for this slot, so `layout-top` content is expected to be taken out of
+ * flow and to publish its own height. Leaving the notice in flow instead
+ * double-counts it: below 960px `.VPNav` is `position: relative` with
+ * `top: var(--vp-layout-top-height)`, so it would drop a second banner's height
+ * below the banner it already follows.
+ *
+ * The height is measured rather than hard-coded because the notice wraps to two
+ * lines on narrow viewports.
+ */
+const TOP_HEIGHT = '--vp-layout-top-height'
+
+function clearTopHeight(): void {
+    document.documentElement.style.removeProperty(TOP_HEIGHT)
+}
+
+watch(banner, (el) => {
+    observer?.disconnect()
+
+    if (!el) {
+        clearTopHeight()
+        return
+    }
+
+    observer = new ResizeObserver(([entry]) => {
+        // The border-box size rather than `offsetHeight`, which rounds to whole
+        // pixels: at text sizes that wrap to a fractional height, rounding down
+        // leaves the nav bar overlapping the notice by up to a pixel.
+        const height =
+            entry?.borderBoxSize?.[0]?.blockSize ?? el.getBoundingClientRect().height
+
+        document.documentElement.style.setProperty(TOP_HEIGHT, `${height}px`)
+    })
+    observer.observe(el)
+})
+
+onUnmounted(() => {
+    observer?.disconnect()
+    clearTopHeight()
+})
+</script>
+
+<template>
+    <div v-if="notice" ref="banner" class="version-banner" role="status">
+        <p class="version-banner__text">
+            <template v-if="notice.kind === 'development'">
+                You are reading the development documentation, which tracks the
+                <code>main</code> branch.
+            </template>
+            <template v-else>
+                You are reading the documentation for
+                <strong>{{ notice.current.label }}</strong>, which is not the
+                current release.
+            </template>
+
+            <!--
+              A cross-version link must bypass VitePress's router, which would
+              otherwise resolve the target against this build. The router skips
+              any link carrying a `target`.
+            -->
+            <a
+                v-if="notice.target"
+                class="version-banner__link"
+                :href="versionHref(notice.target, pagePath)"
+                target="_self"
+            >Switch to {{ notice.target.label }}</a>
+        </p>
+    </div>
+</template>
+
+<style scoped>
+.version-banner {
+    position: fixed;
+    top: 0;
+    right: 0;
+    left: 0;
+    z-index: var(--vp-z-index-layout-top);
+    padding: 0.5rem 1.5rem;
+    /* The shared accent is already the amber end of the palette, so it carries a
+       cautionary tone without introducing a warning colour the design package
+       does not define. */
+    background: var(--vp-c-brand-soft);
+    border-bottom: 1px solid var(--vp-c-divider);
+}
+
+.version-banner__text {
+    max-width: var(--sqlfluff-content-width);
+    margin: 0 auto;
+    color: var(--vp-c-text-1);
+    font-size: 14px;
+    line-height: 1.5;
+    text-align: center;
+}
+
+.version-banner__text code {
+    font-family: var(--vp-font-family-mono);
+    font-size: 0.9em;
+}
+
+.version-banner__link {
+    margin-left: 0.5rem;
+    color: var(--vp-c-brand-1);
+    font-weight: 600;
+    text-decoration: underline;
+    text-underline-offset: 0.18em;
+    white-space: nowrap;
+}
+
+.version-banner__link:hover {
+    color: var(--vp-c-brand-2);
+}
+
+/* The notice is fixed, so every line it wraps to is vertical space taken from
+   the page for as long as the reader stays on it. */
+@media (max-width: 767px) {
+    .version-banner {
+        padding: 0.45rem 1rem;
+    }
+
+    .version-banner__text {
+        font-size: 13px;
+    }
+}
+</style>

--- a/docsv/.vitepress/theme/VersionPicker.vue
+++ b/docsv/.vitepress/theme/VersionPicker.vue
@@ -1,170 +1,358 @@
 <script setup lang="ts">
-import { computed, onMounted, ref } from 'vue'
-import { useData, useRoute } from 'vitepress'
-import { manifestPath, normalizeBase } from '../path-utils'
+/**
+ * The documentation version picker.
+ *
+ * This is a disclosure rather than a `<select>`. A native select cannot style
+ * its popup, so the closed control and the open list were drawn in two
+ * different visual languages — and VitePress's `base.css` strips the native
+ * chevron from every select, which left the closed state with no affordance at
+ * all. Both states are now ours to draw, and they follow the appearance of the
+ * flyout menus the default theme puts next to this one in the nav bar.
+ *
+ * A disclosure of links is used in preference to `role="menu"`: menu semantics
+ * oblige us to reimplement arrow-key focus movement, typeahead and Home/End,
+ * whereas a list of links after the trigger in DOM order is already reachable
+ * with Tab. Real links also restore middle-click, copy-link and open-in-new-tab,
+ * which the old change handler could not support.
+ */
+import { computed, onUnmounted, ref, useId, watch } from 'vue'
+import {
+    isChannel,
+    useVersions,
+    versionHref,
+    versionTitle,
+    type VersionEntry,
+} from './versions'
 
 const props = withDefaults(
     defineProps<{
-        inline?: boolean
+        /**
+         * `flyout` overlays the panel, for the nav bar. `list` keeps it in flow
+         * and full width, for the mobile nav screen.
+         */
+        variant?: 'flyout' | 'list'
         showLabel?: boolean
     }>(),
     {
-        inline: false,
-        showLabel: true,
+        variant: 'flyout',
+        showLabel: false,
     }
 )
 
-interface VersionEntry {
-    key: string
-    label: string
-    path: string
-}
+const { entries, current, channels, releases, pagePath } = useVersions()
 
-interface VersionManifest {
-    versions: VersionEntry[]
-}
+const open = ref(false)
+const root = ref<HTMLElement>()
+const trigger = ref<HTMLButtonElement>()
+const panelId = useId()
 
-const manifest = ref<VersionManifest | null>(null)
-const route = useRoute()
-const { site } = useData()
-const currentPath = ref('/')
+/** Headings only earn their space when there is more than one group. */
+const showGroupTitles = computed(
+    () => channels.value.length > 0 && releases.value.length > 0
+)
 
-const docsBase = computed(() => normalizeBase(site.value.base, '/'))
+/**
+ * Until the manifest arrives there is only the version this build was published
+ * as, and nothing to switch to. The version is still worth stating, so it
+ * renders as a label rather than a control which would open an empty menu — the
+ * state a failed manifest request leaves this in permanently.
+ */
+const interactive = computed(() => entries.value.length > 1)
 
-const fallbackVersion = computed<VersionEntry[]>(() => {
-    const segments = docsBase.value.split('/').filter(Boolean)
-
-    if (segments.length < 2) {
-        return []
-    }
-
-    const [language, versionKey] = segments
-
-    return [{
-        key: versionKey,
-        label: versionKey,
-        path: `/${language}/${versionKey}/`
-    }]
+/**
+ * Releases get a `v` so the trigger reads as a version rather than a bare
+ * number; the channel names already read as words.
+ */
+const triggerLabel = computed(() => {
+    const entry = current.value
+    if (!entry) return ''
+    return isChannel(entry) ? entry.label : `v${entry.label}`
 })
 
-const versions = computed(() => {
-    if (manifest.value?.versions.length) {
-        return manifest.value.versions
-    }
-
-    return fallbackVersion.value
+const dateFormat = new Intl.DateTimeFormat('en', {
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+    // `published_at` is a plain date, which parses as UTC midnight. Formatting
+    // in the reader's zone would show the previous day west of Greenwich.
+    timeZone: 'UTC',
 })
 
-const selectedVersion = computed(() => {
-    return versions.value.find((version) => {
-        const versionPath = normalizeBase(version.path, '/')
-        return currentPath.value === versionPath || currentPath.value.startsWith(versionPath)
-    })
-})
+/** Secondary line for an entry, or `null` when there is nothing to add. */
+function entryMeta(entry: VersionEntry): string | null {
+    if (!entry.published_at) return null
 
-async function loadManifest(): Promise<void> {
-    if (!fallbackVersion.value.length) {
-        return
-    }
+    const published = new Date(entry.published_at)
+    if (Number.isNaN(published.getTime())) return null
 
-    const response = await fetch(manifestPath(docsBase.value), {
-        headers: {
-            Accept: 'application/json'
-        }
-    })
-
-    if (response.ok) {
-        manifest.value = await response.json() as VersionManifest
-        return
-    }
-
-    throw new Error(`Failed to load versions manifest from ${manifestPath(docsBase.value)}`)
+    return dateFormat.format(published)
 }
 
-function onChange(event: Event): void {
-    const target = event.target as HTMLSelectElement
-    const version = versions.value.find((entry) => entry.key === target.value)
-
-    if (!version) {
-        return
-    }
-
-    window.location.href = version.path
+function close(): void {
+    open.value = false
 }
 
-onMounted(async () => {
-    currentPath.value = normalizeBase(window.location.pathname || route.path, '/')
+function onDocumentPointerDown(event: PointerEvent): void {
+    if (!root.value?.contains(event.target as Node)) close()
+}
 
-    try {
-        await loadManifest()
-    } catch (error) {
-        console.error(error)
+watch(open, (isOpen) => {
+    if (isOpen) {
+        document.addEventListener('pointerdown', onDocumentPointerDown)
+    } else {
+        document.removeEventListener('pointerdown', onDocumentPointerDown)
     }
 })
+
+onUnmounted(() => {
+    document.removeEventListener('pointerdown', onDocumentPointerDown)
+})
+
+function onKeydown(event: KeyboardEvent): void {
+    if (event.key !== 'Escape' || !open.value) return
+
+    close()
+    // Escape must not also close the surrounding nav screen.
+    event.stopPropagation()
+    trigger.value?.focus()
+}
 </script>
 
 <template>
-        <div v-if="versions.length" :class="['version-picker', { 'version-picker--inline': props.inline }]">
-        <label v-if="props.showLabel" class="version-picker__label" for="version-picker-select">Version</label>
-                <select
-                        id="version-picker-select"
-                        class="version-picker__select"
-                        :value="selectedVersion?.key"
-                        @change="onChange"
-                >
-                        <option
-                                v-for="version in versions"
-                                :key="version.key"
-                                :value="version.key"
-                        >
-                                {{ version.label }}
-                        </option>
-                </select>
+    <div
+        v-if="current"
+        ref="root"
+        class="version-picker"
+        :class="`version-picker--${props.variant}`"
+        @keydown="onKeydown"
+    >
+        <span v-if="props.showLabel" class="version-picker__label">Version</span>
+
+        <button
+            v-if="interactive"
+            ref="trigger"
+            type="button"
+            class="version-picker__trigger"
+            :aria-expanded="open"
+            :aria-controls="panelId"
+            @click="open = !open"
+        >
+            <span class="version-picker__trigger-text">
+                <span class="sqlfluff-visually-hidden">Documentation version:</span>
+                {{ triggerLabel }}
+            </span>
+            <span class="vpi-chevron-down version-picker__chevron" aria-hidden="true" />
+        </button>
+
+        <span v-else class="version-picker__static">
+            <span class="sqlfluff-visually-hidden">Documentation version:</span>
+            {{ triggerLabel }}
+        </span>
+
+        <div v-if="interactive" :id="panelId" class="version-picker__panel" :hidden="!open">
+            <template v-for="(group, index) in [channels, releases]" :key="index">
+                <div v-if="group.length" class="version-picker__group">
+                    <p v-if="showGroupTitles" class="version-picker__group-title">
+                        {{ index === 0 ? 'Channels' : 'Releases' }}
+                    </p>
+
+                    <!--
+                      `target` is load-bearing. VitePress's router intercepts
+                      every same-origin link and would resolve another version's
+                      page against this build; it skips any link which carries a
+                      `target`, so this forces a real navigation.
+                    -->
+                    <a
+                        v-for="entry in group"
+                        :key="entry.key"
+                        class="version-picker__item"
+                        :class="{ 'is-current': entry.key === current.key }"
+                        :href="versionHref(entry, pagePath)"
+                        :aria-current="entry.key === current.key ? 'page' : undefined"
+                        target="_self"
+                        @click="close"
+                    >
+                        <span class="version-picker__item-title">
+                            {{ versionTitle(entry) }}
+                            <span v-if="entry.prerelease" class="version-picker__tag">
+                                pre-release
+                            </span>
+                        </span>
+                        <span
+                            v-if="entryMeta(entry)"
+                            class="version-picker__item-meta"
+                        >{{ entryMeta(entry) }}</span>
+                    </a>
+                </div>
+            </template>
         </div>
+    </div>
 </template>
 
 <style scoped>
 .version-picker {
+    position: relative;
+}
+
+/* The trigger takes the theme switcher's height, radius and surface so the two
+   read as one cluster of controls, while the panel below follows the default
+   theme's own flyout menus. Each half matches what sits nearest to it. */
+.version-picker__trigger {
     display: flex;
+    height: 36px;
     align-items: center;
-    gap: 0.5rem;
-    padding: 0.5rem 0;
-}
-
-.version-picker--inline {
-    padding: 0;
-}
-
-.version-picker__label {
-    font-size: 0.875rem;
-    font-weight: 600;
-    color: var(--vp-c-text-2);
-}
-
-.version-picker__select {
-    min-width: 7rem;
-    padding: 0.35rem 2rem 0.35rem 0.65rem;
-    border: 1px solid var(--vp-c-divider);
-    border-radius: 999px;
-    background: var(--vp-c-bg-soft);
+    gap: 0.35rem;
+    padding: 0 0.6rem;
     color: var(--vp-c-text-1);
-    font-size: 0.875rem;
+    font-size: 14px;
+    font-weight: 500;
+    background: var(--vp-c-bg-soft);
+    border: 1px solid var(--vp-c-divider);
+    border-radius: var(--sqlfluff-radius-md);
+    transition: color 0.25s, border-color 0.25s;
 }
 
-.version-picker--inline .version-picker__select {
-    min-width: 5.5rem;
-    padding-right: 1.5rem;
-    background: transparent;
+.version-picker__trigger:hover {
+    color: var(--vp-c-brand-1);
+    border-color: var(--vp-c-border);
 }
 
-.version-picker__select:focus {
-    outline: 2px solid var(--vp-c-brand-1);
-    outline-offset: 2px;
+.version-picker__trigger-text,
+.version-picker__static {
+    font-variant-numeric: tabular-nums;
 }
 
-@media (max-width: 960px) {
-    .version-picker {
-        justify-content: space-between;
-    }
+/* No border or chevron: it is a statement of fact, not something to press. It
+   keeps the trigger's height and side padding so gaining the control shifts the
+   row as little as possible. */
+.version-picker__static {
+    display: flex;
+    height: 36px;
+    align-items: center;
+    padding: 0 0.6rem;
+    color: var(--vp-c-text-2);
+    font-size: 14px;
+    font-weight: 500;
+}
+
+.version-picker__chevron {
+    width: 14px;
+    height: 14px;
+    color: var(--vp-c-text-2);
+    transition: transform 0.25s;
+}
+
+/* `vpi-chevron-down` is a right-pointing glyph already turned by `rotate(90deg)`,
+   so pointing it up means replacing that rotation rather than adding to it. */
+.version-picker__trigger[aria-expanded='true'] .version-picker__chevron {
+    transform: rotate(270deg);
+}
+
+.version-picker__panel {
+    padding: 12px;
+    background: var(--vp-c-bg-elv);
+    border: 1px solid var(--vp-c-divider);
+    /* Matches VPMenu, so this panel and the nav menus beside it agree. */
+    border-radius: 12px;
+    box-shadow: var(--vp-shadow-3);
+}
+
+.version-picker__panel[hidden] {
+    display: none;
+}
+
+.version-picker--flyout .version-picker__panel {
+    position: absolute;
+    top: calc(100% + 12px);
+    right: 0;
+    z-index: 30;
+    min-width: 15rem;
+    max-height: calc(100vh - var(--vp-nav-height) - 2rem);
+    overflow-y: auto;
+}
+
+.version-picker__group + .version-picker__group {
+    margin-top: 12px;
+    padding-top: 12px;
+    border-top: 1px solid var(--vp-c-divider);
+}
+
+.version-picker__group-title {
+    margin: 0 0 4px;
+    padding: 0 12px;
+    color: var(--vp-c-text-2);
+    font-size: 12px;
+    font-weight: 500;
+    line-height: 20px;
+}
+
+.version-picker__item {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 1rem;
+    padding: 4px 12px;
+    border-radius: 6px;
+    color: var(--vp-c-text-1);
+    font-size: 14px;
+    font-weight: 500;
+    line-height: 24px;
+    text-decoration: none;
+    white-space: nowrap;
+    transition: background-color 0.25s, color 0.25s;
+}
+
+.version-picker__item:hover {
+    color: var(--vp-c-brand-1);
+    background-color: var(--vp-c-default-soft);
+}
+
+.version-picker__item.is-current {
+    color: var(--vp-c-brand-1);
+}
+
+.version-picker__item-title {
+    font-variant-numeric: tabular-nums;
+}
+
+/* Weight as well as colour, so the current version is still distinguishable
+   without relying on hue. */
+.version-picker__item.is-current .version-picker__item-title {
+    font-weight: 700;
+}
+
+.version-picker__item-meta {
+    color: var(--vp-c-text-2);
+    font-size: 12px;
+    font-weight: 400;
+}
+
+.version-picker__tag {
+    margin-left: 0.35rem;
+    padding: 0 0.35rem;
+    color: var(--vp-c-text-2);
+    font-size: 11px;
+    font-weight: 500;
+    background: var(--vp-c-default-soft);
+    border-radius: var(--sqlfluff-radius-sm);
+}
+
+/* Nav screen: the panel sits in flow under a full-width trigger, matching how
+   the default theme expands its own nav groups there. */
+.version-picker--list .version-picker__label {
+    display: block;
+    margin-bottom: 0.5rem;
+    color: var(--vp-c-text-2);
+    font-size: 14px;
+    font-weight: 500;
+}
+
+.version-picker--list .version-picker__trigger {
+    width: 100%;
+    justify-content: space-between;
+}
+
+.version-picker--list .version-picker__panel {
+    margin-top: 0.5rem;
 }
 </style>

--- a/docsv/.vitepress/theme/design-adapter.css
+++ b/docsv/.vitepress/theme/design-adapter.css
@@ -61,11 +61,76 @@
 /* The shared theme control is placed in the nav bar and nav screen slots in
    place of VitePress's own two-state toggle. Only spacing is set here; the
    control's appearance comes from the shared components stylesheet. */
+
+/* The version picker and the theme control are one group: both describe how the
+   reader is viewing the docs rather than where they are in it. The separator
+   therefore belongs before the picker, and the theme control drops the one it
+   carries by default so the pair are not split from each other. */
+.VPNavBar .version-picker {
+  margin-left: 0.5rem;
+  padding-left: 0.75rem;
+  border-left: 1px solid var(--vp-c-divider);
+}
+
 .VPNavBar .sqlfluff-theme-control {
   margin-left: 0.5rem;
+  padding-left: 0;
+  border-left: 0;
+}
+
+/*
+ * Below the hamburger breakpoint the nav screen renders its own copies of both
+ * controls, so the nav bar copies would be duplicates. They also overflowed:
+ * at 420px the theme control ended at 433px and pushed the wordmark out of the
+ * viewport. The default theme hides its own nav-bar extras the same way.
+ *
+ * The threshold is 768px rather than the 1280px the default theme uses for
+ * social links and its appearance toggle. Those two stay reachable between the
+ * breakpoints through the `...` menu, but that menu is VitePress's own and
+ * cannot be extended, so hiding these at 1280px would put the version picker
+ * out of reach on every window between 768px and 1280px. The block below
+ * carves out the one band where that budget does not stretch to both controls.
+ */
+@media (max-width: 767px) {
+  .VPNavBar .version-picker,
+  .VPNavBar .sqlfluff-theme-control {
+    display: none;
+  }
+}
+
+/*
+ * Between the hamburger breakpoint and 880px the nav bar cannot hold the
+ * default theme's inline menu, its search field at minimum width, and both of
+ * these controls: at 768px they overflow the viewport by 112px, which is why
+ * the wordmark used to be clipped there.
+ *
+ * The nav screen is not an escape hatch in this band — `useNav` hard-codes the
+ * 768px threshold in JavaScript, so moving the collapse point in CSS alone would
+ * leave a hamburger which closes itself on resize.
+ *
+ * So the band gives up two things. The theme control yields because it sets a
+ * preference rather than a destination, the preference survives in a cookie
+ * across SQLFluff sites, and it is still reachable on either side of this band.
+ * The default theme's `...` menu yields because with `appearance: false` and a
+ * single locale it holds nothing but the social links, which the footer also
+ * carries. The version picker keeps its place because it is navigation.
+ */
+@media (min-width: 768px) and (max-width: 879px) {
+  .VPNavBar .sqlfluff-theme-control,
+  .VPNavBar .VPNavBarExtra {
+    display: none;
+  }
 }
 
 .VPNavScreen .sqlfluff-theme-control {
+  /* Full width so the separator above it spans the screen, rather than only the
+     three buttons, which `inline-flex` would limit it to. The shared stylesheet
+     right-aligns the control at this width for its own header layout, which
+     full width makes visible; the nav screen stacks everything else from the
+     left, including the version picker directly above. */
+  display: flex;
+  width: 100%;
+  justify-content: flex-start;
   margin-left: 0;
   padding-left: 0;
   border-left: 0;

--- a/docsv/.vitepress/theme/versions.ts
+++ b/docsv/.vitepress/theme/versions.ts
@@ -1,0 +1,220 @@
+/**
+ * Shared access to the published versions manifest.
+ *
+ * `scripts/assemble-site.py` writes the manifest at the language root, outside
+ * any single version's base, so a build learns about versions published after
+ * it. That makes the manifest a runtime fetch rather than build-time data, and
+ * it is the reason the picker and the banner can only render after mount.
+ *
+ * The fetch is cached at module scope so the two components share one request.
+ * Nothing populates the cache during SSR — the fetch only runs from `onMounted`
+ * — so this module holds no cross-request state when the site is prerendered.
+ */
+import { computed, onMounted, ref, type ComputedRef, type Ref } from 'vue'
+import { useData, useRoute } from 'vitepress'
+import { languageRoot, manifestPath, normalizeBase } from '../path-utils'
+
+export interface VersionEntry {
+    key: string
+    label: string
+    /** Display title from the publishing workflow; `--title` is optional. */
+    title?: string | null
+    path: string
+    kind?: 'channel' | 'release'
+    prerelease?: boolean
+    published_at?: string
+}
+
+export interface VersionManifest {
+    /** The channel the site root redirects to. */
+    default?: string
+    latest?: string
+    /** The release the `stable` channel currently points at. */
+    stable?: string
+    versions: VersionEntry[]
+}
+
+/** The mutable channels, which name a moving target rather than a release. */
+const CHANNEL_KEYS = new Set(['latest', 'stable'])
+
+const manifest = ref<VersionManifest | null>(null)
+let pending: Promise<void> | null = null
+
+async function fetchManifest(base: string): Promise<void> {
+    const url = manifestPath(base)
+    const response = await fetch(url, { headers: { Accept: 'application/json' } })
+
+    if (!response.ok) {
+        throw new Error(`Failed to load versions manifest from ${url}`)
+    }
+
+    manifest.value = (await response.json()) as VersionManifest
+}
+
+/** Load the manifest at most once per page load. */
+function loadManifest(base: string): Promise<void> {
+    if (!pending) {
+        pending = fetchManifest(base).catch((error) => {
+            // A missing manifest is expected for an unversioned build, such as
+            // local development. Both consumers degrade to rendering nothing.
+            console.error(error)
+        })
+    }
+
+    return pending
+}
+
+/** True for a mutable channel rather than a pinned release. */
+export function isChannel(entry: VersionEntry): boolean {
+    return entry.kind === 'channel' || CHANNEL_KEYS.has(entry.key)
+}
+
+/** The line a reader identifies a version by. */
+export function versionTitle(entry: VersionEntry): string {
+    return entry.title || entry.label || entry.key
+}
+
+/**
+ * Build a cross-version link which keeps the reader on the same page.
+ *
+ * The page may not exist in the target version, in which case that version's
+ * own 404 handling takes over. That is a better trade than always landing on
+ * the target's home page, which is a certain loss of place rather than a
+ * possible one.
+ */
+export function versionHref(
+    entry: VersionEntry,
+    pagePath: string
+): string {
+    return normalizeBase(entry.path, '/') + pagePath
+}
+
+export type NoticeKind = 'development' | 'outdated'
+
+export interface VersionNotice {
+    kind: NoticeKind
+    /** The version the reader is on. */
+    current: VersionEntry
+    /** Where to send them instead, when there is somewhere better. */
+    target: VersionEntry | null
+}
+
+export interface UseVersions {
+    /** Every published version, channels before releases. */
+    entries: Ref<VersionEntry[]>
+    /** The version this build was published as, if it is versioned at all. */
+    current: Ref<VersionEntry | null>
+    channels: Ref<VersionEntry[]>
+    releases: Ref<VersionEntry[]>
+    /** The current page's path within its version, for cross-version links. */
+    pagePath: ComputedRef<string>
+    notice: Ref<VersionNotice | null>
+}
+
+export function useVersions(): UseVersions {
+    const { site } = useData()
+    const route = useRoute()
+    const docsBase = computed(() => normalizeBase(site.value.base, '/'))
+
+    /**
+     * Taken from the route rather than read once from `window`, so cross-version
+     * links keep pointing at the page the reader is actually on after a
+     * client-side navigation.
+     */
+    const pagePath = computed(() => {
+        const base = docsBase.value
+        const path = route.path
+
+        return path.startsWith(base) ? path.slice(base.length) : ''
+    })
+
+    /**
+     * The version key comes from the build's own base rather than the browser
+     * URL: the base is what the build was published as, so it is correct before
+     * the manifest arrives and during prerendering.
+     */
+    const currentKey = computed(() => {
+        const segments = docsBase.value.split('/').filter(Boolean)
+        return segments.length < 2 ? null : segments[1]
+    })
+
+    /**
+     * Stand in for the manifest so an unversioned or offline build still names
+     * the version it is, rather than showing an empty control.
+     */
+    const fallback = computed<VersionEntry[]>(() => {
+        if (!currentKey.value) return []
+
+        return [{
+            key: currentKey.value,
+            label: currentKey.value,
+            path: `${languageRoot(docsBase.value)}${currentKey.value}/`,
+        }]
+    })
+
+    const entries = computed<VersionEntry[]>(() => {
+        const published = manifest.value?.versions
+
+        if (!published?.length) return fallback.value
+
+        // `version_sort_key` in assemble-site.py already orders channels first
+        // and then releases newest-first. Partitioning preserves that order
+        // within each group, which the "newest release" checks below rely on.
+        return [
+            ...published.filter(isChannel),
+            ...published.filter((entry) => !isChannel(entry)),
+        ]
+    })
+
+    const channels = computed(() => entries.value.filter(isChannel))
+    const releases = computed(() => entries.value.filter((e) => !isChannel(e)))
+
+    const current = computed(
+        () => entries.value.find((entry) => entry.key === currentKey.value) ?? null
+    )
+
+    /** The release the `stable` channel points at, when it is published. */
+    const stableRelease = computed(() => {
+        const key = manifest.value?.stable
+        return releases.value.find((entry) => entry.key === key) ?? null
+    })
+
+    /** Where a reader on an unsuitable version should be sent instead. */
+    const recommended = computed<VersionEntry | null>(() => {
+        const stableChannel = channels.value.find((entry) => entry.key === 'stable')
+        return stableRelease.value ?? stableChannel ?? releases.value[0] ?? null
+    })
+
+    const notice = computed<VersionNotice | null>(() => {
+        const entry = current.value
+
+        // Nothing to warn about when there is nowhere else to go. This also
+        // keeps the banner off a single-channel deployment such as the beta
+        // site, where every build is `latest`.
+        if (!entry || entries.value.length < 2) return null
+
+        const target = recommended.value
+        const alternative = target && target.key !== entry.key ? target : null
+
+        // `latest` tracks main, so it is worth flagging even when it is the
+        // channel the site root redirects to.
+        if (entry.key === 'latest' || entry.prerelease) {
+            return { kind: 'development', current: entry, target: alternative }
+        }
+
+        if (isChannel(entry)) return null
+
+        // Releases are ordered newest-first, so anything but the first is old.
+        if (releases.value.indexOf(entry) > 0) {
+            return { kind: 'outdated', current: entry, target: alternative }
+        }
+
+        return null
+    })
+
+    onMounted(() => {
+        if (currentKey.value) void loadManifest(docsBase.value)
+    })
+
+    return { entries, current, channels, releases, pagePath, notice }
+}

--- a/docsv/README.md
+++ b/docsv/README.md
@@ -83,6 +83,31 @@ pnpm run docs:dev
 
 Then open http://localhost:5173 in your browser.
 
+#### Working on the version picker
+
+The version picker and the "you are reading an old version" notice both read the
+versions manifest, and both take the current version from the site base. Neither
+appears under the default unversioned base, so serve a versioned one:
+
+```bash
+SQLFLUFF_DOCS_BASE=/en/latest/ pnpm run docs:dev
+```
+
+In production the manifest is written at the language root by
+`scripts/assemble-site.py`, above any single version's base. The dev server
+cannot serve that path out of `public/`, so it comes from the fixture at
+`.vitepress/dev-versions.json` instead — edit it to try other sets of versions,
+or delete it to see how the picker behaves when no manifest is reachable. The
+releases it names are not built locally, so following one of those links in dev
+lands on the dev server's 404.
+
+To see the outdated-version notice rather than the development one, serve a base
+which is not the newest release:
+
+```bash
+SQLFLUFF_DOCS_BASE=/en/3.4.1/ pnpm run docs:dev
+```
+
 ### Build for Production
 
 Build static HTML for deployment:


### PR DESCRIPTION

<img width="2560" height="1240" alt="2-panel-open-light" src="https://github.com/user-attachments/assets/9152de5e-c4c9-41a9-b1e7-fbd3767bb8d5" />


The picker we load into the VitePress docs looked out of place: cramped spacing, and an open dropdown that shared no visual language with the closed control.

## What was wrong

The control was a native `<select>` styled as an 88×37 stadium pill.

- **No dropdown affordance at all.** VitePress's `base.css` sets `select { -webkit-appearance: none }`, which strips the chevron. The closed state read as an inert text field or a second search box.
- **Closed and open could never match.** A `<select>` popup is drawn by the OS — system font, system highlight, native radius and shadow — and no CSS reaches it. This was unfixable while it stayed a select.
- **Negative spacing.** The pill's box started at x=1040 while the social links ended at x=1048: an 8px overlap, no gap, no separator. The theme control *did* have one, so the grouping read as `nav | social+version | theme` instead of putting the version and theme controls together.
- **Off-system shape.** `border-radius: 999px` was the only stadium in the chrome (tokens are 4/8px, theme switcher 7px, search 8px), and 37px vs the switcher's 36px looked like a near miss rather than a rhythm.
- **Broken on mobile.** Both controls rendered at every width despite the nav screen rendering its own copies, so a phone showed two version pickers, and at 420px the switcher ran to x=433 in a 420px viewport, clipping the wordmark.
- **Metadata discarded.** `assemble-site.py` writes `title`, `kind`, `prerelease` and `published_at` per entry; the picker showed `label` only.

## What this does

**Rebuilds the picker as a disclosure.** The trigger takes the theme control's height and 8px radius; the panel follows the default theme's own flyout menus, so each half matches whatever sits nearest to it and the open panel now belongs to the same chrome as the `Guide ▾` menus one row over. Channels and releases are separate groups with titles and dates, and the current version is marked by weight as well as colour.

Real links replace the change handler, restoring middle-click, copy-link and open-in-new-tab. A disclosure is used rather than `role="menu"` so Tab order does the work instead of a hand-rolled reimplementation of arrow-key movement and typeahead. Escape closes and returns focus; outside clicks close.

**Adds a notice on docs you probably didn't mean to read.** Most readers arrive from a search engine, which favours whichever version accumulated links rather than the current one — a picker doesn't help someone who doesn't know they need it. So `latest` and superseded releases now say so, and link to the same page in the recommended version. Nothing renders when there's nowhere better to go, which also keeps it off a single-channel deployment like the beta site.

**Fixes the surrounding layout.** Separator moved before the picker; matched 36px heights; nav-bar copies hidden below the hamburger breakpoint so they stop duplicating the nav screen and overflowing.

**Makes the components developable locally**, which they weren't — see below.

## Things worth a reviewer's attention

Two non-obvious traps, both commented where they bite:

- **`target="_self"` on cross-version links is load-bearing.** VitePress's router intercepts *every* same-origin link, so without it another version's page gets resolved against this build. `hasAttribute('target')` is the router's documented opt-out. Please don't let it get tidied away.
- **`layout-top` content must be out of flow.** Left in flow it double-counts, because below 960px `.VPNav` is `position: relative; top: var(--vp-layout-top-height)`. The reserved `--vp-z-index-layout-top: 40` layer confirms the intent. Height is measured from the border box, not `offsetHeight`, which rounds and left the nav overlapping by up to 1px where the text wraps to a fractional height.

**One deliberate trade-off.** Between 768px and 879px the nav bar cannot hold the inline menu, search at minimum width, and both controls — it overflowed by 112px at 768px, which is pre-existing. The collapse point can't move, because `useNav` hard-codes `outerWidth >= 768` in JS, so a CSS-only change would leave a hamburger that closes itself on resize. In that band the theme control and VitePress's `...` menu yield and the picker keeps its place, on the grounds that the picker is navigation while the other two are a preference and a set of decorative links the footer also carries. Cost: on an ~800px window you can't change theme from the docs, though the cookie preference still carries over from sqlfluff.com. Happy to trade differently.

**Also fixed on the way:** `pagePath` was read once on mount, so after any client-side navigation the picker's links still pointed at the page you first landed on.

**Known limitation:** the notice uses `role="status"`, but since the element is inserted wholesale rather than being a pre-existing live region, some screen readers won't announce it. It's encountered normally on navigation. Fixing properly means prerendering an empty live region, which didn't seem worth it — say if you disagree.

## Local development

The manifest lives at the language root, above any single version's base, so the dev server can't serve it from `public/` — the request 404s and the picker degrades to a static label. That meant neither component could be seen locally at all, whatever base you gave the server. A dev-only Vite plugin now serves `.vitepress/dev-versions.json` at the deployed path; `apply: 'serve'` keeps it out of builds.

```bash
SQLFLUFF_DOCS_BASE=/en/latest/ pnpm docs:dev   # development notice
SQLFLUFF_DOCS_BASE=/en/3.4.1/ pnpm docs:dev    # superseded-release notice
```

## Verification

Checked at 420/640/767/768/820/879/880/900/1100/1280/1440px in both themes: no horizontal overflow, the picker present exactly once, the nav flush under the notice to sub-pixel precision, and no console errors. Disclosure behaviour, `aria-expanded`/`aria-controls`/`aria-current`, Escape focus return and outside-click all confirmed, plus both notice variants, cross-version hrefs after client-side navigation, and the degraded no-manifest path. Production build prerenders clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rebuilt the docs version picker as a link-based disclosure that matches the theme, and added a banner that warns when you’re reading development or outdated docs. Also fixed layout issues and enabled local testing by serving a dev versions manifest.

- **New Features**
  - Replaced the native select with a link-based disclosure that matches nearby `vitepress` menus (flyout in the nav bar; full-width list in the nav screen).
  - Separates channels and releases; shows titles/dates; highlights the current version; keeps the same page across versions.
  - Added a banner that warns on `latest`/prerelease and superseded releases, with a link to the recommended version.
  - Shared `versions.ts` fetches and caches the versions manifest once for all components.
  - Dev-only plugin serves `.vitepress/dev-versions.json` at the deployed path for local testing; docs updated.

- **Bug Fixes**
  - Removed duplicate pickers on mobile; moved the separator before the picker; matched 36px heights; no overflow around 420–880px.
  - Cross-version links set `target="_self"` to bypass the `vitepress` router and force full navigation.
  - Version links stay correct after client-side navigation.
  - Banner reports its height via `--vp-layout-top-height` using border-box size to avoid double-counting and 1px overlaps.

<sup>Written for commit cfa0984ba598d36b26186bbab9b8e1f99a82cc0b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8300?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

