### PR TITLE
refactor(docsv): replace usage/index stub with sidebar section group

### DIFF
--- a/docsv/.vitepress/config.ts
+++ b/docsv/.vitepress/config.ts
@@ -53,7 +53,6 @@ const CONFIGURATION_NAV: DefaultTheme.NavItemWithLink[] = [
 ]
 
 const USAGE_GUIDES: DefaultTheme.NavItemWithLink[] = [
-    { text: 'Production Usage', link: '/usage/' },
     { text: 'CLI Exit Codes', link: '/usage/cli' },
     { text: 'Security', link: '/usage/security' },
     { text: 'Team Rollout', link: '/usage/team-rollout' },

--- a/docsv/guide/install.md
+++ b/docsv/guide/install.md
@@ -83,7 +83,7 @@ From here, there are several more things to explore.
 * To find out more about configuring *SQLFluff* and what other options
   are available, see [Configuration](/configuration/).
 * Once you're ready to start using *SQLFluff* on a project or with the
-  rest of your team, check out [Production Usage](/usage/index).
+  rest of your team, check out [Team Rollout](/usage/team-rollout).
 
 One last thing to note is that *SQLFluff* is a relatively new project
 and you may find bugs or strange things while using it. If you do find

--- a/docsv/usage/index.md
+++ b/docsv/usage/index.md
@@ -1,3 +1,0 @@
-# Production Usage
-
-SQLFluff is designed to be used both as a utility for developers but also to be part of CI/CD pipelines.


### PR DESCRIPTION
## Summary

- Removes the single-sentence `usage/index.md` stub page, which was acting as a section heading without the site being structured to support it
- The outer "Usage Guides" sidebar group already serves as the implicit section label, so no content is lost
- Fixes the dead `/usage/index` link in `guide/install.md`, pointing it to `/usage/team-rollout` to match the surrounding "with the rest of your team" context

## Test plan

- [ ] VitePress build completes without dead-link warnings
- [ ] Sidebar "Usage Guides" section renders correctly with CLI Exit Codes as the first item
- [ ] Link in Installation page (`guide/install.md`) resolves to Team Rollout page

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the `usage/index.md` stub and its "Production Usage" nav item so the existing "Usage Guides" sidebar acts as the section label, and fixes the dead link in Installation to point to Team Rollout. Previously `/usage/` was a one-line stub; now there is no `/usage/index`, and "CLI Exit Codes" appears first under "Usage Guides". Links to `/usage/` or `/usage/index` will 404 and must be updated.

**Review and rollout**
- Verify `docsv/.vitepress/config.ts` no longer lists "Production Usage" and that the sidebar renders with "CLI Exit Codes" first.
- Confirm `guide/install.md` now links to `/usage/team-rollout` and resolves.
- Update any remaining links to `/usage/` or `/usage/index` to a specific guide (e.g., `/usage/team-rollout` or `/usage/cli`).

<sup>Written for commit 0a8496f338f6a7653d264048aa3df9557bfe2310. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8337?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

