### PR TITLE
fix(CV11): preserve the full operand of a shorthand cast

### DIFF
--- a/src/sqlfluff/rules/convention/CV11.py
+++ b/src/sqlfluff/rules/convention/CV11.py
@@ -104,6 +104,28 @@ class Rule_CV11(BaseRule):
         )
 
     @staticmethod
+    def _split_shorthand_cast(
+        expression_datatype_segment: Segments,
+    ) -> tuple[Segments, BaseSegment, Segments]:
+        """Split a ``::`` shorthand cast into value, datatype and later casts.
+
+        The value being cast can span more than one segment: an array subscript
+        such as ``a[1]`` parses as a ``column_reference`` followed by one or
+        more ``array_accessor`` children. Locate the target type by finding the
+        first ``data_type`` child rather than assuming it sits at a fixed index,
+        so the whole left-hand operand is kept intact. Anything after that first
+        ``data_type`` is a chained cast (e.g. the ``text`` in ``1::int::text``).
+        """
+        for data_type_idx, seg in enumerate(expression_datatype_segment):
+            if seg.is_type("data_type"):
+                break
+        return (
+            expression_datatype_segment[:data_type_idx],
+            expression_datatype_segment[data_type_idx],
+            expression_datatype_segment[data_type_idx + 1 :],
+        )
+
+    @staticmethod
     def _build_function(name: str, contents: list[BaseSegment]) -> FunctionSegment:
         """Construct a parse-shaped ``function`` segment.
 
@@ -181,7 +203,7 @@ class Rule_CV11(BaseRule):
         cls,
         context: RuleContext,
         convert_arg_1: BaseSegment,
-        convert_arg_2: BaseSegment,
+        convert_arg_2: Iterable[BaseSegment],
         later_types=None,
     ) -> list[LintFix]:
         """Generate list of fixes to convert CAST and ShorthandCast to CONVERT.
@@ -201,7 +223,7 @@ class Rule_CV11(BaseRule):
                 convert_arg_1,
                 SymbolSegment(",", type="comma"),
                 WhitespaceSegment(),
-                convert_arg_2,
+                *convert_arg_2,
             ],
         )
 
@@ -347,14 +369,16 @@ class Rule_CV11(BaseRule):
                     expression_datatype_segment = self._get_children(
                         functional_context.segment
                     )
-
+                    # We can have multiple shorthandcast e.g 1::int::text
+                    # in that case, we need to introduce nested CAST().
+                    value, data_type, later_types = self._split_shorthand_cast(
+                        expression_datatype_segment
+                    )
                     fixes = self._cast_fix_list(
                         context,
-                        [expression_datatype_segment[0]],
-                        expression_datatype_segment[1],
-                        # We can have multiple shorthandcast e.g 1::int::text
-                        # in that case, we need to introduce nested CAST()
-                        expression_datatype_segment[2:],
+                        value,
+                        data_type,
+                        later_types,
                     )
 
             elif prior_type_casting_style == "convert":
@@ -369,17 +393,20 @@ class Rule_CV11(BaseRule):
                     fixes = self._convert_fix_list(
                         context,
                         cast_content[1],
-                        cast_content[0],
+                        [cast_content[0]],
                     )
                 elif current_type_casting_style == "shorthand":
                     expression_datatype_segment = self._get_children(
                         functional_context.segment
                     )
