### PR TITLE
Support templater overrides in nested configuration

### DIFF
--- a/docs/source/configuration/setting_configuration.rst
+++ b/docs/source/configuration/setting_configuration.rst
@@ -118,9 +118,10 @@ Nesting
 **SQLFluff** uses **nesting** in its configuration files, with files
 closer *overriding* (or *patching*, if you will) values from other files.
 That means you'll end up with a final config which will be a patchwork
-of all the values from the config files loaded up to that path. The exception
-to this is the value for `templater`, which cannot be set in config files in
-subdirectories of the working directory.
+of all the values from the config files loaded up to that path. Templaters,
+including independently configured dbt projects, may be selected in nested
+configuration files. Nested ``sql_file_exts`` settings also control which files
+are discovered below that configuration file.
 You don't **need** any config files to be present to make *SQLFluff*
 work. If you do want to override any values though SQLFluff will use
 files in the following locations in order, with values from later

--- a/docs/source/configuration/setting_configuration.rst
+++ b/docs/source/configuration/setting_configuration.rst
@@ -121,7 +121,8 @@ That means you'll end up with a final config which will be a patchwork
 of all the values from the config files loaded up to that path. Templaters,
 including independently configured dbt projects, may be selected in nested
 configuration files. Nested ``sql_file_exts`` settings also control which files
-are discovered below that configuration file.
+are discovered below that configuration file. SQLFluff groups files by effective
+templater configuration and renders stateful templaters in the main process.
 You don't **need** any config files to be present to make *SQLFluff*
 work. If you do want to override any values though SQLFluff will use
 files in the following locations in order, with values from later

--- a/docs/source/configuration/templating/dbt.rst
+++ b/docs/source/configuration/templating/dbt.rst
@@ -156,6 +156,8 @@ See below configuration and its equivalent dbt command:
 Known Caveats
 """""""""""""
 
-- To use the dbt templater, you must set `templater = dbt` in the `.sqlfluff`
-  config file in the directory where sqlfluff is run. The templater cannot
-  be changed in `.sqlfluff` files in subdirectories.
+- The dbt templater may be selected in nested ``.sqlfluff`` files. A single
+  SQLFluff invocation may include multiple dbt projects and other templaters.
+  Each effective dbt configuration is compiled and rendered independently in
+  the main process before parsing and linting are distributed to any configured
+  workers.

--- a/docs/source/guides/contributing/plugins.rst
+++ b/docs/source/guides/contributing/plugins.rst
@@ -59,6 +59,15 @@ plugin can implement multiple Rules or Templaters.
 We recommend that the name of a plugin should start with *"sqlfluff-"* to be
 clear on the purpose of your plugin.
 
+Templater instances are scoped to one public lint, parse, or render operation.
+Stateless templaters can use the default ``session_key()``, which shares one
+instance by templater name. Stateful templaters should override
+``session_key()`` with a deterministic key containing every configuration value
+that defines reusable state, and override ``close()`` to release that state.
+Templaters that cannot render safely in worker processes should also set
+``templates_in_worker = False``. These methods must remain safe when setup only
+partially completes or an operation exits early.
+
 A plugin may need to include a default configuration if its rules
 are configurable: use plugin default configurations **only for that reason**!
 We advise against overwriting core configurations by using a default

--- a/docsv/configuration/index.md
+++ b/docsv/configuration/index.md
@@ -74,7 +74,7 @@ Here is a simple configuration file which would be suitable for a starterproject
 
 ### Nesting
 
