### PR TITLE
fix(reflow): ignore cross-line neighbours when aligning elements

### DIFF
--- a/src/sqlfluff/cli/formatters.py
+++ b/src/sqlfluff/cli/formatters.py
@@ -623,7 +623,7 @@ class OutputStreamFormatter(FormatterInterface):
                     )
                     for t in linter.rule_tuples()
                 ],
-                col_width=80,
+                col_width=self.output_line_length,
                 cols=1,
                 label_color=Color.blue,
                 val_align="left",

--- a/src/sqlfluff/utils/reflow/respace.py
+++ b/src/sqlfluff/utils/reflow/respace.py
@@ -463,6 +463,17 @@ def _determine_aligned_inline_spacing(
                     )
                 else:
                     loc = last_code.pos_marker.working_loc_after(last_code.raw)
+                # If the preceding code is on a different line, then this sibling
+                # is the first thing on its own line. The whitespace before it is
+                # indentation (handled by the reindent routines and not here), so
+                # including it would inflate the alignment target with a position
+                # from an unrelated line.
+                if loc[0] != _pos_line(sibling.pos_marker, use_source_positions):
+                    reflow_logger.debug(
+                        "    Skipping %s for alignment. Preceded by a newline.",
+                        sibling,
+                    )
+                    continue
                 reflow_logger.debug(
                     "    loc for %s: %s from %s",
                     sibling,

--- a/test/cli/commands_test.py
+++ b/test/cli/commands_test.py
@@ -1340,6 +1340,20 @@ def test__cli__command_rules():
     invoke_assert_code(args=[rules])
 
 
+def test__cli__command_rules_output_line_length(tmpdir, monkeypatch):
+    """Check the rules command respects the configured `output_line_length`."""
+    with open(str(tmpdir / ".sqlfluff"), "w") as f:
+        print("[sqlfluff]\noutput_line_length = 140", file=f)
+    # TRICKY: Switch current directory to the one with the config file. The
+    # `rules` command has no path argument, so nested config isn't an option.
+    monkeypatch.chdir(str(tmpdir))
+    result = invoke_assert_code(args=[rules])
+    # The first line is the header, the rest is the table of rules.
+    table_lines = result.stdout.splitlines()[1:]
+    assert table_lines
+    assert max(len(line) for line in table_lines) == 140
+
+
 def test__cli__command_dialects():
     """Check dialects command for exceptions."""
     invoke_assert_code(args=[dialects])

--- a/test/fixtures/rules/std_rule_cases/LT01-alignment.yml
+++ b/test/fixtures/rules/std_rule_cases/LT01-alignment.yml
@@ -252,6 +252,57 @@ test_excess_space_with_align_alias_tsql_mixed:
     FROM foo
   configs: *tsql_align_alias
 
+test_align_alias_leading_commas:
+  # Leading commas shouldn't disrupt the alignment of the aliases.
+  # https://github.com/sqlfluff/sqlfluff/issues/8256
+  fail_str: |
+    SELECT
+        'a' AS first_column
+        , 'bb' AS second_column
+        , 'c' AS third_column
+    FROM foo
+  fix_str: |
+    SELECT
+        'a'    AS first_column
+        , 'bb' AS second_column
+        , 'c'  AS third_column
+    FROM foo
+  configs: *align_alias
+
+test_align_alias_leading_commas_tsql:
+  # As above, but with the tsql `=` syntax, where the aligned
+  # `alias_expression` starts with the column name rather than a keyword.
+  # The first column is preceded by a newline rather than by a comma, so it
+  # shouldn't push the other columns to the right.
+  # https://github.com/sqlfluff/sqlfluff/issues/8256
+  fail_str: |
+    SELECT
+        first_column = a
+        , second_column = b
+        , third_column = c
+    FROM foo
+  fix_str: |
+    SELECT
+        first_column    = a
+        , second_column = b
+        , third_column  = c
+    FROM foo
+  configs:
+    core:
+      dialect: tsql
+    layout:
+      type:
+        comma:
+          line_position: leading
+        alias_operator:
+          spacing_before: align
+          align_within: select_clause
+          align_scope: bracketed
+        alias_expression:
+          spacing_before: align
+          align_within: select_clause
+          align_scope: bracketed
+
 test_align_multiple_a:
   # https://github.com/sqlfluff/sqlfluff/issues/4023
   fail_str: |


### PR DESCRIPTION
fix(reflow): ignore cross-line neighbours when aligning elements

## Testing

test/fixtures/rules/std_rule_cases/LT01-alignment.yml: test_align_alias_leading_commas (ANSI AS syntax, no-regression guard) and test_align_alias_leading_commas_tsql (tsql '=' alias syntax with leading commas; fails before the fix, passes after)

The added cases fail on `main` and pass with this change; the relevant test files were run locally.

## AI assistance

Disclosing per the AI-Assisted Contributions section of CONTRIBUTING.md: this code was written with the assistance of AI.

- AI-assisted: the implementation diff and the accompanying test cases.
- Manually validated: the behaviour was checked against the reproduction in the linked issue, the new test cases were confirmed to fail before the change and pass after it, and the surrounding rule/fixture conventions were followed.

I take responsibility for the correctness and maintainability of this pull request and am happy to rework any part of it.

Closes #8256