### PR TITLE
fix(parser): Bracketed no longer matches empty brackets when content is required

### DIFF
--- a/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/bracketed.rs
+++ b/sqlfluffrs/sqlfluffrs_parser/src/parser/table_driven/bracketed.rs
@@ -444,13 +444,14 @@ impl Parser<'_> {
             // This check should only happen AFTER all content elements have been processed.
             let check_pos = self.skip_start_index_forward_to_code(self.pos, self.tokens.len());
 
-            // A required element failing after some content already matched
-            // is a genuine partial match: STRICT must fail here rather than
-            // let the gap check below match the closing bracket over it.
-            // Gated on `last_matched_end > content_start` so a required
-            // element failing with nothing consumed - an empty bracket `()` -
-            // still succeeds. Content starts at the end of the opening
-            // bracket, always the first recorded child match.
+            // A required element failing must fail the match in STRICT mode:
+            // after a partial match it's a genuine partial match (we must not
+            // let the gap check below match the closing bracket over it), and
+            // with nothing consumed it's an empty bracket `()` whose content
+            // grammar requires content, which must not match either
+            // (https://github.com/sqlfluff/sqlfluff/issues/8368). Content
+            // starts at the end of the opening bracket, always the first
+            // recorded child match.
             let content_start = child_matches
                 .first()
                 .map(|m| m.matched_slice.end)
@@ -460,12 +461,31 @@ impl Parser<'_> {
                 .map(|m| m.matched_slice.end)
                 .max()
                 .unwrap_or(content_start);
+            if current_required_failed && parse_mode == ParseMode::Strict {
+                vdebug!(
+                    "Bracketed[table] STRICT mode: required content element failed, returning Empty. frame_id={}, frame.pos={}",
+                    frame.frame_id, frame.pos
+                );
+                self.pos = frame.pos;
+                frame.end_pos = Some(frame.pos);
+                frame.state = FrameState::Combining;
+                stack.push(frame);
+                return Ok(TableFrameResult::Done);
+            }
+
+            // The empty-body case must fail in GREEDY mode too (Python
+            // parity: Bracketed.match returns no match in *any* parse mode
+            // when the content grammar requires content and the body is
+            // empty), while non-empty invalid content is still claimed and
+            // wrapped as unparsable below. The body is empty when the
+            // required element failed with nothing consumed and the next
+            // code token is already the closing bracket.
             if current_required_failed
-                && parse_mode == ParseMode::Strict
-                && last_matched_end > content_start
+                && last_matched_end <= content_start
+                && *bracket_max_idx == Some(check_pos)
             {
                 vdebug!(
-                    "Bracketed[table] STRICT mode: required content element failed after a partial match, returning Empty. frame_id={}, frame.pos={}",
+                    "Bracketed[table]: required content element failed on an empty bracket body, returning Empty. frame_id={}, frame.pos={}",
                     frame.frame_id, frame.pos
                 );
                 self.pos = frame.pos;

--- a/src/sqlfluff/core/parser/grammar/sequence.py
+++ b/src/sqlfluff/core/parser/grammar/sequence.py
@@ -512,6 +512,24 @@ class Bracketed(Sequence):
         ) as ctx:
             content_match = super().match(segments, content_start_idx, ctx)
 
+        # If the content grammar contains required (i.e. non-optional)
+        # elements, then it cannot validly match an empty bracket body.
+        # In that case a zero length content match means the content
+        # didn't match, and we shouldn't continue on to match the end
+        # bracket (which would otherwise allow empty brackets `()` to
+        # match regardless of the content grammar). By returning no
+        # match (in any parse mode), we allow any other grammars which
+        # *can* match empty brackets to be tried, or the surrounding
+        # grammar to mark the section as unparsable.
+        # https://github.com/sqlfluff/sqlfluff/issues/8368
+        if is_zero_slice(content_match.matched_slice) and any(
+            not elem.is_optional()
+            for elem in self._elements
+            if not isinstance(elem, Conditional)
+            and not (isinstance(elem, type) and issubclass(elem, Indent))
+        ):
+            return MatchResult.empty_at(idx)
+
         # Get position after content for end bracket check
         gap_start = end_bracket_idx = content_match.matched_slice.stop
 

