### PR TITLE
Snowflake: DCM DEFINE gaps (DEFINE PIPE, DEFINE FILE FORMAT, external stages in DEFINE STAGE)

### DIFF
--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -265,6 +265,90 @@ snowflake_dialect.add(
             optional=True,
         ),
     ),
+    # Per-cloud external stage parameter blocks (cloud parameters plus the
+    # matching directory-table options), shared by CREATE STAGE and
+    # DEFINE STAGE so the two grammars cannot drift.
+    S3ExternalStageOptionsGrammar=Sequence(
+        Ref("S3ExternalStageParameters", optional=True),
+        Sequence(
+            "DIRECTORY",
+            Ref("EqualsSegment"),
+            Bracketed(
+                Sequence(
+                    "ENABLE",
+                    Ref("EqualsSegment"),
+                    Ref("BooleanLiteralGrammar"),
+                ),
+                Sequence(
+                    "AUTO_REFRESH",
+                    Ref("EqualsSegment"),
+                    Ref("BooleanLiteralGrammar"),
+                    optional=True,
+                ),
+            ),
+            optional=True,
+        ),
+    ),
+    GCSExternalStageOptionsGrammar=Sequence(
+        Ref("GCSExternalStageParameters", optional=True),
+        Sequence(
+            "DIRECTORY",
+            Ref("EqualsSegment"),
+            Bracketed(
+                Sequence(
+                    "ENABLE",
+                    Ref("EqualsSegment"),
+                    Ref("BooleanLiteralGrammar"),
+                ),
+                Sequence(
+                    "AUTO_REFRESH",
+                    Ref("EqualsSegment"),
+                    Ref("BooleanLiteralGrammar"),
+                    optional=True,
+                ),
+                Sequence(
+                    "NOTIFICATION_INTEGRATION",
+                    Ref("EqualsSegment"),
+                    OneOf(
+                        Ref("NakedIdentifierSegment"),
+                        Ref("QuotedLiteralSegment"),
+                    ),
+                    optional=True,
+                ),
+            ),
+            optional=True,
+        ),
+    ),
+    AzureBlobStorageExternalStageOptionsGrammar=Sequence(
+        Ref("AzureBlobStorageExternalStageParameters", optional=True),
+        Sequence(
+            "DIRECTORY",
+            Ref("EqualsSegment"),
+            Bracketed(
+                Sequence(
+                    "ENABLE",
+                    Ref("EqualsSegment"),
+                    Ref("BooleanLiteralGrammar"),
+                ),
+                Sequence(
+                    "AUTO_REFRESH",
+                    Ref("EqualsSegment"),
+                    Ref("BooleanLiteralGrammar"),
+                    optional=True,
+                ),
+                Sequence(
+                    "NOTIFICATION_INTEGRATION",
+                    Ref("EqualsSegment"),
+                    OneOf(
+                        Ref("NakedIdentifierSegment"),
+                        Ref("QuotedLiteralSegment"),
+                    ),
+                    optional=True,
+                ),
+            ),
+            optional=True,
+        ),
+    ),
     # In snowflake, these are case sensitive even though they're not quoted
     # so they need a different `name` and `type` so they're not picked up
     # by other rules.
