### PR TITLE
Snowflake: support INTO variable clause in CALL statements (#8364)

### DIFF
--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -10175,7 +10175,11 @@ class CallStatementSegment(BaseSegment):
         ),
         Sequence(
             "INTO",
-            Ref("BindVariableSegment"),
+            OneOf(
+                Ref("BindVariableSegment"),
+                Ref("LocalVariableNameSegment"),
+                Ref("SingleIdentifierGrammar"),
+            ),
             optional=True,
         ),
     )

--- a/test/fixtures/dialects/snowflake/call_statement.sql
+++ b/test/fixtures/dialects/snowflake/call_statement.sql
@@ -3,3 +3,18 @@ CALL sv_proc1('Manitoba', 127.4);
 
 SET Variable1 = 49;
 CALL sv_proc2($Variable1);
+
+CALL sv_proc1('Manitoba', 127.4) INTO :ret1;
+CALL sv_proc1('Manitoba', 127.4) INTO ret1;
+CALL my_db.my_schema.sv_proc1() INTO :result;
+CALL my_db.my_schema.sv_proc1() INTO result;
+CALL sv_proc1(a => 1, b => 'x') INTO :ret1;
+CALL sv_proc1(a => 1, b => 'x') INTO ret1;
+
+DECLARE
+    myvar VARCHAR DEFAULT NULL;
+BEGIN
+    CALL myproc('arg') INTO :myvar;
+    CALL myproc('arg') INTO myvar;
+    RETURN :myvar;
+END;

--- a/test/fixtures/dialects/snowflake/call_statement.yml
+++ b/test/fixtures/dialects/snowflake/call_statement.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 7f7351943cd4f95d2828d2d969298e1d114ab1ce6c75c10db25ebc18cc7bdb71
+_hash: 338d9cd49189d0a4c81d90bd46d116ecce046b8c95201e1af00354c45ebabd83
 file:
 - statement:
     call_segment:
@@ -61,4 +61,171 @@ file:
             expression:
               variable: $Variable1
             end_bracket: )
