### PR TITLE
fix(ci): update actions and configure dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/ci-test-dbt.yml
+++ b/.github/workflows/ci-test-dbt.yml
@@ -88,7 +88,7 @@ jobs:
       run: tox -e ${{ inputs.dbt-version }} -- plugins/sqlfluff-templater-dbt
 
     - name: Upload coverage data (github)
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       if: ${{ inputs.coverage }}
       with:
         name: coverage-data-py${{ inputs.python-version }}-${{ inputs.dbt-version }}

--- a/.github/workflows/ci-test-python.yml
+++ b/.github/workflows/ci-test-python.yml
@@ -63,7 +63,7 @@ jobs:
     - name: Download built wheels
       # Reuse the Linux x86_64 abi3 wheel across all supported CPython versions.
       if: ${{ inputs.with-rust == '-rust' }}
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         path: ./dist
         name: wheels-linux-x86_64
@@ -105,7 +105,7 @@ jobs:
         for file in .coverage.*; do mv "$file" "$file.$COVSUFFIX"; done;
 
     - name: Upload coverage data (github)
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       if: ${{ inputs.coverage }}
       with:
         name: coverage-data-py${{ inputs.python-version }}-${{ inputs.marks }}${{ inputs.with-rust }}

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -183,7 +183,7 @@ jobs:
           CARGO_BUILD_JOBS: 4
 
       - name: Upload wheels
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: wheels-linux-x86_64
           path: dist
@@ -230,7 +230,7 @@ jobs:
           manylinux: auto
 
       - name: Upload wheels
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: wheels-linux-${{ matrix.target }}
           path: dist
@@ -282,7 +282,7 @@ jobs:
           manylinux: musllinux_1_2
 
       - name: Upload wheels
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: wheels-musllinux-${{ matrix.platform.target }}
           path: dist
@@ -329,7 +329,7 @@ jobs:
           args: --release --out dist --manifest-path sqlfluffrs/Cargo.toml
 
       - name: Upload wheels
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: wheels-windows-${{ matrix.platform.target }}
           path: dist
@@ -375,7 +375,7 @@ jobs:
           args: --release --out dist --manifest-path sqlfluffrs/Cargo.toml
 
       - name: Upload wheels
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: wheels-macos-${{ matrix.platform.target }}
           path: dist
@@ -414,7 +414,7 @@ jobs:
           args: --out dist --manifest-path sqlfluffrs/Cargo.toml
 
       - name: Upload sdist
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: wheels-sdist
           path: dist
@@ -658,7 +658,7 @@ jobs:
         python -m tox -e winpy -- --cov=sqlfluff -n 2 test -m "not integration"
 
     - name: Upload coverage data (github)
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: coverage-data-winpy3.14
         path: ".coverage.*"
@@ -852,7 +852,7 @@ jobs:
       - run: uv pip install --system --upgrade coverage[toml]
 
       - name: Download coverage data.
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: coverage-data-*
           merge-multiple: true
@@ -869,7 +869,7 @@ jobs:
           python -m coverage report --fail-under=100 --skip-covered --skip-empty -m | tee coverage-report.txt
 
       - name: Upload HTML report if check failed.
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: html-report
           path: htmlcov
@@ -886,7 +886,7 @@ jobs:
         # NOTE: We don't actually comment on the PR from here, we'll do that in
         # a more secure way by triggering a more secure workflow.
         # https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: txt-report
           path: |

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -63,7 +63,7 @@ jobs:
           out: ${{ env.CS_XML }}
 
       - name: Provide log as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: ${{ !cancelled() }}
         with:
           name: precommit-logs

--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -319,7 +319,7 @@ jobs:
           --site-dir ${{ env.DOCS_SITE_DIR }}
 
       - name: ⬆️ Upload assembled site artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: assembled-docs-site
           path: ${{ env.DOCS_SITE_DIR }}

--- a/.github/workflows/publish-sqlfluffrs-release-to-pypi.yaml
+++ b/.github/workflows/publish-sqlfluffrs-release-to-pypi.yaml
@@ -30,7 +30,7 @@ jobs:
           python utils/rustify.py build
 
       - name: Upload generated Rust dialects
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: generated-rust-dialects
           path: sqlfluffrs/sqlfluffrs_dialects/src/
@@ -65,7 +65,7 @@ jobs:
           fetch-depth: 1
 
       - name: Download generated Rust dialects
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: generated-rust-dialects
           path: sqlfluffrs/sqlfluffrs_dialects/src/
@@ -93,7 +93,7 @@ jobs:
           manylinux: ${{ matrix.platform.manylinux || '' }}
 
       - name: Upload wheels
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: wheels-${{ matrix.platform.artifact }}
           path: dist
@@ -107,7 +107,7 @@ jobs:
           fetch-depth: 1
 
       - name: Download generated Rust dialects
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: generated-rust-dialects
           path: sqlfluffrs/sqlfluffrs_dialects/src/
@@ -119,7 +119,7 @@ jobs:
           args: --out dist --manifest-path sqlfluffrs/Cargo.toml
 
       - name: Upload sdist
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: wheels-sdist
           path: dist
@@ -137,7 +137,7 @@ jobs:
       attestations: write
     steps:
       - name: Download all wheels
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
 
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v2


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
When reviewing PRs, I noticed we get plenty of GitHub warnings for using outdated actions, e.g. 
<img width="1260" height="111" alt="image" src="https://github.com/user-attachments/assets/7bf9cc54-7538-4acd-b823-2eab6cfb68d3" />
I've bumped `actions/upload-artifact@v4` to `v7.0.1` and `actions/download-artifact@v4` to `v8.0.1`, both using SHA pins now.
Additionally, I've configured dependabot to get once a month a PR with all action updates. 
I feel like we already get enough PRs to go through and don't need many more with individual GitHub Actions updates, better to have a single PR with all changes in one go.

### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [ ] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops CI warnings about outdated artifact actions by upgrading and pinning them, and reduces PR noise by grouping GitHub Actions updates.

- Dependencies
  - Bumped `actions/upload-artifact` from `v4` to `v7.0.1` and pinned by SHA.
  - Bumped `actions/download-artifact` from `v4` to `v8.0.1` and pinned by SHA.
  - Added `.github/dependabot.yml` to group `github-actions` updates into a single monthly PR.
  - No runtime or build behavior changes; workflows only.

<sup>Written for commit 479cb6ec05e858a11ea0c15721c42aae4b71a01c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8400?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

