### PR TITLE
fix(CV06): flag statements which run into the next one

### DIFF
--- a/src/sqlfluff/rules/convention/CV06.py
+++ b/src/sqlfluff/rules/convention/CV06.py
@@ -1,6 +1,6 @@
 """Implementation of Rule CV06."""
 
-from collections.abc import Sequence
+from collections.abc import Iterator, Sequence
 from typing import NamedTuple, Optional, cast
 
 from sqlfluff.core.parser import BaseSegment, NewlineSegment, RawSegment, SymbolSegment
@@ -76,6 +76,20 @@ class Rule_CV06(BaseRule):
         # If no direct statement found, look recursively (e.g., T-SQL batch structure)
         statements = list(file_segment.recursive_crawl("statement"))
         return statements[-1] if statements else None
+
+    @staticmethod
+    def _iter_top_level_segments(file_segment: BaseSegment) -> Iterator[BaseSegment]:
+        """Iterate the top level segments of a file, unpacking any batches.
+
+        Some dialects (e.g. Oracle & T-SQL) group statements into ``batch``
+        segments, so they need unpacking to see all of the statements in a
+        file in the order they appear.
+        """
+        for seg in file_segment.segments:
+            if seg.is_type("batch"):
+                yield from seg.segments
+            else:
+                yield seg
 
     def _has_final_non_semicolon_terminator(self, file_segment: BaseSegment) -> bool:
         """Check if a statement has a non-semicolon terminator at the end."""
@@ -375,8 +389,12 @@ class Rule_CV06(BaseRule):
             last_statement.raw_segments
         ) and self._is_segment_semicolon(last_statement.raw_segments[-1])
 
+        # NOTE: We look across the whole file (unpacking any batches) rather
+        # than just within the statement container, because a terminator which
+        # this rule has already created will be a sibling of the container
+        # rather than a child of it.
         found_last_statement = False
-        for seg in statement_container.segments:
+        for seg in self._iter_top_level_segments(parent_segment):
             if seg is last_statement:
                 found_last_statement = True
             elif found_last_statement:
@@ -464,6 +482,74 @@ class Rule_CV06(BaseRule):
             )
         return None  # pragma: no cover
 
+    def _handle_missing_terminator(
+        self, statement: BaseSegment, parent_segment: BaseSegment
+    ) -> LintResult:
+        """Create a fix for a statement which isn't followed by a semi-colon."""
+        # Anchor on the last code segment of the statement.
+        anchor_segment: BaseSegment = (
+            Segments(*statement.raw_segments).reversed().select(sp.is_code())[0]
+        )
+        is_one_line = not any(statement.recursive_crawl("newline"))
+        semicolon_newline = self.multiline_newline if not is_one_line else False
+
+        create_segments: list[BaseSegment] = [
+            SymbolSegment(raw=";", type="statement_terminator")
+        ]
+        if semicolon_newline:
+            # Don't move any trailing inline comment as it could contain noqa
+            # instructions. Insert the semi-colon after it instead.
+            anchor_segment = self._handle_trailing_inline_comments(
+                parent_segment, anchor_segment
+            )
+            create_segments.insert(0, NewlineSegment())
+
+        return LintResult(
+            anchor=anchor_segment,
+            fixes=[
+                LintFix.create_after(
+                    self._choose_anchor_segment(
+                        parent_segment,
+                        "create_after",
+                        anchor_segment,
+                        filter_meta=True,
+                    ),
+                    create_segments,
+                )
+            ],
+        )
+
+    def _ensure_intermediate_semicolons(
+        self, file_segment: BaseSegment
+    ) -> list[LintResult]:
+        """Find statements which aren't separated from the next by a semi-colon.
+
+        In dialects which support batches (e.g. Oracle & T-SQL) consecutive
+        statements can parse successfully without any terminator between them,
+        so they need flagging explicitly.
+
+        NOTE: The final statement of the file is deliberately not handled here.
+        Whether it requires a terminator is governed by the
+        ``require_final_semicolon`` config option and is handled by
+        :meth:`_ensure_final_semicolon`.
+        """
+        results: list[LintResult] = []
+        unterminated: Optional[BaseSegment] = None
+        for seg in self._iter_top_level_segments(file_segment):
+            if not seg.is_code:
+                continue
+            if seg.is_type("statement"):
+                if unterminated is not None:
+                    results.append(
+                        self._handle_missing_terminator(unterminated, file_segment)
+                    )
+                unterminated = seg
+            else:
+                # Any other code (e.g. a terminator, or a batch delimiter such
+                # as Oracle's `/` or T-SQL's `GO`) closes off the statement.
+                unterminated = None
+        return results
+
     def _eval(self, context: RuleContext) -> list[LintResult]:
         """Statements must end with a semi-colon."""
         # Config type hints
@@ -472,7 +558,9 @@ class Rule_CV06(BaseRule):
 
         # We should only be dealing with a root segment
         assert context.segment.is_type("file")
-        results = []
+        # Statements which run straight into the next one are always missing a
+        # terminator, regardless of the configured conventions.
+        results = self._ensure_intermediate_semicolons(context.segment)
 
         # Process file segments and any batch segments (for T-SQL)
         # Collect all containers that should be processed

--- a/test/fixtures/rules/std_rule_cases/CV06.yml
+++ b/test/fixtures/rules/std_rule_cases/CV06.yml
@@ -751,3 +751,112 @@ test_fail_bigquery_procedure_missing_semicolon:
     rules:
       convention.terminator:
         require_final_semicolon: true
