### PR TITLE
fix(teradata): accept arbitrary single-line BTEQ dot-commands

### DIFF
--- a/src/sqlfluff/dialects/dialect_teradata.py
+++ b/src/sqlfluff/dialects/dialect_teradata.py
@@ -32,6 +32,7 @@ from sqlfluff.core.parser import (
     Sequence,
     StringParser,
     TypedParser,
+    WhitespaceSegment,
 )
 from sqlfluff.dialects import dialect_ansi as ansi
 
@@ -194,6 +195,12 @@ teradata_dialect.add(
     # A bare newline, used to terminate single-line BTEQ dot-commands so their
     # opaque arguments are not consumed across the end of the line.
     BteqNewlineGrammar=TypedParser("newline", NewlineSegment, type="newline"),
+    # Same-line whitespace (explicitly not a newline). Used to anchor a BTEQ
+    # command's arguments to its own line so a command with no arguments does
+    # not reach across the end-of-line newline into the next statement.
+    BteqInlineWhitespaceGrammar=TypedParser(
+        "whitespace", WhitespaceSegment, type="whitespace"
+    ),
     # The command word of a BTEQ dot-command that we don't model explicitly
     # (e.g. `.SET`, `.OS`, `.REMARK`, `.SHOW`). Matches any bare word.
     BteqCommandNameSegment=TypedParser(
@@ -288,27 +295,38 @@ class BteqStatementSegment(BaseSegment):
         # parse; any other command word (e.g. `.SET`, `.OS`, `.REMARK`) is
         # accepted generically so the full BTEQ command set is supported.
         OneOf(Ref("BteqKeyWordSegment"), Ref("BteqCommandNameSegment")),
-        # Structured arguments for the commands we model in detail.
-        AnyNumberOf(
-            Ref("BteqKeyWordSegment"),
-            # FILE=<path> argument, e.g. `.RUN FILE=POSTING`.
-            Sequence(
-                "FILE",
-                Ref("EqualsSegment"),
-                OneOf(Ref("QuotedLiteralSegment"), Ref("BteqFilePathSegment")),
+        # Optional arguments, anchored to the command's own line by the leading
+        # same-line whitespace. Because the outer sequence disallows gaps, a
+        # command with no arguments (e.g. `.LOGOFF`) stops here rather than
+        # skipping the end-of-line newline and absorbing the next statement.
+        Sequence(
+            Ref("BteqInlineWhitespaceGrammar"),
+            # Structured arguments for the commands we model in detail.
+            AnyNumberOf(
+                Ref("BteqKeyWordSegment"),
+                # FILE=<path> argument, e.g. `.RUN FILE=POSTING`.
+                Sequence(
+                    "FILE",
+                    Ref("EqualsSegment"),
+                    OneOf(Ref("QuotedLiteralSegment"), Ref("BteqFilePathSegment")),
+                ),
+                # if ... then: the ...
+                Sequence(Ref("ComparisonOperatorGrammar"), Ref("LiteralGrammar")),
+                optional=True,
             ),
-            # if ... then: the ...
-            Sequence(Ref("ComparisonOperatorGrammar"), Ref("LiteralGrammar")),
+            # Any remaining tokens on the line are treated as opaque command
+            # arguments, bounded by the newline (or a semicolon) so they never
+            # bleed into the following statement.
+            Anything(
+                terminators=[Ref("BteqNewlineGrammar"), Ref("SemicolonSegment")],
+                optional=True,
+            ),
+            # No gaps: the leading whitespace above must be matched explicitly
+            # (rather than skipped) to anchor the arguments to the command line.
+            allow_gaps=False,
             optional=True,
         ),
-        # Any remaining tokens on the line are treated as opaque command
-        # arguments. BTEQ commands are confined to a single line, so terminate
-        # on the newline (or a semicolon) rather than consuming the next
-        # statement.
-        Anything(
-            terminators=[Ref("BteqNewlineGrammar"), Ref("SemicolonSegment")],
-            optional=True,
-        ),
+        allow_gaps=False,
     )
 
 

--- a/src/sqlfluff/dialects/dialect_teradata.py
+++ b/src/sqlfluff/dialects/dialect_teradata.py
@@ -24,6 +24,7 @@ from sqlfluff.core.parser import (
     ImplicitIndent,
     Indent,
     Matchable,
+    NewlineSegment,
     OneOf,
     OptionallyBracketed,
     Ref,
@@ -190,6 +191,14 @@ teradata_dialect.add(
     # works where a boolean is expected (e.g. inside CASE WHEN).
     # https://docs.teradata.com/r/kmuOwjp1zEYg98JsB8fu_A/3VIgdwHNVU~tsnNiIR1aEw
     OverlapsOperatorSegment=StringParser("OVERLAPS", ComparisonOperatorSegment),
+    # A bare newline, used to terminate single-line BTEQ dot-commands so their
+    # opaque arguments are not consumed across the end of the line.
+    BteqNewlineGrammar=TypedParser("newline", NewlineSegment, type="newline"),
+    # The command word of a BTEQ dot-command that we don't model explicitly
+    # (e.g. `.SET`, `.OS`, `.REMARK`, `.SHOW`). Matches any bare word.
+    BteqCommandNameSegment=TypedParser(
+        "word", CodeSegment, type="bteq_key_word_segment"
+    ),
 )
 
 
@@ -255,18 +264,31 @@ class BteqFilePathSegment(BaseSegment):
 class BteqStatementSegment(BaseSegment):
     """Bteq statements start with a dot, followed by a Keyword.
 
-    Non exhaustive and maybe catching too many statements?
+    BTEQ has a large set of dot-prefixed control commands (``.LOGON``,
+    ``.SET``, ``.EXPORT``, ``.IMPORT``, ``.OS``, ``.REMARK`` ...), each
+    confined to a single line. Rather than modelling every command and its
+    arguments, we recognise the leading keyword(s) for the common control-flow
+    forms and then consume the remainder of the line as opaque arguments so the
+    command is accepted without producing an unparsable section.
+
+    https://docs.teradata.com/r/jmAxXLdiDu6NiyjT6hhk7g/TvACxJd5BGW6uUDX_l2O4g
 
     # BTEQ commands
     .if errorcode > 0 then .quit 2
     .IF ACTIVITYCOUNT = 0 THEN .QUIT
     .RUN FILE=POSTING
+    .LOGON tdpid/username,password
+    .EXPORT DATA FILE=out.dat
     """
 
     type = "bteq_statement"
     match_grammar = Sequence(
         Ref("DotSegment"),
-        Ref("BteqKeyWordSegment"),
+        # The command keyword. Known control-flow keywords keep a structured
+        # parse; any other command word (e.g. `.SET`, `.OS`, `.REMARK`) is
+        # accepted generically so the full BTEQ command set is supported.
+        OneOf(Ref("BteqKeyWordSegment"), Ref("BteqCommandNameSegment")),
+        # Structured arguments for the commands we model in detail.
         AnyNumberOf(
             Ref("BteqKeyWordSegment"),
             # FILE=<path> argument, e.g. `.RUN FILE=POSTING`.
@@ -276,9 +298,15 @@ class BteqStatementSegment(BaseSegment):
                 OneOf(Ref("QuotedLiteralSegment"), Ref("BteqFilePathSegment")),
             ),
             # if ... then: the ...
-            Sequence(
-                Ref("ComparisonOperatorGrammar"), Ref("LiteralGrammar"), optional=True
-            ),
+            Sequence(Ref("ComparisonOperatorGrammar"), Ref("LiteralGrammar")),
+            optional=True,
+        ),
+        # Any remaining tokens on the line are treated as opaque command
+        # arguments. BTEQ commands are confined to a single line, so terminate
+        # on the newline (or a semicolon) rather than consuming the next
+        # statement.
+        Anything(
+            terminators=[Ref("BteqNewlineGrammar"), Ref("SemicolonSegment")],
             optional=True,
         ),
     )

--- a/src/sqlfluff/dialects/dialect_teradata.py
+++ b/src/sqlfluff/dialects/dialect_teradata.py
@@ -906,6 +906,30 @@ class StatementSegment(ansi.StatementSegment):
     )
 
 
+class FileSegment(ansi.FileSegment):
+    """A Teradata file/script.
+
+    BTEQ dot-commands are terminated by the end of their line rather than a
+    semicolon, so a statement's terminator is optional here. This lets a
+    newline-terminated dot-command be separated from the following statement
+    without a semicolon (a BTEQ script rarely puts semicolons on dot-commands),
+    while ordinary SQL statements continue to be semicolon-terminated. This
+    mirrors the optional-delimiter approach already used by the T-SQL dialect.
+    """
+
+    match_grammar = Sequence(
+        AnyNumberOf(
+            OneOf(
+                Sequence(
+                    Ref("StatementSegment"),
+                    Ref("DelimiterGrammar", optional=True),
+                ),
+                Ref("DelimiterGrammar"),
+            ),
+        ),
+    )
+
+
 class QualifyClauseSegment(BaseSegment):
     """A `QUALIFY` clause like in `SELECT`."""
 

--- a/test/dialects/teradata_test.py
+++ b/test/dialects/teradata_test.py
@@ -14,29 +14,54 @@ def teradata_linter() -> Linter:
 @pytest.mark.parametrize(
     "raw,command",
     [
-        # A dot-command with opaque arguments must not consume the following
-        # statement: its arguments are bounded by the end of its own line.
+        # Opaque arguments.
         (
-            ".LOGON tdpid/username,password\nSELECT 1;\n",
+            ".LOGON tdpid/username,password;\nSELECT 1;\n",
             ".LOGON tdpid/username,password",
         ),
-        # A dot-command with no arguments must likewise stop at the newline
-        # rather than absorbing the next line.
-        (".LOGOFF\nSELECT 1;\n", ".LOGOFF"),
+        # No arguments.
+        (".LOGOFF;\nSELECT 1;\n", ".LOGOFF"),
+        # Structured `.RUN FILE=` argument.
+        (".RUN FILE=POSTING;\nSELECT 1;\n", ".RUN FILE=POSTING"),
     ],
 )
-def test_bteq_command_is_bounded_to_its_line(
+def test_bteq_command_and_sql_parse_as_separate_statements(
     teradata_linter: Linter, raw: str, command: str
 ) -> None:
-    """BTEQ dot-commands are confined to a single line.
+    """A semicolon-terminated BTEQ command followed by SQL parses cleanly.
 
-    Regression test for the newline boundary: opaque command arguments must not
-    bleed across the end of the line into the following statement (see #1673).
+    Both the ``bteq_statement`` and the following ``select_statement`` are
+    parsed as independent statements with no unparsable sections (see #1673).
     """
     parsed = teradata_linter.parse_string(raw)
-    bteq_statements = list(parsed.tree.recursive_crawl("bteq_statement"))
 
+    assert not parsed.violations
+    statement_types = {
+        seg.get_type()
+        for seg in parsed.tree.recursive_crawl("bteq_statement", "select_statement")
+    }
+    assert statement_types == {"bteq_statement", "select_statement"}
+
+    bteq_statements = list(parsed.tree.recursive_crawl("bteq_statement"))
     assert len(bteq_statements) == 1
     assert bteq_statements[0].raw == command
-    # The following statement is not absorbed into the BTEQ command.
+
+
+@pytest.mark.parametrize("command", [".LOGON tdpid/username,password", ".LOGOFF"])
+def test_bteq_command_does_not_absorb_the_next_line(
+    teradata_linter: Linter, command: str
+) -> None:
+    """A BTEQ dot-command is confined to its own line.
+
+    Regression guard for the newline boundary: a command's opaque arguments must
+    stop at the end of its line and never bleed into the following statement,
+    whether or not the command has arguments. Without the newline terminator the
+    following ``SELECT`` would be silently absorbed into the ``bteq_statement``.
+    """
+    parsed = teradata_linter.parse_string(f"{command}\nSELECT 1;\n")
+
+    bteq_statements = list(parsed.tree.recursive_crawl("bteq_statement"))
+    assert len(bteq_statements) == 1
+    # The command stops at the newline; the following line is not part of it.
+    assert bteq_statements[0].raw == command
     assert "SELECT" not in bteq_statements[0].raw

--- a/test/dialects/teradata_test.py
+++ b/test/dialects/teradata_test.py
@@ -14,54 +14,48 @@ def teradata_linter() -> Linter:
 @pytest.mark.parametrize(
     "raw,command",
     [
-        # Opaque arguments.
+        # A dot-command terminated only by the end of its line (no semicolon)
+        # followed by a semicolon-terminated SQL statement.
         (
-            ".LOGON tdpid/username,password;\nSELECT 1;\n",
+            ".LOGON tdpid/username,password\nSELECT 1;\n",
             ".LOGON tdpid/username,password",
         ),
-        # No arguments.
-        (".LOGOFF;\nSELECT 1;\n", ".LOGOFF"),
-        # Structured `.RUN FILE=` argument.
-        (".RUN FILE=POSTING;\nSELECT 1;\n", ".RUN FILE=POSTING"),
+        # A no-argument dot-command followed by SQL.
+        (".LOGOFF\nSELECT 1;\n", ".LOGOFF"),
+        # A dot-command directly followed by another dot-command, both
+        # newline-terminated.
+        (".SET WIDTH 254\n.LOGOFF\nSELECT 1;\n", ".SET WIDTH 254"),
     ],
 )
-def test_bteq_command_and_sql_parse_as_separate_statements(
+def test_bteq_command_is_newline_separated(
     teradata_linter: Linter, raw: str, command: str
 ) -> None:
-    """A semicolon-terminated BTEQ command followed by SQL parses cleanly.
+    """BTEQ dot-commands are terminated by the end of their line.
 
-    Both the ``bteq_statement`` and the following ``select_statement`` are
-    parsed as independent statements with no unparsable sections (see #1673).
+    A dot-command needs no semicolon; the following statement parses
+    independently rather than being absorbed or reported as unparsable
+    (see #1673).
     """
     parsed = teradata_linter.parse_string(raw)
 
+    # The whole script parses cleanly.
     assert not parsed.violations
-    statement_types = {
-        seg.get_type()
-        for seg in parsed.tree.recursive_crawl("bteq_statement", "select_statement")
-    }
-    assert statement_types == {"bteq_statement", "select_statement"}
 
     bteq_statements = list(parsed.tree.recursive_crawl("bteq_statement"))
-    assert len(bteq_statements) == 1
-    assert bteq_statements[0].raw == command
-
-
-@pytest.mark.parametrize("command", [".LOGON tdpid/username,password", ".LOGOFF"])
-def test_bteq_command_does_not_absorb_the_next_line(
-    teradata_linter: Linter, command: str
-) -> None:
-    """A BTEQ dot-command is confined to its own line.
-
-    Regression guard for the newline boundary: a command's opaque arguments must
-    stop at the end of its line and never bleed into the following statement,
-    whether or not the command has arguments. Without the newline terminator the
-    following ``SELECT`` would be silently absorbed into the ``bteq_statement``.
-    """
-    parsed = teradata_linter.parse_string(f"{command}\nSELECT 1;\n")
-
-    bteq_statements = list(parsed.tree.recursive_crawl("bteq_statement"))
-    assert len(bteq_statements) == 1
-    # The command stops at the newline; the following line is not part of it.
+    select_statements = list(parsed.tree.recursive_crawl("select_statement"))
+    # The dot-command is bounded to its own line and the SELECT is a separate
+    # statement (not swallowed by the command).
     assert bteq_statements[0].raw == command
     assert "SELECT" not in bteq_statements[0].raw
+    assert len(select_statements) == 1
+
+
+def test_sql_statements_still_require_a_semicolon(teradata_linter: Linter) -> None:
+    """Newline separation does not relax semicolon termination for SQL.
+
+    Only BTEQ dot-commands are newline-terminated; two SQL statements with no
+    semicolon between them are still reported as unparsable.
+    """
+    parsed = teradata_linter.parse_string("SELECT 1 FROM t\nSELECT 2 FROM t\n")
+
+    assert any(v.rule_code() == "PRS" for v in parsed.violations)

--- a/test/dialects/teradata_test.py
+++ b/test/dialects/teradata_test.py
@@ -1,0 +1,42 @@
+"""Tests specific to the Teradata dialect."""
+
+import pytest
+
+from sqlfluff.core import FluffConfig, Linter
+
+
+@pytest.fixture(scope="module")
+def teradata_linter() -> Linter:
+    """A Linter configured for the Teradata dialect."""
+    return Linter(config=FluffConfig(overrides={"dialect": "teradata"}))
+
+
+@pytest.mark.parametrize(
+    "raw,command",
+    [
+        # A dot-command with opaque arguments must not consume the following
+        # statement: its arguments are bounded by the end of its own line.
+        (
+            ".LOGON tdpid/username,password\nSELECT 1;\n",
+            ".LOGON tdpid/username,password",
+        ),
+        # A dot-command with no arguments must likewise stop at the newline
+        # rather than absorbing the next line.
+        (".LOGOFF\nSELECT 1;\n", ".LOGOFF"),
+    ],
+)
+def test_bteq_command_is_bounded_to_its_line(
+    teradata_linter: Linter, raw: str, command: str
+) -> None:
+    """BTEQ dot-commands are confined to a single line.
+
+    Regression test for the newline boundary: opaque command arguments must not
+    bleed across the end of the line into the following statement (see #1673).
+    """
+    parsed = teradata_linter.parse_string(raw)
+    bteq_statements = list(parsed.tree.recursive_crawl("bteq_statement"))
+
+    assert len(bteq_statements) == 1
+    assert bteq_statements[0].raw == command
+    # The following statement is not absorbed into the BTEQ command.
+    assert "SELECT" not in bteq_statements[0].raw

--- a/test/fixtures/dialects/teradata/bteq_commands.sql
+++ b/test/fixtures/dialects/teradata/bteq_commands.sql
@@ -1,0 +1,17 @@
+-- BTEQ dot-commands are confined to a single line and are accepted without
+-- producing an unparsable section. See issue #1673.
+.LOGON tdpid/username,password;
+.SET WIDTH 254;
+.SET SEPARATOR '|';
+.EXPORT DATA FILE=out.dat;
+.EXPORT RESET;
+.IMPORT DATA FILE=in.dat;
+.RUN FILE=POSTING;
+.LABEL start;
+.GOTO start;
+.REMARK 'load complete';
+.OS ls -l;
+.SHOW CONTROLS;
+.IF ACTIVITYCOUNT = 0 THEN .QUIT 8;
+.LOGOFF;
+.QUIT;

--- a/test/fixtures/dialects/teradata/bteq_commands.yml
+++ b/test/fixtures/dialects/teradata/bteq_commands.yml
@@ -1,0 +1,137 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: e5fa22b19a2c159e9b6edf38539c487897abed84b0ea4801891eae1857375499
+file:
+- statement:
+    bteq_statement:
+    - dot: .
+    - bteq_key_word_segment:
+        keyword: LOGON
+    - word: tdpid
+    - divide: /
+    - word: username
+    - comma: ','
+    - word: password
+- statement_terminator: ;
+- statement:
+    bteq_statement:
+      dot: .
+      bteq_key_word_segment: SET
+      word: WIDTH
+      numeric_literal: '254'
+- statement_terminator: ;
+- statement:
+    bteq_statement:
+      dot: .
+      bteq_key_word_segment: SET
+      word: SEPARATOR
+      single_quote: "'|'"
+- statement_terminator: ;
+- statement:
+    bteq_statement:
+    - dot: .
+    - bteq_key_word_segment:
+        keyword: EXPORT
+    - word: DATA
+    - word: FILE
+    - equals: '='
+    - word: out
+    - dot: .
+    - word: dat
+- statement_terminator: ;
+- statement:
+    bteq_statement:
+      dot: .
+      bteq_key_word_segment:
+        keyword: EXPORT
+      word: RESET
+- statement_terminator: ;
+- statement:
+    bteq_statement:
+    - dot: .
+    - bteq_key_word_segment:
+        keyword: IMPORT
+    - word: DATA
+    - word: FILE
+    - equals: '='
+    - word: in
+    - dot: .
+    - word: dat
+- statement_terminator: ;
+- statement:
+    bteq_statement:
+      dot: .
+      bteq_key_word_segment:
+        keyword: RUN
+      keyword: FILE
+      comparison_operator:
+        raw_comparison_operator: '='
+      bteq_file_path:
+        naked_identifier: POSTING
+- statement_terminator: ;
+- statement:
+    bteq_statement:
+      dot: .
+      bteq_key_word_segment:
+        keyword: LABEL
+      word: start
+- statement_terminator: ;
+- statement:
+    bteq_statement:
+      dot: .
+      bteq_key_word_segment:
+        keyword: GOTO
+      word: start
+- statement_terminator: ;
+- statement:
+    bteq_statement:
+      dot: .
+      bteq_key_word_segment: REMARK
+      single_quote: "'load complete'"
+- statement_terminator: ;
+- statement:
+    bteq_statement:
+    - dot: .
+    - bteq_key_word_segment: OS
+    - word: ls
+    - minus: '-'
+    - word: l
+- statement_terminator: ;
+- statement:
+    bteq_statement:
+      dot: .
+      bteq_key_word_segment: SHOW
+      word: CONTROLS
+- statement_terminator: ;
+- statement:
+    bteq_statement:
+    - dot: .
+    - bteq_key_word_segment:
+        keyword: IF
+    - bteq_key_word_segment:
+        keyword: ACTIVITYCOUNT
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - numeric_literal: '0'
+    - bteq_key_word_segment:
+        keyword: THEN
+    - bteq_key_word_segment:
+        dot: .
+        keyword: QUIT
+        numeric_literal: '8'
+- statement_terminator: ;
+- statement:
+    bteq_statement:
+      dot: .
+      bteq_key_word_segment:
+        keyword: LOGOFF
+- statement_terminator: ;
+- statement:
+    bteq_statement:
+      dot: .
+      bteq_key_word_segment:
+        keyword: QUIT
+- statement_terminator: ;

--- a/test/fixtures/dialects/teradata/bteq_script.sql
+++ b/test/fixtures/dialects/teradata/bteq_script.sql
@@ -1,0 +1,11 @@
+-- An authentic BTEQ script: dot-commands are terminated by the end of the
+-- line (no semicolon) and are freely interleaved with semicolon-terminated
+-- SQL statements. See issue #1673.
+.LOGON tdpid/username,password
+.SET WIDTH 254
+DATABASE mydb;
+.IF ERRORCODE <> 0 THEN .QUIT 1
+SELECT col1, col2 FROM my_table WHERE col1 > 10;
+.EXPORT DATA FILE=out.dat
+.LOGOFF
+.QUIT

--- a/test/fixtures/dialects/teradata/bteq_script.yml
+++ b/test/fixtures/dialects/teradata/bteq_script.yml
@@ -1,0 +1,94 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: b68e14ca3a82946e2c047c2db58a244b88f1a824e74e0f612689be21d79da28e
+file:
+- statement:
+    bteq_statement:
+    - dot: .
+    - bteq_key_word_segment:
+        keyword: LOGON
+    - word: tdpid
+    - divide: /
+    - word: username
+    - comma: ','
+    - word: password
+- statement:
+    bteq_statement:
+      dot: .
+      bteq_key_word_segment: SET
+      word: WIDTH
+      numeric_literal: '254'
+- statement:
+    database_statement:
+      keyword: DATABASE
+      database_reference:
+        naked_identifier: mydb
+- statement_terminator: ;
+- statement:
+    bteq_statement:
+    - dot: .
+    - bteq_key_word_segment:
+        keyword: IF
+    - bteq_key_word_segment:
+        keyword: ERRORCODE
+    - comparison_operator:
+      - raw_comparison_operator: <
+      - raw_comparison_operator: '>'
+    - numeric_literal: '0'
+    - bteq_key_word_segment:
+        keyword: THEN
+    - bteq_key_word_segment:
+        dot: .
+        keyword: QUIT
+        numeric_literal: '1'
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            naked_identifier: col1
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            naked_identifier: col2
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: my_table
+      where_clause:
+        keyword: WHERE
+        expression:
+          column_reference:
+            naked_identifier: col1
+          comparison_operator:
+            raw_comparison_operator: '>'
+          numeric_literal: '10'
+- statement_terminator: ;
+- statement:
+    bteq_statement:
+    - dot: .
+    - bteq_key_word_segment:
+        keyword: EXPORT
+    - word: DATA
+    - word: FILE
+    - equals: '='
+    - word: out
+    - dot: .
+    - word: dat
+- statement:
+    bteq_statement:
+      dot: .
+      bteq_key_word_segment:
+        keyword: LOGOFF
+- statement:
+    bteq_statement:
+      dot: .
+      bteq_key_word_segment:
+        keyword: QUIT


### PR DESCRIPTION
### Brief summary of the change made

BTEQ has a large set of dot-prefixed control commands (`.LOGON`, `.SET`,
`.EXPORT`, `.IMPORT`, `.OS`, `.REMARK`, `.SHOW`, ...), each confined to a single
line. `BteqStatementSegment` previously only recognised a small enumerated
keyword set with narrowly-modelled arguments, so most real BTEQ commands
produced an unparsable section:

```
echo ".LOGON tdpid/user,pass" | sqlfluff parse --dialect teradata -
# ... unparsable
echo ".SET WIDTH 254"         | sqlfluff parse --dialect teradata -
# ... unparsable
```

This generalises `BteqStatementSegment` to:

- accept **any** command word after the leading dot (known control-flow
  keywords still keep their structured parse), and
- consume the remainder of the line as opaque arguments, terminating on the
  newline (or a semicolon) so it never absorbs the following statement.

The existing structured parses for `.RUN FILE=` (#8023) and
`.IF ... THEN .QUIT` are preserved unchanged.

fixes #1673

### Are there any other side effects of this change that we should be aware of?

- A newline `TypedParser` grammar (`BteqNewlineGrammar`) is added so the opaque
  argument matcher stops at the end of the line rather than crossing into the
  next statement.
- As before this change, a BTEQ command still parses as a `bteq_statement`, so
  layout rules can flag spacing inside a command's arguments (e.g. `FILE=` in
  `.RUN FILE=POSTING`). This is unchanged pre-existing behaviour, not new.
- Newline-separated dot-commands are now supported. BTEQ dot-commands are
  terminated by the end of their line, so the Teradata `FileSegment` makes a
  statement's terminator optional (the same optional-delimiter approach the
  T-SQL dialect already uses). An authentic BTEQ script — newline-terminated
  dot-commands interleaved with semicolon-terminated SQL — now parses cleanly
  (see `bteq_script.sql`). Semicolon termination is **not** relaxed for ordinary
  SQL: two SQL statements with no separator between them are still reported as an
  unparsable section.

### Pull Request checklist

- [x] Included test cases to demonstrate the code change:
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects/teradata/bteq_commands.sql` / `.yml`.
- [x] Verified `tox`-equivalent checks locally: full dialect parse suite (6761 passed), `ruff format`, `ruff check`, and `mypy` all clean.

---

<sub>Disclosure: this change was AI-assisted (drafted with Claude Code). The
grammar design, test fixtures, and full local verification (parser test suite,
ruff, and mypy) were reviewed by the submitter.</sub>


