### PR TITLE
fix(docsv): update stale content across 5 pages

### DIFF
--- a/docsv/configuration/layout.md
+++ b/docsv/configuration/layout.md
@@ -273,11 +273,6 @@ FROM indented_the_same_as_select
 
 ### Comment Indents
 
-::: tip NOTE
-The notes here about block comments are not implemented prior
-to 2.0.x. They should be coming in that release or soon after.
-:::
-
 **Comments** are dealt with differently, depending on whether they're
 *block* comments (`/* like this */`), which might optionally
 include newlines, or *inline* comments (`-- like this`) which

--- a/docsv/configuration/templating/dbt.md
+++ b/docsv/configuration/templating/dbt.md
@@ -1,16 +1,5 @@
 # `dbt` templater
 
-::: tip NOTE
-From sqlfluff version 0.7.0 onwards, the dbt templater has been moved
-to a separate plugin and python package. Projects that were already using
-the dbt templater may initially fail after an upgrade to 0.7.0+. See the
-installation instructions below to install the dbt templater.
-
-dbt templating is still a relatively new feature added in 0.4.0 and
-is still in very active development! If you encounter an issue, please
-let us know in a GitHub issue or on the SQLFluff slack workspace.
-:::
-
 `dbt` is not the default templater for *SQLFluff* (it is `jinja`).
 `dbt` is a complex tool, so using the default `jinja` templater
 will be simpler. You should be aware when using the `dbt` templater that

--- a/docsv/development/documentation.md
+++ b/docsv/development/documentation.md
@@ -99,8 +99,12 @@ pnpm run docs:build
 pnpm run docs:preview
 ```
 
-Or for a live-reloading dev server during writing:
+For a live-reloading dev server during writing, you must generate the auto-generated reference
+pages first — otherwise all `/reference/...` links will 404:
 
 ```bash
-pnpm run docs:dev
+pnpm run docs:prebuild   # generates rules, CLI, dialect, and API pages
+pnpm run docs:dev        # then start the hot-reloading server
 ```
+
+If you edit any Python source or docstrings, re-run `docs:prebuild` to update the reference pages.

--- a/docsv/development/documentation.md
+++ b/docsv/development/documentation.md
@@ -9,14 +9,14 @@ Documentation takes two forms:
 
 1. Embedded documentation found in function and module [docstrings](https://en.wikipedia.org/wiki/Docstring).
 
-2. The free-standing documentation which you're reading now, and hosted
-   at [docs.sqlfluff.com](https://docs.sqlfluff.com) (built using `sphinx` and [ReadtheDocs](https://about.readthedocs.com/)).
+2. The free-standing documentation which you're reading now, hosted at
+   [docs.sqlfluff.com](https://docs.sqlfluff.com) and built using [VitePress](https://vitepress.dev/).
 
-The two are somewhat blurred by the use of [autodoc](https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html) (and some other custom
-integrations), where documentation is generated directly off [docstrings](https://en.wikipedia.org/wiki/Docstring)
-within the codebase, for example the [Rules Reference](/reference/rules/index), [CLI Reference](/reference/cli/index) and
-[Dialect Reference](/reference/dialects/index). To understand more about how the custom integrations
-we use to generate these docs, see the [generate-auto-docs.py](https://github.com/sqlfluff/sqlfluff/blob/main/docs/generate-auto-docs.py) file.
+The two are somewhat blurred by a set of custom generation scripts that emit Markdown pages
+directly from [docstrings](https://en.wikipedia.org/wiki/Docstring) in the codebase — for example the
+[Rules Reference](/reference/rules/index), [CLI Reference](/reference/cli/index),
+[Dialect Reference](/reference/dialects/index), and [Internal API Reference](/reference/internals/index).
+All generation is orchestrated by [`docsv/scripts/generate-all-docs.py`](https://github.com/sqlfluff/sqlfluff/blob/main/docsv/scripts/generate-all-docs.py).
 
 For the active beta-docs migration and deployment work, see the
 [Versioned Beta Docs Hosting Plan](/development/versioned-docs-hosting).
@@ -31,74 +31,76 @@ that docstrings are present and correctly formatted using the
 [pydocstyle rules for ruff](https://docs.astral.sh/ruff/rules/#pydocstyle-d), which we have configured to enforce the
 [google style of docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).
 
-## Sphinx Docs
+## VitePress Docs
 
-The main documentation (which you're reading now), is build using [sphinx](https://www.sphinx-doc.org/en/master/),
-and written using [reStructuredText](https://www.sphinx-doc.org/en/master/usage/restructuredtext/index.html) (files ending with `.rst`). The
-[sphinx](https://www.sphinx-doc.org/en/master/) project offers a [reStructuredText primer](https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html) for people who are new
-to the syntax (and the SQLFluff project uses [doc8](https://github.com/PyCQA/doc8) in the CI process to try
-and catch any issues early).
+The free-standing documentation is written in [Markdown](https://www.markdownguide.org/) (files ending
+with `.md`) and built with [VitePress](https://vitepress.dev/). Source files live under `docsv/`.
 
-On top of those docs, there are a few areas worth highlighting for new (or
-returning) users, which are either specific to the SQLFluff project, or not
-particularly clear in the sphinx docs:
+### Writing Markdown
 
-* [reStructuredText](https://www.sphinx-doc.org/en/master/usage/restructuredtext/index.html) is very similar to, but differs from (the somewhat more
-  well known) [Markdown](https://www.markdownguide.org/) syntax. Importantly:
+VitePress uses standard [CommonMark](https://commonmark.org/) Markdown with some extensions:
 
-  * `*text with single asterisks*` renders as *italics*. Use
-    `**double asterisks**` for **bold text**.
+- `*single asterisks*` or `_underscores_` render as *italics*; `**double asterisks**` for **bold**.
+- Inline code uses single backticks: `` `code` ``. Fenced code blocks use triple backticks with an
+  optional language tag for syntax highlighting:
 
-  * `code snippets` are created using the |codesnippet|
-    directive, rather than just lone backticks (|backquotes|) as found in
-    most [Markdown](https://www.markdownguide.org/).
+  ````md
+  ```sql
+  SELECT 1;
+  ```
+  ````
 
-* To create links to other parts of the documentation (i.e.
-  [Cross-referencing](https://www.sphinx-doc.org/en/master/usage/referencing.html)), use either the `:ref:` syntax.
+- VitePress supports custom containers for callouts:
 
-  * Docs for all the SQL dialects are auto generated with associated anchors
-    to use for referencing. For example to link to the
-    `:ref:postgres_dialect_ref` dialect docs, you can use the |postgresref|.
-    Replace the `postgres` portion with the `name` of the
-    dialect you want to link to.
+  ```md
+  ::: tip
+  A helpful tip.
+  :::
 
