### PR TITLE
Snowflake: mixed GROUPING SETS in GROUP BY, PIVOT aggregate alias, UNPIVOT IN-list aliases

### DIFF
--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -533,6 +533,8 @@ snowflake_dialect.add(
     ),
     GroupByContentsGrammar=Delimited(
         OneOf(
+            Ref("GroupingSetsClauseSegment"),
+            Ref("CubeRollupClauseSegment"),
             Ref("ColumnReferenceSegment"),
             # Can `GROUP BY 1`
             Ref("NumericLiteralSegment"),
@@ -1576,9 +1578,10 @@ class ConnectByClauseSegment(BaseSegment):
 class GroupByClauseSegment(ansi.GroupByClauseSegment):
     """A `GROUP BY` clause like in `SELECT`.
 
-    Snowflake supports Cube, Rollup, and Grouping Sets
+    Snowflake supports GROUP BY ALL, and mixing CUBE, ROLLUP and
+    GROUPING SETS with ordinary grouping expressions in one list.
 
-    https://docs.snowflake.com/en/sql-reference/constructs/group-by.html
+    https://docs.snowflake.com/en/sql-reference/constructs/group-by
     """
 
     match_grammar: Matchable = Sequence(
@@ -1586,12 +1589,6 @@ class GroupByClauseSegment(ansi.GroupByClauseSegment):
         "BY",
         Indent,
         OneOf(
-            Sequence(
-                OneOf("CUBE", "ROLLUP", Sequence("GROUPING", "SETS")),
-                Bracketed(
-                    Ref("GroupByContentsGrammar"),
-                ),
-            ),
             "ALL",
             Ref("GroupByContentsGrammar"),
         ),
@@ -2136,6 +2133,7 @@ class FromPivotExpressionSegment(BaseSegment):
         "PIVOT",
         Bracketed(
             Ref("FunctionSegment"),
+            Ref("AliasExpressionSegment", optional=True),
             "FOR",
             Ref("SingleIdentifierGrammar"),
             "IN",
@@ -2159,7 +2157,10 @@ class FromPivotExpressionSegment(BaseSegment):
 
 
 class FromUnpivotExpressionSegment(BaseSegment):
-    """An UNPIVOT expression."""
+    """An UNPIVOT expression.
+
+    https://docs.snowflake.com/en/sql-reference/constructs/unpivot
+    """
 
     type = "from_unpivot_expression"
     match_grammar = Sequence(
@@ -2170,7 +2171,14 @@ class FromUnpivotExpressionSegment(BaseSegment):
             "FOR",
             Ref("SingleIdentifierGrammar"),
             "IN",
-            Bracketed(Delimited(Ref("SingleIdentifierGrammar"))),
+            Bracketed(
+                Delimited(
+                    Sequence(
+                        Ref("SingleIdentifierGrammar"),
+                        Ref("AliasExpressionSegment", optional=True),
+                    )
+                )
+            ),
         ),
     )
 

--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -1585,7 +1585,7 @@ class CubeRollupClauseSegment(ansi.CubeRollupClauseSegment):
     https://docs.snowflake.com/en/sql-reference/constructs/group-by
     """
 
-    match_grammar: Matchable = Sequence(
+    match_grammar = Sequence(
         OneOf("CUBE", "ROLLUP"),
         Bracketed(
             Ref("GroupingExpressionList"),

--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -1591,13 +1591,11 @@ class GroupingSetsClauseSegment(ansi.GroupingSetsClauseSegment):
         "SETS",
         Bracketed(
             Delimited(
-                OneOf(
-                    Ref("CubeRollupClauseSegment"),
-                    Ref("ColumnReferenceSegment"),
-                    Ref("NumericLiteralSegment"),
-                    Ref("ExpressionSegment"),
-                    Bracketed(),  # Allows an empty grouping set
-                ),
+                Ref("CubeRollupClauseSegment"),
+                Ref("ColumnReferenceSegment"),
+                Ref("NumericLiteralSegment"),
+                Ref("ExpressionSegment"),
+                Bracketed(),  # Allows an empty grouping set
             ),
         ),
     )

--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -1575,6 +1575,34 @@ class ConnectByClauseSegment(BaseSegment):
     )
 
 
+class GroupingSetsClauseSegment(ansi.GroupingSetsClauseSegment):
+    """`GROUPING SETS` clause within the `GROUP BY` clause.
+
+    Unlike the ANSI implementation, the elements of the list are matched
+    one by one, so a CUBE / ROLLUP entry mixed with ordinary grouping
+    expressions keeps its dedicated node instead of being swallowed into
+    a single grouping expression list.
+
+    https://docs.snowflake.com/en/sql-reference/constructs/group-by
+    """
+
+    match_grammar: Matchable = Sequence(
+        "GROUPING",
+        "SETS",
+        Bracketed(
+            Delimited(
+                OneOf(
+                    Ref("CubeRollupClauseSegment"),
+                    Ref("ColumnReferenceSegment"),
+                    Ref("NumericLiteralSegment"),
+                    Ref("ExpressionSegment"),
+                    Bracketed(),  # Allows an empty grouping set
+                ),
+            ),
+        ),
+    )
+
+
 class GroupByClauseSegment(ansi.GroupByClauseSegment):
     """A `GROUP BY` clause like in `SELECT`.
 

--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -1575,6 +1575,24 @@ class ConnectByClauseSegment(BaseSegment):
     )
 
 
+class CubeRollupClauseSegment(ansi.CubeRollupClauseSegment):
+    """`CUBE` / `ROLLUP` clause within the `GROUP BY` clause.
+
+    Snowflake treats CUBE and ROLLUP as keywords rather than as the
+    function names the ANSI dialect uses, so that keyword capitalisation
+    applies to them.
+
+    https://docs.snowflake.com/en/sql-reference/constructs/group-by
+    """
+
+    match_grammar: Matchable = Sequence(
+        OneOf("CUBE", "ROLLUP"),
+        Bracketed(
+            Ref("GroupingExpressionList"),
+        ),
+    )
+
+
 class GroupingSetsClauseSegment(ansi.GroupingSetsClauseSegment):
     """`GROUPING SETS` clause within the `GROUP BY` clause.
 

--- a/test/fixtures/dialects/snowflake/pivot.sql
+++ b/test/fixtures/dialects/snowflake/pivot.sql
@@ -84,3 +84,20 @@ PIVOT (
     )
 )
 WHERE q1_2023_sales IS NOT NULL;
+
+-- Alias for the aggregate in PIVOT (from Snowflake's PIVOT docs)
+SELECT *
+FROM quarterly_sales
+  PIVOT(SUM(amount) AS total FOR quarter IN ('2023_Q1', '2023_Q2'))
+ORDER BY empid;
+
+SELECT *
+FROM quarterly_sales
+  PIVOT(SUM(amount) total FOR quarter IN (ANY ORDER BY quarter))
+ORDER BY empid;
+
+-- Aliases in the UNPIVOT IN-list (from Snowflake's UNPIVOT docs)
+SELECT *
+FROM monthly_sales
+  UNPIVOT(sales FOR month IN (jan AS january, feb february, mar AS 'MARCH', apr))
+ORDER BY empid;

--- a/test/fixtures/dialects/snowflake/pivot.yml
+++ b/test/fixtures/dialects/snowflake/pivot.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: d674046a53ed47d09f5b4a274078b474773a4b684f1f1dc9ed53a2451f918be4
+_hash: b04fddd0b293e87e8493314968adcc922de0b18f926e18c611921ac2a96a890a
 file:
 - statement:
     select_statement:
@@ -579,4 +579,153 @@ file:
         - keyword: IS
         - keyword: NOT
         - null_literal: 'NULL'
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: quarterly_sales
+          from_pivot_expression:
+            keyword: PIVOT
+            bracketed:
+            - start_bracket: (
+            - function:
+                function_name:
+                  function_name_identifier: SUM
+                function_contents:
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                      column_reference:
+                        naked_identifier: amount
+                    end_bracket: )
+            - alias_expression:
+                alias_operator:
+                  keyword: AS
+                naked_identifier: total
+            - keyword: FOR
+            - naked_identifier: quarter
+            - keyword: IN
+            - bracketed:
+              - start_bracket: (
+              - quoted_literal: "'2023_Q1'"
+              - comma: ','
+              - quoted_literal: "'2023_Q2'"
+              - end_bracket: )
+            - end_bracket: )
+      orderby_clause:
+      - keyword: ORDER
+      - keyword: BY
+      - column_reference:
+          naked_identifier: empid
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: quarterly_sales
+          from_pivot_expression:
+            keyword: PIVOT
+            bracketed:
+            - start_bracket: (
+            - function:
+                function_name:
+                  function_name_identifier: SUM
+                function_contents:
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                      column_reference:
+                        naked_identifier: amount
+                    end_bracket: )
+            - alias_expression:
+                naked_identifier: total
+            - keyword: FOR
+            - naked_identifier: quarter
+            - keyword: IN
+            - bracketed:
+                start_bracket: (
+                keyword: ANY
+                orderby_clause:
+                - keyword: ORDER
+                - keyword: BY
+                - column_reference:
+                    naked_identifier: quarter
+                end_bracket: )
+            - end_bracket: )
+      orderby_clause:
+      - keyword: ORDER
+      - keyword: BY
+      - column_reference:
+          naked_identifier: empid
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: monthly_sales
+          from_unpivot_expression:
+            keyword: UNPIVOT
+            bracketed:
+            - start_bracket: (
+            - naked_identifier: sales
+            - keyword: FOR
+            - naked_identifier: month
+            - keyword: IN
+            - bracketed:
+              - start_bracket: (
+              - naked_identifier: jan
+              - alias_expression:
+                  alias_operator:
+                    keyword: AS
+                  naked_identifier: january
+              - comma: ','
+              - naked_identifier: feb
+              - alias_expression:
+                  naked_identifier: february
+              - comma: ','
+              - naked_identifier: mar
+              - alias_expression:
+                  alias_operator:
+                    keyword: AS
+                  quoted_identifier: "'MARCH'"
+              - comma: ','
+              - naked_identifier: apr
+              - end_bracket: )
+            - end_bracket: )
+      orderby_clause:
+      - keyword: ORDER
+      - keyword: BY
+      - column_reference:
+          naked_identifier: empid
 - statement_terminator: ;

--- a/test/fixtures/dialects/snowflake/select_group_by_cube_rollup.yml
+++ b/test/fixtures/dialects/snowflake/select_group_by_cube_rollup.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 4818add87d4c958185d0995564609885bfd9b64656a40cc3c37a7887871985cd
+_hash: 7c55716eb38ea72fdadc5ec75218ab5a70bb4496c252b02864a4e3c74f9cd81e
 file:
 - statement:
     select_statement:
@@ -41,8 +41,7 @@ file:
       - keyword: GROUP
       - keyword: BY
       - cube_rollup_clause:
-          function_name:
-            function_name_identifier: CUBE
+          keyword: CUBE
           bracketed:
             start_bracket: (
             grouping_expression_list:
@@ -89,8 +88,7 @@ file:
       - keyword: GROUP
       - keyword: BY
       - cube_rollup_clause:
-          function_name:
-            function_name_identifier: ROLLUP
+          keyword: ROLLUP
           bracketed:
             start_bracket: (
             grouping_expression_list:

--- a/test/fixtures/dialects/snowflake/select_group_by_cube_rollup.yml
+++ b/test/fixtures/dialects/snowflake/select_group_by_cube_rollup.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 935928ae7e17c4455f72f492823e264a5128c2ebc46d3a981db139869aba2f38
+_hash: 4818add87d4c958185d0995564609885bfd9b64656a40cc3c37a7887871985cd
 file:
 - statement:
     select_statement:
@@ -40,15 +40,18 @@ file:
       groupby_clause:
       - keyword: GROUP
       - keyword: BY
-      - keyword: CUBE
-      - bracketed:
-        - start_bracket: (
-        - column_reference:
-            naked_identifier: name
-        - comma: ','
-        - column_reference:
-            naked_identifier: age
-        - end_bracket: )
+      - cube_rollup_clause:
+          function_name:
+            function_name_identifier: CUBE
+          bracketed:
+            start_bracket: (
+            grouping_expression_list:
+            - column_reference:
+                naked_identifier: name
+            - comma: ','
+            - column_reference:
+                naked_identifier: age
+            end_bracket: )
 - statement_terminator: ;
 - statement:
     select_statement:
@@ -85,13 +88,16 @@ file:
       groupby_clause:
       - keyword: GROUP
       - keyword: BY
-      - keyword: ROLLUP
-      - bracketed:
-        - start_bracket: (
-        - column_reference:
-            naked_identifier: name
-        - comma: ','
-        - column_reference:
-            naked_identifier: age
-        - end_bracket: )
+      - cube_rollup_clause:
+          function_name:
+            function_name_identifier: ROLLUP
+          bracketed:
+            start_bracket: (
+            grouping_expression_list:
+            - column_reference:
+                naked_identifier: name
+            - comma: ','
+            - column_reference:
+                naked_identifier: age
+            end_bracket: )
 - statement_terminator: ;

--- a/test/fixtures/dialects/snowflake/select_group_by_grouping_sets_mixed.sql
+++ b/test/fixtures/dialects/snowflake/select_group_by_grouping_sets_mixed.sql
@@ -1,0 +1,17 @@
+-- Mixing ordinary grouping expressions with GROUPING SETS / ROLLUP / CUBE
+-- https://docs.snowflake.com/en/sql-reference/constructs/group-by
+SELECT a, b, count(*)
+FROM t
+GROUP BY a, GROUPING SETS (b, ());
+
+SELECT a, b, c, sum(x)
+FROM t
+GROUP BY a, ROLLUP (b, c), CUBE (b);
+
+SELECT a, b, sum(x)
+FROM t
+GROUP BY GROUPING SETS (a, ROLLUP (b), ());
+
+SELECT a, sum(x)
+FROM t
+GROUP BY 1, coalesce(a, 'x');

--- a/test/fixtures/dialects/snowflake/select_group_by_grouping_sets_mixed.yml
+++ b/test/fixtures/dialects/snowflake/select_group_by_grouping_sets_mixed.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 02c877e9c759c0e662b220f1a51487d14343e7c133d1a0eba5d6047bdf6e6719
+_hash: d60fb3c0621548a9a6b13505cc2c9cfb86a7823d3cd943e3642096f92519c9cf
 file:
 - statement:
     select_statement:
@@ -44,14 +44,13 @@ file:
         - keyword: SETS
         - bracketed:
             start_bracket: (
-            grouping_expression_list:
-              column_reference:
-                naked_identifier: b
-              comma: ','
-              expression:
-                bracketed:
-                  start_bracket: (
-                  end_bracket: )
+            column_reference:
+              naked_identifier: b
+            comma: ','
+            expression:
+              bracketed:
+                start_bracket: (
+                end_bracket: )
             end_bracket: )
 - statement_terminator: ;
 - statement:
@@ -154,28 +153,25 @@ file:
         - keyword: GROUPING
         - keyword: SETS
         - bracketed:
-            start_bracket: (
-            grouping_expression_list:
-            - column_reference:
-                naked_identifier: a
-            - comma: ','
-            - expression:
-                function:
-                  function_name:
-                    function_name_identifier: ROLLUP
-                  function_contents:
-                    bracketed:
-                      start_bracket: (
-                      expression:
-                        column_reference:
-                          naked_identifier: b
-                      end_bracket: )
-            - comma: ','
-            - expression:
-                bracketed:
-                  start_bracket: (
-                  end_bracket: )
-            end_bracket: )
+          - start_bracket: (
+          - column_reference:
+              naked_identifier: a
+          - comma: ','
+          - cube_rollup_clause:
+              function_name:
+                function_name_identifier: ROLLUP
+              bracketed:
+                start_bracket: (
+                grouping_expression_list:
+                  column_reference:
+                    naked_identifier: b
+                end_bracket: )
+          - comma: ','
+          - expression:
+              bracketed:
+                start_bracket: (
+                end_bracket: )
+          - end_bracket: )
 - statement_terminator: ;
 - statement:
     select_statement:

--- a/test/fixtures/dialects/snowflake/select_group_by_grouping_sets_mixed.yml
+++ b/test/fixtures/dialects/snowflake/select_group_by_grouping_sets_mixed.yml
@@ -1,0 +1,225 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 02c877e9c759c0e662b220f1a51487d14343e7c133d1a0eba5d6047bdf6e6719
+file:
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            naked_identifier: a
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            naked_identifier: b
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: count
+            function_contents:
+              bracketed:
+                start_bracket: (
+                star: '*'
+                end_bracket: )
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: t
+      groupby_clause:
+      - keyword: GROUP
+      - keyword: BY
+      - column_reference:
+          naked_identifier: a
+      - comma: ','
+      - grouping_sets_clause:
+        - keyword: GROUPING
+        - keyword: SETS
+        - bracketed:
+            start_bracket: (
+            grouping_expression_list:
+              column_reference:
+                naked_identifier: b
+              comma: ','
+              expression:
+                bracketed:
+                  start_bracket: (
+                  end_bracket: )
+            end_bracket: )
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            naked_identifier: a
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            naked_identifier: b
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            naked_identifier: c
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: sum
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  column_reference:
+                    naked_identifier: x
+                end_bracket: )
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: t
+      groupby_clause:
+      - keyword: GROUP
+      - keyword: BY
+      - column_reference:
+          naked_identifier: a
+      - comma: ','
+      - cube_rollup_clause:
+          function_name:
+            function_name_identifier: ROLLUP
+          bracketed:
+            start_bracket: (
+            grouping_expression_list:
+            - column_reference:
+                naked_identifier: b
+            - comma: ','
+            - column_reference:
+                naked_identifier: c
+            end_bracket: )
+      - comma: ','
+      - cube_rollup_clause:
+          function_name:
+            function_name_identifier: CUBE
+          bracketed:
+            start_bracket: (
+            grouping_expression_list:
+              column_reference:
+                naked_identifier: b
+            end_bracket: )
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            naked_identifier: a
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            naked_identifier: b
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: sum
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  column_reference:
+                    naked_identifier: x
+                end_bracket: )
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: t
+      groupby_clause:
+      - keyword: GROUP
+      - keyword: BY
+      - grouping_sets_clause:
+        - keyword: GROUPING
+        - keyword: SETS
+        - bracketed:
+            start_bracket: (
+            grouping_expression_list:
+            - column_reference:
+                naked_identifier: a
+            - comma: ','
+            - expression:
+                function:
+                  function_name:
+                    function_name_identifier: ROLLUP
+                  function_contents:
+                    bracketed:
+                      start_bracket: (
+                      expression:
+                        column_reference:
+                          naked_identifier: b
+                      end_bracket: )
+            - comma: ','
+            - expression:
+                bracketed:
+                  start_bracket: (
+                  end_bracket: )
+            end_bracket: )
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            naked_identifier: a
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: sum
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  column_reference:
+                    naked_identifier: x
+                end_bracket: )
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: t
+      groupby_clause:
+      - keyword: GROUP
+      - keyword: BY
+      - numeric_literal: '1'
+      - comma: ','
+      - expression:
+          function:
+            function_name:
+              function_name_identifier: coalesce
+            function_contents:
+              bracketed:
+              - start_bracket: (
+              - expression:
+                  column_reference:
+                    naked_identifier: a
+              - comma: ','
+              - expression:
+                  quoted_literal: "'x'"
+              - end_bracket: )
+- statement_terminator: ;

--- a/test/fixtures/dialects/snowflake/select_group_by_grouping_sets_mixed.yml
+++ b/test/fixtures/dialects/snowflake/select_group_by_grouping_sets_mixed.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: d60fb3c0621548a9a6b13505cc2c9cfb86a7823d3cd943e3642096f92519c9cf
+_hash: 247a5683ec31c51c0f074d3d4d7d3ccf0cdf2799e1739372c362445137dff0bb
 file:
 - statement:
     select_statement:
@@ -94,8 +94,7 @@ file:
           naked_identifier: a
       - comma: ','
       - cube_rollup_clause:
-          function_name:
-            function_name_identifier: ROLLUP
+          keyword: ROLLUP
           bracketed:
             start_bracket: (
             grouping_expression_list:
@@ -107,8 +106,7 @@ file:
             end_bracket: )
       - comma: ','
       - cube_rollup_clause:
-          function_name:
-            function_name_identifier: CUBE
+          keyword: CUBE
           bracketed:
             start_bracket: (
             grouping_expression_list:
@@ -158,8 +156,7 @@ file:
               naked_identifier: a
           - comma: ','
           - cube_rollup_clause:
-              function_name:
-                function_name_identifier: ROLLUP
+              keyword: ROLLUP
               bracketed:
                 start_bracket: (
                 grouping_expression_list:

--- a/test/fixtures/dialects/snowflake/select_grouping_sets.yml
+++ b/test/fixtures/dialects/snowflake/select_grouping_sets.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 3ebb65b3bbf3f5f2924ad469ba97ad940ac89d440b90b03acd69eca3cb6b3aba
+_hash: 5a6abf6ecbb0fc7c90649986ae3e8836127662c65d8aae797fa0c12069978589
 file:
 - statement:
     select_statement:
@@ -26,16 +26,18 @@ file:
       groupby_clause:
       - keyword: GROUP
       - keyword: BY
-      - keyword: GROUPING
-      - keyword: SETS
-      - bracketed:
-        - start_bracket: (
-        - column_reference:
-            naked_identifier: foo
-        - comma: ','
-        - column_reference:
-            naked_identifier: bar
-        - end_bracket: )
+      - grouping_sets_clause:
+        - keyword: GROUPING
+        - keyword: SETS
+        - bracketed:
+            start_bracket: (
+            grouping_expression_list:
+            - column_reference:
+                naked_identifier: foo
+            - comma: ','
+            - column_reference:
+                naked_identifier: bar
+            end_bracket: )
 - statement_terminator: ;
 - statement:
     select_statement:
@@ -68,16 +70,18 @@ file:
       groupby_clause:
       - keyword: group
       - keyword: by
-      - keyword: grouping
-      - keyword: sets
-      - bracketed:
-        - start_bracket: (
-        - column_reference:
-            naked_identifier: medical_license
-        - comma: ','
-        - column_reference:
-            naked_identifier: radio_license
-        - end_bracket: )
+      - grouping_sets_clause:
+        - keyword: grouping
+        - keyword: sets
+        - bracketed:
+            start_bracket: (
+            grouping_expression_list:
+            - column_reference:
+                naked_identifier: medical_license
+            - comma: ','
+            - column_reference:
+                naked_identifier: radio_license
+            end_bracket: )
 - statement_terminator: ;
 - statement:
     select_statement:
@@ -110,14 +114,16 @@ file:
       groupby_clause:
       - keyword: group
       - keyword: by
-      - keyword: grouping
-      - keyword: sets
-      - bracketed:
-        - start_bracket: (
-        - column_reference:
-            naked_identifier: medical_license
-        - comma: ','
-        - column_reference:
-            naked_identifier: radio_license
-        - end_bracket: )
+      - grouping_sets_clause:
+        - keyword: grouping
+        - keyword: sets
+        - bracketed:
+            start_bracket: (
+            grouping_expression_list:
+            - column_reference:
+                naked_identifier: medical_license
+            - comma: ','
+            - column_reference:
+                naked_identifier: radio_license
+            end_bracket: )
 - statement_terminator: ;

--- a/test/fixtures/dialects/snowflake/select_grouping_sets.yml
+++ b/test/fixtures/dialects/snowflake/select_grouping_sets.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 5a6abf6ecbb0fc7c90649986ae3e8836127662c65d8aae797fa0c12069978589
+_hash: 1992e89d371efebb0ca9bb6addfb9579dde7bb775e060796b4b0a313cdbec83d
 file:
 - statement:
     select_statement:
@@ -30,14 +30,13 @@ file:
         - keyword: GROUPING
         - keyword: SETS
         - bracketed:
-            start_bracket: (
-            grouping_expression_list:
-            - column_reference:
-                naked_identifier: foo
-            - comma: ','
-            - column_reference:
-                naked_identifier: bar
-            end_bracket: )
+          - start_bracket: (
+          - column_reference:
+              naked_identifier: foo
+          - comma: ','
+          - column_reference:
+              naked_identifier: bar
+          - end_bracket: )
 - statement_terminator: ;
 - statement:
     select_statement:
@@ -74,14 +73,13 @@ file:
         - keyword: grouping
         - keyword: sets
         - bracketed:
-            start_bracket: (
-            grouping_expression_list:
-            - column_reference:
-                naked_identifier: medical_license
-            - comma: ','
-            - column_reference:
-                naked_identifier: radio_license
-            end_bracket: )
+          - start_bracket: (
+          - column_reference:
+              naked_identifier: medical_license
+          - comma: ','
+          - column_reference:
+              naked_identifier: radio_license
+          - end_bracket: )
 - statement_terminator: ;
 - statement:
     select_statement:
@@ -118,12 +116,11 @@ file:
         - keyword: grouping
         - keyword: sets
         - bracketed:
-            start_bracket: (
-            grouping_expression_list:
-            - column_reference:
-                naked_identifier: medical_license
-            - comma: ','
-            - column_reference:
-                naked_identifier: radio_license
-            end_bracket: )
+          - start_bracket: (
+          - column_reference:
+              naked_identifier: medical_license
+          - comma: ','
+          - column_reference:
+              naked_identifier: radio_license
+          - end_bracket: )
 - statement_terminator: ;


### PR DESCRIPTION
### Brief summary of the change made

- GROUP BY mixing ordinary expressions with GROUPING SETS / CUBE / ROLLUP in the same list
  (`GROUP BY a, GROUPING SETS (b, ())`), by moving the CUBE / ROLLUP / GROUPING SETS
  alternatives inside the delimited list of `GroupByClauseSegment`, following the pattern
  already used in the postgres dialect. As a side effect, `ROLLUP (...)` and `CUBE (...)` now
  parse as proper grouping constructs instead of ordinary function calls, which corrects the
  parse tree labels.
- Optional alias for the aggregate in PIVOT: `PIVOT (SUM(amount) AS total FOR ...)`.
- Aliases in the UNPIVOT IN-list: `UNPIVOT (sales FOR month IN (jan AS 'JANUARY', feb))`.

Reference documentation:

- https://docs.snowflake.com/en/sql-reference/constructs/group-by
- https://docs.snowflake.com/en/sql-reference/constructs/pivot
- https://docs.snowflake.com/en/sql-reference/constructs/unpivot

### Are there any other side effects of this change that we should be aware of?

The GROUP BY restructuring changes the parse tree of existing fixtures that use
`GROUP BY ROLLUP (...)` / `CUBE (...)`: those previously parsed as function calls and now
parse as dedicated grouping clauses. The regenerated YAML diffs in this PR are exactly that
relabelling; no statement that parsed before stops parsing.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes:
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects/snowflake` (YML files generated
    with `python test/generate_parse_fixture_yml.py -d snowflake`, and the full cross-dialect
    regeneration produces no unrelated diffs).
- Added appropriate documentation for the change: the docstrings of the touched segments link
  to the relevant official Snowflake documentation (dialect reference docs are auto-generated).
- No followup issues were needed for this change.

### AI assistance declaration

This change was developed with AI assistance: the grammar changes and the test fixtures were
drafted with an LLM. Every clause was checked against the official Snowflake documentation
linked above, and each statement in the fixtures was verified locally with
`sqlfluff parse --dialect snowflake`. The full dialect suite
(`pytest test/dialects/dialects_test.py -k snowflake` and `pytest test/dialects/snowflake_test.py`)
passes, a full `python test/generate_parse_fixture_yml.py` produces no diff outside the fixtures
listed above, and `ruff format --check` / `ruff check` are clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Snowflake support for mixing GROUPING SETS/ROLLUP/CUBE with ordinary GROUP BY expressions, optional aggregate aliases in PIVOT, and per-column aliases in UNPIVOT IN-lists. Previously ROLLUP/CUBE parsed as function calls or keyword+bracketed nodes; now they parse as dedicated grouping elements and remain keywords, fixing parse trees and restoring keyword-capitalization behavior.

**Review notes**
- GROUP BY accepts mixed `GROUPING SETS`/`CUBE`/`ROLLUP` and expressions, emitting `grouping_sets_clause` and `cube_rollup_clause` nodes; `CUBE`/`ROLLUP` inside `GROUPING SETS` also emit `cube_rollup_clause`. `CUBE`/`ROLLUP` are keywords (CP01 capitalization applies).
- `PIVOT` supports an optional aggregate alias (`AS` or bare).
- `UNPIVOT` IN-list supports per-column aliases (`AS` or bare; quoted allowed).
- Updated `CubeRollupClauseSegment` typing to satisfy mypy; no behavior change.

**Migration**
- Update parse tree expectations from function-call or keyword+bracketed shapes to `cube_rollup_clause`/`grouping_sets_clause` in GROUP BY, including when `CUBE`/`ROLLUP` appear inside `GROUPING SETS`.
- If you inspect token types, note `CUBE`/`ROLLUP` are keywords, not function names.

<sup>Written for commit 244f1b6b51b2329b7efc78c6e17fb2124eb5bf91. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8351?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

