### PR TITLE
Databricks: Allow trailing whitespace after magic marker

### DIFF
--- a/src/sqlfluff/dialects/dialect_databricks.py
+++ b/src/sqlfluff/dialects/dialect_databricks.py
@@ -147,7 +147,7 @@ databricks_dialect.insert_lexer_matchers(
             r"(-- MAGIC %)([^\n]{2,})( [^%]{1})([^\n]*)",
             CodeSegment,
         ),
-        RegexLexer("magic_line", r"(-- MAGIC)( [^%]{1})([^\n]*)", CodeSegment),
+        RegexLexer("magic_line", r"(-- MAGIC)(?! ?%)([^\n]*)", CodeSegment),
         RegexLexer("magic_start", r"(-- MAGIC %)([^\n]{2,})(\r?\n)", CodeSegment),
         RegexLexer(
             "bare_magic_sql",

--- a/test/fixtures/dialects/databricks/magic_line.sql
+++ b/test/fixtures/dialects/databricks/magic_line.sql
@@ -1,6 +1,8 @@
 -- Databricks notebook source
 -- MAGIC %md
 -- MAGIC # Dummy Notebook
+-- MAGIC 
+-- MAGIC
 
 -- COMMAND ----------
 

--- a/test/fixtures/dialects/databricks/magic_line.yml
+++ b/test/fixtures/dialects/databricks/magic_line.yml
@@ -3,12 +3,14 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 21260d3f306da0a5bbba78fe749673da7a1d26cada40e248ba79dac55316d6e5
+_hash: e6ecf0b46b2d87ca711c350316f17a3a963de723e56eee4c7f453577fb7cf28b
 file:
 - statement:
     magic_cell_segment:
-      magic_start: "-- MAGIC %md\n"
-      magic_line: '-- MAGIC # Dummy Notebook'
+    - magic_start: "-- MAGIC %md\n"
+    - magic_line: '-- MAGIC # Dummy Notebook'
+    - magic_line: '-- MAGIC '
+    - magic_line: -- MAGIC
 - command_cell: -- COMMAND ----------
 - statement:
     select_statement:


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->


### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allows Databricks magic lines that contain only the marker or trailing whitespace to be parsed as part of the same magic cell. Previously, lines like "-- MAGIC" or "-- MAGIC " were not recognized and could break cell grouping; they now parse as a magic line, while lines starting with "-- MAGIC %..." continue to start a magic cell.

- Update `magic_line` regex to accept empty/trailing-whitespace content and exclude `-- MAGIC %...`.
- Extend fixtures to include empty magic lines; YAML now lists multiple `magic_line` entries within one `magic_cell_segment`.

<sup>Written for commit 30250c5c5e53e6ccf562445074210cb8b1e55939. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8377?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