+
+# Statements which run straight into the following statement. Dialects with
+# batches (e.g. Oracle & T-SQL) parse these successfully, so the missing
+# terminator has to be flagged by this rule.
+# https://github.com/sqlfluff/sqlfluff/issues/5987
+test_fail_oracle_intermediate_statement_missing_semicolon:
+  fail_str: |
+    DELETE FROM code_detail
+    INSERT INTO code_head(code_type) VALUES('PLTQ');
+  fix_str: |
+    DELETE FROM code_detail;
+    INSERT INTO code_head(code_type) VALUES('PLTQ');
+  configs:
+    core:
+      dialect: oracle
+
+test_fail_oracle_intermediate_statement_missing_semicolon_multiline:
+  fail_str: |
+    DELETE
+      FROM code_detail
+     WHERE code_type IN ('PLTQ',
+                         'PLTM')
+    --
+    -- Plot quality
+    INSERT INTO code_head(code_type, code_desc)
+    VALUES('PLTQ', 'Plot Quality');
+  fix_str: |
+    DELETE
+      FROM code_detail
+     WHERE code_type IN ('PLTQ',
+                         'PLTM')
+    ;
+    --
+    -- Plot quality
+    INSERT INTO code_head(code_type, code_desc)
+    VALUES('PLTQ', 'Plot Quality')
+    ;
+  configs:
+    core:
+      dialect: oracle
+    rules:
+      convention.terminator:
+        multiline_newline: true
+
+test_fail_oracle_intermediate_statement_missing_semicolon_require_final:
+  fail_str: |
+    DELETE FROM code_detail
+    INSERT INTO code_head(code_type) VALUES('PLTQ')
+  fix_str: |
+    DELETE FROM code_detail;
+    INSERT INTO code_head(code_type) VALUES('PLTQ');
+  configs:
+    core:
+      dialect: oracle
+    rules:
+      convention.terminator:
+        require_final_semicolon: true
+
+test_fail_oracle_intermediate_statement_missing_semicolon_inline_comment:
+  fail_str: |
+    DELETE
+      FROM code_detail -- trailing comment
+    INSERT INTO code_head(code_type) VALUES('PLTQ');
+  fix_str: |
+    DELETE
+      FROM code_detail -- trailing comment
+    ;
+    INSERT INTO code_head(code_type) VALUES('PLTQ');
+  configs:
+    core:
+      dialect: oracle
+    rules:
+      convention.terminator:
+        multiline_newline: true
+
+test_fail_tsql_intermediate_statement_missing_semicolon:
+  fail_str: |
+    CREATE SCHEMA staging
+    CREATE TABLE test (id INT);
+  fix_str: |
+    CREATE SCHEMA staging;
+    CREATE TABLE test (id INT);
+  configs:
+    core:
+      dialect: tsql
+
+test_pass_tsql_go_terminates_statement:
+  # `GO` delimits the batch, so the preceding statement isn't run into the
+  # following one and doesn't need a semi-colon.
+  pass_str: |
+    CREATE SCHEMA staging
+    GO
+    CREATE TABLE test (id INT);
+  configs:
+    core:
+      dialect: tsql
+
+test_pass_oracle_slash_terminates_statement:
+  # Oracle's `/` delimits the batch in the same way that `GO` does for T-SQL.
+  pass_str: |
+    CREATE PROCEDURE test_proc AS
+    BEGIN
+        NULL;
+    END;
+    /
+    SELECT 1 FROM dual;
+  configs:
+    core:
+      dialect: oracle


### PR DESCRIPTION
CV06 only looks at semi-colons that are already present, plus the final statement in the file when `require_final_semicolon` is set. In dialects that support batches, such as Oracle and T-SQL, two statements in a row parse fine with nothing between them, so a missing semi-colon in the middle of a file was never reported.

This walks the top level segments of the file, unpacking batches, and flags a statement that is followed by another statement instead of by a terminator or a batch delimiter (`/` on Oracle, `GO` on T-SQL). The final-semicolon check now looks across the whole file as well, so a terminator this rule has just inserted is not added a second time on a later fix pass.

Testing: new cases in `test/fixtures/rules/std_rule_cases/CV06.yml` for an Oracle file and a T-SQL file that are each missing an intermediate semi-colon, plus a case for a file that is already correct so the rule stays quiet. The new cases fail on main and pass with this change. I ran the CV06 tests locally.

Code written with the assistance of AI. I checked it against the reproduction in the issue and confirmed the new cases fail without the change.

Closes #5987


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Flags intermediate statements missing terminators in batch-capable dialects and avoids duplicating final semicolons. Previously CV06 only checked existing semicolons and the final statement; now it detects when one statement runs directly into the next and inserts a single semicolon fix while respecting batch delimiters.

- Walks top-level file segments, unpacking `batch` segments, and treats `/` (Oracle) and `GO` (T‑SQL) as delimiters that end the preceding statement.
- Inserts one semicolon at the end of the unterminated statement; with `multiline_newline: true`, places a newline then the semicolon after any trailing inline comment to preserve `noqa`.
- Extends the final-semicolon check to scan the full file so a terminator added by this rule is not added again.
- No config changes required. Expect new lint violations in Oracle/T‑SQL where intermediate semicolons were previously accepted.

<sup>Written for commit 3c7c603e4b9e19f9de3881006b1e9c0c30a2eaf0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8328?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

