### PR TITLE
correct typo: seleect -> select

### DIFF
--- a/src/sqlfluff/rules/ambiguous/AM07.py
+++ b/src/sqlfluff/rules/ambiguous/AM07.py
@@ -33,7 +33,7 @@ class Rule_AM07(BaseRule):
     **Best practice**
 
     Always specify columns when writing set queries
-    and ensure that they all seleect same number of columns
+    and ensure that they all select same number of columns
 
     .. code-block:: sql
 


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
This corrects a simple typo in the docs

### Are there any other side effects of this change that we should be aware of?

I don't believe so

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a typo in the AM07 rule documentation: “seleect” -> “select” to improve clarity. No linting behavior or API changes.

<sup>Written for commit 637f3ef5cca48b62e52828c8b6c237521f87fb7f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8381?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

