### PR TITLE
fix(LT09): don't put zero-width metas in a create fix

### DIFF
--- a/src/sqlfluff/rules/layout/LT09.py
+++ b/src/sqlfluff/rules/layout/LT09.py
@@ -425,12 +425,19 @@ class Rule_LT09(BaseRule):
                             fixes.append(LintFix.delete(seg))
                             all_deletes.add(seg)
 
-                    if move_after_select_clause or add_newline:
+                    # The slice can contain zero-width metas, e.g. the Indent
+                    # after a select modifier, or the select clause Indent
+                    # itself on dialects which place it after the newline. A
+                    # create fix requires every edit segment to have a raw, so
+                    # drop them; reflow recalculates indentation anyway.
+                    move_edits = [seg for seg in move_after_select_clause if seg.raw]
+
+                    if move_edits or add_newline:
                         fixes.append(
                             LintFix.create_after(
                                 select_clause[0],
                                 ([NewlineSegment()] if add_newline else [])
-                                + list(move_after_select_clause),
+                                + move_edits,
                             )
                         )
 

--- a/test/fixtures/rules/std_rule_cases/LT09.yml
+++ b/test/fixtures/rules/std_rule_cases/LT09.yml
@@ -258,6 +258,34 @@ test_distinct_single_fail_b:
     SELECT distinct a
     FROM my_table
 
+# A create fix cannot contain zero-width segments, so an Indent meta must
+# never end up in the segments moved after the select clause. Two ways it can:
+#
+#  - any dialect, when a select modifier moves the start of the moved slice
+#    onto the modifier, which the parser follows with an Indent
+#  - sparksql/databricks, which place the select clause Indent after the
+#    newline rather than before it, so it is inside the slice regardless
+#
+# NOTE: The residual whitespace in the first two fix_str below is expected:
+# these cases isolate LT09, and LT01 removes it in a normal run.
+test_distinct_single_fail_from_same_line:
+  fail_str: "SELECT\n  distinct a FROM my_table\n"
+  fix_str: "SELECT distinct a  \n FROM my_table\n"
+
+test_top_single_fail_from_same_line:
+  fail_str: "SELECT\n  top 5 a FROM my_table\n"
+  fix_str: "SELECT top 5 a  \n FROM my_table\n"
+  configs:
+    core:
+      dialect: tsql
+
+test_sparksql_single_fail_from_same_line:
+  fail_str: "SELECT\n  SUM(x) OVER (ORDER BY t) FROM m\n"
+  fix_str: "SELECT SUM(x) OVER (ORDER BY t)\n  FROM m\n"
+  configs:
+    core:
+      dialect: sparksql
+
 test_single_select_with_no_from:
   fail_str: "SELECT\n   10000000\n"
   fix_str: "SELECT 10000000\n"


### PR DESCRIPTION
### Brief summary of the change made

`Rule_LT09` raises `AssertionError: Invalid edit found` on some single-select-target
queries where the `FROM` sits on the same line as the target:

```sql
SELECT
  DISTINCT a FROM my_table
```

```
CRITICAL [LT09] Applying rule LT09 to 'x.sql' threw an Exception: Invalid edit found:
[<NewlineSegment: (None) '\n'>, <Indent: (None) ''>, <WhitespaceSegment: (None) ' '>].
...
  File ".../sqlfluff/rules/layout/LT09.py", line 430, in _eval_single_select_target_element
    LintFix.create_after(
  File ".../sqlfluff/core/rules/fix.py", line 82, in __init__
    assert all(seg.raw for seg in self.edit), (
AssertionError
```

The rule crawler catches the exception, so the CLI does not crash. Instead the user gets
`Unexpected exception: Invalid edit found ...; Could you open an issue at ...` and
**LT09 stops linting and fixing that file.**

Reproduces on 4.3.0 and on current `main`.

### Cause

`_eval_single_select_target_element` collects the segments between the start of the moved
slice and the select target, and passes them straight into `LintFix.create_after`, which
asserts that every edit segment has a non-empty raw. If an `Indent` meta falls inside that
slice, the assert fires.

Two independent ways that happens:

**1. Any dialect, when a select clause modifier is present.** The modifier moves the start
of the slice off the newline and onto the modifier itself:

```python
start_idx = modifier_idx
start_seg = modifier[0]
```

and the parser places an `Indent` directly after a modifier:

