### PR TITLE
Snowflake: STREAM gaps (WITH TAG, AT(STREAM =>), ON EVENT TABLE, CREATE OR ALTER, clone COPY GRANTS)

### DIFF
--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -1845,7 +1845,7 @@ class ChangesClauseSegment(BaseSegment):
         Sequence(
             "END",
             Bracketed(
-                OneOf("TIMESTAMP", "OFFSET", "STATEMENT"),
+                OneOf("TIMESTAMP", "OFFSET", "STATEMENT", "STREAM"),
                 Ref("ParameterAssignerSegment"),
                 Ref("ExpressionSegment"),
                 parse_mode=ParseMode.GREEDY,
@@ -1862,7 +1862,7 @@ class FromAtExpressionSegment(BaseSegment):
     match_grammar = Sequence(
         "AT",
         Bracketed(
-            OneOf("TIMESTAMP", "OFFSET", "STATEMENT"),
+            OneOf("TIMESTAMP", "OFFSET", "STATEMENT", "STREAM"),
             Ref("ParameterAssignerSegment"),
             Ref("ExpressionSegment"),
         ),
@@ -1876,7 +1876,7 @@ class FromBeforeExpressionSegment(BaseSegment):
     match_grammar = Sequence(
         "BEFORE",
         Bracketed(
-            OneOf("TIMESTAMP", "OFFSET", "STATEMENT"),
+            OneOf("TIMESTAMP", "OFFSET", "STATEMENT", "STREAM"),
             Ref("ParameterAssignerSegment"),
             Ref("ExpressionSegment"),
             parse_mode=ParseMode.GREEDY,
@@ -3558,6 +3558,7 @@ class CreateCloneStatementSegment(BaseSegment):
             Ref("FromBeforeExpressionSegment"),
             optional=True,
         ),
+        Sequence("COPY", "GRANTS", optional=True),
     )
 
 
@@ -7955,15 +7956,21 @@ class CreateStreamStatementSegment(BaseSegment):
 
     match_grammar = Sequence(
         "CREATE",
-        Ref("OrReplaceGrammar", optional=True),
+        Ref("AlterOrReplaceGrammar", optional=True),
         "STREAM",
         Ref("IfNotExistsGrammar", optional=True),
         Ref("ObjectReferenceSegment"),
+        Ref("TagBracketedEqualsSegment", optional=True),
         Sequence("COPY", "GRANTS", optional=True),
         "ON",
         OneOf(
             Sequence(
-                OneOf("TABLE", "VIEW", Sequence("DYNAMIC", "TABLE")),
+                OneOf(
+                    "TABLE",
+                    "VIEW",
+                    Sequence("DYNAMIC", "TABLE"),
+                    Sequence("EVENT", "TABLE"),
+                ),
                 Ref("ObjectReferenceSegment"),
                 OneOf(
                     Ref("FromAtExpressionSegment"),

--- a/test/fixtures/dialects/snowflake/create_stream_extra.sql
+++ b/test/fixtures/dialects/snowflake/create_stream_extra.sql
@@ -1,0 +1,27 @@
+-- CREATE STREAM clauses
+-- https://docs.snowflake.com/en/sql-reference/sql/create-stream
+
+CREATE OR REPLACE STREAM s WITH TAG (cost_center = 'sales') COPY GRANTS ON TABLE t;
+
+CREATE STREAM s TAG (cost_center = 'sales', team = 'data') ON TABLE t;
+
+CREATE STREAM s ON TABLE t AT (STREAM => 'oldstream');
+
+CREATE STREAM s ON TABLE t BEFORE (STREAM => 'oldstream');
+
+CREATE STREAM s ON EVENT TABLE et;
+
+CREATE STREAM IF NOT EXISTS s ON EVENT TABLE my_db.my_schema.et COMMENT = 'event table stream';
+
+CREATE OR REPLACE STREAM s CLONE s2 COPY GRANTS;
+
+CREATE STREAM s CLONE s2 AT (OFFSET => -60) COPY GRANTS;
+
+CREATE OR ALTER STREAM s ON TABLE t APPEND_ONLY = TRUE;
+
+CREATE OR ALTER STREAM s ON TABLE t APPEND_ONLY = TRUE COMMENT = 'append only stream';
+
+-- AT ( STREAM => ... ) is also valid in time travel queries
+SELECT * FROM mytable AT (STREAM => 'mystream');
+
+SELECT * FROM mytable BEFORE (STREAM => 'mystream');

--- a/test/fixtures/dialects/snowflake/create_stream_extra.yml
+++ b/test/fixtures/dialects/snowflake/create_stream_extra.yml
@@ -1,0 +1,262 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 804e21f1dc18483a6ca741d8cbb4f7fc0342a44588ccc99de341e1187cad08ec
+file:
+- statement:
+    create_stream_statement:
+    - keyword: CREATE
+    - keyword: OR
+    - keyword: REPLACE
+    - keyword: STREAM
+    - object_reference:
+        naked_identifier: s
+    - tag_bracketed_equals:
+      - keyword: WITH
+      - keyword: TAG
+      - bracketed:
+          start_bracket: (
+          tag_reference:
+            naked_identifier: cost_center
+          comparison_operator:
+            raw_comparison_operator: '='
+          quoted_literal: "'sales'"
+          end_bracket: )
+    - keyword: COPY
+    - keyword: GRANTS
+    - keyword: 'ON'
+    - keyword: TABLE
+    - object_reference:
+        naked_identifier: t
+- statement_terminator: ;
+- statement:
+    create_stream_statement:
+    - keyword: CREATE
+    - keyword: STREAM
+    - object_reference:
+        naked_identifier: s
+    - tag_bracketed_equals:
+        keyword: TAG
+        bracketed:
+        - start_bracket: (
+        - tag_reference:
+            naked_identifier: cost_center
+        - comparison_operator:
+            raw_comparison_operator: '='
+        - quoted_literal: "'sales'"
+        - comma: ','
+        - tag_reference:
+            naked_identifier: team
+        - comparison_operator:
+            raw_comparison_operator: '='
+        - quoted_literal: "'data'"
+        - end_bracket: )
+    - keyword: 'ON'
+    - keyword: TABLE
+    - object_reference:
+        naked_identifier: t
+- statement_terminator: ;
+- statement:
+    create_stream_statement:
+    - keyword: CREATE
+    - keyword: STREAM
+    - object_reference:
+        naked_identifier: s
+    - keyword: 'ON'
+    - keyword: TABLE
+    - object_reference:
+        naked_identifier: t
+    - from_at_expression:
+        keyword: AT
+        bracketed:
+          start_bracket: (
+          keyword: STREAM
+          parameter_assigner: =>
+          expression:
+            quoted_literal: "'oldstream'"
+          end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_stream_statement:
+    - keyword: CREATE
+    - keyword: STREAM
+    - object_reference:
+        naked_identifier: s
+    - keyword: 'ON'
+    - keyword: TABLE
+    - object_reference:
+        naked_identifier: t
+    - from_before_expression:
+        keyword: BEFORE
+        bracketed:
+          start_bracket: (
+          keyword: STREAM
+          parameter_assigner: =>
+          expression:
+            quoted_literal: "'oldstream'"
+          end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_stream_statement:
+    - keyword: CREATE
+    - keyword: STREAM
+    - object_reference:
+        naked_identifier: s
+    - keyword: 'ON'
+    - keyword: EVENT
+    - keyword: TABLE
+    - object_reference:
+        naked_identifier: et
+- statement_terminator: ;
+- statement:
+    create_stream_statement:
+    - keyword: CREATE
+    - keyword: STREAM
+    - keyword: IF
+    - keyword: NOT
+    - keyword: EXISTS
+    - object_reference:
+        naked_identifier: s
+    - keyword: 'ON'
+    - keyword: EVENT
+    - keyword: TABLE
+    - object_reference:
+      - naked_identifier: my_db
+      - dot: .
+      - naked_identifier: my_schema
+      - dot: .
+      - naked_identifier: et
+    - comment_equals_clause:
+        keyword: COMMENT
+        comparison_operator:
+          raw_comparison_operator: '='
+        quoted_literal: "'event table stream'"
+- statement_terminator: ;
+- statement:
+    create_clone_statement:
+    - keyword: CREATE
+    - keyword: OR
+    - keyword: REPLACE
+    - keyword: STREAM
+    - object_reference:
+        naked_identifier: s
+    - keyword: CLONE
+    - object_reference:
+        naked_identifier: s2
+    - keyword: COPY
+    - keyword: GRANTS
+- statement_terminator: ;
+- statement:
+    create_clone_statement:
+    - keyword: CREATE
+    - keyword: STREAM
+    - object_reference:
+        naked_identifier: s
+    - keyword: CLONE
+    - object_reference:
+        naked_identifier: s2
+    - from_at_expression:
+        keyword: AT
+        bracketed:
+          start_bracket: (
+          keyword: OFFSET
+          parameter_assigner: =>
+          expression:
+            numeric_literal:
+              sign_indicator: '-'
+              numeric_literal: '60'
+          end_bracket: )
+    - keyword: COPY
+    - keyword: GRANTS
+- statement_terminator: ;
+- statement:
+    create_stream_statement:
+    - keyword: CREATE
+    - keyword: OR
+    - keyword: ALTER
+    - keyword: STREAM
+    - object_reference:
+        naked_identifier: s
+    - keyword: 'ON'
+    - keyword: TABLE
+    - object_reference:
+        naked_identifier: t
+    - keyword: APPEND_ONLY
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - boolean_literal: 'TRUE'
+- statement_terminator: ;
+- statement:
+    create_stream_statement:
+    - keyword: CREATE
+    - keyword: OR
+    - keyword: ALTER
+    - keyword: STREAM
+    - object_reference:
+        naked_identifier: s
+    - keyword: 'ON'
+    - keyword: TABLE
+    - object_reference:
+        naked_identifier: t
+    - keyword: APPEND_ONLY
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - boolean_literal: 'TRUE'
+    - comment_equals_clause:
+        keyword: COMMENT
+        comparison_operator:
+          raw_comparison_operator: '='
+        quoted_literal: "'append only stream'"
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: mytable
+            from_at_expression:
+              keyword: AT
+              bracketed:
+                start_bracket: (
+                keyword: STREAM
+                parameter_assigner: =>
+                expression:
+                  quoted_literal: "'mystream'"
+                end_bracket: )
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: mytable
+            from_before_expression:
+              keyword: BEFORE
+              bracketed:
+                start_bracket: (
+                keyword: STREAM
+                parameter_assigner: =>
+                expression:
+                  quoted_literal: "'mystream'"
+                end_bracket: )
+- statement_terminator: ;


### PR DESCRIPTION
### Brief summary of the change made

- [ WITH ] TAG ( <tag_name> = '<value>' [ , ... ] ) on CREATE STREAM
- CREATE OR ALTER STREAM
- ON EVENT TABLE <name>
- { AT | BEFORE } ( STREAM => '<name>' ), both in CREATE STREAM and in
  time travel queries, since the AT/BEFORE segments are shared
- COPY GRANTS after CREATE ... CLONE

Reference documentation:

- https://docs.snowflake.com/en/sql-reference/sql/create-stream
- https://docs.snowflake.com/en/sql-reference/sql/alter-stream
- https://docs.snowflake.com/en/sql-reference/constructs/at-before

### Are there any other side effects of this change that we should be aware of?

`FromAtExpressionSegment` and `FromBeforeExpressionSegment` are shared with time travel in queries, so `AT ( STREAM => ... )` becomes valid there too. That matches the AT/BEFORE documentation, and the fixtures cover both positions. `CreateCloneStatementSegment` gains `COPY GRANTS` for every clonable object type it handles, which is what the CREATE ... CLONE docs specify. No existing fixture YAML changes.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes:
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects/snowflake` (YML files generated with `python test/generate_parse_fixture_yml.py -d snowflake`, and the full cross-dialect regeneration produces no unrelated diffs).
- Added appropriate documentation for the change: the docstrings of the touched segments link to the relevant official Snowflake documentation (dialect reference docs are auto-generated).
- No followup issues were needed for this change.

### AI assistance declaration

This change was developed with AI assistance: the grammar changes and the test fixtures were
drafted with an LLM. Every clause was checked against the official Snowflake documentation linked
above, and each statement in the fixtures was verified locally with
`sqlfluff parse --dialect snowflake`. The full dialect suite
(`pytest test/dialects/dialects_test.py -k snowflake` and `pytest test/dialects/snowflake_test.py`)
passes, a full `python test/generate_parse_fixture_yml.py` produces no diff outside the fixtures
listed above, and `ruff format --check` / `ruff check` are clean.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expands Snowflake STREAM grammar in `sqlfluff` to match Snowflake docs. Adds tags, event table support, time-travel by stream, and clone grant handling for more accurate parsing.

- **New Features**
  - `WITH TAG (...)` and `TAG (...)` on `CREATE STREAM`
  - `CREATE OR ALTER STREAM`
  - `ON EVENT TABLE <name>`
  - `AT | BEFORE (STREAM => '<name>')` in `CREATE STREAM` and time-travel queries
  - `COPY GRANTS` after `CREATE ... CLONE`

<sup>Written for commit 64ddcb12d21e09322ffc42d050e1f93638d6bd28. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8309?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

