### PR TITLE
LT01: don't apply `spacing_within` inside composite operators

### DIFF
--- a/docs/source/configuration/layout.rst
+++ b/docs/source/configuration/layout.rst
@@ -772,6 +772,13 @@ available:
       :code:`my_schema.my_table` which uses `touch:inline` or other clauses
       where we want to force some elements to be on the same line.
 
+   *  A few operators are made up of more than one symbol which SQL does not
+      allow to be separated, such as :code:`||`, :code:`>=` and :code:`<>`.
+      The :code:`spacing_within` setting does not apply *inside* those
+      operators, because any spacing there would not be valid SQL. Spacing
+      *around* them is still governed by :code:`spacing_before` and
+      :code:`spacing_after` as normal.
+
 *  **Line Position**: set using the :code:`line_position` option. By default
    this is unset, which implies no particular line position requirements. The
    available options are:

--- a/src/sqlfluff/core/parser/segments/common.py
+++ b/src/sqlfluff/core/parser/segments/common.py
@@ -99,10 +99,22 @@ class BinaryOperatorSegment(CodeSegment):
     type = "binary_operator"
 
 
-class CompositeBinaryOperatorSegment(BaseSegment):
+class CompositeOperatorSegment(BaseSegment):
+    """An operator made up of more than one raw symbol.
+
+    The grammars of these segments match their parts with ``allow_gaps=False``,
+    so whitespace can never legally appear between them. The
+    ``composite_operator`` type records that for the layout engine, so it knows
+    not to place spacing within them.
+    """
+
+    type = "composite_operator"
+
+
+class CompositeBinaryOperatorSegment(CompositeOperatorSegment):
     """A composite binary operator segment.
 
-    Defined here for type inheritance. Inherits from BaseSegment.
+    Defined here for type inheritance. Inherits from CompositeOperatorSegment.
     """
 
     type = "binary_operator"
@@ -117,10 +129,10 @@ class ComparisonOperatorSegment(CodeSegment):
     type = "comparison_operator"
 
 
-class CompositeComparisonOperatorSegment(BaseSegment):
+class CompositeComparisonOperatorSegment(CompositeOperatorSegment):
     """A comparison operator segment.
 
-    Defined here for type inheritance. Inherits from BaseSegment.
+    Defined here for type inheritance. Inherits from CompositeOperatorSegment.
     """
 
     type = "comparison_operator"

