### PR TITLE
Improve versioned docs publishing: manual republish, pre-upload validation

### DIFF
--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -80,15 +80,45 @@ jobs:
                   build_stable=true
               fi
           elif [ -n "${DISPATCH_VERSION}" ]; then
+              # `version` is free text typed into the dispatch form, and it
+              # becomes a directory name, a manifest path, and a docs base. Pin
+              # it to the shape of a tag before any of that: no separators, no
+              # traversal, and nothing a shell would treat as syntax.
+              case "${DISPATCH_VERSION}" in
+                  *[!A-Za-z0-9._-]* | *..* | .* | -*)
+                      echo "::error::version must be a release tag made up of" \
+                          "letters, digits, dots, underscores and hyphens," \
+                          "got '${DISPATCH_VERSION}'." >&2
+                      exit 1
+                      ;;
+              esac
+
               # The release path refuses to promote a prerelease to stable, and
               # versioned-docs-hosting.md keeps prereleases off that channel, so
-              # a manual run must not be able to do it either. Fail loudly rather
-              # than quietly ignoring one of the two inputs.
-              if [ "${DISPATCH_PRERELEASE}" = "true" ] \
-                  && [ "${DISPATCH_REFRESH_STABLE}" = "true" ]; then
-                  echo "::error::refresh_stable cannot be used with prerelease:" \
-                      "/en/stable/ must point at a final release." >&2
-                  exit 1
+              # a manual run must not be able to do it either.
+              #
+              # The `prerelease` input alone cannot enforce that: it defaults to
+              # false and nothing checks it against the tag, so `4.0.0a1` with the
+              # box left unticked would repoint stable at a prerelease. Require
+              # the tag itself to look like a final release instead, which does not
+              # depend on the operator having classified it correctly.
+              if [ "${DISPATCH_REFRESH_STABLE}" = "true" ]; then
+                  if [ "${DISPATCH_PRERELEASE}" = "true" ]; then
+                      echo "::error::refresh_stable cannot be used with" \
+                          "prerelease: /en/stable/ must point at a final" \
+                          "release." >&2
+                      exit 1
+                  fi
+
+                  case "${DISPATCH_VERSION}" in
+                      *[!0-9.]*)
+                          echo "::error::refresh_stable needs a final release" \
+                              "version such as 3.4.2, got" \
+                              "'${DISPATCH_VERSION}'. /en/stable/ must point at" \
+                              "a final release." >&2
+                          exit 1
+                          ;;
+                  esac
               fi
 
               version="${DISPATCH_VERSION}"
@@ -98,6 +128,15 @@ jobs:
               build_release=true
               build_stable="${DISPATCH_REFRESH_STABLE}"
           else
+              # There is no version for stable to point at on this path, and
+              # publishing `latest` while ignoring the request would look like it
+              # had worked.
+              if [ "${DISPATCH_REFRESH_STABLE}" = "true" ]; then
+                  echo "::error::refresh_stable needs a version to point" \
+                      "/en/stable/ at." >&2
+                  exit 1
+              fi
+
               version=latest
               prerelease=false
               published_at=
@@ -179,17 +218,34 @@ jobs:
         working-directory: docsv
         run: corepack pnpm run docs:build
 
+      # The version and the timestamp originate as free text on the dispatch
+      # path, so they are passed through `env` and quoted rather than pasted into
+      # the command by expression substitution, which the shell would evaluate
+      # before the script ran.
       - name: Assemble release site
         if: ${{ steps.docs-target.outputs.build_release == 'true' }}
-        run: >-
-          python docsv/scripts/assemble-site.py
-          --vitepress-dist docsv/.vitepress/dist
-          --output-dir ${{ env.DOCS_SITE_DIR }}
-          --channel ${{ steps.docs-target.outputs.version }}
-          --title ${{ steps.docs-target.outputs.version }}
-          --kind release
-          ${{ steps.docs-target.outputs.published_at && format('--published-at {0}', steps.docs-target.outputs.published_at) || '' }}
-          ${{ steps.docs-target.outputs.prerelease == 'true' && '--prerelease' || '' }}
+        env:
+          VERSION: ${{ steps.docs-target.outputs.version }}
+          PUBLISHED_AT: ${{ steps.docs-target.outputs.published_at }}
+          PRERELEASE: ${{ steps.docs-target.outputs.prerelease }}
+        run: |
+          args=(
+              --vitepress-dist docsv/.vitepress/dist
+              --output-dir "${DOCS_SITE_DIR}"
+              --channel "${VERSION}"
+              --title "${VERSION}"
+              --kind release
+          )
+
+          if [ -n "${PUBLISHED_AT}" ]; then
+              args+=(--published-at "${PUBLISHED_AT}")
+          fi
+
+          if [ "${PRERELEASE}" = "true" ]; then
+              args+=(--prerelease)
+          fi
+
+          python docsv/scripts/assemble-site.py "${args[@]}"
 
       - name: ⚒️ Build VitePress stable docs
         if: ${{ steps.docs-target.outputs.build_stable == 'true' }}
@@ -201,14 +257,16 @@ jobs:
 
       - name: Assemble stable site
         if: ${{ steps.docs-target.outputs.build_stable == 'true' }}
-        run: >-
-          python docsv/scripts/assemble-site.py
-          --vitepress-dist docsv/.vitepress/dist
-          --output-dir ${{ env.DOCS_SITE_DIR }}
-          --channel stable
-          --title Stable
-          --kind channel
-          --stable-release ${{ steps.docs-target.outputs.version }}
+        env:
+          VERSION: ${{ steps.docs-target.outputs.version }}
+        run: |
+          python docsv/scripts/assemble-site.py \
+              --vitepress-dist docsv/.vitepress/dist \
+              --output-dir "${DOCS_SITE_DIR}" \
+              --channel stable \
+              --title Stable \
+              --kind channel \
+              --stable-release "${VERSION}"
 
       # Runs after every assemble step and before anything leaves the runner, so
       # a tree which would 404 or advertise a version it did not build fails the

--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -9,6 +9,25 @@ on:
     types:
       - published
   workflow_dispatch:
