### PR TITLE
fix: escape file paths in github-annotation-native output

### DIFF
--- a/src/sqlfluff/cli/commands.py
+++ b/src/sqlfluff/cli/commands.py
@@ -668,6 +668,23 @@ def dump_file_payload(filename: Optional[str], payload: str) -> None:
         click.echo(payload)
 
 
+def _gha_escape_data(value: str) -> str:
+    """Escape the message body of a GitHub Actions workflow command.
+
+    https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-commands
+    """
+    # NOTE: '%' must be replaced first, or the escapes get double encoded.
+    return value.replace("%", "%25").replace("\r", "%0D").replace("\n", "%0A")
+
+
+def _gha_escape_property(value: str) -> str:
+    """Escape a property value of a GitHub Actions workflow command.
+
+    Properties additionally escape ':' and ',', which delimit the property block.
+    """
+    return _gha_escape_data(value).replace(":", "%3A").replace(",", "%2C")
+
+
 @cli.command()
 @common_options
 @core_options
@@ -884,7 +901,7 @@ def lint(
 
             # Add a group, titled with the filename
             if record["violations"]:
-                github_result_native.append(f"::group::{filepath}")
+                github_result_native.append(f"::group::{_gha_escape_data(filepath)}")
 
             for violation in record["violations"]:
                 # NOTE: The output format is designed for GitHub action:
@@ -898,7 +915,7 @@ def lint(
                 line = "::notice " if violation["warning"] else f"::{annotation_level} "
 
                 line += "title=SQLFluff,"
-                line += f"file={filepath},"
+                line += f"file={_gha_escape_property(filepath)},"
                 line += f"line={violation['start_line_no']},"
                 line += f"col={violation['start_line_pos']}"
                 if "end_line_no" in violation:
@@ -906,9 +923,10 @@ def lint(
                 if "end_line_pos" in violation:
                     line += f",endColumn={violation['end_line_pos']}"
                 line += "::"
-                line += f"{violation['code']}: {violation['description']}"
+                message = f"{violation['code']}: {violation['description']}"
                 if violation["name"]:
-                    line += f" [{violation['name']}]"
+                    message += f" [{violation['name']}]"
+                line += _gha_escape_data(message)
 
                 github_result_native.append(line)
 

--- a/test/cli/commands_test.py
+++ b/test/cli/commands_test.py
@@ -2427,6 +2427,30 @@ def test__cli__command_lint_serialize_github_annotation_native(
     assert result.stdout == expected_output.format(filename=fpath_normalised)
 
 
+def test__cli__command_lint_serialize_github_annotation_native_escaping(tmp_path):
+    """Test that a comma in a filename is escaped in the annotation properties."""
+    sql_file = tmp_path / "we,ird.sql"
+    sql_file.write_text("SELECT 1 from t\n")
+
+    result = invoke_assert_code(
+        args=[
+            lint,
+            (
+                str(sql_file),
+                "--dialect",
+                "ansi",
+                "--format",
+                "github-annotation-native",
+                "--disable-progress-bar",
+            ),
+        ],
+        ret_code=1,
+    )
+    # An unescaped comma would terminate the `file=` property early.
+    assert f"file={str(sql_file).replace(',', '%2C')}," in result.stdout
+    assert f"file={sql_file}," not in result.stdout
+
+
 @pytest.mark.parametrize("serialize", ["github-annotation", "github-annotation-native"])
 def test__cli__command_lint_serialize_annotation_level_error_failure_equivalent(
     serialize,


### PR DESCRIPTION
## What type of PR is this?

- bug

## What this PR does / why we need it:

`--format github-annotation-native` interpolates the file path and the message into a GitHub workflow command without escaping either, so a path containing `,` or `:` produces an annotation the runner mis-parses.

A comma truncates the `file=` property:

```
before: ::warning title=SQLFluff,file=/tmp/d/we,ird.sql,line=1,col=14,...
after:  ::warning title=SQLFluff,file=/tmp/d/we%2Cird.sql,line=1,col=14,...
```

The runner splits the property block on `,`, so it reads `file=/tmp/d/we` and then treats `ird.sql` as a malformed property. The annotation either lands on the wrong path or is dropped, and the failure is silent, since the lint run itself succeeds and the missing annotation only shows up as a clean-looking PR.

A `:` in a path does the same to the `::` that ends the property block.

The [workflow command spec](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-commands) requires `%`, CR and LF to be escaped in the message body, and additionally `:` and `,` in property values.

Per file:

- `src/sqlfluff/cli/commands.py`: adds `_gha_escape_data` and `_gha_escape_property`, and applies them to the `file=` property, the message body, and the `::group::` title. `%` is replaced first in both, otherwise the `%0D`/`%0A` escapes get double encoded.
- `test/cli/commands_test.py`: a case linting a file whose name contains a comma, asserting the escaped form appears in the `file=` property.

The message body gets `_gha_escape_data` rather than the property escaper, because `:` and `,` are legal there and are common in rule descriptions. Escaping them would make every annotation noisier for no gain.

## Which issue(s) this PR fixes:

None filed.

## Special notes for your reviewer:

The `::group::` title is escaped with the data escaper too. It is not a property, but a newline in a path would break the grouping, and the escape is a no-op for ordinary paths.

## Testing

```
$ printf 'select 1 from  t\n' > 'we,ird.sql'
$ sqlfluff lint --dialect ansi --format github-annotation-native 'we,ird.sql'
```
gives the before and after shown above. I ran the same for a path containing `:`.

`pytest test/cli/` is 268 passed. `pytest test/core test/cli` is 1188 passed, 3 failed, and those 3 `plugin_test.py` failures reproduce on a clean tree here.

Reverting only the `file=` escaping fails the new test:

```
AssertionError: assert 'file=.../we%2Cird.sql,' in '...file=.../we,ird.sql,line=1,col=10...'
FAILED test__cli__command_lint_serialize_github_annotation_native_escaping
```

Ruff check and format are clean on both files.

*Per CONTRIBUTING: this was AI-assisted (Claude Code). The escaping rules were taken from the linked GitHub spec, and I validated the before and after output by running the CLI on paths containing `,` and `:`, plus the revert check above. I have read every line and am accountable for it.*

## Release Notes

```release-note
Fixed `github-annotation-native` output emitting unescaped file paths, which caused GitHub to mis-parse annotations for files whose path contains a comma or colon.
```


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Escape file paths, group titles, and message bodies in `--format github-annotation-native` so GitHub Actions parses annotations correctly. Previously, paths and messages were unescaped; commas truncated the `file=` property and colons broke parsing, causing misplaced or missing annotations without failing the job.

- Add `_gha_escape_data` for message bodies and group titles (`%`, CR, LF) and `_gha_escape_property` for properties (adds `:` and `,`), with `%` replaced first to avoid double-encoding.
- Apply property escaping to `file=` and data escaping to the annotation message; do not escape `:` or `,` in messages to keep rule text readable.
- Add a test that asserts a filename with a comma is percent-escaped in `file=`; other formats and CLI behavior are unchanged.

<sup>Written for commit f75b35a411dabb4d90f0d2158cbaa7b9dbc26d4e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8346?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

