### PR TITLE
fix: Parse MySQL IF statements as ordered compound statements

### DIFF
--- a/src/sqlfluff/dialects/dialect_mysql.py
+++ b/src/sqlfluff/dialects/dialect_mysql.py
@@ -2450,15 +2450,17 @@ class IfStatementListSegment(BaseSegment):
 
     match_grammar = AnyNumberOf(
         Sequence(
-            Ref("StatementSegment"),
+            Ref(
+                "StatementSegment",
+                exclude=OneOf(
+                    "ELSEIF",
+                    "ELSE",
+                    Sequence("END", "IF"),
+                ),
+            ),
             Ref("DelimiterGrammar"),
         ),
-        terminators=[
-            "ELSEIF",
-            "ELSE",
-            Sequence("END", "IF"),
-        ],
-        reset_terminators=True,
+        min_times=1,
     )
 
 
@@ -2475,7 +2477,7 @@ class IfExpressionStatement(BaseSegment):
         Ref("ExpressionSegment"),
         "THEN",
         Indent,
-        Ref("IfStatementListSegment", optional=True),
+        Ref("IfStatementListSegment"),
         Dedent,
         AnyNumberOf(
             Sequence(
@@ -2483,14 +2485,14 @@ class IfExpressionStatement(BaseSegment):
                 Ref("ExpressionSegment"),
                 "THEN",
                 Indent,
-                Ref("IfStatementListSegment", optional=True),
+                Ref("IfStatementListSegment"),
                 Dedent,
             ),
         ),
         Sequence(
             "ELSE",
             Indent,
-            Ref("IfStatementListSegment", optional=True),
+            Ref("IfStatementListSegment"),
             Dedent,
             optional=True,
         ),

--- a/src/sqlfluff/dialects/dialect_mysql.py
+++ b/src/sqlfluff/dialects/dialect_mysql.py
@@ -2443,6 +2443,25 @@ class TransactionStatementSegment(BaseSegment):
     )
 
 
