### PR TITLE
fix(reflow): ignore cross-line neighbours when aligning elements

### DIFF
--- a/src/sqlfluff/utils/reflow/respace.py
+++ b/src/sqlfluff/utils/reflow/respace.py
@@ -463,6 +463,17 @@ def _determine_aligned_inline_spacing(
                     )
                 else:
                     loc = last_code.pos_marker.working_loc_after(last_code.raw)
+                # If the preceding code is on a different line, then this sibling
+                # is the first thing on its own line. The whitespace before it is
+                # indentation (handled by the reindent routines and not here), so
+                # including it would inflate the alignment target with a position
+                # from an unrelated line.
+                if loc[0] != _pos_line(sibling.pos_marker, use_source_positions):
+                    reflow_logger.debug(
+                        "    Skipping %s for alignment. Preceded by a newline.",
+                        sibling,
+                    )
+                    continue
                 reflow_logger.debug(
                     "    loc for %s: %s from %s",
                     sibling,

--- a/test/fixtures/rules/std_rule_cases/LT01-alignment.yml
+++ b/test/fixtures/rules/std_rule_cases/LT01-alignment.yml
@@ -252,6 +252,57 @@ test_excess_space_with_align_alias_tsql_mixed:
     FROM foo
   configs: *tsql_align_alias
 
+test_align_alias_leading_commas:
+  # Leading commas shouldn't disrupt the alignment of the aliases.
+  # https://github.com/sqlfluff/sqlfluff/issues/8256
+  fail_str: |
+    SELECT
+        'a' AS first_column
+        , 'bb' AS second_column
+        , 'c' AS third_column
+    FROM foo
+  fix_str: |
+    SELECT
+        'a'    AS first_column
+        , 'bb' AS second_column
+        , 'c'  AS third_column
+    FROM foo
+  configs: *align_alias
+
+test_align_alias_leading_commas_tsql:
+  # As above, but with the tsql `=` syntax, where the aligned
+  # `alias_expression` starts with the column name rather than a keyword.
+  # The first column is preceded by a newline rather than by a comma, so it
+  # shouldn't push the other columns to the right.
+  # https://github.com/sqlfluff/sqlfluff/issues/8256
+  fail_str: |
+    SELECT
+        first_column = a
+        , second_column = b
+        , third_column = c
+    FROM foo
+  fix_str: |
+    SELECT
+        first_column    = a
+        , second_column = b
+        , third_column  = c
+    FROM foo
+  configs:
+    core:
+      dialect: tsql
+    layout:
+      type:
+        comma:
+          line_position: leading
+        alias_operator:
+          spacing_before: align
+          align_within: select_clause
+          align_scope: bracketed
+        alias_expression:
+          spacing_before: align
+          align_within: select_clause
+          align_scope: bracketed
+
 test_align_multiple_a:
   # https://github.com/sqlfluff/sqlfluff/issues/4023
   fail_str: |


### PR DESCRIPTION
When working out the alignment target for an `align` spacing constraint, the position after the preceding code segment was used even when that segment was on an earlier line. In a select clause written with leading commas and the T-SQL `col = value` alias syntax, the preceding code for the first element is the `SELECT` keyword itself, so its end column inflated the target and a spurious space was added after the leading comma on every other element.

Elements that start their own line have their leading whitespace handled by the reindent routines, so they are now skipped when the target column is calculated.

This is the same problem as #8265, which was closed for inactivity. The test lives in `test/fixtures/rules/std_rule_cases/LT01-alignment.yml`, which is where the review on that PR asked for it.

Testing: `test_align_alias_leading_commas_tsql` covers the T-SQL `=` alias syntax with leading commas and fails on main, and `test_align_alias_leading_commas` covers the ANSI `AS` form as a no-regression guard. I ran the LT01 tests locally.

Code written with the assistance of AI. I verified the before and after output on the query from the issue.

Closes #8256


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes alignment target calculation for `align` spacing by ignoring predecessors on a different line. Previously, we used the position after the preceding code even when it was on an earlier line, inflating the target and adding a spurious space after leading commas in SELECT clauses (notably with T‑SQL `col = value`). Now elements starting a new line rely on reindent for indentation; inline alignment ignores cross-line neighbors.

- Changes are localized to `_determine_aligned_inline_spacing()`: skip alignment when the preceding code’s line differs from the sibling’s line.
- Adds tests for leading-commas alignment with ANSI `AS` and T‑SQL `=` alias syntax in `test/fixtures/rules/std_rule_cases/LT01-alignment.yml`; they fail on `main` and pass with this change.
- No rule or config changes; only affects inline alignment behavior during reflow. Closes #8256.

<sup>Written for commit 1f0968cde390c3ffa12c176dc72e2a4fe98db8f7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8330?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