+    inputs:
+      version:
+        description: Release tag to rebuild. Leave empty to publish latest from the selected ref.
+        required: false
+        type: string
+      refresh_stable:
+        description: Also refresh /en/stable/ from the selected release tag.
+        required: false
+        default: false
+        type: boolean
+      prerelease:
+        description: Mark the manually rebuilt version as a prerelease.
+        required: false
+        default: false
+        type: boolean
+      published_at:
+        description: Optional published_at timestamp to preserve in versions.json.
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -32,7 +51,70 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          ref: ${{ github.event_name == 'release' && github.event.release.tag_name || github.ref }}
+          ref: ${{ github.event_name == 'release' && github.event.release.tag_name || inputs.version || github.ref }}
+
+      # Resolves the three trigger paths — push, release, and manual dispatch —
+      # into one set of outputs, so the build and assemble steps below share a
+      # single decision rather than restating the release semantics in each
+      # `if:` expression.
+      - name: Determine docs publish target
+        id: docs-target
+        env:
+          DISPATCH_VERSION: ${{ inputs.version }}
+          DISPATCH_REFRESH_STABLE: ${{ inputs.refresh_stable }}
+          DISPATCH_PRERELEASE: ${{ inputs.prerelease }}
+          DISPATCH_PUBLISHED_AT: ${{ inputs.published_at }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_PRERELEASE: ${{ github.event.release.prerelease }}
+          RELEASE_PUBLISHED_AT: ${{ github.event.release.published_at }}
+        run: |
+          if [ "${{ github.event_name }}" = "release" ]; then
+              version="${RELEASE_TAG}"
+              prerelease="${RELEASE_PRERELEASE}"
+              published_at="${RELEASE_PUBLISHED_AT}"
+              build_latest=false
+              build_release=true
+              if [ "${RELEASE_PRERELEASE}" = "true" ]; then
+                  build_stable=false
+              else
+                  build_stable=true
+              fi
+          elif [ -n "${DISPATCH_VERSION}" ]; then
+              # The release path refuses to promote a prerelease to stable, and
+              # versioned-docs-hosting.md keeps prereleases off that channel, so
+              # a manual run must not be able to do it either. Fail loudly rather
+              # than quietly ignoring one of the two inputs.
+              if [ "${DISPATCH_PRERELEASE}" = "true" ] \
+                  && [ "${DISPATCH_REFRESH_STABLE}" = "true" ]; then
+                  echo "::error::refresh_stable cannot be used with prerelease:" \
+                      "/en/stable/ must point at a final release." >&2
+                  exit 1
+              fi
+
+              version="${DISPATCH_VERSION}"
+              prerelease="${DISPATCH_PRERELEASE}"
+              published_at="${DISPATCH_PUBLISHED_AT}"
+              build_latest=false
+              build_release=true
+              build_stable="${DISPATCH_REFRESH_STABLE}"
+          else
+              version=latest
+              prerelease=false
+              published_at=
+              build_latest=true
+              build_release=false
+              build_stable=false
+          fi
+
+          {
+              echo "version=${version}"
+              echo "release_base=/en/${version}/"
+              echo "prerelease=${prerelease}"
+              echo "published_at=${published_at}"
+              echo "build_latest=${build_latest}"
+              echo "build_release=${build_release}"
+              echo "build_stable=${build_stable}"
+          } >> "${GITHUB_OUTPUT}"
 
       - name: 📦 Enable corepack
         run: corepack enable
@@ -72,7 +154,7 @@ jobs:
           --endpoint-url https://${{ secrets.R2_ACCOUNT_ID }}.r2.cloudflarestorage.com
 
       - name: ⚒️ Build VitePress latest docs
-        if: ${{ github.event_name != 'release' }}
+        if: ${{ steps.docs-target.outputs.build_latest == 'true' }}
         env:
           SQLFLUFF_DOCS_BASE: /en/latest/
           SQLFLUFF_DOCS_NOINDEX: ${{ env.SQLFLUFF_DOCS_NOINDEX }}
@@ -80,7 +162,7 @@ jobs:
         run: corepack pnpm run docs:build
 
       - name: Assemble latest site
-        if: ${{ github.event_name != 'release' }}
+        if: ${{ steps.docs-target.outputs.build_latest == 'true' }}
         run: >-
           python docsv/scripts/assemble-site.py
           --vitepress-dist docsv/.vitepress/dist
@@ -90,27 +172,27 @@ jobs:
           --kind channel
 
       - name: ⚒️ Build VitePress release docs
-        if: ${{ github.event_name == 'release' }}
+        if: ${{ steps.docs-target.outputs.build_release == 'true' }}
         env:
-          SQLFLUFF_DOCS_BASE: /en/${{ github.event.release.tag_name }}/
+          SQLFLUFF_DOCS_BASE: ${{ steps.docs-target.outputs.release_base }}
           SQLFLUFF_DOCS_NOINDEX: ${{ env.SQLFLUFF_DOCS_NOINDEX }}
         working-directory: docsv
         run: corepack pnpm run docs:build
 
       - name: Assemble release site
-        if: ${{ github.event_name == 'release' }}
+        if: ${{ steps.docs-target.outputs.build_release == 'true' }}
         run: >-
           python docsv/scripts/assemble-site.py
           --vitepress-dist docsv/.vitepress/dist
           --output-dir ${{ env.DOCS_SITE_DIR }}
-          --channel ${{ github.event.release.tag_name }}
-          --title ${{ github.event.release.tag_name }}
+          --channel ${{ steps.docs-target.outputs.version }}
+          --title ${{ steps.docs-target.outputs.version }}
           --kind release
-          --published-at ${{ github.event.release.published_at }}
-          ${{ github.event.release.prerelease && '--prerelease' || '' }}
+          ${{ steps.docs-target.outputs.published_at && format('--published-at {0}', steps.docs-target.outputs.published_at) || '' }}
+          ${{ steps.docs-target.outputs.prerelease == 'true' && '--prerelease' || '' }}
 
       - name: ⚒️ Build VitePress stable docs
-        if: ${{ github.event_name == 'release' && !github.event.release.prerelease }}
+        if: ${{ steps.docs-target.outputs.build_stable == 'true' }}
         env:
           SQLFLUFF_DOCS_BASE: /en/stable/
           SQLFLUFF_DOCS_NOINDEX: ${{ env.SQLFLUFF_DOCS_NOINDEX }}
@@ -118,7 +200,7 @@ jobs:
         run: corepack pnpm run docs:build
 
       - name: Assemble stable site
-        if: ${{ github.event_name == 'release' && !github.event.release.prerelease }}
+        if: ${{ steps.docs-target.outputs.build_stable == 'true' }}
         run: >-
           python docsv/scripts/assemble-site.py
           --vitepress-dist docsv/.vitepress/dist
@@ -126,7 +208,7 @@ jobs:
           --channel stable
           --title Stable
           --kind channel
-          --stable-release ${{ github.event.release.tag_name }}
+          --stable-release ${{ steps.docs-target.outputs.version }}
 
       - name: ⬆️ Upload assembled site artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -210,6 +210,14 @@ jobs:
           --kind channel
           --stable-release ${{ steps.docs-target.outputs.version }}
 
+      # Runs after every assemble step and before anything leaves the runner, so
+      # a tree which would 404 or advertise a version it did not build fails the
+      # run instead of reaching R2 and Netlify.
+      - name: Smoke check assembled site
+        run: >-
+          python docsv/scripts/smoke-check-assembled-site.py
+          --site-dir ${{ env.DOCS_SITE_DIR }}
+
       - name: ⬆️ Upload assembled site artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -93,6 +93,20 @@ jobs:
                       ;;
               esac
 
+              # `published_at` reaches `$GITHUB_OUTPUT`, which is a list of
+              # `key=value` lines, so a newline in it writes further keys. Those
+              # land after the ones set above and would take precedence over
+              # them, which is enough to restore a `version` this validation has
+              # just rejected. Restrict it to the characters a timestamp needs;
+              # that excludes newlines by construction.
+              case "${DISPATCH_PUBLISHED_AT}" in
+                  *[!0-9TZ:.+-]*)
+                      echo "::error::published_at must be a timestamp such as" \
+                          "2026-07-14 or 2026-07-14T09:30:00Z." >&2
+                      exit 1
+                      ;;
+              esac
+
               # The release path refuses to promote a prerelease to stable, and
               # versioned-docs-hosting.md keeps prereleases off that channel, so
               # a manual run must not be able to do it either.
@@ -110,10 +124,25 @@ jobs:
                       exit 1
                   fi
 
-                  case "${DISPATCH_VERSION}" in
+                  # A post-release is a final release: `4.0.1.post1` is a real
+                  # tag here. Set it aside before requiring digits and dots, so
+                  # the check still rejects the prerelease form this project
+                  # uses, `4.0.0a1`, without also rejecting a post-release.
+                  final_version="${DISPATCH_VERSION}"
+                  case "${final_version}" in
+                      *.post*)
+                          post_segment="${final_version##*.post}"
+                          case "${post_segment}" in
+                              "" | *[!0-9]*) ;;
+                              *) final_version="${final_version%.post*}" ;;
+                          esac
+                          ;;
+                  esac
+
+                  case "${final_version}" in
                       *[!0-9.]*)
                           echo "::error::refresh_stable needs a final release" \
-                              "version such as 3.4.2, got" \
+                              "version such as 3.4.2 or 4.0.1.post1, got" \
                               "'${DISPATCH_VERSION}'. /en/stable/ must point at" \
                               "a final release." >&2
                           exit 1

