### PR TITLE
Support multiple placeholder parameter styles

### DIFF
--- a/docs/source/configuration/templating/placeholder.rst
+++ b/docs/source/configuration/templating/placeholder.rst
@@ -78,6 +78,21 @@ above. Notice that the value needs to be escaped as it will be replaced as a
 string during parsing. When the sample values aren't provided, the templater
 will use parameter names themselves by default.
 
+Multiple styles can be combined using a comma-separated value:
+
+.. code-block:: cfg
+
+    [sqlfluff:templater:placeholder]
+    param_style = colon, pyformat
+
+When configuring SQLFluff in :code:`pyproject.toml`, the styles can instead be
+provided as an array:
+
+.. code-block:: toml
+
+    [tool.sqlfluff.templater.placeholder]
+    param_style = ["colon", "pyformat"]
+
 When parameters are positional, like `question_mark`, then their name is
 simply the order in which they appear, starting with `1`.
 

--- a/docsv/configuration/templating/placeholder.md
+++ b/docsv/configuration/templating/placeholder.md
@@ -74,6 +74,21 @@ above. Notice that the value needs to be escaped as it will be replaced as a
 string during parsing. When the sample values aren't provided, the templater
 will use parameter names themselves by default.
 
+Multiple styles can be combined using a comma-separated value:
+
+```ini
+[sqlfluff:templater:placeholder]
+param_style = colon, pyformat
+```
+
+When configuring SQLFluff in `pyproject.toml`, the styles can instead be
+provided as an array:
+
+```toml
+[tool.sqlfluff.templater.placeholder]
+param_style = ["colon", "pyformat"]
+```
+
 When parameters are positional, like `question_mark`, then their name is
 simply the order in which they appear, starting with `1`.
 

--- a/src/sqlfluff/core/templaters/placeholder.py
+++ b/src/sqlfluff/core/templaters/placeholder.py
@@ -9,6 +9,7 @@ from sqlfluff.core.config import FluffConfig
 from sqlfluff.core.errors import SQLTemplaterError
 from sqlfluff.core.formatter import FormatterInterface
 from sqlfluff.core.helpers.slice import offset_slice
