### PR TITLE
Snowflake: accept the exception name on RAISE

### DIFF
--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -11086,7 +11086,7 @@ class ScriptingRaiseStatementSegment(BaseSegment):
         "RAISE",
         # The exception name is omitted only when re-raising the exception
         # currently being handled from inside an exception handler.
-        Ref("LocalVariableNameSegment", optional=True),
+        Ref("NakedIdentifierSegment", optional=True),
     )
 
 

--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -11082,7 +11082,12 @@ class ScriptingRaiseStatementSegment(BaseSegment):
     """
 
     type = "scripting_raise_statement"
-    match_grammar = Ref.keyword("RAISE")
+    match_grammar = Sequence(
+        "RAISE",
+        # The exception name is omitted only when re-raising the exception
+        # currently being handled from inside an exception handler.
+        Ref("LocalVariableNameSegment", optional=True),
+    )
 
 
 class LambdaExpressionSegment(BaseSegment):

--- a/test/fixtures/dialects/snowflake/raise_statement.sql
+++ b/test/fixtures/dialects/snowflake/raise_statement.sql
@@ -4,3 +4,19 @@ EXCEPTION
     WHEN OTHER THEN
         RAISE;
 END;
+
+DECLARE
+    MY_EXCEPTION EXCEPTION (-20002, 'Raised MY_EXCEPTION.');
+BEGIN
+    RAISE MY_EXCEPTION;
+END;
+
+BEGIN
+    LET v INTEGER := (SELECT 1);
+    DECLARE
+        e_bad EXCEPTION (-20980, 'nope');
+    BEGIN
+        RAISE e_bad;
+    END;
+    RETURN v;
+END;

--- a/test/fixtures/dialects/snowflake/raise_statement.yml
+++ b/test/fixtures/dialects/snowflake/raise_statement.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 9419cdea1862c77df07807eb56ac9e2d3a26e5a1c4bf9f050ead8033f2b14e43
+_hash: 29eb4c03dc1b00b49d04366804f3d263eb08976f34ac81fe989aaa1a47cc5491
 file:
 - statement:
     scripting_block_statement:
@@ -47,7 +47,7 @@ file:
     - statement:
         scripting_raise_statement:
           keyword: RAISE
-          variable: MY_EXCEPTION
+          naked_identifier: MY_EXCEPTION
     - statement_terminator: ;
     - keyword: END
 - statement_terminator: ;
@@ -91,7 +91,7 @@ file:
         - statement:
             scripting_raise_statement:
               keyword: RAISE
-              variable: e_bad
+              naked_identifier: e_bad
         - statement_terminator: ;
         - keyword: END
     - statement_terminator: ;

--- a/test/fixtures/dialects/snowflake/raise_statement.yml
+++ b/test/fixtures/dialects/snowflake/raise_statement.yml
@@ -3,9 +3,9 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 8abbd1bbc0ff686a86549113f3c08a9359c11795b9643b583ad7b484a4cea1e7
+_hash: 9419cdea1862c77df07807eb56ac9e2d3a26e5a1c4bf9f050ead8033f2b14e43
 file:
-  statement:
+- statement:
     scripting_block_statement:
     - keyword: BEGIN
     - statement:
@@ -27,4 +27,80 @@ file:
               keyword: RAISE
     - statement_terminator: ;
     - keyword: END
-  statement_terminator: ;
+- statement_terminator: ;
+- statement:
+    scripting_declare_statement:
+    - keyword: DECLARE
+    - variable: MY_EXCEPTION
+    - keyword: EXCEPTION
+    - bracketed:
+        start_bracket: (
+        sign_indicator: '-'
+        exception_code: '20002'
+        comma: ','
+        quoted_literal: "'Raised MY_EXCEPTION.'"
+        end_bracket: )
+- statement_terminator: ;
+- statement:
+    scripting_block_statement:
+    - keyword: BEGIN
+    - statement:
+        scripting_raise_statement:
+          keyword: RAISE
+          variable: MY_EXCEPTION
+    - statement_terminator: ;
+    - keyword: END
+- statement_terminator: ;
+- statement:
+    scripting_block_statement:
+    - keyword: BEGIN
+    - statement:
+        scripting_let_statement:
+          keyword: LET
+          variable: v
+          data_type:
+            data_type_identifier: INTEGER
+          assignment_operator: :=
+          expression:
+            bracketed:
+              start_bracket: (
+              expression:
+                select_statement:
+                  select_clause:
+                    keyword: SELECT
+                    select_clause_element:
+                      numeric_literal: '1'
+              end_bracket: )
+    - statement_terminator: ;
+    - statement:
+        scripting_declare_statement:
+        - keyword: DECLARE
+        - variable: e_bad
+        - keyword: EXCEPTION
+        - bracketed:
+            start_bracket: (
+            sign_indicator: '-'
+            exception_code: '20980'
+            comma: ','
+            quoted_literal: "'nope'"
+            end_bracket: )
+    - statement_terminator: ;
+    - statement:
+        scripting_block_statement:
+        - keyword: BEGIN
+        - statement:
+            scripting_raise_statement:
+              keyword: RAISE
+              variable: e_bad
+        - statement_terminator: ;
+        - keyword: END
+    - statement_terminator: ;
+    - statement:
+        return_statement:
+          keyword: RETURN
+          expression:
+            column_reference:
+              naked_identifier: v
+    - statement_terminator: ;
+    - keyword: END
+- statement_terminator: ;


### PR DESCRIPTION
### Brief summary of the change made

Fixes #8384.

`ScriptingRaiseStatementSegment` matched the bare `RAISE` keyword:

```python
match_grammar = Ref.keyword("RAISE")
```

so `RAISE <exception_name>;` was unparsable and only the argument-less form parsed. Per
[the docs](https://docs.snowflake.com/en/sql-reference/snowflake-scripting/raise) the name is
required and omitted **only** when re-raising the exception currently being handled — so the grammar
accepted just the exceptional case. The example on that documentation page did not parse:

```sql
DECLARE
    MY_EXCEPTION EXCEPTION (-20002, 'Raised MY_EXCEPTION.');
BEGIN
    RAISE MY_EXCEPTION;   -- PRS: Found unparsable section
END;
```

The name is now an optional trailing `LocalVariableNameSegment` — the same segment the `DECLARE`
section uses for the exception it declares. The argument-less form still parses.

Fixture cases added to `test/fixtures/dialects/snowflake/raise_statement.sql`: the documented named
form, and a named raise from a nested block's `DECLARE` section (a common guard idiom). The existing
bare re-raise case is unchanged.

### Are there any other side effects of this change that we should be aware of?

One inconsistency worth a maintainer opinion, which I have deliberately not changed:
`ExceptionBlockStatementSegment` matches these same exception names with `ObjectReferenceSegment`,
while the `DECLARE` section declares them with `LocalVariableNameSegment`. I followed the declaration
side. Happy to switch to `ObjectReferenceSegment` for consistency with the handler, or to align all
three, if you would rather.

Otherwise none. The optional trailing identifier cannot over-consume across a statement boundary, and
a full `python test/generate_parse_fixture_yml.py` over **all** dialects produces no diff outside the
one fixture pair below.

Worth noting why this is worth fixing beyond the parse error itself: an unparsable section swallows
everything to EOF and no rule fires inside it, so a single `RAISE MY_EXCEPTION;` silently disables
every style rule for the rest of the file. Under `--ignore parsing` those files report clean. On the
Snowflake repo where I found this, the change takes the unparsable-file count from **70 to 22**.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` — `raise_statement.sql` / `.yml`,
    the `.yml` generated with `python test/generate_parse_fixture_yml.py -d snowflake`.
- Added appropriate documentation for the change: the segment's docstring already links the official
  RAISE documentation; dialect reference docs are auto-generated.
- Created GitHub issues for any relevant followup/future enhancements if appropriate: #8385 covers a
  separate gap found alongside this one (no grammar for `CREATE`/`ALTER`/`DROP ALERT`).

### Verification

| Check | Result |
|---|---|
| `pytest test/dialects/dialects_test.py -k snowflake` | 687 passed |
| `pytest test/dialects/snowflake_test.py` | 15 passed |
| `generate_parse_fixture_yml.py` (all dialects, 2248 fixtures) | no diff outside `raise_statement.*` |
| `ruff format --check` / `ruff check` on the touched file | clean |
| Negative control — new fixture cases with the grammar change reverted | 2 unparsable sections, as expected |

### AI assistance declaration

Developed with AI assistance. The grammar change and fixtures were drafted with an LLM; every clause
was checked against the linked Snowflake documentation, the parse trees were inspected by hand, and
the test runs and the negative control above were executed locally.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Parses Snowflake RAISE statements with a named exception. Previously only bare `RAISE` parsed; now `RAISE <name>;` parses and bare re-raise still works, preventing unparsable sections that disabled linting to EOF.

- Uses `Sequence("RAISE", Ref("NakedIdentifierSegment", optional=True))`, which rejects `RAISE` followed by numerics or reserved keywords (e.g., `RAISE 123;`, `RAISE SELECT;`).
- Adds fixtures for named raises, including a nested declare/raise; only `raise_statement` fixtures change.
- Note: exception handlers still use `ObjectReferenceSegment`, declarations use `LocalVariableNameSegment`, and `RAISE` now uses `NakedIdentifierSegment`; align these in a follow-up if preferred.

<sup>Written for commit fc663450637c928e6f2027c3de5ec457c67a2123. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8386?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

