### PR TITLE
fix(RF01): treat Trino as a dot-access dialect

### DIFF
--- a/src/sqlfluff/rules/references/RF01.py
+++ b/src/sqlfluff/rules/references/RF01.py
@@ -42,7 +42,7 @@ class Rule_RF01(BaseRule):
     .. note::
 
        This rule is disabled by default for Athena, BigQuery, Databricks, DuckDB, Hive,
-       Redshift, SOQL and SparkSQL due to the support of things like
+       Redshift, SOQL, SparkSQL and Trino due to the support of things like
        structs and lateral views which trigger false positives. It can be
        enabled with the ``force_enable = True`` flag.
 
@@ -369,6 +369,8 @@ class Rule_RF01(BaseRule):
         # https://duckdb.org/docs/sql/data_types/struct#retrieving-from-structs
         # Redshift:
         # https://docs.aws.amazon.com/redshift/latest/dg/query-super.html
+        # Trino:
+        # https://trino.io/docs/current/language/types.html#row
         # TODO: all doc links to all referenced dialects
         return dialect.name in (
             "athena",
@@ -379,4 +381,5 @@ class Rule_RF01(BaseRule):
             "redshift",
             "soql",
             "sparksql",
+            "trino",
         )

--- a/test/fixtures/rules/std_rule_cases/RF01.yml
+++ b/test/fixtures/rules/std_rule_cases/RF01.yml
@@ -910,3 +910,41 @@ test_pass_mysql_comma_multi_table_update_alias_correlated_subquery:
   configs:
     core:
       dialect: mysql
+
+test_pass_trino_row_field_access_if_single_table:
+  # https://github.com/sqlfluff/sqlfluff/issues/5519
+  # Trino ROW columns expose their named fields via dot access, which is
+  # indistinguishable from a table reference.
+  pass_str: |
+    select
+        metadata.sub_column,
+        metadata.nested.sub_column
+    from sch.t1
+  configs:
+    core:
+      dialect: trino
+
+test_fail_trino_row_field_access_if_single_table_and_force_enable:
+  fail_str: |
+    select
+        metadata.sub_column,
+        metadata.nested.sub_column
+    from sch.t1
+  configs:
+    core:
+      dialect: trino
+    rules:
+      references.from:
+        force_enable: true
+
+test_fail_trino_row_field_access_if_multiple_tables:
+  fail_str: |
+    select
+        metadata.sub_column,
+        metadata.nested.sub_column
+    from sch.table1 as t1
+    left join sch.table2 as t2
+    on t1.id = t2.id
+  configs:
+    core:
+      dialect: trino


### PR DESCRIPTION
In Trino, a ROW column exposes its named fields through the `.` operator, so `metadata.sub_column` in a single table query is a struct field access and not a `table.column` reference. RF01 could not tell the two apart, so it reported the reference as pointing at a table that is missing from the FROM clause.

Trino is now included in the set of dialects that support dot access, alongside the other struct capable dialects that are already listed there. The rule stays quiet when only one table is in scope, and still fires when `force_enable` is set or when more than one table is in scope.

Testing: added cases to `test/fixtures/rules/std_rule_cases/RF01.yml` for a Trino ROW field access with a single table, and for the multiple table case where the violation should still be raised. The first fails on main. I ran the RF01 tests locally.

Code written with the assistance of AI. I confirmed the behaviour against the query in the issue.

Closes #5519


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Treats Trino as a dot-access dialect in RF01 to prevent false positives on ROW field access. Previously, `metadata.sub_column` in a single-table Trino query was read as `table.column` and RF01 raised a missing-FROM violation; now RF01 permits dot access with one table in scope, and still flags with `force_enable` or when multiple tables are present.

**Review notes**
- Adds Trino to `_dialect_supports_dot_access` in `RF01.py`.
- Adds Trino pass/fail cases to `test/fixtures/rules/std_rule_cases/RF01.yml` (single table pass; `force_enable` and multi-table fail).

<sup>Written for commit 3b3166811a1edd364d3ee89cdc84e986751609e2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8329?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

