### PR TITLE
LT02: don't force a line break before join elements that lead into a bracket

### DIFF
--- a/src/sqlfluff/utils/reflow/reindent.py
+++ b/src/sqlfluff/utils/reflow/reindent.py
@@ -1054,6 +1054,46 @@ def _crawl_indent_points(
             )
 
 
+def _leads_to_bracket(elements: ReflowSequenceType, start_idx: int) -> bool:
+    """Check whether the element at ``start_idx`` begins a bracketed expression.
+
+    Given the index of the first element *after* an untaken indent point,
+    return whether that element leads into a bracketed expression on the
+    same line, i.e. a ``start_bracket`` appears before any line break.
+    This is used to extend the bracket special case (see issue #4234) to
+    layouts like ``JOIN LATERAL (`` or ``JOIN my_func(`` where the untaken
+    indent is followed by a keyword rather than the bracket directly.
+    """
+    for elem in elements[start_idx:]:
+        if isinstance(elem, ReflowPoint):
+            # A line break before the bracket means the indent leads into
+            # a line, not a bracketed expression.
+            if elem.num_newlines() > 0:
+                return False
+            continue
+        if "start_bracket" in elem.class_types:
+            return True
+    return False
+
+
+def _in_join_clause(block: ReflowBlock) -> bool:
+    """Check whether a reflow block belongs to a ``join_clause``.
+
+    The reflow elements carry no grammar context of their own, but the
+    segments they wrap retain their parent pointers from the parse tree,
+    so we walk up the tree to determine whether this element is part of
+    a join clause.
+    """
+    seg = block.segments[0]
+    parent = seg.get_parent()
+    while parent is not None:
+        parent_seg, _ = parent
+        if parent_seg.type == "join_clause":
+            return True
+        parent = parent_seg.get_parent()
+    return False
+
+
 def _map_line_buffers(
     elements: ReflowSequenceType, implicit_indents: str = "forbid"
 ) -> tuple[list[_IndentLine], list[int], set[int]]:
@@ -1186,8 +1226,25 @@ def _map_line_buffers(
                 # NOTE: We can safely "look ahead" here because we know all files
                 # end with an IndentBlock, and we know here that `loc` refers to
                 # an IndentPoint.
-                if "start_bracket" in elements[loc + 1].class_types:
-                    continue
+                #
+                # We also apply this protection where the untaken indent leads
+                # into a bracketed expression on the same line *within a join
+                # clause* (e.g. `JOIN LATERAL (` or `JOIN my_func(`). Keeping
+                # the element on the same line as the join keyword is common
+                # practice there (see issue #8345), so the untaken indent
+                # should not be forced. We scope this to join clauses so that
+                # the "hanger" correction for other elements (e.g. a `SELECT`
+                # element which wraps around a function call) is preserved.
+                if _leads_to_bracket(elements, loc + 1):
+                    if "start_bracket" in elements[loc + 1].class_types:
+                        # The original special case: the element starts with
+                        # the bracket directly (e.g. `WHERE (`).
+                        continue
+                    if _in_join_clause(elements[loc + 1]):
+                        # The element starts with a keyword (or function
+                        # name) which leads into a bracket, e.g. `JOIN
+                        # LATERAL (`.
+                        continue
 
                 # If the location was in the line we're just closing. That's
                 # not a problem because it's an untaken indent which is closed

--- a/test/fixtures/rules/std_rule_cases/LT02-indent.yml
+++ b/test/fixtures/rules/std_rule_cases/LT02-indent.yml
@@ -279,6 +279,47 @@ test_pass_indented_using_on_merge_statment_false:
     indentation:
       indented_using_on: false
 
+test_pass_indented_joins_lateral_subquery:
+  # Regression test for #8345: `CROSS JOIN LATERAL (` should stay on
+  # the same line even when a second sibling join follows, rather than
+  # forcing a line break before the `LATERAL` keyword of the first join.
+  pass_str: |
+    SELECT *
+    FROM (
+        SELECT 1 AS id
+    ) t
+        CROSS JOIN LATERAL (
+            SELECT 1 AS x
+        ) a
+        CROSS JOIN LATERAL (
+            SELECT 1 AS y
+        ) b
+  configs:
+    core:
+      dialect: postgres
+    indentation:
+      indented_joins: true
+
+test_pass_indented_joins_function_subquery:
+  # As above, but where the join element starts with a function call
+  # which wraps over multiple lines via its own brackets.
+  pass_str: |
+    SELECT *
+    FROM (
+        SELECT 1 AS id
+    ) t
+        CROSS JOIN my_func(
+            a,
+            b
+        ) AS x
+        CROSS JOIN my_func(
+            c,
+            d
+        ) AS y
+  configs:
+    indentation:
+      indented_joins: true
+
 test_pass_indented_on_contents_default:
   # Test indented_on_contents when default (true)
   pass_str: |


### PR DESCRIPTION
### Brief summary of the change made

Fixes #8345.

When a `FROM` clause contains 2+ `CROSS JOIN LATERAL (...)` clauses (or any join whose element wraps over multiple lines via its own brackets, e.g. `JOIN my_func(...)`), LT02 forces the **first** join's element onto its own line while leaving the **second** one attached:

```sql
-- Before (first LATERAL forced onto its own line)
    CROSS JOIN
        LATERAL (
            SELECT 1 AS x
        ) a
    CROSS JOIN LATERAL (
        SELECT 1 AS y
    ) b
```

The root cause is in the reflow imbalance detection (`_map_line_buffers`). The join clause's element indent is *untaken* (the element stays on the same line as `CROSS JOIN`). When a second sibling join's line break closes that indent level, the imbalance detector fires and forces a line break at the untaken indent — but only for the first join, because the second is protected by the end-of-file special case.

The existing bracket special case (issue #4234) already protects untaken indents whose element starts with the bracket directly (e.g. `WHERE (`). This PR extends that protection to join elements which *lead into* a bracketed expression via a keyword or function name (`CROSS JOIN LATERAL (`, `JOIN my_func(`), scoped to `join_clause` elements so the "hanger" correction for other elements (e.g. a `SELECT` element wrapping a function call) is preserved.

The layout in the issue's expected behaviour now passes:

```sql
    CROSS JOIN LATERAL (
        SELECT 1 AS x
    ) a
    CROSS JOIN LATERAL (
        SELECT 1 AS y
    ) b
```

### Are there any other side effects of this change that we should be aware of?

None intended. The suppression only applies to untaken indents whose following element belongs to a join clause and leads into a bracketed expression on the same line. All existing LT02 rule tests (including the hanger cases) and the full `test/rules/` suite pass unchanged.

### Pull Request checklist

- Included test cases: yes — two `pass_str` cases in `test/fixtures/rules/std_rule_cases/LT02-indent.yml` covering the `LATERAL` subquery and the function-call variant.
- Added appropriate documentation: not required (bug fix, changelog is auto-generated from PRs).

---

### AI-assisted contribution disclosure

In line with the [AI-assisted contribution guidelines](https://github.com/sqlfluff/sqlfluff/blob/main/CONTRIBUTING.md#ai-assisted-contributions), this contribution was developed with AI assistance. What was AI-assisted:

- Root-cause analysis of the reflow imbalance detection and the design of the scoped fix (the parent-chain check against `join_clause`).
- Implementation of the change and the two regression test cases.
- Running the validation suite.

What was manually validated:

- Reproduced the exact issue with the `postgres` dialect and `indented_joins: true` before and after the change.
- Confirmed `sqlfluff lint` and `sqlfluff fix` are clean on the reported repro.
- Ran the full rule test suite (`test/rules/`: 2539 passed, 101 skipped), the reflow unit tests (`test/utils/reflow/`: 122 passed), and the fix/autofix tests (75 passed) — no regressions, including the pre-existing "hanger" LT02 cases whose behavior is intentionally unchanged.
