### PR TITLE
fix(reflow): ignore alignment predecessors from other lines

### DIFF
--- a/src/sqlfluff/utils/reflow/respace.py
+++ b/src/sqlfluff/utils/reflow/respace.py
@@ -469,6 +469,21 @@ def _determine_aligned_inline_spacing(
                     loc,
                     last_code,
                 )
+                # Only siblings whose preceding code is on their own line tell us
+                # anything about alignment. When a sibling is the first code on its
+                # line, `last_code` is the trailing code of an *earlier* line, and
+                # its column is unrelated to where this sibling starts. Counting it
+                # inflates the target column and pads every other line to match.
+                # See https://github.com/sqlfluff/sqlfluff/issues/8256.
+                sibling_line = _pos_line(sibling.pos_marker, use_source_positions)
+                if loc[0] != sibling_line:
+                    reflow_logger.debug(
+                        "    Skipping %s: preceding code is on line %s, not %s.",
+                        last_code,
+                        loc[0],
+                        sibling_line,
+                    )
+                    continue
                 # When using tabs, convert to visual column position
                 if indent_unit == "tab" and last_code.pos_marker:
                     # Get visual position after the last code segment

--- a/test/utils/reflow/respace_test.py
+++ b/test/utils/reflow/respace_test.py
@@ -42,6 +42,60 @@ def test_reflow__respace_does_not_strip_newline_before_comment():
     assert new_seq.get_raw() == sql
 
 
+def test_reflow__respace_align_ignores_predecessor_on_another_line():
+    """Aligning must ignore a preceding code segment from an earlier line.
+
+    Regression test for #8256. With leading commas and the T-SQL ``=`` alias
+    syntax, the first aliased column is the first code on its line, so the
+    code preceding it is the trailing token of an *earlier* line (``SELECT``).
+    Its column bore no relation to where that alias starts, but it was still
+    counted when picking the alignment target, inflating the target column and
+    padding every *other* line to match. That produced two spaces after the
+    leading comma on aliased rows while non-aliased rows kept one.
+
+    The commas must keep a single following space; alignment is achieved by
+    padding before the ``=`` instead.
+    """
+    config = FluffConfig(
+        overrides={"dialect": "tsql"},
+        configs={
+            "layout": {
+                "type": {
+                    "comma": {"line_position": "leading"},
+                    "alias_operator": {
+                        "spacing_before": "align",
+                        "align_within": "select_clause",
+                        "align_scope": "bracketed",
+                    },
+                    "alias_expression": {
+                        "spacing_before": "align",
+                        "align_within": "select_clause",
+                        "align_scope": "bracketed",
+                    },
+                }
+            }
+        },
+    )
+    sql = (
+        "SELECT\n"
+        "    FirstCol = 'a'\n"
+        "    , SecondCol = 'b'\n"
+        "    , ThirdCol = 'c'\n"
+        "    , t.NonaliasedCol\n"
+        "FROM TestTable AS t\n"
+    )
+    linter = Linter(config=config)
+    root = linter.parse_string(sql).tree
+    seq = ReflowSequence.from_root(root, config=config)
+    result = seq.respace().get_raw()
+
+    # Every leading comma keeps exactly one following space.
+    assert ",  " not in result
+    # Alignment is still achieved, via padding before the `=`.
+    operator_columns = {line.index("=") for line in result.splitlines() if "=" in line}
+    assert len(operator_columns) == 1
+
+
 @pytest.mark.parametrize(
     "raw_sql_in,kwargs,raw_sql_out",
     [


### PR DESCRIPTION
Fixes #8256

## Problem

`_determine_aligned_inline_spacing` picks the target column for an `align`
constraint from the end column of the code preceding each aligned sibling,
without checking that the predecessor is on the *same line* as the sibling.

When a sibling is the first code on its line, that predecessor is the trailing
token of an earlier line. Its column says nothing about where the sibling
starts, but it still sets the target, so every other line is padded to match.

With leading commas and the T-SQL `=` alias syntax this is directly visible.
Debug logging for the reported query:

loc for <AltAliasExpressionSegment: ([L:2, P:5])>: (1, 7) from <KeywordSegment 'SELECT'>
loc for <AltAliasExpressionSegment: ([L:3, P:7])>: (3, 6) from <SymbolSegment ','>
loc for <AltAliasExpressionSegment: ([L:4, P:7])>: (4, 6) from <SymbolSegment ','>



Column 7 comes from `SELECT` on line 1. The commas end at column 6, so
`pad_width = max(1, 1 + 7 - 6)` = 2, giving two spaces after each leading comma
while rows without an alias keep one.

## Fix

Skip predecessors that lie on a different line than the sibling they precede.
The `code_before_ws` lookup further down already guards the same hazard for the
current line, noting `last_code` "may refer to code segments from other lines".

Before / after (dots are spaces):


FIRSTCOL.....=.'Some Value'          FIRSTCOL....=.'Some Value'
,..SECONDCOL.=.'Some other value'    ,.SECONDCOL.=.'Some other value'
,..THIRDCOL..=.'yet another val'     ,.THIRDCOL..=.'yet another val'
,.T.NONALIASEDCOL                    ,.T.NONALIASEDCOL


This matches the expected output in the issue. The `AS` alias form (the second
example, already correct) is unchanged.

## Tests

`test_reflow__respace_align_ignores_predecessor_on_another_line` in
`test/utils/reflow/respace_test.py`, confirmed to fail before the change.

## Verification

- `pytest test/utils/reflow/` -> 122 passed
- Full suite -> 10,887 passed. The four `diff_quality_plugin_test.py` failures I
  see locally also fail on a clean `main`.
- `ruff check`, `ruff format --check`, `mypy -p sqlfluff.core --strict` all clean

## AI assistance disclosure

Per CONTRIBUTING.md: this change was developed with AI assistance (Claude). The
root-cause analysis, the same-line guard, and the regression test were
AI-drafted. I reviewed the diff, reproduced the bug and the fixed output myself,
and confirmed the new test fails without the change and passes with it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes reflow alignment for T-SQL leading-comma alias blocks by ignoring alignment predecessors from previous lines, so each row aligns without extra spaces after the comma. Previously, the first aliased column on a line used the trailing token of an earlier line as the alignment target, padding all other lines incorrectly (issue #8256). Adds a same-line guard for alignment predecessors in `_determine_aligned_inline_spacing` and a regression test covering leading commas with the `=` alias syntax.

<sup>Written for commit c6919bdc374f99c8f0c281b0a81c981560594b32. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8411?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

