### PR TITLE
fix(docsv): resolve RST migration rendering artifacts

### DIFF
--- a/docsv/.vitepress/config.ts
+++ b/docsv/.vitepress/config.ts
@@ -13,6 +13,18 @@ import sidebarInternals from './sidebar-internals.json'
 import { manifestPath, normalizeBase, withDocsBase } from './path-utils'
 import { DESIGN_SOURCE, assertDesignPackage } from '../scripts/sync-design.mjs'
 
+const configDir = dirname(fileURLToPath(import.meta.url))
+const repoRoot = join(configDir, '../../')
+
+/** Stable release version from pyproject.toml — mirrors Sphinx's `|release|` substitution. */
+function readStableVersion(): string {
+    const pyproject = readFileSync(join(repoRoot, 'pyproject.toml'), 'utf-8')
+    const match = pyproject.match(/stable_version\s*=\s*"([^"]+)"/)
+    return match?.[1] ?? '0.0.0'
+}
+
+const stableVersion = readStableVersion()
+
 const GUIDE: DefaultTheme.NavItemWithLink[] = [
     { text: 'Introduction', link: '/guide/' },
     { text: 'Installation', link: '/guide/install' },
@@ -248,7 +260,13 @@ export default defineConfig({
             light: 'github-light',
             dark: 'github-dark'
         },
-        lineNumbers: false
+        lineNumbers: false,
+        config(md) {
+            // Sphinx RST substitution variables (e.g. |release|) carried over in Markdown sources.
+            md.core.ruler.before('normalize', 'sqlfluff-rst-substitutions', (state) => {
+                state.src = state.src.replace(/\|release\|/g, stableVersion)
+            })
+        },
     },
 
     vite: {

--- a/docsv/configuration/rules.md
+++ b/docsv/configuration/rules.md
@@ -74,11 +74,11 @@ the other).
 
 The effect of this is that we recommend one of two approaches:
 
-#. Simply only use `rules`. This has the upshot of each area of
+1. Simply only use `rules`. This has the upshot of each area of
     your project being very explicit in which rules are enabled. When
     that changes for part of your project you just reset the whole list
     of applicable rules for that part of the project.
-#. Set a single `rules` value in your master project config file
+2. Set a single `rules` value in your master project config file
     and then only use `exclude_rules` in sub-configuration files
     to *turn off* specific rules for parts of the project where those
     rules are inappropriate. This keeps the simplicity of only having

--- a/docsv/development/architecture.md
+++ b/docsv/development/architecture.md
@@ -68,9 +68,9 @@ lifting.
       pre-defined way. For example the `OneOf` grammar will match if any
       one of its child elements match.
 
-   #. During the recursion, the parser eventually reaches segments which have
-      no children (raw segments containing a single token), and so the
-      recursion naturally finishes.
+   * During the recursion, the parser eventually reaches segments which have
+     no children (raw segments containing a single token), and so the
+     recursion naturally finishes.
 
 4. If no match is found for a segment, the contents will be wrapped in an
    `UnparsableSegment` which is picked up as a *parsing* error later.

--- a/docsv/reference/release-notes.md
+++ b/docsv/reference/release-notes.md
@@ -181,18 +181,18 @@ Upgrading to 2.0 brings several important breaking changes:
 
 To upgrade smoothly between versions, we recommend the following sequence:
 
-#. The upgrade path will be simpler if you have a slimmer configuration file.
+1. The upgrade path will be simpler if you have a slimmer configuration file.
    Before upgrading, consider removing any sections from your configuration
    file (often `.sqlfluff`, see [Conf](../configuration/index)) which match the current
    [Default Configuration](../configuration/defaults). There is no need to respecify defaults in your local
    config if they are not different to the stock config.
 
-#. In a local (or other *non-production*) environment, upgrade to SQLFluff
+2. In a local (or other *non-production*) environment, upgrade to SQLFluff
    2.0.x. We recommend using a [compatible release](https://peps.python.org/pep-0440/#compatible-release) specifier such
    as `~=2.0.0`, to ensure any minor bugfix releases are automatically
    included.
 
-#. Examine your configuration file (as mentioned above), and evaluate how
+3. Examine your configuration file (as mentioned above), and evaluate how
    rules are currently specified. We recommend primarily using *either*
    `rules` *or* `exclude_rules` rather than both, as detailed
    in [Enabling and Disabling Rules](../configuration/rules#enabling-and-disabling-rules). Using either the `sqlfluff rules` CLI
@@ -225,10 +225,10 @@ To upgrade smoothly between versions, we recommend the following sequence:
    * Review the [Configuring Layout](../configuration/layout#configuring-layout) documentation, and check whether any
      indentation or layout configuration should be revised.
 
-#. Check your project for [In-File Configuration Directives](../configuration/index#in-file-configuration-directives) which refer to rule codes.
+4. Check your project for [In-File Configuration Directives](../configuration/index#in-file-configuration-directives) which refer to rule codes.
    Alter these in the same manner as described above for configuration files.
 
-#. Test linting your project for unexpected linting issues. Where found,
+5. Test linting your project for unexpected linting issues. Where found,
    consider whether to use `sqlfluff fix` to repair them in bulk,
    or (if you disagree with the changes) consider changing which rules
    you enable or their configuration accordingly. In particular you may notice:


### PR DESCRIPTION
## Summary
- Convert leftover Sphinx `#.` auto-numbered list syntax to proper Markdown ordered lists and bullets in architecture, rules config, and release notes pages.
- Add a VitePress markdown plugin that substitutes `|release|` from `pyproject.toml` `stable_version`, so the pre-commit hook example shows the current stable release instead of a literal `|release|` string.

## Test plan
- [x] `npm run docs:build` completes successfully
- [x] Built HTML contains no visible `#.` literals on affected pages
- [x] Pre-commit page shows `rev: 4.3.0` (or current `stable_version`) in the YAML example
- [x] Manual review of architecture, rules config, and release notes upgrade steps in dev server


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes RST migration artifacts in the docs. Lists render as proper Markdown, and the `|release|` placeholder is replaced at build time with the current stable version from `pyproject.toml` instead of rendering literally.

- Old: Built pages showed visible `#.` list markers and `|release|`. New: Standard ordered/bulleted lists render, and `|release|` resolves to `stable_version`. Side effect: Adds a small `VitePress` Markdown plugin in `docsv/.vitepress/config.ts` that reads `pyproject.toml` once and replaces all `|release|` occurrences (falls back to `0.0.0` if missing).

**Review notes**
- Check the Markdown plugin scope: it only substitutes `|release|` and reads `stable_version` via a simple regex.
- Verify the updated Markdown files no longer use `#.` and render correctly in architecture, rules config, and release notes.
- Build the docs to confirm no visible `#.` or `|release|`, and that the pre-commit example shows the current `stable_version`.

<sup>Written for commit c3c62edd58ce5c083073baeb1226eb8df27d07f4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8340?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

