### PR TITLE
fix: make ignore matching case-insensitive on Windows

### DIFF
--- a/src/sqlfluff/core/linter/discovery.py
+++ b/src/sqlfluff/core/linter/discovery.py
@@ -36,6 +36,13 @@ IgnoreSpecRecord = tuple[str, str, IgnoreSpec]
 IgnoreSpecRecords = list[IgnoreSpecRecord]
 
 
+def _normalize_ignore_case(value: str) -> str:
+    """Normalize ignore matching case on case-insensitive filesystems."""
+    if os.path.normcase("A") == os.path.normcase("a"):
+        return value.casefold()
+    return value
+
+
 def _check_ignore_specs(
     absolute_filepath: str, ignore_specs: IgnoreSpecRecords
 ) -> Optional[str]:
@@ -45,7 +52,8 @@ def _check_ignore_specs(
         The path of an ignorefile if found, None otherwise.
     """
     for dirname, filename, spec in ignore_specs:
-        if spec.match_file(os.path.relpath(absolute_filepath, dirname)):
+        relative_path = os.path.relpath(absolute_filepath, dirname)
+        if spec.match_file(_normalize_ignore_case(relative_path)):
             return os.path.join(dirname, filename)
     return None
 
@@ -56,7 +64,8 @@ def _load_specs_from_lines(lines: Iterable[str], logging_reference: str) -> Igno
     Raises SQLFluffUserError if unparsable for any reason.
     """
     try:
-        return pathspec.PathSpec.from_lines("gitignore", lines)
+        normalized_lines = (_normalize_ignore_case(line) for line in lines)
+        return pathspec.PathSpec.from_lines("gitignore", normalized_lines)
     except Exception:
         _error_msg = f"Error parsing ignore patterns in {logging_reference}"
         # If the iterable is a Sequence type, then include the patterns.

--- a/test/core/linter/discovery_test.py
+++ b/test/core/linter/discovery_test.py
@@ -5,7 +5,11 @@ import os
 import pytest
 
 from sqlfluff.core.errors import SQLFluffUserError
-from sqlfluff.core.linter.discovery import _load_specs_from_lines, paths_from_path
+from sqlfluff.core.linter.discovery import (
+    _check_ignore_specs,
+    _load_specs_from_lines,
+    paths_from_path,
+)
 
 
 def normalise_paths(paths):
@@ -115,6 +119,20 @@ def test__linter__path_from_paths__ignore(path):
     assert normalise_paths(paths_from_path(path)) == {
         "test.fixtures.linter.sqlfluffignore.path_b.query_b.sql"
     }
+
+
+def test__linter__ignore_match_case_insensitive_filesystem(monkeypatch, tmp_path):
+    """Ignore matching follows filesystem case sensitivity."""
+    monkeypatch.setattr(os.path, "normcase", lambda value: value.casefold())
+    ignore_dir = str(tmp_path / "Project")
+    spec = _load_specs_from_lines(["database/skip.sql"], "<test>")
+
+    ignored_by = _check_ignore_specs(
+        os.path.join(ignore_dir, "DATABASE", "SKIP.SQL"),
+        [(ignore_dir, ".sqlfluffignore", spec)],
+    )
+
+    assert ignored_by == os.path.join(ignore_dir, ".sqlfluffignore")
 
 
 def test__linter__path_from_paths__specific_bad_ext():


### PR DESCRIPTION
### Brief summary of the change made

Fixes the mismatch in #5123 where SQLFluff can discover a Windows path using different drive/path casing, but `.sqlfluffignore` matching still treats the relative path as case-sensitive.

This change normalizes the case of both ignore patterns and candidate relative paths only when `os.path.normcase()` reports a case-insensitive platform. On case-sensitive platforms, matching is unchanged.

A focused regression test simulates Windows-style case normalization and verifies that an ignore pattern such as `database/skip.sql` also matches `DATABASE/SKIP.SQL`.

Fixes #5123

### Testing

I could not run the repository test suite locally in this execution environment because a repository checkout could not be fetched from GitHub. The added regression test is scoped to `test/core/linter/discovery_test.py`; CI should exercise it along with the normal project checks.

### AI-assisted contribution disclosure

AI assistance was used to identify the relevant discovery code, reason about the Windows path-case mismatch, and draft the focused implementation and regression test. The issue, existing contribution guidance, absence of a competing PR, and the resulting code changes were manually inspected before submission.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `.sqlfluffignore` matching case-insensitive on Windows so ignored files are consistently detected even if the path casing differs. This prevents missed ignores when SQLFluff discovers paths with different drive/path casing.

- **Bug Fixes**
  - Normalize case for ignore patterns and relative paths only on case-insensitive filesystems (via `os.path.normcase`), leaving other platforms unchanged.
  - Added a regression test that simulates Windows behavior to ensure `database/skip.sql` matches `DATABASE/SKIP.SQL`.

<sup>Written for commit 8f1f9ec4e62d053a4dcaa3f4a024c9b121d6e5af. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8315?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

