### PR TITLE
Hive/Impala: support the NULL-safe equals operator `<=>`

### DIFF
--- a/src/sqlfluff/dialects/dialect_hive.py
+++ b/src/sqlfluff/dialects/dialect_hive.py
@@ -6,6 +6,7 @@ from sqlfluff.core.parser import (
     BaseSegment,
     Bracketed,
     CodeSegment,
+    CompositeComparisonOperatorSegment,
     Dedent,
     Delimited,
     IdentifierSegment,
@@ -298,6 +299,9 @@ hive_dialect.replace(
     LikeGrammar=OneOf(
         "LIKE", "RLIKE", "ILIKE", "REGEXP", "IREGEXP"
     ),  # Impala dialect uses REGEXP and IREGEXP
+    ComparisonOperatorGrammar=ansi_dialect.get_grammar(
+        "ComparisonOperatorGrammar"
+    ).copy(insert=[Ref("NullSafeEqualsSegment")]),
 )
 
 
@@ -326,6 +330,21 @@ class EqualsSegment(ansi.EqualsSegment):
     match_grammar: Matchable = Sequence(
         Ref("RawEqualsSegment"),
         Ref("RawEqualsSegment", optional=True),
+    )
+
+
+class NullSafeEqualsSegment(CompositeComparisonOperatorSegment):
+    """NULL-safe equals operator.
+
+    Hive returns TRUE when both operands are NULL, rather than NULL:
+    https://cwiki.apache.org/confluence/display/Hive/LanguageManual+UDF
+    """
+
+    match_grammar: Matchable = Sequence(
+        Ref("RawLessThanSegment"),
+        Ref("RawEqualsSegment"),
+        Ref("RawGreaterThanSegment"),
+        allow_gaps=False,
     )
 
 

--- a/test/fixtures/dialects/hive/null_safe_equal.sql
+++ b/test/fixtures/dialects/hive/null_safe_equal.sql
@@ -1,0 +1,9 @@
+SELECT 1 <=> 1, NULL <=> NULL, 1 <=> NULL;
+
+SELECT a <=> b FROM tbl WHERE c <=> NULL;
+
+SELECT *
+FROM tbl_a
+INNER JOIN tbl_b ON tbl_a.col <=> tbl_b.col;
+
+SELECT * FROM tbl WHERE NOT a <=> b;

--- a/test/fixtures/dialects/hive/null_safe_equal.yml
+++ b/test/fixtures/dialects/hive/null_safe_equal.yml
@@ -1,0 +1,136 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 509c935aeff6c37e82c6a40c26e61f5df39820e9729c76716cb10d990a4829fe
+file:
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          expression:
+          - numeric_literal: '1'
+          - comparison_operator:
+            - raw_comparison_operator: <
+            - raw_comparison_operator: '='
+            - raw_comparison_operator: '>'
+          - numeric_literal: '1'
+      - comma: ','
+      - select_clause_element:
+          expression:
+          - null_literal: 'NULL'
+          - comparison_operator:
+            - raw_comparison_operator: <
+            - raw_comparison_operator: '='
+            - raw_comparison_operator: '>'
+          - null_literal: 'NULL'
+      - comma: ','
+      - select_clause_element:
+          expression:
+            numeric_literal: '1'
+            comparison_operator:
+            - raw_comparison_operator: <
+            - raw_comparison_operator: '='
+            - raw_comparison_operator: '>'
+            null_literal: 'NULL'
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+          - column_reference:
+              naked_identifier: a
+          - comparison_operator:
+            - raw_comparison_operator: <
+            - raw_comparison_operator: '='
+            - raw_comparison_operator: '>'
+          - column_reference:
+              naked_identifier: b
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: tbl
+      where_clause:
+        keyword: WHERE
+        expression:
+          column_reference:
+            naked_identifier: c
+          comparison_operator:
+          - raw_comparison_operator: <
+          - raw_comparison_operator: '='
+          - raw_comparison_operator: '>'
+          null_literal: 'NULL'
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: tbl_a
+          join_clause:
+          - keyword: INNER
+          - keyword: JOIN
+          - from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: tbl_b
+          - join_on_condition:
+              keyword: 'ON'
+              expression:
+              - column_reference:
+                - naked_identifier: tbl_a
+                - dot: .
+                - naked_identifier: col
+              - comparison_operator:
+                - raw_comparison_operator: <
+                - raw_comparison_operator: '='
+                - raw_comparison_operator: '>'
+              - column_reference:
+                - naked_identifier: tbl_b
+                - dot: .
+                - naked_identifier: col
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: tbl
+      where_clause:
+        keyword: WHERE
+        expression:
+        - keyword: NOT
+        - column_reference:
+            naked_identifier: a
+        - comparison_operator:
+          - raw_comparison_operator: <
+          - raw_comparison_operator: '='
+          - raw_comparison_operator: '>'
+        - column_reference:
+            naked_identifier: b
+- statement_terminator: ;

--- a/test/fixtures/dialects/impala/null_safe_equal.sql
+++ b/test/fixtures/dialects/impala/null_safe_equal.sql
@@ -1,0 +1,7 @@
+SELECT 1 <=> 1, NULL <=> NULL, 1 <=> NULL;
+
+SELECT a <=> b FROM tbl WHERE c <=> NULL;
+
+SELECT *
+FROM tbl_a
+INNER JOIN tbl_b ON tbl_a.col <=> tbl_b.col;

--- a/test/fixtures/dialects/impala/null_safe_equal.yml
+++ b/test/fixtures/dialects/impala/null_safe_equal.yml
@@ -1,0 +1,108 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 0f6d67e9933cb552207071a07cd66c2a119a9e96fc1544e334396c7ed39eec89
+file:
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          expression:
+          - numeric_literal: '1'
+          - comparison_operator:
+            - raw_comparison_operator: <
+            - raw_comparison_operator: '='
+            - raw_comparison_operator: '>'
+          - numeric_literal: '1'
+      - comma: ','
+      - select_clause_element:
+          expression:
+          - null_literal: 'NULL'
+          - comparison_operator:
+            - raw_comparison_operator: <
+            - raw_comparison_operator: '='
+            - raw_comparison_operator: '>'
+          - null_literal: 'NULL'
+      - comma: ','
+      - select_clause_element:
+          expression:
+            numeric_literal: '1'
+            comparison_operator:
+            - raw_comparison_operator: <
+            - raw_comparison_operator: '='
+            - raw_comparison_operator: '>'
+            null_literal: 'NULL'
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+          - column_reference:
+              naked_identifier: a
+          - comparison_operator:
+            - raw_comparison_operator: <
+            - raw_comparison_operator: '='
+            - raw_comparison_operator: '>'
+          - column_reference:
+              naked_identifier: b
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: tbl
+      where_clause:
+        keyword: WHERE
+        expression:
+          column_reference:
+            naked_identifier: c
+          comparison_operator:
+          - raw_comparison_operator: <
+          - raw_comparison_operator: '='
+          - raw_comparison_operator: '>'
+          null_literal: 'NULL'
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: tbl_a
+          join_clause:
+          - keyword: INNER
+          - keyword: JOIN
+          - from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: tbl_b
+          - join_on_condition:
+              keyword: 'ON'
+              expression:
+              - column_reference:
+                - naked_identifier: tbl_a
+                - dot: .
+                - naked_identifier: col
+              - comparison_operator:
+                - raw_comparison_operator: <
+                - raw_comparison_operator: '='
+                - raw_comparison_operator: '>'
+              - column_reference:
+                - naked_identifier: tbl_b
+                - dot: .
+                - naked_identifier: col
+- statement_terminator: ;


### PR DESCRIPTION
### Brief summary of the change made

Hive has had the NULL-safe equality operator `<=>` since 0.9 ([LanguageManual UDF](https://cwiki.apache.org/confluence/display/Hive/LanguageManual+UDF) — "Returns same result with EQUAL(=) operator for non-null operands, but returns TRUE if both are NULL"), and Impala supports it as an alias for `IS NOT DISTINCT FROM` ([Impala operators](https://impala.apache.org/docs/build/html/topics/impala_operators.html)). SQLFluff currently reports both as unparsable:

```
$ sqlfluff parse --dialect hive <<< "SELECT a <=> b FROM t;"
L:   1 | P:  10 |  PRS | Line 1, Position 10: Found unparsable section: '<=> b'
```

This adds a `NullSafeEqualsSegment` to the Hive dialect, built from the raw `<`, `=` and `>` segments with `allow_gaps=False`, and inserts it into `ComparisonOperatorGrammar`. It deliberately mirrors the existing MySQL implementation added in #6929, so no lexer change is needed and the resulting parse tree is identical to MySQL's:

```
comparison_operator:
    raw_comparison_operator: '<'
    raw_comparison_operator: '='
    raw_comparison_operator: '>'
```

Because that shape matches, `ST09` — which already lists `<=>` among the operators it understands — handles it with no modification.

### Are there any other side effects of this change that we should be aware of?

**Impala is covered by the same change**, since `impala` inherits from `hive`. I've added parser fixtures for both dialects to lock that in.

**Athena is deliberately unaffected**: it inherits from `ansi`, not `hive`, and Athena v3 is Trino-based with no `<=>`. I verified it still rejects the operator after this change.

I checked the other dialects while I was here. `mysql`, `mariadb`, `doris`, `starrocks`, `sparksql`, `databricks`, `vertica` and `postgres` (pgvector's cosine distance) already accept `<=>`. `clickhouse`, `duckdb`, `trino` and `sqlite` reject it, which is correct — they use `IS NOT DISTINCT FROM` instead. So Hive/Impala looked like the only remaining gap.

**Note on overlap:** #8404 is an open PR that rewrites `dialect_impala.py` substantially. I checked its diff and it does not add `<=>`, and this change lives in `dialect_hive.py`, so the two shouldn't conflict — but flagging it in case the maintainers would rather see this folded in there. Happy to rebase or narrow this to Hive only.

### Test results

- `test/dialects/` — 6939 passed
- `test/rules/` — 2546 passed, 101 skipped
- `ruff format --check` and `ruff check` — clean
- `mypy src/sqlfluff/dialects/dialect_hive.py` — Success

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` — added `null_safe_equal.sql`/`.yml` for both `hive` and `impala`, with the `.yml` files generated by `test/generate_parse_fixture_yml.py`.
- Added appropriate documentation for the change — the new segment carries a docstring linking the Hive reference; no user-facing docs list per-dialect operators.
- Created GitHub issues for any relevant followup/future enhancements if appropriate — none needed.

### AI assistance disclosure

Per the AI-Assisted Contributions section of `CONTRIBUTING.md`: this change was written with AI assistance (Claude). The AI drafted the grammar addition and the test fixtures, and ran the verification listed above. I reviewed the diff, confirmed the operator's semantics against the Hive and Impala documentation linked above, and confirmed the dialect inheritance behaviour (Impala covered, Athena unaffected) before submitting.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for the NULL-safe equals operator `<=>` in the Hive and Impala dialects, which previously reported it as unparsable. The operator returns TRUE when both operands are NULL, matching Hive and Impala semantics.

**Notes**
- The operator is built from the existing `<`, `=`, and `>` raw segments, mirroring the MySQL implementation.
- Impala inherits the grammar from Hive; Athena is unaffected since it inherits from ANSI.
- The resulting parse tree matches MySQL's shape, so rule ST09 handles it without changes.

<sup>Written for commit f41287210edc9e5c407b8d94cd5effb3b099c888. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8409?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

