### PR TITLE
Don't assert-crash the analyzer on a non-lambda `->` operator

### DIFF
--- a/src/sqlfluff/utils/analysis/select.py
+++ b/src/sqlfluff/utils/analysis/select.py
@@ -414,7 +414,13 @@ def _get_lambda_argument_columns(
                 ),
             )
 
-            assert len(argument_segments) == 1
+            if len(argument_segments) != 1:
+                # The `->` isn't really a lambda arrow. Some dialects reuse `->`
+                # as a binary operator (e.g. duckdb/trino JSON extraction, as in
+                # `1::json -> 'a'`), where the left operand isn't a single lambda
+                # parameter. Those contribute no lambda argument columns, so skip
+                # rather than crashing the whole analyzer.
+                continue
             child_segment = argument_segments[0]
 
             if child_segment.is_type("bracketed"):

--- a/src/sqlfluff/utils/analysis/select.py
+++ b/src/sqlfluff/utils/analysis/select.py
@@ -377,6 +377,16 @@ def _get_unpivot_table_aliases(
     return unpivot_aliases
 
 
+# Dialects whose grammar has a dedicated lambda function, so that a lambda always
+# parses as a "lambda_function" holding a "lambda_arrow". In these dialects a plain
+# "->" binary operator is something else - duckdb and trino also use it for JSON
+# extraction - and must not be read as a lambda.
+_LAMBDA_FUNCTION_DIALECTS = ("duckdb", "trino", "snowflake")
+
+# Dialects that parse a lambda as an ordinary expression with a "->" binary operator.
+_LAMBDA_EXPRESSION_DIALECTS = ("athena", "sparksql", "databricks")
+
+
 # Lambda arguments,
 # e.g. `x` and `y` in `x -> x is not null` and `(x, y) -> x + y`
 # are declared in-place, and are as such standalone – i.e. they do not reference
@@ -386,21 +396,24 @@ def _get_unpivot_table_aliases(
 def _get_lambda_argument_columns(
     segment: BaseSegment, dialect: Optional[Dialect]
 ) -> list[BaseSegment]:
-    if not dialect or dialect.name not in [
-        "athena",
-        "sparksql",
-        "duckdb",
-        "trino",
-        "databricks",
-        "snowflake",
-    ]:
-        # Only athena and sparksql are known to have lambda expressions,
-        # so all other dialects will have zero lambda columns
+    if not dialect or dialect.name not in (
+        _LAMBDA_FUNCTION_DIALECTS + _LAMBDA_EXPRESSION_DIALECTS
+    ):
+        # Dialects without lambda expressions have zero lambda columns.
         return []
+
+    uses_lambda_function = dialect.name in _LAMBDA_FUNCTION_DIALECTS
 
     lambda_argument_columns: list[BaseSegment] = []
     for potential_lambda in segment.recursive_crawl("expression", "lambda_function"):
-        potential_arrow = potential_lambda.get_child("binary_operator", "lambda_arrow")
+        if uses_lambda_function:
+            # A bare expression with a "->" is not a lambda in these dialects.
+            if not potential_lambda.is_type("lambda_function"):
+                continue
+            potential_arrow = potential_lambda.get_child("lambda_arrow")
+        else:
+            potential_arrow = potential_lambda.get_child("binary_operator")
+
         if potential_arrow and potential_arrow.raw == "->":
             arrow_operator = potential_arrow
             # The arguments will be before the arrow operator, so we get anything
@@ -415,11 +428,8 @@ def _get_lambda_argument_columns(
             )
 
             if len(argument_segments) != 1:
-                # The `->` isn't really a lambda arrow. Some dialects reuse `->`
-                # as a binary operator (e.g. duckdb/trino JSON extraction, as in
-                # `1::json -> 'a'`), where the left operand isn't a single lambda
-                # parameter. Those contribute no lambda argument columns, so skip
-                # rather than crashing the whole analyzer.
+                # Not a shape we recognise as a lambda parameter list. Contribute
+                # no columns rather than crashing the whole analyzer.
                 continue
             child_segment = argument_segments[0]
 

--- a/test/fixtures/rules/std_rule_cases/RF02.yml
+++ b/test/fixtures/rules/std_rule_cases/RF02.yml
@@ -195,6 +195,16 @@ test_json_arrow_operator_is_not_a_lambda_trino:
     core:
       dialect: trino
 
+test_arrow_with_non_parameter_left_operand_is_not_a_lambda:
+  # The left operand of `->` is a function call, not a single lambda parameter,
+  # so it is not treated as a lambda (and must not crash the analyzer). All real
+  # column references are qualified, so there is nothing for RF02 to flag.
+  pass_str: |
+    select filter(t1.arr, foo() -> 1) from t1 join t2 on t1.id = t2.id
+  configs:
+    core:
+      dialect: databricks
+
 test_json_arrow_on_plain_column_is_not_a_lambda_duckdb:
   # A plain column on the left of `->` is still JSON extraction, not a lambda
   # parameter, so the column must still be reported as unqualified.

--- a/test/fixtures/rules/std_rule_cases/RF02.yml
+++ b/test/fixtures/rules/std_rule_cases/RF02.yml
@@ -178,6 +178,23 @@ test_disallow_unqualified_references_in_malformed_lambdas:
     core:
       dialect: athena
 
+test_json_arrow_operator_is_not_a_lambda_duckdb:
+  # The `->` here is the JSON extraction operator, not a lambda arrow. The
+  # left operand is a cast, not a lambda parameter, so it must not be treated
+  # as a lambda (and must not crash the analyzer).
+  pass_str: |
+    select 1::json -> 'a' from t
+  configs:
+    core:
+      dialect: duckdb
+
+test_json_arrow_operator_is_not_a_lambda_trino:
+  pass_str: |
+    select 1::json -> 'a' from t
+  configs:
+    core:
+      dialect: trino
+
 test_fail_column_and_alias_same_name:
   # See issue #2169
   fail_str: |

--- a/test/fixtures/rules/std_rule_cases/RF02.yml
+++ b/test/fixtures/rules/std_rule_cases/RF02.yml
@@ -195,6 +195,37 @@ test_json_arrow_operator_is_not_a_lambda_trino:
     core:
       dialect: trino
 
+test_json_arrow_on_plain_column_is_not_a_lambda_duckdb:
+  # A plain column on the left of `->` is still JSON extraction, not a lambda
+  # parameter, so the column must still be reported as unqualified.
+  fail_str: |
+    select payload -> 'a' from t1 join t2 on t1.id = t2.id
+  configs:
+    core:
+      dialect: duckdb
+
+test_json_arrow_on_plain_column_is_not_a_lambda_trino:
+  fail_str: |
+    select payload -> 'a' from t1 join t2 on t1.id = t2.id
+  configs:
+    core:
+      dialect: trino
+
+test_lambda_parameters_are_still_standalone_duckdb:
+  # The lambda parameter `x` is declared in place and must not be reported.
+  fail_str: |
+    select list_filter(t1.l, x -> x > n) from t1 join t2 on t1.id = t2.id
+  configs:
+    core:
+      dialect: duckdb
+
+test_lambda_parameters_are_still_standalone_snowflake:
+  fail_str: |
+    select filter(t1.l, x -> x > n) from t1 join t2 on t1.id = t2.id
+  configs:
+    core:
+      dialect: snowflake
+
 test_fail_column_and_alias_same_name:
   # See issue #2169
   fail_str: |


### PR DESCRIPTION
Fixes #8398

`_get_lambda_argument_columns` treated every `->` as a lambda arrow and did `assert len(argument_segments) == 1`. When `->` is used as a binary/JSON-arrow operator instead — e.g. `1::json -> 'a'` on duckdb/trino, where the left operand is a cast rather than a single lambda parameter — `argument_segments` is empty and the hard assert fires. Because it runs during `get_select_statement_info`, `BaseRule.crawl` catches it and every affected rule (AL04, AL05, AM04, RF01, RF02, RF03, ST05) reports an "Unexpected exception" on otherwise-valid SQL.

This replaces the assert with a guard: when the segments before `->` aren't exactly one lambda parameter, it isn't a lambda, so it contributes no lambda argument columns and we skip it instead of crashing. Genuine lambdas (`x -> x + 1`, `(x, y) -> x + y`) are unaffected.

Added RF02 fixture cases for `1::json -> 'a'` on duckdb and trino; they fail on `main` with the `AssertionError` and pass with this change. The existing analysis/rule suites (including the lambda cases) stay green.

### AI usage

I used an AI assistant (Claude Code) to help navigate the analysis code and draft the fix and fixtures. I found and reproduced the crash myself on sqlfluff 4.3.0 (the duckdb/trino `1::json -> 'a'` case, and confirmed databricks does *not* trigger it), verified the root cause is the lambda-arrow assert over-matching a binary `->`, and confirmed the new cases fail on `main` and pass after while the lambda tests still pass. I've reviewed every line and stand by it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents the analyzer from assert-crashing when `->` is a binary/JSON operator (e.g., `1::json -> 'a'` on duckdb/trino) instead of a lambda arrow, and stops it from misclassifying JSON extraction as a lambda.

**Bug Fixes**
- Classifies lambdas by segment type: duckdb, trino, and snowflake parse a real lambda as a `lambda_function` holding a `lambda_arrow`, so a plain `->` binary operator in those dialects is never a lambda.
- athena, sparksql, and databricks parse lambdas as an ordinary expression and keep matching on the `binary_operator`.
- Keeps a count check as a guard so an unexpected shape — including a non-parameter left operand — returns no columns instead of raising.
- Adds RF02 fixtures for duckdb/trino JSON extraction and for lambda parameters staying standalone, including a case exercising the guard.

<sup>Written for commit e39bade67815fd383e3343b36d95cabb89eaa4dd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8399?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