--- a/src/sqlfluff/utils/reflow/respace.py
+++ b/src/sqlfluff/utils/reflow/respace.py
@@ -181,7 +181,17 @@ def determine_constraints(
         # so it doesn't matter whether we get it from prev_block or next_block.
         idx = prev_block.depth_info.stack_hashes.index(common[-1])
 
-        within_constraint = prev_block.stack_spacing_configs.get(common[-1], None)
+        within_constraint: Optional[str]
+        if "composite_operator" in prev_block.depth_info.stack_class_types[idx]:
+            # Operators such as `||`, `>=` and `<>` are parsed as a single
+            # segment containing their raw symbols, matched with
+            # `allow_gaps=False`. Whitespace can therefore never legally sit
+            # between those symbols, so any configured `spacing_within` would
+            # raise a violation that cannot be fixed without making the file
+            # unparsable. Treat them as `touch` regardless of configuration.
+            within_constraint = "touch"
+        else:
+            within_constraint = prev_block.stack_spacing_configs.get(common[-1], None)
         if within_constraint:
             within_spacing, strip_newlines = _unpack_constraint(
                 within_constraint, strip_newlines

--- a/test/fixtures/rules/std_rule_cases/LT01-operators.yml
+++ b/test/fixtures/rules/std_rule_cases/LT01-operators.yml
@@ -181,3 +181,30 @@ fail_oracle_modulo_still_spaced:
   configs:
     core:
       dialect: oracle
+
+pass_composite_operator_spacing_within_override:
+  # https://github.com/sqlfluff/sqlfluff/issues/5818
+  # `||`, `>=` and `<>` are each a single segment holding two raw symbols,
+  # matched with `allow_gaps=False`. `spacing_within` must not apply inside
+  # them, otherwise this raises a violation which cannot be fixed without
+  # making the file unparsable.
+  pass_str: SELECT 'a' || 'b' AS s, 1 >= 2 AS g, 3 <> 4 AS n FROM t
+  configs:
+    layout:
+      type:
+        binary_operator:
+          spacing_within: single
+        comparison_operator:
+          spacing_within: single
+
+fail_composite_operator_outer_spacing_still_enforced:
+  # The same override must still enforce spacing *around* those operators.
+  fail_str: SELECT 'a'||'b' AS s, 3<>4 AS n FROM t
+  fix_str: SELECT 'a' || 'b' AS s, 3 <> 4 AS n FROM t
+  configs:
+    layout:
+      type:
+        binary_operator:
+          spacing_within: single
+        comparison_operator:
+          spacing_within: single


### PR DESCRIPTION
## Summary

Closes #5818.

`LT01` reports a violation *inside* composite operators — `||`, `>=`, `<>` and friends — whenever `spacing_within` is configured to anything other than `touch`. The violation is reported as fixable, but `sqlfluff fix` then refuses to apply it and asks the user to file a bug, so it can never be resolved.

The issue is filed under `bigquery`, but the cause is dialect-agnostic. On `ansi`:

```ini
[sqlfluff:layout:type:binary_operator]
spacing_within = single
[sqlfluff:layout:type:comparison_operator]
spacing_within = single
```

```sql
SELECT 'a' || 'b' AS s, 1 >= 2 AS g, 3 <> 4 AS n FROM t
```

**Before:**

```
L: 1 | P: 13 | LT01 | Expected single whitespace between pipe '|' and pipe '|'.
L: 1 | P: 28 | LT01 | Expected single whitespace between raw comparison operator '>' and raw comparison operator '='.
L: 1 | P: 41 | LT01 | Expected single whitespace between raw comparison operator '<' and raw comparison operator '>'.
```

and `sqlfluff fix` bails out with its own bug-report prompt:

```
WARNING  Fixes for LT01 not applied, as it would result in an unparsable file.
         Please report this as a bug with a minimal query which demonstrates this warning.
```

**After:** clean, and `fix` applies normally.

## Why it happens

These operators are not raw segments. `ConcatSegment`, `GreaterThanOrEqualToSegment`, `NotEqualToSegment` and the rest subclass `CompositeBinaryOperatorSegment` / `CompositeComparisonOperatorSegment`, whose grammars match their parts with `allow_gaps=False`:

```python
class ConcatSegment(CompositeBinaryOperatorSegment):
    match_grammar: Matchable = Sequence(
        Ref("PipeSegment"), Ref("PipeSegment"), allow_gaps=False
    )
```

Those composites carry the same `type` as the raw operators (`binary_operator`, `comparison_operator`). `ReflowBlock.from_config` records `spacing_within` for every enclosing segment in the stack, so a user setting on `binary_operator` is applied to the gap *between the two pipes* — a position where whitespace can never be valid SQL. `determine_constraints` then asks for a space there, and the resulting fix is discarded as unparsable.

It only surfaces on a non-default config, because the shipped defaults for both types are already `touch`.

## The change

Two small pieces:

1. A `CompositeOperatorSegment` base class carrying a new `composite_operator` type, which the two existing composite operator bases now inherit from. Because `_class_types` accumulates up the inheritance chain, they keep `binary_operator` / `comparison_operator` exactly as before and simply gain the marker.
2. `determine_constraints` treats the gap inside such a segment as `touch`, whatever `spacing_within` says.

Spacing *around* these operators is untouched and still governed by `spacing_before` / `spacing_after` — with the config above, `SELECT 'a'||'b'` is still corrected to `SELECT 'a' || 'b'`.

## Trade-offs considered

- **Match on the type names directly in the reflow engine** (e.g. "if the parent is a `binary_operator`, force touch"). Rejected: it hard-codes dialect vocabulary into the layout engine, and would silently miss composites that dialects define with other types. The marker type keeps the knowledge next to the grammar that creates the constraint, and dialect authors inherit the correct behaviour for free.
- **Reject the config with a user error.** Rejected: it turns a bad-but-quiet config into a hard failure for anyone who already has it, and the setting is meaningful for other types, so the error would have to be type-specific anyway.
- **Keep raising the violation but mark it unfixable.** Rejected: it is still a false positive. There is no edit the user could make to satisfy it.
- **Default `0` / leave as is.** Not viable — the current behaviour is an unfixable lint.

The new type is deliberately not exported from `sqlfluff.core.parser`, to avoid widening the public API for what is an internal marker; dialects get it by subclassing the existing composite bases as they already do. Happy to export it if you would rather it were public.

## Tests

Two cases added to `test/fixtures/rules/std_rule_cases/LT01-operators.yml`:

- `pass_composite_operator_spacing_within_override` — the query from the issue, under the config from the issue, now passes.
- `fail_composite_operator_outer_spacing_still_enforced` — under the *same* config, spacing around the operators is still enforced and fixed, which is the regression this could plausibly cause.

## Verification

Run locally on Windows, Python 3.13:

| Check | Result |
| --- | --- |
| `pytest test/` | **10708 passed**, 2549 skipped, 7 failed — see below |
| `pytest test/rules/yaml_test_cases_test.py -k LT01` | 185 passed |
| `pytest test/utils/reflow/` | 122 passed |
| `mypy src/sqlfluff/...` | clean |
| `ruff check` / `ruff format --check` | clean |
| `doc8 docs/source/configuration/layout.rst` | clean |

The 7 failures are all in `test/core/plugin_test.py` and `test/diff_quality_plugin_test.py`. They are **pre-existing in my environment and unrelated to this change** — I verified that by reverting the change, rebuilding, and re-running those two files, which produced exactly the same 7 failures. They stem from the example plugin not being installed and from my `diff_cover` setup, not from the linter.

**What I could not run locally:** the dbt templater tests under `plugins/sqlfluff-templater-dbt`, as I do not have a dbt environment set up. I am flagging it because the acceptance principles call it out specifically for architectural changes. Nothing here touches templating, but I did not want to imply coverage I do not have — say the word if you would like me to set that up before review.

---

_AI disclosure, per the "AI-Assisted Contributions" section of `CONTRIBUTING.md`: I used Claude Code in a material way on this change — to navigate the reflow and parser code, draft the fix and the test cases, and draft this description. What I validated manually: I reproduced the bug from source before changing anything, confirmed `fix` refused to apply, confirmed the fix resolves it and that `fix` now produces correct SQL, and confirmed that spacing around the operators is still enforced. I ran every check in the table above myself, and mypy caught a typing error in my first draft which I then corrected._


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop applying `spacing_within` inside composite operators like `||`, `>=`, and `<>` to avoid unfixable `LT01` violations. `sqlfluff fix` now applies cleanly, and spacing around these operators still follows `spacing_before`/`spacing_after`.

- **Bug Fixes**
  - Added `CompositeOperatorSegment` (type `composite_operator`) and updated composite operator bases to inherit it while keeping `binary_operator`/`comparison_operator`.
  - In `determine_constraints()`, treat internal gaps of `composite_operator` as `touch` regardless of `spacing_within`.
  - Clarified docs that `spacing_within` does not apply inside multi-symbol operators; added tests to ensure inner spacing is ignored and outer spacing is enforced.

<sup>Written for commit b0025f9c60e8b2e3dd35a65d99ee92950b70b56e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8304?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