--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -97,12 +97,25 @@ jobs:
               # `key=value` lines, so a newline in it writes further keys. Those
               # land after the ones set above and would take precedence over
               # them, which is enough to restore a `version` this validation has
-              # just rejected. Restrict it to the characters a timestamp needs;
-              # that excludes newlines by construction.
+              # just rejected.
+              #
+              # Matched against the shapes a timestamp actually takes rather than
+              # a permitted character set. A character set stops the injection,
+              # but it also accepts `+++`, which would be written into
+              # versions.json and shown to readers by the picker. The accepted
+              # forms are a plain date and the `published_at` format the release
+              # event supplies, so a value can be copied from a release.
               case "${DISPATCH_PUBLISHED_AT}" in
-                  *[!0-9TZ:.+-]*)
-                      echo "::error::published_at must be a timestamp such as" \
-                          "2026-07-14 or 2026-07-14T09:30:00Z." >&2
+                  "") ;;
+                  [0-9][0-9][0-9][0-9]-[0-1][0-9]-[0-3][0-9]) ;;
+                  [0-9][0-9][0-9][0-9]-[0-1][0-9]-[0-3][0-9]T[0-2][0-9]:[0-5][0-9]:[0-6][0-9]Z) ;;
+                  [0-9][0-9][0-9][0-9]-[0-1][0-9]-[0-3][0-9]T[0-2][0-9]:[0-5][0-9]:[0-6][0-9]) ;;
+                  [0-9][0-9][0-9][0-9]-[0-1][0-9]-[0-3][0-9]T[0-2][0-9]:[0-5][0-9]:[0-6][0-9][+-][0-2][0-9]:[0-5][0-9]) ;;
+                  *)
+                      echo "::error::published_at must be a date such as" \
+                          "2026-07-14, or a timestamp such as" \
+                          "2026-07-14T09:30:00Z, got" \
+                          "'${DISPATCH_PUBLISHED_AT}'." >&2
                       exit 1
                       ;;
               esac

--- a/docsv/.vitepress/config.ts
+++ b/docsv/.vitepress/config.ts
@@ -76,7 +76,14 @@ const REFERENCES: DefaultTheme.NavItemWithLink[] = [
     { text: 'Release Notes', link: '/reference/release-notes' },
 ]
 
-const docsBase = normalizeBase(process.env.SQLFLUFF_DOCS_BASE, '/sqlfluff/')
+/**
+ * Defaults to the layout the site is actually published under, so a local build
+ * matches production without being told to. `/sqlfluff/` matched nothing that is
+ * deployed, and because the version picker reads the current version out of the
+ * base, an unversioned default meant the picker and the version notice could not
+ * appear locally at all. Every publishing path sets this explicitly.
+ */
+const docsBase = normalizeBase(process.env.SQLFLUFF_DOCS_BASE, '/en/latest/')
 const noIndex = process.env.SQLFLUFF_DOCS_NOINDEX === '1'
 
 assertDesignPackage()
