### PR TITLE
docs(rust): refresh AGENTS.md status and fix three stale symbol names

### DIFF
--- a/sqlfluffrs/AGENTS.md
+++ b/sqlfluffrs/AGENTS.md
@@ -19,15 +19,17 @@ from 5.0.
   `MatchResult.apply()` still builds the `BaseSegment` AST. A parallel,
   id-addressable Rust arena (`_rs_tree`, `RsTree`/`RsHandle`) is built and cached
   as the substrate for Rust-side rules (read-only to Python today).
-- **Linting rules** — mostly Python; **one experimental rule is wired end to
-  end**. CP01 detection lives in the `sqlfluffrs_rules` crate, runs over the
-  arena's public read API (`sqlfluffrs_parser::Arena`), and is dispatched by the
-  linter via `BaseRule._eval_rust` when **`core.use_rust_rules`** is enabled
-  (default `False`; also requires the Rust parser's arena, else it falls back
-  per-rule to Python). Validated at parity with stock CP01. **Fixing is still
-  Python-side** — the Rust rule returns `(leaf_index, fixed_raw)` and the linter
-  anchors a `LintFix`; Rust-side (mutating) fixing waits on the arena mutation
-  milestone. See `sqlfluffrs_rules/`, `BaseRule._eval_rust`, and PR #7984.
+- **Linting rules** — mostly Python; **three experimental rules are wired end
+  to end**. CP01, CP03 and CP04 detection lives in the `sqlfluffrs_rules` crate
+  (CP02 and CP05 remain Python-only), runs over the arena's public read API
+  (`sqlfluffrs_parser::Arena`), and is dispatched by the linter via
+  `BaseRule._eval_rust` when **`core.use_rust_rules`** is enabled (default
+  `False`; also requires the Rust parser's arena, else it falls back per-rule to
+  Python). Each is validated at parity with its stock Python rule. **Fixing is
+  still Python-side** — the Rust rule returns `(leaf_index, fixed_raw)` and the
+  linter anchors a `LintFix`; Rust-side (mutating) fixing waits on the arena
+  mutation milestone. See `sqlfluffrs_rules/`, `BaseRule._eval_rust`, and PRs
+  #7984 (CP01) and #8069 (CP03/CP04).
 
 **Not a replacement**: the Rust components work alongside Python. When
 `sqlfluffrs` is unavailable, Python falls back transparently (auto mode).
@@ -335,7 +337,7 @@ four stages so you can see where the time goes:
 - `rust_core` — the Rust parse (`parse_match_result_from_tokens`)
 - `convert` — rebuilding the result as a Python `MatchResult`
 - `apply` — building the `BaseSegment` tree (`MatchResult.apply`)
-- `apply_as_node` — building the `_rs_node` tree
+- `apply_as_tree` — building the Rust arena tree (`_rs_tree`)
 
 Enable it via the `SQLFLUFF_RS_PROFILE` env var or `set_profiling(True)`, then
 read the most recent parse with `get_parse_profile()`. The benchmark harness
@@ -478,8 +480,10 @@ tox -e py312
 
 ## Current Limitations
 
-- **Lexing and parsing only** — linting rules and the fix/format pipeline are
-  still entirely Python; the Rust node tree (`_rs_node`) has no consumers yet.
+- **Linting is mostly Python** — only the CP01/CP03/CP04 detection loops run
+  in Rust, behind `core.use_rust_rules` (default off). Every other rule, and the
+  whole fix/format pipeline, is still Python; the arena (`_rs_tree`) is
+  read-only, so Rust-side fixing waits on the arena mutation milestone.
 - **Hybrid parse** — Rust returns a `MatchResult`; Python still builds the AST.
 - **Performance gains scale with file size** — small files see little benefit
   because of the Python↔Rust crossing overhead.


### PR DESCRIPTION
### Brief summary of the change made

Three statements in `sqlfluffrs/AGENTS.md` no longer match the code. Documentation only — no code, config, CI or test changes.

