### PR TITLE
ci: pass newVersionNumber through env in the release workflow

### DIFF
--- a/.github/workflows/create-release-pull-request.yaml
+++ b/.github/workflows/create-release-pull-request.yaml
@@ -16,8 +16,10 @@ jobs:
           fetch-depth: 1
 
       - name: Abort if branch already exists
+        env:
+          NEW_VERSION: ${{ github.event.inputs.newVersionNumber }}
         run: |
-            _check_branch=$(git ls-remote --heads origin prep-${{ github.event.inputs.newVersionNumber }})
+            _check_branch=$(git ls-remote --heads origin "prep-${NEW_VERSION}")
             if [[ -z ${_check_branch} ]]; then
                 echo "Release branch doesn't exist yet, continuing"
             else
@@ -39,8 +41,9 @@ jobs:
 
       - name: Prepare release
         run: |
-          python util.py release ${{ github.event.inputs.newVersionNumber }}
+          python util.py release "${NEW_VERSION}"
         env:
+          NEW_VERSION: ${{ github.event.inputs.newVersionNumber }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY_OWNER: ${{ secrets.GITHUB_REPOSITORY_OWNER }}
 


### PR DESCRIPTION
## What

Two steps in `create-release-pull-request.yaml` expand the `workflow_dispatch` input `newVersionNumber` directly into a shell body. This passes it through `env` and quotes it instead.

```diff
       - name: Abort if branch already exists
+        env:
+          NEW_VERSION: ${{ github.event.inputs.newVersionNumber }}
         run: |
-            _check_branch=$(git ls-remote --heads origin prep-${{ github.event.inputs.newVersionNumber }})
+            _check_branch=$(git ls-remote --heads origin "prep-${NEW_VERSION}")
```

```diff
       - name: Prepare release
         run: |
-          python util.py release ${{ github.event.inputs.newVersionNumber }}
+          python util.py release "${NEW_VERSION}"
         env:
+          NEW_VERSION: ${{ github.event.inputs.newVersionNumber }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
```

## Why

A `${{ ... }}` expression is substituted as *text* before bash parses the line. The value is therefore not an argument being passed — it becomes part of the program. Through `env` it is an ordinary variable, which is only ever data.

Two details make these worth fixing rather than leaving as theory:

- The first site sits inside a **command substitution**, so anything the input introduces runs in that subshell.
- The second runs in the step that carries **`GITHUB_TOKEN`** in its environment.

Dispatching the workflow needs write access, so this is not something an outside party can reach — it is a way for one mistyped or pasted value to become execution in the release path, next to a token. Quoting also fixes the plainer failure mode: a version string with a space currently word-splits instead of failing the check.

## Behaviour

Unchanged for every well-formed version string. `NEW_VERSION` holds exactly what the expression held before, and both consumers receive the same value. A malformed input now arrives as one argument rather than as shell syntax.

## Verification

Workflow files carry no tests, so:

- **`zizmor --min-severity high`** on this file: `template-injection` findings **0**, down from **2**. No other finding in the file changed.
- **Parsed with PyYAML** to confirm the file is still valid and the two steps carry the expected `env` keys.
- Confirmed the pushed file is byte-identical to the one I ran those checks against.

I could not execute the workflow itself — it is `workflow_dispatch` on this repository, which I cannot trigger.

## Not included

`zizmor` also flags four sites in `ci-test-python.yml` (`inputs.marks`, `inputs.with-rust`). Those are `workflow_call` inputs supplied by callers inside this repository rather than by a person at dispatch time, so the exposure is different and the fix is arguably unnecessary churn. I left them alone rather than bundle a judgement call into a mechanical fix. Happy to open that separately if you want it.

## AI disclosure

Per `CONTRIBUTING.md` — this change was prepared with assistance from Claude (Anthropic). The finding, the scope decision to exclude `ci-test-python.yml`, and every verification step above I checked myself; none of it is asserted on the model's say-so.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Passes the `workflow_dispatch` input `newVersionNumber` through step `env` as `NEW_VERSION` and quotes its use in the release workflow. Old behavior expanded the input directly into shell bodies; new behavior treats it as data to prevent template injection and word splitting, with no change for well-formed versions.

- Only changes are in “Abort if branch already exists” and “Prepare release”: set `NEW_VERSION` from `${{ github.event.inputs.newVersionNumber }}` and use `"${NEW_VERSION}"` in both commands.
- Behavior is unchanged for valid versions; malformed input is now a single argument. `zizmor` template-injection findings on this file drop from 2 to 0.

<sup>Written for commit 336a57235a30ce9524242b750942f860f4242b41. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8375?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