@@ -125,10 +132,9 @@ if (noIndex) {
  * The release entries it names are not built locally, so following one of those
  * links in dev lands on the dev server's own 404.
  *
- * A versioned base is required for any of this to appear, since the picker takes
- * the current version from the base:
- *
- *   SQLFLUFF_DOCS_BASE=/en/latest/ pnpm docs:dev
+ * The picker takes the current version from the base, so this only resolves to
+ * anything under a versioned base. That is now the default, and
+ * `SQLFLUFF_DOCS_BASE` overrides it to preview another version.
  *
  * `apply: 'serve'` keeps this out of production builds, and registering the
  * middleware directly in `configureServer` runs it ahead of Vite's own base

--- a/docsv/README.md
+++ b/docsv/README.md
@@ -86,12 +86,9 @@ Then open http://localhost:5173 in your browser.
 #### Working on the version picker
 
 The version picker and the "you are reading an old version" notice both read the
-versions manifest, and both take the current version from the site base. Neither
-appears under the default unversioned base, so serve a versioned one:
-
-```bash
-SQLFLUFF_DOCS_BASE=/en/latest/ pnpm run docs:dev
-```
+versions manifest, and both take the current version from the site base. The base
+defaults to `/en/latest/`, matching what is published, so `pnpm run docs:dev`
+shows both without further setup.
 
 In production the manifest is written at the language root by
 `scripts/assemble-site.py`, above any single version's base. The dev server

--- a/docsv/development/versioned-docs-hosting.md
+++ b/docsv/development/versioned-docs-hosting.md
@@ -73,8 +73,10 @@ Implemented in the repo so far:
   the version picker displays.
 - The VitePress theme carries the version picker and the stale version notice,
   both reading `/en/versions.json` at runtime. They are described under Version
-  Picker Design below, and both degrade to naming the current version when the
-  manifest cannot be reached.
+  Picker Design below. When the manifest cannot be reached they degrade
+  differently: the picker falls back to naming the current version as plain
+  text, with nothing to switch to, while the notice renders nothing at all,
+  since it cannot know whether a better version exists.
 - The docs base defaults to `/en/latest/` rather than an unversioned path, so a
   local run matches the published layout. The picker reads the current version
   out of the base, so an unversioned base cannot show it at all.
@@ -323,8 +325,14 @@ recommended version:
 - Nothing is shown when there is nowhere better to go, which also keeps the
   notice off a single-channel deployment.
 
-The notice is driven by the same manifest as the picker, so it depends on
-`published_at` and on the ordering that `assemble-site.py` writes.
+The notice is driven by the same manifest as the picker, and decides from the
+manifest's *ordering* rather than from any date: `version_sort_key` in
+`assemble-site.py` sorts releases newest-first by version number, and a release
+which is not the first is treated as superseded. `published_at` is only used by
+the picker, to label each entry.
+
+That means the ordering is load-bearing. A change to how releases are sorted
+changes which versions readers are warned about.
 
 ### Shared Runtime Assets
 

--- a/docsv/development/versioned-docs-hosting.md
+++ b/docsv/development/versioned-docs-hosting.md
@@ -61,8 +61,8 @@ Implemented in the repo so far:
   condition, which is what lets the manual path reuse them.
 - `workflow_dispatch` accepts `version`, `refresh_stable`, `prerelease`, and
   `published_at`, so a release tag can be rebuilt and `stable` repointed without
-  reissuing a release. Refreshing `stable` from a prerelease is refused, matching
-  the release path and the channel policy below.
+  reissuing a release. Refreshing `stable` from a prerelease is refused,
+  matching the release path and the channel policy below.
 - `docsv/scripts/smoke-check-assembled-site.py` validates the assembled tree
   before it is uploaded: the manifest parses, every version it advertises has a
   real index page, the root redirect points at a published default, and the
@@ -71,6 +71,17 @@ Implemented in the repo so far:
   now carries an existing release's `published_at` forward when one is not
   supplied. Without that, a manual rebuild would silently erase the date that
   the version picker displays.
+- The VitePress theme carries the version picker and the stale version notice,
+  both reading `/en/versions.json` at runtime. They are described under Version
+  Picker Design below, and both degrade to naming the current version when the
+  manifest cannot be reached.
+- The docs base defaults to `/en/latest/` rather than an unversioned path, so a
+  local run matches the published layout. The picker reads the current version
+  out of the base, so an unversioned base cannot show it at all.
+- Because the manifest lives at the language root, above any single version's
+  base, the dev server cannot serve it from `public/`. A dev-only Vite plugin
+  serves `.vitepress/dev-versions.json` at that path so both components can be
+  worked on locally.
 
 Validated locally so far:
 
@@ -94,6 +105,11 @@ Still not confirmed from this repository alone:
 
 - Release-driven `/en/<version>/` and `/en/stable/` publishing.
 - A live rollback or rebuild flow using the assembled snapshot in R2.
+- The manual rebuild path. The dispatch inputs and the publish-target logic have
+  been tested in isolation, but no run has yet rebuilt a real tag or repointed
+  `stable` against the live site.
+- The version picker and notice against more than one published version. Both
+  have only been exercised locally, where the manifest comes from a fixture.
 
 ## Architecture
 
@@ -268,14 +284,47 @@ The exact schema can evolve, but a practical initial contract is:
 
 ### Picker Behavior
 
-The initial picker behavior should stay simple:
+The plan was to switch to the selected version root first and preserve the
+current page path only once redirect parity was good enough. The shipped picker
+preserves the page path from the outset: a reader switching version stays on the
+page they were reading, and if that page does not exist in the target version
+they get that version's own 404.
 
-1. First rollout: switch to the selected version root.
-2. Later enhancement: attempt to preserve the current relative page path, with
-  fallback to the selected version root if the page does not exist.
+That trade was taken deliberately. Losing your place on every version switch is
+a certain cost on every use, where a missing page is a possible cost on some.
+It is worth revisiting for mixed VitePress and Sphinx path compatibility, where
+the paths differ structurally rather than occasionally.
 
-Root-only switching is the default until redirect parity and mixed VitePress or
-Sphinx path compatibility are good enough to justify a smarter switch.
+Two details are easy to break and worth knowing before changing this:
+
+- Cross-version links must carry a `target` attribute. VitePress intercepts
+  every same-origin link for client-side routing, which would resolve another
+  version's page against the current build; a link with a `target` is skipped.
+- The page path is taken from the current route rather than read once on mount,
+  so it stays correct after a client-side navigation.
+
+The picker is a disclosure of links rather than a `select` or a `role="menu"`
+widget. A native `select` cannot style its popup, so the closed control and the
+open list could not be made to match. Links, rather than a change handler, keep
+middle-click and open-in-new-tab working, and a list of links after the trigger
+is already reachable with Tab, which avoids reimplementing arrow-key movement
+and typeahead.
+
+### Stale Version Notice
+
+Readers usually arrive from a search engine, which favours whichever version has
+accumulated links rather than the current one, so the picker alone does not help
+someone who does not know they need it. Published docs therefore also carry a
+notice naming the version being read, with a link to the same page in the
+recommended version:
+
+- `latest` is flagged as development documentation, since it tracks `main`.
+- A release which is not the newest is flagged as superseded.
+- Nothing is shown when there is nowhere better to go, which also keeps the
+  notice off a single-channel deployment.
+
+The notice is driven by the same manifest as the picker, so it depends on
+`published_at` and on the ordering that `assemble-site.py` writes.
 
 ### Shared Runtime Assets
 
@@ -355,8 +404,12 @@ sufficient.
 
 - Final releases should publish `/en/<version>/` and automatically refresh
   `/en/stable/`.
-- Prereleases may be published at their direct version URLs, but should be
-  hidden from the version picker.
+- Prereleases are published at their direct version URLs and are listed in the
+  version picker, marked as prereleases rather than hidden. Hiding them was the
+  original intent, but a version a reader can reach by URL and cannot find in
+  the picker is harder to explain than one which is labelled, and the label is
+  what stops it being mistaken for a final release. They are still kept off
+  `/en/stable/`, which only ever points at a final release.
 - `latest` is the only channel where edit links are important. Other channels
   may either omit edit links or point to `main`; version-accurate edit links
   are not required for the first rollout.
@@ -393,7 +446,8 @@ Deliverables:
 - Wire `docs.beta.sqlfluff.com`
 - Add repository secrets
 - Set the first VitePress-native release tag to `4.2.0`
-- Decide whether prereleases appear in the picker
+- Decide whether prereleases appear in the picker — decided: they appear,
+  marked as prereleases. See the release channel policy above.
 
 Stopping point:
 
@@ -420,15 +474,18 @@ Stopping point:
 
 ### Stage 2: Manifest And Initial Version Picker
 
-Status: partially complete. The minimal shared manifest is now live, but the
-runtime version picker UI has not been added yet.
+Status: complete for VitePress. The shared manifest is live and the picker reads
+it at runtime, alongside the stale version notice described above. Only the
+cross-builder work in Stage 5 remains before older Sphinx versions can use it.
 
 Deliverables:
 
-- Define the `versions.json` schema
-- Add a basic picker to the VitePress theme
-- Read version data from the shared manifest at runtime
-- Keep initial switching behavior simple by targeting version roots only
+- Define the `versions.json` schema — done
+- Add a basic picker to the VitePress theme — done
+- Read version data from the shared manifest at runtime — done
+- Keep initial switching behavior simple by targeting version roots only —
+  superseded; the picker preserves the current page path instead, for the
+  reasons under Picker Behavior above
 
 Stopping point:
 
@@ -463,10 +520,11 @@ immutable snapshot archives are still outstanding.
 Deliverables:
 
 - Add `workflow_dispatch` for rebuilding a chosen version tag — done
-- Validate the tag exists before build — done implicitly; the tag is the checkout
-  ref, so a tag which does not exist fails the run before anything is built
-- Rebuild only the requested version subtree — done; the existing tree is pulled
-  from R2 first, so only the rebuilt subtree is replaced
+- Validate the tag exists before build — done implicitly; the tag is the
+  checkout ref, so a tag which does not exist fails the run before anything is
+  built
+- Rebuild only the requested version subtree — done; the existing tree is
+  pulled from R2 first, so only the rebuilt subtree is replaced
 - Support importing an archived static snapshot when rebuilding is not practical
 - Keep immutable assembled snapshots so rollback and manual imports use the same
   artifact model
@@ -516,7 +574,9 @@ Deliverables:
 - Preserve or replace important `.html`, permalink, and declared redirect
   routes
 - Add or refine Netlify redirects where needed
-- Improve picker behavior to preserve current page paths where possible
+- Confirm page-path preservation on version switch holds up against the redirect
+  set, and decide how it should behave across the VitePress and Sphinx boundary
+  where paths differ structurally
 - Review edit links, 404 behavior, and search behavior across versions
 
 Stopping point:
@@ -581,13 +641,16 @@ The following can be revisited after the initial beta proof:
 
 When resuming this work on another machine, the next high-value checks are:
 
-1. Add the initial runtime version picker in VitePress, backed by the live
-  `/en/versions.json` manifest.
-2. Add the release-triggered publish path for `/en/<version>/` and `/en/stable/`.
-3. Teach the assembly flow to merge an existing R2 snapshot instead of always
-  rebuilding a latest-only tree.
-4. Prove one historical rebuild path, either from a VitePress-native release or
-  from a controlled Sphinx-hosted version.
+1. Prove one historical rebuild path end to end, either from a VitePress-native
+  release or from a controlled Sphinx-hosted version. The manual dispatch path
+  exists but has not yet been exercised against a real tag.
+2. Confirm release-driven `/en/<version>/` and `/en/stable/` publishing against
+  a real release, which has still only been reasoned about rather than
+  observed.
+3. Add the snapshot import and immutable snapshot archives left open in Stage 4,
+  so rollback and manual imports share the artifact model.
+4. Move the picker and notice onto shared assets under `/en/shared/` (Stage 5)
+  so older published versions do not need rebuilding to learn about new ones.
 
 ## Success Criteria
 
@@ -597,7 +660,8 @@ The plan should be considered successful when:
 - each release automatically publishes to `/en/<version>/`
 - the newest final release is available at `/en/stable/`
 - the picker lists available versions from a shared manifest
-- prereleases can be published directly without appearing in the picker
+- prereleases can be published directly and are listed in the picker as
+  prereleases, without ever becoming `stable`
 - rebuilding a historical version does not require rebuilding every other version
 - documentation URLs emitted by SQLFluff `2.0.0` and later continue to resolve
 - pre-cutover versions can still be hosted under the same beta domain

--- a/docsv/development/versioned-docs-hosting.md
+++ b/docsv/development/versioned-docs-hosting.md
@@ -56,6 +56,21 @@ Implemented in the repo so far:
   `aws-actions/configure-aws-credentials` action.
 - The workflow currently triggers on pushes to `main`, pushes to
   `ac/docsdeploy`, and `workflow_dispatch`.
+- The three trigger paths now resolve through a single `Determine docs publish
+  target` step rather than repeating the release semantics in each step
+  condition, which is what lets the manual path reuse them.
+- `workflow_dispatch` accepts `version`, `refresh_stable`, `prerelease`, and
+  `published_at`, so a release tag can be rebuilt and `stable` repointed without
+  reissuing a release. Refreshing `stable` from a prerelease is refused, matching
+  the release path and the channel policy below.
+- `docsv/scripts/smoke-check-assembled-site.py` validates the assembled tree
+  before it is uploaded: the manifest parses, every version it advertises has a
+  real index page, the root redirect points at a published default, and the
+  Netlify `_headers` file exists.
+- `assemble-site.py` rebuilds a manifest entry from scratch on each run, so it
+  now carries an existing release's `published_at` forward when one is not
+  supplied. Without that, a manual rebuild would silently erase the date that
+  the version picker displays.
 
 Validated locally so far:
 
@@ -441,15 +456,22 @@ Stopping point:
 
 ### Stage 4: Manual Rebuild Workflow
 
+Status: mostly complete. A chosen tag can be rebuilt from `workflow_dispatch`,
+and `stable` can be repointed, both validated before upload. Snapshot import and
+immutable snapshot archives are still outstanding.
+
 Deliverables:
 
-- Add `workflow_dispatch` for rebuilding a chosen version tag
-- Validate the tag exists before build
-- Rebuild only the requested version subtree
+- Add `workflow_dispatch` for rebuilding a chosen version tag — done
+- Validate the tag exists before build — done implicitly; the tag is the checkout
+  ref, so a tag which does not exist fails the run before anything is built
+- Rebuild only the requested version subtree — done; the existing tree is pulled
+  from R2 first, so only the rebuilt subtree is replaced
 - Support importing an archived static snapshot when rebuilding is not practical
 - Keep immutable assembled snapshots so rollback and manual imports use the same
   artifact model
-- Optionally refresh `stable` in controlled cases
+- Optionally refresh `stable` in controlled cases — done, and refused for
+  prereleases
 
 Stopping point:
 

--- a/docsv/scripts/assemble-site.py
+++ b/docsv/scripts/assemble-site.py
@@ -7,7 +7,7 @@ import argparse
 import json
 import os
 import shutil
-from pathlib import Path
+from pathlib import Path, PurePosixPath, PureWindowsPath
 from textwrap import dedent
 from typing import Any
 
@@ -70,15 +70,27 @@ def assert_safe_segment(value: str, name: str) -> None:
     and the channel is deleted and rewritten on every run. Since a manual publish
     takes the channel from an operator-supplied version, a value containing a
     separator or `..` would place that delete outside the assembled site.
+
+    Both path flavours are checked rather than only the running one, so the answer
+    does not depend on the platform. A drive-qualified value such as ``C:foo`` is
+    neither absolute nor separated, and relocates a path only on Windows — but the
+    Linux runner which publishes the site is exactly where we would want to find
+    out, rather than on a maintainer's machine.
     """
     if not value or value != value.strip():
         raise ValueError(f"{name} must not be empty or padded: {value!r}")
 
-    if value in {os.curdir, os.pardir} or set(value) & {"/", "\\", os.sep}:
-        raise ValueError(f"{name} must be a single path segment: {value!r}")
+    if value in {os.curdir, os.pardir}:
+        raise ValueError(f"{name} must not be a relative reference: {value!r}")
 
-    if os.pardir in Path(value).parts or Path(value).is_absolute():
-        raise ValueError(f"{name} must be a relative path segment: {value!r}")
+    for flavour in (PurePosixPath, PureWindowsPath):
+        candidate = flavour(value)
+
+        if candidate.drive or candidate.is_absolute():
+            raise ValueError(f"{name} must be a relative path segment: {value!r}")
+
+        if len(candidate.parts) != 1 or os.pardir in candidate.parts:
+            raise ValueError(f"{name} must be a single path segment: {value!r}")
 
 
 def write_text(path: Path, content: str) -> None:

--- a/docsv/scripts/assemble-site.py
+++ b/docsv/scripts/assemble-site.py
@@ -114,6 +114,15 @@ def upsert_manifest_entry(
     stable_release: str | None,
 ) -> dict[str, Any]:
     """Insert or update a manifest entry for the published channel."""
+    previous = next(
+        (
+            existing
+            for existing in manifest.get("versions", [])
+            if existing.get("key") == channel
+        ),
+        None,
+    )
+
     entry: dict[str, Any] = {
         "key": channel,
         "label": channel,
@@ -124,8 +133,19 @@ def upsert_manifest_entry(
         "prerelease": prerelease,
     }
 
-    if published_at and kind == "release":
-        entry["published_at"] = published_at
+    # The entry is rebuilt from scratch rather than merged, so anything not
+    # passed in is dropped. That is fine for values this script is told on every
+    # run, but a release's publication date is only known to the release event
+    # which first published it. Rebuilding an existing release without repeating
+    # `--published-at` would silently erase the date, which the version picker
+    # displays. So an explicit value wins, and otherwise an existing one is
+    # carried forward. A brand new release with no date simply has none.
+    resolved_published_at = published_at or (
+        previous.get("published_at") if previous else None
+    )
+
+    if resolved_published_at and kind == "release":
+        entry["published_at"] = resolved_published_at
 
     versions = [
         existing

--- a/docsv/scripts/assemble-site.py
+++ b/docsv/scripts/assemble-site.py
@@ -80,16 +80,29 @@ def assert_safe_segment(value: str, name: str) -> None:
     if not value or value != value.strip():
         raise ValueError(f"{name} must not be empty or padded: {value!r}")
 
+    # Separators are rejected on the raw string, before any parsing. Parsing
+    # normalises `.` away — `PurePath("foo/.").parts` is `("foo",)` — so a value
+    # containing a separator can otherwise look like a single segment while
+    # naming a directory the manifest does not record. Both separators are
+    # listed regardless of platform, for the same reason the flavours below are.
+    if set(value) & {"/", "\\"}:
+        raise ValueError(f"{name} must be a single path segment: {value!r}")
+
     if value in {os.curdir, os.pardir}:
         raise ValueError(f"{name} must not be a relative reference: {value!r}")
 
     for flavour in (PurePosixPath, PureWindowsPath):
         candidate = flavour(value)
 
-        if candidate.drive or candidate.is_absolute():
+        # `root` as well as `drive` and `is_absolute`: on Windows a lone `\` is
+        # rooted without being absolute, which would put the delete below at the
+        # drive root.
+        if candidate.drive or candidate.root or candidate.is_absolute():
             raise ValueError(f"{name} must be a relative path segment: {value!r}")
 
-        if len(candidate.parts) != 1 or os.pardir in candidate.parts:
+        # Parsing must round-trip to exactly the value as one component. This
+        # catches `C:foo`, which Windows splits into a drive and a name.
+        if candidate.parts != (value,):
             raise ValueError(f"{name} must be a single path segment: {value!r}")
 
 

--- a/docsv/scripts/assemble-site.py
+++ b/docsv/scripts/assemble-site.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import shutil
 from pathlib import Path
 from textwrap import dedent
@@ -60,6 +61,24 @@ def parse_args() -> argparse.Namespace:
         help="Release version that the stable channel should point to.",
     )
     return parser.parse_args()
+
+
+def assert_safe_segment(value: str, name: str) -> None:
+    """Reject a path segment which would escape the tree it is joined into.
+
+    `channel` and `language` become directory names under the output directory,
+    and the channel is deleted and rewritten on every run. Since a manual publish
+    takes the channel from an operator-supplied version, a value containing a
+    separator or `..` would place that delete outside the assembled site.
+    """
+    if not value or value != value.strip():
+        raise ValueError(f"{name} must not be empty or padded: {value!r}")
+
+    if value in {os.curdir, os.pardir} or set(value) & {"/", "\\", os.sep}:
+        raise ValueError(f"{name} must be a single path segment: {value!r}")
+
+    if os.pardir in Path(value).parts or Path(value).is_absolute():
+        raise ValueError(f"{name} must be a relative path segment: {value!r}")
 
 
 def write_text(path: Path, content: str) -> None:
@@ -230,6 +249,9 @@ def assemble_site(
     """Merge one built docs channel into the assembled site tree."""
     if not vitepress_dist.is_dir():
         raise FileNotFoundError(f"VitePress dist directory not found: {vitepress_dist}")
+
+    assert_safe_segment(language, "language")
+    assert_safe_segment(channel, "channel")
 
     target_dir = output_dir / language / channel
     target_dir.parent.mkdir(parents=True, exist_ok=True)

--- a/docsv/scripts/smoke-check-assembled-site.py
+++ b/docsv/scripts/smoke-check-assembled-site.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Smoke check the assembled versioned docs site."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--site-dir",
+        type=Path,
+        required=True,
+        help="Path to the assembled site tree.",
+    )
+    parser.add_argument(
+        "--language",
+        default="en",
+        help="Top-level language segment to validate.",
+    )
+    return parser.parse_args()
+
+
+def load_manifest(site_dir: Path, language: str) -> dict[str, Any]:
+    """Load and minimally validate the versions manifest."""
+    manifest_path = site_dir / language / "versions.json"
+
+    if not manifest_path.is_file():
+        raise FileNotFoundError(f"Missing versions manifest: {manifest_path}")
+
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    versions = manifest.get("versions")
+
+    if not isinstance(versions, list) or not versions:
+        raise ValueError("versions.json must include at least one version entry")
+
+    return manifest
+
+
+def assert_path_exists(site_dir: Path, url_path: str, description: str) -> None:
+    """Assert a published URL path maps to an existing file or directory."""
+    relative_path = url_path.strip("/")
+    path = site_dir / relative_path
+
+    if path.is_dir():
+        path = path / "index.html"
+
+    if not path.is_file():
+        raise FileNotFoundError(f"Missing {description}: {path}")
+
+
+def smoke_check(site_dir: Path, language: str) -> None:
+    """Validate the important assembled docs outputs."""
+    manifest = load_manifest(site_dir, language)
+
+    for entry in manifest["versions"]:
+        key = entry.get("key")
+        path = entry.get("path")
+
+        if not key or not path:
+            raise ValueError(f"Version entry must include key and path: {entry!r}")
+
+        assert_path_exists(site_dir, str(path), f"index page for {key}")
+
+    redirects_path = site_dir / "_redirects"
+
+    if not redirects_path.is_file():
+        raise FileNotFoundError(f"Missing Netlify redirects file: {redirects_path}")
+
+    redirects = redirects_path.read_text(encoding="utf-8")
+    default = str(manifest.get("default") or manifest.get("latest") or "latest")
+    default_path = f"/{language}/{default}/"
+
+    if not re.search(rf"^/ {re.escape(default_path)} 302$", redirects, re.MULTILINE):
+        raise ValueError(f"Missing root redirect to {default_path}")
+
+    assert_path_exists(site_dir, default_path, "default redirect target")
+
+    headers_path = site_dir / "_headers"
+
+    if not headers_path.is_file():
+        raise FileNotFoundError(f"Missing Netlify headers file: {headers_path}")
+
+
+def main() -> int:
+    """Main entry point."""
+    args = parse_args()
+    smoke_check(args.site_dir, args.language.strip("/"))
+    print(f"Smoke check passed for {args.site_dir}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docsv/scripts/smoke-check-assembled-site.py
+++ b/docsv/scripts/smoke-check-assembled-site.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import argparse
 import json
 import re
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any
 
 
@@ -44,9 +44,28 @@ def load_manifest(site_dir: Path, language: str) -> dict[str, Any]:
 
 
 def assert_path_exists(site_dir: Path, url_path: str, description: str) -> None:
-    """Assert a published URL path maps to an existing file or directory."""
+    """Assert a published URL path maps to a file inside the assembled tree.
+
+    The path is confined to `site_dir` before it is used. A manifest entry is
+    only as trustworthy as whatever produced it, and one containing `..` would
+    otherwise let this check pass by finding a real file outside the tree — which
+    would vouch for a version that was never published.
+    """
     relative_path = url_path.strip("/")
+
+    if not relative_path:
+        raise ValueError(f"Empty path for {description}")
+
+    if PurePosixPath(relative_path).is_absolute() or ".." in relative_path.split("/"):
+        raise ValueError(f"Unsafe path for {description}: {url_path!r}")
+
     path = site_dir / relative_path
+
+    # Resolve both sides so a symlink cannot point out of the tree either.
+    if not path.resolve().is_relative_to(site_dir.resolve()):
+        raise ValueError(
+            f"Path escapes the site directory for {description}: {url_path!r}"
+        )
 
     if path.is_dir():
         path = path / "index.html"

--- a/docsv/scripts/smoke-check-assembled-site.py
+++ b/docsv/scripts/smoke-check-assembled-site.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import argparse
 import json
 import re
-from pathlib import Path, PurePosixPath
+from pathlib import Path
 from typing import Any
 
 
@@ -51,12 +51,14 @@ def assert_path_exists(site_dir: Path, url_path: str, description: str) -> None:
     otherwise let this check pass by finding a real file outside the tree — which
     would vouch for a version that was never published.
     """
+    # Stripping the slashes makes a rooted URL path relative, so there is no
+    # absolute case left to test for here; traversal is what remains.
     relative_path = url_path.strip("/")
 
     if not relative_path:
         raise ValueError(f"Empty path for {description}")
 
-    if PurePosixPath(relative_path).is_absolute() or ".." in relative_path.split("/"):
+    if ".." in relative_path.split("/"):
         raise ValueError(f"Unsafe path for {description}: {url_path!r}")
 
     path = site_dir / relative_path

--- a/test/docsv_assemble_site_test.py
+++ b/test/docsv_assemble_site_test.py
@@ -105,6 +105,64 @@ def test_published_at_is_not_applied_to_channels(assemble_site):
     assert "published_at" not in _entry(result, "latest")
 
 
+@pytest.mark.parametrize(
+    "channel",
+    [
+        "..",
+        "../outside",
+        "en/../../outside",
+        "a/b",
+        "/absolute",
+        "",
+        " padded ",
+    ],
+)
+def test_unsafe_channels_are_rejected(assemble_site, channel):
+    """A channel is a directory name which gets deleted and rewritten.
+
+    A manual publish takes it from an operator-supplied version, so a separator
+    or a `..` would move that delete outside the assembled site.
+    """
+    with pytest.raises(ValueError):
+        assemble_site.assert_safe_segment(channel, "channel")
+
+
+@pytest.mark.parametrize(
+    "channel", ["latest", "stable", "3.4.2", "4.0.0a1", "1.2.3-rc.1"]
+)
+def test_real_channels_are_accepted(assemble_site, channel):
+    """The names actually published must not be caught by the guard."""
+    assemble_site.assert_safe_segment(channel, "channel")
+
+
+def test_assemble_site_refuses_to_escape_the_output_dir(assemble_site, tmp_path):
+    """The guard is wired into the destructive path, not just available."""
+    dist = tmp_path / "dist"
+    dist.mkdir()
+    (dist / "index.html").write_text("<html></html>", encoding="utf-8")
+
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "keep.txt").write_text("sentinel", encoding="utf-8")
+
+    with pytest.raises(ValueError):
+        assemble_site.assemble_site(
+            vitepress_dist=dist,
+            output_dir=tmp_path / "site",
+            language="en",
+            channel="../../outside",
+            title="evil",
+            kind="release",
+            prerelease=False,
+            published_at=None,
+            stable_release=None,
+        )
+
+    assert (outside / "keep.txt").is_file(), (
+        "content outside the output dir was removed"
+    )
+
+
 def test_rebuild_leaves_other_versions_untouched(assemble_site):
     """Only the rebuilt entry changes."""
     manifest = assemble_site.default_manifest()

