### PR TITLE
fix: LT02 false positive forcing line break before `LATERAL` in multi-join statements (#8345)

### DIFF
--- a/src/sqlfluff/utils/reflow/reindent.py
+++ b/src/sqlfluff/utils/reflow/reindent.py
@@ -1054,6 +1054,33 @@ def _crawl_indent_points(
             )
 
 
+def _has_start_bracket_before_line_break(
+    elements: ReflowSequenceType, idx: int
+) -> bool:
+    """Check whether a keyword-prefixed bracket opens after an untaken indent.
+
+    If an untaken indent is followed on the same line by a bracket which
+    opens directly after keywords (e.g. ``JOIN LATERAL (``), then the
+    bracket content picks up the indent at its first line break, and
+    forcing a line break at the indent position would be wrong.
+
+    NOTE: Any other content before the bracket (e.g. a function name in
+    ``SELECT coalesce(``) means the bracket opens mid-content, and the
+    untaken indent should still be forced.
+    """
+    for elem in elements[idx + 1 :]:
+        if isinstance(elem, ReflowPoint):
+            # A point with a newline closes the lookahead window.
+            if elem.num_newlines():
+                return False
+            continue
+        if "start_bracket" in elem.class_types:
+            return True
+        if "keyword" not in elem.class_types:
+            return False
+    return False
+
+
 def _map_line_buffers(
     elements: ReflowSequenceType, implicit_indents: str = "forbid"
 ) -> tuple[list[_IndentLine], list[int], set[int]]:
@@ -1186,7 +1213,14 @@ def _map_line_buffers(
                 # NOTE: We can safely "look ahead" here because we know all files
                 # end with an IndentBlock, and we know here that `loc` refers to
                 # an IndentPoint.
-                if "start_bracket" in elements[loc + 1].class_types:
+                # NOTE: The bracket doesn't need to be the *immediate* next
+                # element for the same logic to apply. An opening bracket
+                # preceded by keywords on the same line (e.g. `JOIN LATERAL (`)
+                # still absorbs the untaken indent at the first line break
+                # within the bracket, so we shouldn't force a line break at
+                # the indent itself.
+                # https://github.com/sqlfluff/sqlfluff/issues/8345
+                if _has_start_bracket_before_line_break(elements, loc):
                     continue
 
                 # If the location was in the line we're just closing. That's

--- a/test/fixtures/rules/std_rule_cases/LT02-indent.yml
+++ b/test/fixtures/rules/std_rule_cases/LT02-indent.yml
@@ -168,6 +168,27 @@ test_fail_indented_joins_false_fix:
     indentation:
       indented_joins: false
 
+# https://github.com/sqlfluff/sqlfluff/issues/8345
+test_pass_indented_joins_true_lateral:
+  # Multiple CROSS JOIN LATERAL clauses should stay on one line,
+  # regardless of how many there are.
+  pass_str: |
+    SELECT *
+    FROM (
+        SELECT 1 AS id
+    ) t
+        CROSS JOIN LATERAL (
+            SELECT 1 AS x
+        ) a
+        CROSS JOIN LATERAL (
+            SELECT 1 AS y
+        ) b
+  configs:
+    core:
+      dialect: postgres
+    indentation:
+      indented_joins: true
+
 test_pass_indented_using_on_default:
   # Configurable using_on indents work.
   # 2.a) default


### PR DESCRIPTION
## Brief summary of the change made

Fixes #8345.

When a `FROM` clause is followed by 2+ consecutive `CROSS JOIN LATERAL` clauses, LT02 wrongly forced the first `LATERAL` keyword onto its own indented line, while leaving the second join untouched. With a single lateral join there was no violation at all.

### Root cause

The reindent logic in `_map_line_buffers` forces a line break at any "untaken" indent (an indent with no newline at its own position) whose matching dedent lands at a line break. A join body indent (the unconditional `Indent` inside `join_clause` in the ANSI dialect) is routinely untaken in the standard `indented_joins` layout — the body stays on the `JOIN` line. This is normally harmless because:

- when the join is the *last* clause, the closing line break also carries the `from_expression` conditional dedent, so the outer balance is checked first and the join indent key is never reached;
- when the join body starts with a bracket (`JOIN (...)`), the existing "special case 2" exempts indents immediately followed by a `start_bracket`.

Neither protection applies to `JOIN LATERAL (...)`: the `LATERAL` keyword sits between the indent and the bracket, so the bracket exemption missed it, and with a second join following, the trough of the first join's closing line break no longer reaches the outer balance — leaving the untaken join indent as the innermost match, which forced the bogus break.

### The fix

Extend the bracket special case: an untaken indent followed on the same line by a bracket which opens *directly after keywords* (e.g. `JOIN LATERAL (`) is also exempt — the bracket content absorbs the indent at its first line break, exactly as with an immediate bracket. The lookahead is bounded by the next newline, and any non-keyword content before the bracket (e.g. a function name in `SELECT coalesce(`) still means the indent is forced, preserving the existing hanger behaviour.

### Are there any other side effects of this change that we should be aware of?

None known. Existing hanger-formatting tests (`SELECT coalesce(...)`) still pass unchanged, as do all other LT02 fixture cases.

### AI-assisted contribution disclosure

This change was developed with the assistance of an AI coding tool (opencode, using Anthropic's Claude model family). AI-assisted work: root-cause analysis, implementation of the fix in `src/sqlfluff/utils/reflow/reindent.py`, and the new fixture test in `test/fixtures/rules/std_rule_cases/LT02-indent.yml`. Manually validated: reproduction of the issue, the full `test/rules/` suite (2537 passed), and confirmation that the new test fails without the fix and passes with it.

### Pull Request checklist
- [x] Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
- [x] Appropriate documentation updated where needed.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes LT02 falsely forcing a line break before the first LATERAL in multi-join FROM clauses. Previously, with `indented_joins: true`, the first `CROSS JOIN LATERAL (...)` moved to its own line when another join followed; now all `CROSS JOIN LATERAL` clauses stay on the join line as expected.

**Review notes**
- Extends the bracket exemption to cover brackets that open after keywords on the same line (e.g., "JOIN LATERAL ("). Adds `_has_start_bracket_before_line_break` and calls it from `_map_line_buffers`.
- Lookahead stops at the next newline; any non-keyword before the bracket disables the exemption to preserve existing hanger behavior (e.g., `SELECT coalesce(`).
- Adds a passing fixture `test_pass_indented_joins_true_lateral` in `LT02-indent.yml` for Postgres with `indented_joins: true`; no other LT02 cases or hanger-formatting tests change.

<sup>Written for commit 23495d92bf34104d038cb553832761eb02d9a16f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8348?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

