### PR TITLE
fix(docsv): inline starter config to remove Sphinx cross-dependency

### DIFF
--- a/docsv/configuration/index.md
+++ b/docsv/configuration/index.md
@@ -70,7 +70,76 @@ When setting up a new project with SQLFluff, we recommend keeping your configura
 
 Here is a simple configuration file which would be suitable for a starterproject:
 
-<<< @/../docs/source/_partials/starter_config.cfg{ini}
+```ini
+[sqlfluff]
+
+# Supported dialects https://docs.sqlfluff.com/en/stable/perma/dialects.html
+# Or run 'sqlfluff dialects'
+dialect = snowflake
+
+# One of [raw|jinja|python|placeholder]
+templater = jinja
+
+# Comma separated list of rules to exclude, or None
+# See https://docs.sqlfluff.com/en/stable/perma/rule_disabling.html
+# AM04 (ambiguous.column_count) and ST06 (structure.column_order) are
+# two of the more controversial rules included to illustrate usage.
+exclude_rules = ambiguous.column_count, structure.column_order
+
+# The standard max_line_length is 80 in line with the convention of
+# other tools and several style guides. Many projects however prefer
+# something a little longer.
+# Set to zero or negative to disable checks.
+max_line_length = 120
+
+# CPU processes to use while linting.
+# The default is "single threaded" to allow easy debugging, but this
+# is often undesirable at scale.
+# If positive, just implies number of processes.
+# If negative or zero, implies number_of_cpus - specified_number.
+# e.g. -1 means use all processors but one. 0 means all cpus.
+processes = -1
+
+# If using the dbt templater, we recommend setting the project dir.
+[sqlfluff:templater:dbt]
+project_dir = ./
+
+[sqlfluff:indentation]
+# While implicit indents are not enabled by default. Many of the
+# SQLFluff maintainers do use them in their projects.
+implicit_indents = allow
+
+[sqlfluff:rules:aliasing.length]
+min_alias_length = 3
+
+# The default configuration for capitalisation rules is "consistent"
+# which will auto-detect the setting from the rest of the file. This
+# is less desirable in a new project and you may find this (slightly
+# more strict) setting more useful.
+# Typically we find users rely on syntax highlighting rather than
+# capitalisation to distinguish between keywords and identifiers.
+# Clearly, if your organisation has already settled on uppercase
+# formatting for any of these syntax elements then set them to "upper".
+# See https://stackoverflow.com/questions/608196/why-should-i-capitalize-my-sql-keywords-is-there-a-good-reason
+[sqlfluff:rules:capitalisation.keywords]
+capitalisation_policy = lower
+[sqlfluff:rules:capitalisation.identifiers]
+extended_capitalisation_policy = lower
+[sqlfluff:rules:capitalisation.functions]
+extended_capitalisation_policy = lower
+[sqlfluff:rules:capitalisation.literals]
+capitalisation_policy = lower
+[sqlfluff:rules:capitalisation.types]
+extended_capitalisation_policy = lower
+
+# The default configuration for the not equal convention rule is "consistent"
+# which will auto-detect the setting from the rest of the file. This
+# is less desirable in a new project and you may find this (slightly
+# more strict) setting more useful.
+[sqlfluff:rules:convention.not_equal]
+# Default to preferring the "c_style" (i.e. `!=`)
+preferred_not_equal_style = c_style
+```
 
 ### Nesting
 


### PR DESCRIPTION
## Summary

- Replaces the VitePress `<<<` snippet directive in `docsv/configuration/index.md` that referenced `docs/source/_partials/starter_config.cfg` (inside the Sphinx source tree) with an inlined fenced code block
- Removes the last remaining hard dependency from the VitePress docs on the Sphinx source tree
- VitePress docs can now build and operate independently of `docs/source/`

## Test plan

- [ ] Verify `docsv/configuration/index.md` renders the starter config block correctly in a local VitePress build
- [ ] Confirm no remaining `docs/source/` references in `docsv/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Inlines the starter configuration in `docsv/configuration/index.md` and removes the `VitePress` snippet that pulled from the `Sphinx` source tree. Previously the page used `<<< @/../docs/source/_partials/starter_config.cfg{ini}`; now it uses a fenced code block so `VitePress` builds no longer depend on `docs/source/`.

- Review
  - Verify the inlined block renders correctly in a local `VitePress` build.
  - Confirm there are no remaining `docs/source/` references in `docsv/`.

- Migration
  - When updating the starter config, edit the inlined block in `docsv/configuration/index.md`; it no longer auto-syncs from `docs/source/_partials/starter_config.cfg`.

<sup>Written for commit e9b6a90a19c4d3b4ffef7a13e74484ffa743a37d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8338?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