@@ -8329,182 +8413,22 @@ class CreateStageSegment(BaseSegment):
                     ),
                     OneOf(
                         # External S3 stage
-                        Sequence(
-                            Ref("S3ExternalStageParameters", optional=True),
-                            Sequence(
-                                "DIRECTORY",
-                                Ref("EqualsSegment"),
-                                Bracketed(
-                                    Sequence(
-                                        "ENABLE",
-                                        Ref("EqualsSegment"),
-                                        Ref("BooleanLiteralGrammar"),
-                                    ),
-                                    Sequence(
-                                        "AUTO_REFRESH",
-                                        Ref("EqualsSegment"),
-                                        Ref("BooleanLiteralGrammar"),
-                                        optional=True,
-                                    ),
-                                ),
-                                optional=True,
-                            ),
-                        ),
+                        Ref("S3ExternalStageOptionsGrammar"),
                         # External GCS stage
-                        Sequence(
-                            Ref("GCSExternalStageParameters", optional=True),
-                            Sequence(
-                                "DIRECTORY",
-                                Ref("EqualsSegment"),
-                                Bracketed(
-                                    Sequence(
-                                        "ENABLE",
-                                        Ref("EqualsSegment"),
-                                        Ref("BooleanLiteralGrammar"),
-                                    ),
-                                    Sequence(
-                                        "AUTO_REFRESH",
-                                        Ref("EqualsSegment"),
-                                        Ref("BooleanLiteralGrammar"),
-                                        optional=True,
-                                    ),
-                                    Sequence(
-                                        "NOTIFICATION_INTEGRATION",
-                                        Ref("EqualsSegment"),
-                                        OneOf(
-                                            Ref("NakedIdentifierSegment"),
-                                            Ref("QuotedLiteralSegment"),
-                                        ),
-                                        optional=True,
-                                    ),
-                                ),
-                                optional=True,
-                            ),
-                        ),
+                        Ref("GCSExternalStageOptionsGrammar"),
                         # External Azure Blob Storage stage
-                        Sequence(
-                            Ref(
-                                "AzureBlobStorageExternalStageParameters", optional=True
-                            ),
-                            Sequence(
-                                "DIRECTORY",
-                                Ref("EqualsSegment"),
-                                Bracketed(
-                                    Sequence(
-                                        "ENABLE",
-                                        Ref("EqualsSegment"),
-                                        Ref("BooleanLiteralGrammar"),
-                                    ),
-                                    Sequence(
-                                        "AUTO_REFRESH",
-                                        Ref("EqualsSegment"),
-                                        Ref("BooleanLiteralGrammar"),
-                                        optional=True,
-                                    ),
-                                    Sequence(
-                                        "NOTIFICATION_INTEGRATION",
-                                        Ref("EqualsSegment"),
-                                        OneOf(
-                                            Ref("NakedIdentifierSegment"),
-                                            Ref("QuotedLiteralSegment"),
-                                        ),
-                                        optional=True,
-                                    ),
-                                ),
-                                optional=True,
-                            ),
-                        ),
+                        Ref("AzureBlobStorageExternalStageOptionsGrammar"),
                         optional=True,
                     ),
                 ),
                 Sequence(
                     OneOf(
                         # External S3 stage
-                        Sequence(
-                            Ref("S3ExternalStageParameters", optional=True),
-                            Sequence(
-                                "DIRECTORY",
-                                Ref("EqualsSegment"),
-                                Bracketed(
-                                    Sequence(
-                                        "ENABLE",
-                                        Ref("EqualsSegment"),
-                                        Ref("BooleanLiteralGrammar"),
-                                    ),
-                                    Sequence(
-                                        "AUTO_REFRESH",
-                                        Ref("EqualsSegment"),
-                                        Ref("BooleanLiteralGrammar"),
-                                        optional=True,
-                                    ),
-                                ),
-                                optional=True,
-                            ),
-                        ),
+                        Ref("S3ExternalStageOptionsGrammar"),
                         # External GCS stage
-                        Sequence(
-                            Ref("GCSExternalStageParameters", optional=True),
-                            Sequence(
-                                "DIRECTORY",
-                                Ref("EqualsSegment"),
-                                Bracketed(
-                                    Sequence(
-                                        "ENABLE",
-                                        Ref("EqualsSegment"),
-                                        Ref("BooleanLiteralGrammar"),
-                                    ),
-                                    Sequence(
-                                        "AUTO_REFRESH",
-                                        Ref("EqualsSegment"),
-                                        Ref("BooleanLiteralGrammar"),
-                                        optional=True,
-                                    ),
-                                    Sequence(
-                                        "NOTIFICATION_INTEGRATION",
-                                        Ref("EqualsSegment"),
-                                        OneOf(
-                                            Ref("NakedIdentifierSegment"),
-                                            Ref("QuotedLiteralSegment"),
-                                        ),
-                                        optional=True,
-                                    ),
-                                ),
-                                optional=True,
-                            ),
-                        ),
+                        Ref("GCSExternalStageOptionsGrammar"),
                         # External Azure Blob Storage stage
-                        Sequence(
-                            Ref(
-                                "AzureBlobStorageExternalStageParameters", optional=True
-                            ),
-                            Sequence(
-                                "DIRECTORY",
-                                Ref("EqualsSegment"),
-                                Bracketed(
-                                    Sequence(
-                                        "ENABLE",
-                                        Ref("EqualsSegment"),
-                                        Ref("BooleanLiteralGrammar"),
-                                    ),
-                                    Sequence(
-                                        "AUTO_REFRESH",
-                                        Ref("EqualsSegment"),
-                                        Ref("BooleanLiteralGrammar"),
-                                        optional=True,
-                                    ),
-                                    Sequence(
-                                        "NOTIFICATION_INTEGRATION",
-                                        Ref("EqualsSegment"),
-                                        OneOf(
-                                            Ref("NakedIdentifierSegment"),
-                                            Ref("QuotedLiteralSegment"),
-                                        ),
-                                        optional=True,
-                                    ),
-                                ),
-                                optional=True,
-                            ),
-                        ),
+                        Ref("AzureBlobStorageExternalStageOptionsGrammar"),
                         optional=True,
                     ),
                     "URL",
@@ -8575,91 +8499,31 @@ class DefineStageSegment(BaseSegment):
                     # External S3 stage
                     Sequence(
                         Ref("S3Path"),
-                        Ref("S3ExternalStageParameters", optional=True),
-                        Sequence(
-                            "DIRECTORY",
-                            Ref("EqualsSegment"),
-                            Bracketed(
-                                Sequence(
-                                    "ENABLE",
-                                    Ref("EqualsSegment"),
-                                    Ref("BooleanLiteralGrammar"),
-                                ),
-                                Sequence(
-                                    "AUTO_REFRESH",
-                                    Ref("EqualsSegment"),
-                                    Ref("BooleanLiteralGrammar"),
-                                    optional=True,
-                                ),
-                            ),
-                            optional=True,
-                        ),
+                        Ref("S3ExternalStageOptionsGrammar", optional=True),
                     ),
                     # External GCS stage
                     Sequence(
                         Ref("GCSPath"),
-                        Ref("GCSExternalStageParameters", optional=True),
-                        Sequence(
-                            "DIRECTORY",
-                            Ref("EqualsSegment"),
-                            Bracketed(
-                                Sequence(
-                                    "ENABLE",
-                                    Ref("EqualsSegment"),
-                                    Ref("BooleanLiteralGrammar"),
-                                ),
-                                Sequence(
-                                    "AUTO_REFRESH",
-                                    Ref("EqualsSegment"),
-                                    Ref("BooleanLiteralGrammar"),
-                                    optional=True,
-                                ),
-                                Sequence(
-                                    "NOTIFICATION_INTEGRATION",
-                                    Ref("EqualsSegment"),
-                                    OneOf(
-                                        Ref("NakedIdentifierSegment"),
-                                        Ref("QuotedLiteralSegment"),
-                                    ),
-                                    optional=True,
-                                ),
-                            ),
-                            optional=True,
-                        ),
+                        Ref("GCSExternalStageOptionsGrammar", optional=True),
                     ),
                     # External Azure Blob Storage stage
                     Sequence(
                         Ref("AzureBlobStoragePath"),
-                        Ref("AzureBlobStorageExternalStageParameters", optional=True),
-                        Sequence(
-                            "DIRECTORY",
-                            Ref("EqualsSegment"),
-                            Bracketed(
-                                Sequence(
-                                    "ENABLE",
-                                    Ref("EqualsSegment"),
-                                    Ref("BooleanLiteralGrammar"),
-                                ),
-                                Sequence(
-                                    "AUTO_REFRESH",
-                                    Ref("EqualsSegment"),
-                                    Ref("BooleanLiteralGrammar"),
-                                    optional=True,
-                                ),
-                                Sequence(
-                                    "NOTIFICATION_INTEGRATION",
-                                    Ref("EqualsSegment"),
-                                    OneOf(
-                                        Ref("NakedIdentifierSegment"),
-                                        Ref("QuotedLiteralSegment"),
-                                    ),
-                                    optional=True,
-                                ),
-                            ),
+                        Ref(
+                            "AzureBlobStorageExternalStageOptionsGrammar", optional=True
+                        ),
+                    ),
+                    # Variable URLs: the cloud is unknown, so accept any
+                    # cloud's parameter set
+                    Sequence(
+                        Ref("ReferencedVariableNameSegment"),
+                        OneOf(
+                            Ref("S3ExternalStageOptionsGrammar"),
+                            Ref("GCSExternalStageOptionsGrammar"),
+                            Ref("AzureBlobStorageExternalStageOptionsGrammar"),
                             optional=True,
                         ),
                     ),
-                    Ref("ReferencedVariableNameSegment"),
                 ),
             ),
             optional=True,

