### PR TITLE
Oracle: parse bare / division in CREATE VIEW AS SELECT

### DIFF
--- a/src/sqlfluff/dialects/dialect_oracle.py
+++ b/src/sqlfluff/dialects/dialect_oracle.py
@@ -168,6 +168,25 @@ oracle_dialect.insert_lexer_matchers(
 
 oracle_dialect.insert_lexer_matchers(
     [
+        # A SQL*Plus slash buffer-executor is a `/` alone on its own line. Lex
+        # it as a distinct token (anchored to the end of the line) so a bare
+        # `/` division operator mid-expression stays an ordinary `divide`
+        # token and isn't mistaken for the executor. Only the end of the line
+        # can be anchored here: the lexer matches from the `/` forwards, so a
+        # `/` left dangling at the end of a line (e.g. `a /` then the operand
+        # on the next line) is still treated as the executor.
+        # https://github.com/sqlfluff/sqlfluff/issues/8373
+        RegexLexer(
+            "slash_buffer_executor",
+            r"/(?=[^\S\r\n]*(?:\r?\n|$))",
+            CodeSegment,
+        ),
+    ],
+    before="divide",
+)
+
+oracle_dialect.insert_lexer_matchers(
+    [
         StringLexer("power_operator", "**", CodeSegment),
     ],
     before="star",
@@ -1475,7 +1494,9 @@ class SlashBufferExecutorSegment(BaseSegment):
     """A `/` standalone, functioning as a batch delimiter for SQL*Plus."""
 
     type = "slash_buffer_executor"
-    match_grammar = Ref("SlashSegment")
+    # Match the distinct `slash_buffer_executor` lexer token but keep the inner
+    # segment typed as a plain `slash`, so existing parse trees are unchanged.
+    match_grammar = TypedParser("slash_buffer_executor", SymbolSegment, type="slash")
 
 
 class SqlplusSetStatementSegment(BaseSegment):

--- a/test/fixtures/dialects/oracle/create_view_bare_division.sql
+++ b/test/fixtures/dialects/oracle/create_view_bare_division.sql
@@ -1,0 +1,16 @@
+-- A bare (unparenthesized) `/` division operator inside a CREATE VIEW ... AS
+-- SELECT must parse as division, not as a SQL*Plus slash buffer-executor.
+-- https://github.com/sqlfluff/sqlfluff/issues/8373
+CREATE VIEW myview AS
+SELECT 1 / 100 AS z FROM dual;
+
+CREATE VIEW ratios AS
+SELECT nvl(bytes, 0) / 1024 / 1024 AS size_mb
+FROM stats
+WHERE sample_time > sysdate - 1 / 24;
+
+-- A `/` alone on its own line is still the slash buffer-executor.
+CREATE OR REPLACE VIEW example AS
+SELECT smthng
+FROM smwhr
+/

--- a/test/fixtures/dialects/oracle/create_view_bare_division.yml
+++ b/test/fixtures/dialects/oracle/create_view_bare_division.yml
@@ -1,0 +1,112 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 44166436eb967db4994964b4d3d24da7584635a9f1554a21a828a94d9a8cea9b
+file:
+  batch:
+  - statement:
+      create_view_statement:
+      - keyword: CREATE
+      - keyword: VIEW
+      - table_reference:
+          naked_identifier: myview
+      - keyword: AS
+      - select_statement:
+          select_clause:
+            keyword: SELECT
+            select_clause_element:
+              expression:
+              - numeric_literal: '1'
+              - binary_operator: /
+              - numeric_literal: '100'
+              alias_expression:
+                alias_operator:
+                  keyword: AS
+                naked_identifier: z
+          from_clause:
+            keyword: FROM
+            from_expression:
+              from_expression_element:
+                table_expression:
+                  table_reference:
+                    naked_identifier: dual
+  - statement_terminator: ;
+  - statement:
+      create_view_statement:
+      - keyword: CREATE
+      - keyword: VIEW
+      - table_reference:
+          naked_identifier: ratios
+      - keyword: AS
+      - select_statement:
+          select_clause:
+            keyword: SELECT
+            select_clause_element:
+              expression:
+              - function:
+                  function_name:
+                    function_name_identifier: nvl
+                  function_contents:
+                    bracketed:
+                    - start_bracket: (
+                    - expression:
+                        column_reference:
+                          naked_identifier: bytes
+                    - comma: ','
+                    - expression:
+                        numeric_literal: '0'
+                    - end_bracket: )
+              - binary_operator: /
+              - numeric_literal: '1024'
+              - binary_operator: /
+              - numeric_literal: '1024'
+              alias_expression:
+                alias_operator:
+                  keyword: AS
+                naked_identifier: size_mb
+          from_clause:
+            keyword: FROM
+            from_expression:
+              from_expression_element:
+                table_expression:
+                  table_reference:
+                    naked_identifier: stats
+          where_clause:
+            keyword: WHERE
+            expression:
+            - column_reference:
+                naked_identifier: sample_time
+            - comparison_operator:
+                raw_comparison_operator: '>'
+            - bare_function: sysdate
+            - binary_operator: '-'
+            - numeric_literal: '1'
+            - binary_operator: /
+            - numeric_literal: '24'
+  - statement_terminator: ;
+  - statement:
+      create_view_statement:
+      - keyword: CREATE
+      - keyword: OR
+      - keyword: REPLACE
+      - keyword: VIEW
+      - table_reference:
+          naked_identifier: example
+      - keyword: AS
+      - select_statement:
+          select_clause:
+            keyword: SELECT
+            select_clause_element:
+              column_reference:
+                naked_identifier: smthng
+          from_clause:
+            keyword: FROM
+            from_expression:
+              from_expression_element:
+                table_expression:
+                  table_reference:
+                    naked_identifier: smwhr
+  - slash_buffer_executor:
+      slash: /


### PR DESCRIPTION
### Brief summary of the change made

Fixes #8373. A bare `/` division inside an Oracle `CREATE VIEW ... AS SELECT` was getting read as the SQL*Plus slash executor (the `AS` clause uses it as a terminator), so the select stopped dead at the `/` and the rest turned unparsable. Came in with #8067. Fix: lex a `/` sitting alone on its line as its own token so a normal division `/` stays normal. Kept it typed as `slash` underneath so no fixtures moved.

### Are there any other side effects?

Only looks at the line end, not the start, so `a /` with the operand on the next line still reads as the executor. Haven't seen anyone write division that way though.

### Pull Request checklist

- [x] Parser test cases (`create_view_bare_division`).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Correctly parses division `/` inside Oracle `CREATE VIEW ... AS SELECT`. Previously, `/` was treated as the SQL*Plus slash buffer executor and prematurely terminated the SELECT; now only a `/` alone on its own line is the executor.

- Insert a `RegexLexer("slash_buffer_executor", r"/(?=[^\S\r\n]*(?:\r?\n|$))")` before the `divide` matcher in the Oracle lexer.
- Keep parse trees stable: `SlashBufferExecutorSegment` matches the new token but preserves the inner segment type as `slash`.
- Add fixtures covering inline division and a standalone-line `/`.
- Edge case: `a /` at the end of a line with the right operand on the next line is still treated as the executor.

<sup>Written for commit c7b95264b6eeb45f7c810914e2c7232f04c6919c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8379?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

