### PR TITLE
Snowflake: added ERROR_INTEGRATION and SUCCESS_INTEGRATION for CREATE TASK

### DIFF
--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -6028,6 +6028,16 @@ class CreateTaskSegment(BaseSegment):
                 ),
             ),
             Sequence(
+                "ERROR_INTEGRATION",
+                Ref("EqualsSegment"),
+                Ref("ObjectReferenceSegment"),
+            ),
+            Sequence(
+                "SUCCESS_INTEGRATION",
+                Ref("EqualsSegment"),
+                Ref("ObjectReferenceSegment"),
+            ),
+            Sequence(
                 "SCHEDULE",
                 Ref("EqualsSegment"),
                 OneOf(

--- a/test/fixtures/dialects/snowflake/create_task.sql
+++ b/test/fixtures/dialects/snowflake/create_task.sql
@@ -129,3 +129,11 @@ CREATE TASK mytask
     SCHEDULE = '5 MINUTE'
 AS
     SELECT 1;
+
+CREATE TASK mytask_with_error_integration
+  ERROR_INTEGRATION = some_integration
+AS SELECT 1;
+
+CREATE TASK mytask_with_success_integration
+  SUCCESS_INTEGRATION = some_integration
+AS SELECT 1;

--- a/test/fixtures/dialects/snowflake/create_task.yml
+++ b/test/fixtures/dialects/snowflake/create_task.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: c18ac771488b0e0f07705544697da2498251c1298ef601737f4cfe42f92c3359
+_hash: f07ff0dd95995f7283699ffd8c78fc0b1467ad21f87396cb13c1feec5805ab67
 file:
 - statement:
     create_task_statement:
@@ -725,6 +725,44 @@ file:
     - comparison_operator:
         raw_comparison_operator: '='
     - quoted_literal: "'5 MINUTE'"
+    - keyword: AS
+    - statement:
+        select_statement:
+          select_clause:
+            keyword: SELECT
+            select_clause_element:
+              numeric_literal: '1'
+- statement_terminator: ;
+- statement:
+    create_task_statement:
+    - keyword: CREATE
+    - keyword: TASK
+    - object_reference:
+        naked_identifier: mytask_with_error_integration
+    - keyword: ERROR_INTEGRATION
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - object_reference:
+        naked_identifier: some_integration
+    - keyword: AS
+    - statement:
+        select_statement:
+          select_clause:
+            keyword: SELECT
+            select_clause_element:
+              numeric_literal: '1'
+- statement_terminator: ;
+- statement:
+    create_task_statement:
+    - keyword: CREATE
+    - keyword: TASK
+    - object_reference:
+        naked_identifier: mytask_with_success_integration
+    - keyword: SUCCESS_INTEGRATION
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - object_reference:
+        naked_identifier: some_integration
     - keyword: AS
     - statement:
         select_statement:


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made

The snowflake [CREATE TASK](https://docs.snowflake.com/en/sql-reference/sql/create-task#syntax) statement also allows an `ERROR_INTEGRATION` and `SUCCESS_INTEGRATION` parameter to be set prior to defining the task body itself. For example:

```sql
CREATE TASK my_task
  WAREHOUSE = my_warehouse
  ERROR_INTEGRATION = oh_no
  SUCCESS_INTEGRATION = victory
AS
  SELECT 1;
```

This PR updates the grammar for this statement to allow these settings to be configured.

### Are there any other side effects of this change that we should be aware of?

N/A

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow `ERROR_INTEGRATION` and `SUCCESS_INTEGRATION` in Snowflake CREATE TASK so these statements parse successfully. Previously, statements using these parameters failed to parse; now they are accepted with no other behavior changes.

- Adds grammar support for `ERROR_INTEGRATION = <object>` and `SUCCESS_INTEGRATION = <object>` in the CREATE TASK options before the task body.
- Adds parsing tests and updates fixtures.
- No config changes or migrations required.

<sup>Written for commit 84b0b8b69cb8a74f0ef2132afc58896365f52584. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8390?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