--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -234,6 +234,37 @@ snowflake_dialect.sets("initialize_types").update(
 )
 
 snowflake_dialect.add(
+    # Pipe properties shared by CREATE PIPE and DEFINE PIPE
+    # https://docs.snowflake.com/en/sql-reference/sql/create-pipe
+    PipePropertiesGrammar=Sequence(
+        Sequence(
+            "AUTO_INGEST",
+            Ref("EqualsSegment"),
+            Ref("BooleanLiteralGrammar"),
+            optional=True,
+        ),
+        Sequence(
+            "ERROR_INTEGRATION",
+            Ref("EqualsSegment"),
+            Ref("ObjectReferenceSegment"),
+            optional=True,
+        ),
+        Sequence(
+            "AWS_SNS_TOPIC",
+            Ref("EqualsSegment"),
+            Ref("QuotedLiteralSegment"),
+            optional=True,
+        ),
+        Sequence(
+            "INTEGRATION",
+            Ref("EqualsSegment"),
+            OneOf(
+                Ref("QuotedLiteralSegment"),
+                Ref("ObjectReferenceSegment"),
+            ),
+            optional=True,
+        ),
+    ),
     # In snowflake, these are case sensitive even though they're not quoted
     # so they need a different `name` and `type` so they're not picked up
     # by other rules.
@@ -6514,36 +6545,7 @@ class CreateStatementSegment(BaseSegment):
         ),
         # Next set are Pipe statements
         # https://docs.snowflake.com/en/sql-reference/sql/create-pipe.html
-        Sequence(
-            Sequence(
-                "AUTO_INGEST",
-                Ref("EqualsSegment"),
-                Ref("BooleanLiteralGrammar"),
-                optional=True,
-            ),
-            Sequence(
-                "ERROR_INTEGRATION",
-                Ref("EqualsSegment"),
-                Ref("ObjectReferenceSegment"),
-                optional=True,
-            ),
-            Sequence(
-                "AWS_SNS_TOPIC",
-                Ref("EqualsSegment"),
-                Ref("QuotedLiteralSegment"),
-                optional=True,
-            ),
-            Sequence(
-                "INTEGRATION",
-                Ref("EqualsSegment"),
-                OneOf(
-                    Ref("QuotedLiteralSegment"),
-                    Ref("ObjectReferenceSegment"),
-                ),
-                optional=True,
-            ),
-            optional=True,
-        ),
+        Ref("PipePropertiesGrammar", optional=True),
         # Next are WAREHOUSE options
         # https://docs.snowflake.com/en/sql-reference/sql/create-warehouse.html
         Sequence(
@@ -7568,33 +7570,7 @@ class DefinePipeSegment(BaseSegment):
         "PIPE",
         Ref("ObjectReferenceSegment"),
         Indent,
-        Sequence(
-            "AUTO_INGEST",
-            Ref("EqualsSegment"),
-            Ref("BooleanLiteralGrammar"),
-            optional=True,
-        ),
-        Sequence(
-            "ERROR_INTEGRATION",
-            Ref("EqualsSegment"),
-            Ref("ObjectReferenceSegment"),
-            optional=True,
-        ),
-        Sequence(
-            "AWS_SNS_TOPIC",
-            Ref("EqualsSegment"),
-            Ref("QuotedLiteralSegment"),
-            optional=True,
-        ),
-        Sequence(
-            "INTEGRATION",
-            Ref("EqualsSegment"),
-            OneOf(
-                Ref("QuotedLiteralSegment"),
-                Ref("ObjectReferenceSegment"),
-            ),
-            optional=True,
-        ),
+        Ref("PipePropertiesGrammar", optional=True),
         Ref("CommentEqualsClauseSegment", optional=True),
         "AS",
         Ref("CopyIntoTableStatementSegment"),
@@ -8590,48 +8566,100 @@ class DefineStageSegment(BaseSegment):
                 ),
                 optional=True,
             ),
