### PR TITLE
fix(cli): honour output_line_length in `sqlfluff rules`

### DIFF
--- a/src/sqlfluff/cli/formatters.py
+++ b/src/sqlfluff/cli/formatters.py
@@ -623,7 +623,7 @@ class OutputStreamFormatter(FormatterInterface):
                     )
                     for t in linter.rule_tuples()
                 ],
-                col_width=80,
+                col_width=self.output_line_length,
                 cols=1,
                 label_color=Color.blue,
                 val_align="left",

--- a/test/cli/commands_test.py
+++ b/test/cli/commands_test.py
@@ -1340,6 +1340,20 @@ def test__cli__command_rules():
     invoke_assert_code(args=[rules])
 
 
+def test__cli__command_rules_output_line_length(tmpdir, monkeypatch):
+    """Check the rules command respects the configured `output_line_length`."""
+    with open(str(tmpdir / ".sqlfluff"), "w") as f:
+        print("[sqlfluff]\noutput_line_length = 140", file=f)
+    # TRICKY: Switch current directory to the one with the config file. The
+    # `rules` command has no path argument, so nested config isn't an option.
+    monkeypatch.chdir(str(tmpdir))
+    result = invoke_assert_code(args=[rules])
+    # The first line is the header, the rest is the table of rules.
+    table_lines = result.stdout.splitlines()[1:]
+    assert table_lines
+    assert max(len(line) for line in table_lines) == 140
+
+
 def test__cli__command_dialects():
     """Check dialects command for exceptions."""
     invoke_assert_code(args=[dialects])


### PR DESCRIPTION
The rules table was rendered with a hardcoded column width of 80, so setting `output_line_length` in a config file had no effect on the output of `sqlfluff rules` and longer rule descriptions were always wrapped at 72 characters. Use the configured `output_line_length` instead, which still defaults to 80.

Closes #6334


<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->


### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [ ] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `sqlfluff rules` respect the `output_line_length` config when rendering the rules table. Previously the table used a hardcoded width of 80 (causing premature wrapping); now it uses the configured value and still defaults to 80.

**Review notes**
- Replace fixed `col_width=80` with `col_width=self.output_line_length` in the CLI formatter.
- Add a CLI test that sets `output_line_length = 140` via `.sqlfluff` and asserts the table lines max length is 140.
- No migration required; this only affects the `sqlfluff rules` output formatting.

<sup>Written for commit aec8e9ba83c0802399905ceb6d0105a829756928. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8332?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