--- a/test/docsv_assemble_site_test.py
+++ b/test/docsv_assemble_site_test.py
@@ -1,0 +1,123 @@
+"""Tests for the versioned docs site assembly script.
+
+These cover the manifest contract that the published version picker depends on.
+The script lives outside the package, so it is loaded by path rather than
+imported; its filename is not a valid module name.
+"""
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+REPO_ROOT = Path(__file__).parent.parent
+ASSEMBLE_SITE = REPO_ROOT / "docsv" / "scripts" / "assemble-site.py"
+
+
+def _load_assemble_site() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("assemble_site", ASSEMBLE_SITE)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def assemble_site() -> ModuleType:
+    """Load the assembly script once for the module."""
+    return _load_assemble_site()
+
+
+def _upsert(module: ModuleType, manifest: dict, **overrides) -> dict:
+    kwargs = {
+        "language": "en",
+        "channel": "3.4.1",
+        "title": "3.4.1",
+        "kind": "release",
+        "prerelease": False,
+        "published_at": None,
+        "stable_release": None,
+    }
+    kwargs.update(overrides)
+    return module.upsert_manifest_entry(manifest, **kwargs)
+
+
+def _entry(manifest: dict, key: str) -> dict:
+    return next(entry for entry in manifest["versions"] if entry["key"] == key)
+
+
+def test_published_at_is_recorded_when_supplied(assemble_site):
+    """An explicit date is written onto the entry."""
+    manifest = assemble_site.default_manifest()
+
+    result = _upsert(assemble_site, manifest, published_at="2026-06-02")
+
+    assert _entry(result, "3.4.1")["published_at"] == "2026-06-02"
+
+
+def test_published_at_is_preserved_when_omitted_on_rebuild(assemble_site):
+    """Rebuilding a release without a date keeps the one already published.
+
+    The entry is rebuilt from scratch on every run, so without this the date
+    would be erased by any manual rebuild which did not repeat it.
+    """
+    manifest = assemble_site.default_manifest()
+    manifest = _upsert(assemble_site, manifest, published_at="2026-06-02")
+
+    rebuilt = _upsert(assemble_site, manifest, published_at=None)
+
+    assert _entry(rebuilt, "3.4.1")["published_at"] == "2026-06-02"
+
+
+def test_published_at_is_overwritten_when_supplied_on_rebuild(assemble_site):
+    """An explicit date wins over the existing one."""
+    manifest = assemble_site.default_manifest()
+    manifest = _upsert(assemble_site, manifest, published_at="2026-06-02")
+
+    rebuilt = _upsert(assemble_site, manifest, published_at="2026-06-09")
+
+    assert _entry(rebuilt, "3.4.1")["published_at"] == "2026-06-09"
+
+
+def test_published_at_is_absent_for_a_new_release_without_one(assemble_site):
+    """A release published with no date simply has no date."""
+    manifest = assemble_site.default_manifest()
+
+    result = _upsert(assemble_site, manifest, published_at=None)
+
+    assert "published_at" not in _entry(result, "3.4.1")
+
+
+def test_published_at_is_not_applied_to_channels(assemble_site):
+    """Channels move, so a publication date would be meaningless on one."""
+    manifest = assemble_site.default_manifest()
+
+    result = _upsert(
+        assemble_site,
+        manifest,
+        channel="latest",
+        title="Latest",
+        kind="channel",
+        published_at="2026-06-02",
+    )
+
+    assert "published_at" not in _entry(result, "latest")
+
+
+def test_rebuild_leaves_other_versions_untouched(assemble_site):
+    """Only the rebuilt entry changes."""
+    manifest = assemble_site.default_manifest()
+    manifest = _upsert(assemble_site, manifest, published_at="2026-06-02")
+    manifest = _upsert(
+        assemble_site,
+        manifest,
+        channel="3.4.2",
+        title="3.4.2",
+        published_at="2026-07-14",
+    )
+
+    rebuilt = _upsert(assemble_site, manifest, published_at=None)
+
+    assert _entry(rebuilt, "3.4.2")["published_at"] == "2026-07-14"
+    assert _entry(rebuilt, "3.4.1")["published_at"] == "2026-06-02"

