### PR TITLE
Fix a comment typo and a broken CONTRIBUTING.md link

### DIFF
--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -1231,7 +1231,7 @@ snowflake_dialect.replace(
                 "UUID",
                 # Vector data types
                 "VECTOR",
-                # Scriptiong data types
+                # Scripting data types
                 # https://docs.snowflake.com/en/developer-guide/snowflake-scripting/variables
                 "RESULTSET",
                 "CURSOR",


### PR DESCRIPTION
Two small docs fixes, no behavior change:

- `src/sqlfluff/dialects/dialect_snowflake.py`: comment "Scriptiong data types" -> "Scripting data types" (the doc link on the next line is the Snowflake Scripting variables page).
- `CONTRIBUTING.md`: the release section links `.github/workflows/publish-release-to-pypi.yaml`, which does not exist. The actual workflow is `publish-sqlfluff-release-to-pypi.yaml` (there are also `publish-dbt-templater-` and `publish-sqlfluffrs-` variants, so the unqualified name was never valid).