--- a/src/sqlfluff/core/parser/grammar/sequence.py
+++ b/src/sqlfluff/core/parser/grammar/sequence.py
@@ -474,9 +474,14 @@ class Bracketed(Sequence):
 
         How the grammar behaves on different content depends on the `parse_mode`:
 
-        - If the parse mode is `GREEDY`, this always returns a match if
-          the opening and closing brackets are found. Anything unexpected
-          within the brackets is marked as `unparsable`.
+        - If the parse mode is `GREEDY`, this returns a match if the
+          opening and closing brackets are found, with anything unexpected
+          within the brackets marked as `unparsable`. The exception is an
+          empty bracket body when the content grammar contains required
+          elements: that returns no match (in *any* parse mode), so that
+          any other grammars which *can* match empty brackets may be
+          tried, or so the surrounding grammar can mark the section as
+          unparsable.
         - If the parse mode is `STRICT`, then this only returns a match if
           the content of the brackets matches (and matches *completely*)
           one of the elements of the grammar. Otherwise no match.

--- a/src/sqlfluff/dialects/dialect_bigquery.py
+++ b/src/sqlfluff/dialects/dialect_bigquery.py
@@ -2123,7 +2123,9 @@ class OptionsSegment(BaseSegment):
                     Ref("ParameterNameSegment"),
                     Ref("EqualsSegment"),
                     Ref("BaseExpressionElementGrammar"),
-                )
+                ),
+                # The brackets might be empty i.e. `OPTIONS()`.
+                optional=True,
             )
         ),
     )

--- a/src/sqlfluff/dialects/dialect_clickhouse.py
+++ b/src/sqlfluff/dialects/dialect_clickhouse.py
@@ -629,6 +629,8 @@ class MergeTreesOrderByClauseSegment(BaseSegment):
                 Delimited(
                     Ref("ColumnReferenceSegment"),
                     Ref("ExpressionSegment"),
+                    # The brackets might be empty i.e. `ORDER BY ()`.
+                    optional=True,
                 ),
             ),
             Ref("ColumnReferenceSegment"),
@@ -937,6 +939,8 @@ class DateTime64ArgumentsSegment(BaseSegment):
                 Ref("QuotedLiteralSegment"),  # timezone
                 optional=True,
             ),
+            # The brackets might be empty i.e. `DateTime64()`.
+            optional=True,
         )
     )
 
@@ -3054,10 +3058,12 @@ class FunctionContentsSegment(BaseSegment):
         # Double parentheses pattern: func(params)(args)
         Sequence(
             Bracketed(
-                Ref("FunctionContentsGrammar"),
+                # The parameter brackets might be empty
+                # i.e. `studentTTestOneSample()(...)`.
+                Ref("FunctionContentsGrammar", optional=True),
             ),
             Bracketed(
-                Ref("FunctionContentsGrammar"),
+                Ref("FunctionContentsGrammar", optional=True),
             ),
         ),
         # Standard ANSI single parentheses

--- a/src/sqlfluff/dialects/dialect_doris.py
+++ b/src/sqlfluff/dialects/dialect_doris.py
@@ -243,7 +243,10 @@ class PartitionSegment(BaseSegment):
                             OneOf(
                                 Ref("RangePartitionDefinitionSegment"),
                                 Ref("RangePartitionIntervalSegment"),
-                            )
+                            ),
+                            # The partition list might be empty for
+                            # dynamic partitioning.
+                            optional=True,
                         )
                     ),
                 ),
@@ -251,7 +254,14 @@ class PartitionSegment(BaseSegment):
                 Sequence(
                     "LIST",
                     Bracketed(Delimited(Ref("ColumnReferenceSegment"))),
-                    Bracketed(Delimited(Ref("ListPartitionDefinitionSegment"))),
+                    Bracketed(
+                        Delimited(
+                            Ref("ListPartitionDefinitionSegment"),
+                            # The partition list might be empty for
+                            # dynamic partitioning.
+                            optional=True,
+                        )
+                    ),
                 ),
             ),
         ),

--- a/test/core/parser/grammar/grammar_sequence_test.py
+++ b/test/core/parser/grammar/grammar_sequence_test.py
@@ -335,6 +335,40 @@ def test__parser__grammar_sequence_modes(
             {"allow_gaps": False},
             (),
         ),
