### PR TITLE
Clickhouse: support CONSTRAINT ... CHECK/ASSUME table constraints

### DIFF
--- a/src/sqlfluff/dialects/dialect_clickhouse.py
+++ b/src/sqlfluff/dialects/dialect_clickhouse.py
@@ -1571,9 +1571,10 @@ class TableConstraintSegment(ansi.TableConstraintSegment):
         "CONSTRAINT",
         Ref("ObjectReferenceSegment"),
         OneOf(
-            Sequence("CHECK", Ref("ExpressionSegment")),
-            Sequence("ASSUME", Ref("ExpressionSegment")),
+            "CHECK",
+            "ASSUME",
         ),
+        Ref("ExpressionSegment"),
     )
 
 

--- a/src/sqlfluff/dialects/dialect_clickhouse.py
+++ b/src/sqlfluff/dialects/dialect_clickhouse.py
@@ -1559,6 +1559,24 @@ class ColumnConstraintSegment(BaseSegment):
     )
 
 
+class TableConstraintSegment(ansi.TableConstraintSegment):
+    """A table constraint, e.g. for CREATE TABLE.
+
+    ClickHouse's CONSTRAINT clause only supports CHECK and ASSUME
+    https://clickhouse.com/docs/en/sql-reference/statements/create/table#constraints
+    """
+
+    type = "table_constraint"
+    match_grammar: Matchable = Sequence(
+        "CONSTRAINT",
+        Ref("ObjectReferenceSegment"),
+        OneOf(
+            Sequence("CHECK", Ref("ExpressionSegment")),
+            Sequence("ASSUME", Ref("ExpressionSegment")),
+        ),
+    )
+
+
 class CreateDatabaseStatementSegment(ansi.CreateDatabaseStatementSegment):
     """A `CREATE DATABASE` statement.
 

--- a/src/sqlfluff/dialects/dialect_clickhouse_keywords.py
+++ b/src/sqlfluff/dialects/dialect_clickhouse_keywords.py
@@ -104,6 +104,7 @@ UNRESERVED_KEYWORDS = [
     "AS",
     "ASCENDING",
     "ASOF",
+    "ASSUME",
     "AST",
     "ASYNC",
     "ATOMIC",

--- a/test/fixtures/dialects/clickhouse/create_table.sql
+++ b/test/fixtures/dialects/clickhouse/create_table.sql
@@ -85,3 +85,10 @@ ORDER BY d
 TTL d + INTERVAL 1 MONTH DELETE,
     d + INTERVAL 1 WEEK TO VOLUME 'aaa',
     d + INTERVAL 2 WEEK TO DISK 'bbb';
+
+CREATE TABLE my_table
+(
+    name1 String,
+    CONSTRAINT constraint_name_1 ASSUME (name1 = 'test')
+)
+ENGINE = MergeTree;

--- a/test/fixtures/dialects/clickhouse/create_table.yml
+++ b/test/fixtures/dialects/clickhouse/create_table.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 4dee5ecad8c6d6523207b03f6b22dedb4895f60935f2b35751c5e3228b7a7fa2
+_hash: 02e93d2b4a90a471ee3fba20d90c6b29cee1a4cf6cca8a4e879dfab1a579343b
 file:
 - statement:
     create_table_statement:
@@ -608,18 +608,18 @@ file:
     - table_reference:
         naked_identifier: table_name
     - bracketed:
-      - start_bracket: (
-      - column_definition:
+        start_bracket: (
+        column_definition:
           naked_identifier: name1
           data_type:
             data_type_identifier: String
-      - comma: ','
-      - column_definition:
-          naked_identifier: CONSTRAINT
-          data_type:
-            data_type_identifier: constraint_name_1
-          column_constraint_segment:
-            keyword: CHECK
+        comma: ','
+        table_constraint:
+        - keyword: CONSTRAINT
+        - object_reference:
+            naked_identifier: constraint_name_1
+        - keyword: CHECK
+        - expression:
             bracketed:
               start_bracket: (
               expression:
@@ -629,7 +629,7 @@ file:
                   raw_comparison_operator: '='
                 quoted_literal: "'test'"
               end_bracket: )
-      - end_bracket: )
+        end_bracket: )
     - engine:
         keyword: ENGINE
         comparison_operator:
@@ -792,4 +792,41 @@ file:
       - keyword: TO
       - keyword: DISK
       - quoted_literal: "'bbb'"
+- statement_terminator: ;
+- statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: my_table
+    - bracketed:
+        start_bracket: (
+        column_definition:
+          naked_identifier: name1
+          data_type:
+            data_type_identifier: String
+        comma: ','
+        table_constraint:
+        - keyword: CONSTRAINT
+        - object_reference:
+            naked_identifier: constraint_name_1
+        - keyword: ASSUME
+        - expression:
+            bracketed:
+              start_bracket: (
+              expression:
+                column_reference:
+                  naked_identifier: name1
+                comparison_operator:
+                  raw_comparison_operator: '='
+                quoted_literal: "'test'"
+              end_bracket: )
+        end_bracket: )
+    - engine:
+        keyword: ENGINE
+        comparison_operator:
+          raw_comparison_operator: '='
+        table_engine_function:
+          function_name:
+            function_name_identifier: MergeTree
 - statement_terminator: ;


### PR DESCRIPTION
### Brief summary of the change made
fixes #8387 
Adds support for table constraints to the Clickhouse dialect. Previously valid Clickhouse CREATE TABLE statements would generate parsing violations. E.g. the following query would fail to parse:
```SQL
CREATE TABLE my_table
(
    name1 String,
    CONSTRAINT constraint_name_1 ASSUME (name1 = 'test')
)
ENGINE = MergeTree;
```

An existing Clickhouse create table statement with a table constraint in the fixture file parses but would incorrectly classify the constraint as a column. This change fixes the parsing logic so that the constraint is correctly classified.

### Verification
After making the change, the old test case correctly parses the constraint syntax. Diff between old and new parses:
```diff
24,25c24,25
< [L:  4, P:  5]      |                column_definition:
< [L:  4, P:  5]      |                    naked_identifier:                         'CONSTRAINT'
---
> [L:  4, P:  5]      |                table_constraint:
> [L:  4, P:  5]      |                    keyword:                                  'CONSTRAINT'
27,28c27,28
< [L:  4, P: 16]      |                    data_type:
< [L:  4, P: 16]      |                        data_type_identifier:                 'constraint_name_1'
---
> [L:  4, P: 16]      |                    object_reference:
> [L:  4, P: 16]      |                        naked_identifier:                     'constraint_name_1'
30,32c30,32
< [L:  4, P: 34]      |                    column_constraint_segment:
< [L:  4, P: 34]      |                        keyword:                              'CHECK'
< [L:  4, P: 39]      |                        whitespace:                           ' '
---
> [L:  4, P: 34]      |                    keyword:                                  'CHECK'
> [L:  4, P: 39]      |                    whitespace:                               ' '
> [L:  4, P: 40]      |                    expression:
```

The `ASSUME` keyword also no longer generates parsing violations:
```bash
echo "CREATE TABLE table_name
(
    name1 String,
    CONSTRAINT constraint_name_1 ASSUME (name1 = 'test')
) ENGINE = engine;" | sqlfluff format --dialect clickhouse -
```
->
```sql
CREATE TABLE table_name
(
    name1 String,
    CONSTRAINT constraint_name_1 ASSUME (name1 = 'test')
) ENGINE = engine;
```


### Are there any other side effects of this change that we should be aware of?
Not that I know of.

### AI Disclosure
PR was prepared with assistance from Claude Code. Clickhouse syntax was manually verified along with code change.

### Pull Request checklist
- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - [x] `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds ClickHouse parsing for CONSTRAINT ... CHECK and CONSTRAINT ... ASSUME in CREATE TABLE to prevent parse errors and correct prior misclassification as a column.

- Introduces a ClickHouse `TableConstraintSegment` supporting CONSTRAINT <name> CHECK|ASSUME (<expr>).
- Adds `ASSUME` to the ClickHouse keyword list.
- Updates ClickHouse CREATE TABLE fixtures; constraints now appear as `table_constraint` in parse trees.
- Behavior change: sequences previously parsed as a column definition now parse as `table_constraint`. Update any custom rules to read `table_constraint` instead.

<sup>Written for commit 472047ef580687489f61a5f4fffea45253f9239a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8388?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

