### PR TITLE
Postgres: reject keywords that cannot be a type name

### DIFF
--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -41,11 +41,19 @@ from sqlfluff.core.parser.grammar.lookbehind import is_distinct_from_lookbehind
 from sqlfluff.dialects import dialect_ansi as ansi
 from sqlfluff.dialects.dialect_postgres_keywords import (
     get_keywords,
+    postgres_cannot_be_function_or_type_keywords,
     postgres_keywords,
     postgres_postgis_datatype_keywords,
 )
 
 ansi_dialect = load_raw_dialect("ansi")
+
+# Keywords PostgreSQL rejects where a bare function or type name is expected.
+# Sorted longest-first so the alternation in the anti-templates below prefers the
+# longest match (e.g. "SELECT" over a hypothetical "SEL").
+_CANNOT_BE_FUNCTION_OR_TYPE = sorted(
+    postgres_cannot_be_function_or_type_keywords, key=lambda kw: (-len(kw), kw)
+)
 
 postgres_dialect = ansi_dialect.copy_as(
     "postgres",
@@ -629,6 +637,21 @@ postgres_dialect.replace(
         r"[A-Z_][A-Z0-9_$]*",
         CodeSegment,
         type="function_name_identifier",
+    ),
+    # PostgreSQL will not accept a reserved keyword (or a non-reserved keyword
+    # flagged "cannot be function or type name") where a bare type name is
+    # expected. Without this, `CREATE TABLE t (x between NOT NULL)` parses
+    # happily with `between` as the type. See issue #6430.
+    DatatypeIdentifierSegment=SegmentGenerator(
+        lambda dialect: OneOf(
+            RegexParser(
+                r"[A-Z_][A-Z0-9_]*",
+                CodeSegment,
+                type="data_type_identifier",
+                anti_template=r"^(" + r"|".join(_CANNOT_BE_FUNCTION_OR_TYPE) + r")$",
+            ),
+            Ref("SingleIdentifierGrammar", exclude=Ref("NakedIdentifierSegment")),
+        ),
     ),
     FunctionContentsExpressionGrammar=OneOf(
         Ref("ExpressionSegment"),

--- a/src/sqlfluff/dialects/dialect_postgres_keywords.py
+++ b/src/sqlfluff/dialects/dialect_postgres_keywords.py
@@ -5,8 +5,9 @@ https://www.postgresql.org/docs/13/sql-keywords-appendix.html
 Here, "not-keyword" refers to a word not being a keyword, and will be removed from any
 default keyword definition, these keywords are, or have been, an ANSI keyword.
 
-There are also some keywords that are(n't) supported as types and function, but there
-isn't support for that distinction at present.
+The appendix also distinguishes keywords which cannot be used as a function or
+type name. That distinction is preserved in the keyword types below and is
+surfaced through the ``postgres_cannot_be_function_or_type_keywords`` set.
 """
 
 
@@ -42,10 +43,27 @@ def get_keywords(keyword_list: list[tuple[str, str]], keyword_type: str) -> list
     """Get a list of keywords of the required type.
 
     keyword_type should be one of "not-keyword", "reserved", "non-reserved"
+
+    Note that this matches on a prefix, so "reserved" also returns the
+    "reserved-(can-be-function-or-type)" keywords, and "non-reserved" also
+    returns the "non-reserved-(cannot-be-function-or-type)" keywords. Use
+    :func:`get_keywords_exact` where that distinction matters.
     """
     keywords = [x[0] for x in keyword_list if x[1].startswith(keyword_type)]
 
     return keywords
+
+
+def get_keywords_exact(
+    keyword_list: list[tuple[str, str]], keyword_type: str
+) -> list[str]:
+    """Get a list of keywords whose type matches exactly.
+
+    Unlike :func:`get_keywords` this does not match on a prefix, so
+    "reserved" returns only the strictly reserved keywords and not the
+    "reserved-(can-be-function-or-type)" ones.
+    """
+    return [x[0] for x in keyword_list if x[1] == keyword_type]
 
 
 postgres_docs_keywords = [
@@ -1056,4 +1074,20 @@ postgres_keywords = priority_keyword_merge(
     postgres_postgis_datatype_keywords,
     postgres_postgis_other_keywords,
     postgres_pgvector_keywords,
+)
+
+# Keywords which PostgreSQL will not accept as a bare function or type name.
+# https://www.postgresql.org/docs/current/sql-keywords-appendix.html
+#
+# This is the union of the strictly reserved keywords and the non-reserved
+# keywords which the appendix marks as "cannot be function or type name".
+# The "reserved-(can-be-function-or-type)" keywords are deliberately excluded:
+# those are reserved in general but *are* valid as a function or type name.
+postgres_cannot_be_function_or_type_keywords = sorted(
+    set(get_keywords_exact(postgres_keywords, "reserved"))
+    | set(
+        get_keywords_exact(
+            postgres_keywords, "non-reserved-(cannot-be-function-or-type)"
+        )
+    )
 )

--- a/test/dialects/postgres_test.py
+++ b/test/dialects/postgres_test.py
@@ -208,9 +208,9 @@ def test_keyword_is_not_a_valid_datatype(raw: str) -> None:
     https://github.com/sqlfluff/sqlfluff/issues/6430
     """
     tree = _postgres_parse_tree(raw)
-    assert list(
-        tree.recursive_crawl("unparsable")
-    ), f"Expected an unparsable section for {raw!r}, but it parsed cleanly."
+    assert list(tree.recursive_crawl("unparsable")), (
+        f"Expected an unparsable section for {raw!r}, but it parsed cleanly."
+    )
 
 
 @pytest.mark.parametrize(

--- a/test/dialects/postgres_test.py
+++ b/test/dialects/postgres_test.py
@@ -8,6 +8,7 @@ from _pytest.logging import LogCaptureFixture
 from sqlfluff.core import FluffConfig, Linter
 from sqlfluff.dialects.dialect_postgres_keywords import (
     get_keywords,
+    get_keywords_exact,
     priority_keyword_merge,
 )
 
@@ -157,3 +158,77 @@ def test_get_keywords() -> None:
     expected_result_3 = ["B"]
 
     assert sorted(get_keywords(kw_list, "reserved")) == sorted(expected_result_3)
+
+
+def test_get_keywords_exact() -> None:
+    """Test that exact keyword filtering does not match on a prefix."""
+    kw_list = [
+        ("A", "not-keyword"),
+        ("B", "reserved"),
+        ("C", "non-reserved"),
+        ("D", "reserved-(can-be-function-or-type)"),
+        ("E", "non-reserved-(cannot-be-function-or-type)"),
+    ]
+
+    # The prefix-matching helper lumps the parenthesised variants in.
+    assert sorted(get_keywords(kw_list, "reserved")) == ["B", "D"]
+    assert sorted(get_keywords(kw_list, "non-reserved")) == ["C", "E"]
+
+    # The exact helper keeps them apart.
+    assert get_keywords_exact(kw_list, "reserved") == ["B"]
+    assert get_keywords_exact(kw_list, "non-reserved") == ["C"]
+    assert get_keywords_exact(kw_list, "reserved-(can-be-function-or-type)") == ["D"]
+    assert get_keywords_exact(kw_list, "non-reserved-(cannot-be-function-or-type)") == [
+        "E"
+    ]
+
+
+def _postgres_parse_tree(raw: str):
+    """Parse a string with the postgres dialect and return the tree."""
+    cfg = FluffConfig(configs={"core": {"dialect": "postgres"}})
+    parsed = Linter(config=cfg).parse_string(raw)
+    assert parsed.tree is not None
+    return parsed.tree
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        # "BETWEEN" is non-reserved but flagged "cannot be function or type
+        # name" by the keyword appendix, so it is not a valid bare type.
+        "CREATE TABLE test_table (type between NOT NULL);",
+        # Strictly reserved keywords are equally invalid there.
+        "CREATE TABLE test_table (a select);",
+        "CREATE TABLE test_table (a grant);",
+    ],
+)
+def test_keyword_is_not_a_valid_datatype(raw: str) -> None:
+    """Keywords which cannot be a type name should not parse as one.
+
+    https://github.com/sqlfluff/sqlfluff/issues/6430
+    """
+    tree = _postgres_parse_tree(raw)
+    assert list(
+        tree.recursive_crawl("unparsable")
+    ), f"Expected an unparsable section for {raw!r}, but it parsed cleanly."
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        # Built-in types are matched by explicit grammar, not by the
+        # identifier fallback, so they must keep working.
+        "CREATE TABLE t (a int, b varchar(10), c numeric(10, 2));",
+        "CREATE TABLE t (a timestamp with time zone, b interval, c boolean);",
+        "CREATE TABLE t (a double precision, b text[], c json);",
+        # "reserved-(can-be-function-or-type)" keywords remain valid types.
+        "CREATE TABLE t (a binary);",
+        # User-defined types still fall through to the identifier.
+        "CREATE TABLE t (a my_custom_type);",
+    ],
+)
+def test_valid_datatypes_still_parse(raw: str) -> None:
+    """The tightened type grammar must not reject legitimate types."""
+    tree = _postgres_parse_tree(raw)
+    unparsable = list(tree.recursive_crawl("unparsable"))
+    assert not unparsable, f"{raw!r} unexpectedly failed to parse: {unparsable}"