+        # Empty brackets shouldn't match if the content grammar contains
+        # required elements.
+        # https://github.com/sqlfluff/sqlfluff/issues/8368
+        (
+            ["(", ")"],
+            ParseMode.STRICT,
+            ["a"],
+            {},
+            (),
+        ),
+        (
+            ["(", " ", ")"],
+            ParseMode.STRICT,
+            ["a"],
+            {},
+            (),
+        ),
+        # The same applies in GREEDY mode: by not matching, we allow any
+        # other grammars which *can* match empty brackets to be tried, or
+        # the surrounding grammar to mark the section as unparsable.
+        (
+            ["(", ")"],
+            ParseMode.GREEDY,
+            ["a"],
+            {},
+            (),
+        ),
+        (
+            ["(", " ", ")"],
+            ParseMode.GREEDY,
+            ["a"],
+            {},
+            (),
+        ),
         # Happy path content match.
         (
             ["(", "a", ")"],

--- a/test/fixtures/dialects/athena/select_group_by.yml
+++ b/test/fixtures/dialects/athena/select_group_by.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 83514a0915632a2c850321b3d61197b25008f6e4f95342bb1df5de8af668e27a
+_hash: 0ddc6abe3d416783cfd8e7ad71fdba26255b3505263695cdef7d31b60fc93975
 file:
 - statement:
     select_statement:
@@ -224,10 +224,9 @@ file:
                       naked_identifier: as_of_date
                   end_bracket: )
             - comma: ','
-            - expression:
-                bracketed:
-                  start_bracket: (
-                  end_bracket: )
+            - bracketed:
+                start_bracket: (
+                end_bracket: )
             end_bracket: )
 - statement_terminator: ;
 - statement:
@@ -295,9 +294,8 @@ file:
             - column_reference:
                 naked_identifier: channel
             - comma: ','
-            - expression:
-                bracketed:
-                  start_bracket: (
-                  end_bracket: )
+            - bracketed:
+                start_bracket: (
+                end_bracket: )
             end_bracket: )
 - statement_terminator: ;

--- a/test/fixtures/dialects/bigquery/select_group_by.yml
+++ b/test/fixtures/dialects/bigquery/select_group_by.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 112fa70a0e52c988c9eaa79cf6d401471472ece3b4084a04d67b104b71fdd7ae
+_hash: 2488b50085ca8f68d0542adcea1efd64e73333ba2c15f6787680b1d822c76428
 file:
 - statement:
     select_statement:
@@ -75,10 +75,9 @@ file:
             grouping_expression_list:
               numeric_literal: '1'
               comma: ','
-              expression:
-                bracketed:
-                  start_bracket: (
-                  end_bracket: )
+              bracketed:
+                start_bracket: (
+                end_bracket: )
             end_bracket: )
 - statement_terminator: ;
 - statement:
@@ -123,10 +122,9 @@ file:
               column_reference:
                 naked_identifier: letter
               comma: ','
-              expression:
-                bracketed:
-                  start_bracket: (
-                  end_bracket: )
+              bracketed:
+                start_bracket: (
+                end_bracket: )
             end_bracket: )
 - statement_terminator: ;
 - statement:

--- a/test/fixtures/dialects/bigquery/select_struct.yml
+++ b/test/fixtures/dialects/bigquery/select_struct.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: b7c378252d3e544c5d02c42689a9d7e718ec0a5e4d7335659d2041d0de252f2c
+_hash: 96514a48f19d6a3953bbe32b84f82166f822ab14afc3c1366f41f4a3a9db9769
 file:
 - statement:
     select_statement:
@@ -348,14 +348,13 @@ file:
             function_contents:
               bracketed:
                 start_bracket: (
-                expression:
-                  typed_struct_literal:
-                    data_type:
-                      keyword: STRUCT
-                    struct_literal:
-                      bracketed:
-                        start_bracket: (
-                        end_bracket: )
+                typed_struct_literal:
+                  data_type:
+                    keyword: STRUCT
+                  struct_literal:
+                    bracketed:
+                      start_bracket: (
+                      end_bracket: )
                 end_bracket: )
           alias_expression:
             alias_operator:

--- a/test/fixtures/dialects/databricks/select_group_by.yml
+++ b/test/fixtures/dialects/databricks/select_group_by.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 190c1ef57480e9d5090ba1f22a86f90bc2b578398d70d4ff73845635196e682d
+_hash: 987baa34e9a2ef0710e53e0faa64775e30f9421f2d398e2da1d631edba932e48
 file:
 - statement:
     select_statement:
@@ -304,10 +304,9 @@ file:
                       naked_identifier: car_model
                   end_bracket: )
             - comma: ','
-            - expression:
-                bracketed:
-                  start_bracket: (
-                  end_bracket: )
+            - bracketed:
+                start_bracket: (
+                end_bracket: )
             end_bracket: )
       orderby_clause:
       - keyword: ORDER
@@ -389,10 +388,9 @@ file:
                       naked_identifier: car_model
                   end_bracket: )
             - comma: ','
-            - expression:
-                bracketed:
-                  start_bracket: (
-                  end_bracket: )
+            - bracketed:
+                start_bracket: (
+                end_bracket: )
             end_bracket: )
       orderby_clause:
       - keyword: ORDER
@@ -475,10 +473,9 @@ file:
                       naked_identifier: car_model
                   end_bracket: )
             - comma: ','
-            - expression:
-                bracketed:
-                  start_bracket: (
-                  end_bracket: )
+            - bracketed:
+                start_bracket: (
+                end_bracket: )
             end_bracket: )
       orderby_clause:
       - keyword: ORDER

--- a/test/fixtures/dialects/exasol/select_statement.yml
+++ b/test/fixtures/dialects/exasol/select_statement.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: ed63b494837b3e04680e3fd2fe69a5d776274ab689dd31550247f6d74a979c33
+_hash: baeed41847d4855aac3f70038e92ab27054f152596ec9a73cf591f59a79979d3
 file:
 - statement:
     select_statement:
@@ -299,10 +299,9 @@ file:
               - column_reference:
                   naked_identifier: store
               - comma: ','
-              - expression:
-                  bracketed:
-                    start_bracket: (
-                    end_bracket: )
+              - bracketed:
+                  start_bracket: (
+                  end_bracket: )
               end_bracket: )
 - statement_terminator: ;
 - statement:

--- a/test/fixtures/dialects/hive/grouping_sets_trailing.yml
+++ b/test/fixtures/dialects/hive/grouping_sets_trailing.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: c50ecbc9e9c0b0add6659f263272f85554904d18a52ea7a4102b12bb01f2b377
+_hash: 353d764834fe235224c20b0f886743134add4b9a75c8a4081451b996e26c6395
 file:
 - statement:
     select_statement:
@@ -65,10 +65,9 @@ file:
                       naked_identifier: a
                   end_bracket: )
             - comma: ','
-            - expression:
-                bracketed:
-                  start_bracket: (
-                  end_bracket: )
+            - bracketed:
+                start_bracket: (
+                end_bracket: )
             end_bracket: )
       having_clause:
         keyword: HAVING
@@ -120,17 +119,16 @@ file:
         - bracketed:
             start_bracket: (
             grouping_expression_list:
-            - expression:
+              expression:
                 bracketed:
                   start_bracket: (
                   expression:
                     column_reference:
                       naked_identifier: a
                   end_bracket: )
-            - comma: ','
-            - expression:
-                bracketed:
-                  start_bracket: (
-                  end_bracket: )
+              comma: ','
+              bracketed:
+                start_bracket: (
+                end_bracket: )
             end_bracket: )
 - statement_terminator: ;

--- a/test/fixtures/dialects/postgres/group_by.yml
+++ b/test/fixtures/dialects/postgres/group_by.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 18124d129b5b153297e8f27e9a86e7f1c039154b996e15fdb7b50b47d9fedf99
+_hash: b6d526c29d4522f77fa40a565f5a30b8832640079b9dcb7a8427d635aa0612e5
 file:
 - statement:
     select_statement:
@@ -145,10 +145,9 @@ file:
                     naked_identifier: city
                 - end_bracket: )
             - comma: ','