-            # External stages
+            # External stages, with each cloud's parameters bound to its
+            # URL scheme (mirroring CreateStageSegment)
             Sequence(
                 "URL",
                 Ref("EqualsSegment"),
                 OneOf(
-                    Ref("S3Path"),
-                    Ref("GCSPath"),
-                    Ref("AzureBlobStoragePath"),
-                    Ref("ReferencedVariableNameSegment"),
-                ),
-                OneOf(
-                    Ref("S3ExternalStageParameters"),
-                    Ref("GCSExternalStageParameters"),
-                    Ref("AzureBlobStorageExternalStageParameters"),
-                    optional=True,
-                ),
-                Sequence(
-                    "DIRECTORY",
-                    Ref("EqualsSegment"),
-                    Bracketed(
+                    # External S3 stage
+                    Sequence(
+                        Ref("S3Path"),
+                        Ref("S3ExternalStageParameters", optional=True),
                         Sequence(
-                            "ENABLE",
+                            "DIRECTORY",
                             Ref("EqualsSegment"),
-                            Ref("BooleanLiteralGrammar"),
-                        ),
-                        Sequence(
-                            "AUTO_REFRESH",
-                            Ref("EqualsSegment"),
-                            Ref("BooleanLiteralGrammar"),
-                            optional=True,
-                        ),
-                        Sequence(
-                            "NOTIFICATION_INTEGRATION",
-                            Ref("EqualsSegment"),
-                            OneOf(
-                                Ref("NakedIdentifierSegment"),
-                                Ref("QuotedLiteralSegment"),
+                            Bracketed(
+                                Sequence(
+                                    "ENABLE",
+                                    Ref("EqualsSegment"),
+                                    Ref("BooleanLiteralGrammar"),
+                                ),
+                                Sequence(
+                                    "AUTO_REFRESH",
+                                    Ref("EqualsSegment"),
+                                    Ref("BooleanLiteralGrammar"),
+                                    optional=True,
+                                ),
                             ),
                             optional=True,
                         ),
                     ),
-                    optional=True,
+                    # External GCS stage
+                    Sequence(
+                        Ref("GCSPath"),
+                        Ref("GCSExternalStageParameters", optional=True),
+                        Sequence(
+                            "DIRECTORY",
+                            Ref("EqualsSegment"),
+                            Bracketed(
+                                Sequence(
+                                    "ENABLE",
+                                    Ref("EqualsSegment"),
+                                    Ref("BooleanLiteralGrammar"),
+                                ),
+                                Sequence(
+                                    "AUTO_REFRESH",
+                                    Ref("EqualsSegment"),
+                                    Ref("BooleanLiteralGrammar"),
+                                    optional=True,
+                                ),
+                                Sequence(
+                                    "NOTIFICATION_INTEGRATION",
+                                    Ref("EqualsSegment"),
+                                    OneOf(
+                                        Ref("NakedIdentifierSegment"),
+                                        Ref("QuotedLiteralSegment"),
+                                    ),
+                                    optional=True,
+                                ),
+                            ),
+                            optional=True,
+                        ),
+                    ),
+                    # External Azure Blob Storage stage
+                    Sequence(
+                        Ref("AzureBlobStoragePath"),
+                        Ref("AzureBlobStorageExternalStageParameters", optional=True),
+                        Sequence(
+                            "DIRECTORY",
+                            Ref("EqualsSegment"),
+                            Bracketed(
+                                Sequence(
+                                    "ENABLE",
+                                    Ref("EqualsSegment"),
+                                    Ref("BooleanLiteralGrammar"),
+                                ),
+                                Sequence(
+                                    "AUTO_REFRESH",
+                                    Ref("EqualsSegment"),
+                                    Ref("BooleanLiteralGrammar"),
+                                    optional=True,
+                                ),
+                                Sequence(
+                                    "NOTIFICATION_INTEGRATION",
+                                    Ref("EqualsSegment"),
+                                    OneOf(
+                                        Ref("NakedIdentifierSegment"),
+                                        Ref("QuotedLiteralSegment"),
+                                    ),
+                                    optional=True,
+                                ),
+                            ),
+                            optional=True,
+                        ),
+                    ),
+                    Ref("ReferencedVariableNameSegment"),
                 ),
             ),
             optional=True,

--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -1852,6 +1852,7 @@ class StatementSegment(ansi.StatementSegment):
             Ref("CreateExternalFunctionStatementSegment"),
             Ref("CreateStageSegment"),
             Ref("DefineStageSegment"),
+            Ref("DefinePipeSegment"),
             Ref("AlterStageSegment"),
             Ref("CreateStreamStatementSegment"),
             Ref("CreateStreamlitStatementSegment"),
@@ -7165,10 +7166,17 @@ class CreateFileFormatSegment(BaseSegment):
 
     type = "create_file_format_segment"
     match_grammar = Sequence(
-        "CREATE",
-        Ref("AlterOrReplaceGrammar", optional=True),
-        Sequence("FILE", "FORMAT"),
-        Ref("IfNotExistsGrammar", optional=True),
+        OneOf(
+            Sequence(
+                "CREATE",
+                Ref("AlterOrReplaceGrammar", optional=True),
+                Sequence("FILE", "FORMAT"),
+                Ref("IfNotExistsGrammar", optional=True),
+            ),
+            # DCM projects support DEFINE FILE FORMAT:
+            # https://docs.snowflake.com/en/user-guide/dcm-projects/dcm-projects-supported-entities
+            Sequence("DEFINE", "FILE", "FORMAT"),
+        ),
         Ref("ObjectReferenceSegment"),
         # TYPE = <FILE_FORMAT> is included in below parameter segments.
         # It is valid syntax to have TYPE = <FILE_FORMAT> after other parameters.
@@ -7542,6 +7550,55 @@ class XmlFileFormatTypeParameters(BaseSegment):
             Ref("EqualsSegment"),
             Ref("BooleanLiteralGrammar"),
         ),
+    )
+
+
+class DefinePipeSegment(BaseSegment):
+    """A Snowflake DEFINE PIPE statement (specific to DCM projects).
+
+    All pipe properties supported by CREATE PIPE are available in DEFINE PIPE:
+    https://docs.snowflake.com/en/user-guide/dcm-projects/dcm-projects-supported-entities
+    https://docs.snowflake.com/en/sql-reference/sql/create-pipe
+    """
+
+    type = "define_pipe_statement"
+
+    match_grammar = Sequence(
+        "DEFINE",
+        "PIPE",
+        Ref("ObjectReferenceSegment"),
+        Indent,
+        Sequence(
+            "AUTO_INGEST",
+            Ref("EqualsSegment"),
+            Ref("BooleanLiteralGrammar"),
+            optional=True,
+        ),
+        Sequence(
+            "ERROR_INTEGRATION",
+            Ref("EqualsSegment"),
+            Ref("ObjectReferenceSegment"),
+            optional=True,
+        ),
+        Sequence(
+            "AWS_SNS_TOPIC",
+            Ref("EqualsSegment"),
+            Ref("QuotedLiteralSegment"),
+            optional=True,
+        ),
+        Sequence(
+            "INTEGRATION",
+            Ref("EqualsSegment"),
+            OneOf(
+                Ref("QuotedLiteralSegment"),
+                Ref("ObjectReferenceSegment"),
+            ),
+            optional=True,
+        ),
+        Ref("CommentEqualsClauseSegment", optional=True),
+        "AS",
+        Ref("CopyIntoTableStatementSegment"),
+        Dedent,
     )
 
 
@@ -8502,7 +8559,11 @@ class CreateStageSegment(BaseSegment):
 
 
 class DefineStageSegment(BaseSegment):
-    """A Snowflake DEFINE STAGE statement (specific to DCM projects)."""
+    """A Snowflake DEFINE STAGE statement (specific to DCM projects).
+
+    DCM projects support both internal and external stages:
+    https://docs.snowflake.com/en/user-guide/dcm-projects/dcm-projects-supported-entities
+    """
 
     type = "define_stage_statement"
 
@@ -8511,25 +8572,78 @@ class DefineStageSegment(BaseSegment):
         "STAGE",
         Ref("ObjectReferenceSegment"),
         Indent,
-        # Only internal stages supported in DCM projects currently
-        Sequence(
-            Ref("InternalStageParameters", optional=True),
+        OneOf(
+            # Internal stages
             Sequence(
-                "DIRECTORY",
-                Ref("EqualsSegment"),
-                Bracketed(
-                    Sequence(
-                        "ENABLE",
-                        Ref("EqualsSegment"),
-                        Ref("BooleanLiteralGrammar"),
-                    )
+                Ref("InternalStageParameters", optional=True),
+                Sequence(
+                    "DIRECTORY",
+                    Ref("EqualsSegment"),
+                    Bracketed(
+                        Sequence(
+                            "ENABLE",
+                            Ref("EqualsSegment"),
+                            Ref("BooleanLiteralGrammar"),
+                        )
+                    ),
+                    optional=True,
                 ),
                 optional=True,
+            ),
+            # External stages
+            Sequence(
+                "URL",
+                Ref("EqualsSegment"),
+                OneOf(
+                    Ref("S3Path"),
+                    Ref("GCSPath"),
+                    Ref("AzureBlobStoragePath"),
+                    Ref("ReferencedVariableNameSegment"),
+                ),
+                OneOf(
+                    Ref("S3ExternalStageParameters"),
+                    Ref("GCSExternalStageParameters"),
+                    Ref("AzureBlobStorageExternalStageParameters"),
+                    optional=True,
+                ),
+                Sequence(
+                    "DIRECTORY",
+                    Ref("EqualsSegment"),
+                    Bracketed(
+                        Sequence(
+                            "ENABLE",
+                            Ref("EqualsSegment"),
+                            Ref("BooleanLiteralGrammar"),
+                        ),
+                        Sequence(
+                            "AUTO_REFRESH",
+                            Ref("EqualsSegment"),
+                            Ref("BooleanLiteralGrammar"),
+                            optional=True,
+                        ),
+                        Sequence(
+                            "NOTIFICATION_INTEGRATION",
+                            Ref("EqualsSegment"),
+                            OneOf(
+                                Ref("NakedIdentifierSegment"),
+                                Ref("QuotedLiteralSegment"),
+                            ),
+                            optional=True,
+                        ),
+                    ),
+                    optional=True,
+                ),
             ),
             optional=True,
         ),
         Sequence(
             "FILE_FORMAT", Ref("EqualsSegment"), Ref("FileFormatSegment"), optional=True
+        ),
+        Sequence(
+            "COPY_OPTIONS",
+            Ref("EqualsSegment"),
+            Bracketed(Ref("CopyOptionsSegment")),
+            optional=True,
         ),
         Ref("TagBracketedEqualsSegment", optional=True),
         Ref("CommentEqualsClauseSegment", optional=True),

--- a/test/fixtures/dialects/snowflake/define_file_format.sql
+++ b/test/fixtures/dialects/snowflake/define_file_format.sql
@@ -1,0 +1,9 @@
+DEFINE FILE FORMAT my_db.my_schema.my_json_format
+  TYPE = 'JSON'
+  COMPRESSION = NONE
+  COMMENT = 'uncompressed JSON file format for raw ingestion';
+
+DEFINE FILE FORMAT my_db.my_schema.my_csv_format
+  TYPE = 'CSV'
+  FIELD_DELIMITER = ','
+  SKIP_HEADER = 1;

--- a/test/fixtures/dialects/snowflake/define_file_format.yml
+++ b/test/fixtures/dialects/snowflake/define_file_format.yml
@@ -1,0 +1,58 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 731681e9a5c475e3af98e7d19e321dfc021153c90c45e11fff77745b848fae2d
+file:
+- statement:
+    create_file_format_segment:
+    - keyword: DEFINE
+    - keyword: FILE
+    - keyword: FORMAT
+    - object_reference:
+      - naked_identifier: my_db
+      - dot: .
+      - naked_identifier: my_schema
+      - dot: .
+      - naked_identifier: my_json_format
+    - json_file_format_type_parameters:
+      - keyword: TYPE
+      - comparison_operator:
+          raw_comparison_operator: '='
+      - file_type: "'JSON'"
+      - keyword: COMPRESSION
+      - comparison_operator:
+          raw_comparison_operator: '='
+      - compression_type: NONE
+    - comment_equals_clause:
+        keyword: COMMENT
+        comparison_operator:
+          raw_comparison_operator: '='
+        quoted_literal: "'uncompressed JSON file format for raw ingestion'"
+- statement_terminator: ;
+- statement:
+    create_file_format_segment:
+    - keyword: DEFINE
+    - keyword: FILE
+    - keyword: FORMAT
+    - object_reference:
+      - naked_identifier: my_db
+      - dot: .
+      - naked_identifier: my_schema
+      - dot: .
+      - naked_identifier: my_csv_format
+    - csv_file_format_type_parameters:
+      - keyword: TYPE
+      - comparison_operator:
+          raw_comparison_operator: '='
+      - file_type: "'CSV'"
+      - keyword: FIELD_DELIMITER
+      - comparison_operator:
+          raw_comparison_operator: '='
+      - quoted_literal: "','"
+      - keyword: SKIP_HEADER
+      - comparison_operator:
+          raw_comparison_operator: '='
+      - integer_literal: '1'
+- statement_terminator: ;

--- a/test/fixtures/dialects/snowflake/define_pipe.sql
+++ b/test/fixtures/dialects/snowflake/define_pipe.sql
@@ -1,0 +1,35 @@
+DEFINE PIPE my_db.my_schema.my_pipe
+AS
+  COPY INTO my_db.my_schema.my_table
+  FROM @my_db.my_schema.my_stage;
+
+DEFINE PIPE my_db.my_schema.gcs_auto_ingest_pipe
+  AUTO_INGEST = TRUE
+  INTEGRATION = 'MY_NOTIFICATION_INT'
+  COMMENT = 'auto-ingest pipe for event files'
+AS
+  COPY INTO my_db.my_schema.event_histories (
+    payload,
+    _file_name,
+    _file_row,
+    _loaded_at
+  )
+  FROM (
+    SELECT
+      $1,
+      metadata$filename,
+      metadata$file_row_number,
+      CURRENT_TIMESTAMP
+    FROM @my_db.my_schema.my_stage/events/histories
+  )
+  FILE_FORMAT = (FORMAT_NAME = 'my_db.my_schema.my_json_format')
+  PATTERN = '.*\.json$';
+
+DEFINE PIPE my_db.my_schema.s3_pipe
+  AUTO_INGEST = TRUE
+  ERROR_INTEGRATION = my_error_int
+  AWS_SNS_TOPIC = 'arn:aws:sns:us-west-2:001234567890:s3_mybucket'
+AS
+  COPY INTO my_db.my_schema.my_table
+  FROM @my_db.my_schema.my_s3_stage
+  FILE_FORMAT = (TYPE = 'JSON');

--- a/test/fixtures/dialects/snowflake/define_pipe.yml
+++ b/test/fixtures/dialects/snowflake/define_pipe.yml
@@ -1,0 +1,171 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 03d982defd754435160c9874a54a00191c772e6b21146694bdf80bf411f0815d
+file:
+- statement:
+    define_pipe_statement:
+    - keyword: DEFINE
+    - keyword: PIPE
+    - object_reference:
+      - naked_identifier: my_db
+      - dot: .
+      - naked_identifier: my_schema
+      - dot: .
+      - naked_identifier: my_pipe
+    - keyword: AS
+    - copy_into_table_statement:
+      - keyword: COPY
+      - keyword: INTO
+      - table_reference:
+        - naked_identifier: my_db
+        - dot: .
+        - naked_identifier: my_schema
+        - dot: .
+        - naked_identifier: my_table
+      - keyword: FROM
+      - storage_location:
+          stage_path: '@my_db.my_schema.my_stage'
+- statement_terminator: ;
+- statement:
+    define_pipe_statement:
+    - keyword: DEFINE
+    - keyword: PIPE
+    - object_reference:
+      - naked_identifier: my_db
+      - dot: .
+      - naked_identifier: my_schema
+      - dot: .
+      - naked_identifier: gcs_auto_ingest_pipe
+    - keyword: AUTO_INGEST
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - boolean_literal: 'TRUE'
+    - keyword: INTEGRATION
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - quoted_literal: "'MY_NOTIFICATION_INT'"
+    - comment_equals_clause:
+        keyword: COMMENT
+        comparison_operator:
+          raw_comparison_operator: '='
+        quoted_literal: "'auto-ingest pipe for event files'"
+    - keyword: AS
+    - copy_into_table_statement:
+      - keyword: COPY
+      - keyword: INTO
+      - table_reference:
+        - naked_identifier: my_db
+        - dot: .
+        - naked_identifier: my_schema
+        - dot: .
+        - naked_identifier: event_histories
+      - bracketed:
+        - start_bracket: (
+        - column_reference:
+            naked_identifier: payload
+        - comma: ','
+        - column_reference:
+            naked_identifier: _file_name
+        - comma: ','
+        - column_reference:
+            naked_identifier: _file_row
+        - comma: ','
+        - column_reference:
+            naked_identifier: _loaded_at
+        - end_bracket: )
+      - keyword: FROM
+      - bracketed:
+          start_bracket: (
+          select_statement:
+            select_clause:
+            - keyword: SELECT
+            - select_clause_element:
+                column_reference:
+                  column_index_identifier_segment: $1
+            - comma: ','
+            - select_clause_element:
+                column_reference:
+                  naked_identifier: metadata$filename
+            - comma: ','
+            - select_clause_element:
+                column_reference:
+                  naked_identifier: metadata$file_row_number
+            - comma: ','
+            - select_clause_element:
+                bare_function: CURRENT_TIMESTAMP
+            from_clause:
+              keyword: FROM
+              from_expression:
+                from_expression_element:
+                  table_expression:
+                    table_reference:
+                      stage_path: '@my_db.my_schema.my_stage/events/histories'
+          end_bracket: )
+      - keyword: FILE_FORMAT
+      - comparison_operator:
+          raw_comparison_operator: '='
+      - file_format_segment:
+          bracketed:
+            start_bracket: (
+            keyword: FORMAT_NAME
+            comparison_operator:
+              raw_comparison_operator: '='
+            quoted_literal: "'my_db.my_schema.my_json_format'"
+            end_bracket: )
+      - keyword: PATTERN
+      - comparison_operator:
+          raw_comparison_operator: '='
+      - quoted_literal: "'.*\\.json$'"
+- statement_terminator: ;
+- statement:
+    define_pipe_statement:
+    - keyword: DEFINE
+    - keyword: PIPE
+    - object_reference:
+      - naked_identifier: my_db
+      - dot: .
+      - naked_identifier: my_schema
+      - dot: .
+      - naked_identifier: s3_pipe
+    - keyword: AUTO_INGEST
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - boolean_literal: 'TRUE'
+    - keyword: ERROR_INTEGRATION
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - object_reference:
+        naked_identifier: my_error_int
+    - keyword: AWS_SNS_TOPIC
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - quoted_literal: "'arn:aws:sns:us-west-2:001234567890:s3_mybucket'"
+    - keyword: AS
+    - copy_into_table_statement:
+      - keyword: COPY
+      - keyword: INTO
+      - table_reference:
+        - naked_identifier: my_db
+        - dot: .
+        - naked_identifier: my_schema
+        - dot: .
+        - naked_identifier: my_table
+      - keyword: FROM
+      - storage_location:
+          stage_path: '@my_db.my_schema.my_s3_stage'
+      - keyword: FILE_FORMAT
+      - comparison_operator:
+          raw_comparison_operator: '='
+      - file_format_segment:
+          bracketed:
+            start_bracket: (
+            json_file_format_type_parameters:
+              keyword: TYPE
+              comparison_operator:
+                raw_comparison_operator: '='
+              file_type: "'JSON'"
+            end_bracket: )
+- statement_terminator: ;

--- a/test/fixtures/dialects/snowflake/define_stage.sql
+++ b/test/fixtures/dialects/snowflake/define_stage.sql
@@ -1,2 +1,18 @@
 DEFINE STAGE FINANCE_DB.RAW.TASTY_BYTES_ORDERS
   COMMENT='Internal stage for uploading files';
+
+DEFINE STAGE my_db.my_schema.gcs_events_stage
+  URL = 'gcs://my-bucket/'
+  STORAGE_INTEGRATION = my_gcs_int
+  FILE_FORMAT = (FORMAT_NAME = 'my_db.my_schema.my_json_format')
+  COMMENT = 'events GCS stage';
+
+DEFINE STAGE my_db.my_schema.s3_stage
+  URL = 's3://my-bucket/files/'
+  STORAGE_INTEGRATION = my_s3_int
+  DIRECTORY = (ENABLE = TRUE AUTO_REFRESH = TRUE);
+
+DEFINE STAGE my_db.my_schema.azure_stage
+  URL = 'azure://myaccount.blob.core.windows.net/mycontainer/files/'
+  STORAGE_INTEGRATION = my_azure_int
+  DIRECTORY = (ENABLE = TRUE NOTIFICATION_INTEGRATION = my_notification_int);

--- a/test/fixtures/dialects/snowflake/define_stage.sql
+++ b/test/fixtures/dialects/snowflake/define_stage.sql
@@ -16,3 +16,9 @@ DEFINE STAGE my_db.my_schema.azure_stage
   URL = 'azure://myaccount.blob.core.windows.net/mycontainer/files/'
   STORAGE_INTEGRATION = my_azure_int
   DIRECTORY = (ENABLE = TRUE NOTIFICATION_INTEGRATION = my_notification_int);
+
+DEFINE STAGE my_db.my_schema.var_url_stage
+  URL = $STAGE_URL
+  STORAGE_INTEGRATION = my_gcs_int
+  DIRECTORY = (ENABLE = TRUE)
+  COMMENT = 'external stage with variable URL';

--- a/test/fixtures/dialects/snowflake/define_stage.yml
+++ b/test/fixtures/dialects/snowflake/define_stage.yml
@@ -3,9 +3,9 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: a379e475429cc7ec7ecfecadaba273749335488e5e24dfd9eff083187c19026e
+_hash: 87b540612757694e84072145b693ed4bc2e4f6a465f65c513d79c726ebeedd2c
 file:
-  statement:
+- statement:
     define_stage_statement:
     - keyword: DEFINE
     - keyword: STAGE
@@ -20,4 +20,111 @@ file:
         comparison_operator:
           raw_comparison_operator: '='
         quoted_literal: "'Internal stage for uploading files'"
-  statement_terminator: ;
+- statement_terminator: ;
+- statement:
+    define_stage_statement:
+    - keyword: DEFINE
+    - keyword: STAGE
+    - object_reference:
+      - naked_identifier: my_db
+      - dot: .
+      - naked_identifier: my_schema
+      - dot: .
+      - naked_identifier: gcs_events_stage
+    - keyword: URL
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - bucket_path: "'gcs://my-bucket/'"
+    - stage_parameters:
+        keyword: STORAGE_INTEGRATION
+        comparison_operator:
+          raw_comparison_operator: '='
+        object_reference:
+          naked_identifier: my_gcs_int
+    - keyword: FILE_FORMAT
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - file_format_segment:
+        bracketed:
+          start_bracket: (
+          keyword: FORMAT_NAME
+          comparison_operator:
+            raw_comparison_operator: '='
+          quoted_literal: "'my_db.my_schema.my_json_format'"
+          end_bracket: )
+    - comment_equals_clause:
+        keyword: COMMENT
+        comparison_operator:
+          raw_comparison_operator: '='
+        quoted_literal: "'events GCS stage'"
+- statement_terminator: ;
+- statement:
+    define_stage_statement:
+    - keyword: DEFINE
+    - keyword: STAGE
+    - object_reference:
+      - naked_identifier: my_db
+      - dot: .
+      - naked_identifier: my_schema
+      - dot: .
+      - naked_identifier: s3_stage
+    - keyword: URL
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - bucket_path: "'s3://my-bucket/files/'"
+    - stage_parameters:
+        keyword: STORAGE_INTEGRATION
+        comparison_operator:
+          raw_comparison_operator: '='
+        object_reference:
+          naked_identifier: my_s3_int
+    - keyword: DIRECTORY
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - bracketed:
+      - start_bracket: (
+      - keyword: ENABLE
+      - comparison_operator:
+          raw_comparison_operator: '='
+      - boolean_literal: 'TRUE'
+      - keyword: AUTO_REFRESH
+      - comparison_operator:
+          raw_comparison_operator: '='
+      - boolean_literal: 'TRUE'
+      - end_bracket: )
+- statement_terminator: ;
+- statement:
+    define_stage_statement:
+    - keyword: DEFINE
+    - keyword: STAGE
+    - object_reference:
+      - naked_identifier: my_db
+      - dot: .
+      - naked_identifier: my_schema
+      - dot: .
+      - naked_identifier: azure_stage
+    - keyword: URL
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - bucket_path: "'azure://myaccount.blob.core.windows.net/mycontainer/files/'"
+    - stage_parameters:
+        keyword: STORAGE_INTEGRATION
+        comparison_operator:
+          raw_comparison_operator: '='
+        object_reference:
+          naked_identifier: my_azure_int
+    - keyword: DIRECTORY
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - bracketed:
+      - start_bracket: (
+      - keyword: ENABLE
+      - comparison_operator:
+          raw_comparison_operator: '='
+      - boolean_literal: 'TRUE'
+      - keyword: NOTIFICATION_INTEGRATION
+      - comparison_operator:
+          raw_comparison_operator: '='
+      - naked_identifier: my_notification_int
+      - end_bracket: )
+- statement_terminator: ;

--- a/test/fixtures/dialects/snowflake/define_stage.yml
+++ b/test/fixtures/dialects/snowflake/define_stage.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 87b540612757694e84072145b693ed4bc2e4f6a465f65c513d79c726ebeedd2c
+_hash: ae93fbf87337ed896625d8901d935db4d4df00e4730d94b515a9c4ec56ccaf32
 file:
 - statement:
     define_stage_statement:
@@ -127,4 +127,40 @@ file:
           raw_comparison_operator: '='
       - naked_identifier: my_notification_int
       - end_bracket: )
+- statement_terminator: ;
+- statement:
+    define_stage_statement:
+    - keyword: DEFINE
+    - keyword: STAGE
+    - object_reference:
+      - naked_identifier: my_db
+      - dot: .
+      - naked_identifier: my_schema
+      - dot: .
+      - naked_identifier: var_url_stage
+    - keyword: URL
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - variable: $STAGE_URL
+    - stage_parameters:
+        keyword: STORAGE_INTEGRATION
+        comparison_operator:
+          raw_comparison_operator: '='
+        object_reference:
+          naked_identifier: my_gcs_int
+    - keyword: DIRECTORY
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - bracketed:
+        start_bracket: (
+        keyword: ENABLE
+        comparison_operator:
+          raw_comparison_operator: '='
+        boolean_literal: 'TRUE'
+        end_bracket: )
+    - comment_equals_clause:
+        keyword: COMMENT
+        comparison_operator:
+          raw_comparison_operator: '='
+        quoted_literal: "'external stage with variable URL'"
 - statement_terminator: ;


### PR DESCRIPTION
### Brief summary of the change made

DCM projects support pipes, file formats, and both internal and external stages ([Supported object types in DCM Projects](https://docs.snowflake.com/en/user-guide/dcm-projects/dcm-projects-supported-entities)), but the Snowflake dialect only parsed `DEFINE` for a subset of object types:

- **`DEFINE PIPE`** was entirely unparsable. Added `DefinePipeSegment` mirroring the CREATE PIPE property set (`AUTO_INGEST`, `ERROR_INTEGRATION`, `AWS_SNS_TOPIC`, `INTEGRATION`, `COMMENT`) followed by `AS COPY INTO ...`. Per the docs, "All pipe properties supported by CREATE PIPE are available in DEFINE PIPE".
- **`DEFINE FILE FORMAT`** was entirely unparsable. `CreateFileFormatSegment` now accepts the `DEFINE` keyword, following the same pattern already used for `CREATE TABLE` / `CREATE VIEW` / `CREATE FUNCTION`.
- **`DEFINE STAGE`** only parsed internal stages (the segment carried a "Only internal stages supported in DCM projects currently" comment, which no longer reflects the DCM docs). External stage parameters (`URL`, per-cloud `STORAGE_INTEGRATION` / `ENCRYPTION` parameter sets, directory tables with `AUTO_REFRESH` / `NOTIFICATION_INTEGRATION`) and `COPY_OPTIONS` are now accepted, mirroring `CreateStageSegment`.

Reference documentation:

- https://docs.snowflake.com/en/user-guide/dcm-projects/dcm-projects-supported-entities
- https://docs.snowflake.com/en/sql-reference/sql/create-pipe
- https://docs.snowflake.com/en/sql-reference/sql/create-stage

### Are there any other side effects of this change that we should be aware of?

None expected. Regenerating the full Snowflake fixture set only touched the fixtures added/extended by this PR (228 fixtures rebuilt, no unrelated diffs). Note: open PR #8362 refactors the stage directory-table grammars; if that merges first I am happy to rebase this on top of it.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - [x] `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - [x] `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - [ ] Full autofix test cases in `test/fixtures/linter/autofix`.
  - [ ] Other.
- [ ] Added appropriate documentation for the change.
- [x] Created GitHub issues for any relevant followups/future enhancements if appropriate.

### AI-assisted contribution disclosure

This change was developed with AI assistance (Claude Code). The grammar changes, fixtures and docs references were manually reviewed, and validated by running the Snowflake dialect test suite (699 passed) and regenerating all Snowflake parse fixtures (no unrelated changes). The syntax was additionally verified against real DCM project sources deployed via `snow dcm deploy` on a live Snowflake account.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds full Snowflake DCM parsing for DEFINE PIPE, DEFINE FILE FORMAT, and external DEFINE STAGE so DCM project sources parse correctly. Previously, DEFINE PIPE/DEFINE FILE FORMAT failed to parse and DEFINE STAGE only handled internal stages; now external options are supported and bound to the URL scheme, with variable URLs accepting any cloud's options, matching CREATE STAGE.

- Adds DefinePipeSegment with AS COPY INTO and pipe properties (AUTO_INGEST, ERROR_INTEGRATION, AWS_SNS_TOPIC, INTEGRATION) via a shared PipePropertiesGrammar reused by CREATE PIPE; COMMENT before AS is supported.
- Extends CreateFileFormatSegment to accept DEFINE FILE FORMAT.
- Expands DefineStageSegment to support external stages: URL with per-cloud parameters tied to s3://, gcs://, or azure://; variable URLs accept any cloud's parameter set; DIRECTORY (ENABLE, AUTO_REFRESH, NOTIFICATION_INTEGRATION where valid); FILE_FORMAT. Extracts per-cloud external-stage option grammars and reuses them in both CREATE STAGE and DEFINE STAGE to prevent drift; CREATE STAGE behavior is unchanged.
- Adds/updates fixtures for define_pipe, define_file_format, and define_stage only. No migration needed.

<sup>Written for commit 3f48475bb95143c7df1ca2b43f05a05b1a0a334b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8365?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

