### PR TITLE
MariaDB: support NEXT VALUE FOR / PREVIOUS VALUE FOR sequence value expressions

### DIFF
--- a/src/sqlfluff/dialects/dialect_mariadb.py
+++ b/src/sqlfluff/dialects/dialect_mariadb.py
@@ -70,7 +70,42 @@ mariadb_dialect.replace(
             ),
         ),
     ),
+    # Allow the MariaDB sequence value expressions `NEXT VALUE FOR seq` and
+    # `PREVIOUS VALUE FOR seq` anywhere an expression is valid (SELECT, VALUES).
+    # The dedicated segment is tried first so a leading NEXT/PREVIOUS is not
+    # consumed as a column reference.
+    Expression_C_Grammar=OneOf(
+        Ref("SequenceValueForSegment"),
+        mysql_dialect.get_grammar("Expression_C_Grammar"),
+    ),
+    # A column DEFAULT may use a sequence value expression, either bare
+    # (`DEFAULT NEXT VALUE FOR seq`) or bracketed (`DEFAULT (NEXT VALUE FOR
+    # seq)`) -- both are accepted by MariaDB. The base column-default grammar
+    # only allows literals/functions, so it does not cover this.
+    ColumnConstraintDefaultGrammar=OneOf(
+        Ref("SequenceValueForSegment"),
+        Bracketed(Ref("SequenceValueForSegment")),
+        mysql_dialect.get_grammar("ColumnConstraintDefaultGrammar"),
+    ),
 )
+
+
+class SequenceValueForSegment(BaseSegment):
+    """A MariaDB ``NEXT VALUE FOR`` / ``PREVIOUS VALUE FOR`` sequence expression.
+
+    ``NEXT VALUE FOR seq`` is equivalent to ``NEXTVAL(seq)`` and
+    ``PREVIOUS VALUE FOR seq`` to ``LASTVAL(seq)``.
+
+    https://mariadb.com/kb/en/sequence-overview/
+    """
+
+    type = "sequence_value_for_expression"
+    match_grammar: Matchable = Sequence(
+        OneOf("NEXT", "PREVIOUS"),
+        "VALUE",
+        "FOR",
+        Ref("SequenceReferenceSegment"),
+    )
 
 
 class ColumnConstraintSegment(mysql.ColumnConstraintSegment):

--- a/test/dialects/dialects_test.py
+++ b/test/dialects/dialects_test.py
@@ -219,3 +219,20 @@ def test_tsql_cursor_rejects_disallowed_select_clauses(sql: str) -> None:
     parsing_errors = [v for v in parsed.violations if v.rule_code() == "PRS"]
 
     assert parsing_errors
+
+
+@pytest.mark.parametrize(
+    "sql",
+    [
+        # `FOR` is mandatory (real MariaDB rejects `NEXT VALUE OF s`).
+        "SELECT NEXT VALUE OF s;",
+        # The sequence name is mandatory.
+        "SELECT NEXT VALUE FOR;",
+    ],
+)
+def test_mariadb_sequence_value_for_requires_sequence(sql: str) -> None:
+    """`NEXT/PREVIOUS VALUE FOR` needs the `FOR` keyword and a sequence name."""
+    parsed = Linter(dialect="mariadb").parse_string(sql)
+    parsing_errors = [v for v in parsed.violations if v.rule_code() == "PRS"]
+
+    assert parsing_errors

--- a/test/fixtures/dialects/mariadb/sequence_value_for.sql
+++ b/test/fixtures/dialects/mariadb/sequence_value_for.sql
@@ -1,0 +1,19 @@
+-- MariaDB sequence value expressions.
+-- NEXT VALUE FOR seq     == NEXTVAL(seq)
+-- PREVIOUS VALUE FOR seq == LASTVAL(seq)
+-- https://mariadb.com/kb/en/sequence-overview/
+
+SELECT NEXT VALUE FOR s;
+
+SELECT PREVIOUS VALUE FOR s;
+
+-- Schema-qualified sequence name.
+SELECT NEXT VALUE FOR my_schema.s;
+
+-- Usable wherever an expression is valid.
+INSERT INTO t (id) VALUES (NEXT VALUE FOR s);
+
+-- As a column DEFAULT, bracketed and bare (both accepted by MariaDB).
+CREATE TABLE t_bracketed (a INT PRIMARY KEY DEFAULT (NEXT VALUE FOR s), b INT);
+
+CREATE TABLE t_bare (a INT DEFAULT NEXT VALUE FOR s);