-**SQLFluff** uses **nesting** in its configuration files, with files closer *overriding* (or *patching*, if you will) values from other files. That means you'll end up with a final config which will be a patchwork of all the values from the config files loaded up to that path. The exception to this is the value for `templater`, which cannot be set in config files in subdirectories of the working directory. You don't **need** any config files to be present to make *SQLFluff* work. If you do want to override any values though SQLFluff will use files in the following locations in order, with values from later steps overriding those from earlier:
+**SQLFluff** uses **nesting** in its configuration files, with files closer *overriding* (or *patching*, if you will) values from other files. That means you'll end up with a final config which will be a patchwork of all the values from the config files loaded up to that path. Templaters, including independently configured `dbt` projects, may be selected in nested configuration files. Nested `sql_file_exts` settings also control which files are discovered below that configuration file. SQLFluff groups files by effective templater configuration and renders stateful templaters in the main process. You don't **need** any config files to be present to make *SQLFluff* work. If you do want to override any values though SQLFluff will use files in the following locations in order, with values from later steps overriding those from earlier:
 
 0. *[...and this one doesn't really count]* There's a default config as
    part of the SQLFluff package. You can find this below, in the

--- a/docsv/configuration/templating/dbt.md
+++ b/docsv/configuration/templating/dbt.md
@@ -166,9 +166,11 @@ dbt run --vars '{"my_variable": 1}'
 
 ## Known Caveats
 
-- To use the dbt templater, you must set `templater = dbt` in the `.sqlfluff`
-  config file in the directory where sqlfluff is run. The templater cannot
-  be changed in `.sqlfluff` files in subdirectories.
+- The dbt templater may be selected in nested `.sqlfluff` files. A single
+  SQLFluff invocation may include multiple dbt projects and other templaters.
+  Each effective dbt configuration is compiled and rendered independently in
+  the main process before parsing and linting are distributed to any configured
+  workers.
 - In SQLFluff 0.4.0 using the dbt templater requires that all files
   within the root and child directories of the dbt project must be part
   of the project. If there are deployment scripts which refer to SQL files

--- a/docsv/development/plugins.md
+++ b/docsv/development/plugins.md
@@ -34,6 +34,8 @@ Currently, only Rules and Templaters can be added through plugins. Over time we 
 
 We recommend that the name of a plugin should start with *`sqlfluff-`* to be clear on the purpose of your plugin.
 
+Templater instances are scoped to one public lint, parse, or render operation. Stateless templaters can use the default `session_key()`, which shares one instance by templater name. Stateful templaters should override `session_key()` with a deterministic key containing every configuration value that defines reusable state, and override `close()` to release that state. Templaters that cannot render safely in worker processes should also set `templates_in_worker = False`. These methods must remain safe when setup only partially completes or an operation exits early.
+
 A plugin may need to include a default configuration if its rules are configurable: use plugin default configurations **only for that reason**! We advise against overwriting core configurations by using a default plugin configuration, as there is no mechanism in place to enforce precedence between the core library configs and plugin configs, and multiple plugins could clash.
 
 A plugin Rule class name should have the structure: `Rule_PluginName_L000`. The 'L' can be any letter and is meant to categorize rules; you could use the letter 'S' to denote rules that enforce security checks for example.

--- a/plugins/sqlfluff-templater-dbt/sqlfluff_templater_dbt/templater.py
+++ b/plugins/sqlfluff-templater-dbt/sqlfluff_templater_dbt/templater.py
@@ -9,9 +9,11 @@ such, all imports of the dbt libraries are contained within the
 DbtTemplater class and so are only imported when necessary.
 """
 
+import json
 import logging
 import os
 import os.path
+import threading
 from collections import deque
 from contextlib import contextmanager
 from dataclasses import dataclass
@@ -44,6 +46,7 @@ if TYPE_CHECKING:  # pragma: no cover
 
 # Instantiate the templater logger
 templater_logger = logging.getLogger("sqlfluff.templater")
+_ADAPTER_LOCK = threading.RLock()
 
 
 @dataclass
@@ -173,7 +176,6 @@ class DbtTemplater(JinjaTemplater):
 
     name = "dbt"
     sequential_fail_limit = 3
-    adapters = {}
     # dbt builds a cross-file manifest in the main process, so templating
     # cannot be deferred to worker processes.
     templates_in_worker = False
@@ -185,11 +187,67 @@ class DbtTemplater(JinjaTemplater):
         self.profiles_dir = None
         self.working_dir = os.getcwd()
         self.dbt_skip_compilation_error = True
+        self._adapter = None
+        self._adapter_initialized = False
+        self._adapter_type = None
+        self._adapter_lock_acquired = False
         super().__init__(override_context=override_context)
 
     def config_pairs(self):
         """Returns info about the given templater for output by the cli."""
         return [("templater", self.name), ("dbt", self.dbt_version)]
+
+    def session_key(self, config: "FluffConfig") -> tuple[str, ...]:
+        """Return a key for one effective dbt project configuration."""
+        return (
+            self.name,
+            self._get_project_dir(config),
+            self._get_profiles_dir(config),
+            repr(self._get_profile(config)),
+            repr(self._get_target(config)),
+            repr(self._get_target_path(config)),
+            repr(self._get_threads(config)),
+            json.dumps(
+                self._get_cli_vars(config), sort_keys=True, separators=(",", ":")
+            ),
+        )
+
+    def _release_adapter(self) -> None:
+        """Release this session's adapter without disturbing unrelated adapters."""
+        if not self._adapter_lock_acquired:
+            return
+        from dbt.adapters.factory import FACTORY
+
+        try:
+            if self._adapter_type is not None:
+                with FACTORY.lock:
+                    if FACTORY.adapters.get(self._adapter_type) is self._adapter:
+                        del FACTORY.adapters[self._adapter_type]
+            if self._adapter is not None:
+                self._adapter.cleanup_connections()
+        finally:
+            self._adapter = None
+            self._adapter_initialized = False
+            self._adapter_type = None
+            self._adapter_lock_acquired = False
+            _ADAPTER_LOCK.release()
+
+    def _reset_project_state(self) -> None:
+        """Reset all state scoped to one effective dbt project."""
+        self._release_adapter()
+        for name in (
+            "dbt_config",
+            "dbt_compiler",
+            "dbt_manifest",
+            "dbt_selector_method",
+        ):
+            self.__dict__.pop(name, None)
+        self.project_dir = None
+        self.profiles_dir = None
+
+    def close(self) -> None:
+        """Release this dbt session's adapter connections."""
+        self._reset_project_state()
 
     @cached_property
     def _dbt_version(self) -> "VersionSpecifier":
@@ -248,54 +306,74 @@ class DbtTemplater(JinjaTemplater):
     def dbt_config(self):
         """Loads the dbt config."""
         from dbt import flags
-        from dbt.adapters.factory import register_adapter
+        from dbt.adapters.factory import FACTORY, register_adapter
         from dbt.config.runtime import RuntimeConfig as DbtRuntimeConfig
 
-        if self.dbt_version_tuple >= (1, 8):
-            from dbt_common.clients.system import get_env
-            from dbt_common.context import set_invocation_context
+        _ADAPTER_LOCK.acquire()
+        self._adapter_lock_acquired = True
+        try:
+            with FACTORY.lock:
+                if FACTORY.adapters:
+                    raise SQLFluffUserError(
+                        "dbt adapter is already in use by another operation."
+                    )
+            if self.dbt_version_tuple >= (1, 8):
+                from dbt_common.clients.system import get_env
+                from dbt_common.context import set_invocation_context
 
-            set_invocation_context(get_env())
+                set_invocation_context(get_env())
 
-        # Attempt to silence internal logging at this point.
-        # https://github.com/sqlfluff/sqlfluff/issues/5054
-        self.try_silence_dbt_logs()
+            # Attempt to silence internal logging at this point.
+            # https://github.com/sqlfluff/sqlfluff/issues/5054
+            self.try_silence_dbt_logs()
 
-        user_config = None
-        # 1.5.x+ this is a dict.
-        cli_vars = self._get_cli_vars()
-
-        _threads = self._get_threads()
-
-        flags.set_from_args(
-            DbtConfigArgs(
-                project_dir=self.project_dir,
-                profiles_dir=self.profiles_dir,
-                profile=self._get_profile(),
-                target_path=self._get_target_path(),
-                vars=cli_vars,
-                threads=_threads,
-            ),
-            user_config,
-        )
-        _dbt_config = DbtRuntimeConfig.from_args(
-            DbtConfigArgs(
-                project_dir=self.project_dir,
-                profiles_dir=self.profiles_dir,
-                profile=self._get_profile(),
-                target=self._get_target(),
-                target_path=self._get_target_path(),
-                vars=cli_vars,
-                threads=_threads,
+            user_config = None
+            # 1.5.x+ this is a dict.
+            cli_vars = self._get_cli_vars()
+            _threads = self._get_threads()
+            flags.set_from_args(
+                DbtConfigArgs(
+                    project_dir=self.project_dir,
+                    profiles_dir=self.profiles_dir,
+                    profile=self._get_profile(),
+                    target_path=self._get_target_path(),
+                    vars=cli_vars,
+                    threads=_threads,
+                ),
+                user_config,
             )
-        )
+            _dbt_config = DbtRuntimeConfig.from_args(
+                DbtConfigArgs(
+                    project_dir=self.project_dir,
+                    profiles_dir=self.profiles_dir,
+                    profile=self._get_profile(),
+                    target=self._get_target(),
+                    target_path=self._get_target_path(),
+                    vars=cli_vars,
+                    threads=_threads,
+                )
+            )
+            self._adapter_type = _dbt_config.credentials.type
+            if self.dbt_version_tuple >= (1, 8):
+                from dbt.mp_context import get_mp_context
 
-        if self.dbt_version_tuple >= (1, 8):
-            from dbt.mp_context import get_mp_context
-
-            register_adapter(_dbt_config, get_mp_context())
-        else:
-            register_adapter(_dbt_config)
+                register_adapter(_dbt_config, get_mp_context())
+            else:
+                register_adapter(_dbt_config)
+            registered_adapter = FACTORY.lookup_adapter(self._adapter_type)
+            if registered_adapter.config is not _dbt_config:
+                raise SQLFluffUserError(
+                    "dbt adapter registration was claimed by another operation."
+                )
+            self._adapter = registered_adapter
+            with FACTORY.lock:
+                if set(FACTORY.adapters.values()) != {registered_adapter}:
+                    raise SQLFluffUserError(
+                        "Another dbt adapter was registered during SQLFluff startup."
+                    )
+        except BaseException:
+            self._release_adapter()
+            raise
 
         return _dbt_config
 
@@ -351,7 +429,7 @@ class DbtTemplater(JinjaTemplater):
 
         return _dbt_selector_method
 
-    def _get_profiles_dir(self):
+    def _get_profiles_dir(self, config=None):
         """Get the dbt profiles directory from the configuration.
 
         The default is `~/.dbt` but we use the
@@ -373,7 +451,9 @@ class DbtTemplater(JinjaTemplater):
 
         dbt_profiles_dir = os.path.abspath(
             os.path.expanduser(
-                self._get_dbt_config_value("profiles_dir", "PROFILES_DIR", default_dir)
+                self._get_dbt_config_value(
+                    "profiles_dir", "PROFILES_DIR", default_dir, config
+                )
             )
         )
 
@@ -386,7 +466,11 @@ class DbtTemplater(JinjaTemplater):
         return dbt_profiles_dir
 
     def _get_dbt_config_value(
-        self, config_key: str, env_var_suffix: str, default: Optional[str] = None
+        self,
+        config_key: str,
+        env_var_suffix: str,
+        default: Optional[str] = None,
+        config=None,
     ) -> Optional[str]:
         """Get a dbt config value from SQLFluff config or dbt env vars.
 
@@ -396,7 +480,7 @@ class DbtTemplater(JinjaTemplater):
         the legacy DBT_* variables for compatibility.
         """
         return (
-            self.sqlfluff_config.get_section(
+            (config or self.sqlfluff_config).get_section(
                 (self.templater_selector, self.name, config_key)
             )
             or os.getenv(f"DBT_ENGINE_{env_var_suffix}")
@@ -404,14 +488,16 @@ class DbtTemplater(JinjaTemplater):
             or default
         )
 
-    def _get_project_dir(self):
+    def _get_project_dir(self, config=None):
         """Get the dbt project directory from the configuration.
 
         Defaults to the working directory.
         """
         dbt_project_dir = os.path.abspath(
             os.path.expanduser(
-                self._get_dbt_config_value("project_dir", "PROJECT_DIR", os.getcwd())
+                self._get_dbt_config_value(
+                    "project_dir", "PROJECT_DIR", os.getcwd(), config
+                )
             )
         )
         if not os.path.exists(dbt_project_dir):
@@ -422,31 +508,31 @@ class DbtTemplater(JinjaTemplater):
 
         return dbt_project_dir
 
-    def _get_profile(self):
+    def _get_profile(self, config=None):
         """Get a dbt profile name from the configuration."""
-        return self._get_dbt_config_value("profile", "PROFILE")
+        return self._get_dbt_config_value("profile", "PROFILE", config=config)
 
-    def _get_target(self):
+    def _get_target(self, config=None):
         """Get a dbt target name from the configuration."""
-        return self._get_dbt_config_value("target", "TARGET")
+        return self._get_dbt_config_value("target", "TARGET", config=config)
 
-    def _get_target_path(self):
+    def _get_target_path(self, config=None):
         """Get a dbt target path from the configuration."""
-        return self._get_dbt_config_value("target_path", "TARGET_PATH")
+        return self._get_dbt_config_value("target_path", "TARGET_PATH", config=config)
 
-    def _get_threads(self) -> Optional[int]:
+    def _get_threads(self, config=None) -> Optional[int]:
         """Get the dbt threads value from the configuration.
 
         If not set, returns ``None`` which lets dbt use the value
         from ``profiles.yml``.
         """
-        value = self.sqlfluff_config.get_section(
+        value = (config or self.sqlfluff_config).get_section(
             (self.templater_selector, self.name, "threads")
         )
         return int(value) if value is not None else None
 
-    def _get_cli_vars(self) -> dict:
-        cli_vars = self.sqlfluff_config.get_section(
+    def _get_cli_vars(self, config=None) -> dict:
+        cli_vars = (config or self.sqlfluff_config).get_section(
             (self.templater_selector, self.name, "context")
         )
 
@@ -877,10 +963,11 @@ class DbtTemplater(JinjaTemplater):
         # We have to register the connection in dbt >= 1.0.0 ourselves
         # In previous versions, we relied on the functionality removed in
         # https://github.com/dbt-labs/dbt-core/pull/4062.
-        adapter = self.adapters.get(self.project_dir)
+        adapter = self._adapter
         if adapter is None:
             adapter = get_adapter(self.dbt_config)
-            self.adapters[self.project_dir] = adapter
+            self._adapter = adapter
+        if not self._adapter_initialized:
             adapter.acquire_connection("master")
             if self.dbt_version_tuple >= (1, 8):
                 # See notes from https://github.com/dbt-labs/dbt-adapters/discussions/87
@@ -892,6 +979,7 @@ class DbtTemplater(JinjaTemplater):
                 adapter.set_relations_cache(self.dbt_manifest.nodes.values())
             else:
                 adapter.set_relations_cache(self.dbt_manifest)
+            self._adapter_initialized = True
 
         yield
         # :TRICKY: Once connected, we never disconnect. Making multiple

--- a/plugins/sqlfluff-templater-dbt/test/conftest.py
+++ b/plugins/sqlfluff-templater-dbt/test/conftest.py
@@ -62,9 +62,11 @@ def profiles_dir(dbt_fluff_config):
 @pytest.fixture()
 def dbt_templater():
     """Returns an instance of the DbtTemplater."""
-    return FluffConfig(
+    templater = FluffConfig(
         overrides={"dialect": "ansi", "templater": "dbt"}
     ).get_templater()
+    yield templater
+    templater.close()
 
 
 @pytest.fixture(scope="session")

--- a/plugins/sqlfluff-templater-dbt/test/linter_test.py
+++ b/plugins/sqlfluff-templater-dbt/test/linter_test.py
@@ -3,14 +3,21 @@
 import os
 import os.path
 import shutil
+from pathlib import Path
+from unittest import mock
 
 import pytest
 
 from sqlfluff.cli.commands import lint
 from sqlfluff.core import FluffConfig, Linter
 from sqlfluff.core.linter import runner
-from sqlfluff.core.linter.common import DeferredRenderTask
+from sqlfluff.core.linter.common import DeferredRenderTask, RenderedLintTask
 from sqlfluff.utils.testing.cli import invoke_assert_code
+
+
+def _write_config(path: Path, contents: str) -> None:
+    """Write a test configuration file."""
+    path.write_text(contents, encoding="utf-8")
 
 
 @pytest.mark.parametrize(
@@ -117,7 +124,7 @@ def test__dbt_linter__parallel_partials_path(project_dir, dbt_fluff_config):
     """Parallel linting with the dbt templater uses the main-process render path.
 
     Because DbtTemplater.templates_in_worker=False, ParallelRunner.iter_partials
-    must yield callable partials (RenderedFile already attached), NOT
+    must yield rendered tasks (RenderedFile already attached), not
     DeferredRenderTask objects. This ensures the manifest is only compiled once
     in the main process and the worker only handles the lint step.
     """
@@ -134,10 +141,85 @@ def test__dbt_linter__parallel_partials_path(project_dir, dbt_fluff_config):
 
     assert len(partials) == 2
     for _fname, task in partials:
-        # Must be a callable partial, not a DeferredRenderTask.
-        assert callable(task)
+        assert isinstance(task, RenderedLintTask)
         assert not isinstance(task, DeferredRenderTask)
 
     # Also verify that the full parallel lint run completes without error.
     results = list(thd_runner.run(files, fix=False))
     assert len(results) == 2
+
+
+@pytest.mark.parametrize("processes", [1, 2])
+@mock.patch("dbt.adapters.postgres.impl.PostgresAdapter.set_relations_cache")
+def test__linter__supports_nested_dbt_projects(
+    set_relations_cache, tmp_path, dbt_project_folder, processes
+):
+    """Lint built-in and independent nested dbt templaters together."""
+    root = tmp_path / "mixed_projects"
+    root.mkdir()
+    jinja_file = root / "jinja.sql"
+    jinja_file.write_text("select 1 from {{ table_name }}\n", encoding="utf-8")
+    _write_config(
+        root / ".sqlfluff",
+        """[sqlfluff]
+dialect = postgres
+templater = jinja
+
+[sqlfluff:templater:jinja:context]
+table_name = table_a
+""",
+    )
+
+    profiles_dir = Path(dbt_project_folder, "profiles_yml").resolve()
+    dbt_files = []
+    expected_rendered = {}
+    for project_index, project_name in enumerate(("project_a", "project_b"), start=1):
+        project_root = root / project_name
+        shutil.copytree(Path(dbt_project_folder, "dbt_project"), project_root)
+        _write_config(
+            project_root / ".sqlfluff",
+            f"""[sqlfluff]
+dialect = postgres
+templater = dbt
+
+[sqlfluff:templater:dbt]
+profiles_dir = {profiles_dir}
+project_dir = {project_root}
+
+[sqlfluff:templater:dbt:context]
+passed_through_cli = {project_index}
+""",
+        )
+        dbt_file = str(project_root / "models/vars_from_cli.sql")
+        dbt_files.append(dbt_file)
+        expected_rendered[dbt_file] = f"-- Issue #1262\nSELECT {project_index}\n"
+
+    config = FluffConfig.from_path(str(root))
+    linter = Linter(config=config)
+    result = linter.lint_paths(
+        (str(jinja_file), *dbt_files),
+        processes=processes,
+    )
+
+    linted_files = {
+        linted_file.path: linted_file
+        for linted_path in result.paths
+        for linted_file in linted_path.files
+    }
+    assert len(linted_files) == 3
+    assert not [violation for violation in result.get_violations() if violation.fatal]
+    assert linted_files[str(jinja_file)].templated_file.templated_str == (
+        "select 1 from table_a\n"
+    )
+    for dbt_file, rendered_sql in expected_rendered.items():
+        assert linted_files[dbt_file].templated_file.templated_str == rendered_sql
+
+    reversed_result = linter.lint_paths(tuple(reversed(dbt_files)), processes=processes)
+    reversed_files = {
+        linted_file.path: linted_file
+        for linted_path in reversed_result.paths
+        for linted_file in linted_path.files
+    }
+    assert list(reversed_files) == list(reversed(dbt_files))
+    for dbt_file, rendered_sql in expected_rendered.items():
+        assert reversed_files[dbt_file].templated_file.templated_str == rendered_sql

--- a/plugins/sqlfluff-templater-dbt/test/templater_test.py
+++ b/plugins/sqlfluff-templater-dbt/test/templater_test.py
@@ -18,7 +18,6 @@ from sqlfluff.core import FluffConfig, Lexer, Linter
 from sqlfluff.core.errors import SQLFluffSkipFile, SQLFluffUserError, SQLTemplaterError
 from sqlfluff.utils.testing.cli import invoke_assert_code
 from sqlfluff.utils.testing.logging import fluff_log_catcher
-from sqlfluff_templater_dbt.templater import DbtTemplater
 
 
 def test__templater_dbt_missing(dbt_templater, project_dir, dbt_fluff_config):
@@ -704,7 +703,7 @@ def test__templater_dbt_handle_database_connection_failure(
             )
 
     # Clear the adapter cache to force this test to create a new connection.
-    DbtTemplater.adapters.clear()
+    dbt_templater._reset_project_state()
 
     set_relations_cache.side_effect = DbtFailedToConnectException("dummy error")
 

--- a/plugins/sqlfluff-templater-dbt/test/templater_test.py
+++ b/plugins/sqlfluff-templater-dbt/test/templater_test.py
@@ -738,6 +738,106 @@ def test__templater_dbt_handle_database_connection_failure(
     assert "dbt tried to connect to the database" in error_message
 
 
+def test__templater_dbt_rejects_existing_adapter(dbt_templater):
+    """An existing dbt adapter prevents this session from claiming the factory."""
+    from dbt.adapters.factory import FACTORY
+
+    existing_adapter = mock.Mock()
+    with mock.patch.object(FACTORY, "adapters", {"postgres": existing_adapter}):
+        with pytest.raises(
+            SQLFluffUserError,
+            match="dbt adapter is already in use by another operation",
+        ):
+            _ = dbt_templater.dbt_config
+
+        assert FACTORY.adapters == {"postgres": existing_adapter}
+
+    assert dbt_templater._adapter is None
+    assert not dbt_templater._adapter_lock_acquired
+
+
+@pytest.mark.parametrize(
+    "extra_adapter, error_message",
+    [
+        (False, "dbt adapter registration was claimed by another operation"),
+        (True, "Another dbt adapter was registered during SQLFluff startup"),
+    ],
+)
+def test__templater_dbt_rejects_adapter_registration_race(
+    dbt_templater, extra_adapter, error_message
+):
+    """A dbt adapter registration race is detected and cleaned up."""
+    from dbt.adapters.factory import FACTORY
+    from dbt.config.runtime import RuntimeConfig
+
+    dbt_config = mock.Mock()
+    dbt_config.credentials.type = "postgres"
+    registered_adapter = mock.Mock()
+    registered_adapter.config = (
+        dbt_config if extra_adapter else mock.sentinel.other_config
+    )
+    other_adapter = mock.Mock()
+
+    def register_adapter(*args):
+        FACTORY.adapters["postgres"] = registered_adapter
+        if extra_adapter:
+            FACTORY.adapters["other"] = other_adapter
+
+    dbt_templater.sqlfluff_config = FluffConfig(
+        configs={
+            "core": {"dialect": "postgres", "templater": "dbt"},
+            "templater": {
+                "dbt": {"project_dir": "/project", "profiles_dir": "/profiles"}
+            },
+        }
+    )
+    dbt_templater.project_dir = dbt_templater._get_project_dir()
+    dbt_templater.profiles_dir = dbt_templater._get_profiles_dir()
+    with (
+        mock.patch.object(FACTORY, "adapters", {}),
+        mock.patch.object(RuntimeConfig, "from_args", return_value=dbt_config),
+        mock.patch(
+            "dbt.adapters.factory.register_adapter", side_effect=register_adapter
+        ),
+        mock.patch.object(dbt_templater, "try_silence_dbt_logs"),
+    ):
+        with pytest.raises(SQLFluffUserError, match=error_message):
+            _ = dbt_templater.dbt_config
+
+        if extra_adapter:
+            assert FACTORY.adapters == {"other": other_adapter}
+            registered_adapter.cleanup_connections.assert_called_once_with()
+        else:
+            assert FACTORY.adapters == {"postgres": registered_adapter}
+            registered_adapter.cleanup_connections.assert_not_called()
+
+    assert dbt_templater._adapter is None
+    assert not dbt_templater._adapter_lock_acquired
+
+
+def test__templater_dbt_connection_gets_uncached_adapter(dbt_templater):
+    """The connection context lazily retrieves an uncached adapter."""
+    adapter = mock.Mock()
+    dbt_config = mock.sentinel.dbt_config
+    dbt_templater._adapter_initialized = True
+
+    with (
+        mock.patch(
+            "dbt.adapters.factory.get_adapter", return_value=adapter
+        ) as get_adapter,
+        mock.patch.object(
+            type(dbt_templater),
+            "dbt_config",
+            new_callable=mock.PropertyMock,
+            return_value=dbt_config,
+        ),
+    ):
+        with dbt_templater.connection():
+            assert dbt_templater._adapter is adapter
+
+    get_adapter.assert_called_once_with(dbt_config)
+
+
 def test__project_dir_from_env(dbt_templater, project_dir, monkeypatch):
     """Test possibility to set project_dir from env variable."""
     dbt_templater.sqlfluff_config = FluffConfig(

--- a/plugins/sqlfluff-templater-dbt/test/templater_test.py
+++ b/plugins/sqlfluff-templater-dbt/test/templater_test.py
@@ -609,7 +609,7 @@ def test__templater_dbt_templating_absolute_path(
         ),
         pytest.param(
             "compile_missing_table.sql",
-            "Runtime Error",
+            'relation "this_table_does_not_exist" does not exist',
             False,
             SQLTemplaterError,
             id="dbt_skip_compilation_error",

--- a/src/sqlfluff/core/config/fluffconfig.py
+++ b/src/sqlfluff/core/config/fluffconfig.py
@@ -137,7 +137,8 @@ class FluffConfig:
         assert _dialect is None or isinstance(_dialect, str)
         self._initialise_dialect(_dialect, require_dialect)
 
-        self._configs["core"]["templater_obj"] = self.get_templater()
+        self.get_templater_class()
+        self._configs["core"]["templater_obj"] = None
 
         # Guard against an impossible Rust configuration.
         self._verify_rust_config()
@@ -587,11 +588,19 @@ class FluffConfig:
         ... )
         'consistent'
         """
-        section_dict = self.get_section(section)
+        normalized_section: str | tuple[str, ...] = (
+            section if isinstance(section, str) else tuple(section)
+        )
+        section_dict = self.get_section(normalized_section)
         if section_dict is None:
             return default
 
-        return section_dict.get(val, default)
+        value = section_dict.get(val, default)
+        is_core_section = normalized_section in ("core", ("core",))
+        if val == "templater_obj" and is_core_section and value is None:
+            value = self.get_templater()
+            section_dict[val] = value
+        return value
 
     def get_section(self, section: str | Iterable[str]) -> Any:
         """Return a whole section of config as a dict.
@@ -747,6 +756,14 @@ class FluffConfig:
         config_dict: ConfigMappingType = records_to_nested_dict([config_record])
         validate_config_dict(config_dict, f"inline config in {fname}")
         config_val = list(iter_records_from_nested_dict(config_dict))[0]
+
+        if config_val[0] == ("core", "templater"):
+            config_logger.warning(
+                "Ignoring inline templater configuration in %r. Set templater in a "
+                "configuration file instead.",
+                fname,
+            )
+            return
 
         # Set the value
         self.set_value(config_key, config_value)

--- a/src/sqlfluff/core/linter/common.py
+++ b/src/sqlfluff/core/linter/common.py
@@ -1,6 +1,6 @@
 """Defines small container classes to hold intermediate results during linting."""
 
-from typing import Any, NamedTuple, Optional, Union
+from typing import TYPE_CHECKING, Any, NamedTuple, Optional, Union
 
 from sqlfluff.core.config import FluffConfig
 from sqlfluff.core.errors import (
@@ -11,6 +11,9 @@ from sqlfluff.core.errors import (
 )
 from sqlfluff.core.parser.segments.base import BaseSegment
 from sqlfluff.core.templaters import TemplatedFile
+
+if TYPE_CHECKING:  # pragma: no cover
+    from sqlfluff.core.rules import BaseRule
 
 
 class RuleTuple(NamedTuple):
@@ -50,6 +53,15 @@ class DeferredRenderTask(NamedTuple):
     fname: str
     root_config: FluffConfig
     fix: bool
+    user_rules: tuple[type["BaseRule"], ...] = ()
+
+
+class RenderedLintTask(NamedTuple):
+    """A rendered file ready for worker-side parsing and linting."""
+
+    rendered: RenderedFile
+    fix: bool
+    user_rules: tuple[type["BaseRule"], ...] = ()
 
 
 class ParsedVariant(NamedTuple):

--- a/src/sqlfluff/core/linter/discovery.py
+++ b/src/sqlfluff/core/linter/discovery.py
@@ -141,6 +141,7 @@ def _process_exact_path(
     working_path: str,
     lower_file_exts: tuple[str, ...],
     outer_ignore_specs: IgnoreSpecRecords,
+    target_file_exts_for_path: Optional[Callable[[str], Sequence[str]]] = None,
 ) -> list[str]:
     """Handle exact paths being passed to paths_from_path.
 
@@ -150,6 +151,10 @@ def _process_exact_path(
     then return nothing, but include a warning for the user.
     """
     # Does it have a relevant extension? If not, just return an empty list.
+    if target_file_exts_for_path:
+        lower_file_exts = tuple(
+            extension.lower() for extension in target_file_exts_for_path(path)
+        )
     if not _match_file_extension(path, lower_file_exts):
         return []
 
@@ -179,6 +184,7 @@ def _iter_files_in_path(
     ignore_files: bool,
     outer_ignore_specs: IgnoreSpecRecords,
     lower_file_exts: tuple[str, ...],
+    target_file_exts_for_path: Optional[Callable[[str], Sequence[str]]] = None,
 ) -> Iterator[str]:
     """Handle directory paths being passed to paths_from_path.
 
@@ -192,6 +198,11 @@ def _iter_files_in_path(
     ignore_filename_set = frozenset(ignore_file_loaders.keys())
 
     for dirname, subdirs, filenames in os.walk(path, topdown=True):
+        current_file_exts = lower_file_exts
+        if target_file_exts_for_path:
+            current_file_exts = tuple(
+                extension.lower() for extension in target_file_exts_for_path(dirname)
+            )
         # Before adding new ignore specs, remove any which are no longer relevant
         # as indicated by us no longer being in a subdirectory of them.
         # NOTE: Slice so we can modify as we go.
@@ -229,7 +240,7 @@ def _iter_files_in_path(
             absolute_path = os.path.abspath(relative_path)
 
             # Check file extension is relevant
-            if not _match_file_extension(filename, lower_file_exts):
+            if not _match_file_extension(filename, current_file_exts):
                 continue
             # Check not ignored by outer & inner ignore specs
             if _check_ignore_specs(absolute_path, outer_ignore_specs):
@@ -248,6 +259,7 @@ def paths_from_path(
     working_path: str = os.getcwd(),
     target_file_exts: Sequence[str] = (".sql",),
     check_non_existent_file: bool = False,
+    target_file_exts_for_path: Optional[Callable[[str], Sequence[str]]] = None,
 ) -> list[str]:
     """Return a set of sql file paths from a potentially more ambiguous path string.
 
@@ -293,11 +305,21 @@ def paths_from_path(
     # Handle being passed an exact file first.
     if os.path.isfile(path) or check_non_existent_file:
         return _process_exact_path(
-            path, working_path, lower_file_exts, outer_ignore_specs
+            path,
+            working_path,
+            lower_file_exts,
+            outer_ignore_specs,
+            target_file_exts_for_path,
         )
 
     # Otherwise, it's not an exact path and we're going to walk the path
     # progressively, processing ignore files as we go.
     return sorted(
-        _iter_files_in_path(path, ignore_files, outer_ignore_specs, lower_file_exts)
+        _iter_files_in_path(
+            path,
+            ignore_files,
+            outer_ignore_specs,
+            lower_file_exts,
+            target_file_exts_for_path,
+        )
     )

--- a/src/sqlfluff/core/linter/linter.py
+++ b/src/sqlfluff/core/linter/linter.py
@@ -3,9 +3,11 @@
 import fnmatch
 import logging
 import os
+import sys
 import time
 from collections.abc import Iterator, Sequence
-from typing import TYPE_CHECKING, Optional, Union, cast
+from contextlib import contextmanager
+from typing import TYPE_CHECKING, Callable, Optional, Union, cast
 
 import regex
 from tqdm import tqdm
@@ -55,6 +57,96 @@ RuleTimingsType = list[tuple[str, str, float]]
 linter_logger: logging.Logger = logging.getLogger("sqlfluff.linter")
 
 
+class TemplaterSession:
+    """Own templater instances used during one public linter operation."""
+
+    def __init__(
+        self, templater_factory: Callable[[FluffConfig], "RawTemplater"]
+    ) -> None:
+        self._templater_factory = templater_factory
+        self._templaters: dict[tuple[str, ...], "RawTemplater"] = {}
+        self._config_templaters: dict[FluffConfig, "RawTemplater"] = {}
+        self._owned_templaters: set[int] = set()
+
+    def get(self, config: FluffConfig) -> "RawTemplater":
+        """Return the templater for an effective file configuration."""
+        existing_config_templater = self._config_templaters.get(config)
+        if existing_config_templater is not None:
+            return existing_config_templater
+        configured_templater = self._templater_factory(config)
+        self._owned_templaters.add(id(configured_templater))
+        try:
+            selected_templater = self._cache(config, configured_templater)
+        except BaseException as error:
+            self._owned_templaters.discard(id(configured_templater))
+            try:
+                configured_templater.close()
+            except BaseException:
+                linter_logger.exception(
+                    "Failed to close templater after session setup failed"
+                )
+            raise error
+        if selected_templater is not configured_templater:
+            self._owned_templaters.remove(id(configured_templater))
+            configured_templater.close()
+        return selected_templater
+
+    def borrow(self, config: FluffConfig, templater: "RawTemplater") -> "RawTemplater":
+        """Use a caller-owned templater without taking lifecycle ownership."""
+        existing_config_templater = self._config_templaters.get(config)
+        if existing_config_templater is not None:
+            return existing_config_templater
+        return self._cache(config, templater)
+
+    def _cache(
+        self, config: FluffConfig, configured_templater: "RawTemplater"
+    ) -> "RawTemplater":
+        """Cache a templater by effective session and configuration."""
+        key = configured_templater.session_key(config)
+        existing_templater = self._templaters.get(key)
+        if existing_templater is not None:
+            self._config_templaters[config] = existing_templater
+            return existing_templater
+        self._templaters[key] = configured_templater
+        self._config_templaters[config] = configured_templater
+        return configured_templater
+
+    def release(self, templater: "RawTemplater") -> None:
+        """Close and remove one templater before an exclusive session starts."""
+        keys = [key for key, value in self._templaters.items() if value is templater]
+        for key in keys:
+            del self._templaters[key]
+        self._config_templaters = {
+            config: configured_templater
+            for config, configured_templater in self._config_templaters.items()
+            if configured_templater is not templater
+        }
+        if id(templater) in self._owned_templaters:
+            try:
+                templater.close()
+            finally:
+                self._owned_templaters.remove(id(templater))
+
+    def close(self) -> None:
+        """Close every templater, without one failure preventing another close."""
+        first_error: Optional[BaseException] = None
+        for templater in reversed(self._templaters.values()):
+            if id(templater) not in self._owned_templaters:
+                continue
+            try:
+                templater.close()
+            except BaseException as error:  # pragma: no cover - defensive cleanup
+                if first_error is None:
+                    first_error = error
+                else:
+                    linter_logger.exception("Failed to close templater session")
+        self._templaters.clear()
+        self._config_templaters.clear()
+        self._owned_templaters.clear()
+        if first_error is not None:
+            raise first_error
+
+
 class Linter:
     """The interface class to interact with the linter."""
 
@@ -90,13 +182,22 @@ class Linter:
         )
         # Get the dialect and templater
         self.dialect: "Dialect" = cast("Dialect", self.config.get("dialect_obj"))
-        self.templater: "RawTemplater" = cast(
-            "RawTemplater", self.config.get("templater_obj")
-        )
+        self._templater_session: Optional[TemplaterSession] = None
+        self._templater_session_depth = 0
         # Store the formatter for output
         self.formatter = formatter
         # Store references to user rule classes
         self.user_rules = user_rules or []
+
+    @property
+    def templater(self) -> "RawTemplater":
+        """Return the root-configured templater for API compatibility."""
+        return cast("RawTemplater", self.config.get("templater_obj"))
+
+    @templater.setter
+    def templater(self, templater: "RawTemplater") -> None:
+        """Set a caller-owned root templater override."""
+        self.config._configs["core"]["templater_obj"] = templater
 
     def get_rulepack(self, config: Optional[FluffConfig] = None) -> RulePack:
         """Get hold of a set of rules."""
@@ -124,6 +225,12 @@ class Linter:
     ) -> tuple[str, FluffConfig, str]:
         """Load a raw file and the associated config."""
         file_config = root_config.make_child_from_path(fname)
+        raw_file, encoding = Linter.load_raw_file(fname, file_config)
+        return raw_file, file_config, encoding
+
+    @staticmethod
+    def load_raw_file(fname: str, file_config: FluffConfig) -> tuple[str, str]:
+        """Load a raw file using its effective configuration."""
         config_encoding: str = file_config.get("encoding", default="autodetect")
         encoding = get_encoding(fname=fname, config_encoding=config_encoding)
         # Check file size before loading.
@@ -158,8 +265,7 @@ class Linter:
             raw_file = target_file.read()
         # Scan the raw file for config commands.
         file_config.process_raw_file_for_config(raw_file, fname)
-        # Return the raw file and config
-        return raw_file, file_config, encoding
+        return raw_file, encoding
 
     @staticmethod
     def _normalise_newlines(string: str) -> str:
@@ -918,11 +1024,81 @@ class Linter:
     # These are tied to a specific instance and so are not necessarily
     # safe to use in parallel operations.
 
+    @contextmanager
+    def templater_session(self) -> Iterator[TemplaterSession]:
+        """Create or reuse the templater session for a public operation."""
+        if self._templater_session is None:
+            self._templater_session = TemplaterSession(
+                lambda config: config.get_templater()
+            )
+            root_templater = cast(
+                Optional["RawTemplater"],
+                self.config._configs["core"].get("templater_obj"),
+            )
+            if root_templater is not None:
+                self._templater_session.borrow(self.config, root_templater)
+        session = self._templater_session
+        self._templater_session_depth += 1
+        try:
+            yield session
+        finally:
+            self._templater_session_depth -= 1
+            if self._templater_session_depth == 0:
+                self._templater_session = None
+                operation_failed = sys.exc_info()[0] is not None
+                try:
+                    session.close()
+                except BaseException:
+                    if not operation_failed:  # pragma: no cover
+                        raise
+                    linter_logger.exception("Failed to close templater session")
+
+    def templater_for_config(self, config: FluffConfig) -> "RawTemplater":
+        """Return the operation-scoped templater for an effective config."""
+        if self._templater_session is None:  # pragma: no cover - internal guard
+            raise RuntimeError("Templater requested outside a linter operation")
+        return self._templater_session.get(config)
+
+    def borrow_templater_for_config(
+        self, config: FluffConfig, templater: "RawTemplater"
+    ) -> "RawTemplater":
+        """Use a caller-owned templater for an effective config."""
+        if self._templater_session is None:  # pragma: no cover - internal guard
+            raise RuntimeError("Templater requested outside a linter operation")
+        return self._templater_session.borrow(config, templater)
+
+    def release_templater(self, templater: "RawTemplater") -> None:
+        """Release an operation-owned templater after its file group."""
+        if self._templater_session is None:  # pragma: no cover - internal guard
+            raise RuntimeError("Templater released outside a linter operation")
+        operation_failed = sys.exc_info()[0] is not None
+        try:
+            self._templater_session.release(templater)
+        except BaseException:
+            if not operation_failed:
+                raise
+            linter_logger.exception("Failed to close templater session")
+
+    def _file_extensions_for_path(self, path: str) -> list[str]:
+        """Return file extensions configured at a discovery path."""
+        config = self.config.make_child_from_path(path, require_dialect=False)
+        extensions = config.get("sql_file_exts", default=".sql")
+        assert isinstance(extensions, str)
+        return extensions.lower().split(",")
+
     def render_string(
         self, in_str: str, fname: str, config: FluffConfig, encoding: str
     ) -> RenderedFile:
         """Template the file."""
-        linter_logger.info("Rendering String [%s] (%s)", self.templater.name, fname)
+        with self.templater_session():
+            return self._render_string(in_str, fname, config, encoding)
+
+    def _render_string(
+        self, in_str: str, fname: str, config: FluffConfig, encoding: str
+    ) -> RenderedFile:
+        """Template a string within an active templater session."""
+        templater = self.templater_for_config(config)
+        linter_logger.info("Rendering String [%s] (%s)", templater.name, fname)
 
         # Start the templating timer
         t0 = time.monotonic()
@@ -937,24 +1113,16 @@ class Linter:
         # not going to pick up a .sqlfluff or other config file to provide a
         # missing dialect at this point.)
         config.verify_dialect_specified()
-        if not config.get("templater_obj") == self.templater:
-            linter_logger.warning(
-                f"Attempt to set templater to {config.get('templater_obj').name} "
-                f"failed. Using {self.templater.name} templater. Templater cannot "
-                "be set in a .sqlfluff file in a subdirectory of the current "
-                "working directory. It can be set in a .sqlfluff in the current "
-                "working directory. See Nesting section of the docs for more "
-                "details."
-            )
-
         variant_limit = config.get("render_variant_limit")
         templated_variants: list[TemplatedFile] = []
         templater_violations: list[SQLTemplaterError] = []
 
+        variants = templater.process_with_variants(
+            in_str=in_str, fname=fname, config=config, formatter=self.formatter
+        )
+        render_error: Optional[BaseException] = None
         try:
-            for variant, templater_errs in self.templater.process_with_variants(
-                in_str=in_str, fname=fname, config=config, formatter=self.formatter
-            ):
+            for variant, templater_errs in variants:
                 if variant:
                     templated_variants.append(variant)
                 # Duplicate templater errors can arise across variants. Final
@@ -966,9 +1134,25 @@ class Linter:
                     break
         except SQLTemplaterError as templater_err:
             # Fatal templating error. Capture it and don't generate a variant.
+            render_error = templater_err
             templater_violations.append(templater_err)
         except SQLFluffSkipFile as skip_file_err:  # pragma: no cover
+            render_error = skip_file_err
             linter_logger.warning(str(skip_file_err))
+        except BaseException as error:
+            render_error = error
+            raise
+        finally:
+            close_variants = getattr(variants, "close", None)
+            if close_variants:
+                try:
+                    close_variants()
+                except BaseException:
+                    if render_error is None:
+                        raise
+                    linter_logger.exception(
+                        "Failed to close templater variants after rendering failed."
+                    )
 
         if not templated_variants:
             linter_logger.info("TEMPLATING FAILED: %s", templater_violations)
@@ -1156,10 +1340,9 @@ class Linter:
             paths = (os.getcwd(),)
         # Set up the result to hold what we get back
         result = LintingResult()
-
         expanded_paths: list[str] = []
         expanded_path_to_linted_dir = {}
-        sql_exts = self.config.get("sql_file_exts", default=".sql").lower().split(",")
+        sql_exts = self._file_extensions_for_path(os.getcwd())
 
         for path in paths:
             linted_dir = LintedDir(path, retain_files=retain_files)
@@ -1169,6 +1352,7 @@ class Linter:
                 ignore_non_existent_files=ignore_non_existent_files,
                 ignore_files=ignore_files,
                 target_file_exts=sql_exts,
+                target_file_exts_for_path=self._file_extensions_for_path,
             ):
                 expanded_paths.append(fname)
                 expanded_path_to_linted_dir[fname] = linted_dir
@@ -1255,25 +1439,23 @@ class Linter:
         NB: This a generator which will yield the result of each file
         within the path iteratively.
         """
-        sql_exts = self.config.get("sql_file_exts", default=".sql").lower().split(",")
-        for fname in paths_from_path(
-            path,
-            target_file_exts=sql_exts,
-        ):
-            if self.formatter:
-                self.formatter.dispatch_path(path)
-            # Load the file with the config and yield the result.
-            try:
-                raw_file, config, encoding = self.load_raw_file_and_config(
-                    fname, self.config
+        with self.templater_session():
+            sql_exts = self._file_extensions_for_path(os.getcwd())
+            fnames = list(
+                paths_from_path(
+                    path,
+                    target_file_exts=sql_exts,
+                    target_file_exts_for_path=self._file_extensions_for_path,
                 )
-            except SQLFluffSkipFile as s:
-                linter_logger.warning(str(s))
-                continue
-            yield self.parse_string(
-                raw_file,
-                fname=fname,
-                config=config,
-                encoding=encoding,
-                parse_statistics=parse_statistics,
             )
+            from sqlfluff.core.linter.runner import SequentialRunner
+
+            parse_runner = SequentialRunner(self, self.config)
+            for fname, rendered in parse_runner.iter_rendered(fnames):
+                if self.formatter:
+                    self.formatter.dispatch_path(path)
+                    self.formatter.dispatch_template_header(
+                        fname, self.config, rendered.config
+                    )
+                    self.formatter.dispatch_parse_header(fname)
+                yield self.parse_rendered(rendered, parse_statistics=parse_statistics)

--- a/src/sqlfluff/core/linter/runner.py
+++ b/src/sqlfluff/core/linter/runner.py
@@ -8,7 +8,6 @@ Implements various runner types for SQLFluff:
 """
 
 import bdb
-import functools
 import logging
 import multiprocessing
 import multiprocessing.dummy
@@ -17,19 +16,32 @@ import signal
 import sys
 import traceback
 from abc import ABC, abstractmethod
+from collections import defaultdict, deque
 from collections.abc import Iterable, Iterator
 from types import TracebackType
-from typing import Callable, Optional, Union
+from typing import TYPE_CHECKING, Callable, NamedTuple, Optional, Union
 
 from sqlfluff.core import FluffConfig, Linter
 from sqlfluff.core.errors import SQLFluffSkipFile
 from sqlfluff.core.linter import LintedFile, RenderedFile
-from sqlfluff.core.linter.common import DeferredRenderTask
+from sqlfluff.core.linter.common import DeferredRenderTask, RenderedLintTask
 from sqlfluff.core.plugin.host import is_main_process
 
 linter_logger: logging.Logger = logging.getLogger("sqlfluff.linter")
 
-PartialLintCallable = Callable[[], LintedFile]
+if TYPE_CHECKING:  # pragma: no cover
+    from sqlfluff.core.formatter import FormatterInterface
+    from sqlfluff.core.templaters import RawTemplater
+
+LintTask = Union[RenderedLintTask, DeferredRenderTask]
+
+
+class PreparedFile(NamedTuple):
+    """A file paired with its effective configuration."""
+
+    discovery_index: int
+    fname: str
+    config: FluffConfig
 
 
 class BaseRunner(ABC):
@@ -44,43 +56,129 @@ class BaseRunner(ABC):
         self.config = config
         self.skipped_file_count: int = 0
 
-    pass_formatter = True
+    def _file_groups(
+        self, fnames: list[str], start_index: int = 0
+    ) -> list[tuple["RawTemplater", FluffConfig, list[PreparedFile]]]:
+        """Group files by invocation-scoped templater in discovery order."""
+        groups: list[tuple["RawTemplater", FluffConfig, list[PreparedFile]]] = []
+        group_indexes: dict[int, int] = {}
+        for index, fname in enumerate(fnames, start=start_index):
+            file_config = self.config.make_child_from_path(fname)
+            prepared = PreparedFile(index, fname, file_config)
+            templater = self.linter.templater_for_config(file_config)
+            templater_id = id(templater)
+            if templater_id not in group_indexes:
+                group_indexes[templater_id] = len(groups)
+                groups.append((templater, file_config, []))
+            group_index = group_indexes[templater_id]
+            groups[group_index][2].append(prepared)
+        return groups
+
+    def _render_group(
+        self,
+        templater: "RawTemplater",
+        file_config: FluffConfig,
+        group_files: list[PreparedFile],
+        formatter: Optional["FormatterInterface"],
+    ) -> Iterator[tuple[PreparedFile, RenderedFile]]:
+        """Render one templater group in its required file order."""
+        files_by_name: dict[str, deque[PreparedFile]] = defaultdict(deque)
+        for prepared in group_files:
+            files_by_name[prepared.fname].append(prepared)
+        for fname in templater.sequence_files(
+            [prepared.fname for prepared in group_files],
+            config=file_config,
+            formatter=formatter,
+        ):
+            prepared = files_by_name[fname].popleft()
+            try:
+                source_str, encoding = self.linter.load_raw_file(
+                    prepared.fname, prepared.config
+                )
+                yield (
+                    prepared,
+                    self.linter._render_string(
+                        source_str,
+                        prepared.fname,
+                        prepared.config,
+                        encoding,
+                    ),
+                )
+            except SQLFluffSkipFile as error:
+                linter_logger.warning(str(error))
+                self.skipped_file_count += 1
 
     def iter_rendered(self, fnames: list[str]) -> Iterator[tuple[str, RenderedFile]]:
         """Iterate through rendered files ready for linting."""
-        for fname in self.linter.templater.sequence_files(
-            fnames, config=self.config, formatter=self.linter.formatter
-        ):
-            try:
-                yield fname, self.linter.render_file(fname, self.config)
-            except SQLFluffSkipFile as s:
-                linter_logger.warning(str(s))
-                self.skipped_file_count += 1
+        from sqlfluff.core.templaters import RawTemplater
 
-    def iter_partials(
+        for index, fname in enumerate(fnames):
+            file_config = self.config.make_child_from_path(fname)
+            templater = self.linter.templater_for_config(file_config)
+            prepared = PreparedFile(index, fname, file_config)
+            if type(templater).sequence_files is RawTemplater.sequence_files:
+                yield from (
+                    (rendered.fname, rendered)
+                    for _, rendered in self._render_group(
+                        templater,
+                        file_config,
+                        [prepared],
+                        self.linter.formatter,
+                    )
+                )
+                continue
+
+            groups = [(templater, file_config, [prepared])]
+            group_indexes = {id(templater): 0}
+            for remaining_group in self._file_groups(
+                fnames[index + 1 :], start_index=index + 1
+            ):
+                remaining_templater, remaining_config, remaining_files = remaining_group
+                group_index = group_indexes.get(id(remaining_templater))
+                if group_index is None:
+                    group_indexes[id(remaining_templater)] = len(groups)
+                    groups.append(remaining_group)
+                else:
+                    groups[group_index][2].extend(remaining_files)
+            yield from self._iter_rendered_groups(groups)
+            return
+
+    def _iter_rendered_groups(
         self,
-        fnames: list[str],
-        fix: bool = False,
-    ) -> Iterator[tuple[str, Union[PartialLintCallable, DeferredRenderTask]]]:
-        """Iterate through partials for linted files.
-
-        Generates filenames and objects which return LintedFiles.
-        """
-        for fname, rendered in self.iter_rendered(fnames):
-            # Generate a fresh ruleset
-            rule_pack = self.linter.get_rulepack(config=rendered.config)
-            yield (
-                fname,
-                functools.partial(
-                    self.linter.lint_rendered,
-                    rendered,
-                    rule_pack,
-                    fix,
-                    # Formatters may or may not be passed. They don't pickle
-                    # nicely so aren't appropriate in a multiprocessing world.
-                    self.linter.formatter if self.pass_formatter else None,
-                ),
+        groups: list[tuple["RawTemplater", FluffConfig, list[PreparedFile]]],
+    ) -> Iterator[tuple[str, RenderedFile]]:
+        """Iterate through already grouped files ready for linting."""
+        rendered_files: dict[int, RenderedFile] = {}
+        completed_indexes: set[int] = set()
+        next_index = min(
+            prepared.discovery_index
+            for _, _, group_files in groups
+            for prepared in group_files
+        )
+        for templater, file_config, group_files in groups:
+            try:
+                for prepared, rendered in self._render_group(
+                    templater,
+                    file_config,
+                    group_files,
+                    self.linter.formatter,
+                ):
+                    rendered_files[prepared.discovery_index] = rendered
+                    completed_indexes.add(prepared.discovery_index)
+                    while next_index in rendered_files:
+                        next_rendered = rendered_files.pop(next_index)
+                        yield next_rendered.fname, next_rendered
+                        next_index += 1
+            finally:
+                self.linter.release_templater(templater)
+            completed_indexes.update(
+                prepared.discovery_index for prepared in group_files
             )
+            while next_index in completed_indexes:
+                if next_index in rendered_files:
+                    rendered = rendered_files.pop(next_index)
+                    yield rendered.fname, rendered
+                next_index += 1
 
     @abstractmethod
     def run(self, fnames: list[str], fix: bool) -> Iterator[LintedFile]:
@@ -114,34 +212,23 @@ class SequentialRunner(BaseRunner):
 
     def run(self, fnames: list[str], fix: bool) -> Iterator[LintedFile]:
         """Sequential implementation."""
-        for fname, partial in self.iter_partials(fnames, fix=fix):
-            try:
-                if isinstance(partial, DeferredRenderTask):  # pragma: no cover
-                    # DeferredRenderTask is normally only emitted by
-                    # ParallelRunner.iter_partials.  Handle it here as a
-                    # safety net: render + lint in one step in the main process.
-                    rendered = self.linter.render_file(
-                        partial.fname, partial.root_config
-                    )
+        with self.linter.templater_session():
+            for fname, rendered in self.iter_rendered(fnames):
+                try:
                     rule_pack = self.linter.get_rulepack(config=rendered.config)
                     yield self.linter.lint_rendered(
-                        rendered, rule_pack, partial.fix, self.linter.formatter
+                        rendered, rule_pack, fix, self.linter.formatter
                     )
-                else:
-                    yield partial()
-            except (bdb.BdbQuit, KeyboardInterrupt):  # pragma: no cover
-                raise
-            except Exception as e:
-                self._handle_lint_path_exception(fname, e)
+                except (bdb.BdbQuit, KeyboardInterrupt):  # pragma: no cover
+                    raise
+                except Exception as e:
+                    self._handle_lint_path_exception(fname, e)
 
 
 class ParallelRunner(BaseRunner):
     """Base class for parallel runner implementations (process or thread)."""
 
     POOL_TYPE: Callable[..., multiprocessing.pool.Pool]
-    # Don't pass the formatter in a parallel world, they
-    # don't pickle well.
-    pass_formatter = False
 
     def __init__(self, linter: Linter, config: FluffConfig, processes: int) -> None:
         super().__init__(linter, config)
@@ -151,7 +238,7 @@ class ParallelRunner(BaseRunner):
         self,
         fnames: list[str],
         fix: bool = False,
-    ) -> Iterator[tuple[str, Union[PartialLintCallable, DeferredRenderTask]]]:
+    ) -> Iterator[tuple[str, LintTask]]:
         """Iterate through partials or deferred tasks for parallel linting.
 
         When the active templater supports worker-side rendering
@@ -163,13 +250,41 @@ class ParallelRunner(BaseRunner):
         For templaters that require main-process state (e.g. dbt), we fall
         back to the base-class behaviour and template in the main process.
         """
-        if self.linter.templater.templates_in_worker:
-            for fname in self.linter.templater.sequence_files(
-                fnames, config=self.config, formatter=None
-            ):
-                yield fname, DeferredRenderTask(fname, self.config, fix)
-        else:
-            yield from super().iter_partials(fnames, fix=fix)
+        with self.linter.templater_session():
+            for templater, file_config, group_files in self._file_groups(fnames):
+                try:
+                    files_by_name: dict[str, deque[PreparedFile]] = defaultdict(deque)
+                    for prepared in group_files:
+                        files_by_name[prepared.fname].append(prepared)
+                    if templater.templates_in_worker:
+                        sequenced_files = templater.sequence_files(
+                            [prepared.fname for prepared in group_files],
+                            config=file_config,
+                            formatter=None,
+                        )
+                        for fname in sequenced_files:
+                            prepared = files_by_name[fname].popleft()
+                            yield (
+                                prepared.fname,
+                                DeferredRenderTask(
+                                    prepared.fname,
+                                    self.config,
+                                    fix,
+                                    tuple(self.linter.user_rules),
+                                ),
+                            )
+                    else:
+                        for prepared, rendered in self._render_group(
+                            templater, file_config, group_files, None
+                        ):
+                            yield (
+                                prepared.fname,
+                                RenderedLintTask(
+                                    rendered, fix, tuple(self.linter.user_rules)
+                                ),
+                            )
+                finally:
+                    self.linter.release_templater(templater)
 
     def run(self, fnames: list[str], fix: bool) -> Iterator[LintedFile]:
         """Parallel implementation.
@@ -184,10 +299,7 @@ class ParallelRunner(BaseRunner):
         # processes may still be alive when Python's resource_tracker runs at
         # shutdown, causing "leaked semaphore objects" warnings from the named
         # POSIX semaphores used by the pool's internal SimpleQueue locks.
-        pool = self._create_pool(
-            self.processes,
-            self._init_global,
-        )
+        pool = self._create_pool(self.processes, self._init_global)
         try:
             for lint_result in self._map(
                 pool,
@@ -231,7 +343,7 @@ class ParallelRunner(BaseRunner):
 
     @staticmethod
     def _apply(
-        partial_tuple: tuple[str, Union[PartialLintCallable, DeferredRenderTask]],
+        partial_tuple: tuple[str, LintTask],
     ) -> Union["DelayedException", LintedFile]:
         """Shim function used in parallel mode."""
         fname, task = partial_tuple
@@ -240,16 +352,17 @@ class ParallelRunner(BaseRunner):
                 # Worker-side rendering: reconstruct a Linter from the root
                 # config and do render + lint in one step, keeping the full
                 # RenderedFile off the IPC boundary.
-                linter = Linter(config=task.root_config)
-                # FluffConfig.__getstate__ strips templater_obj to None before
-                # pickling (it's designed for main-process use only). Since we
-                # are deliberately rendering here in the worker, re-instantiate
-                # the templater from the config's templater name.
-                linter.templater = task.root_config.get_templater()
+                linter = Linter(
+                    config=task.root_config, user_rules=list(task.user_rules)
+                )
                 rendered = linter.render_file(task.fname, task.root_config)
                 rule_pack = linter.get_rulepack(config=rendered.config)
                 return Linter.lint_rendered(rendered, rule_pack, task.fix, None)
-            return task()
+            linter = Linter(
+                config=task.rendered.config, user_rules=list(task.user_rules)
+            )
+            rule_pack = linter.get_rulepack(config=task.rendered.config)
+            return Linter.lint_rendered(task.rendered, rule_pack, task.fix, None)
         # Capture any exceptions and return as delayed exception to handle
         # in the main thread.
         except Exception as e:
@@ -273,10 +386,10 @@ class ParallelRunner(BaseRunner):
         cls,
         pool: multiprocessing.pool.Pool,
         func: Callable[
-            [tuple[str, Union[PartialLintCallable, DeferredRenderTask]]],
+            [tuple[str, LintTask]],
             Union["DelayedException", LintedFile],
         ],
-        iterable: Iterable[tuple[str, Union[PartialLintCallable, DeferredRenderTask]]],
+        iterable: Iterable[tuple[str, LintTask]],
     ) -> Iterable[Union["DelayedException", LintedFile]]:  # pragma: no cover
         """Class-specific map method.
 
@@ -313,15 +426,14 @@ class MultiProcessRunner(ParallelRunner):
         cls,
         pool: multiprocessing.pool.Pool,
         func: Callable[
-            [tuple[str, Union[PartialLintCallable, DeferredRenderTask]]],
+            [tuple[str, LintTask]],
             Union["DelayedException", LintedFile],
         ],
-        iterable: Iterable[tuple[str, Union[PartialLintCallable, DeferredRenderTask]]],
+        iterable: Iterable[tuple[str, LintTask]],
     ) -> Iterable[Union["DelayedException", LintedFile]]:
         """Map using imap unordered.
 
-        We use this so we can iterate through results as they arrive, and while other
-        files are still being processed.
+        Yield files as workers finish processing them.
         """
         return pool.imap_unordered(func=func, iterable=iterable)
 
@@ -339,10 +451,10 @@ class MultiThreadRunner(ParallelRunner):
         cls,
         pool: multiprocessing.pool.Pool,
         func: Callable[
-            [tuple[str, Union[PartialLintCallable, DeferredRenderTask]]],
+            [tuple[str, LintTask]],
             Union["DelayedException", LintedFile],
         ],
-        iterable: Iterable[tuple[str, Union[PartialLintCallable, DeferredRenderTask]]],
+        iterable: Iterable[tuple[str, LintTask]],
     ) -> Iterable[Union["DelayedException", LintedFile]]:
         """Map using imap.
 

--- a/src/sqlfluff/core/templaters/base.py
+++ b/src/sqlfluff/core/templaters/base.py
@@ -541,6 +541,13 @@ class RawTemplater:
         # Default is to process in the original order.
         return fnames
 
+    def session_key(self, config: FluffConfig) -> tuple[str, ...]:
+        """Return a key for sharing this templater within one operation."""
+        return (self.name,)
+
+    def close(self) -> None:
+        """Release resources held by this templater after a file group."""
+
     @large_file_check
     def process(
         self,

--- a/test/cli/commands_test.py
+++ b/test/cli/commands_test.py
@@ -108,6 +108,52 @@ def test__cli__command_directed():
     assert result.stdout.replace("\\", "/").startswith(expected_output)
 
 
+@pytest.mark.parametrize("command", [lint, fix, cli_format])
+@pytest.mark.parametrize("processes", [1, 2])
+def test__cli__mixed_templaters(command, processes):
+    """CLI commands use templaters selected by nested file configuration."""
+    result = invoke_assert_code(
+        ret_code=0,
+        args=[
+            command,
+            [
+                "--disable-progress-bar",
+                "--processes",
+                str(processes),
+                "test/fixtures/linter/mixed_templaters/jinja.sql",
+                "test/fixtures/linter/mixed_templaters/placeholder/placeholder.sql",
+            ],
+        ],
+    )
+
+    assert "Attempt to set templater" not in result.output
+
+
+def test__cli__parse_mixed_templaters():
+    """Parse uses templaters selected by nested file configuration."""
+    result = invoke_assert_code(
+        ret_code=0,
+        args=[parse, ["test/fixtures/linter/mixed_templaters"]],
+    )
+
+    assert result.output.count("|file:") == 2
+    assert "numeric_literal:                          '1'" in result.output
+    assert "naked_identifier:                     'value'" in result.output
+
+
+def test__cli__render_nested_templater():
+    """Render uses the templater selected by nested file configuration."""
+    result = invoke_assert_code(
+        ret_code=0,
+        args=[
+            render,
+            ["test/fixtures/linter/mixed_templaters/placeholder/placeholder.sql"],
+        ],
+    )
+
+    assert "SELECT value FROM my_table" in result.output
+
+
 def test__cli__command_dialect():
     """Check the script raises the right exception on an unknown dialect."""
     # The dialect is unknown should be a non-zero exit code

--- a/test/cli/commands_test.py
+++ b/test/cli/commands_test.py
@@ -110,8 +110,11 @@ def test__cli__command_directed():
 
 @pytest.mark.parametrize("command", [lint, fix, cli_format])
 @pytest.mark.parametrize("processes", [1, 2])
-def test__cli__mixed_templaters(command, processes):
+def test__cli__mixed_templaters(command, processes, tmp_path):
     """CLI commands use templaters selected by nested file configuration."""
+    fixture_path = pathlib.Path("test/fixtures/linter/mixed_templaters")
+    test_path = tmp_path / "mixed_templaters"
+    shutil.copytree(fixture_path, test_path)
     result = invoke_assert_code(
         ret_code=0,
         args=[
@@ -120,8 +123,8 @@ def test__cli__mixed_templaters(command, processes):
                 "--disable-progress-bar",
                 "--processes",
                 str(processes),
-                "test/fixtures/linter/mixed_templaters/jinja.sql",
-                "test/fixtures/linter/mixed_templaters/placeholder/placeholder.sql",
+                str(test_path / "jinja.sql"),
+                str(test_path / "placeholder/placeholder.sql"),
             ],
         ],
     )

--- a/test/core/config/fluffconfig_test.py
+++ b/test/core/config/fluffconfig_test.py
@@ -105,7 +105,7 @@ def test__config__templater_selection(templater_name, templater_class, raises_er
     else:
         cfg = FluffConfig(overrides={"dialect": "ansi", "templater": templater_name})
         assert cfg.get_templater().__class__ is templater_class
-        assert cfg._configs["core"]["templater_obj"].__class__ is templater_class
+        assert cfg.get("templater_obj").__class__ is templater_class
 
 
 def test__config__glob_exclude_config_tests():
@@ -366,6 +366,17 @@ def test__process_inline_config():
     # Check that JSON arrays are not mangled
     cfg.process_inline_config('-- sqlfluff:jinja:my_dict:[{"k":"v"}]', "test.sql")
     assert cfg.get("my_dict", section="jinja") == '[{"k":"v"}]'
+
+
+def test__process_inline_config__ignores_templater():
+    """Inline configuration cannot change templater lifecycle requirements."""
+    config = FluffConfig(overrides={"dialect": "ansi"})
+
+    with fluff_log_catcher(logging.WARNING, "sqlfluff.config") as caplog:
+        config.process_inline_config("-- sqlfluff:templater:dbt", "test.sql")
+
+    assert config.get("templater") == "jinja"
+    assert "Ignoring inline templater configuration" in caplog.text
 
 
 def test__process_inline_config__malformed_equals_syntax():

--- a/test/core/linter/discovery_test.py
+++ b/test/core/linter/discovery_test.py
@@ -46,6 +46,44 @@ def test__linter__path_from_paths__exts():
     assert "test.fixtures.linter.discovery_file.txt.j2" in paths
 
 
+def test__linter__path_from_paths__nested_exts(tmp_path):
+    """Test configuration of file discovery by directory."""
+    nested = tmp_path / "nested"
+    nested.mkdir()
+    root_file = tmp_path / "root.sql"
+    nested_file = nested / "nested.bq"
+    root_file.touch()
+    nested_file.touch()
+
+    paths = paths_from_path(
+        str(tmp_path),
+        target_file_exts=[".sql"],
+        target_file_exts_for_path=lambda path: (
+            [".bq"] if os.path.normpath(path) == os.path.normpath(nested) else [".sql"]
+        ),
+    )
+
+    assert set(paths) == {str(root_file), str(nested_file)}
+
+
+def test__linter__path_from_paths__exact_nested_ext(tmp_path):
+    """Test exact file discovery with path-specific extensions."""
+    nested = tmp_path / "nested"
+    nested.mkdir()
+    nested_file = nested / "nested.bq"
+    nested_file.touch()
+
+    paths = paths_from_path(
+        str(nested_file),
+        target_file_exts=[".sql"],
+        target_file_exts_for_path=lambda path: (
+            [".bq"] if os.path.dirname(path) == str(nested) else [".sql"]
+        ),
+    )
+
+    assert paths == [str(nested_file)]
+
+
 def test__linter__path_from_paths__file():
     """Test extracting paths from a file path."""
     paths = paths_from_path("test/fixtures/linter/indentation_errors.sql")

--- a/test/core/linter/linter_test.py
+++ b/test/core/linter/linter_test.py
@@ -2,6 +2,7 @@
 
 import logging
 import os
+import pickle
 from unittest.mock import patch
 
 import pytest
@@ -18,7 +19,8 @@ from sqlfluff.core.errors import (
     SQLTemplaterError,
 )
 from sqlfluff.core.linter import runner
-from sqlfluff.core.linter.common import DeferredRenderTask
+from sqlfluff.core.linter.common import DeferredRenderTask, RenderedLintTask
+from sqlfluff.core.linter.linter import TemplaterSession
 from sqlfluff.core.linter.linting_result import combine_dicts, sum_dicts
 from sqlfluff.core.linter.runner import get_runner
 from sqlfluff.core.templaters import RawTemplater, TemplatedFile
@@ -420,7 +422,7 @@ def test__parallel_runner__iter_partials_non_worker_path(monkeypatch):
     config = FluffConfig(overrides={"dialect": "ansi"})
     lntr = Linter(dialect="ansi")
     # Force the flag off (mirrors what DbtTemplater sets)
-    monkeypatch.setattr(lntr.templater, "templates_in_worker", False)
+    monkeypatch.setattr(RawTemplater, "templates_in_worker", False)
     thd_runner = runner.MultiThreadRunner(lntr, config, processes=1)
     partials = list(
         thd_runner.iter_partials(
@@ -430,8 +432,7 @@ def test__parallel_runner__iter_partials_non_worker_path(monkeypatch):
     )
     assert len(partials) == 1
     _fname, task = partials[0]
-    assert callable(task)
-    assert not isinstance(task, DeferredRenderTask)
+    assert isinstance(task, RenderedLintTask)
 
 
 def test__parallel_runner__apply_deferred_task():
@@ -439,6 +440,7 @@ def test__parallel_runner__apply_deferred_task():
     from sqlfluff.core.linter import LintedFile
 
     config = FluffConfig(overrides={"dialect": "ansi"})
+    config = pickle.loads(pickle.dumps(config))
     task = DeferredRenderTask(
         fname="test/fixtures/linter/passing.sql",
         root_config=config,
@@ -448,21 +450,15 @@ def test__parallel_runner__apply_deferred_task():
     assert isinstance(result, LintedFile)
 
 
-def test__parallel_runner__apply_callable_task(monkeypatch):
-    """_apply with a PartialLintCallable covers the dbt-like non-deferred path.
-
-    When templates_in_worker=False (as with DbtTemplater), ParallelRunner
-    iter_partials falls back to the base class and yields callables rather than
-    DeferredRenderTask objects.  _apply() should call the callable directly and
-    return a LintedFile.
-    """
+def test__parallel_runner__apply_rendered_task(monkeypatch):
+    """_apply lints a main-process rendered task without a bound Linter."""
     from sqlfluff.core.linter import LintedFile
 
     config = FluffConfig(overrides={"dialect": "ansi"})
     lntr = Linter(dialect="ansi")
     # Simulate a main-process-only templater (e.g. dbt) that disables
     # worker-side rendering.
-    monkeypatch.setattr(lntr.templater, "templates_in_worker", False)
+    monkeypatch.setattr(RawTemplater, "templates_in_worker", False)
     thd_runner = runner.MultiThreadRunner(lntr, config, processes=1)
     partials = list(
         thd_runner.iter_partials(
@@ -471,7 +467,7 @@ def test__parallel_runner__apply_callable_task(monkeypatch):
         )
     )
     fname, task = partials[0]
-    assert callable(task) and not isinstance(task, DeferredRenderTask)
+    assert isinstance(task, RenderedLintTask)
     result = runner.ParallelRunner._apply((fname, task))
     assert isinstance(result, LintedFile)
 
@@ -954,7 +950,9 @@ WHERE c < 0
     assert fixed_sql == expected
 
 
-def test__linter__deduplicates_duplicate_templater_violations_in_linted_output():
+def test__linter__deduplicates_duplicate_templater_violations_in_linted_output(
+    monkeypatch,
+):
     """Verify duplicate templater errors from variants collapse in lint output."""
     config = FluffConfig(
         overrides={
@@ -964,10 +962,10 @@ def test__linter__deduplicates_duplicate_templater_violations_in_linted_output()
     )
     linter = Linter(config=config)
     templater = DuplicateViolationTemplater()
-    linter.templater = templater
-    linter.config._configs["core"]["templater_obj"] = templater
+    monkeypatch.setattr(config, "get_templater", lambda: templater)
 
     parsed = linter.parse_string("SELECT 1\n")
+    monkeypatch.setattr(config, "get_templater", DuplicateViolationTemplater)
     linted = linter.lint_string("SELECT 1\n")
 
     assert len(parsed.templating_violations) == 2
@@ -1117,23 +1115,349 @@ def test_delayed_exception():
         de.reraise()
 
 
-def test__attempt_to_change_templater_warning():
-    """Test warning when changing templater in .sqlfluff file in subdirectory."""
+def test__linter__uses_stateful_templater_from_file_config(monkeypatch):
+    """Test a stateful templater can be selected by a file configuration."""
     initial_config = FluffConfig(
         configs={"core": {"templater": "jinja", "dialect": "ansi"}}
     )
     lntr = Linter(config=initial_config)
     updated_config = FluffConfig(
-        configs={"core": {"templater": "python", "dialect": "ansi"}}
+        configs={
+            "core": {"templater": "python", "dialect": "ansi"},
+            "templater": {"python": {"context": {"table": "table"}}},
+        }
     )
-    with fluff_log_catcher(logging.WARNING, "sqlfluff.linter") as caplog:
-        lntr.render_string(
-            in_str="select * from table",
-            fname="test.sql",
-            config=updated_config,
-            encoding="utf-8",
-        )
-    assert "Attempt to set templater to " in caplog.text
+    updated_templater = updated_config.get("templater_obj")
+    monkeypatch.setattr(updated_templater, "templates_in_worker", False)
+
+    rendered = lntr.render_string(
+        in_str="select * from {table}",
+        fname="test.sql",
+        config=updated_config,
+        encoding="utf-8",
+    )
+
+    assert rendered.templated_variants[0].templated_str == "select * from table"
+
+
+def test__templater_session_does_not_mutate_or_close_config_templaters():
+    """A session leaves caller-owned configuration templaters untouched."""
+
+    class TrackingTemplater(RawTemplater):
+        name = "tracking"
+
+        def __init__(self):
+            self.close_count = 0
+
+        def close(self):
+            self.close_count += 1
+
+    first_templater = TrackingTemplater()
+    second_templater = TrackingTemplater()
+    first_config = FluffConfig(overrides={"dialect": "ansi"})
+    second_config = FluffConfig(overrides={"dialect": "ansi"})
+    first_config._configs["core"]["templater_obj"] = first_templater
+    second_config._configs["core"]["templater_obj"] = second_templater
+    session = TemplaterSession(lambda config: config.get_templater())
+
+    assert session.borrow(first_config, first_templater) is first_templater
+    assert session.borrow(second_config, second_templater) is first_templater
+    assert session.borrow(second_config, second_templater) is first_templater
+    assert second_templater.close_count == 0
+
+    session.close()
+    assert first_templater.close_count == 0
+    assert first_config.get("templater_obj") is first_templater
+    assert second_config.get("templater_obj") is second_templater
+
+
+def test__templater_session_factory_owns_created_templaters():
+    """A session closes templaters returned by its explicit factory."""
+
+    class TrackingTemplater(RawTemplater):
+        def __init__(self):
+            self.closed = False
+
+        def close(self):
+            self.closed = True
+
+    templater = TrackingTemplater()
+    config = FluffConfig(overrides={"dialect": "ansi"})
+    session = TemplaterSession(lambda _: templater)
+
+    assert session.get(config) is templater
+    session.close()
+
+    assert templater.closed
+
+
+@pytest.mark.parametrize("operation", ["render", "lint"])
+def test__linter__uses_fresh_templater_for_repeated_string_operations(
+    monkeypatch, operation
+):
+    """Each public string operation gets a usable templater instance."""
+
+    class SingleUseTemplater(RawTemplater):
+        def __init__(self):
+            self.closed = False
+
+        def process(self, **kwargs):
+            assert not self.closed
+            return super().process(**kwargs)
+
+        def close(self):
+            self.closed = True
+
+    config = FluffConfig(overrides={"dialect": "ansi"})
+    linter = Linter(config=config)
+    instances = []
+
+    def get_templater():
+        templater = SingleUseTemplater()
+        instances.append(templater)
+        return templater
+
+    config._configs["core"]["templater_obj"] = None
+    monkeypatch.setattr(config, "get_templater", get_templater)
+
+    if operation == "render":
+        linter.render_string("SELECT 1", "first.sql", config, "utf-8")
+        linter.render_string("SELECT 2", "second.sql", config, "utf-8")
+    else:
+        linter.lint_string("SELECT 1", fname="first.sql")
+        linter.lint_string("SELECT 2", fname="second.sql")
+
+    assert len(instances) == 2
+    assert all(templater.closed for templater in instances)
+
+
+def test__linter__shares_stateless_templater_with_different_configs(tmp_path):
+    """One run shares a stateless templater across per-file configurations."""
+    first_dir = tmp_path / "first"
+    second_dir = tmp_path / "second"
+    first_dir.mkdir()
+    second_dir.mkdir()
+    first_file = first_dir / "query.sql"
+    second_file = second_dir / "query.sql"
+    first_file.write_text("SELECT :value\n", encoding="utf-8")
+    second_file.write_text("SELECT {value}\n", encoding="utf-8")
+    first_dir.joinpath(".sqlfluff").write_text(
+        """[sqlfluff]
+dialect = ansi
+templater = placeholder
+
+[sqlfluff:templater:placeholder]
+param_style = colon
+""",
+        encoding="utf-8",
+    )
+    second_dir.joinpath(".sqlfluff").write_text(
+        """[sqlfluff]
+dialect = ansi
+templater = placeholder
+
+[sqlfluff:templater:placeholder]
+param_regex = \\{(?P<param_name>\\w+)\\}
+""",
+        encoding="utf-8",
+    )
+
+    config = FluffConfig(overrides={"dialect": "ansi"})
+    linter = Linter(config=config)
+
+    result = linter.lint_paths(
+        (str(first_file), str(second_file)),
+        processes=2,
+    )
+
+    assert not result.get_violations()
+    rendered_files = {
+        linted_file.path: linted_file.templated_file.templated_str
+        for linted_path in result.paths
+        for linted_file in linted_path.files
+    }
+    assert rendered_files == {
+        str(first_file): "SELECT value\n",
+        str(second_file): "SELECT value\n",
+    }
+
+
+@pytest.mark.parametrize("processes", [1, 2])
+@pytest.mark.parametrize("fix", [False, True])
+def test__linter__uses_templater_from_file_config(processes, fix):
+    """Lint files using different built-in templaters in one invocation."""
+    config = FluffConfig.from_path("test/fixtures/linter/mixed_templaters")
+    linter = Linter(config=config)
+
+    result = linter.lint_paths(
+        ("test/fixtures/linter/mixed_templaters",),
+        fix=fix,
+        processes=processes,
+    )
+
+    assert not result.get_violations()
+
+
+def test__linter__mixed_templaters_preserve_file_order(tmp_path):
+    """Sequential templater grouping preserves discovery order."""
+    nested = tmp_path / "placeholder"
+    nested.mkdir()
+    tmp_path.joinpath(".sqlfluff").write_text(
+        "[sqlfluff]\ndialect = ansi\ntemplater = jinja\n", encoding="utf-8"
+    )
+    nested.joinpath(".sqlfluff").write_text(
+        "[sqlfluff]\ntemplater = placeholder\n\n"
+        "[sqlfluff:templater:placeholder]\nparam_style = colon\n",
+        encoding="utf-8",
+    )
+    paths = (
+        tmp_path / "first.sql",
+        nested / "second.sql",
+        tmp_path / "third.sql",
+    )
+    for path in paths:
+        path.write_text("SELECT 1\n", encoding="utf-8")
+    string_paths = tuple(str(path) for path in paths)
+    linter = Linter(config=FluffConfig.from_path(str(tmp_path)))
+
+    result = linter.lint_paths(string_paths, processes=1)
+
+    assert [file.path for path in result.paths for file in path.files] == list(
+        string_paths
+    )
+
+
+def test__sequential_runner__streams_worker_safe_files(tmp_path, monkeypatch):
+    """Sequential linting completes each worker-safe file before loading the next."""
+    first_file = tmp_path / "first.sql"
+    second_file = tmp_path / "second.sql"
+    first_file.write_text("SELECT 1\n", encoding="utf-8")
+    second_file.write_text("SELECT 2\n", encoding="utf-8")
+    linter = Linter(dialect="ansi")
+    events = []
+    original_load = linter.load_raw_file
+    original_lint = linter.lint_rendered
+
+    def tracking_load(fname, config):
+        events.append(("load", fname))
+        return original_load(fname, config)
+
+    def tracking_lint(rendered, rule_pack, fix, formatter):
+        events.append(("lint", rendered.fname))
+        return original_lint(rendered, rule_pack, fix, formatter)
+
+    monkeypatch.setattr(linter, "load_raw_file", tracking_load)
+    monkeypatch.setattr(linter, "lint_rendered", tracking_lint)
+
+    linter.lint_paths((str(first_file), str(second_file)), processes=1)
+
+    assert events == [
+        ("load", str(first_file)),
+        ("lint", str(first_file)),
+        ("load", str(second_file)),
+        ("lint", str(second_file)),
+    ]
+
+
+def test__linter__discovers_extensions_from_nested_config(tmp_path):
+    """Directory discovery uses file extensions from nested configuration."""
+    nested = tmp_path / "nested"
+    nested.mkdir()
+    tmp_path.joinpath(".sqlfluff").write_text(
+        "[sqlfluff]\ndialect = ansi\ntemplater = jinja\n", encoding="utf-8"
+    )
+    nested.joinpath(".sqlfluff").write_text(
+        "[sqlfluff]\ntemplater = placeholder\nsql_file_exts = .bq\n\n"
+        "[sqlfluff:templater:placeholder]\nparam_style = colon\n",
+        encoding="utf-8",
+    )
+    nested_file = nested / "query.bq"
+    nested_file.write_text("SELECT :value\n", encoding="utf-8")
+    linter = Linter(config=FluffConfig.from_path(str(tmp_path)))
+
+    result = linter.lint_paths((str(tmp_path),))
+
+    assert [file.path for path in result.paths for file in path.files] == [
+        str(nested_file)
+    ]
+
+
+def test__linter__parse_path_uses_nested_templaters():
+    """Path parsing uses effective templaters and operation cleanup."""
+    root = "test/fixtures/linter/mixed_templaters"
+    linter = Linter(config=FluffConfig.from_path(root))
+
+    parsed = list(linter.parse_path(root))
+
+    assert len(parsed) == 2
+    assert not [violation for result in parsed for violation in result.violations]
+
+
+def test__linter__render_string_closes_owned_templater_after_error(monkeypatch):
+    """Direct rendering closes its templater without masking the render error."""
+
+    class FailingTemplater(RawTemplater):
+        """Templater that fails rendering and records cleanup."""
+
+        def __init__(self):
+            super().__init__()
+            self.closed = False
+
+        def process_with_variants(self, **kwargs):
+            raise ValueError("render failed")
+            yield  # pragma: no cover
+
+        def close(self):
+            self.closed = True
+            raise RuntimeError("close failed")
+
+    config = FluffConfig(overrides={"dialect": "ansi"})
+    templater = FailingTemplater()
+    config._configs["core"]["templater_obj"] = None
+    monkeypatch.setattr(config, "get_templater", lambda: templater)
+    linter = Linter(config=config)
+
+    with pytest.raises(ValueError, match="render failed"):
+        linter.render_string("SELECT 1", "test.sql", config, "utf-8")
+
+    assert templater.closed
+
+
+def test__linter__variant_cleanup_does_not_mask_render_error(monkeypatch):
+    """Variant iterator cleanup preserves the active rendering exception."""
+
+    class FailingVariants:
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            raise ValueError("render failed")
+
+        def close(self):
+            raise RuntimeError("variant close failed")
+
+    class FailingTemplater(RawTemplater):
+        def process_with_variants(self, **kwargs):
+            return FailingVariants()
+
+    config = FluffConfig(overrides={"dialect": "ansi"})
+    templater = FailingTemplater()
+    monkeypatch.setattr(config, "get_templater", lambda: templater)
+
+    with pytest.raises(ValueError, match="render failed"):
+        Linter(config=config).render_string("SELECT 1", "test.sql", config, "utf-8")
+
+
+def test__linter__closing_parse_path_releases_session():
+    """Closing a partially consumed path parser permits another operation."""
+    root = "test/fixtures/linter/mixed_templaters"
+    linter = Linter(config=FluffConfig.from_path(root))
+    parsed = linter.parse_path(root)
+
+    assert next(parsed).tree
+    parsed.close()
+
+    assert not linter.lint_paths((root,)).get_violations()
 
 
 def test_advanced_api_methods():

--- a/test/core/linter/linter_test.py
+++ b/test/core/linter/linter_test.py
@@ -19,7 +19,11 @@ from sqlfluff.core.errors import (
     SQLTemplaterError,
 )
 from sqlfluff.core.linter import runner
-from sqlfluff.core.linter.common import DeferredRenderTask, RenderedLintTask
+from sqlfluff.core.linter.common import (
+    DeferredRenderTask,
+    RenderedFile,
+    RenderedLintTask,
+)
 from sqlfluff.core.linter.linter import TemplaterSession
 from sqlfluff.core.linter.linting_result import combine_dicts, sum_dicts
 from sqlfluff.core.linter.runner import get_runner
@@ -1191,6 +1195,97 @@ def test__templater_session_factory_owns_created_templaters():
     assert templater.closed
 
 
+def test__templater_session_closes_templater_after_setup_failure(caplog):
+    """A session preserves setup errors when closing a failed templater."""
+
+    class FailingTemplater(RawTemplater):
+        def __init__(self):
+            self.close_count = 0
+
+        def session_key(self, config):
+            raise ValueError("setup failed")
+
+        def close(self):
+            self.close_count += 1
+            raise RuntimeError("close failed")
+
+    templater = FailingTemplater()
+    session = TemplaterSession(lambda _: templater)
+
+    with pytest.raises(ValueError, match="setup failed"):
+        session.get(FluffConfig(overrides={"dialect": "ansi"}))
+
+    assert templater.close_count == 1
+    assert "Failed to close templater after session setup failed" in caplog.text
+    session.close()
+    assert templater.close_count == 1
+
+
+def test__linter__templater_override_is_borrowed():
+    """A root templater override remains caller-owned within an operation."""
+
+    class TrackingTemplater(RawTemplater):
+        def __init__(self):
+            self.closed = False
+
+        def close(self):
+            self.closed = True
+
+    config = FluffConfig(overrides={"dialect": "ansi"})
+    linter = Linter(config=config)
+    root_templater = TrackingTemplater()
+    other_templater = TrackingTemplater()
+    other_config = FluffConfig(overrides={"dialect": "ansi"})
+    linter.templater = root_templater
+
+    assert linter.templater is root_templater
+    with linter.templater_session():
+        assert (
+            linter.borrow_templater_for_config(other_config, other_templater)
+            is root_templater
+        )
+
+    assert not root_templater.closed
+    assert not other_templater.closed
+
+
+@pytest.mark.parametrize("operation_failed", [False, True])
+def test__linter__release_templater_close_failure(
+    monkeypatch, caplog, operation_failed
+):
+    """Releasing a templater only suppresses cleanup errors during failure."""
+
+    class FailingTemplater(RawTemplater):
+        def __init__(self):
+            self.close_count = 0
+
+        def close(self):
+            self.close_count += 1
+            raise RuntimeError("close failed")
+
+    config = FluffConfig(overrides={"dialect": "ansi"})
+    config._configs["core"]["templater_obj"] = None
+    templater = FailingTemplater()
+    monkeypatch.setattr(config, "get_templater", lambda: templater)
+    linter = Linter(config=config)
+
+    expected_error = ValueError if operation_failed else RuntimeError
+    expected_message = "operation failed" if operation_failed else "close failed"
+    with pytest.raises(expected_error, match=expected_message):
+        with linter.templater_session():
+            linter.templater_for_config(config)
+            if operation_failed:
+                try:
+                    raise ValueError("operation failed")
+                except ValueError:
+                    linter.release_templater(templater)
+                    raise
+            linter.release_templater(templater)
+
+    assert templater.close_count == 1
+    assert ("Failed to close templater session" in caplog.text) is operation_failed
+
+
 @pytest.mark.parametrize("operation", ["render", "lint"])
 def test__linter__uses_fresh_templater_for_repeated_string_operations(
     monkeypatch, operation
@@ -1327,6 +1422,71 @@ def test__linter__mixed_templaters_preserve_file_order(tmp_path):
     )
 
 
+def test__sequential_runner__groups_and_orders_sequenced_templaters(monkeypatch):
+    """Custom sequencing groups templaters and preserves discovery order."""
+
+    class SequencingTemplater(RawTemplater):
+        def __init__(self, key):
+            self.key = key
+
+        def session_key(self, config):
+            return (self.key,)
+
+        def sequence_files(self, fnames, *, config=None, formatter=None):
+            return fnames
+
+    templater_a = SequencingTemplater("a")
+    templater_b = SequencingTemplater("b")
+    templater_c = SequencingTemplater("c")
+    configs = [FluffConfig(overrides={"dialect": "ansi"}) for _ in range(4)]
+    templaters = [templater_a, templater_b, templater_c, templater_a]
+    for config, templater in zip(configs, templaters):
+        monkeypatch.setattr(config, "get_templater", lambda t=templater: t)
+
+    root_config = FluffConfig(overrides={"dialect": "ansi"})
+    fnames = ["first.sql", "second.sql", "third.sql", "fourth.sql"]
+    monkeypatch.setattr(
+        root_config,
+        "make_child_from_path",
+        lambda fname: configs[fnames.index(fname)],
+    )
+    linter = Linter(config=root_config)
+    test_runner = runner.SequentialRunner(linter, root_config)
+    rendered_groups = []
+
+    def render_group(templater, file_config, group_files, formatter):
+        rendered_groups.append(
+            (templater.key, [file.discovery_index for file in group_files])
+        )
+        indexes = (
+            [3] if templater is templater_a else [1] if templater is templater_b else []
+        )
+        for index in indexes:
+            yield (
+                group_files[-1],
+                RenderedFile(
+                    [TemplatedFile("SELECT 1", fname=fnames[index])],
+                    [],
+                    configs[index],
+                    {},
+                    fnames[index],
+                    "utf-8",
+                    "SELECT 1",
+                ),
+            )
+
+    released = []
+    monkeypatch.setattr(test_runner, "_render_group", render_group)
+    monkeypatch.setattr(linter, "release_templater", released.append)
+
+    with linter.templater_session():
+        rendered = list(test_runner.iter_rendered(fnames))
+
+    assert rendered_groups == [("a", [0, 3]), ("b", [1]), ("c", [2])]
+    assert [fname for fname, _ in rendered] == [fnames[1], fnames[3]]
+    assert released == [templater_a, templater_b, templater_c]
+
+
 def test__sequential_runner__streams_worker_safe_files(tmp_path, monkeypatch):
     """Sequential linting completes each worker-safe file before loading the next."""
     first_file = tmp_path / "first.sql"
@@ -1445,6 +1605,27 @@ def test__linter__variant_cleanup_does_not_mask_render_error(monkeypatch):
     monkeypatch.setattr(config, "get_templater", lambda: templater)
 
     with pytest.raises(ValueError, match="render failed"):
+        Linter(config=config).render_string("SELECT 1", "test.sql", config, "utf-8")
+
+
+def test__linter__variant_cleanup_error_is_raised(monkeypatch):
+    """Variant cleanup errors propagate after successful iteration."""
+
+    class FailingVariants:
+        def __iter__(self):
+            return iter(())
+
+        def close(self):
+            raise RuntimeError("variant close failed")
+
+    class FailingTemplater(RawTemplater):
+        def process_with_variants(self, **kwargs):
+            return FailingVariants()
+
+    config = FluffConfig(overrides={"dialect": "ansi"})
+    monkeypatch.setattr(config, "get_templater", FailingTemplater)
+
+    with pytest.raises(RuntimeError, match="variant close failed"):
         Linter(config=config).render_string("SELECT 1", "test.sql", config, "utf-8")
 
 

--- a/test/fixtures/linter/mixed_templaters/.sqlfluff
+++ b/test/fixtures/linter/mixed_templaters/.sqlfluff
@@ -1,0 +1,6 @@
+[sqlfluff]
+dialect = ansi
+templater = jinja
+
+[sqlfluff:templater:jinja:context]
+table_name = my_table

--- a/test/fixtures/linter/mixed_templaters/jinja.sql
+++ b/test/fixtures/linter/mixed_templaters/jinja.sql
@@ -1,0 +1,1 @@
+SELECT 1 FROM {{ table_name }}

--- a/test/fixtures/linter/mixed_templaters/placeholder/.sqlfluff
+++ b/test/fixtures/linter/mixed_templaters/placeholder/.sqlfluff
@@ -1,0 +1,5 @@
+[sqlfluff]
+templater = placeholder
+
+[sqlfluff:templater:placeholder]
+param_regex = \{(?P<param_name>\w+)\}

--- a/test/fixtures/linter/mixed_templaters/placeholder/placeholder.sql
+++ b/test/fixtures/linter/mixed_templaters/placeholder/placeholder.sql
@@ -1,0 +1,1 @@
+SELECT {value} FROM my_table


### PR DESCRIPTION
## Summary
- select templaters and SQL file extensions from each file's effective nested configuration
- add operation-scoped templater sessions with explicit lifecycle, sequencing, and multiprocessing behavior
- support multiple independent dbt projects in one lint or fix operation
- document plugin lifecycle requirements and nested configuration behavior

## Verification
- 372 focused core, config, discovery, linter, and CLI tests passed
- focused mixed/nested dbt tests passed for one and two processes
- Ruff formatting, linting, and import contracts passed
- standard and strict mypy passed
- doctests passed
- documentation lint and build passed

Full database-backed dbt integration tests were not run. The feature-specific dbt tests patch relation-cache setup and do not require a database.

Closes #3057

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds nested templater selection and operation-scoped templater sessions so each file uses the templater from its nearest `.sqlfluff`. Enables linting, parsing, and fixing across mixed templaters, including multiple independent `dbt` projects, with safe parallelism and predictable order.

- **New Features**
  - Nested templater config: files are grouped by their effective templater; nested `sql_file_exts` control discovery per directory and for exact paths.
  - Multiple `dbt` projects in one run: each project’s config is compiled and rendered once in the main process, then parsing/linting is parallelized.
  - Operation-scoped templater lifecycle: templaters share instances via `session_key(config)`, are cleaned up via `close()`, and use `templates_in_worker` to gate worker-side rendering. Fail-safe cleanup runs even on partial setup or early exit.
  - Isolated `dbt` adapter lifecycle: exclusive, lock-guarded adapter registration with race detection and cleanup prevents cross-operation conflicts.
  - Stable ordering and streaming: results preserve discovery order, and CLI parse/render/lint respect nested templaters.

- **Migration**
  - Plugin authors: if your templater is stateful, implement `session_key(config)` to include all state-affecting config, override `close()`, and set `templates_in_worker = False` if worker rendering is unsafe. Ensure methods are safe on partial setup/early exit.
  - Inline templater directives are ignored; set the templater in configuration files instead.

<sup>Written for commit 36db6e5c7dfeca1d980faefc501a2db6ac60b2e8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8301?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

