### PR TITLE
duckdb: parse INSTALL and LOAD extension statements (fixes #8354)

### DIFF
--- a/src/sqlfluff/dialects/dialect_duckdb.py
+++ b/src/sqlfluff/dialects/dialect_duckdb.py
@@ -69,6 +69,7 @@ duckdb_dialect.sets("unreserved_keywords").update(
         "COMPRESSION",
         "COMPRESSION_LEVEL",
         "GLOB",
+        "INSTALL",
         "MACRO",
         "MAP",
         "OVERWRITE",
@@ -1033,7 +1034,49 @@ class StatementSegment(postgres.StatementSegment):
         insert=[
             Ref("SimplifiedPivotExpressionSegment"),
             Ref("SimplifiedUnpivotExpressionSegment"),
+            Ref("InstallStatementSegment"),
+            Ref("LoadStatementSegment"),
         ]
+    )
+
+
+class InstallStatementSegment(BaseSegment):
+    """An `INSTALL` statement for DuckDB extensions.
+
+    Installs a DuckDB extension, optionally forcing a re-install and/or
+    selecting the repository to install from (an alias such as ``community``
+    or a single-quoted URL string). The extension itself is named either by a
+    bare identifier or, for a local file, a single-quoted path string.
+
+    https://duckdb.org/docs/stable/sql/statements/load_and_install
+    """
+
+    type = "install_statement"
+    match_grammar = Sequence(
+        Ref.keyword("FORCE", optional=True),
+        "INSTALL",
+        OneOf(Ref("SingleIdentifierGrammar"), Ref("QuotedLiteralSegment")),
+        Sequence(
+            "FROM",
+            OneOf(Ref("SingleIdentifierGrammar"), Ref("QuotedLiteralSegment")),
+            optional=True,
+        ),
+    )
+
+
+class LoadStatementSegment(BaseSegment):
+    """A `LOAD` statement for DuckDB extensions.
+
+    Loads an installed extension into the current session. The extension is
+    named either by a bare identifier or a single-quoted path string.
+
+    https://duckdb.org/docs/stable/sql/statements/load_and_install
+    """
+
+    type = "load_statement"
+    match_grammar = Sequence(
+        "LOAD",
+        OneOf(Ref("SingleIdentifierGrammar"), Ref("QuotedLiteralSegment")),
     )
 
 

--- a/test/fixtures/dialects/duckdb/install_and_load.sql
+++ b/test/fixtures/dialects/duckdb/install_and_load.sql
@@ -1,0 +1,26 @@
+-- Install and load DuckDB extensions.
+-- https://duckdb.org/docs/stable/sql/statements/load_and_install
+
+INSTALL spatial;
+
+INSTALL httpfs;
+
+LOAD spatial;
+
+LOAD httpfs;
+
+-- Force a re-install (e.g. to switch repositories).
+FORCE INSTALL spatial;
+
+-- Install from a named repository (an alias such as community or core_nightly).
+INSTALL h3 FROM community;
+
+FORCE INSTALL httpfs FROM core_nightly;
+
+-- Install from a direct URL, provided as a single-quoted string.
+INSTALL spatial FROM 'https://some.custom/repository';
+
+-- Install a local extension from a single-quoted file path.
+INSTALL 'path/to/spatial.duckdb_extension';
+
+LOAD 'path/to/spatial.duckdb_extension';

--- a/test/fixtures/dialects/duckdb/install_and_load.yml
+++ b/test/fixtures/dialects/duckdb/install_and_load.yml
@@ -1,0 +1,65 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: cfd44590f03bbdbce3ff3755c38ecaaedbfa78570e534b759447ba95f7ac4149
+file:
+- statement:
+    install_statement:
+      keyword: INSTALL
+      naked_identifier: spatial
+- statement_terminator: ;
+- statement:
+    install_statement:
+      keyword: INSTALL
+      naked_identifier: httpfs
+- statement_terminator: ;
+- statement:
+    load_statement:
+      keyword: LOAD
+      naked_identifier: spatial
+- statement_terminator: ;
+- statement:
+    load_statement:
+      keyword: LOAD
+      naked_identifier: httpfs
+- statement_terminator: ;
+- statement:
+    install_statement:
+    - keyword: FORCE
+    - keyword: INSTALL
+    - naked_identifier: spatial
+- statement_terminator: ;
+- statement:
+    install_statement:
+    - keyword: INSTALL
+    - naked_identifier: h3
+    - keyword: FROM
+    - naked_identifier: community
+- statement_terminator: ;
+- statement:
+    install_statement:
+    - keyword: FORCE
+    - keyword: INSTALL
+    - naked_identifier: httpfs
+    - keyword: FROM
+    - naked_identifier: core_nightly
+- statement_terminator: ;
+- statement:
+    install_statement:
+    - keyword: INSTALL
+    - naked_identifier: spatial
+    - keyword: FROM
+    - quoted_literal: "'https://some.custom/repository'"
+- statement_terminator: ;
+- statement:
+    install_statement:
+      keyword: INSTALL
+      quoted_literal: "'path/to/spatial.duckdb_extension'"
+- statement_terminator: ;
+- statement:
+    load_statement:
+      keyword: LOAD
+      quoted_literal: "'path/to/spatial.duckdb_extension'"
+- statement_terminator: ;


### PR DESCRIPTION
### Brief summary of the change made

The DuckDB dialect couldn't parse `INSTALL` or `LOAD` extension statements — valid DuckDB SQL that failed with "Found unparsable section". This adds `InstallStatementSegment` and `LoadStatementSegment` and registers them in the DuckDB `StatementSegment`.

The grammar follows the DuckDB docs (https://duckdb.org/docs/stable/sql/statements/load_and_install):
- `INSTALL <name>` where name is a bare identifier or a single-quoted file path
- optional `FORCE` prefix (`FORCE INSTALL ...`)
- optional `FROM <repository>` — an alias identifier (`community`, `core_nightly`) or a single-quoted URL string
- `LOAD <name>` with the same name forms

`INSTALL` is added as an *unreserved* keyword, so it still works as an identifier (`SELECT install FROM t` still parses); `LOAD` and `FORCE` were already present.

fixes #8354

### Are there any other side effects of this change that we should be aware of?

None. `INSTALL` is unreserved, so it does not affect its use as an identifier, and the change only adds two new statement types to the DuckDB dialect. All 123 existing DuckDB dialect tests continue to pass.

### Pull Request checklist

- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - [x] `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds parsing support for DuckDB extension statements, fixing failures on valid `INSTALL` and `LOAD` SQL. Previously these statements errored with “Found unparsable section”; now they parse with optional `FORCE` and `FROM` forms, and `INSTALL` remains usable as an identifier.

**Review notes**
- Adds `InstallStatementSegment` and `LoadStatementSegment`; registers both in the DuckDB `StatementSegment`.
- Grammar: `INSTALL` with optional `FORCE` prefix and optional `FROM <repository>`; name is a bare identifier or single-quoted string. `LOAD` accepts the same name forms.
- Marks `INSTALL` as an unreserved keyword; `LOAD` and `FORCE` were already present.
- New fixtures: `install_and_load.sql` and auto-generated `.yml` to cover the above forms.

<sup>Written for commit e9a4d128c5179ef7fc3fab2bce0f1888d9234843. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8357?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