+class IfStatementListSegment(BaseSegment):
+    """Statements within an IF...END IF statement."""
+
+    type = "if_statement_list"
+
+    match_grammar = AnyNumberOf(
+        Sequence(
+            Ref("StatementSegment"),
+            Ref("DelimiterGrammar"),
+        ),
+        terminators=[
+            "ELSEIF",
+            "ELSE",
+            Sequence("END", "IF"),
+        ],
+        reset_terminators=True,
+    )
+
+
 class IfExpressionStatement(BaseSegment):
     """IF-THEN-ELSE-ELSEIF-END IF statement.
 
@@ -2451,21 +2470,32 @@ class IfExpressionStatement(BaseSegment):
 
     type = "if_then_statement"
 
-    match_grammar = AnyNumberOf(
-        Sequence(
-            "IF",
-            Ref("ExpressionSegment"),
-            "THEN",
-            Ref("StatementSegment"),
+    match_grammar = Sequence(
+        "IF",
+        Ref("ExpressionSegment"),
+        "THEN",
+        Indent,
+        Ref("IfStatementListSegment", optional=True),
+        Dedent,
+        AnyNumberOf(
+            Sequence(
+                "ELSEIF",
+                Ref("ExpressionSegment"),
+                "THEN",
+                Indent,
+                Ref("IfStatementListSegment", optional=True),
+                Dedent,
+            ),
         ),
         Sequence(
-            "ELSEIF",
-            Ref("ExpressionSegment"),
-            "THEN",
-            Ref("StatementSegment"),
+            "ELSE",
+            Indent,
+            Ref("IfStatementListSegment", optional=True),
+            Dedent,
+            optional=True,
         ),
-        Sequence("ELSE", Ref("StatementSegment"), optional=True),
-        Sequence("END", "IF"),
+        "END",
+        "IF",
     )
 
 

--- a/test/dialects/mysql_test.py
+++ b/test/dialects/mysql_test.py
@@ -15,12 +15,16 @@ from _pytest.logging import LogCaptureFixture
         "IF x = 0 THEN SELECT 1;",
         "IF x = 0 THEN SELECT 1; ELSE SELECT 2; ELSEIF x = 1 THEN SELECT 3; END IF",
         "IF x = 0 THEN SELECT 1; ELSE SELECT 2; ELSE SELECT 3; END IF",
+        "IF x = 0 THEN END IF",
+        "IF x = 0 THEN SELECT 1; ELSEIF x = 1 THEN END IF",
+        "IF x = 0 THEN SELECT 1; ELSE END IF",
+        "IF x = 0 THEN SELECT 1 END IF",
     ],
 )
-def test_mysql_if_statement_does_not_match_invalid_clause_order(
+def test_mysql_if_statement_does_not_match_invalid_syntax(
     raw: str,
     caplog: LogCaptureFixture,
     dialect_specific_segment_not_match: Callable,
 ) -> None:
-    """Test that invalid IF statement forms do not match."""
+    """Test that invalid IF statements do not match."""
     dialect_specific_segment_not_match("mysql", "IfExpressionStatement", raw, caplog)

--- a/test/dialects/mysql_test.py
+++ b/test/dialects/mysql_test.py
@@ -1,0 +1,26 @@
+"""Tests specific to the MySQL dialect."""
+
+from typing import Callable
+
+import pytest
+from _pytest.logging import LogCaptureFixture
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "ELSEIF x = 1 THEN SELECT 1; END IF",
+        "ELSE SELECT 1; END IF",
+        "x = 0 THEN SELECT 1; END IF",
+        "IF x = 0 THEN SELECT 1;",
+        "IF x = 0 THEN SELECT 1; ELSE SELECT 2; ELSEIF x = 1 THEN SELECT 3; END IF",
+        "IF x = 0 THEN SELECT 1; ELSE SELECT 2; ELSE SELECT 3; END IF",
+    ],
+)
+def test_mysql_if_statement_does_not_match_invalid_clause_order(
+    raw: str,
+    caplog: LogCaptureFixture,
+    dialect_specific_segment_not_match: Callable,
+) -> None:
+    """Test that invalid IF statement forms do not match."""
+    dialect_specific_segment_not_match("mysql", "IfExpressionStatement", raw, caplog)

--- a/test/fixtures/dialects/mariadb/if.yml
+++ b/test/fixtures/dialects/mariadb/if.yml
@@ -3,9 +3,9 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: da9fd2e77d3348ffe9c07370381c002cd0968f76c1863adb19a260b7f9aa396a
+_hash: 27f59c485a128f222dfdef84aa7db0663ebd48d8eb1d490a4abcd4b7ec2b0008
 file:
-- statement:
+  statement:
     if_then_statement:
     - keyword: if
     - expression:
@@ -19,23 +19,22 @@ file:
             numeric_literal: '0'
           end_bracket: )
     - keyword: then
-    - statement:
-        set_statement:
-          keyword: set
-          variable: '@errmsg'
-          comparison_operator:
-            raw_comparison_operator: '='
-          quoted_literal: "''"
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-        keyword: select
-        select_clause_element:
-          numeric_literal: '1'
-- statement_terminator: ;
-- statement:
-    if_then_statement:
+    - if_statement_list:
+      - statement:
+          set_statement:
+            keyword: set
+            variable: '@errmsg'
+            comparison_operator:
+              raw_comparison_operator: '='
+            quoted_literal: "''"
+      - statement_terminator: ;
+      - statement:
+          select_statement:
+            select_clause:
+              keyword: select
+              select_clause_element:
+                numeric_literal: '1'
+      - statement_terminator: ;
     - keyword: end
     - keyword: if
-- statement_terminator: ;
+  statement_terminator: ;

--- a/test/fixtures/dialects/mariadb/if_else.sql
+++ b/test/fixtures/dialects/mariadb/if_else.sql
@@ -2,4 +2,5 @@ if (x = 0) then
 set @errmsg = '';
 select 1;
 else
+select 2;
 end if;

--- a/test/fixtures/dialects/mariadb/if_else.yml
+++ b/test/fixtures/dialects/mariadb/if_else.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: b5c577e6fce17c036998bf6083ea37786a8bcd0144672f75100925af8e122a37
+_hash: 5d939dd6aedf3731816d4d13f98e04ffb4fd9d22a30e0626d2583f18b8f3bdd7
 file:
   statement:
     if_then_statement:
@@ -36,6 +36,14 @@ file:
                 numeric_literal: '1'
       - statement_terminator: ;
     - keyword: else
+    - if_statement_list:
+        statement:
+          select_statement:
+            select_clause:
+              keyword: select
+              select_clause_element:
+                numeric_literal: '2'
+        statement_terminator: ;
     - keyword: end
     - keyword: if
   statement_terminator: ;

--- a/test/fixtures/dialects/mariadb/if_else.yml
+++ b/test/fixtures/dialects/mariadb/if_else.yml
@@ -3,9 +3,9 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 69efae2cc2e5a1387423945d404086dba866559c76178f3462f598157ce7bb77
+_hash: b5c577e6fce17c036998bf6083ea37786a8bcd0144672f75100925af8e122a37
 file:
-- statement:
+  statement:
     if_then_statement:
     - keyword: if
     - expression:
@@ -19,26 +19,23 @@ file:
             numeric_literal: '0'
           end_bracket: )
     - keyword: then
-    - statement:
-        set_statement:
-          keyword: set
-          variable: '@errmsg'
-          comparison_operator:
-            raw_comparison_operator: '='
-          quoted_literal: "''"
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-        keyword: select
-        select_clause_element:
-          numeric_literal: '1'
-- statement_terminator: ;
-- statement:
-    if_then_statement:
-      keyword: else
-      statement:
-        if_then_statement:
-        - keyword: end
-        - keyword: if
-- statement_terminator: ;
+    - if_statement_list:
+      - statement:
+          set_statement:
+            keyword: set
+            variable: '@errmsg'
+            comparison_operator:
+              raw_comparison_operator: '='
+            quoted_literal: "''"
+      - statement_terminator: ;
+      - statement:
+          select_statement:
+            select_clause:
+              keyword: select
+              select_clause_element:
+                numeric_literal: '1'
+      - statement_terminator: ;
+    - keyword: else
+    - keyword: end
+    - keyword: if
+  statement_terminator: ;

--- a/test/fixtures/dialects/mariadb/if_elseif.sql
+++ b/test/fixtures/dialects/mariadb/if_elseif.sql
@@ -3,6 +3,8 @@ set @errmsg = '';
 select 1;
 elseif (x = 1) then
 set _test = 1;
+elseif (x = 2) then
+set _test = 2;
 else
 select 2;
 end if;

--- a/test/fixtures/dialects/mariadb/if_elseif.yml
+++ b/test/fixtures/dialects/mariadb/if_elseif.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: d39dae77d4fcb17baeef3b49b0e6e9393ea3b46429e8c93f33bfa01e3154fa25
+_hash: dad8749ab0f02c7bb73240f15466270bd3a32bee78fb55a7d6de0817e260c230
 file:
   statement:
     if_then_statement:
@@ -55,6 +55,27 @@ file:
             comparison_operator:
               raw_comparison_operator: '='
             numeric_literal: '1'
+        statement_terminator: ;
+    - keyword: elseif
+    - expression:
+        bracketed:
+          start_bracket: (
+          expression:
+            column_reference:
+              naked_identifier: x
+            comparison_operator:
+              raw_comparison_operator: '='
+            numeric_literal: '2'
+          end_bracket: )
+    - keyword: then
+    - if_statement_list:
+        statement:
+          set_statement:
+            keyword: set
+            variable: _test
+            comparison_operator:
+              raw_comparison_operator: '='
+            numeric_literal: '2'
         statement_terminator: ;
     - keyword: else
     - if_statement_list:

--- a/test/fixtures/dialects/mariadb/if_elseif.yml
+++ b/test/fixtures/dialects/mariadb/if_elseif.yml
@@ -3,9 +3,9 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: b03d179afec3edaf60243ad42bbd2ff4372a446e28fd033ec04c0b17e74adf7e
+_hash: d39dae77d4fcb17baeef3b49b0e6e9393ea3b46429e8c93f33bfa01e3154fa25
 file:
-- statement:
+  statement:
     if_then_statement:
     - keyword: if
     - expression:
@@ -19,23 +19,22 @@ file:
             numeric_literal: '0'
           end_bracket: )
     - keyword: then
-    - statement:
-        set_statement:
-          keyword: set
-          variable: '@errmsg'
-          comparison_operator:
-            raw_comparison_operator: '='
-          quoted_literal: "''"
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-        keyword: select
-        select_clause_element:
-          numeric_literal: '1'
-- statement_terminator: ;
-- statement:
-    if_then_statement:
+    - if_statement_list:
+      - statement:
+          set_statement:
+            keyword: set
+            variable: '@errmsg'
+            comparison_operator:
+              raw_comparison_operator: '='
+            quoted_literal: "''"
+      - statement_terminator: ;
+      - statement:
+          select_statement:
+            select_clause:
+              keyword: select
+              select_clause_element:
+                numeric_literal: '1'
+      - statement_terminator: ;
     - keyword: elseif
     - expression:
         bracketed:
@@ -48,26 +47,24 @@ file:
             numeric_literal: '1'
           end_bracket: )
     - keyword: then
-    - statement:
-        set_statement:
-          keyword: set
-          variable: _test
-          comparison_operator:
-            raw_comparison_operator: '='
-          numeric_literal: '1'
-- statement_terminator: ;
-- statement:
-    if_then_statement:
-      keyword: else
-      statement:
-        select_statement:
-          select_clause:
-            keyword: select
-            select_clause_element:
-              numeric_literal: '2'
-- statement_terminator: ;
-- statement:
-    if_then_statement:
+    - if_statement_list:
+        statement:
+          set_statement:
+            keyword: set
+            variable: _test
+            comparison_operator:
+              raw_comparison_operator: '='
+            numeric_literal: '1'
+        statement_terminator: ;
+    - keyword: else
+    - if_statement_list:
+        statement:
+          select_statement:
+            select_clause:
+              keyword: select
+              select_clause_element:
+                numeric_literal: '2'
+        statement_terminator: ;
     - keyword: end
     - keyword: if
-- statement_terminator: ;
+  statement_terminator: ;

--- a/test/fixtures/dialects/mariadb/if_multiple_expression.yml
+++ b/test/fixtures/dialects/mariadb/if_multiple_expression.yml
@@ -3,9 +3,9 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: e29aea27c8f69eaf0019d88861f60a0204978037b4d672f5d74daa3054b5db49
+_hash: 2cbec091810d462ef1cba38f90d18f65b684be371bb6c991211d471877f66fa8
 file:
-- statement:
+  statement:
     if_then_statement:
     - keyword: if
     - expression:
@@ -46,23 +46,22 @@ file:
           - numeric_literal: '1'
           end_bracket: )
     - keyword: then
-    - statement:
-        set_statement:
-          keyword: set
-          variable: '@errmsg'
-          comparison_operator:
-            raw_comparison_operator: '='
-          quoted_literal: "''"
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-        keyword: select
-        select_clause_element:
-          numeric_literal: '1'
-- statement_terminator: ;
-- statement:
-    if_then_statement:
+    - if_statement_list:
+      - statement:
+          set_statement:
+            keyword: set
+            variable: '@errmsg'
+            comparison_operator:
+              raw_comparison_operator: '='
+            quoted_literal: "''"
+      - statement_terminator: ;
+      - statement:
+          select_statement:
+            select_clause:
+              keyword: select
+              select_clause_element:
+                numeric_literal: '1'
+      - statement_terminator: ;
     - keyword: end
     - keyword: if
-- statement_terminator: ;
+  statement_terminator: ;

--- a/test/fixtures/dialects/mariadb/if_nested.sql
+++ b/test/fixtures/dialects/mariadb/if_nested.sql
@@ -5,3 +5,7 @@ set @errmsg = '';
 select 1;
 end if;
 end if;
+
+if (x = 0) then
+select case when a = 1 then 1 else 2 end;
+end if;

--- a/test/fixtures/dialects/mariadb/if_nested.yml
+++ b/test/fixtures/dialects/mariadb/if_nested.yml
@@ -3,9 +3,9 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 07c6e891e87ea4ccbb9c0fe4cd9ba3ef478c0a6511409b6f00e0effd5d086b99
+_hash: f994973c259616b721927dc9374c5ebed1e0137928600f736d5a6650fce885eb
 file:
-  statement:
+- statement:
     if_then_statement:
     - keyword: if
     - expression:
@@ -62,4 +62,47 @@ file:
       - statement_terminator: ;
     - keyword: end
     - keyword: if
-  statement_terminator: ;
+- statement_terminator: ;
+- statement:
+    if_then_statement:
+    - keyword: if
+    - expression:
+        bracketed:
+          start_bracket: (
+          expression:
+            column_reference:
+              naked_identifier: x
+            comparison_operator:
+              raw_comparison_operator: '='
+            numeric_literal: '0'
+          end_bracket: )
+    - keyword: then
+    - if_statement_list:
+        statement:
+          select_statement:
+            select_clause:
+              keyword: select
+              select_clause_element:
+                expression:
+                  case_expression:
+                  - keyword: case
+                  - when_clause:
+                    - keyword: when
+                    - expression:
+                        column_reference:
+                          naked_identifier: a
+                        comparison_operator:
+                          raw_comparison_operator: '='
+                        numeric_literal: '1'
+                    - keyword: then
+                    - expression:
+                        numeric_literal: '1'
+                  - else_clause:
+                      keyword: else
+                      expression:
+                        numeric_literal: '2'
+                  - keyword: end
+        statement_terminator: ;
+    - keyword: end
+    - keyword: if
+- statement_terminator: ;

--- a/test/fixtures/dialects/mariadb/if_nested.yml
+++ b/test/fixtures/dialects/mariadb/if_nested.yml
@@ -3,9 +3,9 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: b374d03f02f5c7eb800e9262fd5075764b7775db085d5eb2fe21e78c8d5ab96d
+_hash: 07c6e891e87ea4ccbb9c0fe4cd9ba3ef478c0a6511409b6f00e0effd5d086b99
 file:
-- statement:
+  statement:
     if_then_statement:
     - keyword: if
     - expression:
@@ -19,49 +19,47 @@ file:
             numeric_literal: '0'
           end_bracket: )
     - keyword: then
-    - statement:
-        select_statement:
-          select_clause:
-            keyword: select
-            select_clause_element:
-              numeric_literal: '0'
-- statement_terminator: ;
-- statement:
-    if_then_statement:
-    - keyword: if
-    - expression:
-        bracketed:
-          start_bracket: (
-          expression:
-            column_reference:
-              naked_identifier: y
-            comparison_operator:
-              raw_comparison_operator: '='
-            numeric_literal: '1'
-          end_bracket: )
-    - keyword: then
-    - statement:
-        set_statement:
-          keyword: set
-          variable: '@errmsg'
-          comparison_operator:
-            raw_comparison_operator: '='
-          quoted_literal: "''"
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-        keyword: select
-        select_clause_element:
-          numeric_literal: '1'
-- statement_terminator: ;
-- statement:
-    if_then_statement:
+    - if_statement_list:
+      - statement:
+          select_statement:
+            select_clause:
+              keyword: select
+              select_clause_element:
+                numeric_literal: '0'
+      - statement_terminator: ;
+      - statement:
+          if_then_statement:
+          - keyword: if
+          - expression:
+              bracketed:
+                start_bracket: (
+                expression:
+                  column_reference:
+                    naked_identifier: y
+                  comparison_operator:
+                    raw_comparison_operator: '='
+                  numeric_literal: '1'
+                end_bracket: )
+          - keyword: then
+          - if_statement_list:
+            - statement:
+                set_statement:
+                  keyword: set
+                  variable: '@errmsg'
+                  comparison_operator:
+                    raw_comparison_operator: '='
+                  quoted_literal: "''"
+            - statement_terminator: ;
+            - statement:
+                select_statement:
+                  select_clause:
+                    keyword: select
+                    select_clause_element:
+                      numeric_literal: '1'
+            - statement_terminator: ;
+          - keyword: end
+          - keyword: if
+      - statement_terminator: ;
     - keyword: end
     - keyword: if
-- statement_terminator: ;
-- statement:
-    if_then_statement:
-    - keyword: end
-    - keyword: if
-- statement_terminator: ;
+  statement_terminator: ;

--- a/test/fixtures/dialects/mariadb/if_session_variable.yml
+++ b/test/fixtures/dialects/mariadb/if_session_variable.yml
@@ -3,9 +3,9 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: fdd4b0c9117b6b228762f9b46873ba13b9207f58d2cdeb6a2ebadc2068dea99f
+_hash: a1190ff7fa9c6b8be25e6fa3cb12476c026c171e454b58ee98fac80ee3196d41
 file:
-- statement:
+  statement:
     if_then_statement:
     - keyword: if
     - expression:
@@ -18,23 +18,22 @@ file:
             numeric_literal: '0'
           end_bracket: )
     - keyword: then
-    - statement:
-        set_statement:
-          keyword: set
-          variable: '@b'
-          comparison_operator:
-            raw_comparison_operator: '='
-          quoted_literal: "''"
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-        keyword: select
-        select_clause_element:
-          numeric_literal: '1'
-- statement_terminator: ;
-- statement:
-    if_then_statement:
+    - if_statement_list:
+      - statement:
+          set_statement:
+            keyword: set
+            variable: '@b'
+            comparison_operator:
+              raw_comparison_operator: '='
+            quoted_literal: "''"
+      - statement_terminator: ;
+      - statement:
+          select_statement:
+            select_clause:
+              keyword: select
+              select_clause_element:
+                numeric_literal: '1'
+      - statement_terminator: ;
     - keyword: end
     - keyword: if
-- statement_terminator: ;
+  statement_terminator: ;

--- a/test/fixtures/dialects/mariadb/if_subquery_expression.yml
+++ b/test/fixtures/dialects/mariadb/if_subquery_expression.yml
@@ -3,9 +3,9 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 5626b33570f2e08309801628d9fd5dc612419586627f73721e2abb1adc1028cc
+_hash: 71e4844eadd31d43ec2ea2960b13f0943cb61f94f31ee6aecae329a4456fd9b0
 file:
-- statement:
+  statement:
     if_then_statement:
     - keyword: if
     - expression:
@@ -40,23 +40,22 @@ file:
             numeric_literal: '0'
           end_bracket: )
     - keyword: then
-    - statement:
-        set_statement:
-          keyword: set
-          variable: '@errmsg'
-          comparison_operator:
-            raw_comparison_operator: '='
-          quoted_literal: "''"
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-        keyword: select
-        select_clause_element:
-          numeric_literal: '1'
-- statement_terminator: ;
-- statement:
-    if_then_statement:
+    - if_statement_list:
+      - statement:
+          set_statement:
+            keyword: set
+            variable: '@errmsg'
+            comparison_operator:
+              raw_comparison_operator: '='
+            quoted_literal: "''"
+      - statement_terminator: ;
+      - statement:
+          select_statement:
+            select_clause:
+              keyword: select
+              select_clause_element:
+                numeric_literal: '1'
+      - statement_terminator: ;
     - keyword: end
     - keyword: if
-- statement_terminator: ;
+  statement_terminator: ;

--- a/test/fixtures/dialects/mysql/if.yml
+++ b/test/fixtures/dialects/mysql/if.yml
@@ -3,9 +3,9 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: da9fd2e77d3348ffe9c07370381c002cd0968f76c1863adb19a260b7f9aa396a
+_hash: 27f59c485a128f222dfdef84aa7db0663ebd48d8eb1d490a4abcd4b7ec2b0008
 file:
-- statement:
+  statement:
     if_then_statement:
     - keyword: if
     - expression:
@@ -19,23 +19,22 @@ file:
             numeric_literal: '0'
           end_bracket: )
     - keyword: then
-    - statement:
-        set_statement:
-          keyword: set
-          variable: '@errmsg'
-          comparison_operator:
-            raw_comparison_operator: '='
-          quoted_literal: "''"
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-        keyword: select
-        select_clause_element:
-          numeric_literal: '1'
-- statement_terminator: ;
-- statement:
-    if_then_statement:
+    - if_statement_list:
+      - statement:
+          set_statement:
+            keyword: set
+            variable: '@errmsg'
+            comparison_operator:
+              raw_comparison_operator: '='
+            quoted_literal: "''"
+      - statement_terminator: ;
+      - statement:
+          select_statement:
+            select_clause:
+              keyword: select
+              select_clause_element:
+                numeric_literal: '1'
+      - statement_terminator: ;
     - keyword: end
     - keyword: if
-- statement_terminator: ;
+  statement_terminator: ;

--- a/test/fixtures/dialects/mysql/if_else.sql
+++ b/test/fixtures/dialects/mysql/if_else.sql
@@ -2,4 +2,5 @@ if (x = 0) then
 set @errmsg = '';
 select 1;
 else
+select 2;
 end if;

--- a/test/fixtures/dialects/mysql/if_else.yml
+++ b/test/fixtures/dialects/mysql/if_else.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: b5c577e6fce17c036998bf6083ea37786a8bcd0144672f75100925af8e122a37
+_hash: 5d939dd6aedf3731816d4d13f98e04ffb4fd9d22a30e0626d2583f18b8f3bdd7
 file:
   statement:
     if_then_statement:
@@ -36,6 +36,14 @@ file:
                 numeric_literal: '1'
       - statement_terminator: ;
     - keyword: else
+    - if_statement_list:
+        statement:
+          select_statement:
+            select_clause:
+              keyword: select
+              select_clause_element:
+                numeric_literal: '2'
+        statement_terminator: ;
     - keyword: end
     - keyword: if
   statement_terminator: ;

--- a/test/fixtures/dialects/mysql/if_else.yml
+++ b/test/fixtures/dialects/mysql/if_else.yml
@@ -3,9 +3,9 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 69efae2cc2e5a1387423945d404086dba866559c76178f3462f598157ce7bb77
+_hash: b5c577e6fce17c036998bf6083ea37786a8bcd0144672f75100925af8e122a37
 file:
-- statement:
+  statement:
     if_then_statement:
     - keyword: if
     - expression:
@@ -19,26 +19,23 @@ file:
             numeric_literal: '0'
           end_bracket: )
     - keyword: then
-    - statement:
-        set_statement:
-          keyword: set
-          variable: '@errmsg'
-          comparison_operator:
-            raw_comparison_operator: '='
-          quoted_literal: "''"
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-        keyword: select
-        select_clause_element:
-          numeric_literal: '1'
-- statement_terminator: ;
-- statement:
-    if_then_statement:
-      keyword: else
-      statement:
-        if_then_statement:
-        - keyword: end
-        - keyword: if
-- statement_terminator: ;
+    - if_statement_list:
+      - statement:
+          set_statement:
+            keyword: set
+            variable: '@errmsg'
+            comparison_operator:
+              raw_comparison_operator: '='
+            quoted_literal: "''"
+      - statement_terminator: ;
+      - statement:
+          select_statement:
+            select_clause:
+              keyword: select
+              select_clause_element:
+                numeric_literal: '1'
+      - statement_terminator: ;
+    - keyword: else
+    - keyword: end
+    - keyword: if
+  statement_terminator: ;

--- a/test/fixtures/dialects/mysql/if_elseif.sql
+++ b/test/fixtures/dialects/mysql/if_elseif.sql
@@ -3,6 +3,8 @@ set @errmsg = '';
 select 1;
 elseif (x = 1) then
 set _test = 1;
+elseif (x = 2) then
+set _test = 2;
 else
 select 2;
 end if;

--- a/test/fixtures/dialects/mysql/if_elseif.yml
+++ b/test/fixtures/dialects/mysql/if_elseif.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: d39dae77d4fcb17baeef3b49b0e6e9393ea3b46429e8c93f33bfa01e3154fa25
+_hash: dad8749ab0f02c7bb73240f15466270bd3a32bee78fb55a7d6de0817e260c230
 file:
   statement:
     if_then_statement:
@@ -55,6 +55,27 @@ file:
             comparison_operator:
               raw_comparison_operator: '='
             numeric_literal: '1'
+        statement_terminator: ;
+    - keyword: elseif
+    - expression:
+        bracketed:
+          start_bracket: (
+          expression:
+            column_reference:
+              naked_identifier: x
+            comparison_operator:
+              raw_comparison_operator: '='
+            numeric_literal: '2'
+          end_bracket: )
+    - keyword: then
+    - if_statement_list:
+        statement:
+          set_statement:
+            keyword: set
+            variable: _test
+            comparison_operator:
+              raw_comparison_operator: '='
+            numeric_literal: '2'
         statement_terminator: ;
     - keyword: else
     - if_statement_list:

--- a/test/fixtures/dialects/mysql/if_elseif.yml
+++ b/test/fixtures/dialects/mysql/if_elseif.yml
@@ -3,9 +3,9 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: b03d179afec3edaf60243ad42bbd2ff4372a446e28fd033ec04c0b17e74adf7e
+_hash: d39dae77d4fcb17baeef3b49b0e6e9393ea3b46429e8c93f33bfa01e3154fa25
 file:
-- statement:
+  statement:
     if_then_statement:
     - keyword: if
     - expression:
@@ -19,23 +19,22 @@ file:
             numeric_literal: '0'
           end_bracket: )
     - keyword: then
-    - statement:
-        set_statement:
-          keyword: set
-          variable: '@errmsg'
-          comparison_operator:
-            raw_comparison_operator: '='
-          quoted_literal: "''"
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-        keyword: select
-        select_clause_element:
-          numeric_literal: '1'
-- statement_terminator: ;
-- statement:
-    if_then_statement:
+    - if_statement_list:
+      - statement:
+          set_statement:
+            keyword: set
+            variable: '@errmsg'
+            comparison_operator:
+              raw_comparison_operator: '='
+            quoted_literal: "''"
+      - statement_terminator: ;
+      - statement:
+          select_statement:
+            select_clause:
+              keyword: select
+              select_clause_element:
+                numeric_literal: '1'
+      - statement_terminator: ;
     - keyword: elseif
     - expression:
         bracketed:
@@ -48,26 +47,24 @@ file:
             numeric_literal: '1'
           end_bracket: )
     - keyword: then
-    - statement:
-        set_statement:
-          keyword: set
-          variable: _test
-          comparison_operator:
-            raw_comparison_operator: '='
-          numeric_literal: '1'
-- statement_terminator: ;
-- statement:
-    if_then_statement:
-      keyword: else
-      statement:
-        select_statement:
-          select_clause:
-            keyword: select
-            select_clause_element:
-              numeric_literal: '2'
-- statement_terminator: ;
-- statement:
-    if_then_statement:
+    - if_statement_list:
+        statement:
+          set_statement:
+            keyword: set
+            variable: _test
+            comparison_operator:
+              raw_comparison_operator: '='
+            numeric_literal: '1'
+        statement_terminator: ;
+    - keyword: else
+    - if_statement_list:
+        statement:
+          select_statement:
+            select_clause:
+              keyword: select
+              select_clause_element:
+                numeric_literal: '2'
+        statement_terminator: ;
     - keyword: end
     - keyword: if
-- statement_terminator: ;
+  statement_terminator: ;

--- a/test/fixtures/dialects/mysql/if_multiple_expression.yml
+++ b/test/fixtures/dialects/mysql/if_multiple_expression.yml
@@ -3,9 +3,9 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: e29aea27c8f69eaf0019d88861f60a0204978037b4d672f5d74daa3054b5db49
+_hash: 2cbec091810d462ef1cba38f90d18f65b684be371bb6c991211d471877f66fa8
 file:
-- statement:
+  statement:
     if_then_statement:
     - keyword: if
     - expression:
@@ -46,23 +46,22 @@ file:
           - numeric_literal: '1'
           end_bracket: )
     - keyword: then
-    - statement:
-        set_statement:
-          keyword: set
-          variable: '@errmsg'
-          comparison_operator:
-            raw_comparison_operator: '='
-          quoted_literal: "''"
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-        keyword: select
-        select_clause_element:
-          numeric_literal: '1'
-- statement_terminator: ;
-- statement:
-    if_then_statement:
+    - if_statement_list:
+      - statement:
+          set_statement:
+            keyword: set
+            variable: '@errmsg'
+            comparison_operator:
+              raw_comparison_operator: '='
+            quoted_literal: "''"
+      - statement_terminator: ;
+      - statement:
+          select_statement:
+            select_clause:
+              keyword: select
+              select_clause_element:
+                numeric_literal: '1'
+      - statement_terminator: ;
     - keyword: end
     - keyword: if
-- statement_terminator: ;
+  statement_terminator: ;

--- a/test/fixtures/dialects/mysql/if_nested.sql
+++ b/test/fixtures/dialects/mysql/if_nested.sql
@@ -5,3 +5,7 @@ set @errmsg = '';
 select 1;
 end if;
 end if;
+
+if (x = 0) then
+select case when a = 1 then 1 else 2 end;
+end if;

--- a/test/fixtures/dialects/mysql/if_nested.yml
+++ b/test/fixtures/dialects/mysql/if_nested.yml
@@ -3,9 +3,9 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 07c6e891e87ea4ccbb9c0fe4cd9ba3ef478c0a6511409b6f00e0effd5d086b99
+_hash: f994973c259616b721927dc9374c5ebed1e0137928600f736d5a6650fce885eb
 file:
-  statement:
+- statement:
     if_then_statement:
     - keyword: if
     - expression:
@@ -62,4 +62,47 @@ file:
       - statement_terminator: ;
     - keyword: end
     - keyword: if
-  statement_terminator: ;
+- statement_terminator: ;
+- statement:
+    if_then_statement:
+    - keyword: if
+    - expression:
+        bracketed:
+          start_bracket: (
+          expression:
+            column_reference:
+              naked_identifier: x
+            comparison_operator:
+              raw_comparison_operator: '='
+            numeric_literal: '0'
+          end_bracket: )
+    - keyword: then
+    - if_statement_list:
+        statement:
+          select_statement:
+            select_clause:
+              keyword: select
+              select_clause_element:
+                expression:
+                  case_expression:
+                  - keyword: case
+                  - when_clause:
+                    - keyword: when
+                    - expression:
+                        column_reference:
+                          naked_identifier: a
+                        comparison_operator:
+                          raw_comparison_operator: '='
+                        numeric_literal: '1'
+                    - keyword: then
+                    - expression:
+                        numeric_literal: '1'
+                  - else_clause:
+                      keyword: else
+                      expression:
+                        numeric_literal: '2'
+                  - keyword: end
+        statement_terminator: ;
+    - keyword: end
+    - keyword: if
+- statement_terminator: ;

--- a/test/fixtures/dialects/mysql/if_nested.yml
+++ b/test/fixtures/dialects/mysql/if_nested.yml
@@ -3,9 +3,9 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: b374d03f02f5c7eb800e9262fd5075764b7775db085d5eb2fe21e78c8d5ab96d
+_hash: 07c6e891e87ea4ccbb9c0fe4cd9ba3ef478c0a6511409b6f00e0effd5d086b99
 file:
-- statement:
+  statement:
     if_then_statement:
     - keyword: if
     - expression:
@@ -19,49 +19,47 @@ file:
             numeric_literal: '0'
           end_bracket: )
     - keyword: then
-    - statement:
-        select_statement:
-          select_clause:
-            keyword: select
-            select_clause_element:
-              numeric_literal: '0'
-- statement_terminator: ;
-- statement:
-    if_then_statement:
-    - keyword: if
-    - expression:
-        bracketed:
-          start_bracket: (
-          expression:
-            column_reference:
-              naked_identifier: y
-            comparison_operator:
-              raw_comparison_operator: '='
-            numeric_literal: '1'
-          end_bracket: )
-    - keyword: then
-    - statement:
-        set_statement:
-          keyword: set
-          variable: '@errmsg'
-          comparison_operator:
-            raw_comparison_operator: '='
-          quoted_literal: "''"
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-        keyword: select
-        select_clause_element:
-          numeric_literal: '1'
-- statement_terminator: ;
-- statement:
-    if_then_statement:
+    - if_statement_list:
+      - statement:
+          select_statement:
+            select_clause:
+              keyword: select
+              select_clause_element:
+                numeric_literal: '0'
+      - statement_terminator: ;
+      - statement:
+          if_then_statement:
+          - keyword: if
+          - expression:
+              bracketed:
+                start_bracket: (
+                expression:
+                  column_reference:
+                    naked_identifier: y
+                  comparison_operator:
+                    raw_comparison_operator: '='
+                  numeric_literal: '1'
+                end_bracket: )
+          - keyword: then
+          - if_statement_list:
+            - statement:
+                set_statement:
+                  keyword: set
+                  variable: '@errmsg'
+                  comparison_operator:
+                    raw_comparison_operator: '='
+                  quoted_literal: "''"
+            - statement_terminator: ;
+            - statement:
+                select_statement:
+                  select_clause:
+                    keyword: select
+                    select_clause_element:
+                      numeric_literal: '1'
+            - statement_terminator: ;
+          - keyword: end
+          - keyword: if
+      - statement_terminator: ;
     - keyword: end
     - keyword: if
-- statement_terminator: ;
-- statement:
-    if_then_statement:
-    - keyword: end
-    - keyword: if
-- statement_terminator: ;
+  statement_terminator: ;

--- a/test/fixtures/dialects/mysql/if_session_variable.yml
+++ b/test/fixtures/dialects/mysql/if_session_variable.yml
@@ -3,9 +3,9 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: fdd4b0c9117b6b228762f9b46873ba13b9207f58d2cdeb6a2ebadc2068dea99f
+_hash: a1190ff7fa9c6b8be25e6fa3cb12476c026c171e454b58ee98fac80ee3196d41
 file:
-- statement:
+  statement:
     if_then_statement:
     - keyword: if
     - expression:
@@ -18,23 +18,22 @@ file:
             numeric_literal: '0'
           end_bracket: )
     - keyword: then
-    - statement:
-        set_statement:
-          keyword: set
-          variable: '@b'
-          comparison_operator:
-            raw_comparison_operator: '='
-          quoted_literal: "''"
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-        keyword: select
-        select_clause_element:
-          numeric_literal: '1'
-- statement_terminator: ;
-- statement:
-    if_then_statement:
+    - if_statement_list:
+      - statement:
+          set_statement:
+            keyword: set
+            variable: '@b'
+            comparison_operator:
+              raw_comparison_operator: '='
+            quoted_literal: "''"
+      - statement_terminator: ;
+      - statement:
+          select_statement:
+            select_clause:
+              keyword: select
+              select_clause_element:
+                numeric_literal: '1'
+      - statement_terminator: ;
     - keyword: end
     - keyword: if
-- statement_terminator: ;
+  statement_terminator: ;

--- a/test/fixtures/dialects/mysql/if_subquery_expression.yml
+++ b/test/fixtures/dialects/mysql/if_subquery_expression.yml
@@ -3,9 +3,9 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 5626b33570f2e08309801628d9fd5dc612419586627f73721e2abb1adc1028cc
+_hash: 71e4844eadd31d43ec2ea2960b13f0943cb61f94f31ee6aecae329a4456fd9b0
 file:
-- statement:
+  statement:
     if_then_statement:
     - keyword: if
     - expression:
@@ -40,23 +40,22 @@ file:
             numeric_literal: '0'
           end_bracket: )
     - keyword: then
-    - statement:
-        set_statement:
-          keyword: set
-          variable: '@errmsg'
-          comparison_operator:
-            raw_comparison_operator: '='
-          quoted_literal: "''"
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-        keyword: select
-        select_clause_element:
-          numeric_literal: '1'
-- statement_terminator: ;
-- statement:
-    if_then_statement:
+    - if_statement_list:
+      - statement:
+          set_statement:
+            keyword: set
+            variable: '@errmsg'
+            comparison_operator:
+              raw_comparison_operator: '='
+            quoted_literal: "''"
+      - statement_terminator: ;
+      - statement:
+          select_statement:
+            select_clause:
+              keyword: select
+              select_clause_element:
+                numeric_literal: '1'
+      - statement_terminator: ;
     - keyword: end
     - keyword: if
-- statement_terminator: ;
+  statement_terminator: ;


### PR DESCRIPTION
### Brief summary of the change made

Reshape `IfExpressionStatement` in `src/sqlfluff/dialects/dialect_mysql.py` as an ordered sequence: a required `IF ... THEN` branch, repeatable `ELSEIF ... THEN` branches, an optional single `ELSE`, and a required `END IF`.

MySQL procedural `IF` input is currently split into several top-level statements: the opening `IF`, each `ELSEIF` or `ELSE`, and `END IF` all match independently. The current `IfExpressionStatement` uses an unordered `AnyNumberOf`, so it also accepts orphaned branches, missing terminators, duplicate or misordered clauses, and other shapes outside MySQL's stored-program grammar. Recent work means `END IF` is no longer parsed as a labelled `END`, but the checked-in MySQL and inherited MariaDB parse fixtures confirm that the complete construct is still not represented as one nested statement. This plan completes the original issue without changing unrelated procedural constructs such as `WHILE`, `LOOP`, or `REPEAT`.

Fixes #3318

### Are there any other side effects of this change that we should be aware of?

Not applicable to this change.

### Pull Request checklist

- [ ] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.

AI was used for assistance.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Parse MySQL procedural IF as a single ordered compound statement and correctly scope branch bodies. Previously IF/ELSEIF/ELSE/END IF parsed as separate top-level statements and could accept misordered or dangling clauses; now we require IF ... THEN, optional ELSEIF ... THEN branches, optional ELSE, and a closing END IF in order, and nested CASE ELSE no longer terminates the IF branch.

- Introduces an `if_statement_list` segment to hold branch statements with `DelimiterGrammar` and indentation, and excludes `ELSEIF`, `ELSE`, and `END IF` from branch-body matches so nested CASE ELSE remains inside the branch. Updates MySQL and MariaDB fixtures (including nested CASE and multiple ELSEIF cases) and adds tests rejecting invalid IF shapes.

**Migration**
- If you consume the parse tree, update references: branch statements now appear under `if_then_statement.if_statement_list` instead of as sibling top-level statements.

<sup>Written for commit b85439c106f2d876533ac00c4af84ac464fccf16. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8380?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

