### PR TITLE
Add SECOND(S) unreserved keyword to dialect_databricks_keywords.py

### DIFF
--- a/src/sqlfluff/dialects/dialect_databricks_keywords.py
+++ b/src/sqlfluff/dialects/dialect_databricks_keywords.py
@@ -55,6 +55,8 @@ UNRESERVED_KEYWORDS = [
     "REFRESH",
     "RELY",
     "ROW",
+    "SECOND",
+    "SECONDS",
     "SCHEDULE",
     "SHALLOW",
     "SOURCE",

--- a/test/fixtures/dialects/databricks/date_functions.sql
+++ b/test/fixtures/dialects/databricks/date_functions.sql
@@ -8,6 +8,7 @@ LEFT JOIN other_table
 SELECT
     DATE_ADD(MICROSECOND, 5, start_dt) AS date_add_micro,
     DATE_DIFF(MILLISECOND, start_dt, end_dt) AS datediff_milli,
+    DATE_DIFF(SECOND, start_dt, end_dt) AS datediff_sec,
     DATEADD(MINUTE, 5, start_dt) AS dateadd_min,
     DATEDIFF(HOUR, start_dt, end_dt) AS datediff_hr,
     TIMEDIFF(DAY, start_dt, end_dt) AS timediff_day,

--- a/test/fixtures/dialects/databricks/date_functions.yml
+++ b/test/fixtures/dialects/databricks/date_functions.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 120308fb701a79a33f52d92cc4c06f4f80c63dd71a46ef50b848868a97e789c0
+_hash: 0eedee1ec131c992b4e94d1b1db963e283b2e650eae6cb1f7563b0903925dd2c
 file:
 - statement:
     select_statement:
@@ -107,6 +107,28 @@ file:
             alias_operator:
               keyword: AS
             naked_identifier: datediff_milli
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: DATE_DIFF
+            function_contents:
+              bracketed:
+              - start_bracket: (
+              - date_part: SECOND
+              - comma: ','
+              - expression:
+                  column_reference:
+                    naked_identifier: start_dt
+              - comma: ','
+              - expression:
+                  column_reference:
+                    naked_identifier: end_dt
+              - end_bracket: )
+          alias_expression:
+            alias_operator:
+              keyword: AS
+            naked_identifier: datediff_sec
       - comma: ','
       - select_clause_element:
           function:


### PR DESCRIPTION
date_diff() function accepts unit of measurement such as SECONDS/HOURS/DAYS/etc however SECOND is not an unreserved keyword causing linting to fail, with it being incorrectly identified as a column reference. 

Resolves rule error: RF02

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Marks `SECOND`/`SECONDS` unreserved in the Databricks dialect so `DATE_DIFF` parses them as time units, not identifiers, fixing RF02.

- Adds a `DATE_DIFF(SECOND, ...)` case to `test/fixtures/dialects/databricks/date_functions.sql`.
- Regenerates `test/fixtures/dialects/databricks/date_functions.yml` to reflect the new parse.

<sup>Written for commit 2fe736267a81ab4302503d315ea7b601f312c3c8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8303?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