+- statement_terminator: ;
+- statement:
+    call_statement:
+    - keyword: CALL
+    - function_name:
+        function_name_identifier: sv_proc1
+    - function_contents:
+        bracketed:
+        - start_bracket: (
+        - expression:
+            quoted_literal: "'Manitoba'"
+        - comma: ','
+        - expression:
+            numeric_literal: '127.4'
+        - end_bracket: )
+    - keyword: INTO
+    - bind_variable:
+        colon_prefix: ':'
+        variable: ret1
+- statement_terminator: ;
+- statement:
+    call_statement:
+    - keyword: CALL
+    - function_name:
+        function_name_identifier: sv_proc1
+    - function_contents:
+        bracketed:
+        - start_bracket: (
+        - expression:
+            quoted_literal: "'Manitoba'"
+        - comma: ','
+        - expression:
+            numeric_literal: '127.4'
+        - end_bracket: )
+    - keyword: INTO
+    - variable: ret1
+- statement_terminator: ;
+- statement:
+    call_statement:
+    - keyword: CALL
+    - function_name:
+      - naked_identifier: my_db
+      - dot: .
+      - naked_identifier: my_schema
+      - dot: .
+      - function_name_identifier: sv_proc1
+    - function_contents:
+        bracketed:
+          start_bracket: (
+          end_bracket: )
+    - keyword: INTO
+    - bind_variable:
+        colon_prefix: ':'
+        variable: result
+- statement_terminator: ;
+- statement:
+    call_statement:
+    - keyword: CALL
+    - function_name:
+      - naked_identifier: my_db
+      - dot: .
+      - naked_identifier: my_schema
+      - dot: .
+      - function_name_identifier: sv_proc1
+    - function_contents:
+        bracketed:
+          start_bracket: (
+          end_bracket: )
+    - keyword: INTO
+    - variable: result
+- statement_terminator: ;
+- statement:
+    call_statement:
+    - keyword: CALL
+    - function_name:
+        function_name_identifier: sv_proc1
+    - function_contents:
+        bracketed:
+        - start_bracket: (
+        - snowflake_keyword_expression:
+            parameter: a
+            parameter_assigner: =>
+            numeric_literal: '1'
+        - comma: ','
+        - snowflake_keyword_expression:
+            parameter: b
+            parameter_assigner: =>
+            quoted_literal: "'x'"
+        - end_bracket: )
+    - keyword: INTO
+    - bind_variable:
+        colon_prefix: ':'
+        variable: ret1
+- statement_terminator: ;
+- statement:
+    call_statement:
+    - keyword: CALL
+    - function_name:
+        function_name_identifier: sv_proc1
+    - function_contents:
+        bracketed:
+        - start_bracket: (
+        - snowflake_keyword_expression:
+            parameter: a
+            parameter_assigner: =>
+            numeric_literal: '1'
+        - comma: ','
+        - snowflake_keyword_expression:
+            parameter: b
+            parameter_assigner: =>
+            quoted_literal: "'x'"
+        - end_bracket: )
+    - keyword: INTO
+    - variable: ret1
+- statement_terminator: ;
+- statement:
+    scripting_declare_statement:
+    - keyword: DECLARE
+    - variable: myvar
+    - data_type:
+        data_type_identifier: VARCHAR
+    - keyword: DEFAULT
+    - expression:
+        null_literal: 'NULL'
+- statement_terminator: ;
+- statement:
+    scripting_block_statement:
+    - keyword: BEGIN
+    - statement:
+        call_statement:
+        - keyword: CALL
+        - function_name:
+            function_name_identifier: myproc
+        - function_contents:
+            bracketed:
+              start_bracket: (
+              expression:
+                quoted_literal: "'arg'"
+              end_bracket: )
+        - keyword: INTO
+        - bind_variable:
+            colon_prefix: ':'
+            variable: myvar
+    - statement_terminator: ;
+    - statement:
+        call_statement:
+        - keyword: CALL
+        - function_name:
+            function_name_identifier: myproc
+        - function_contents:
+            bracketed:
+              start_bracket: (
+              expression:
+                quoted_literal: "'arg'"
+              end_bracket: )
+        - keyword: INTO
+        - variable: myvar
+    - statement_terminator: ;
+    - statement:
+        return_statement:
+          keyword: RETURN
+          expression:
+            bind_variable:
+              colon_prefix: ':'
+              variable: myvar
+    - statement_terminator: ;
+    - keyword: END
 - statement_terminator: ;


### PR DESCRIPTION
### Summary
In Snowflake Scripting, calling a stored procedure allows capturing the return value into a variable via the INTO clause:
`sql
CALL <procedure_name>( [ <arg1> , ... ] ) [ INTO [ : ] <variable> ]
`
Previously, CallStatementSegment only supported bind variables with a colon prefix (:var). When an identifier without a colon was provided (or when calling inside a BEGIN ... END block), parsing would fail.

This PR extends CallStatementSegment in the Snowflake dialect to support both bind variables (:var) and identifiers/variable names (ar) in the INTO clause.

Fixes #8364

### Changes
- Updated CallStatementSegment match grammar in src/sqlfluff/dialects/dialect_snowflake.py to allow OneOf(Ref(BindVariableSegment), Ref(LocalVariableNameSegment), Ref(SingleIdentifierGrammar)) after INTO.
- Added test cases covering standalone calls and script blocks in 	est/fixtures/dialects/snowflake/call_statement.sql and regenerated YAML fixture assertions.

### Verification
- Ran full Snowflake dialect test suite: pytest test/dialects/ -k snowflake (702 passed).
- Ran code style checks: uff check and lack --check.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for the INTO variable clause in Snowflake CALL statements, accepting both bind variables (:var) and unprefixed identifiers (ret1). Previously, the parser only accepted bind variables; now both forms parse in standalone calls and in Snowflake Scripting blocks.

- Updates `CallStatementSegment` to allow `BindVariableSegment`, `LocalVariableNameSegment`, or `SingleIdentifierGrammar` after INTO.
- Adds tests for standalone calls, named args, fully qualified procedure names, and BEGIN…END blocks.
- Parser output under INTO may now be either `bind_variable` or `variable`; if you consume the parse tree, handle both shapes.

<sup>Written for commit 0025ad7cecf2b9cdde8decdd57038db0bffa9600. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8371?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