-            - expression:
-                bracketed:
-                  start_bracket: (
-                  end_bracket: )
+            - bracketed:
+                start_bracket: (
+                end_bracket: )
             end_bracket: )
 - statement_terminator: ;
 - statement:

--- a/test/fixtures/dialects/snowflake/select_group_by_grouping_sets_mixed.yml
+++ b/test/fixtures/dialects/snowflake/select_group_by_grouping_sets_mixed.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 247a5683ec31c51c0f074d3d4d7d3ccf0cdf2799e1739372c362445137dff0bb
+_hash: b5b730f3b0683995297c6ca3aa6bcca4db9ba5910f3bed166b40bab09de0f6a4
 file:
 - statement:
     select_statement:
@@ -47,10 +47,9 @@ file:
             column_reference:
               naked_identifier: b
             comma: ','
-            expression:
-              bracketed:
-                start_bracket: (
-                end_bracket: )
+            bracketed:
+              start_bracket: (
+              end_bracket: )
             end_bracket: )
 - statement_terminator: ;
 - statement:
@@ -164,10 +163,9 @@ file:
                     naked_identifier: b
                 end_bracket: )
           - comma: ','
-          - expression:
-              bracketed:
-                start_bracket: (
-                end_bracket: )
+          - bracketed:
+              start_bracket: (
+              end_bracket: )
           - end_bracket: )
 - statement_terminator: ;
 - statement:

--- a/test/fixtures/dialects/sparksql/select_group_by.yml
+++ b/test/fixtures/dialects/sparksql/select_group_by.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: e48d313c611a5c62fe32a3b2687b0858ccd9529ccd25acfc0eeeafc4cfadfae5
+_hash: e1dd9dd743f5d67fc44a3fca58402fd167010df7f1b548029da39e70c1883066
 file:
 - statement:
     select_statement:
@@ -304,10 +304,9 @@ file:
                       naked_identifier: car_model
                   end_bracket: )
             - comma: ','
-            - expression:
-                bracketed:
-                  start_bracket: (
-                  end_bracket: )
+            - bracketed:
+                start_bracket: (
+                end_bracket: )
             end_bracket: )
       orderby_clause:
       - keyword: ORDER
@@ -389,10 +388,9 @@ file:
                       naked_identifier: car_model
                   end_bracket: )
             - comma: ','
-            - expression:
-                bracketed:
-                  start_bracket: (
-                  end_bracket: )
+            - bracketed:
+                start_bracket: (
+                end_bracket: )
             end_bracket: )
       orderby_clause:
       - keyword: ORDER
@@ -475,10 +473,9 @@ file:
                       naked_identifier: car_model
                   end_bracket: )
             - comma: ','
-            - expression:
-                bracketed:
-                  start_bracket: (
-                  end_bracket: )
+            - bracketed:
+                start_bracket: (
+                end_bracket: )
             end_bracket: )
       orderby_clause:
       - keyword: ORDER

--- a/test/fixtures/dialects/trino/grouping_sets.yml
+++ b/test/fixtures/dialects/trino/grouping_sets.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: f9bceb6c6582f68314a2a832fb20711b9610e6799791898457a70f9acceba56e
+_hash: a4cd18e83a3380d7b847cfaf2ab1fbdd088e1987538d7b76570013460f514e62
 file:
   statement:
     with_compound_statement:
@@ -102,9 +102,8 @@ file:
               - column_reference:
                   naked_identifier: store
               - comma: ','
-              - expression:
-                  bracketed:
-                    start_bracket: (
-                    end_bracket: )
+              - bracketed:
+                  start_bracket: (
+                  end_bracket: )
               end_bracket: )
   statement_terminator: ;

--- a/test/fixtures/dialects/tsql/merge.yml
+++ b/test/fixtures/dialects/tsql/merge.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: f91f474bfec6523b98ddd6be79b122aaab65c0456c9f9534712f7e281c42d982
+_hash: 70a5b3bc59b926385cc2e033bb93535faa30e849d14e3aea00b40e8e96ae250b
 file:
 - batch:
     statement:
@@ -1515,14 +1515,15 @@ file:
           naked_identifier: t
       - keyword: USING
       - table_expression:
-          table_reference:
-          - naked_identifier: dbo
-          - dot: .
-          - naked_identifier: SomeFunction
-          post_table_expression:
-            bracketed:
-              start_bracket: (
-              end_bracket: )
+          function:
+            function_name:
+              naked_identifier: dbo
+              dot: .
+              function_name_identifier: SomeFunction
+            function_contents:
+              bracketed:
+                start_bracket: (
+                end_bracket: )
       - alias_expression:
           naked_identifier: s
       - join_on_condition:

--- a/test/fixtures/parity/regressions.yml
+++ b/test/fixtures/parity/regressions.yml
@@ -183,13 +183,6 @@ materialize_webhook_overlapping_matches:
     \ FORMAT JSON\n (\n (\n my_webhook_share"
   dialect: materialize
   expect: tree
-  xfail:
-    python_vs_rust: Since the Bracketed empty-body fix (required content grammars no
-      longer match empty brackets), Python no longer parses the leading "( ) ( );"
-      down a path that reaches the trailing unclosed brackets, so it now returns a
-      tree with an unparsable section instead of raising. Rust still raises for the
-      unresolved trailing brackets until the same Bracketed empty-body fix is
-      mirrored in bracketed.rs.
   pins: 'Originally pinned the same root cause as materialize_curly_cross_silent_recovery
     - core.rs''s match_bracket_recursively silently fabricated a close for deeply
     crossed/unmatched brackets instead of raising, and downstream the resulting
@@ -197,8 +190,8 @@ materialize_webhook_overlapping_matches:
     builder''s invariant check (ValueError). Fixed by the same change: an unresolved
     bracket now raises immediately instead of ever reaching the builder. The expectation
     later changed from error to tree when Bracketed stopped matching empty brackets
-    for required content grammars, which reroutes this input to a graceful unparsable
-    section on the Python side.'
+    for required content grammars (in both engines), which reroutes this input to a
+    graceful unparsable section instead of the raising path.'
 depth_guard_error_position:
   sql: SELECT CASE WHEN 1 THEN CASE WHEN 1 THEN CASE WHEN 1 THEN CASE WHEN 1 THEN CASE WHEN
     1 THEN CASE WHEN 1 THEN CASE WHEN 1 THEN CASE WHEN 1 THEN CASE WHEN 1 THEN CASE WHEN 1

--- a/test/fixtures/parity/regressions.yml
+++ b/test/fixtures/parity/regressions.yml
@@ -182,13 +182,23 @@ materialize_webhook_overlapping_matches:
   sql: "(\n ) ( );\nCREATE SOURCE my_webhook_source IN CLUSTER my_cluster FROM WEBHOOK\n BODY\
     \ FORMAT JSON\n (\n (\n my_webhook_share"
   dialect: materialize
-  expect: error
-  pins: 'Same root cause as materialize_curly_cross_silent_recovery - core.rs''s
-    match_bracket_recursively silently fabricated a close for deeply crossed/unmatched
-    brackets instead of raising, and downstream the resulting malformed match ended up
-    with overlapping child matches, tripping the Python-side builder''s invariant check
-    (ValueError). Fixed by the same change: an unresolved bracket now raises immediately
-    instead of ever reaching the builder.'
+  expect: tree
+  xfail:
+    python_vs_rust: Since the Bracketed empty-body fix (required content grammars no
+      longer match empty brackets), Python no longer parses the leading "( ) ( );"
+      down a path that reaches the trailing unclosed brackets, so it now returns a
+      tree with an unparsable section instead of raising. Rust still raises for the
+      unresolved trailing brackets until the same Bracketed empty-body fix is
+      mirrored in bracketed.rs.
+  pins: 'Originally pinned the same root cause as materialize_curly_cross_silent_recovery
+    - core.rs''s match_bracket_recursively silently fabricated a close for deeply
+    crossed/unmatched brackets instead of raising, and downstream the resulting
+    malformed match ended up with overlapping child matches, tripping the Python-side
+    builder''s invariant check (ValueError). Fixed by the same change: an unresolved
+    bracket now raises immediately instead of ever reaching the builder. The expectation
+    later changed from error to tree when Bracketed stopped matching empty brackets
+    for required content grammars, which reroutes this input to a graceful unparsable
+    section on the Python side.'
 depth_guard_error_position:
   sql: SELECT CASE WHEN 1 THEN CASE WHEN 1 THEN CASE WHEN 1 THEN CASE WHEN 1 THEN CASE WHEN
     1 THEN CASE WHEN 1 THEN CASE WHEN 1 THEN CASE WHEN 1 THEN CASE WHEN 1 THEN CASE WHEN 1


### PR DESCRIPTION
### Brief summary of the change made

Fixes #8368.

`Bracketed.match` never checked whether its content grammar actually matched: after matching the content it proceeded straight to matching the end bracket, so empty brackets `()` matched successfully even when the content grammar contained required (non-optional) elements — in STRICT parse mode too. This made it impossible for a dialect to express "these brackets must not be empty" (e.g. `SELECT * FROM t WHERE a IN ()` parsed cleanly with no `PRS` violation).

**The fix** (in `Bracketed.match`): if the content match is zero-length and the content grammar contains any required elements (ignoring metas and conditionals), the bracketed match now fails — in *any* parse mode.

**Design trade-off considered**: an alternative for GREEDY mode was to claim the brackets and wrap them as `unparsable`. I implemented and rejected that: a claimed-but-unparsable match blocks sibling `OneOf` alternatives that legitimately accept empty brackets — e.g. the explicit `Bracketed()` alternative ANSI uses for empty grouping sets, so `GROUP BY GROUPING SETS ((a), ())` stopped parsing. Returning no match lets those alternatives be tried, or lets the surrounding grammar mark the section as unparsable, and turned out to be correct in both modes.

**Dialect grammars which relied on the old behaviour** (where empty brackets are legitimate SQL) now say so explicitly with `optional=True`:
- BigQuery: `OPTIONS()`
- ClickHouse: MergeTree `ORDER BY ()`, `DateTime64()`, parametric aggregates `func()(args)`
- Doris: empty partition definition lists

### Are there any other side effects of this change that we should be aware of?

- **Parse tree changes** (regenerated fixtures, all structural improvements): empty grouping sets `()` now parse directly as `bracketed` via the explicit `Bracketed()` alternative instead of a spurious `expression` wrapper; TSQL `MERGE ... USING dbo.fn()` now parses as a function call instead of a table reference with empty `post_table_expression`.
- **Parity case behaviour change**: `materialize_webhook_overlapping_matches` (in `test/fixtures/parity/regressions.yml`) previously raised `SQLParseError`; both parsers now return a tree with an unparsable section instead, and the case's `expect` is updated to `tree`. **The Rust parser mirror is included in this PR** (`table_driven/bracketed.rs` — it deliberately reproduced the old empty-bracket behaviour, so the same empty-body check is applied there), keeping the `python_vs_rust` dialect fixture corpus sweep green. The dialect grammar changes need no Rust-side work (generated by `rustify.py`).
- Dialects not covered by test fixtures could conceivably rely on empty brackets matching a required content grammar; the remedy is the same documented `optional=True` pattern that `FunctionContentsSegment` already uses.

**Test status**: core, dialect, and rules suites pass locally (~10.4k tests), all 2,249 parse fixtures regenerate with no diff, and pre-commit (mypy/ruff/yamllint/codespell) passes. With `sqlfluffrs` built locally, the full parity suite passes (2,322 tests including the dialect fixture corpus sweep), `cargo test` passes (108 tests), and cargo fmt/clippy are clean. The dbt templater suite runs 57 passed / 6 failed locally, but the same 6 tests fail identically on clean `main` in my environment (they require a live Postgres at `localhost:5432`), so no regression there.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (regenerated for the affected fixtures).
  - Other: new `Bracketed` grammar mode test cases in `test/core/parser/grammar/grammar_sequence_test.py`, and an updated parity regression case.
- Added appropriate documentation for the change (inline comments; no user-facing docs affected).
- Created GitHub issues for any relevant followup/future enhancements if appropriate (none needed — the Rust-side mirror is included in this PR).

### AI disclosure

Per the contribution guidelines: this change was developed with AI assistance (Claude Code). The root-cause analysis, implementation, and test/fixture updates were AI-assisted; I reviewed the diff and validated behaviour by running the reproduction cases from the issue, the core/dialect/rules test suites, the full fixture regeneration, and pre-commit locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