### PR DESCRIPTION
### Brief summary of the change made

Fixes #6430.

PostgreSQL's [keyword appendix](https://www.postgresql.org/docs/current/sql-keywords-appendix.html) marks certain keywords as unusable as a function or type name. The dialect already carried that information, but had no way to read it: `get_keywords` matches on a **prefix**, so asking for `"reserved"` also returned the `"reserved-(can-be-function-or-type)"` entries, and `"non-reserved"` also returned `"non-reserved-(cannot-be-function-or-type)"`. The module docstring said as much — *"there isn't support for that distinction at present"*.

Nothing therefore used the distinction, `DatatypeIdentifierSegment` accepted any bare word, and this parsed cleanly with `between` as the column's data type instead of being reported as unparsable:

```sql
CREATE TABLE test_table (
    type between NOT NULL
);
```

The change:

- adds `get_keywords_exact` alongside `get_keywords`, matching the category exactly;
- derives `postgres_cannot_be_function_or_type_keywords` — the strictly reserved keywords plus the non-reserved "cannot be function or type name" ones (160 keywords). `reserved-(can-be-function-or-type)` is deliberately excluded, since those are reserved in general but *are* valid as a type name;
- uses that set as an `anti_template` on the postgres `DatatypeIdentifierSegment`;
- updates the now-inaccurate module docstring.

