### PR TITLE
Snowflake: RESOURCE MONITOR gaps (IF NOT EXISTS position, quoted monitor names)

### DIFF
--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -5192,6 +5192,7 @@ class WarehouseObjectPropertiesSegment(BaseSegment):
             Ref("EqualsSegment"),
             OneOf(
                 Ref("NakedIdentifierSegment"),
+                Ref("QuotedIdentifierSegment"),
                 Ref("QuotedLiteralSegment"),
             ),
         ),
@@ -9479,6 +9480,7 @@ class AlterAccountStatementSegment(BaseSegment):
                 Ref("EqualsSegment"),
                 OneOf(
                     Ref("NakedIdentifierSegment"),
+                    Ref("QuotedIdentifierSegment"),
                     Ref("QuotedLiteralSegment"),
                 ),
             ),

--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -5190,7 +5190,10 @@ class WarehouseObjectPropertiesSegment(BaseSegment):
         Sequence(
             "RESOURCE_MONITOR",
             Ref("EqualsSegment"),
-            Ref("NakedIdentifierSegment"),
+            OneOf(
+                Ref("NakedIdentifierSegment"),
+                Ref("QuotedLiteralSegment"),
+            ),
         ),
         Sequence(
             "ENABLE_QUERY_ACCELERATION",
@@ -9474,7 +9477,10 @@ class AlterAccountStatementSegment(BaseSegment):
                 "SET",
                 "RESOURCE_MONITOR",
                 Ref("EqualsSegment"),
-                Ref("NakedIdentifierSegment"),
+                OneOf(
+                    Ref("NakedIdentifierSegment"),
+                    Ref("QuotedLiteralSegment"),
+                ),
             ),
             Sequence(
                 "SET",
@@ -9702,8 +9708,8 @@ class CreateResourceMonitorStatementSegment(BaseSegment):
     match_grammar = Sequence(
         "CREATE",
         Ref("OrReplaceGrammar", optional=True),
-        Ref("IfNotExistsGrammar", optional=True),
         Sequence("RESOURCE", "MONITOR"),
+        Ref("IfNotExistsGrammar", optional=True),
         Ref("ObjectReferenceSegment"),
         "WITH",
         Ref("ResourceMonitorOptionsSegment"),

--- a/test/fixtures/dialects/snowflake/alter_warehouse.sql
+++ b/test/fixtures/dialects/snowflake/alter_warehouse.sql
@@ -48,6 +48,8 @@ ALTER WAREHOUSE LOAD_WH SET
 ENABLE_QUERY_ACCELERATION = true
 QUERY_ACCELERATION_MAX_SCALE_FACTOR = 4;
 
+alter warehouse LOAD_WH set RESOURCE_MONITOR = 'monitor_name';
+
 -- The warehouse name can be omitted when suspending / resuming / aborting.
 ALTER WAREHOUSE SUSPEND;
 ALTER WAREHOUSE RESUME IF SUSPENDED;

--- a/test/fixtures/dialects/snowflake/alter_warehouse.sql
+++ b/test/fixtures/dialects/snowflake/alter_warehouse.sql
@@ -50,6 +50,8 @@ QUERY_ACCELERATION_MAX_SCALE_FACTOR = 4;
 
 alter warehouse LOAD_WH set RESOURCE_MONITOR = 'monitor_name';
 
+alter warehouse LOAD_WH set RESOURCE_MONITOR = "My Monitor";
+
 -- The warehouse name can be omitted when suspending / resuming / aborting.
 ALTER WAREHOUSE SUSPEND;
 ALTER WAREHOUSE RESUME IF SUSPENDED;

--- a/test/fixtures/dialects/snowflake/alter_warehouse.yml
+++ b/test/fixtures/dialects/snowflake/alter_warehouse.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: ab6530f46a2764e4dc5100e53a450e2ff98f0a31d684f875047e745db907c9c3
+_hash: 4ec2abc17f4d4b2ebe0877c0b62baf206068ddd5bb72fa061b160110b20fa8bd
 file:
 - statement:
     alter_warehouse_statement:
@@ -467,6 +467,32 @@ file:
       - comparison_operator:
           raw_comparison_operator: '='
       - numeric_literal: '4'
+- statement_terminator: ;
+- statement:
+    alter_warehouse_statement:
+    - keyword: alter
+    - keyword: warehouse
+    - object_reference:
+        naked_identifier: LOAD_WH
+    - keyword: set
+    - warehouse_object_properties:
+        keyword: RESOURCE_MONITOR
+        comparison_operator:
+          raw_comparison_operator: '='
+        quoted_literal: "'monitor_name'"
+- statement_terminator: ;
+- statement:
+    alter_warehouse_statement:
+    - keyword: alter
+    - keyword: warehouse
+    - object_reference:
+        naked_identifier: LOAD_WH
+    - keyword: set
+    - warehouse_object_properties:
+        keyword: RESOURCE_MONITOR
+        comparison_operator:
+          raw_comparison_operator: '='
+        quoted_identifier: '"My Monitor"'
 - statement_terminator: ;
 - statement:
     alter_warehouse_statement:

--- a/test/fixtures/dialects/snowflake/create_resource_monitor.sql
+++ b/test/fixtures/dialects/snowflake/create_resource_monitor.sql
@@ -20,3 +20,8 @@ create or replace resource monitor limiter with credit_quota=5000
            on 100 percent do suspend
            on 110 percent do suspend_immediate
 ;
+
+create resource monitor if not exists my_monitor with
+  credit_quota = 100
+  frequency = monthly
+  start_timestamp = immediately;

--- a/test/fixtures/dialects/snowflake/create_resource_monitor.yml
+++ b/test/fixtures/dialects/snowflake/create_resource_monitor.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 6af381138c77c33c9a0d66b5cba1c4f3677e9f8bc00efce29a1c90d48d7e4284
+_hash: 802cc0ab82a3c79a39cae1ecef1d708a69e921edeed328732c05579088f4a72c
 file:
 - statement:
     create_statement:
@@ -163,4 +163,29 @@ file:
       - keyword: percent
       - keyword: do
       - keyword: suspend_immediate
+- statement_terminator: ;
+- statement:
+    create_resource_monitor_statement:
+    - keyword: create
+    - keyword: resource
+    - keyword: monitor
+    - keyword: if
+    - keyword: not
+    - keyword: exists
+    - object_reference:
+        naked_identifier: my_monitor
+    - keyword: with
+    - resource_monitor_options:
+      - keyword: credit_quota
+      - comparison_operator:
+          raw_comparison_operator: '='
+      - integer_literal: '100'
+      - keyword: frequency
+      - comparison_operator:
+          raw_comparison_operator: '='
+      - keyword: monthly
+      - keyword: start_timestamp
+      - comparison_operator:
+          raw_comparison_operator: '='
+      - keyword: immediately
 - statement_terminator: ;


### PR DESCRIPTION
### Brief summary of the change made

Two small RESOURCE MONITOR parsing gaps ([CREATE RESOURCE MONITOR](https://docs.snowflake.com/en/sql-reference/sql/create-resource-monitor)):

- **`CREATE RESOURCE MONITOR IF NOT EXISTS <name> WITH ...` failed to parse.** `CreateResourceMonitorStatementSegment` had `IfNotExistsGrammar` placed *before* the `RESOURCE MONITOR` keywords, i.e. it parsed the undocumented order `CREATE IF NOT EXISTS RESOURCE MONITOR`. The documented order is `CREATE [ OR REPLACE ] RESOURCE MONITOR [ IF NOT EXISTS ] <name> WITH ...`. (The bare form without `WITH` happened to parse via the generic `CreateStatementSegment`, which is why the existing `create resource monitor if not exists test;` fixture passed and hid the bug.)
- **`RESOURCE_MONITOR = '<name>'` with a quoted monitor name failed to parse** in `ALTER WAREHOUSE ... SET`, `CREATE WAREHOUSE` and `ALTER ACCOUNT SET` — only naked identifiers were accepted. Snowflake accepts both forms; the value is now `OneOf(NakedIdentifierSegment, QuotedLiteralSegment)`.

### Are there any other side effects of this change that we should be aware of?

None expected. The Snowflake dialect suite passes (699 tests) and full fixture regeneration only touched the two fixtures extended by this PR.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - [ ] `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - [x] `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - [ ] Full autofix test cases in `test/fixtures/linter/autofix`.
  - [ ] Other.
- [ ] Added appropriate documentation for the change.
- [x] Created GitHub issues for any relevant followups/future enhancements if appropriate.

### AI-assisted contribution disclosure

This change was developed with AI assistance (Claude Code). The grammar changes, fixtures and docs references were manually reviewed, and validated by running the Snowflake dialect test suite and regenerating all Snowflake parse fixtures. Both forms were additionally verified against resource monitor statements running on a live Snowflake account.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two Snowflake RESOURCE MONITOR parsing gaps so documented statements now parse correctly.

- `CREATE [OR REPLACE] RESOURCE MONITOR [IF NOT EXISTS] <name> WITH ...` now parses with `IF NOT EXISTS` after `RESOURCE MONITOR`, instead of the previously accepted undocumented `CREATE IF NOT EXISTS RESOURCE MONITOR` order.
- `RESOURCE_MONITOR = <name>` now accepts bare identifiers, single-quoted strings, and double-quoted identifiers in `ALTER`/`CREATE WAREHOUSE` and `ALTER ACCOUNT SET`.
- Updates fixtures to cover both cases; Snowflake dialect tests pass with only these fixture changes.

<sup>Written for commit c2e4976d240fec2ca04ac2a42567fdad5748cd86. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8370?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