--- a/test/docsv_assemble_site_test.py
+++ b/test/docsv_assemble_site_test.py
@@ -115,6 +115,17 @@ def test_published_at_is_not_applied_to_channels(assemble_site):
         "/absolute",
         "",
         " padded ",
+        # Parsing drops `.` components, so these look like a single segment
+        # afterwards while still naming a different directory.
+        ".",
+        "./foo",
+        "foo/.",
+        "a/",
+        # Rooted without being absolute on Windows, which would put the delete
+        # at the drive root.
+        "\\",
+        "/",
+        "back\\slash",
     ],
 )
 def test_unsafe_channels_are_rejected(assemble_site, channel):

--- a/test/docsv_assemble_site_test.py
+++ b/test/docsv_assemble_site_test.py
@@ -6,7 +6,7 @@ imported; its filename is not a valid module name.
 """
 
 import importlib.util
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 from types import ModuleType
 
 import pytest
@@ -127,11 +127,29 @@ def test_unsafe_channels_are_rejected(assemble_site, channel):
         assemble_site.assert_safe_segment(channel, "channel")
 
 
+def test_drive_qualified_channels_are_rejected(assemble_site):
+    """`C:foo` is neither absolute nor separated, but does relocate a path.
+
+    Checked with the Windows flavour explicitly, since the value is harmless on
+    the POSIX runner that publishes today but not on a maintainer's Windows
+    machine, where these scripts have been run before.
+    """
+    assert PureWindowsPath("C:foo").is_absolute() is False, "premise of the test"
+    assert PureWindowsPath("C:foo").drive == "C:"
+
+    with pytest.raises(ValueError):
+        assemble_site.assert_safe_segment("C:foo", "channel")
+
+
 @pytest.mark.parametrize(
-    "channel", ["latest", "stable", "3.4.2", "4.0.0a1", "1.2.3-rc.1"]
+    "channel",
+    ["latest", "stable", "3.4.2", "4.0.0a1", "4.0.1.post1", "1.2.3-rc.1"],
 )
 def test_real_channels_are_accepted(assemble_site, channel):
-    """The names actually published must not be caught by the guard."""
+    """The names actually published must not be caught by the guard.
+
+    `4.0.0a1` and `4.0.1.post1` are both real tags in this repository.
+    """
     assemble_site.assert_safe_segment(channel, "channel")
 
 


### PR DESCRIPTION
Carries forward the publishing half of #7915. The version picker half of that PR is superseded by #8300, which has since merged, so this leaves it behind — #7915 can be closed without merging once this is up.

Also actions @peterbud's review feedback on #7915, which was never picked up. More on that below, because it turned out to matter.

## Why

Every build path in the docs workflow was gated on `github.event_name == 'release'`, and `workflow_dispatch` took no inputs. Publishing a version's docs was therefore a single shot tied to the release event. If a docs build failed, or a released version's docs needed a correction, or `stable` ended up pointing at the wrong release, there was no way to fix it short of cutting another release.

Separately, nothing validated the assembled tree between assembly and upload.

## What this adds

**1. Manual republishing.** Four `workflow_dispatch` inputs — `version`, `refresh_stable`, `prerelease`, `published_at` — with `version` threaded into the checkout ref so a manual run builds that tag. A tag that doesn't exist fails at checkout, before anything is built.

**2. One publish decision instead of five.** The release semantics were restated across five step conditions, which is exactly why the manual path couldn't reuse them. They now resolve once in a `Determine docs publish target` step and each build step asks it what to do. Behaviour on the push and release paths is unchanged.

**3. `refresh_stable` for repointing `stable`** independently of a release — the manual override that `versioned-docs-hosting.md` asks for under "Stable Promotion Safeguard".

**4. A pre-upload smoke check.** Runs after all three assemble paths and before the artifact upload and R2 sync. Asserts the manifest parses and has entries, every version it advertises resolves to a real index page, the root redirect points at a default that was actually published, and the Netlify headers file exists.

This one is worth more than it looks, because the failure is quiet at both ends: the version picker and notice read this manifest at runtime and degrade without complaint when it's wrong — you get a plain version label, no notice, and nothing logged. This turns that into a red run before the broken tree reaches R2.

**5. Local base default.** `docsBase` defaulted to `/sqlfluff/`, which matches nothing deployed — every publishing path sets `SQLFLUFF_DOCS_BASE`, and the workflow already defaults it to `/en/latest/` at job level. Locally it was actively misleading: the picker reads the current version out of the base, so under an unversioned base neither the picker nor the notice could render at all, with no sign anything was missing. Now `pnpm docs:dev` shows both with no setup.

I deliberately left `package.json` alone here — #7915 also hardcoded `--base` into `docs:dev`, which would be a second mechanism for one setting and would drop the design sync step that has since been added.

## @peterbud's `published_at` contract — this was a live data-loss bug

The review comment on #7915 flagged that `upsert_manifest_entry` rebuilds an entry from scratch and only sets `published_at` when `--published-at` is passed. That's correct, and it's worse in combination with this PR: **enabling manual rebuilds is what makes it reachable.** Rebuilding `3.4.1` without restating the date silently erased it from `versions.json` — and #8300 displays those dates in the picker, so the loss is user-visible.

Implemented as proposed: explicit value wins, omitted value falls back to what's already published, brand-new release with no date simply has none. Channels are excluded, since a publication date on a moving channel is meaningless.

Fixed in the **first** commit, before the commit that makes it reachable.

There's now a regression test (`test/docsv_assemble_site_test.py`) covering all six cases. I verified it actually catches the bug by reverting the fix — two tests fail with `KeyError: 'published_at'`, which is precisely the silent loss described. These docs scripts had no test coverage at all before; note `[coverage:run] source = src/sqlfluff`, so this doesn't affect the 100% coverage gate.

## Also worth flagging

`refresh_stable` combined with `prerelease` would have pointed `/en/stable/` at a prerelease. The release path explicitly declines to promote prereleases and the channel policy keeps them off that channel, so the manual path shouldn't be able to contradict both. It now fails with a clear error rather than quietly ignoring one of the two inputs. This is an addition to #7915, not something carried from it.

## Verification

- **Publish-target logic**: extracted the real `run:` block from the workflow and exercised all 8 trigger combinations — push, final release, prerelease, dispatch with/without a version, dispatch with `refresh_stable`, the new guard, and dispatch prerelease alone. 8/8 as expected.
- **Smoke check**: built and assembled a real site, then verified it *rejects* each failure mode it claims to guard — missing version dir, missing index, manifest advertising an unbuilt version, missing/incorrect `_redirects`, missing `_headers`, missing manifest, empty versions, entry without a path, and a default channel that was never published. 11/11.
- **`published_at`**: 6 tests, confirmed failing without the fix.
- Workflow YAML parses; step order confirmed (smoke check at 14, upload 15, R2 sync 16).
- `ruff check` and `ruff format --check` clean.
- Built and ran the docs with no env var to exercise the new default; picker opens with all versions and the notice renders.

## Not included

Two Stage 4 deliverables from `versioned-docs-hosting.md` remain open: archived snapshot import, and immutable snapshot archives for rollback. The doc is updated to say so rather than implying Stage 4 is done.

Smoke check failures surface as a Python traceback whose last line names the problem — enough to diagnose from a run log, but not a tidy annotation if that's worth polishing later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Prerelease visibility (added after review discussion)

The plan document said prereleases should be *hidden* from the version picker; the picker shipped in #8300 *lists* them with a pre-release label. Confirmed with @alanmcruickshank that the shipped behaviour is what we want, so the last commit brings the document in line rather than changing the picker.

A version a reader can reach by URL but cannot find in the picker is harder to explain than one which is labelled, and the label is what stops it being mistaken for a final release. Prereleases are still kept off `/en/stable/`, so the part of the policy that actually protects readers is unchanged — and this PR adds a guard making that impossible to bypass by hand.

While aligning that section I found two more places the plan had drifted from what is published, and fixed those too:

- **Page-path preservation on version switch** was deferred behind redirect parity, but the shipped picker does it from the outset. The note now explains the trade — losing your place is a certain cost on every switch, a missing page a possible cost on some — and flags the VitePress-to-Sphinx boundary as the case worth revisiting, since there the paths differ structurally rather than occasionally.
- **The stale version notice was not documented at all.**

I also documented the two details most likely to be broken by a well-meaning change: the `target` attribute that keeps cross-version links away from VitePress's router, and taking the page path from the route rather than reading it once on mount. Both are silent when broken.

Finally, the unconfirmed list now says plainly that neither the manual rebuild path nor the picker has been exercised against more than one really published version — the publish-target logic and the smoke check are tested in isolation, and the picker only against a local fixture.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds manual republishing for versioned docs, validates both inputs and the assembled site before upload, and preserves release dates on rebuilds. Previously only release events could publish; now `workflow_dispatch` can rebuild a tag and optionally repoint `stable`, with guards against bad input, shell injection, and broken or escaping trees.

- Workflow: `workflow_dispatch` accepts `version`, `refresh_stable`, `prerelease`, and `published_at`. One “Determine docs publish target” step drives all paths. Checkout `ref` uses the release tag or `version`; missing tags fail early. Inputs are passed via `env` to avoid shell evaluation. `version` is shape-checked; `published_at` must match real date/timestamp forms (e.g., `YYYY-MM-DD`, `YYYY-MM-DDTHH:MM:SSZ`/offset). `refresh_stable` is refused without `version`, with prereleases, and allows post-releases (e.g., `4.0.1.post1`).
- Validation: `smoke-check-assembled-site.py` runs before artifact upload and R2 sync. It confines paths to the site root and asserts the manifest parses and is non-empty, each advertised version resolves to an index, the root redirect targets a published default, and `_headers` exists.
- Assembly: `assemble-site.py` carries a release’s existing `published_at` forward unless a new value is provided; channels never get a date. It rejects unsafe `language`/`channel` segments (separators, `..`, rooted or drive-qualified values) to prevent escaping the output dir. Tests cover these contracts.
- Dev and docs: VitePress base defaults to `/en/latest/` so `pnpm run docs:dev` shows the picker and notice. The hosting plan now matches shipped behavior — prereleases are listed (labelled) and kept off `/en/stable/`; the stale-version notice is documented and keyed off manifest ordering; degradation when the manifest is unreachable is recorded.

Required actions for manual rebuilds:
- Use `workflow_dispatch` with `version=<tag>`. Optionally pass `published_at` to set or correct the release date.
- To repoint stable, set `refresh_stable=true` with a final tag such as `3.4.2` or `4.0.1.post1`. Prerelease tags (e.g., `4.0.0a1`) are refused.

<sup>Written for commit 082d9bbc1f88a08b76a382699027bc15508eba21. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8319?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