--- a/test/fixtures/dialects/mariadb/sequence_value_for.yml
+++ b/test/fixtures/dialects/mariadb/sequence_value_for.yml
@@ -1,0 +1,127 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: fcfe05030a3eda990c8e487a680a99f739df7070dd40bdeb56ba80a4670ee0a3
+file:
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+            sequence_value_for_expression:
+            - keyword: NEXT
+            - keyword: VALUE
+            - keyword: FOR
+            - sequence_reference:
+                naked_identifier: s
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+            sequence_value_for_expression:
+            - keyword: PREVIOUS
+            - keyword: VALUE
+            - keyword: FOR
+            - sequence_reference:
+                naked_identifier: s
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+            sequence_value_for_expression:
+            - keyword: NEXT
+            - keyword: VALUE
+            - keyword: FOR
+            - sequence_reference:
+              - naked_identifier: my_schema
+              - dot: .
+              - naked_identifier: s
+- statement_terminator: ;
+- statement:
+    insert_statement:
+    - keyword: INSERT
+    - keyword: INTO
+    - table_reference:
+        naked_identifier: t
+    - bracketed:
+        start_bracket: (
+        column_reference:
+          naked_identifier: id
+        end_bracket: )
+    - values_clause:
+        keyword: VALUES
+        bracketed:
+          start_bracket: (
+          expression:
+            sequence_value_for_expression:
+            - keyword: NEXT
+            - keyword: VALUE
+            - keyword: FOR
+            - sequence_reference:
+                naked_identifier: s
+          end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: t_bracketed
+    - bracketed:
+      - start_bracket: (
+      - column_definition:
+        - naked_identifier: a
+        - data_type:
+            data_type_identifier: INT
+        - column_constraint_segment:
+          - keyword: PRIMARY
+          - keyword: KEY
+        - column_constraint_segment:
+            keyword: DEFAULT
+            bracketed:
+              start_bracket: (
+              sequence_value_for_expression:
+              - keyword: NEXT
+              - keyword: VALUE
+              - keyword: FOR
+              - sequence_reference:
+                  naked_identifier: s
+              end_bracket: )
+      - comma: ','
+      - column_definition:
+          naked_identifier: b
+          data_type:
+            data_type_identifier: INT
+      - end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: t_bare
+    - bracketed:
+        start_bracket: (
+        column_definition:
+          naked_identifier: a
+          data_type:
+            data_type_identifier: INT
+          column_constraint_segment:
+            keyword: DEFAULT
+            sequence_value_for_expression:
+            - keyword: NEXT
+            - keyword: VALUE
+            - keyword: FOR
+            - sequence_reference:
+                naked_identifier: s
+        end_bracket: )
+- statement_terminator: ;


### PR DESCRIPTION
### Brief summary of the change made

MariaDB exposes a sequence's value through two equivalent syntaxes: the function form (`NEXTVAL(seq)`, `LASTVAL(seq)`) and the keyword form (`NEXT VALUE FOR seq`, `PREVIOUS VALUE FOR seq`). The function form already parsed; the keyword form was **unparsable**.

This adds a mariadb-only `SequenceValueForSegment` and wires it in two places:
- the expression atom (`Expression_C_Grammar`) — covers `SELECT`, `INSERT ... VALUES`, and any expression context;
- the column `DEFAULT` grammar — MariaDB accepts both the bare (`DEFAULT NEXT VALUE FOR seq`) and bracketed (`DEFAULT (NEXT VALUE FOR seq)`) forms.

The sequence name reuses the existing `SequenceReferenceSegment`, so schema-qualified names (`NEXT VALUE FOR my_schema.s`) parse.

All added cases were validated against a real MariaDB 11.8.8 server, including the negative controls (`NEXT VALUE OF s` and a missing sequence name both raise `ERROR 1064`).

### Are there any other side effects of this change that we should be aware of?

None. MySQL has no sequences, so the change is confined to the mariadb dialect — the mysql and ansi dialects are untouched. A leading `NEXT`/`PREVIOUS` used as an ordinary identifier still parses as before (the dedicated segment is tried first but falls through cleanly). Pre-existing behaviour such as `DEFAULT (1 + 2)` being unsupported is unchanged (it is shared with the mysql dialect and out of scope here).

### Pull Request checklist

- Included test cases:
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects/mariadb/sequence_value_for.sql` (+ generated `.yml`).
  - Negative parse tests in `test/dialects/dialects_test.py` (`test_mariadb_sequence_value_for_requires_sequence`).

> 🤖 This change was developed with the assistance of AI (Claude). The grammar, tests, and syntax were reviewed and validated against a real MariaDB server and the official MariaDB documentation.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Parse MariaDB sequence value expressions in keyword form. Previously, `NEXT VALUE FOR seq` and `PREVIOUS VALUE FOR seq` failed to parse; now they parse in expression contexts and as column DEFAULTs (bare and bracketed).

- Add a MariaDB-only SequenceValueForSegment and wire it into Expression_C_Grammar and ColumnConstraintDefaultGrammar (tried before generic expressions).
- Reuse SequenceReferenceSegment so schema-qualified names parse.
- Scope the change to the mariadb dialect; mysql/ansi are unchanged and identifiers starting with NEXT/PREVIOUS still parse as before.
- Add SQL/YML fixtures and negative tests to require `FOR` and a sequence name.

<sup>Written for commit b7babd306c660a20281f161bc9107d1126674be6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8318?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

