### PR TITLE
fix(mysql): parse charset and collation names as dedicated segments

### DIFF
--- a/src/sqlfluff/dialects/dialect_mariadb.py
+++ b/src/sqlfluff/dialects/dialect_mariadb.py
@@ -1030,7 +1030,8 @@ class TableOptionsSegment(mysql.TableOptionsSegment):
                 Ref("EqualsSegment", optional=True),
                 OneOf(
                     Ref("QuotedLiteralSegment"),
-                    Ref("NakedIdentifierSegment"),
+                    Ref("CharacterSetSegment"),
+                    "BINARY",
                     "DEFAULT",
                 ),
             ),

--- a/src/sqlfluff/dialects/dialect_mysql.py
+++ b/src/sqlfluff/dialects/dialect_mysql.py
@@ -369,7 +369,41 @@ mysql_dialect.add(
         "DUAL", IdentifierSegment, type="naked_identifier"
     ),
     CharsetGrammar=OneOf(Sequence("CHARACTER", "SET"), "CHARSET"),
+    # A character set *name* (e.g. ``ascii``, ``utf8mb4``, ``latin1``).
+    # Matched as its own ``character_set`` type rather than a ``naked_identifier``
+    # so that rule RF04 (keywords used as identifiers) does not flag charset names
+    # that happen to be unreserved keywords -- ``ascii`` being the common case.
+    # Reserved keywords are excluded here (so ``CHARACTER SET DEFAULT`` still
+    # parses ``DEFAULT`` as a keyword); the one reserved keyword that is a valid
+    # charset name, ``BINARY``, is offered explicitly at each usage site.
+    CharacterSetSegment=SegmentGenerator(
+        lambda dialect: RegexParser(
+            r"[A-Z0-9_]*[A-Z][A-Z0-9_]*",
+            CodeSegment,
+            type="character_set",
+            anti_template=r"^("
+            + r"|".join(sorted(dialect.sets("reserved_keywords")))
+            + r")$",
+        )
+    ),
 )
+
+
+class CollationReferenceSegment(ansi.CollationReferenceSegment):
+    """A reference to a collation.
+
+    MySQL and MariaDB accept the reserved keyword ``BINARY`` as a collation name
+    (the ``binary`` collation), which the ANSI identifier-only grammar rejects.
+    Offering it as a keyword (rather than a naked identifier) also keeps rule RF04
+    from flagging it. Other collation names are never keywords, so they keep the
+    inherited identifier grammar.
+    """
+
+    type = "collation_reference"
+    match_grammar: Matchable = OneOf(
+        Ref.keyword("BINARY"),
+        ansi.CollationReferenceSegment.match_grammar,
+    )
 
 
 class GroupByClauseSegment(ansi.GroupByClauseSegment):