### Are there any other side effects of this change that we should be aware of?

Two scoping decisions worth flagging.

**Built-in types fall in the same category.** `INT`, `VARCHAR`, `NUMERIC`, `TIMESTAMP` and friends are all marked "cannot be function or type name", because Postgres handles them in dedicated grammar productions rather than as user-definable names. They are unaffected here for the same reason — sqlfluff matches them via explicit type grammar before the identifier fallback is reached. There are tests asserting this, since it is the most likely way this change could go wrong.

**Function names are deliberately left alone.** That same category contains real callable built-ins — `COALESCE`, `GREATEST`, `XMLTABLE` — which sqlfluff currently matches as ordinary functions. Applying the anti-template to `FunctionNameIdentifierSegment` too breaks `SELECT COALESCE(a, 0)` immediately. Restricting function names would need dedicated grammar for those forms first, so it seemed like a separate change. Happy to follow up if that's wanted.

Verified locally: `test/dialects/postgres_test.py` 30 passed, and 1010 passed across postgres plus every dialect inheriting from it (duckdb, greenplum, materialize, redshift). `ruff format`, `ruff check` and `mypy` clean on the touched files. The three new negative tests were confirmed to fail without the fix.

Happy to squash the commits into one if you'd prefer.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - [x] Other — unit tests in `test/dialects/postgres_test.py`. This is a grammar *restriction*, i.e. input that should fail to parse, which the `.sql`/`.yml` dialect fixtures can't express.
- Added appropriate documentation for the change — n/a, no user-facing configuration or rule behaviour changes.
- Created GitHub issues for any relevant followup/future enhancements if appropriate — the function-name half is described above; happy to open an issue for it if you'd like it tracked.

---

*Disclosure, per the AI-assisted contributions section of `CONTRIBUTING.md`: this change was AI-assisted. The keyword categorisation, the implementation, the tests and the commit messages were AI-generated. All of it was validated by execution against a local checkout — the reproducer, the full postgres and inherited-dialect test suites, a negative check confirming the new tests fail without the fix, and the `ruff format` / `ruff check` / `mypy` runs. The decision to drop the function-name half came from observing `SELECT COALESCE(a, 0)` break under it, not from assumption.*
