### PR TITLE
fix(rules): apply identifier policies to CTE names

### DIFF
--- a/src/sqlfluff/rules/references/RF04.py
+++ b/src/sqlfluff/rules/references/RF04.py
@@ -21,6 +21,11 @@ class Rule_RF04(BaseRule):
        Note that `reserved` keywords cannot be used as unquoted identifiers
        and will cause parsing errors and so are not covered by this rule.
 
+    .. note::
+       The name given to a common table expression is treated as a table
+       alias, and so is covered by the ``aliases`` and ``table_aliases``
+       identifier policies.
+
     **Anti-pattern**
 
     In this example, ``SUM`` (built-in function) is used as an alias.

--- a/src/sqlfluff/utils/identifers.py
+++ b/src/sqlfluff/utils/identifers.py
@@ -22,11 +22,14 @@ def identifiers_policy_applicable(
     is_alias = parent_stack and parent_stack[-1].is_type(
         "alias_expression", "column_definition", "with_compound_statement"
     )
-    if policy == "aliases" and is_alias:
+    # The name given to a CTE isn't parsed as an `alias_expression`, but it
+    # names a table-like object and so is treated as a table alias here.
+    is_cte_name = parent_stack and parent_stack[-1].is_type("common_table_expression")
+    if policy == "aliases" and (is_alias or is_cte_name):
         return True
     is_inside_from = any(p.is_type("from_clause") for p in parent_stack)
     if policy == "column_aliases" and is_alias and not is_inside_from:
         return True
-    if policy == "table_aliases" and is_alias and is_inside_from:
+    if policy == "table_aliases" and (is_cte_name or (is_alias and is_inside_from)):
         return True
     return False

--- a/test/cli/commands_test.py
+++ b/test/cli/commands_test.py
@@ -2195,7 +2195,7 @@ def test__cli__command_lint_serialize_multiple_files(serialize, write_file, tmp_
     print("Result length:", payload_length)
 
     if serialize == "human":
-        assert payload_length == 25 if write_file else 34
+        assert payload_length == 27 if write_file else 36
     elif serialize == "none":
         assert payload_length == 1  # There will be a single newline.
     elif serialize == "json":
@@ -2229,7 +2229,7 @@ def test__cli__command_lint_serialize_multiple_files(serialize, write_file, tmp_
         # SQLFluff produces trailing newline
         if result[-1] == "":
             del result[-1]
-        assert len(result) == 16
+        assert len(result) == 17
     else:
         raise Exception
 
@@ -2774,7 +2774,7 @@ L:  44 | P:  12 | ST09 | Joins should list the table referenced earlier first.
 Are you sure you wish to attempt to fix these? [Y/n] ...
 Invalid input, please enter 'Y' or 'N'
 Aborting...
-  [4 unfixable linting violations found]
+  [5 unfixable linting violations found]
 """
 
 
@@ -2855,7 +2855,7 @@ def test__cli__fix_multiple_errors_show_errors():
         ],
     )
     # We should get a readout of what the error was
-    check_a = "4 unfixable linting violations found"
+    check_a = "5 unfixable linting violations found"
     assert check_a in result.stdout
     # Finally check the WHOLE output to make sure that unexpected newlines are not
     # added. The replace command just accounts for cross platform testing.

--- a/test/fixtures/rules/std_rule_cases/RF04.yml
+++ b/test/fixtures/rules/std_rule_cases/RF04.yml
@@ -115,6 +115,48 @@ test_fail_keyword_as_quoted_identifier_column_alias_config:
     core:
       dialect: tsql
 
+test_fail_keyword_as_cte_name:
+  # A CTE name is effectively a table alias, so the default `aliases` policy
+  # should flag it.
+  fail_str: |
+    WITH sum AS (SELECT 1 AS test_rf04)
+
+    SELECT sum.test_rf04
+    FROM sum
+
+test_pass_keyword_as_cte_name_column_alias_config:
+  pass_str: |
+    WITH sum AS (SELECT 1 AS test_rf04)
+
+    SELECT sum.test_rf04
+    FROM sum
+  configs:
+    rules:
+      references.keywords:
+        unquoted_identifiers_policy: column_aliases
+
+test_fail_keyword_as_cte_name_table_alias_config:
+  fail_str: |
+    WITH sum AS (SELECT 1 AS test_rf04)
+
+    SELECT sum.test_rf04
+    FROM sum
+  configs:
+    rules:
+      references.keywords:
+        unquoted_identifiers_policy: table_aliases
+
+test_fail_keyword_as_quoted_cte_name:
+  fail_str: |
+    WITH "sum" AS (SELECT 1 AS test_rf04)
+
+    SELECT "sum".test_rf04
+    FROM "sum"
+  configs:
+    rules:
+      references.keywords:
+        quoted_identifiers_policy: aliases
+
 test_pass_ignore_word1:
   pass_str: CREATE TABLE artist(create TEXT)
   configs:


### PR DESCRIPTION
`identifiers_policy_applicable` only recognised `alias_expression`, `column_definition` and `with_compound_statement` parents, so the name of a common table expression (whose parent is `common_table_expression`) was never considered an alias. As a result RF04 - which defaults to the `aliases` policy
- silently ignored keywords used as CTE names, e.g. `WITH sum AS (...)`.

A CTE name names a table-like object, so it is now treated as a table alias: it is flagged under the `aliases` and `table_aliases` policies and left alone under `column_aliases`. This also applies to CP02 and RF05, which share the same helper.

Closes #5487


<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->


### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [ ] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Apply identifier policies to common table expression (CTE) names so keyword CTE names are linted. Previously RF04 ignored keyword CTE names because they weren’t treated as aliases; now a CTE name is treated as a table alias, flagged under aliases/table_aliases and not under column_aliases. Also applies to CP02 and RF05. Closes #5487.

- Update `identifiers_policy_applicable` to treat `common_table_expression` names as table aliases; add RF04 CTE tests and adjust CLI expectations for the extra violation.
- Migration: You may see new RF04/CP02/RF05 failures for keyword CTE names. Rename or quote the CTE name, or set `references.keywords.unquoted_identifiers_policy: column_aliases` to suppress.

<sup>Written for commit 5f0d0d5b20b96a328814c3318348f0ba7ce74a6d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8333?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