@@ -1184,6 +1218,11 @@ class ColumnConstraintSegment(ansi.ColumnConstraintSegment):
         Sequence(
             Ref("CharsetGrammar"),
             OneOf(
+                # Bare charset name -> ``character_set`` (kept ahead of the
+                # identifier grammar so unquoted names win this type); the
+                # identifier grammar still covers back-tick-quoted names.
+                Ref("CharacterSetSegment"),
+                "BINARY",
                 Ref("SingleIdentifierGrammar"),
                 Ref("SingleQuotedIdentifierSegment"),
                 Ref("DoubleQuotedIdentifierSegment"),
@@ -1840,7 +1879,8 @@ class TableOptionsSegment(BaseSegment):
                 Ref("EqualsSegment", optional=True),
                 OneOf(
                     Ref("QuotedLiteralSegment"),
-                    Ref("NakedIdentifierSegment"),
+                    Ref("CharacterSetSegment"),
+                    "BINARY",
                     "DEFAULT",
                 ),
             ),
@@ -3590,6 +3630,8 @@ class AlterOptionSegment(BaseSegment):
                 Ref("CharsetGrammar"),
                 Ref("EqualsSegment", optional=True),
                 OneOf(
+                    Ref("CharacterSetSegment"),
+                    "BINARY",
                     Ref("SingleIdentifierGrammar"),
                     Ref("SingleQuotedIdentifierSegment"),
                     Ref("DoubleQuotedIdentifierSegment"),

--- a/src/sqlfluff/dialects/dialect_mysql.py
+++ b/src/sqlfluff/dialects/dialect_mysql.py
@@ -3585,7 +3585,12 @@ class CreateOptionSegment(BaseSegment):
                 "CHARACTER",
                 "SET",
                 Ref("EqualsSegment", optional=True),
-                OneOf(Ref("NakedIdentifierSegment"), Ref("QuotedLiteralSegment")),
+                OneOf(
+                    Ref("CharacterSetSegment"),
+                    "BINARY",
+                    Ref("NakedIdentifierSegment"),
+                    Ref("QuotedLiteralSegment"),
+                ),
             ),
             Sequence(
                 "COLLATE",

--- a/test/fixtures/dialects/mariadb/alter_database.yml
+++ b/test/fixtures/dialects/mariadb/alter_database.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: a1c4b4182cc44aace3c98db61b2527155aad4526958fbad5a5d52dc0be2e7079
+_hash: 924a4851d90aa53a64ec60e5a2acb40894e1cda0f6bdf1f756dbea8417b1307c
 file:
 - statement:
     alter_database_statement:
@@ -15,7 +15,7 @@ file:
       - keyword: DEFAULT
       - keyword: CHARACTER
       - keyword: SET
-      - naked_identifier: utf8mb4
+      - character_set: utf8mb4
     - alter_option_segment:
         keyword: COLLATE
         collation_reference:
@@ -37,7 +37,7 @@ file:
       - keyword: SET
       - comparison_operator:
           raw_comparison_operator: '='
-      - naked_identifier: utf8mb4
+      - character_set: utf8mb4
     - alter_option_segment:
         keyword: COLLATE
         comparison_operator:
@@ -61,7 +61,7 @@ file:
       - keyword: DEFAULT
       - keyword: CHARACTER
       - keyword: SET
-      - naked_identifier: utf8mb4
+      - character_set: utf8mb4
     - alter_option_segment:
         keyword: COLLATE
         collation_reference:

--- a/test/fixtures/dialects/mariadb/alter_table.yml
+++ b/test/fixtures/dialects/mariadb/alter_table.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 240c31e6518c25cc685ad9949dd5a53309cd62388a669d82f44944e564ee71fb
+_hash: 315aad26c8820ddee42120abbd82b3db5c8edde2b05244db48ce71d91fb0aa28
 file:
 - statement:
     alter_table_statement:
@@ -788,7 +788,7 @@ file:
     - alter_option_segment:
       - keyword: CHARACTER
       - keyword: SET
-      - naked_identifier: utf8mb4
+      - character_set: utf8mb4
     - alter_option_segment:
         keyword: COLLATE
         collation_reference:
@@ -1198,7 +1198,7 @@ file:
         naked_identifier: user
     - table_options:
         keyword: CHARSET
-        naked_identifier: utf8mb4
+        character_set: utf8mb4
 - statement_terminator: ;
 - statement:
     alter_table_statement:
@@ -1209,7 +1209,7 @@ file:
     - table_options:
       - keyword: CHARACTER
       - keyword: SET
-      - naked_identifier: utf8mb4
+      - character_set: utf8mb4
 - statement_terminator: ;
 - statement:
     alter_table_statement:
@@ -1219,7 +1219,7 @@ file:
         naked_identifier: user
     - table_options:
       - keyword: CHARSET
-      - naked_identifier: utf8mb4
+      - character_set: utf8mb4
       - keyword: COLLATE
       - naked_identifier: utf8mb4_unicode_ci
 - statement_terminator: ;
@@ -1233,7 +1233,7 @@ file:
       - keyword: DEFAULT
       - keyword: CHARACTER
       - keyword: SET
-      - naked_identifier: utf8mb4
+      - character_set: utf8mb4
       - keyword: COLLATE
       - naked_identifier: utf8mb4_general_ci
 - statement_terminator: ;
@@ -1247,7 +1247,7 @@ file:
         keyword: CHARSET
         comparison_operator:
           raw_comparison_operator: '='
-        naked_identifier: utf8mb4
+        character_set: utf8mb4
 - statement_terminator: ;
 - statement:
     alter_table_statement:
@@ -1260,7 +1260,7 @@ file:
       - keyword: SET
       - comparison_operator:
           raw_comparison_operator: '='
-      - naked_identifier: utf8mb4
+      - character_set: utf8mb4
 - statement_terminator: ;
 - statement:
     alter_table_statement:
@@ -1273,7 +1273,7 @@ file:
       - keyword: CHARSET
       - comparison_operator:
           raw_comparison_operator: '='
-      - naked_identifier: utf8mb4
+      - character_set: utf8mb4
       - keyword: COLLATE
       - comparison_operator:
           raw_comparison_operator: '='
@@ -1291,7 +1291,7 @@ file:
       - keyword: SET
       - comparison_operator:
           raw_comparison_operator: '='
-      - naked_identifier: utf8mb4
+      - character_set: utf8mb4
 - statement_terminator: ;
 - statement:
     alter_table_statement:

--- a/test/fixtures/dialects/mariadb/create_database.sql
+++ b/test/fixtures/dialects/mariadb/create_database.sql
@@ -18,3 +18,6 @@ COLLATE utf8mb4_0900_ai_ci
 DEFAULT ENCRYPTION 'N';
 
 CREATE DATABASE IF NOT EXISTS xxx CHARACTER SET "utf8mb4" COLLATE "utf8mb4_bin";
+
+-- The reserved keyword `binary` is a valid charset and collation name.
+CREATE DATABASE my_database CHARACTER SET binary COLLATE binary;

--- a/test/fixtures/dialects/mariadb/create_database.yml
+++ b/test/fixtures/dialects/mariadb/create_database.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 28d48d2ecab94ea00fef8f5f3e64a0c0f392dab3b36b7d29548cfdd50bb2a0b2
+_hash: d18c958d2435182cdb63a4d4d55fa5d533372e4fdc5e4f39e23b7ad68e379f5a
 file:
 - statement:
     create_database_statement:
@@ -32,7 +32,7 @@ file:
       - keyword: DEFAULT
       - keyword: CHARACTER
       - keyword: SET
-      - naked_identifier: utf8mb4
+      - character_set: utf8mb4
     - create_option_segment:
         keyword: COLLATE
         collation_reference:
@@ -54,7 +54,7 @@ file:
       - keyword: SET
       - comparison_operator:
           raw_comparison_operator: '='
-      - naked_identifier: utf8mb4
+      - character_set: utf8mb4
     - create_option_segment:
         keyword: COLLATE
         comparison_operator:
@@ -78,7 +78,7 @@ file:
       - keyword: DEFAULT
       - keyword: CHARACTER
       - keyword: SET
-      - naked_identifier: utf8mb4
+      - character_set: utf8mb4
     - create_option_segment:
         keyword: COLLATE
         collation_reference:
@@ -105,4 +105,19 @@ file:
         keyword: COLLATE
         collation_reference:
           quoted_literal: '"utf8mb4_bin"'
+- statement_terminator: ;
+- statement:
+    create_database_statement:
+    - keyword: CREATE
+    - keyword: DATABASE
+    - database_reference:
+        naked_identifier: my_database
+    - create_option_segment:
+      - keyword: CHARACTER
+      - keyword: SET
+      - keyword: binary
+    - create_option_segment:
+        keyword: COLLATE
+        collation_reference:
+          keyword: binary
 - statement_terminator: ;

--- a/test/fixtures/dialects/mariadb/create_table_column_charset.sql
+++ b/test/fixtures/dialects/mariadb/create_table_column_charset.sql
@@ -25,3 +25,17 @@ CREATE TABLE t1
       CHARACTER SET "latin1"
       COLLATE "latin1_german1_ci"
 );
+
+-- Keyword charset name (ascii is an unreserved keyword): must parse as a
+-- character_set, not a naked_identifier, so rule RF04 does not flag it.
+CREATE TABLE t2
+(
+    col1 TEXT CHARACTER SET ascii COLLATE ascii_bin
+);
+
+-- The reserved keyword BINARY is a valid charset name and collation name.
+CREATE TABLE t3
+(
+    col1 TEXT CHARACTER SET binary,
+    col2 TEXT COLLATE binary
+);

--- a/test/fixtures/dialects/mariadb/create_table_column_charset.yml
+++ b/test/fixtures/dialects/mariadb/create_table_column_charset.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 3d383e37b65631c852af5deffd0bdde1132fbaef0e98b247fd01bbc2cece2e8c
+_hash: b19bacf50376d28a073039f3e6bf3de2267fc8dd758648579425addf890c39a1
 file:
 - statement:
     create_table_statement:
@@ -25,7 +25,7 @@ file:
         - column_constraint_segment:
           - keyword: CHARACTER
           - keyword: SET
-          - naked_identifier: latin1
+          - character_set: latin1
         - column_constraint_segment:
             keyword: COLLATE
             collation_reference:
@@ -112,4 +112,53 @@ file:
             collation_reference:
               quoted_literal: '"latin1_german1_ci"'
         end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: t2
+    - bracketed:
+        start_bracket: (
+        column_definition:
+        - naked_identifier: col1
+        - data_type:
+            data_type_identifier: TEXT
+        - column_constraint_segment:
+          - keyword: CHARACTER
+          - keyword: SET
+          - character_set: ascii
+        - column_constraint_segment:
+            keyword: COLLATE
+            collation_reference:
+              naked_identifier: ascii_bin
+        end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: t3
+    - bracketed:
+      - start_bracket: (
+      - column_definition:
+          naked_identifier: col1
+          data_type:
+            data_type_identifier: TEXT
+          column_constraint_segment:
+          - keyword: CHARACTER
+          - keyword: SET
+          - keyword: binary
+      - comma: ','
+      - column_definition:
+          naked_identifier: col2
+          data_type:
+            data_type_identifier: TEXT
+          column_constraint_segment:
+            keyword: COLLATE
+            collation_reference:
+              keyword: binary
+      - end_bracket: )
 - statement_terminator: ;

--- a/test/fixtures/dialects/mysql/alter_database.yml
+++ b/test/fixtures/dialects/mysql/alter_database.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: a1c4b4182cc44aace3c98db61b2527155aad4526958fbad5a5d52dc0be2e7079
+_hash: 924a4851d90aa53a64ec60e5a2acb40894e1cda0f6bdf1f756dbea8417b1307c
 file:
 - statement:
     alter_database_statement:
@@ -15,7 +15,7 @@ file:
       - keyword: DEFAULT
       - keyword: CHARACTER
       - keyword: SET
-      - naked_identifier: utf8mb4
+      - character_set: utf8mb4
     - alter_option_segment:
         keyword: COLLATE
         collation_reference:
@@ -37,7 +37,7 @@ file:
       - keyword: SET
       - comparison_operator:
           raw_comparison_operator: '='
-      - naked_identifier: utf8mb4
+      - character_set: utf8mb4
     - alter_option_segment:
         keyword: COLLATE
         comparison_operator:
@@ -61,7 +61,7 @@ file:
       - keyword: DEFAULT
       - keyword: CHARACTER
       - keyword: SET
-      - naked_identifier: utf8mb4
+      - character_set: utf8mb4
     - alter_option_segment:
         keyword: COLLATE
         collation_reference:

--- a/test/fixtures/dialects/mysql/alter_table.yml
+++ b/test/fixtures/dialects/mysql/alter_table.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: df8a42fc85ecff13b46990c670c67d1e556e4910eca549a220059dad24c33d52
+_hash: d40b6f5b21ea0dd5576b1f74d014a3cdf91c60c0b656e37acba8bd52a49d6c85
 file:
 - statement:
     alter_table_statement:
@@ -782,7 +782,7 @@ file:
     - alter_option_segment:
       - keyword: CHARACTER
       - keyword: SET
-      - naked_identifier: utf8mb4
+      - character_set: utf8mb4
     - alter_option_segment:
         keyword: COLLATE
         collation_reference:
@@ -1338,7 +1338,7 @@ file:
         naked_identifier: user
     - table_options:
         keyword: CHARSET
-        naked_identifier: utf8mb4
+        character_set: utf8mb4
 - statement_terminator: ;
 - statement:
     alter_table_statement:
@@ -1349,7 +1349,7 @@ file:
     - table_options:
       - keyword: CHARACTER
       - keyword: SET
-      - naked_identifier: utf8mb4
+      - character_set: utf8mb4
 - statement_terminator: ;
 - statement:
     alter_table_statement:
@@ -1359,7 +1359,7 @@ file:
         naked_identifier: user
     - table_options:
       - keyword: CHARSET
-      - naked_identifier: utf8mb4
+      - character_set: utf8mb4
       - keyword: COLLATE
       - naked_identifier: utf8mb4_unicode_ci
 - statement_terminator: ;
@@ -1373,7 +1373,7 @@ file:
       - keyword: DEFAULT
       - keyword: CHARACTER
       - keyword: SET
-      - naked_identifier: utf8mb4
+      - character_set: utf8mb4
       - keyword: COLLATE
       - naked_identifier: utf8mb4_general_ci
 - statement_terminator: ;
@@ -1387,7 +1387,7 @@ file:
         keyword: CHARSET
         comparison_operator:
           raw_comparison_operator: '='
-        naked_identifier: utf8mb4
+        character_set: utf8mb4
 - statement_terminator: ;
 - statement:
     alter_table_statement:
@@ -1400,7 +1400,7 @@ file:
       - keyword: SET
       - comparison_operator:
           raw_comparison_operator: '='
-      - naked_identifier: utf8mb4
+      - character_set: utf8mb4
 - statement_terminator: ;
 - statement:
     alter_table_statement:
@@ -1413,7 +1413,7 @@ file:
       - keyword: CHARSET
       - comparison_operator:
           raw_comparison_operator: '='
-      - naked_identifier: utf8mb4
+      - character_set: utf8mb4
       - keyword: COLLATE
       - comparison_operator:
           raw_comparison_operator: '='
@@ -1431,5 +1431,5 @@ file:
       - keyword: SET
       - comparison_operator:
           raw_comparison_operator: '='
-      - naked_identifier: utf8mb4
+      - character_set: utf8mb4
 - statement_terminator: ;

--- a/test/fixtures/dialects/mysql/create_database.sql
+++ b/test/fixtures/dialects/mysql/create_database.sql
@@ -18,3 +18,6 @@ COLLATE utf8mb4_0900_ai_ci
 DEFAULT ENCRYPTION 'N';
 
 CREATE DATABASE IF NOT EXISTS xxx CHARACTER SET "utf8mb4" COLLATE "utf8mb4_bin";
+
+-- The reserved keyword `binary` is a valid charset and collation name.
+CREATE DATABASE my_database CHARACTER SET binary COLLATE binary;

--- a/test/fixtures/dialects/mysql/create_database.yml
+++ b/test/fixtures/dialects/mysql/create_database.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 28d48d2ecab94ea00fef8f5f3e64a0c0f392dab3b36b7d29548cfdd50bb2a0b2
+_hash: d18c958d2435182cdb63a4d4d55fa5d533372e4fdc5e4f39e23b7ad68e379f5a
 file:
 - statement:
     create_database_statement:
@@ -32,7 +32,7 @@ file:
       - keyword: DEFAULT
       - keyword: CHARACTER
       - keyword: SET
-      - naked_identifier: utf8mb4
+      - character_set: utf8mb4
     - create_option_segment:
         keyword: COLLATE
         collation_reference:
@@ -54,7 +54,7 @@ file:
       - keyword: SET
       - comparison_operator:
           raw_comparison_operator: '='
-      - naked_identifier: utf8mb4
+      - character_set: utf8mb4
     - create_option_segment:
         keyword: COLLATE
         comparison_operator:
@@ -78,7 +78,7 @@ file:
       - keyword: DEFAULT
       - keyword: CHARACTER
       - keyword: SET
-      - naked_identifier: utf8mb4
+      - character_set: utf8mb4
     - create_option_segment:
         keyword: COLLATE
         collation_reference:
@@ -105,4 +105,19 @@ file:
         keyword: COLLATE
         collation_reference:
           quoted_literal: '"utf8mb4_bin"'
+- statement_terminator: ;
+- statement:
+    create_database_statement:
+    - keyword: CREATE
+    - keyword: DATABASE
+    - database_reference:
+        naked_identifier: my_database
+    - create_option_segment:
+      - keyword: CHARACTER
+      - keyword: SET
+      - keyword: binary
+    - create_option_segment:
+        keyword: COLLATE
+        collation_reference:
+          keyword: binary
 - statement_terminator: ;

--- a/test/fixtures/dialects/mysql/create_table_column_charset.sql
+++ b/test/fixtures/dialects/mysql/create_table_column_charset.sql
@@ -25,3 +25,17 @@ CREATE TABLE t1
       CHARACTER SET "latin1"
       COLLATE "latin1_german1_ci"
 );
+
+-- Keyword charset name (ascii is an unreserved keyword): must parse as a
+-- character_set, not a naked_identifier, so rule RF04 does not flag it.
+CREATE TABLE t2
+(
+    col1 TEXT CHARACTER SET ascii COLLATE ascii_bin
+);
+
+-- The reserved keyword BINARY is a valid charset name and collation name.
+CREATE TABLE t3
+(
+    col1 TEXT CHARACTER SET binary,
+    col2 TEXT COLLATE binary
+);

--- a/test/fixtures/dialects/mysql/create_table_column_charset.yml
+++ b/test/fixtures/dialects/mysql/create_table_column_charset.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 3d383e37b65631c852af5deffd0bdde1132fbaef0e98b247fd01bbc2cece2e8c
+_hash: b19bacf50376d28a073039f3e6bf3de2267fc8dd758648579425addf890c39a1
 file:
 - statement:
     create_table_statement:
@@ -25,7 +25,7 @@ file:
         - column_constraint_segment:
           - keyword: CHARACTER
           - keyword: SET
-          - naked_identifier: latin1
+          - character_set: latin1
         - column_constraint_segment:
             keyword: COLLATE
             collation_reference:
@@ -112,4 +112,53 @@ file:
             collation_reference:
               quoted_literal: '"latin1_german1_ci"'
         end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: t2
+    - bracketed:
+        start_bracket: (
+        column_definition:
+        - naked_identifier: col1
+        - data_type:
+            data_type_identifier: TEXT
+        - column_constraint_segment:
+          - keyword: CHARACTER
+          - keyword: SET
+          - character_set: ascii
+        - column_constraint_segment:
+            keyword: COLLATE
+            collation_reference:
+              naked_identifier: ascii_bin
+        end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: t3
+    - bracketed:
+      - start_bracket: (
+      - column_definition:
+          naked_identifier: col1
+          data_type:
+            data_type_identifier: TEXT
+          column_constraint_segment:
+          - keyword: CHARACTER
+          - keyword: SET
+          - keyword: binary
+      - comma: ','
+      - column_definition:
+          naked_identifier: col2
+          data_type:
+            data_type_identifier: TEXT
+          column_constraint_segment:
+            keyword: COLLATE
+            collation_reference:
+              keyword: binary
+      - end_bracket: )
 - statement_terminator: ;

--- a/test/fixtures/rules/std_rule_cases/RF04.yml
+++ b/test/fixtures/rules/std_rule_cases/RF04.yml
@@ -156,3 +156,55 @@ test_fail_keyword_as_column_name_postgres:
   configs:
     core:
       dialect: postgres
+
+# --- MySQL/MariaDB charset & collation names are not user identifiers ---
+# With unquoted_identifiers_policy=all, charset/collation names that happen to be
+# keywords (e.g. `ascii`) must not be flagged: they are matched as dedicated
+# character_set / keyword segments, not naked identifiers.
+
+test_pass_mysql_column_charset_keyword_name:
+  pass_str: CREATE TABLE t (col1 TEXT CHARACTER SET ascii COLLATE ascii_bin)
+  configs:
+    core:
+      dialect: mysql
+    rules:
+      references.keywords:
+        unquoted_identifiers_policy: all
+
+test_pass_mysql_alter_convert_charset_keyword_name:
+  pass_str: ALTER TABLE t CONVERT TO CHARACTER SET ascii
+  configs:
+    core:
+      dialect: mysql
+    rules:
+      references.keywords:
+        unquoted_identifiers_policy: all
+
+test_pass_mysql_alter_default_charset_keyword_name:
+  pass_str: ALTER TABLE t DEFAULT CHARACTER SET ascii
+  configs:
+    core:
+      dialect: mysql
+    rules:
+      references.keywords:
+        unquoted_identifiers_policy: all
+
+test_pass_mariadb_column_charset_keyword_name:
+  pass_str: CREATE TABLE t (col1 TEXT CHARACTER SET ascii COLLATE ascii_bin)
+  configs:
+    core:
+      dialect: mariadb
+    rules:
+      references.keywords:
+        unquoted_identifiers_policy: all
+
+# Guard: a real keyword used as a column name must still be flagged, i.e. the
+# charset fix did not broaden the rule away from genuine misuse.
+test_fail_mysql_keyword_column_name_still_flagged:
+  fail_str: CREATE TABLE t (ascii TEXT)
+  configs:
+    core:
+      dialect: mysql
+    rules:
+      references.keywords:
+        unquoted_identifiers_policy: all


### PR DESCRIPTION
### Brief summary of the change

Character-set and collation **names** were matched with the identifier grammar, so their leaf became a `naked_identifier` node. Two consequences, both reproducing in `mysql` and — by inheritance — `mariadb`:

1. **RF04 false positive.** With `references.keywords` `unquoted_identifiers_policy = all`, RF04 flags any `naked_identifier` that is a keyword. Legitimate charset/collation names that are keywords — notably `ascii` — were flagged as "keyword used as identifier".
2. **Parse failure on reserved-keyword names.** `CHARACTER SET binary` and `COLLATE binary` are valid MySQL/MariaDB but were **unparsable**, because `binary` is a reserved keyword excluded from naked identifiers.

**Reproduction** (before this PR), `dialect = mysql` or `mariadb`:

```sql
-- RF04 (with unquoted_identifiers_policy = all) wrongly flags `ascii`:
CREATE TABLE t (c TEXT CHARACTER SET ascii COLLATE ascii_bin);
-- Unparsable:
CREATE TABLE t (c TEXT CHARACTER SET binary);
CREATE TABLE t (c TEXT COLLATE binary);
```

### Approach

- New `CharacterSetSegment` — a charset **name** matched as its own `character_set` type instead of `naked_identifier`, so RF04 (which only crawls `naked_identifier`/`quoted_identifier`) no longer treats it as a user identifier. Reserved keywords stay excluded, so `CHARACTER SET DEFAULT` still parses `DEFAULT` as a keyword.
- `CollationReferenceSegment` (mysql override) additionally accepts the reserved `BINARY` keyword.
- The reserved keyword `BINARY` — the one reserved word that is a valid charset/collation name — is offered explicitly at each charset site. Back-tick / quoted names and the `DEFAULT` keyword are preserved unchanged.

Applied at the column, table-option, and `ALTER TABLE` (`CONVERT TO` / `[DEFAULT] CHARACTER SET`) charset sites; mariadb inherits the mysql grammar except for its own `TableOptionsSegment`, which gets the same change. Table-level `param = value` options were already unaffected and are untouched.

### Are there any other side effects?

Charset names that were `naked_identifier` in existing fixtures now serialise as `character_set` (e.g. `utf8mb4`, `latin1`) — reflected in the regenerated `.yml`. A guard test confirms a genuine keyword **column name** is still flagged by RF04.

### Tests

- Extended `create_table_column_charset` fixtures (mysql + mariadb) with keyword (`ascii`) and reserved (`binary`) charset/collation names.
- New `RF04.yml` cases (mysql + mariadb, `policy = all`) asserting charset/collation keyword names pass, plus a guard that a keyword column name still fails.
- Full `mysql`/`mariadb` dialect suite (1289 tests) and `mypy` green.

### AI-Assisted Contributions disclosure

This change was developed with AI assistance (Claude). The grammar design, the root-cause analysis, the empirical reproduction, and all tests were reviewed and validated by me before submission.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix MySQL/MariaDB parsing of charset and collation names by introducing a dedicated `character_set` segment and allowing `BINARY` as a keyword. Also adds support in `CREATE DATABASE`/`CREATE SCHEMA`, removing RF04 false positives (e.g., `ascii`) and fixing parse errors for `CHARACTER SET binary` and `COLLATE binary`.

- **Bug Fixes**
  - Parse charset names as `character_set` (not identifiers); RF04 no longer flags them under `unquoted_identifiers_policy = all`.
  - Accept reserved `BINARY` at charset and collation sites.
  - Applied to column constraints, table options (`CHARSET` / `CHARACTER SET`), `ALTER TABLE` (`CONVERT TO` / `DEFAULT CHARACTER SET`), and `CREATE DATABASE`/`CREATE SCHEMA` in MySQL and MariaDB.
  - Keeps `DEFAULT` and quoted/back-ticked names unchanged.

<sup>Written for commit 96fb3c3bdd3216a83342fd95221422f8e5106dbc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8314?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