-  * Docs for all the bundled rules and handled using a customer [sphinx](https://www.sphinx-doc.org/en/master/)
-    plugin, which means you can refer to them using their name or `code:
-    |LT01ref|` resolves to [LT01](/reference/rules/layout#lt01) and `|layoutspacingref|`
-    resolves to [layout.spacing](/reference/rules/layout#lt01).
+  ::: warning
+  A warning.
+  :::
 
-  * Docs for any of the python classes and modules handled using [autodoc](https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html)
-    can be referenced as per their docs, so the
-    `sqlfluff.core.rules.base.BaseRule` class can be referenced
-    with |baseruleref|. You can also use the `~` prefix (i.e.
-    |shortbaseruleref|) so that it just renders as
-    `~sqlfluff.core.rules.base.BaseRule`. See the docs for
-    [Cross-referencing](https://www.sphinx-doc.org/en/master/usage/referencing.html) for more details.
+  ::: info
+  An informational note.
+  :::
+  ```
 
-```html
-    <code class="code docutils literal notranslate">`...`</code>
+### Linking between pages
+
+Use standard Markdown links with root-relative paths (no `.md` extension needed):
+
+```md
+See [Configuration](/configuration/) for details.
+See [LT01](/reference/rules/layout#lt01) for the rule reference.
 ```
 
-```html
-    <code class="code docutils literal notranslate">`...`</code>
+### Auto-generated pages
+
+Several reference sections are generated automatically by scripts in `docsv/scripts/` and
+should **not** be edited by hand — your changes will be overwritten on the next build:
+
+| Section | Script |
+|---|---|
+| [Rules Reference](/reference/rules/index) | `generate-rules-docs.py` |
+| [CLI Reference](/reference/cli/index) | `generate-cli-docs.py` |
+| [Dialect Reference](/reference/dialects/index) | `generate-dialects-docs.py` |
+| [Internal API Reference](/reference/internals/index) | `generate-internals-docs.py` |
+
+To update auto-generated content, edit the relevant docstrings in the Python source and
+re-run `python docsv/scripts/generate-all-docs.py`.
+
+### Building the docs locally
+
+```bash
+cd docsv
+pnpm install
+pnpm run docs:build
+pnpm run docs:preview
 ```
 
-```html
-    <code class="code docutils literal notranslate">:ref:`postgres_dialect_ref`</code>
-```
+Or for a live-reloading dev server during writing:
 
-```html
-    <code class="code docutils literal notranslate">:sqlfluff:ref:`LT01`</code>
-```
-
-```html
-    <code class="code docutils literal notranslate">:sqlfluff:ref:`layout.spacing`</code>
-```
-
-```html
-    <code class="code docutils literal notranslate">`sqlfluff.core.rules.base.BaseRule`</code>
-```
-
-```html
-    <code class="code docutils literal notranslate">`~sqlfluff.core.rules.base.BaseRule`</code>
+```bash
+pnpm run docs:dev
 ```

--- a/docsv/guide/install.md
+++ b/docsv/guide/install.md
@@ -64,7 +64,7 @@ version number.
 
 ```bash
 sqlfluff version
-3.5.0
+4.3.0
 ```
 
 ## Going further
@@ -85,9 +85,5 @@ From here, there are several more things to explore.
 * Once you're ready to start using *SQLFluff* on a project or with the
   rest of your team, check out [Production Usage](/usage/index).
 
-One last thing to note is that *SQLFluff* is a relatively new project
-and you may find bugs or strange things while using it. If you do find
-anything, the most useful thing you can do is to [post the issue on
-GitHub](https://github.com/sqlfluff/sqlfluff/issues) where the maintainers of the project can work out what to do with
-it. The project is in active development and so updates and fixes may
-come out regularly.
+If you encounter a bug or unexpected behaviour, the best place to report
+it is [GitHub Issues](https://github.com/sqlfluff/sqlfluff/issues).

--- a/docsv/usage/ci-cd.md
+++ b/docsv/usage/ci-cd.md
@@ -11,14 +11,12 @@ There are two way to utilize SQLFluff to annotate Github PRs.
    Which uses Github API to annotate the SQL in [GitHub pull requests](https://docs.github.com/en/github/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests).
 
 ::: warning WARNING
-At present (December 2023), limitations put in place by Github mean that only the
-first 10 annotations will be displayed if the first option (using
-`github-annotation-native`) is used. This is a not something that SQLFluff
-can control itself and so we currently recommend using the second option
-above and the [action from yuzutech](https://github.com/yuzutech/annotations-action).
-
-There is an [open feature request](https://github.com/orgs/community/discussions/68471)
-for GitHub Actions which you can track to follow this issue.
+GitHub currently limits the number of annotations displayed per workflow run when
+using `github-annotation-native`. If you have many violations you may find only
+the first 10 are shown. This is not something SQLFluff can control; we recommend
+using the second option above and the [action from yuzutech](https://github.com/yuzutech/annotations-action)
+if you need full annotation coverage. Track the [GitHub Actions feature request](https://github.com/orgs/community/discussions/68471)
+for updates on this limitation.
 :::
 
 For more information and examples on using SQLFluff in GitHub Actions, see the


### PR DESCRIPTION
## Summary

- **`configuration/templating/dbt.md`**: Removed opening NOTE block describing dbt as a "new feature added in 0.4.0" with warnings about 0.7.0 upgrades — obsolete at 4.x
- **`configuration/layout.md`**: Removed NOTE saying block comment indent rules were unimplemented prior to 2.0.x
- **`guide/install.md`**: Updated example version output `3.5.0` → `4.3.0`; replaced "relatively new project, you may find bugs" paragraph with a neutral bug-reporting note
- **`usage/ci-cd.md`**: Removed stale "At present (December 2023)" date from the GitHub annotation limit warning; rephrased to be timeless
- **`development/documentation.md`**: Replaced the "Sphinx Docs" section (describing `.rst` files, `doc8`, `:ref:` syntax, ReadtheDocs) with a "VitePress Docs" section covering Markdown syntax, VitePress containers, cross-page linking, auto-generated pages table, and local build commands

## Test plan

- [ ] VitePress build passes cleanly (`pnpm run docs:build`)
- [ ] No RST/Sphinx references remain in the rewritten `documentation.md`
- [ ] All 5 pages render correctly in a local dev server

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshes five docs pages to align with 4.x and the `VitePress`/Markdown stack. Replaces the Sphinx/RST guide, removes time-bound notes, updates examples, and clarifies local dev so reference pages don’t 404.

- `docsv/development/documentation.md`: Replace “Sphinx Docs” with “VitePress Docs” (Markdown basics, containers, cross-page links, auto-generated sections, and build commands). Require `pnpm run docs:prebuild` before `pnpm run docs:dev` to generate reference pages; remove all `Sphinx`/`.rst` guidance.
- `docsv/configuration/templating/dbt.md`: Drop obsolete NOTE about 0.4.0/0.7.0 and plugin separation; no longer call `dbt` templating “new”.
- `docsv/configuration/layout.md`: Remove outdated note about block comment indents pre-2.0.x.
- `docsv/guide/install.md`: Update example version to `4.3.0`; replace early-days paragraph with a neutral GitHub Issues link for bug reports.
- `docsv/usage/ci-cd.md`: Make the GitHub annotation limit warning timeless; recommend the yuzutech action and link the feature request.

**Verify locally**
- From `docsv/`: `pnpm install && pnpm run docs:prebuild && pnpm run docs:dev` (or `docs:build` + `docs:preview`).
- Confirm no `Sphinx`/`.rst` references remain and that auto-generated references still come from `docsv/scripts/*` (not hand-edited).

<sup>Written for commit b0ce554b4f90d0d47163b628f42564f1bf1737b4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8339?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