+                    value, data_type, later_types = self._split_shorthand_cast(
+                        expression_datatype_segment
+                    )
                     fixes = self._convert_fix_list(
                         context,
-                        expression_datatype_segment[1],
-                        expression_datatype_segment[0],
-                        expression_datatype_segment[2:],
+                        data_type,
+                        value,
+                        later_types,
                     )
             elif prior_type_casting_style == "shorthand":
                 bracketed = functional_context.segment.children(
@@ -445,16 +472,14 @@ class Rule_CV11(BaseRule):
                     expression_datatype_segment = self._get_children(
                         functional_context.segment
                     )
-
-                    for data_type_idx, seg in enumerate(expression_datatype_segment):
-                        if seg.is_type("data_type"):
-                            break
-
+                    value, data_type, later_types = self._split_shorthand_cast(
+                        expression_datatype_segment
+                    )
                     fixes = self._cast_fix_list(
                         context,
-                        expression_datatype_segment[:data_type_idx],
-                        expression_datatype_segment[data_type_idx],
-                        expression_datatype_segment[data_type_idx + 1 :],
+                        value,
+                        data_type,
+                        later_types,
                     )
 
             elif self.preferred_type_casting_style == "convert":
@@ -466,17 +491,20 @@ class Rule_CV11(BaseRule):
                     fixes = self._convert_fix_list(
                         context,
                         cast_content[1],
-                        cast_content[0],
+                        [cast_content[0]],
                     )
                 elif current_type_casting_style == "shorthand":
                     expression_datatype_segment = self._get_children(
                         functional_context.segment
                     )
+                    value, data_type, later_types = self._split_shorthand_cast(
+                        expression_datatype_segment
+                    )
                     fixes = self._convert_fix_list(
                         context,
-                        expression_datatype_segment[1],
-                        expression_datatype_segment[0],
-                        expression_datatype_segment[2:],
+                        data_type,
+                        value,
+                        later_types,
                     )
             elif self.preferred_type_casting_style == "shorthand":
                 bracketed = functional_context.segment.children(

--- a/test/fixtures/rules/std_rule_cases/CV11.yml
+++ b/test/fixtures/rules/std_rule_cases/CV11.yml
@@ -592,3 +592,52 @@ test_fail_tsql_convert_still_rewritten:
     rules:
       convention.casting_style:
         preferred_type_casting_style: cast
+
+# https://github.com/sqlfluff/sqlfluff - a `::` shorthand cast whose left
+# operand parses into more than one segment (e.g. an array subscript, which
+# is a column_reference plus one or more array_accessor children) must keep
+# the whole operand. The rewrite used to grab the operand and the target type
+# by fixed positional index, so it treated the subscript as the type.
+test_fail_shorthand_array_subscript_to_cast_consistent:
+  # consistent mode: the leading CAST makes it pick the 'cast' style
+  fail_str: SELECT CAST(z AS INT) AS zz, a[1]::INT AS y FROM t
+  fix_str: SELECT CAST(z AS INT) AS zz, cast(a[1] as INT) AS y FROM t
+
+test_fail_shorthand_array_subscript_to_convert_consistent:
+  # consistent mode: the leading CONVERT makes it pick the 'convert' style
+  fail_str: SELECT convert(INT, z) AS zz, a[1]::INT AS y FROM t
+  fix_str: SELECT convert(INT, z) AS zz, convert(INT, a[1]) AS y FROM t
+
+test_fail_shorthand_array_subscript_to_cast:
+  fail_str: SELECT a[1]::int AS y FROM t
+  fix_str: SELECT cast(a[1] as int) AS y FROM t
+  configs:
+    rules:
+      convention.casting_style:
+        preferred_type_casting_style: cast
+
+test_fail_shorthand_array_subscript_to_convert:
+  fail_str: SELECT a[1]::int AS y FROM t
+  fix_str: SELECT convert(int, a[1]) AS y FROM t
+  configs:
+    rules:
+      convention.casting_style:
+        preferred_type_casting_style: convert
+
+test_fail_shorthand_nested_array_subscript_to_convert:
+  # more than one array_accessor: the whole a[1][2] operand must survive
+  fail_str: SELECT a[1][2]::int AS y FROM t
+  fix_str: SELECT convert(int, a[1][2]) AS y FROM t
+  configs:
+    rules:
+      convention.casting_style:
+        preferred_type_casting_style: convert
+
+test_fail_shorthand_multi_cast_operand_unaffected:
+  # a plain chained shorthand cast (single-segment operand) is unchanged
+  fail_str: SELECT 1::int::text AS y FROM t
+  fix_str: SELECT cast(cast(1 as int) as text) AS y FROM t
+  configs:
+    rules:
+      convention.casting_style:
+        preferred_type_casting_style: cast


### PR DESCRIPTION
Fixes #8391

### Brief summary of the change made

CV11's shorthand-cast rewrite assumed the SQL data type was the `cast_expression` child at a fixed positional index. When the operand parses into more than one child — e.g. an array subscript `a[1]::INT` (`column_reference` + `array_accessor`) — it picked the wrong child, so `sqlfluff fix` rewrote `a[1]::INT` into `cast(cast(a as [1]) as INT)`, destroying the subscript.

This locates the `data_type` child by type and splits the `cast_expression` into (operand-before-the-type, the type, any chained casts after it), so the full left operand is preserved. `a[1]::INT` now correctly becomes `cast(a[1] as INT)`, and the `convert` styles preserve it too. Chained shorthand casts like `1::int::text` are handled by the same split.

Added CV11 rule test cases (`test/fixtures/rules/std_rule_cases/CV11.yml`) covering the array-subscript and nested-operand cases for the cast and both convert targets, plus a plain-cast control to confirm simple casts are unchanged. The new cases fail on `main` (showing the corruption) and pass with this change; the full CV11 suite stays green.

### Are there any other side effects of this change that we should be aware of?

No — the change only affects how the operand/type boundary is located within a `cast_expression`; simple `x::INT` casts are unaffected.

### AI usage

I used an AI assistant (Claude Code) to help navigate the rule code and draft the fix and test fixtures. I found and reproduced the bug myself against sqlfluff 4.3.0 (the `a[1]::INT` → `cast(cast(a as [1]) as INT)` case), verified the root cause is the fixed-index child selection, confirmed the new tests fail on `main` and pass after the change, and confirmed the existing CV11 suite still passes. I've reviewed every line and stand by it.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves the full operand when rewriting CV11 `::` shorthand casts. Previously multi‑segment operands (e.g., `a[1]::INT`) were split incorrectly and rewritten as `cast(cast(a as [1]) as INT)`/`convert(INT, convert([1], a))`; now they become `cast(a[1] as INT)`/`convert(INT, a[1])`. Chained shorthand casts (e.g., `1::int::text`) still rewrite correctly, and simple casts are unchanged.

- Locate the `data_type` child by type and split the `cast_expression` into operand, type, and later casts via `_split_shorthand_cast`; use this at all shorthand sites.
- Update `_convert_fix_list` to accept a sequence for the value argument so multi‑segment operands survive.
- Add CV11 rule cases for array subscripts and nested operands; existing CV11 tests remain green.

<sup>Written for commit e2b0b629858f523bc9a0046cdad75b978a6b6ec5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8392?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

