### PR TITLE
feat(duckdb): support INSTALL, FORCE INSTALL, and LOAD extension stat…

### DIFF
--- a/src/sqlfluff/dialects/dialect_duckdb.py
+++ b/src/sqlfluff/dialects/dialect_duckdb.py
@@ -1461,7 +1461,7 @@ class InstallStatementSegment(BaseSegment):
 
     type = "install_statement"
     match_grammar = Sequence(
-        Sequence("FORCE", optional=True),
+        Ref.keyword("FORCE", optional=True),
         "INSTALL",
         OneOf(
             Ref("SingleIdentifierGrammar"),

--- a/src/sqlfluff/dialects/dialect_duckdb.py
+++ b/src/sqlfluff/dialects/dialect_duckdb.py
@@ -68,7 +68,9 @@ duckdb_dialect.sets("unreserved_keywords").update(
         "ASOF",
         "COMPRESSION",
         "COMPRESSION_LEVEL",
+        "FORCE",
         "GLOB",
+        "INSTALL",
         "MACRO",
         "MAP",
         "OVERWRITE",
@@ -1033,6 +1035,7 @@ class StatementSegment(postgres.StatementSegment):
         insert=[
             Ref("SimplifiedPivotExpressionSegment"),
             Ref("SimplifiedUnpivotExpressionSegment"),
+            Ref("InstallStatementSegment"),
         ]
     )
 
@@ -1431,4 +1434,45 @@ class ValuesClauseSegment(postgres.ValuesClauseSegment):
         Ref("AliasExpressionSegment", optional=True),
         Ref("OrderByClauseSegment", optional=True),
         Ref("LimitClauseSegment", optional=True),
+    )
+
+
+class LoadStatementSegment(BaseSegment):
+    """A `LOAD` statement.
+
+    https://duckdb.org/docs/extensions/overview#load
+    """
+
+    type = "load_statement"
+    match_grammar = Sequence(
+        "LOAD",
+        OneOf(
+            Ref("SingleIdentifierGrammar"),
+            Ref("QuotedLiteralSegment"),
+        ),
+    )
+
+
+class InstallStatementSegment(BaseSegment):
+    """An `INSTALL` statement.
+
+    https://duckdb.org/docs/extensions/overview#install
+    """
+
+    type = "install_statement"
+    match_grammar = Sequence(
+        Sequence("FORCE", optional=True),
+        "INSTALL",
+        OneOf(
+            Ref("SingleIdentifierGrammar"),
+            Ref("QuotedLiteralSegment"),
+        ),
+        Sequence(
+            "FROM",
+            OneOf(
+                Ref("SingleIdentifierGrammar"),
+                Ref("QuotedLiteralSegment"),
+            ),
+            optional=True,
+        ),
     )

--- a/test/fixtures/dialects/duckdb/install_and_load.sql
+++ b/test/fixtures/dialects/duckdb/install_and_load.sql
@@ -1,0 +1,11 @@
+INSTALL httpfs;
+INSTALL 'spatial';
+INSTALL sqlite FROM community;
+INSTALL httpfs FROM 'http://custom-repo.org';
+INSTALL 'https://example.com/path/to/extension.duckdb_extension';
+FORCE INSTALL spatial;
+FORCE INSTALL spatial FROM core_nightly;
+FORCE INSTALL 'https://example.com/path/to/extension.duckdb_extension';
+LOAD httpfs;
+LOAD 'spatial';
+LOAD '/path/to/custom_extension.duckdb_extension';

--- a/test/fixtures/dialects/duckdb/install_and_load.yml
+++ b/test/fixtures/dialects/duckdb/install_and_load.yml
@@ -1,0 +1,71 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: f3f38a9ee754ccf7ade8c57ad4b1b733c65b4434d2ce997afe0aaa5f205d51b9
+file:
+- statement:
+    install_statement:
+      keyword: INSTALL
+      naked_identifier: httpfs
+- statement_terminator: ;
+- statement:
+    install_statement:
+      keyword: INSTALL
+      quoted_literal: "'spatial'"
+- statement_terminator: ;
+- statement:
+    install_statement:
+    - keyword: INSTALL
+    - naked_identifier: sqlite
+    - keyword: FROM
+    - naked_identifier: community
+- statement_terminator: ;
+- statement:
+    install_statement:
+    - keyword: INSTALL
+    - naked_identifier: httpfs
+    - keyword: FROM
+    - quoted_literal: "'http://custom-repo.org'"
+- statement_terminator: ;
+- statement:
+    install_statement:
+      keyword: INSTALL
+      quoted_literal: "'https://example.com/path/to/extension.duckdb_extension'"
+- statement_terminator: ;
+- statement:
+    install_statement:
+    - keyword: FORCE
+    - keyword: INSTALL
+    - naked_identifier: spatial
+- statement_terminator: ;
+- statement:
+    install_statement:
+    - keyword: FORCE
+    - keyword: INSTALL
+    - naked_identifier: spatial
+    - keyword: FROM
+    - naked_identifier: core_nightly
+- statement_terminator: ;
+- statement:
+    install_statement:
+    - keyword: FORCE
+    - keyword: INSTALL
+    - quoted_literal: "'https://example.com/path/to/extension.duckdb_extension'"
+- statement_terminator: ;
+- statement:
+    load_statement:
+      keyword: LOAD
+      naked_identifier: httpfs
+- statement_terminator: ;
+- statement:
+    load_statement:
+      keyword: LOAD
+      quoted_literal: "'spatial'"
+- statement_terminator: ;
+- statement:
+    load_statement:
+      keyword: LOAD
+      quoted_literal: "'/path/to/custom_extension.duckdb_extension'"
+- statement_terminator: ;


### PR DESCRIPTION
## Summary
Adds parsing support for DuckDB extension management statements (`INSTALL`, `FORCE INSTALL`, and `LOAD`) in the DuckDB dialect.

As Per the [official DuckDB Extension Documentation](https://duckdb.org/docs/extensions/overview):
- `INSTALL <extension_name | 'extension_name' | 'url'> [FROM <repository | 'repository_url'>]`
- `FORCE INSTALL <extension_name | 'extension_name' | 'url'> [FROM <repository | 'repository_url'>]`
- `LOAD <extension_name | 'extension_name' | 'path'>`
Previously, SQLFluff produced unparsable errors for all `INSTALL` statements and unquoted `LOAD` statements (e.g. `LOAD httpfs;`).

## Changes
- Added `"FORCE"` and `"INSTALL"` to DuckDB's unreserved keywords.
- Defined `InstallStatementSegment` supporting `[FORCE] INSTALL ... [FROM ...]`.
- Defined DuckDB `LoadStatementSegment` accepting identifiers and quoted string literals.
- Registered `InstallStatementSegment` in DuckDB `StatementSegment`.
- Added test fixtures in `test/fixtures/dialects/duckdb/install_and_load.sql` and generated `.yml`.

## Testing
- `pytest test/dialects/dialects_test.py -k duckdb` (123 passed)
- `ruff check src test` (all checks passed)
- `ruff format --check src test`
- `mypy src/sqlfluff/dialects/dialect_duckdb.py` (no issues found)