+from sqlfluff.core.helpers.string import split_comma_separated_string
 from sqlfluff.core.templaters.base import (
     RawFileSlice,
     RawTemplater,
@@ -24,8 +25,10 @@ KNOWN_STYLES = {
     # e.g. WHERE bla = :name
     "colon": regex.compile(r"(?<![:\w\x5c]):(?P<param_name>\w+)", regex.UNICODE),
     # e.g. SELECT :"column" FROM :table WHERE bla = :'name'
+    # Use a named backreference so it remains valid in a combined pattern.
     "colon_optional_quotes": regex.compile(
-        r"(?<!:):(?P<quotation>['\"]?)(?P<param_name>[\w_]+)\1", regex.UNICODE
+        r"(?<!:):(?P<quotation>['\"]?)(?P<param_name>[\w_]+)(?P=quotation)",
+        regex.UNICODE,
     ),
     # e.g. WHERE bla = table:name - use with caution as more prone to false positives
     "colon_nospaces": regex.compile(r"(?<!:):(?P<param_name>\w+)", regex.UNICODE),
@@ -100,13 +103,29 @@ class PlaceholderTemplater(RawTemplater):
             )
         elif "param_style" in live_context:
             param_style = live_context["param_style"]
-            if param_style not in KNOWN_STYLES:
+            param_styles = split_comma_separated_string(param_style)
+            unknown_param_styles = [
+                style for style in param_styles if style not in KNOWN_STYLES
+            ]
+            if not param_styles:
+                unknown_param_styles = [str(param_style)]
+            if unknown_param_styles:
                 raise ValueError(
                     'Unknown param_style "{}", available are: {}'.format(
-                        param_style, list(KNOWN_STYLES.keys())
+                        ", ".join(unknown_param_styles), list(KNOWN_STYLES.keys())
                     )
                 )
-            live_context["__bind_param_regex"] = KNOWN_STYLES[param_style]
+            if len(param_styles) == 1:
+                live_context["__bind_param_regex"] = KNOWN_STYLES[param_styles[0]]
+            else:
+                combined_pattern = "|".join(
+                    f"(?:{KNOWN_STYLES[style].pattern})" for style in param_styles
+                )
+                # Some styles overlap (e.g. $name and $name$), so prefer the
+                # longest complete match regardless of configuration order.
+                live_context["__bind_param_regex"] = regex.compile(
+                    combined_pattern, regex.UNICODE | regex.POSIX
+                )
         else:
             raise ValueError(
                 "No param_regex nor param_style was provided to the placeholder "
@@ -154,18 +173,18 @@ class PlaceholderTemplater(RawTemplater):
         param_counter = 1
         for found_param in regex.finditer(in_str):
             span = found_param.span()
-            if "param_name" not in found_param.groupdict():
+            groups = found_param.groupdict()
+            param_name = groups.get("param_name")
+            if param_name is None:
                 param_name = str(param_counter)
                 param_counter += 1
-            else:
-                param_name = found_param["param_name"]
             last_literal_length = span[0] - last_pos_raw
             if param_name in context:
                 replacement = str(context[param_name])
             else:
                 replacement = param_name
-            if "quotation" in found_param.groupdict():
-                quotation = found_param["quotation"]
+            quotation = groups.get("quotation")
+            if quotation is not None:
                 replacement = quotation + replacement + quotation
             # add the literal to the slices
             template_slices.append(

--- a/test/core/templaters/placeholder_test.py
+++ b/test/core/templaters/placeholder_test.py
@@ -3,6 +3,7 @@
 import pytest
 
 from sqlfluff.core import FluffConfig
+from sqlfluff.core.config import load_config_file
 from sqlfluff.core.templaters import PlaceholderTemplater
 
 
@@ -403,6 +404,102 @@ def test__templater_param_style(instr, expected_outstr, param_style, values):
     assert str(outstr) == expected_outstr
 
 
+@pytest.mark.parametrize(
+    "config_filename,config_string",
+    [
+        (
+            ".sqlfluff",
+            """[sqlfluff]
+dialect = ansi
+templater = placeholder
+
+[sqlfluff:templater:placeholder]
+param_style = colon, pyformat
+user_id = 42
+start_date = '2021-10-01'
+""",
+        ),
+        (
+            "pyproject.toml",
+            """[tool.sqlfluff.core]
+dialect = "ansi"
+templater = "placeholder"
+
+[tool.sqlfluff.templater.placeholder]
+param_style = ["colon", "pyformat"]
+user_id = "42"
+start_date = "'2021-10-01'"
+""",
+        ),
+    ],
+    ids=["comma_separated_ini", "toml_list"],
+)
+def test__templater_multiple_param_styles(tmp_path, config_filename, config_string):
+    """Test combining named parameter styles from supported config formats."""
+    (tmp_path / config_filename).write_text(config_string, encoding="utf-8")
+    config = FluffConfig(configs=load_config_file(str(tmp_path), config_filename))
+    t = PlaceholderTemplater()
+    outstr, _ = t.process(
+        in_str="SELECT :user_id, %(start_date)s",
+        fname="test",
+        config=config,
+    )
+    assert str(outstr) == "SELECT 42, '2021-10-01'"
+
+
+def test__templater_multiple_param_styles_with_positional_parameters():
+    """Test positional numbering across multiple unnamed parameter styles."""
+    t = PlaceholderTemplater(
+        override_context={
+            "param_style": "colon, question_mark, percent",
+            "named": "named_value",
+            "1": "first_value",
+            "2": "second_value",
+        }
+    )
+    outstr, _ = t.process(
+        in_str="SELECT :named, ?, %s",
+        fname="test",
+        config=FluffConfig(overrides={"dialect": "ansi"}),
+    )
+    assert str(outstr) == "SELECT named_value, first_value, second_value"
+
+
+@pytest.mark.parametrize(
+    "param_style,instr,values,expected_outstr",
+    [
+        (
+            "dollar, dollar_surround, flyway_var",
+            "SELECT $plain, $surrounded$, ${flyway:schema}",
+            {
+                "plain": "plain_value",
+                "surrounded": "surrounded_value",
+                "flyway:schema": "schema_value",
+            },
+            "SELECT plain_value, surrounded_value, schema_value",
+        ),
+        (
+            "colon, colon_optional_quotes",
+            "SELECT :plain, :'quoted'",
+            {"plain": "plain_value", "quoted": "quoted_value"},
+            "SELECT plain_value, 'quoted_value'",
+        ),
+    ],
+    ids=["longest_match", "optional_capture"],
+)
+def test__templater_multiple_param_styles_overlap(
+    param_style, instr, values, expected_outstr
+):
+    """Test overlapping styles prefer complete matches and optional captures."""
+    t = PlaceholderTemplater(override_context={**values, "param_style": param_style})
+    outstr, _ = t.process(
+        in_str=instr,
+        fname="test",
+        config=FluffConfig(overrides={"dialect": "ansi"}),
+    )
+    assert str(outstr) == expected_outstr
+
+
 def test__templater_custom_regex():
     """Test custom regex templating."""
     t = PlaceholderTemplater(
@@ -441,4 +538,12 @@ def test__templater_styles():
     """Test the exception raised when parameter style is unknown."""
     t = PlaceholderTemplater(override_context=dict(param_style="pperccent"))
     with pytest.raises(ValueError, match=r"Unknown param_style"):
+        t.process(in_str="SELECT 2+2", fname="test")
+
+
+@pytest.mark.parametrize("param_style", ["colon, invalid", ["colon", "invalid"]])
+def test__templater_multiple_param_styles_unknown(param_style):
+    """Test the exception raised when one parameter style is unknown."""
+    t = PlaceholderTemplater(override_context={"param_style": param_style})
+    with pytest.raises(ValueError, match=r'Unknown param_style "invalid"'):
         t.process(in_str="SELECT 2+2", fname="test")


### PR DESCRIPTION
### Brief summary of the change made

Fixes #6291.

The placeholder templater now accepts multiple known parameter styles in either of the configuration forms SQLFluff supports:

- A comma-separated value in `.sqlfluff`, such as `param_style = colon, pyformat`.
- An array in `pyproject.toml`, such as `param_style = ["colon", "pyformat"]`.

The configured patterns are combined with leftmost-longest matching so overlapping styles such as `dollar` and `dollar_surround` behave consistently regardless of configuration order. Positional numbering is preserved when named and unnamed placeholder styles are mixed.

Regression coverage includes both config formats, named/positional combinations, overlapping styles, optional captures, and invalid entries. The Sphinx and VitePress documentation trees are both updated.

Validation:

- Full Python 3.14 suite: 10,725 passed, 2,544 expected skips.
- Placeholder/config focused suite: 67 passed.
- Repository pre-commit suite, Ruff, mypy (normal and strict), doc8, yamllint, codespell, and import checks passed.
- VitePress production documentation build passed.

AI assistance was used materially for issue analysis, implementation, tests, documentation, diff review, and validation. The contributor manually reviewed the complete four-file diff. The automated and agent-run validation performed is listed above.

### Are there any other side effects of this change that we should be aware of?

Existing single-style configurations retain their existing compiled pattern. Multi-style configurations use the regex module's POSIX mode to resolve overlapping alternatives to the longest complete match. Unknown styles continue to raise a `ValueError`, now identifying the invalid entries in a list.

### Pull Request checklist

- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate the code changes.
- Added appropriate documentation for the change.
- No separate follow-up issue is needed for this scoped change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Support multiple placeholder parameter styles in the `sqlfluff` placeholder templater. This lets users mix styles and ensures overlapping patterns are matched consistently.

- **New Features**
  - Accept multiple `param_style` values via comma-separated `.sqlfluff` or array in `pyproject.toml`.
  - Combine styles with leftmost-longest matching using `regex` POSIX mode to resolve overlaps.
  - Preserve positional numbering when mixing named and unnamed styles.
  - Clear errors list unknown styles; updated docs and tests.

<sup>Written for commit c267a67a46148a4f1b8a0cab1b14182c1c8b8d12. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8317?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


