### PR TITLE
MariaDB: support DELETE HISTORY on system-versioned tables

### DIFF
--- a/src/sqlfluff/dialects/dialect_mariadb.py
+++ b/src/sqlfluff/dialects/dialect_mariadb.py
@@ -211,6 +211,23 @@ class DeleteStatementSegment(BaseSegment):
         Ref.keyword("QUICK", optional=True),
         Ref.keyword("IGNORE", optional=True),
         OneOf(
+            # System-versioned tables: purge history rows.
+            # DELETE HISTORY FROM tbl [PARTITION (...)]
+            #   [BEFORE SYSTEM_TIME [TIMESTAMP|TRANSACTION] expression]
+            # https://mariadb.com/kb/en/delete/
+            Sequence(
+                "HISTORY",
+                "FROM",
+                Ref("TableReferenceSegment"),
+                Ref("SelectPartitionClauseSegment", optional=True),
+                Sequence(
+                    "BEFORE",
+                    "SYSTEM_TIME",
+                    OneOf("TIMESTAMP", "TRANSACTION", optional=True),
+                    Ref("ExpressionSegment"),
+                    optional=True,
+                ),
+            ),
             Sequence(
                 "FROM",
                 Delimited(

--- a/src/sqlfluff/dialects/dialect_mariadb.py
+++ b/src/sqlfluff/dialects/dialect_mariadb.py
@@ -207,11 +207,11 @@ class DeleteStatementSegment(BaseSegment):
     type = "delete_statement"
     match_grammar = Sequence(
         "DELETE",
-        Ref.keyword("LOW_PRIORITY", optional=True),
-        Ref.keyword("QUICK", optional=True),
-        Ref.keyword("IGNORE", optional=True),
         OneOf(
-            # System-versioned tables: purge history rows.
+            # System-versioned tables: purge history rows. Per the MariaDB docs
+            # this is a distinct form that does NOT take LOW_PRIORITY/QUICK/
+            # IGNORE, so it sits ahead of the standard branch (which owns those
+            # modifiers) rather than sharing them.
             # DELETE HISTORY FROM tbl [PARTITION (...)]
             #   [BEFORE SYSTEM_TIME [TIMESTAMP|TRANSACTION] expression]
             # https://mariadb.com/kb/en/delete/
@@ -228,32 +228,41 @@ class DeleteStatementSegment(BaseSegment):
                     optional=True,
                 ),
             ),
+            # Standard DELETE, which alone carries the optional modifiers.
             Sequence(
-                "FROM",
-                Delimited(
-                    Ref("DeleteTargetTableSegment"),
-                    terminators=["USING"],
+                Ref.keyword("LOW_PRIORITY", optional=True),
+                Ref.keyword("QUICK", optional=True),
+                Ref.keyword("IGNORE", optional=True),
+                OneOf(
+                    Sequence(
+                        "FROM",
+                        Delimited(
+                            Ref("DeleteTargetTableSegment"),
+                            terminators=["USING"],
+                        ),
+                        Ref("DeleteUsingClauseSegment"),
+                        Ref("WhereClauseSegment", optional=True),
+                    ),
+                    Sequence(
+                        Delimited(
+                            Ref("DeleteTargetTableSegment"),
+                            terminators=["FROM"],
+                        ),
+                        Ref("FromClauseSegment"),
+                        Ref("WhereClauseSegment", optional=True),
+                    ),
+                    Sequence(
+                        Ref("FromClauseSegment"),
+                        # Application-time:
+                        # DELETE ... FOR PORTION OF period FROM x TO y
+                        Ref("ForPortionOfSegment", optional=True),
+                        Ref("SelectPartitionClauseSegment", optional=True),
+                        Ref("WhereClauseSegment", optional=True),
+                        Ref("OrderByClauseSegment", optional=True),
+                        Ref("LimitClauseSegment", optional=True),
+                        Ref("ReturningClauseSegment", optional=True),
+                    ),
                 ),
-                Ref("DeleteUsingClauseSegment"),
-                Ref("WhereClauseSegment", optional=True),
-            ),
-            Sequence(
-                Delimited(
-                    Ref("DeleteTargetTableSegment"),
-                    terminators=["FROM"],
-                ),
-                Ref("FromClauseSegment"),
-                Ref("WhereClauseSegment", optional=True),
-            ),
-            Sequence(
-                Ref("FromClauseSegment"),
-                # Application-time: DELETE ... FOR PORTION OF period FROM x TO y
-                Ref("ForPortionOfSegment", optional=True),
-                Ref("SelectPartitionClauseSegment", optional=True),
-                Ref("WhereClauseSegment", optional=True),
-                Ref("OrderByClauseSegment", optional=True),
-                Ref("LimitClauseSegment", optional=True),
-                Ref("ReturningClauseSegment", optional=True),
             ),
         ),
     )

--- a/test/dialects/dialects_test.py
+++ b/test/dialects/dialects_test.py
@@ -187,6 +187,28 @@ def test_mysql_family_dual_cannot_be_qualified(dialect: str) -> None:
 @pytest.mark.parametrize(
     "sql",
     [
+        "DELETE LOW_PRIORITY HISTORY FROM t BEFORE SYSTEM_TIME '2020-01-01';",
+        "DELETE QUICK HISTORY FROM t BEFORE SYSTEM_TIME '2020-01-01';",
+        "DELETE IGNORE HISTORY FROM t BEFORE SYSTEM_TIME '2020-01-01';",
+    ],
+)
+def test_mariadb_delete_history_rejects_delete_modifiers(sql: str) -> None:
+    """`DELETE HISTORY` does not accept LOW_PRIORITY/QUICK/IGNORE.
+
+    The purge-only ``BEFORE SYSTEM_TIME`` syntax cannot attach to a standard
+    ``DELETE`` (which is what a modifier forces), so these are parse errors.
+    (Bare ``DELETE QUICK HISTORY FROM t`` remains valid: there ``history`` is
+    just an ordinary target table name.)
+    """
+    parsed = Linter(dialect="mariadb").parse_string(sql)
+    parsing_errors = [v for v in parsed.violations if v.rule_code() == "PRS"]
+
+    assert parsing_errors
+
+
+@pytest.mark.parametrize(
+    "sql",
+    [
         "DECLARE cur_into CURSOR FOR SELECT 1 INTO dbo.t;",
         "DECLARE cur_browse CURSOR FOR SELECT 1 FOR BROWSE;",
     ],

--- a/test/fixtures/dialects/mariadb/delete_history.sql
+++ b/test/fixtures/dialects/mariadb/delete_history.sql
@@ -1,0 +1,19 @@
+-- Purging history rows from system-versioned tables with DELETE HISTORY.
+-- https://mariadb.com/kb/en/delete/
+
+-- Delete all history.
+DELETE HISTORY FROM t;
+
+-- Delete history before a point in time.
+DELETE HISTORY FROM t BEFORE SYSTEM_TIME '2020-01-01 00:00:00';
+
+-- The optional TIMESTAMP / TRANSACTION qualifier.
+DELETE HISTORY FROM t BEFORE SYSTEM_TIME TIMESTAMP '2020-01-01 00:00:00';
+DELETE HISTORY FROM t BEFORE SYSTEM_TIME TRANSACTION 10;
+
+-- Restrict to given partitions.
+DELETE HISTORY FROM t PARTITION (p0, p1) BEFORE SYSTEM_TIME NOW();
+
+-- Regression: ordinary DELETE forms must still parse unchanged.
+DELETE FROM t WHERE a = 1;
+DELETE FROM t FOR PORTION OF date_period FROM '2001-01-01' TO '2018-01-01';

--- a/test/fixtures/dialects/mariadb/delete_history.sql
+++ b/test/fixtures/dialects/mariadb/delete_history.sql
@@ -17,3 +17,8 @@ DELETE HISTORY FROM t PARTITION (p0, p1) BEFORE SYSTEM_TIME NOW();
 -- Regression: ordinary DELETE forms must still parse unchanged.
 DELETE FROM t WHERE a = 1;
 DELETE FROM t FOR PORTION OF date_period FROM '2001-01-01' TO '2018-01-01';
+
+-- The LOW_PRIORITY/QUICK/IGNORE modifiers still apply to ordinary DELETE.
+-- They are NOT valid with DELETE HISTORY (see the unparsable cases in
+-- test/dialects/dialects_test.py).
+DELETE LOW_PRIORITY QUICK IGNORE FROM t WHERE a = 1;

--- a/test/fixtures/dialects/mariadb/delete_history.yml
+++ b/test/fixtures/dialects/mariadb/delete_history.yml
@@ -1,0 +1,122 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 0f92eab802f098ad28a10f360f034f45bb44a511365a491f3b084f5f46b2b0b4
+file:
+- statement:
+    delete_statement:
+    - keyword: DELETE
+    - keyword: HISTORY
+    - keyword: FROM
+    - table_reference:
+        naked_identifier: t
+- statement_terminator: ;
+- statement:
+    delete_statement:
+    - keyword: DELETE
+    - keyword: HISTORY
+    - keyword: FROM
+    - table_reference:
+        naked_identifier: t
+    - keyword: BEFORE
+    - keyword: SYSTEM_TIME
+    - expression:
+        quoted_literal: "'2020-01-01 00:00:00'"
+- statement_terminator: ;
+- statement:
+    delete_statement:
+    - keyword: DELETE
+    - keyword: HISTORY
+    - keyword: FROM
+    - table_reference:
+        naked_identifier: t
+    - keyword: BEFORE
+    - keyword: SYSTEM_TIME
+    - keyword: TIMESTAMP
+    - expression:
+        quoted_literal: "'2020-01-01 00:00:00'"
+- statement_terminator: ;
+- statement:
+    delete_statement:
+    - keyword: DELETE
+    - keyword: HISTORY
+    - keyword: FROM
+    - table_reference:
+        naked_identifier: t
+    - keyword: BEFORE
+    - keyword: SYSTEM_TIME
+    - keyword: TRANSACTION
+    - expression:
+        numeric_literal: '10'
+- statement_terminator: ;
+- statement:
+    delete_statement:
+    - keyword: DELETE
+    - keyword: HISTORY
+    - keyword: FROM
+    - table_reference:
+        naked_identifier: t
+    - partition_clause:
+        keyword: PARTITION
+        bracketed:
+        - start_bracket: (
+        - object_reference:
+            naked_identifier: p0
+        - comma: ','
+        - object_reference:
+            naked_identifier: p1
+        - end_bracket: )
+    - keyword: BEFORE
+    - keyword: SYSTEM_TIME
+    - expression:
+        function:
+          function_name:
+            function_name_identifier: NOW
+          function_contents:
+            bracketed:
+              start_bracket: (
+              end_bracket: )
+- statement_terminator: ;
+- statement:
+    delete_statement:
+      keyword: DELETE
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: t
+      where_clause:
+        keyword: WHERE
+        expression:
+          column_reference:
+            naked_identifier: a
+          comparison_operator:
+            raw_comparison_operator: '='
+          numeric_literal: '1'
+- statement_terminator: ;
+- statement:
+    delete_statement:
+      keyword: DELETE
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: t
+      for_portion_of_clause:
+      - keyword: FOR
+      - keyword: PORTION
+      - keyword: OF
+      - naked_identifier: date_period
+      - keyword: FROM
+      - expression:
+          quoted_literal: "'2001-01-01'"
+      - keyword: TO
+      - expression:
+          quoted_literal: "'2018-01-01'"
+- statement_terminator: ;

--- a/test/fixtures/dialects/mariadb/delete_history.yml
+++ b/test/fixtures/dialects/mariadb/delete_history.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 0f92eab802f098ad28a10f360f034f45bb44a511365a491f3b084f5f46b2b0b4
+_hash: 4c706a6ecab6ac4f4edb0a1da9bb0744c20fe9d1dae8da1fecf6d3bd9df48887
 file:
 - statement:
     delete_statement:
@@ -119,4 +119,26 @@ file:
       - keyword: TO
       - expression:
           quoted_literal: "'2018-01-01'"
+- statement_terminator: ;
+- statement:
+    delete_statement:
+    - keyword: DELETE
+    - keyword: LOW_PRIORITY
+    - keyword: QUICK
+    - keyword: IGNORE
+    - from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: t
+    - where_clause:
+        keyword: WHERE
+        expression:
+          column_reference:
+            naked_identifier: a
+          comparison_operator:
+            raw_comparison_operator: '='
+          numeric_literal: '1'
 - statement_terminator: ;


### PR DESCRIPTION
### Brief summary of the change made

Adds support for the MariaDB `DELETE HISTORY` statement, used to purge history rows from system-versioned tables:

```
DELETE HISTORY FROM tbl_name [PARTITION (partition_list)]
  [BEFORE SYSTEM_TIME [TIMESTAMP|TRANSACTION] expression]
```

This complements the system-versioned tables support added in #8293 (`FOR SYSTEM_TIME`, `PERIOD FOR SYSTEM_TIME`, `WITH SYSTEM VERSIONING`), which had no way to express history cleanup.

Implemented as a new alternative in the mariadb-only `DeleteStatementSegment`, so every existing `DELETE` form (plain, multi-table, `FOR PORTION OF`, `RETURNING`) parses unchanged. A parser fixture covers all forms — plain, `BEFORE SYSTEM_TIME`, the `TIMESTAMP`/`TRANSACTION` qualifiers, and `PARTITION (...)` — plus regression lines.

Reference: https://mariadb.com/kb/en/delete/

### Are there any other side effects?

No. The change is confined to the `mariadb` dialect; `dialect_mysql.py` and `dialect_ansi.py` are untouched. The added grammar is strictly a new optional branch.

### Dialect

mariadb

### AI assistance disclosure

Per the project's AI-assisted contribution guide: this contribution was prepared with AI assistance (Claude Code).

- **AI-assisted:** drafting the `dialect_mariadb.py` grammar change, the `.sql`/`.yml` parser fixtures, and this PR description.
- **Manually validated by me:** the `DELETE HISTORY` grammar was checked verbatim against the official MariaDB documentation linked above (not invented); the fixtures were regenerated and reviewed; and the full suite was run locally — `pytest test/dialects/dialects_test.py -k mariadb` (652 passed), `mypy`, and `ruff` — all passing.

I take responsibility for the correctness, tests, and maintainability of this PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds parser support for MariaDB `DELETE HISTORY` to purge history rows on system-versioned tables, and rejects `LOW_PRIORITY`/`QUICK`/`IGNORE` modifiers for this form. The feature is limited to the `mariadb` dialect; standard `DELETE` syntax remains unchanged.

- **New Features**
  - Parse `DELETE HISTORY FROM tbl [PARTITION(...)] [BEFORE SYSTEM_TIME [TIMESTAMP|TRANSACTION] expr]`.

<sup>Written for commit 68d33abc093364737b454ccebe49e2bb9af0a2cb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8312?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

