### PR TITLE
fix(databricks): update regex patterns to exclude new line from magic lexers

### DIFF
--- a/src/sqlfluff/dialects/dialect_databricks.py
+++ b/src/sqlfluff/dialects/dialect_databricks.py
@@ -144,11 +144,11 @@ databricks_dialect.insert_lexer_matchers(
         ),
         RegexLexer(
             "magic_single_line",
-            r"(-- MAGIC %)([^\n]{2,})( [^%]{1})([^\n]*)",
+            r"(-- MAGIC %)([^\r\n]{2,})( [^%]{1})([^\r\n]*)",
             CodeSegment,
         ),
-        RegexLexer("magic_line", r"(-- MAGIC)( [^%]{1})([^\n]*)", CodeSegment),
-        RegexLexer("magic_start", r"(-- MAGIC %)([^\n]{2,})(\r?\n)", CodeSegment),
+        RegexLexer("magic_line", r"(-- MAGIC)( [^%]{1})([^\r\n]*)", CodeSegment),
+        RegexLexer("magic_start", r"(-- MAGIC %)([^\r\n]{2,})", CodeSegment),
         RegexLexer(
             "bare_magic_sql",
             r"(\r?\n)+-- COMMAND ----------(\r?\n)+%sql\b[^\r\n]*",

--- a/src/sqlfluff/dialects/dialect_databricks.py
+++ b/src/sqlfluff/dialects/dialect_databricks.py
@@ -119,7 +119,10 @@ databricks_dialect.insert_lexer_matchers(
         RegexLexer(
             "notebook_start_bare_magic_cell",
             r"(?s)-- Databricks notebook source(?:\r?\n)"
-            r"%(?:python|scala|r|sh|md|run|fs|pip|conda)\b[^\r\n]*"
+            r"(?:%(?:python|scala|r|sh|md|run|fs|pip|conda|tensorboard|"
+            r"set_cell_max_output_size_in_mb|skip)\b|%%(?:profile|oprofile)\b|"
+            r"%uv[ \t]+pip\b)"
+            r"[^\r\n]*"
             r"(?:(?!(?:\r?\n){2}-- COMMAND ----------(?:\r?\n)).)*"
             r"(?=(?:\r?\n){2}-- COMMAND ----------(?:\r?\n)|\Z)",
             CodeSegment,
@@ -163,7 +166,10 @@ databricks_dialect.insert_lexer_matchers(
         RegexLexer(
             "bare_magic_cell",
             r"(?s)(\r?\n)+-- COMMAND ----------(\r?\n)+"
-            r"%(?:python|scala|r|sh|md|run|fs|pip|conda)\b[^\r\n]*"
+            r"(?:%(?:python|scala|r|sh|md|run|fs|pip|conda|tensorboard|"
+            r"set_cell_max_output_size_in_mb|skip)\b|%%(?:profile|oprofile)\b|"
+            r"%uv[ \t]+pip\b)"
+            r"[^\r\n]*"
             r"(?:(?!(?:\r?\n){2}-- COMMAND ----------(?:\r?\n)).)*"
             r"(?=(?:\r?\n){2}-- COMMAND ----------(?:\r?\n)|\Z)",
             CodeSegment,
@@ -2144,7 +2150,10 @@ class MagicCellStatementSegment(BaseSegment):
                 Ref("MagicStartGrammar", optional=True),
                 AnyNumberOf(Ref("MagicLineGrammar"), optional=True),
             ),
-            Ref("MagicSingleLineGrammar", optional=True),
+            Sequence(
+                Ref("MagicSingleLineGrammar"),
+                AnyNumberOf(Ref("MagicLineGrammar"), optional=True),
+            ),
             # One `bare_magic_cell` token per line (see the lexer subdivider).
             AnyNumberOf(
                 OneOf(

--- a/src/sqlfluff/dialects/dialect_databricks.py
+++ b/src/sqlfluff/dialects/dialect_databricks.py
@@ -147,7 +147,9 @@ databricks_dialect.insert_lexer_matchers(
             r"(-- MAGIC %)([^\r\n]{2,})( [^%]{1})([^\r\n]*)",
             CodeSegment,
         ),
-        RegexLexer("magic_line", r"(-- MAGIC)( [^%]{1})([^\r\n]*)", CodeSegment),
+        RegexLexer(
+            "magic_line", r"(-- MAGIC)(?! ?%)(?: [^%\r\n][^\r\n]*)?", CodeSegment
+        ),
         RegexLexer("magic_start", r"(-- MAGIC %)([^\r\n]{2,})", CodeSegment),
         RegexLexer(
             "bare_magic_sql",

--- a/test/dialects/dialects_test.py
+++ b/test/dialects/dialects_test.py
@@ -10,6 +10,7 @@ import pytest
 
 from sqlfluff.core import FluffConfig, Linter
 from sqlfluff.core.linter import ParsedString, RenderedFile
+from sqlfluff.core.parser.lexer import PyLexer
 from sqlfluff.core.parser.segments.base import BaseSegment
 from sqlfluff.core.templaters import TemplatedFile
 
@@ -55,6 +56,40 @@ def lex_and_parse(config_overrides: dict[str, Any], raw: str) -> Optional[Parsed
     # Check we don't have lexing or parsing issues
     assert not parsed_file.violations
     return parsed_file
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected_segments"),
+    [
+        (
+            "-- MAGIC %python\r\n-- MAGIC print('x')\r\n",
+            [
+                ("magic_start", "-- MAGIC %python"),
+                ("newline", "\r\n"),
+                ("magic_line", "-- MAGIC print('x')"),
+                ("newline", "\r\n"),
+            ],
+        ),
+        (
+            "-- MAGIC %run ./Notebook\r\n",
+            [
+                ("magic_single_line", "-- MAGIC %run ./Notebook"),
+                ("newline", "\r\n"),
+            ],
+        ),
+    ],
+)
+def test_databricks_magic_lexes_crlf_as_newline(
+    raw: str, expected_segments: list[tuple[str, str]]
+) -> None:
+    """Databricks magic lexers must preserve CRLF as newline segments."""
+    segments, errors = PyLexer(dialect="databricks").lex(raw)
+
+    assert not errors
+    assert [
+        (segment.get_type(), segment.raw) for segment in segments[:-1]
+    ] == expected_segments
+    assert segments[-1].is_type("end_of_file")
 
 
 @pytest.mark.parametrize("dialect", ["ansi", "hive"])

--- a/test/fixtures/dialects/databricks/bare_magic_line.sql
+++ b/test/fixtures/dialects/databricks/bare_magic_line.sql
@@ -11,3 +11,27 @@ SELECT a FROM b;
 -- COMMAND ----------
 
 %run ./Notebook
+
+-- COMMAND ----------
+
+%tensorboard --logdir /logs
+
+-- COMMAND ----------
+
+%set_cell_max_output_size_in_mb 10
+
+-- COMMAND ----------
+
+%skip print("This won't run")
+
+-- COMMAND ----------
+
+%%profile my_function()
+
+-- COMMAND ----------
+
+%%oprofile my_function()
+
+-- COMMAND ----------
+
+%uv pip install simplejson

--- a/test/fixtures/dialects/databricks/bare_magic_line.yml
+++ b/test/fixtures/dialects/databricks/bare_magic_line.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 34c6338b801568c732471174a32deec031cacac060661616288225e9eb3f263a
+_hash: d8921ad7d39f9a7a614bfda73fd847e9b23889fb578cab3f9f23839e05aac1b9
 file:
 - command_cell: -- COMMAND ----------
 - statement:
@@ -30,3 +30,27 @@ file:
 - statement:
     magic_cell_segment:
       bare_magic_cell: '%run ./Notebook'
+- command_cell: -- COMMAND ----------
+- statement:
+    magic_cell_segment:
+      bare_magic_cell: '%tensorboard --logdir /logs'
+- command_cell: -- COMMAND ----------
+- statement:
+    magic_cell_segment:
+      bare_magic_cell: '%set_cell_max_output_size_in_mb 10'
+- command_cell: -- COMMAND ----------
+- statement:
+    magic_cell_segment:
+      bare_magic_cell: "%skip print(\"This won't run\")"
+- command_cell: -- COMMAND ----------
+- statement:
+    magic_cell_segment:
+      bare_magic_cell: '%%profile my_function()'
+- command_cell: -- COMMAND ----------
+- statement:
+    magic_cell_segment:
+      bare_magic_cell: '%%oprofile my_function()'
+- command_cell: -- COMMAND ----------
+- statement:
+    magic_cell_segment:
+      bare_magic_cell: '%uv pip install simplejson'

--- a/test/fixtures/dialects/databricks/magic_line.sql
+++ b/test/fixtures/dialects/databricks/magic_line.sql
@@ -1,6 +1,7 @@
 -- Databricks notebook source
 -- MAGIC %md
 -- MAGIC # Dummy Notebook
+-- MAGIC
 
 -- COMMAND ----------
 

--- a/test/fixtures/dialects/databricks/magic_line.yml
+++ b/test/fixtures/dialects/databricks/magic_line.yml
@@ -3,11 +3,11 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 21260d3f306da0a5bbba78fe749673da7a1d26cada40e248ba79dac55316d6e5
+_hash: f10c5e6b84f95c94af1c1ea7efd1d9152921183548a6e7ca565476859f57504b
 file:
 - statement:
     magic_cell_segment:
-      magic_start: "-- MAGIC %md\n"
+      magic_start: -- MAGIC %md
       magic_line: '-- MAGIC # Dummy Notebook'
 - command_cell: -- COMMAND ----------
 - statement:
@@ -27,7 +27,7 @@ file:
 - command_cell: -- COMMAND ----------
 - statement:
     magic_cell_segment:
-    - magic_start: "-- MAGIC %python\n"
+    - magic_start: -- MAGIC %python
     - magic_line: "-- MAGIC foo = 'bar'"
     - magic_line: -- MAGIC print(foo)
 - command_cell: -- COMMAND ----------
@@ -49,5 +49,5 @@ file:
 - command_cell: -- COMMAND ----------
 - statement:
     magic_cell_segment:
-      magic_start: "-- MAGIC %sh\n"
+      magic_start: -- MAGIC %sh
       magic_line: -- MAGIC echo heloworld

--- a/test/fixtures/dialects/databricks/magic_line.yml
+++ b/test/fixtures/dialects/databricks/magic_line.yml
@@ -3,12 +3,13 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: f10c5e6b84f95c94af1c1ea7efd1d9152921183548a6e7ca565476859f57504b
+_hash: e5391e015a9075f664a49304b8a50b487796082d9c7edc336db9a9f300a9f381
 file:
 - statement:
     magic_cell_segment:
-      magic_start: -- MAGIC %md
-      magic_line: '-- MAGIC # Dummy Notebook'
+    - magic_start: -- MAGIC %md
+    - magic_line: '-- MAGIC # Dummy Notebook'
+    - magic_line: -- MAGIC
 - command_cell: -- COMMAND ----------
 - statement:
     select_statement:

--- a/test/fixtures/dialects/databricks/magic_single_line.sql
+++ b/test/fixtures/dialects/databricks/magic_single_line.sql
@@ -1,6 +1,6 @@
 -- Databricks notebook source
--- MAGIC %md
--- MAGIC # Dummy Notebook
+-- MAGIC %md #Dummy notebook
+-- MAGIC Some text here
 
 -- COMMAND ----------
 

--- a/test/fixtures/dialects/databricks/magic_single_line.yml
+++ b/test/fixtures/dialects/databricks/magic_single_line.yml
@@ -3,12 +3,12 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 109dda1a0a592652771dad669a38b42c18f5ec5ce36bb72711afb36689ec96d2
+_hash: 4167ff7e9380126b53c056f612b5b0d378e8c20e655e71954f6e20565ba82731
 file:
 - statement:
     magic_cell_segment:
-      magic_start: -- MAGIC %md
-      magic_line: '-- MAGIC # Dummy Notebook'
+      magic_single_line: '-- MAGIC %md #Dummy notebook'
+      magic_line: -- MAGIC Some text here
 - command_cell: -- COMMAND ----------
 - statement:
     magic_cell_segment:

--- a/test/fixtures/dialects/databricks/magic_single_line.yml
+++ b/test/fixtures/dialects/databricks/magic_single_line.yml
@@ -3,11 +3,11 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 53abfce51501062170299f9b46419942e3be5cf61b9b1e406fa8939828198942
+_hash: 109dda1a0a592652771dad669a38b42c18f5ec5ce36bb72711afb36689ec96d2
 file:
 - statement:
     magic_cell_segment:
-      magic_start: "-- MAGIC %md\n"
+      magic_start: -- MAGIC %md
       magic_line: '-- MAGIC # Dummy Notebook'
 - command_cell: -- COMMAND ----------
 - statement:


### PR DESCRIPTION
### Brief summary of the change made

* Fix Databricks magic-cell lexing so line endings remain separate newline segments, preventing false LT01 spacing violations.
Preserve correct CRLF handling for legacy magic lines.
* Also enable empty lines with only `--MAGIC`
* Regenerate affected parse fixtures and add CRLF regression coverage for magic cells.

Fixes #8376

### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves newline tokens in Databricks magic-cell lexing, fixing LT01 false positives and supporting empty `-- MAGIC` lines. Previously magic lexers consumed the line ending; now they exclude `\r\n`/`\n`, so newlines tokenize separately. Fixes #8376.

- Updates `magic_single_line`, `magic_line`, and `magic_start` regexes to exclude CR/LF and prevents `%` forms from matching the non-`%` rule; `magic_line` now accepts an empty `-- MAGIC` line.
- Extends bare magic-cell lexing to `%tensorboard`, `%set_cell_max_output_size_in_mb`, `%skip`, `%%profile`, `%%oprofile`, and `%uv pip`.
- Adds CRLF regression tests with `PyLexer` and refreshes parse fixtures. No config changes required.

<sup>Written for commit 2cea09d40705aeefa5302394e7476c4f1302aecd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8378?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