```
[0] keyword                 'SELECT'
[1] newline                 '\n'
[2] whitespace              '  '
[3] select_clause_modifier  'DISTINCT'
[4] indent                  ''      <-- in the slice
[5] whitespace              ' '
[6] select_clause_element   'a'
[7] dedent                  ''
```

Not `DISTINCT`-specific — `ALL`, `DISTINCT ON (...)` and `TOP` hit it too:

| Input | Dialects |
|---|---|
| `SELECT\n  DISTINCT a FROM t` | ansi, postgres, snowflake, … |
| `SELECT\n  ALL a FROM t` | ansi |
| `SELECT\n  DISTINCT ON (a) b FROM t` | postgres |
| `SELECT\n  TOP 5 a FROM t` | tsql, snowflake |

**2. sparksql and databricks, with no modifier at all.** These dialects place the select
clause `Indent` *after* the newline rather than before it, so it is inside the slice
regardless of the start position:

```
sparksql                          ansi
[0] keyword     'SELECT'          [0] keyword     'SELECT'
[1] newline     '\n'              [1] indent      ''
[2] whitespace  '    '            [2] newline     '\n'
[3] indent      ''       <--      [3] whitespace  '    '
[4] element     'SUM(x) OVER …'   [4] element     'SUM(x) OVER …'
[5] dedent      ''                [5] dedent      ''
```

```sql
-- sparksql / databricks
SELECT
  SUM(x) OVER (ORDER BY t) FROM m
```

The `FROM`-on-the-same-line condition matters in both cases because the other branch
(`next_segment.is_type("newline")`) recomputes `to_delete` and ends up with an empty slice.

### Fix

Drop zero-width segments when building the create fix. Metas carry no text and reflow
recalculates indentation, so nothing is lost.

### Are there any other side effects of this change that we should be aware of?

No behaviour change for any input that did not previously raise — in those cases the slice
contained no metas, so the filter is a no-op. `test/rules/`, `test/core/` and `test/api/`
pass unchanged.

Running the full rule set on the previously-crashing inputs gives the expected result:

```
'SELECT\n  DISTINCT a FROM my_table\n'  ->  'SELECT DISTINCT a\nFROM my_table\n'
```

which is byte-identical to what the equivalent modifier-less query already produced. Fixed
output re-lints clean (no `PRS`/`LXR`) and is idempotent across ansi, postgres, snowflake,
tsql, sparksql and databricks.

The two modifier test cases isolate LT09, so their `fix_str` still carries the whitespace
that LT01 removes in a normal run. I noted that inline in the fixture.

### Are there any tests that need to be added?

Three YAML cases added to `test/fixtures/rules/std_rule_cases/LT09.yml`: `DISTINCT` (ansi),
`TOP` (tsql) and a window function (sparksql), covering both routes to the bug. All three
fail with `AssertionError` on `main` and pass with this change.

---

### AI disclosure

Per `CONTRIBUTING.md`: this change was developed with AI assistance (Claude).

- **AI-assisted:** a fix/idempotence/crash fuzz harness over a SQL corpus × 24 dialects
  which surfaced the crashing inputs, tracing the failure to the two slice shapes,
  drafting the patch, the test cases and this description.
- **Manually validated by me:** reproduced on the 4.3.0 release and on `main`; inspected
  the parse trees to confirm the `Indent` meta is the offending segment and to establish
  why sparksql differs from ansi; confirmed the three new tests fail without the source
  change and pass with it; ran `test/rules/`, `test/core/` and `test/api/`; checked the
  fixed output re-parses and is idempotent across six dialects; ran black, ruff and mypy.

I am responsible for the final content of this PR.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `LT09` crashes by filtering zero-width meta segments from create fixes so the rule no longer raises “Invalid edit found” when `FROM` is on the same line as the target. Previously, `LT09` emitted an unexpected exception and stopped fixing the file; now it formats these cases correctly with no change to non-crashing inputs.

- Drops zero-width metas (e.g., `Indent`) from segments passed to `LintFix.create_after`; reflow recomputes indentation.
- Handles both paths to the bug: select modifiers present in any dialect (`DISTINCT`, `ALL`, `DISTINCT ON (...)`, `TOP`) and `sparksql`/`databricks` where the select-clause `Indent` follows the newline.
- Adds three focused tests in `test/fixtures/rules/std_rule_cases/LT09.yml`; all fail on `main` and pass with this change; other tests remain unchanged.

<sup>Written for commit 561ad683ee7bf5aae72e6b9cb6fe1757020a49a1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8355?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

