### PR TITLE
fix(config): keep nested sections inside toml config lists

### DIFF
--- a/src/sqlfluff/core/config/toml.py
+++ b/src/sqlfluff/core/config/toml.py
@@ -15,7 +15,7 @@ from sqlfluff.core.helpers.dict import (
     iter_records_from_nested_dict,
     records_to_nested_dict,
 )
-from sqlfluff.core.types import ConfigMappingType
+from sqlfluff.core.types import ConfigListItemType, ConfigMappingType
 
 T = TypeVar("T")
 
@@ -35,6 +35,20 @@ def _condense_rule_record(record: NestedDictRecord[T]) -> NestedDictRecord[T]:
     return key, value
 
 
+def _validate_list(raw_list: list[Any]) -> list[ConfigListItemType]:
+    """Helper function to narrow the types of a list found in a toml config.
+
+    Any mappings within the list keep their structure, so that nested
+    values (e.g. a jinja templater context) survive loading. Anything
+    else is coerced to a string, to be in line with the behaviour of
+    ini configs.
+    """
+    return [
+        _validate_structure(item) if isinstance(item, dict) else str(item)
+        for item in raw_list
+    ]
+
+
 def _validate_structure(raw_config: dict[str, Any]) -> ConfigMappingType:
     """Helper function to narrow types for use by SQLFluff.
 
@@ -45,9 +59,7 @@ def _validate_structure(raw_config: dict[str, Any]) -> ConfigMappingType:
         if isinstance(value, dict):
             validated_config[key] = _validate_structure(value)
         elif isinstance(value, list):
-            # Coerce all list items to strings, to be in line
-            # with the behaviour of ini configs.
-            validated_config[key] = [str(item) for item in value]
+            validated_config[key] = _validate_list(value)
         elif isinstance(value, (str, int, float, bool)) or value is None:
             validated_config[key] = value
         else:  # pragma: no cover

--- a/src/sqlfluff/core/linter/discovery.py
+++ b/src/sqlfluff/core/linter/discovery.py
@@ -88,19 +88,21 @@ def _load_configfile(dirpath: str, filename: str) -> Optional[IgnoreSpecRecord]:
     if not isinstance(ignore_section, dict):
         return None  # pragma: no cover
     patterns = ignore_section.get("ignore_paths", [])
-    # If it's already a list, then we don't need to edit `patterns`,
-    # but if it's not then we either split a string into a list and
-    # then process it, or if there's nothing in the patterns list
-    # (or the pattern input is invalid by not being something other
-    # than a string or list) then we assume there's no ignore pattern
-    # to process and just return None.
+    # If it's already a list, then we only need to filter out any values
+    # which aren't strings (which are invalid as patterns), but if it's
+    # not then we either split a string into a list and then process it,
+    # or if there's nothing in the patterns list (or the pattern input is
+    # invalid by not being something other than a string or list) then we
+    # assume there's no ignore pattern to process and just return None.
     if isinstance(patterns, str):
-        patterns = patterns.split(",")
-    elif not patterns or not isinstance(patterns, list):
+        pattern_lines = patterns.split(",")
+    elif patterns and isinstance(patterns, list):
+        pattern_lines = [pattern for pattern in patterns if isinstance(pattern, str)]
+    else:
         return None
     # By reaching here, we think there is a valid set of ignore patterns
     # to process.
-    spec = _load_specs_from_lines(patterns, filepath)
+    spec = _load_specs_from_lines(pattern_lines, filepath)
     return dirpath, filename, spec
 
 

--- a/src/sqlfluff/core/types.py
+++ b/src/sqlfluff/core/types.py
@@ -8,13 +8,16 @@ from colorama import Fore
 from sqlfluff.core.helpers.dict import NestedDictRecord, NestedStringDict
 
 ConfigValueType = Union[int, float, bool, None, str]
-# NOTE: We allow lists in the config types, but only lists
-# of strings. Lists of other things are not allowed and should
-# be rejected on load (or converted to strings). Given most
-# config loading starts as strings, it's more likely that we
-# just don't _try_ to convert lists from anything other than
-# strings.
-ConfigValueOrListType = Union[ConfigValueType, list[str]]
+# NOTE: We allow lists in the config types, but only lists of
+# strings or of nested sections. Lists of other things are not
+# allowed and should be rejected on load (or converted to strings).
+# Given most config loading starts as strings, it's more likely that
+# we just don't _try_ to convert lists from anything other than
+# strings. Nested sections are only reachable from formats which
+# support them natively (i.e. toml), where they're preserved so that
+# structures like jinja templater contexts survive loading.
+ConfigListItemType = Union[str, "ConfigMappingType"]
+ConfigValueOrListType = Union[ConfigValueType, list[ConfigListItemType]]
 ConfigMappingType = NestedStringDict[ConfigValueOrListType]
 ConfigRecordType = NestedDictRecord[ConfigValueOrListType]
 

--- a/test/core/config/loader_test.py
+++ b/test/core/config/loader_test.py
@@ -373,6 +373,38 @@ def test__config__toml_list_config():
     assert cfg.get("rules") == ["LT03", "LT09"]
 
 
+def test__config__toml_nested_list_config(tmp_path):
+    """Test that sections nested within TOML lists keep their structure.
+
+    Values in the jinja context are arbitrary user data, so nested
+    structures (which only toml configs can express natively) must
+    survive loading. https://github.com/sqlfluff/sqlfluff/issues/6508
+    """
+    pyproject_path = tmp_path / "pyproject.toml"
+    pyproject_path.write_text(
+        "[tool.sqlfluff.core]\n"
+        'dialect = "ansi"\n'
+        "\n"
+        "[tool.sqlfluff.templater.jinja.context]\n"
+        "bundle = { name = 'foo', metrics = ["
+        "{ name = 'bar', definition = 'COUNT(*)' }] }\n",
+        encoding="utf-8",
+    )
+
+    try:
+        cfg = load_config_file(str(tmp_path), "pyproject.toml")
+    finally:
+        clear_config_caches()
+        pyproject_path.unlink(missing_ok=True)
+
+    assert cfg["templater"]["jinja"]["context"] == {
+        "bundle": {
+            "name": "foo",
+            "metrics": [{"name": "bar", "definition": "COUNT(*)"}],
+        }
+    }
+
+
 def test__config__load_toml_invalid_syntax(tmp_path):
     """Invalid TOML should raise a SQLFluff user error with location info."""
     pyproject_path = tmp_path / "pyproject.toml"

--- a/test/core/templaters/jinja_test.py
+++ b/test/core/templaters/jinja_test.py
@@ -762,6 +762,36 @@ def test__templater_jinja_fast_path_library_path_error(tmp_path):
         )
 
 
+def test__templater_jinja_nested_context_from_toml(tmp_path):
+    """Nested context values from a pyproject.toml keep their structure.
+
+    https://github.com/sqlfluff/sqlfluff/issues/6508
+    """
+    (tmp_path / "pyproject.toml").write_text(
+        "[tool.sqlfluff.core]\n"
+        'dialect = "ansi"\n'
+        'templater = "jinja"\n'
+        "\n"
+        "[tool.sqlfluff.templater.jinja.context]\n"
+        "bundle = { metrics = ["
+        "{ name = 'logged_days', definition = 'COUNT(*)' }] }\n",
+        encoding="utf-8",
+    )
+
+    outstr, vs = JinjaTemplater().process(
+        in_str=(
+            "select\n"
+            "{% for metric in bundle.metrics %}"
+            "    {{ metric.definition }} as {{ metric.name }}\n"
+            "{% endfor %}"
+        ),
+        fname="test.sql",
+        config=FluffConfig.from_path(str(tmp_path)),
+    )
+    assert str(outstr) == "select\n    COUNT(*) as logged_days\n"
+    assert not vs
+
+
 def test__templater_jinja_lint_empty():
     """Check that parsing a file which renders to an empty string.
 


### PR DESCRIPTION
Since 3.2.0 the toml loader has coerced every item of a list to a string, so a list of tables (e.g. a nested jinja templater context defined in `pyproject.toml`) was flattened into a list of stringified dicts and attribute access on those items rendered empty. List items which are mappings now keep their structure, while other items are still coerced to strings to stay in line with ini configs.

Closes #6508


<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->


### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [ ] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves nested sections in TOML config lists instead of coercing them to strings. This restores Jinja templater contexts defined in `pyproject.toml` that include lists of tables and fixes the regression introduced in 3.2.0.

**Behavior changes**
- TOML loader: list items that are mappings keep their structure; all other list items are coerced to strings (old behavior coerced everything to strings).
- Jinja templater context from `pyproject.toml` now supports nested objects; attribute access works as expected.
- Config discovery: `ignore_paths` lists are filtered to include only strings; non-string entries are ignored. A string value is still split by comma.
- No migration required.

**Review notes**
- Introduces `_validate_list` and updates types with `ConfigListItemType` to allow `list[str | mapping]`.
- Adds tests for TOML list-of-tables loading and Jinja rendering with a nested context.

<sup>Written for commit df62d35ea2bfaf6945056d6c1aada34031abf50b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8331?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

