### PR TITLE
fix: pin pip-tools in Dockerfile to prevent pip-compile breakage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,10 @@ WORKDIR /app
 ENV VIRTUAL_ENV=/app/.venv
 RUN python -m venv $VIRTUAL_ENV
 ENV PATH=$VIRTUAL_ENV/bin:$PATH
-RUN pip install --no-cache-dir --upgrade pip setuptools wheel pip-tools
+# Pin pip-tools >= 7.6.1: earlier versions import a removed pip internal
+# (stdlib_pkgs) on Python 3.14, which breaks the pip-compile step below
+# and the DockerHub publish (see #8316).
+RUN pip install --no-cache-dir --upgrade pip setuptools wheel "pip-tools>=7.6.1"
 
 # N.B. we extract the requirements from pyproject.toml
 COPY pyproject.toml .


### PR DESCRIPTION
Closes #8316.

The DockerHub publish for 4.3.0 failed because the unpinned `pip-tools` (< 7.6.1)
imported a removed pip internal (`stdlib_pkgs`) on Python 3.14, breaking the
`pip-compile` step in the Dockerfile:

```
ImportError: cannot import name 'stdlib_pkgs' from 'pip._internal.utils.compat'
```

pip-tools 7.6.1 fixed that import (jazzband/pip-tools#2436). Since the Dockerfile
installs `pip-tools` unpinned, a fresh build would pick up the fixed version — but
the same failure will recur the moment the build environment resolves an older one.
This pins `pip-tools>=7.6.1` so the publish step can't break on that import again.

I couldn't run the Docker build locally (no Docker on this machine); the change is a
version constraint verified against pip-tools 7.6.1's release notes, which fix the
exact `stdlib_pkgs` import.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins `pip-tools>=7.6.1` in the Dockerfile to stop `pip-compile` from failing on Python 3.14 due to the removed `pip` internal `stdlib_pkgs`. Previously `pip-tools` was unpinned and DockerHub publishes could fail when an older version was resolved.

**Review notes**
- Change is limited to the Dockerfile; build-time only, no app/runtime changes.
- Ensure the publish pipeline builds with this Dockerfile and runs `pip-compile`; no migration required.

<sup>Written for commit 97bed1fa0bedd3048d3df2d5b09530f22855a518. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8350?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