**1. "Project Status" says one experimental rule (CP01) is wired end to end. Three are.**
CP01, CP03 and CP04 each have Rust detection in `sqlfluffrs_rules`, a PyO3 export registered in that crate's `python::register`, and an `_eval_rust` override on the Python rule. CP02 and CP05 remain Python-only — which the crate's own module docs in `sqlfluffrs_rules/src/lib.rs` already state, so the file disagreed with the code it documents. Adds the #8069 reference alongside #7984.

**2. The profiler stage list names two symbols that do not exist.**
It documents an `apply_as_node` stage building an `_rs_node` tree. Neither identifier appears anywhere in the codebase — the stage emitted by `rust_parser.py` is `apply_as_tree`, and the attribute it populates is `_rs_tree`. Anyone following the docs to profile a parse would be looking for a key that is never emitted.

**3. "Current Limitations" contradicts the file's own "Project Status".**
It states that linting rules are "still entirely Python" and that the Rust node tree "has no consumers yet", while the status section ~460 lines above in the same file describes the CP01/CP03/CP04 detection loops reading the arena. Reworded to say what is still Python (every other rule, and the whole fix/format pipeline) and why Rust-side fixing is blocked (the arena is read-only).

Each claim is reproducible from a checkout:

```
$ grep -rln '_eval_rust' src/sqlfluff/rules/
src/sqlfluff/rules/capitalisation/{CP01,CP03,CP04}.py

$ grep -n 'wrap_pyfunction' sqlfluffrs/sqlfluffrs_rules/src/python.rs
62,63,64:  cp01_violations, cp03_violations, cp04_violations

$ grep -rn '_rs_node\|apply_as_node' src/ sqlfluffrs/*/src sqlfluffrs/src
(no matches)

$ grep -n 'apply_as_tree' src/sqlfluff/core/parser/rust_parser.py
389:  result._rs_tree = rs_match.apply_as_tree(...)
395:  _prof["apply_as_tree"] = ...
```

### Are there any other side effects of this change that we should be aware of?

None. A single markdown file changes; no runtime behaviour, CI, config or tests are affected, and no CI changes are needed to handle this contribution. `codespell`, trailing-whitespace and end-of-file-fixer (the hooks in `.pre-commit-config.yaml` that apply to markdown) pass, and the added lines stay within the file's existing wrapping width.

### AI assistance disclosure

Per the AI-Assisted Contributions section of `CONTRIBUTING.md`: this change was AI-assisted, and the assistance was material.

- **AI-assisted:** spotting the three drifted statements, cross-checking every symbol name in the file against the codebase, drafting the replacement wording, and drafting this description.
- **Validated:** each claim was verified by running the commands shown above against the tree at the base commit, not asserted from the model's reading. The markdown hooks that apply to this file were run locally. I have reviewed the resulting diff and the description, and I take responsibility for both.
- **Scope:** the diff is 16 added / 12 removed lines in one file, small enough to review line by line — this is not a bulk-generated change.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes:
  - Not applicable — documentation-only change, no code paths affected.
- [x] Added appropriate documentation for the change (this *is* the documentation change).
- Created GitHub issues for any relevant followup/future enhancements if appropriate — none needed.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates `sqlfluffrs/AGENTS.md` to match the current Rust integration and correct three stale symbol names. Docs-only; it aligns rule status and profiler keys so readers can profile parses and know which rules run in Rust.

- Project status: was “one experimental rule (CP01) is wired end to end”; now CP01, CP03, and CP04 detect in Rust via `sqlfluffrs_rules` and dispatch through `BaseRule._eval_rust` when `core.use_rust_rules` is enabled. CP02 and CP05 remain Python-only. Adds references to the relevant PRs.
- Profiler stages: replaced nonexistent `apply_as_node`/`_rs_node` with `apply_as_tree`/`_rs_tree` to match `rust_parser.py` and emitted profile keys.
- Current limitations: clarified that linting is mostly Python; only CP01/CP03/CP04 detection loops run in Rust behind the flag, and fixing stays Python because the arena (`_rs_tree`) is read-only.

<sup>Written for commit 4cd69c278af4cb14953f694d570eb14d26ca2288. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8374?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

