### PR TITLE
DuckDB: parse INSTALL and LOAD statements

### DIFF
--- a/src/sqlfluff/dialects/dialect_duckdb.py
+++ b/src/sqlfluff/dialects/dialect_duckdb.py
@@ -69,6 +69,7 @@ duckdb_dialect.sets("unreserved_keywords").update(
         "COMPRESSION",
         "COMPRESSION_LEVEL",
         "GLOB",
+        "INSTALL",
         "MACRO",
         "MAP",
         "OVERWRITE",
@@ -1026,6 +1027,38 @@ class ObjectLiteralElementSegment(ansi.ObjectLiteralElementSegment):
     )
 
 
+class InstallStatementSegment(BaseSegment):
+    """An `INSTALL` statement.
+
+    https://duckdb.org/docs/stable/sql/statements/load_and_install
+    """
+
+    type = "install_statement"
+    match_grammar = Sequence(
+        Ref.keyword("FORCE", optional=True),
+        "INSTALL",
+        OneOf(Ref("SingleIdentifierGrammar"), Ref("QuotedLiteralSegment")),
+        Sequence(
+            "FROM",
+            OneOf(Ref("SingleIdentifierGrammar"), Ref("QuotedLiteralSegment")),
+            optional=True,
+        ),
+    )
+
+
+class LoadStatementSegment(postgres.LoadStatementSegment):
+    """A `LOAD` statement.
+
+    DuckDB names the extension directly, where Postgres takes a quoted
+    filename: https://duckdb.org/docs/stable/sql/statements/load_and_install
+    """
+
+    match_grammar = Sequence(
+        "LOAD",
+        OneOf(Ref("SingleIdentifierGrammar"), Ref("QuotedLiteralSegment")),
+    )
+
+
 class StatementSegment(postgres.StatementSegment):
     """An element in the targets of a select statement."""
 
@@ -1033,6 +1066,7 @@ class StatementSegment(postgres.StatementSegment):
         insert=[
             Ref("SimplifiedPivotExpressionSegment"),
             Ref("SimplifiedUnpivotExpressionSegment"),
+            Ref("InstallStatementSegment"),
         ]
     )
 

--- a/test/fixtures/dialects/duckdb/install_and_load.sql
+++ b/test/fixtures/dialects/duckdb/install_and_load.sql
@@ -1,0 +1,11 @@
+INSTALL spatial;
+
+FORCE INSTALL spatial;
+
+INSTALL h3 FROM community;
+
+FORCE INSTALL h3 FROM community;
+
+INSTALL custom_extension FROM 'https://my-custom-extension-repository';
+
+LOAD spatial;

--- a/test/fixtures/dialects/duckdb/install_and_load.yml
+++ b/test/fixtures/dialects/duckdb/install_and_load.yml
@@ -1,0 +1,45 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: a6723fe2e0cfa9cbdde8c2c844926fa8a02aa5338f39272266ba004440176d95
+file:
+- statement:
+    install_statement:
+      keyword: INSTALL
+      naked_identifier: spatial
+- statement_terminator: ;
+- statement:
+    install_statement:
+    - keyword: FORCE
+    - keyword: INSTALL
+    - naked_identifier: spatial
+- statement_terminator: ;
+- statement:
+    install_statement:
+    - keyword: INSTALL
+    - naked_identifier: h3
+    - keyword: FROM
+    - naked_identifier: community
+- statement_terminator: ;
+- statement:
+    install_statement:
+    - keyword: FORCE
+    - keyword: INSTALL
+    - naked_identifier: h3
+    - keyword: FROM
+    - naked_identifier: community
+- statement_terminator: ;
+- statement:
+    install_statement:
+    - keyword: INSTALL
+    - naked_identifier: custom_extension
+    - keyword: FROM
+    - quoted_literal: "'https://my-custom-extension-repository'"
+- statement_terminator: ;
+- statement:
+    load_statement:
+      keyword: LOAD
+      naked_identifier: spatial
+- statement_terminator: ;


### PR DESCRIPTION
Closes #8354

Both statements from the report now parse:

```
echo "INSTALL spatial;" | sqlfluff parse --dialect duckdb -
echo "LOAD spatial;" | sqlfluff parse --dialect duckdb -
```

They failed for two different reasons:

- **`INSTALL`** had no grammar in the DuckDB dialect at all.
- **`LOAD`** did — inherited from Postgres, where the statement takes a quoted filename (`LOAD 'filename'`). DuckDB names the extension directly, so the inherited grammar could never match `LOAD spatial`.

### Change

- `InstallStatementSegment`, registered on `StatementSegment`, covering the documented forms: a bare `INSTALL`, the `FORCE` variant, and the optional `FROM <repository>` clause where the repository is either an alias (`community`) or a quoted URL.
- `LoadStatementSegment` overridden for DuckDB to accept an extension name as well as a quoted literal. Postgres is untouched — `LOAD 'x.so'` still parses there and its dialect tests are unchanged.
- `INSTALL` added to the DuckDB unreserved keywords. `FORCE` and `LOAD` were already inherited from ANSI.

Syntax follows https://duckdb.org/docs/stable/sql/statements/load_and_install and the extension-installation page. Installing directly from a local file path is not documented there, so it is not included.

### Tests

`test/fixtures/dialects/duckdb/install_and_load.sql` covers all six forms, with the YAML generated by `test/generate_parse_fixture_yml.py`.

The full dialect suite passes — 6921 tests, no failures — as do `mypy` (strict), `black` and `ruff` on the changed file.

### Attribution

This is a human submission. No bots are used.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds parsing for DuckDB INSTALL and LOAD statements so DuckDB extensions parse correctly. Previously INSTALL was not recognized and LOAD required a quoted filename; now both accept an extension name, with DuckDB’s options supported, without affecting Postgres.

**Review notes**
- Adds InstallStatementSegment to DuckDB StatementSegment: supports INSTALL <extension>, FORCE INSTALL, and optional FROM <repository> where repository is an alias (e.g., community) or a quoted URL.
- Overrides DuckDB LoadStatementSegment to accept an extension name or a quoted literal. Postgres LOAD behavior remains unchanged.
- Adds INSTALL to DuckDB unreserved keywords.
- New fixtures cover six forms; dialect and linter tests pass.

<sup>Written for commit f3ca9e4bf34ba07fbf145066b2b880558635ca37. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8358?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

