### PR TITLE
AM04: anchor violations on the wildcard, not the whole SELECT statement

### DIFF
--- a/plugins/sqlfluff-templater-dbt/test/templater_test.py
+++ b/plugins/sqlfluff-templater-dbt/test/templater_test.py
@@ -485,7 +485,10 @@ def test__find_node_with_symlinked_local_package(tmp_path):
 @pytest.mark.parametrize(
     "fname",
     [
-        "use_var.sql",
+        # NOTE: `use_var.sql` is deliberately not in this list. It selects a
+        # wildcard from a literal table, so it carries a genuine AM04
+        # violation which has nothing to do with its templated WHERE clause.
+        # It is covered by the test below instead.
         "incremental.sql",
         "single_trailing_newline.sql",
         "ST06_test.sql",
@@ -517,6 +520,28 @@ def test__dbt_templated_models_do_not_raise_lint_error(
 
     violations = lnt.check_tuples()
     assert len(violations) == 0
+
+
+def test__dbt_lint_error_outside_templated_section_is_reported(
+    project_dir,
+    dbt_fluff_config,
+):
+    """Violations outside a model's templated sections are still reported.
+
+    `use_var.sql` selects a wildcard from a literal table, so AM04 applies to
+    it; only its WHERE clause is templated. AM04 used to anchor the violation
+    on the whole `select_statement`, which spans the `var()` call, so the
+    violation was found and then discarded as templated - any dbt model
+    selecting a wildcard was silently exempt from the rule.
+    https://github.com/sqlfluff/sqlfluff/issues/6032
+    """
+    linter = Linter(config=FluffConfig(configs=dbt_fluff_config))
+    lnt = linter.lint_path(
+        path=os.path.join(project_dir, "models/my_new_project/use_var.sql")
+    )
+    # Line 2, position 8 is the wildcard, which is literal - not the start of
+    # the select statement, which is not.
+    assert lnt.check_tuples() == [("AM04", 2, 8)]
 
 
 def _clean_path(glob_expression):

--- a/src/sqlfluff/rules/ambiguous/AM04.py
+++ b/src/sqlfluff/rules/ambiguous/AM04.py
@@ -10,6 +10,20 @@ from sqlfluff.utils.analysis.query import Query
 _START_TYPES = ["select_statement", "set_expression", "with_compound_statement"]
 
 
+def _wildcard_anchor(select_target: BaseSegment) -> BaseSegment:
+    """The `*` within a wildcard select target, or the target if it has none.
+
+    Only the star is guaranteed to be part of the SQL the user wrote. In
+    `{{ alias }}.*` the qualifier is templated while the star is not, so
+    anchoring on the whole target would hand the templated-section filter a
+    span which is not literal and the violation would be discarded.
+
+    Dialects which structure wildcards without a `star` child fall back to
+    the target itself.
+    """
+    return next(select_target.recursive_crawl("star"), select_target)
+
+
 class RuleFailure(Exception):
     """Exception class for reporting lint failure inside deeply nested code."""
 
@@ -71,7 +85,7 @@ class Rule_AM04(BaseRule):
     # Only evaluate the outermost query.
     crawl_behaviour = SegmentSeekerCrawler(set(_START_TYPES), allow_recurse=False)
 
-    def _handle_alias(self, selectable, alias_info, query) -> None:
+    def _handle_alias(self, alias_info, query, anchor) -> None:
         select_info_target = next(
             query.crawl_sources(alias_info.from_expression_element, True)
         )
@@ -82,13 +96,22 @@ class Rule_AM04(BaseRule):
             self.logger.debug(
                 f"Query target {select_info_target} is external. Generating warning."
             )
-            raise RuleFailure(selectable.selectable)
+            raise RuleFailure(anchor)
         else:
             # Handle nested SELECT.
-            self._analyze_result_columns(select_info_target)
+            self._analyze_result_columns(select_info_target, anchor)
 
-    def _analyze_result_columns(self, query: Query) -> None:
-        """Given info on a list of SELECTs, determine whether to warn."""
+    def _analyze_result_columns(
+        self, query: Query, anchor: Optional[BaseSegment] = None
+    ) -> None:
+        """Given info on a list of SELECTs, determine whether to warn.
+
+        ``anchor`` is the wildcard which started the analysis, and is what any
+        resulting violation is reported against. It is threaded through the
+        recursion so that a wildcard resolving to an ambiguous CTE is still
+        reported against the wildcard the user can act on, rather than against
+        whichever nested query the walk happened to terminate in.
+        """
         # Recursively walk from the given query (select_info_list) to any
         # wildcard columns in the select targets. If every wildcard evdentually
         # resolves to a query without wildcards, all is well. Otherwise, warn.
@@ -97,6 +120,11 @@ class Rule_AM04(BaseRule):
         for selectable in query.selectables:
             self.logger.debug(f"Analyzing query: {selectable.selectable.raw}")
             for wildcard in selectable.get_wildcard_info():
+                # Anchor on the star itself. It is the reason for the
+                # violation, so it is also the right thing to report against -
+                # and, for templated files, the right thing to judge the
+                # violation's actionability by.
+                wildcard_anchor = anchor or _wildcard_anchor(wildcard.segment)
                 if wildcard.tables:
                     for wildcard_table in wildcard.tables:
                         self.logger.debug(
@@ -108,13 +136,13 @@ class Rule_AM04(BaseRule):
                         if alias_info:
                             # Found the alias matching the wildcard. Recurse,
                             # analyzing the query associated with that alias.
-                            self._handle_alias(selectable, alias_info, query)
+                            self._handle_alias(alias_info, query, wildcard_anchor)
                         else:
                             # Not an alias. Is it a CTE?
                             cte = query.lookup_cte(wildcard_table)
                             if cte:
                                 # Wildcard refers to a CTE. Analyze it.
-                                self._analyze_result_columns(cte)
+                                self._analyze_result_columns(cte, wildcard_anchor)
                             else:
                                 # Not CTE, not table alias. Presumably an
                                 # external table. Warn.
@@ -122,19 +150,19 @@ class Rule_AM04(BaseRule):
                                     f"Query target {wildcard_table} is external. "
                                     "Generating warning."
                                 )
-                                raise RuleFailure(selectable.selectable)
+                                raise RuleFailure(wildcard_anchor)
                 else:
                     # No table was specified with the wildcard. Assume we're
                     # querying from a nested select in FROM.
                     for o in query.crawl_sources(selectable.selectable, True):
                         if isinstance(o, Query):
-                            self._analyze_result_columns(o)
+                            self._analyze_result_columns(o, wildcard_anchor)
                             return None
                     self.logger.debug(
                         f'Query target "{selectable.selectable.raw}" has no '
                         "targets. Generating warning."
                     )
-                    raise RuleFailure(selectable.selectable)
+                    raise RuleFailure(wildcard_anchor)
 
     def _eval(self, context: RuleContext) -> Optional[LintResult]:
         """Outermost query should produce known number of columns."""

--- a/test/api/simple_test.py
+++ b/test/api/simple_test.py
@@ -13,19 +13,6 @@ my_bad_query = "SeLEct  *, 1, blah as  fOO  from myTable"
 
 lint_result = [
     {
-        "code": "AM04",
-        "description": "Query produces an unknown number of result columns.",
-        "start_line_no": 1,
-        "start_line_pos": 1,
-        "start_file_pos": 0,
-        "end_line_no": 1,
-        "end_line_pos": 41,
-        "end_file_pos": 40,
-        "name": "ambiguous.column_count",
-        "fixes": [],
-        "warning": False,
-    },
-    {
         "code": "CP01",
         "start_line_no": 1,
         "start_line_pos": 1,
@@ -166,6 +153,19 @@ lint_result = [
                 "end_file_pos": 8,
             }
         ],
+        "warning": False,
+    },
+    {
+        "code": "AM04",
+        "description": "Query produces an unknown number of result columns.",
+        "start_line_no": 1,
+        "start_line_pos": 9,
+        "start_file_pos": 8,
+        "end_line_no": 1,
+        "end_line_pos": 10,
+        "end_file_pos": 9,
+        "name": "ambiguous.column_count",
+        "fixes": [],
         "warning": False,
     },
     {

--- a/test/cli/commands_test.py
+++ b/test/cli/commands_test.py
@@ -2391,6 +2391,12 @@ def test__cli__command_lint_serialize_github_annotation():
             "test/fixtures/linter/jinja_spacing.sql",
             (
                 "::group::{filename}\n"
+                # NOTE: AM04 is anchored on the wildcard, which is literal
+                # even though the table reference beside it is templated.
+                "::error title=SQLFluff,file={filename},"
+                "line=3,col=8,endLine=3,endColumn=9::AM04: "
+                "Query produces an unknown number of result columns. "
+                "[ambiguous.column_count]\n"
                 "::error title=SQLFluff,file={filename},"
                 "line=3,col=15,endLine=3,endColumn=22::JJ01: "
                 "Jinja tags should have a single whitespace on either "

--- a/test/core/config/fluffconfig_test.py
+++ b/test/core/config/fluffconfig_test.py
@@ -118,7 +118,7 @@ def test__config__glob_exclude_config_tests():
     lnt = lntr.lint_path("test/fixtures/config/glob_exclude/test.sql")
     violations = lnt.check_tuples_by_path()
     for k in violations:
-        assert ("AM04", 12, 1) in violations[k]
+        assert ("AM04", 12, 8) in violations[k]
         assert "RF02" not in [c[0] for c in violations[k]]
         assert "LT13" not in [c[0] for c in violations[k]]
         assert "AM05" not in [c[0] for c in violations[k]]
@@ -154,7 +154,7 @@ def test__config__rules_set_to_none():
     violations = lnt.check_tuples_by_path()
     for k in violations:
         assert ("LT13", 1, 1) in violations[k]
-        assert ("AM04", 12, 1) in violations[k]
+        assert ("AM04", 12, 8) in violations[k]
         assert ("CP01", 12, 10) in violations[k]
 
 

--- a/test/core/linter/linter_test.py
+++ b/test/core/linter/linter_test.py
@@ -1001,6 +1001,15 @@ def test__linter__deduplicates_duplicate_templater_violations_in_linted_output()
             ],
         ),
         (
+            # AM04 anchors on the wildcard, which is literal even though the
+            # table reference beside it is templated, so masking templated
+            # areas should not discard the violation.
+            "test/fixtures/linter/jinja_spacing.sql",
+            "AM04",
+            True,
+            [("AM04", 3, 8)],
+        ),
+        (
             "test/fixtures/linter/jinja_variants/simple_CP01.sql",
             "CP01",
             False,

--- a/test/fixtures/rules/std_rule_cases/AM04.yml
+++ b/test/fixtures/rules/std_rule_cases/AM04.yml
@@ -686,3 +686,90 @@ test_pass_resolvable_wildcard_in_non_first_union_branch:
     SELECT a, b FROM t
     UNION
     SELECT * FROM (SELECT c, d FROM tbl2)
+
+test_fail_jinja_templated_table_reference:
+  # The wildcard is literal, only the table reference is templated,
+  # so the violation must still be reported.
+  fail_str: |
+    SELECT foo.*
+    FROM {{ "my_dataset.FOO" }} AS foo
+  configs:
+    core:
+      templater: jinja
+
+test_fail_jinja_templated_table_reference_unqualified_wildcard:
+  # As above, but for an unqualified wildcard.
+  fail_str: |
+    SELECT *
+    FROM {{ "my_dataset.FOO" }}
+  configs:
+    core:
+      templater: jinja
+
+test_pass_jinja_templated_table_reference_explicit_columns:
+  # Explicit columns should still pass with a templated table reference.
+  pass_str: |
+    SELECT a, b
+    FROM {{ "my_dataset.FOO" }}
+  configs:
+    core:
+      templater: jinja
+
+test_pass_wholly_templated_query:
+  # Violations anchored at a templated position are still suppressed: the
+  # user cannot act on SQL they did not write.
+  pass_str: |
+    {{ my_macro() }}
+  configs:
+    core:
+      templater: jinja
+    templater:
+      jinja:
+        macros:
+          my_macro: "{% macro my_macro() %}SELECT * FROM my_dataset.tbl{% endmacro %}"
+
+test_fail_jinja_templated_wildcard_qualifier:
+  # Mixed templated/literal wildcard: the qualifier comes from the template,
+  # the star does not. The star is the user's own SQL and is actionable, so
+  # the violation must be reported. Anchoring on the whole select target
+  # (`{{ alias }}.*`) would hand the templated-section filter a span which is
+  # not literal, and the violation would be discarded.
+  fail_str: |
+    SELECT {{ alias }}.*
+    FROM my_table AS foo
+  configs:
+    core:
+      templater: jinja
+    templater:
+      jinja:
+        context:
+          alias: foo
+
+test_pass_jinja_templated_star_with_literal_qualifier:
+  # The complement of the case above: here the star itself is templated, so
+  # there is nothing in the user's own SQL to act on and the violation stays
+  # suppressed.
+  pass_str: |
+    SELECT foo.{{ star }}
+    FROM my_table AS foo
+  configs:
+    core:
+      templater: jinja
+    templater:
+      jinja:
+        context:
+          star: "*"
+
+test_pass_templated_wildcard:
+  # The wildcard itself comes from the template, so the user's own SQL
+  # contains nothing to act on and the violation stays suppressed.
+  pass_str: |
+    SELECT {{ cols }}
+    FROM my_dataset.tbl
+  configs:
+    core:
+      templater: jinja
+    templater:
+      jinja:
+        context:
+          cols: "*"


### PR DESCRIPTION
AM04 anchored its violation on the enclosing `select_statement` rather
than on the wildcard which caused it. In templated files that made the
violation disappear entirely:

    select pahst.*
    from {{ source('disc_proadm_raw', 'PAHST') }} pahst

`remove_templated_errors()` discards any violation whose anchor is not
literal, and a `select_statement` anchor spans the templated table
reference. So the violation was found (it shows up in `-vvvvv` logs as
`!! Violation Found`) and then dropped before reporting, leaving the
file passing. Any dbt model selecting a wildcard from a `source()` or
`ref()` was affected.

### Brief summary of the change made

Anchor on the wildcard instead. It is the reason for the violation, so
it is both the right thing to report against and the right thing to
judge the violation's actionability by:

- `select pahst.* from {{ source(...) }} pahst` - reported. The wildcard
  is literal; only the table reference beside it is templated.
- `select {{ cols }} from tbl`, where `cols` renders `*` - suppressed.
  The wildcard is templated, so the user's own SQL contains nothing to
  act on.

The anchor is threaded through the recursive walk, so a wildcard which
resolves to an ambiguous CTE is still reported against the wildcard the
user can act on, rather than against whichever nested query the walk
happened to terminate in.

Violations now point at the wildcard rather than at column 1 of the
statement, and carry a real end position. Fixtures asserting the old
position are updated accordingly.

Fixes #6032
Fixes #5496

### Are there any other side effects of this change that we should be aware of?

No

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`. ✅
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change. ✅
- Created GitHub issues for any relevant followup/future enhancements if appropriate.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes AM04 violations being silently dropped in templated files by anchoring them on the wildcard that caused them instead of the whole `select_statement`.

- The wildcard anchor is threaded through the recursive analysis, so wildcards resolving to ambiguous CTEs still report against the wildcard the user can act on.
- Violations now point at the wildcard (including a real end position) instead of column 1 of the statement; fixtures asserting the old positions were updated.
- Wildcards that are themselves templated remain suppressed, since the user's SQL contains nothing to act on.
- The dbt `use_var.sql` fixture now asserts its AM04 violation is reported, since its wildcard is literal even though its WHERE clause is templated.
- Fixes #6032 and #5496, where `SELECT pahst.* FROM {{ source('raw', 'PAHST') }} pahst` passed silently.

<sup>Written for commit dd9cd9f0c586b73f4944ad89f23849e35ffc090b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8410?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



