### PR TITLE
feat(docs): permalink redirects and mixed-builder version picker

### DIFF
--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -246,7 +246,7 @@ jobs:
         if: ${{ steps.docs-target.outputs.build_latest == 'true' }}
         run: >-
           python docsv/scripts/assemble-site.py
-          --vitepress-dist docsv/.vitepress/dist
+          --dist docsv/.vitepress/dist
           --output-dir ${{ env.DOCS_SITE_DIR }}
           --channel latest
           --title Development
@@ -272,7 +272,7 @@ jobs:
           PRERELEASE: ${{ steps.docs-target.outputs.prerelease }}
         run: |
           args=(
-              --vitepress-dist docsv/.vitepress/dist
+              --dist docsv/.vitepress/dist
               --output-dir "${DOCS_SITE_DIR}"
               --channel "${VERSION}"
               --title "${VERSION}"
@@ -303,7 +303,7 @@ jobs:
           VERSION: ${{ steps.docs-target.outputs.version }}
         run: |
           python docsv/scripts/assemble-site.py \
-              --vitepress-dist docsv/.vitepress/dist \
+              --dist docsv/.vitepress/dist \
               --output-dir "${DOCS_SITE_DIR}" \
               --channel stable \
               --title Stable \

--- a/docsv/.vitepress/dev-versions.json
+++ b/docsv/.vitepress/dev-versions.json
@@ -1,8 +1,8 @@
 {
-  "_comment": "Local development fixture for the version picker and version notice. Served only by the dev server; the deployed manifest is written by scripts/assemble-site.py. Edit freely to try other states, or delete to see how the picker degrades when no manifest is reachable.",
+  "_comment": "Local development fixture for the version picker and version notice. Served only by the dev server; the deployed manifest is written by scripts/assemble-site.py. Deliberately a mixed state: VitePress channels and releases, plus archived Sphinx versions, and both listed and unlisted entries. Set SQLFLUFF_DOCS_BASE=/en/4.0.4/ to see how an unlisted version the reader landed on is added back to the picker. Edit freely to try other states, or delete to see how the picker degrades when no manifest is reachable.",
   "default": "latest",
   "latest": "latest",
-  "stable": "3.4.2",
+  "stable": "4.2.1",
   "versions": [
     {
       "key": "latest",
@@ -11,16 +11,62 @@
       "path": "/en/latest/",
       "kind": "channel",
       "builder": "vitepress",
-      "prerelease": false
+      "prerelease": false,
+      "listed": true
     },
     {
       "key": "stable",
       "label": "stable",
-      "title": "Stable (3.4.2)",
+      "title": "Stable (4.2.1)",
       "path": "/en/stable/",
       "kind": "channel",
       "builder": "vitepress",
-      "prerelease": false
+      "prerelease": false,
+      "listed": true
+    },
+    {
+      "key": "4.2.1",
+      "label": "4.2.1",
+      "title": "4.2.1",
+      "path": "/en/4.2.1/",
+      "kind": "release",
+      "builder": "vitepress",
+      "prerelease": false,
+      "listed": true,
+      "published_at": "2026-08-11"
+    },
+    {
+      "key": "4.2.0",
+      "label": "4.2.0",
+      "title": "4.2.0",
+      "path": "/en/4.2.0/",
+      "kind": "release",
+      "builder": "vitepress",
+      "prerelease": false,
+      "listed": false,
+      "published_at": "2026-07-28"
+    },
+    {
+      "key": "4.1.0",
+      "label": "4.1.0",
+      "title": "4.1.0",
+      "path": "/en/4.1.0/",
+      "kind": "release",
+      "builder": "sphinx",
+      "prerelease": false,
+      "listed": true,
+      "published_at": "2026-05-20"
+    },
+    {
+      "key": "4.0.4",
+      "label": "4.0.4",
+      "title": "4.0.4",
+      "path": "/en/4.0.4/",
+      "kind": "release",
+      "builder": "sphinx",
+      "prerelease": false,
+      "listed": false,
+      "published_at": "2026-04-02"
     },
     {
       "key": "3.4.2",
@@ -28,29 +74,10 @@
       "title": "3.4.2",
       "path": "/en/3.4.2/",
       "kind": "release",
-      "builder": "vitepress",
+      "builder": "sphinx",
       "prerelease": false,
-      "published_at": "2026-07-14"
-    },
-    {
-      "key": "3.4.1",
-      "label": "3.4.1",
-      "title": "3.4.1",
-      "path": "/en/3.4.1/",
-      "kind": "release",
-      "builder": "vitepress",
-      "prerelease": false,
-      "published_at": "2026-06-02"
-    },
-    {
-      "key": "3.4.0",
-      "label": "3.4.0",
-      "title": "3.4.0",
-      "path": "/en/3.4.0/",
-      "kind": "release",
-      "builder": "vitepress",
-      "prerelease": false,
-      "published_at": "2026-05-11"
+      "listed": true,
+      "published_at": "2026-02-14"
     },
     {
       "key": "3.3.1",
@@ -58,9 +85,21 @@
       "title": "3.3.1",
       "path": "/en/3.3.1/",
       "kind": "release",
-      "builder": "vitepress",
+      "builder": "sphinx",
       "prerelease": false,
-      "published_at": "2026-03-20"
+      "listed": false,
+      "published_at": "2025-11-03"
+    },
+    {
+      "key": "2.3.5",
+      "label": "2.3.5",
+      "title": "2.3.5",
+      "path": "/en/2.3.5/",
+      "kind": "release",
+      "builder": "sphinx",
+      "prerelease": false,
+      "listed": true,
+      "published_at": "2024-09-16"
     }
   ]
 }

--- a/docsv/.vitepress/theme/VersionBanner.vue
+++ b/docsv/.vitepress/theme/VersionBanner.vue
@@ -16,9 +16,9 @@
  * the current one.
  */
 import { onUnmounted, ref, watch } from 'vue'
-import { useVersions, versionHref } from './versions'
+import { useVersions } from './versions'
 
-const { notice, pagePath } = useVersions()
+const { notice, hrefFor } = useVersions()
 
 const banner = ref<HTMLElement>()
 let observer: ResizeObserver | undefined
@@ -88,7 +88,7 @@ onUnmounted(() => {
             <a
                 v-if="notice.target"
                 class="version-banner__link"
-                :href="versionHref(notice.target, pagePath)"
+                :href="hrefFor(notice.target)"
                 target="_self"
             >Switch to {{ notice.target.label }}</a>
         </p>

--- a/docsv/.vitepress/theme/VersionPicker.vue
+++ b/docsv/.vitepress/theme/VersionPicker.vue
@@ -366,10 +366,11 @@ function onKeydown(event: KeyboardEvent): void {
     color: var(--vp-c-brand-1);
 }
 
-/* Outside the panel it has no surface behind it, so it needs the panel's own
-   left padding removed to line up with the static label above it. */
+/* Outside the panel it sits directly under the static version label, so it
+   takes that label's side padding rather than the panel item's, which would
+   leave the two lines misaligned. */
 .version-picker__all-static {
-    padding-left: 0;
+    padding-left: 0.6rem;
     font-size: 13px;
 }
 

--- a/docsv/.vitepress/theme/VersionPicker.vue
+++ b/docsv/.vitepress/theme/VersionPicker.vue
@@ -19,7 +19,6 @@ import { computed, onUnmounted, ref, useId, watch } from 'vue'
 import {
     isChannel,
     useVersions,
-    versionHref,
     versionTitle,
     type VersionEntry,
 } from './versions'
@@ -39,7 +38,8 @@ const props = withDefaults(
     }
 )
 
-const { entries, current, channels, releases, pagePath } = useVersions()
+const { entries, current, channels, releases, hrefFor, allVersionsHref } =
+    useVersions()
 
 const open = ref(false)
 const root = ref<HTMLElement>()
@@ -167,7 +167,7 @@ function onKeydown(event: KeyboardEvent): void {
                         :key="entry.key"
                         class="version-picker__item"
                         :class="{ 'is-current': entry.key === current.key }"
-                        :href="versionHref(entry, pagePath)"
+                        :href="hrefFor(entry)"
                         :aria-current="entry.key === current.key ? 'page' : undefined"
                         target="_self"
                         @click="close"
@@ -185,6 +185,23 @@ function onKeydown(event: KeyboardEvent): void {
                     </a>
                 </div>
             </template>
+
+            <!--
+              The way to reach the versions this list leaves out. In its own
+              group at the end, so it reads as an escape hatch rather than as
+              another version to switch to.
+            -->
+            <div v-if="allVersionsHref" class="version-picker__group">
+                <a
+                    class="version-picker__item version-picker__item--all"
+                    :href="allVersionsHref"
+                    target="_self"
+                    @click="close"
+                >
+                    <span>All versions</span>
+                    <span aria-hidden="true">&rarr;</span>
+                </a>
+            </div>
         </div>
     </div>
 </template>
@@ -325,6 +342,10 @@ function onKeydown(event: KeyboardEvent): void {
     color: var(--vp-c-text-2);
     font-size: 12px;
     font-weight: 400;
+}
+
+.version-picker__item--all {
+    color: var(--vp-c-brand-1);
 }
 
 .version-picker__tag {

--- a/docsv/.vitepress/theme/VersionPicker.vue
+++ b/docsv/.vitepress/theme/VersionPicker.vue
@@ -144,10 +144,28 @@ function onKeydown(event: KeyboardEvent): void {
             <span class="vpi-chevron-down version-picker__chevron" aria-hidden="true" />
         </button>
 
-        <span v-else class="version-picker__static">
-            <span class="sqlfluff-visually-hidden">Documentation version:</span>
-            {{ triggerLabel }}
-        </span>
+        <template v-else>
+            <span class="version-picker__static">
+                <span class="sqlfluff-visually-hidden">Documentation version:</span>
+                {{ triggerLabel }}
+            </span>
+
+            <!--
+              With nothing to switch to there is no panel, but the archive index
+              still has to be reachable: if every other version is unlisted this
+              is the reader's only route to them. Rendered as a link rather than
+              as a one-item dropdown.
+            -->
+            <a
+                v-if="allVersionsHref"
+                class="version-picker__item version-picker__item--all version-picker__all-static"
+                :href="allVersionsHref"
+                target="_self"
+            >
+                <span>All versions</span>
+                <span aria-hidden="true">&rarr;</span>
+            </a>
+        </template>
 
         <div v-if="interactive" :id="panelId" class="version-picker__panel" :hidden="!open">
             <template v-for="(group, index) in [channels, releases]" :key="index">
@@ -346,6 +364,13 @@ function onKeydown(event: KeyboardEvent): void {
 
 .version-picker__item--all {
     color: var(--vp-c-brand-1);
+}
+
+/* Outside the panel it has no surface behind it, so it needs the panel's own
+   left padding removed to line up with the static label above it. */
+.version-picker__all-static {
+    padding-left: 0;
+    font-size: 13px;
 }
 
 .version-picker__tag {

--- a/docsv/.vitepress/theme/versions.ts
+++ b/docsv/.vitepress/theme/versions.ts
@@ -21,6 +21,13 @@ export interface VersionEntry {
     title?: string | null
     path: string
     kind?: 'channel' | 'release'
+    /** Which toolchain built it. Archived pre-cutover versions are Sphinx. */
+    builder?: 'vitepress' | 'sphinx'
+    /**
+     * Whether the picker offers it. Unlisted versions stay published and
+     * reachable by URL; they are listed on the archive index page instead.
+     */
+    listed?: boolean
     prerelease?: boolean
     published_at?: string
 }
@@ -69,6 +76,16 @@ export function isChannel(entry: VersionEntry): boolean {
     return entry.kind === 'channel' || CHANNEL_KEYS.has(entry.key)
 }
 
+/**
+ * True when the picker should offer this version.
+ *
+ * Absent means listed, so a manifest written before the flag existed still
+ * renders in full rather than emptying the picker.
+ */
+export function isListed(entry: VersionEntry): boolean {
+    return entry.listed !== false
+}
+
 /** The line a reader identifies a version by. */
 export function versionTitle(entry: VersionEntry): string {
     return entry.title || entry.label || entry.key
@@ -81,12 +98,26 @@ export function versionTitle(entry: VersionEntry): string {
  * own 404 handling takes over. That is a better trade than always landing on
  * the target's home page, which is a certain loss of place rather than a
  * possible one.
+ *
+ * Across the Sphinx and VitePress boundary the trade reverses, so the path is
+ * dropped and the link goes to the target version's root. The two builders lay
+ * out URLs differently — `configuration/index.html` against `configuration/` —
+ * and the docs were restructured in the rewrite, with the rules reference going
+ * from one page to many. Carrying the path across is not a near miss but a
+ * certain 404, which makes losing your place the cheaper of the two.
  */
 export function versionHref(
     entry: VersionEntry,
-    pagePath: string
+    pagePath: string,
+    currentBuilder?: VersionEntry['builder']
 ): string {
-    return normalizeBase(entry.path, '/') + pagePath
+    const base = normalizeBase(entry.path, '/')
+
+    if (entry.builder && currentBuilder && entry.builder !== currentBuilder) {
+        return base
+    }
+
+    return base + pagePath
 }
 
 export type NoticeKind = 'development' | 'outdated'
@@ -100,7 +131,7 @@ export interface VersionNotice {
 }
 
 export interface UseVersions {
-    /** Every published version, channels before releases. */
+    /** The versions the picker offers: the listed ones, plus the current one. */
     entries: Ref<VersionEntry[]>
     /** The version this build was published as, if it is versioned at all. */
     current: Ref<VersionEntry | null>
@@ -109,6 +140,10 @@ export interface UseVersions {
     /** The current page's path within its version, for cross-version links. */
     pagePath: ComputedRef<string>
     notice: Ref<VersionNotice | null>
+    /** A link to the same page in another version, from this one. */
+    hrefFor: (entry: VersionEntry) => string
+    /** The archive index page, or null when there is no manifest to index. */
+    allVersionsHref: Ref<string | null>
 }
 
 export function useVersions(): UseVersions {
@@ -152,37 +187,68 @@ export function useVersions(): UseVersions {
         }]
     })
 
-    const entries = computed<VersionEntry[]>(() => {
-        const published = manifest.value?.versions
+    /** Every published version, channels before releases. */
+    const published = computed<VersionEntry[]>(() => {
+        const versions = manifest.value?.versions
 
-        if (!published?.length) return fallback.value
+        if (!versions?.length) return fallback.value
 
         // `version_sort_key` in assemble-site.py already orders channels first
         // and then releases newest-first. Partitioning preserves that order
         // within each group, which the "newest release" checks below rely on.
         return [
-            ...published.filter(isChannel),
-            ...published.filter((entry) => !isChannel(entry)),
+            ...versions.filter(isChannel),
+            ...versions.filter((entry) => !isChannel(entry)),
         ]
     })
+
+    const current = computed(
+        () => published.value.find((entry) => entry.key === currentKey.value) ?? null
+    )
+
+    /**
+     * The versions the picker offers.
+     *
+     * Only one release per series is listed. That is what every comparable
+     * project does — Node.js hosts every patch and lists none of them — and a
+     * scrolling list of a hundred patch releases is the failure mode this
+     * replaces.
+     *
+     * The current version is added back whenever it was left out. Most readers
+     * arrive on an old version from a search engine, and a control which does
+     * not name the version they are reading looks broken rather than curated.
+     */
+    const entries = computed<VersionEntry[]>(() =>
+        published.value.filter(
+            (entry) => isListed(entry) || entry.key === currentKey.value
+        )
+    )
 
     const channels = computed(() => entries.value.filter(isChannel))
     const releases = computed(() => entries.value.filter((e) => !isChannel(e)))
 
-    const current = computed(
-        () => entries.value.find((entry) => entry.key === currentKey.value) ?? null
+    /**
+     * Every published release, listed or not.
+     *
+     * The notice below asks whether the reader is on the newest release, which
+     * is a question about what exists rather than about what the picker shows.
+     * Asking it of the listed set would leave a reader on an unlisted patch
+     * unwarned whenever nothing newer happened to be listed.
+     */
+    const allReleases = computed(() =>
+        published.value.filter((entry) => !isChannel(entry))
     )
 
     /** The release the `stable` channel points at, when it is published. */
     const stableRelease = computed(() => {
         const key = manifest.value?.stable
-        return releases.value.find((entry) => entry.key === key) ?? null
+        return allReleases.value.find((entry) => entry.key === key) ?? null
     })
 
     /** Where a reader on an unsuitable version should be sent instead. */
     const recommended = computed<VersionEntry | null>(() => {
-        const stableChannel = channels.value.find((entry) => entry.key === 'stable')
-        return stableRelease.value ?? stableChannel ?? releases.value[0] ?? null
+        const stableChannel = published.value.find((entry) => entry.key === 'stable')
+        return stableRelease.value ?? stableChannel ?? allReleases.value[0] ?? null
     })
 
     const notice = computed<VersionNotice | null>(() => {
@@ -191,7 +257,7 @@ export function useVersions(): UseVersions {
         // Nothing to warn about when there is nowhere else to go. This also
         // keeps the banner off a single-channel deployment such as the beta
         // site, where every build is `latest`.
-        if (!entry || entries.value.length < 2) return null
+        if (!entry || published.value.length < 2) return null
 
         const target = recommended.value
         const alternative = target && target.key !== entry.key ? target : null
@@ -205,16 +271,47 @@ export function useVersions(): UseVersions {
         if (isChannel(entry)) return null
 
         // Releases are ordered newest-first, so anything but the first is old.
-        if (releases.value.indexOf(entry) > 0) {
+        if (allReleases.value.indexOf(entry) > 0) {
             return { kind: 'outdated', current: entry, target: alternative }
         }
 
         return null
     })
 
+    /**
+     * A cross-version link from this page, which is always the same two
+     * arguments at every call site: the page the reader is on, and the builder
+     * they are on it in.
+     */
+    function hrefFor(entry: VersionEntry): string {
+        return versionHref(entry, pagePath.value, current.value?.builder)
+    }
+
+    /**
+     * Where the versions the picker leaves out stay discoverable.
+     *
+     * `assemble-site.py` writes this page at the language root on every publish,
+     * so it exists whenever a manifest does. Without one there is nothing to
+     * index, which is also the local-development case.
+     */
+    const allVersionsHref = computed(() =>
+        manifest.value?.versions?.length
+            ? `${languageRoot(docsBase.value)}versions.html`
+            : null
+    )
+
     onMounted(() => {
         if (currentKey.value) void loadManifest(docsBase.value)
     })
 
-    return { entries, current, channels, releases, pagePath, notice }
+    return {
+        entries,
+        current,
+        channels,
+        releases,
+        pagePath,
+        notice,
+        hrefFor,
+        allVersionsHref,
+    }
 }

--- a/docsv/README.md
+++ b/docsv/README.md
@@ -25,8 +25,13 @@ docsv/
 │   ├── generate-rules-docs.py    # Extract and convert rule documentation
 │   ├── generate-dialect-docs.py  # Extract and convert dialect documentation
 │   ├── generate-cli-docs.py      # Extract and convert CLI documentation
-│   ├── extract-redirects.py      # Convert Sphinx redirects to VitePress
-│   └── generate-all-docs.py      # Master build script
+│   ├── generate-all-docs.py      # Master build script
+│   ├── inject-shared-picker.py   # Add the shared picker to Sphinx output
+│   ├── assemble-site.py          # Merge one built version into the site tree
+│   └── smoke-check-assembled-site.py  # Validate the assembled tree
+├── shared/                 # Runtime assets published at /en/shared/, above
+│                           # every version, so archived Sphinx builds pick up
+│                           # picker changes without being rebuilt
 ├── reference/
 │   ├── rules/              # Auto-generated rule docs (by bundle)
 │   ├── dialects/           # Auto-generated dialect docs

--- a/docsv/README.md
+++ b/docsv/README.md
@@ -10,7 +10,7 @@ This POC demonstrates:
 2. **Automated Dialect Documentation** - Extracts dialect info
 3. **Automated CLI Documentation** - Extracts CLI commands and options
 4. **API Documentation** - Uses pydoc-markdown to extract Python docstrings from the API
-5. **Redirect System** - Converts Sphinx redirects to VitePress format for backward compatibility
+5. **Redirect System** - A checked-in permalink map that `assemble-site.py` turns into versioned redirect rules, preserving the `/perma/` URLs SQLFluff emits at runtime
 6. **Build Pipeline** - Automated script to generate all documentation before VitePress builds
 
 ## Directory Structure
@@ -75,7 +75,6 @@ This will:
 - Extract all rules and generate `reference/rules/*.md` files
 - Extract dialect and CLI documentation
 - Generate API documentation with pydoc-markdown
-- Extract redirects from Sphinx `conf.py`
 - Create sidebar configuration
 
 ### Development Server
@@ -149,10 +148,16 @@ pnpm run docs:preview
 
 ### Redirects
 
-- ✅ Parses Sphinx `rediraffe_redirects` from `conf.py`
-- ✅ Converts ~90 redirects to VitePress format
-- ✅ Maintains backward compatibility with permalinks
-- ✅ Outputs both JSON and TypeScript formats
+`.vitepress/redirects.json` is a checked-in map from permalink to page. It was
+seeded from the Sphinx `redirects` in `docs/source/conf.py` and is now
+maintained by hand; nothing extracts it at build time.
+
+- ✅ ~100 permalinks, covering the `/perma/` URLs SQLFluff emits from the CLI
+- ✅ `assemble-site.py` turns the map into versioned `_redirects` rules, so a
+  permalink resolves server-side on every published version
+- ✅ The theme also consults the map for in-app navigation, which VitePress
+  intercepts before a request reaches the server
+- ✅ A permalink whose target page no longer exists fails the publish
 
 ### Build System
 
@@ -171,7 +176,7 @@ To validate this POC:
 - [ ] Verify rule documentation has proper formatting and code blocks
 - [ ] Run `npm run docs:dev` - should start dev server
 - [ ] Navigate to rules section - verify layout, links, and anchors work
-- [ ] Check that redirects are loaded in `.vitepress/redirects.json`
+- [ ] Check that every permalink in `.vitepress/redirects.json` still resolves — `assemble-site.py` fails the publish if one does not
 - [ ] Test search functionality with rule codes (e.g., "LT01")
 - [ ] Verify API documentation generated (if pydoc-markdown installed)
 

--- a/docsv/scripts/assemble-site.py
+++ b/docsv/scripts/assemble-site.py
@@ -661,6 +661,31 @@ frozen at the point they were published and are not updated.
 """
 
 
+def publish_not_found_page(dist: Path, output_dir: Path) -> None:
+    """Copy the published build's 404 page to the site root.
+
+    Netlify only serves a `404.html` from the publish root. It does not fall back
+    to one inside a subdirectory, so the VitePress 404 page each version builds
+    was never reached — every miss on the beta site, including inside
+    `/en/latest/`, returned Netlify's own generic page.
+
+    The root copy comes from whichever build ran last rather than being written
+    from scratch, which keeps it styled like the rest of the site and keeps it in
+    step with the fingerprinted assets it references: those are published by the
+    same run that copies this.
+
+    Skipped when the build has no 404 page, which is the Sphinx case. That leaves
+    the previous copy in place rather than removing it, so archiving a version
+    cannot take the site's 404 page away.
+    """
+    source = dist / "404.html"
+
+    if not source.is_file():
+        return
+
+    shutil.copy2(source, output_dir / "404.html")
+
+
 def publish_shared_assets(shared_dir: Path, language_dir: Path) -> None:
     """Copy the shared runtime assets to the language root.
 
@@ -735,6 +760,7 @@ def assemble_site(
     write_text(manifest_path, json.dumps(manifest, indent=2))
     write_text(language_dir / "versions.html", build_versions_page(language, manifest))
     publish_shared_assets(shared_dir, language_dir)
+    publish_not_found_page(dist, output_dir)
     write_text(
         output_dir / "_redirects", build_redirects(language, manifest, permalinks)
     )

--- a/docsv/scripts/assemble-site.py
+++ b/docsv/scripts/assemble-site.py
@@ -196,6 +196,24 @@ RELEASE_PATTERN = re.compile(
 # `3.4` and `3.4.0` compare as the same release.
 RELEASE_DEPTH = 4
 
+# Prerelease stages in PEP 440 order, so `4.0.0a2` is older than `4.0.0b1` rather
+# than being compared on its number alone. Only `aN` has ever been tagged here,
+# which is why this went unnoticed; the ordering is cheap to get right and the
+# manifest's ordering decides which release readers are warned about.
+STAGE_ORDER = {
+    "a": 0,
+    "alpha": 0,
+    "b": 1,
+    "beta": 1,
+    "c": 2,
+    "rc": 2,
+    "pre": 2,
+    "preview": 2,
+}
+
+# One above every prerelease stage, so a final release outranks all of them.
+FINAL_STAGE = max(STAGE_ORDER.values()) + 1
+
 
 def version_sort_key(entry: dict[str, Any]) -> tuple[int, tuple[int, ...] | str]:
     """Sort channels first, then releases in descending version order.
@@ -227,11 +245,12 @@ def version_sort_key(entry: dict[str, Any]) -> tuple[int, tuple[int, ...] | str]
     parts += [0] * (RELEASE_DEPTH - len(parts))
 
     # A prerelease precedes the release it leads up to, and a post-release
-    # follows it: `4.0.0a1` < `4.0.0` < `4.0.1.post1`. Ranking the stage above
-    # the prerelease number keeps `4.0.0` ahead of every `4.0.0aN`, which a bare
-    # number could not express — there is no prerelease number that means "not a
-    # prerelease".
-    stage_rank = 0 if match["stage"] else 1
+    # follows it: `4.0.0a1` < `4.0.0b1` < `4.0.0` < `4.0.1.post1`. Ranking the
+    # stage above the prerelease number keeps `4.0.0` ahead of every `4.0.0aN`,
+    # which a bare number could not express — there is no prerelease number that
+    # means "not a prerelease".
+    stage = (match["stage"] or "").lower()
+    stage_rank = STAGE_ORDER.get(stage, FINAL_STAGE) if stage else FINAL_STAGE
     stage_num = int(match["stage_num"] or 0)
     post = int(match["post"] or 0)
 
@@ -315,12 +334,20 @@ def load_redirect_map(path: Path) -> dict[str, str]:
         return {}
 
     entries = json.loads(path.read_text(encoding="utf-8"))
-
-    return {
-        key: value
-        for key, value in entries.items()
-        if not key.startswith("_") and value
+    # `_comment` is the convention these config files use for notes.
+    permalinks = {
+        key: value for key, value in entries.items() if not key.startswith("_")
     }
+
+    # An empty target is a malformed entry, not a permalink to nowhere. Dropping
+    # it would leave that URL a 404 while the publish reported success, which is
+    # the failure this whole mechanism exists to remove.
+    empty = sorted(key for key, value in permalinks.items() if not value)
+
+    if empty:
+        raise ValueError(f"Permalinks with no target in {path}: {', '.join(empty)}")
+
+    return permalinks
 
 
 def split_fragment(target: str) -> tuple[str, str]:
@@ -435,23 +462,33 @@ def build_permalink_rules(language: str, redirects: dict[str, str]) -> list[str]
     return rules
 
 
+def default_channel(manifest: dict[str, Any]) -> str:
+    """The channel the site root serves, and so the one the site speaks as.
+
+    Shared by the root redirect and the site-wide 404 page, which must name the
+    same channel: a 404 offering to send the reader somewhere other than where
+    `/` goes would be its own small confusion.
+    """
+    versions = [
+        str(version["key"])
+        for version in manifest.get("versions", [])
+        if version.get("key")
+    ]
+    channel = str(manifest.get("default") or manifest.get("latest") or "latest")
+
+    if channel not in versions and versions:
+        channel = "latest" if "latest" in versions else versions[0]
+
+    return channel
+
+
 def build_redirects(
     language: str,
     manifest: dict[str, Any],
     redirects: dict[str, str] | None = None,
 ) -> str:
     """Build the Netlify redirects file from the assembled manifest."""
-    versions = [
-        str(version["key"])
-        for version in manifest.get("versions", [])
-        if version.get("key")
-    ]
-    default_channel = str(manifest.get("default") or manifest.get("latest") or "latest")
-
-    if default_channel not in versions and versions:
-        default_channel = "latest" if "latest" in versions else versions[0]
-
-    target = f"/{language}/{default_channel}/"
+    target = f"/{language}/{default_channel(manifest)}/"
     lines = [
         f"/ {target} 302",
         f"/{language} {target} 302",
@@ -661,24 +698,33 @@ frozen at the point they were published and are not updated.
 """
 
 
-def publish_not_found_page(dist: Path, output_dir: Path) -> None:
-    """Copy the published build's 404 page to the site root.
+def publish_not_found_page(
+    dist: Path, output_dir: Path, language: str, manifest: dict[str, Any]
+) -> None:
+    """Publish the site-wide 404 page, taken from the default channel.
 
     Netlify only serves a `404.html` from the publish root. It does not fall back
     to one inside a subdirectory, so the VitePress 404 page each version builds
     was never reached — every miss on the beta site, including inside
     `/en/latest/`, returned Netlify's own generic page.
 
-    The root copy comes from whichever build ran last rather than being written
-    from scratch, which keeps it styled like the rest of the site and keeps it in
-    step with the fingerprinted assets it references: those are published by the
-    same run that copies this.
+    Copied from a real build rather than written from scratch, which keeps it
+    styled like the rest of the site for free.
 
-    Skipped when the build has no 404 page, which is the Sphinx case. That leaves
-    the previous copy in place rather than removing it, so archiving a version
-    cannot take the site's 404 page away.
+    Taken from the default channel in the assembled tree rather than from the
+    build being published, so it does not depend on which channels a given run
+    happens to assemble. A prerelease publishes only itself — the workflow skips
+    `stable` for prereleases — and the site's 404 page should not become a
+    prerelease's, complete with a home link into it.
+
+    Falls back to this build for the first publish into an empty tree, where
+    there is no default channel to copy from yet. Skipped entirely when neither
+    has a 404 page, which is the Sphinx case: that leaves the previous copy in
+    place rather than removing it, so archiving a version cannot take the site's
+    404 page away.
     """
-    source = dist / "404.html"
+    channel_page = output_dir / language / default_channel(manifest) / "404.html"
+    source = channel_page if channel_page.is_file() else dist / "404.html"
 
     if not source.is_file():
         return
@@ -760,7 +806,7 @@ def assemble_site(
     write_text(manifest_path, json.dumps(manifest, indent=2))
     write_text(language_dir / "versions.html", build_versions_page(language, manifest))
     publish_shared_assets(shared_dir, language_dir)
-    publish_not_found_page(dist, output_dir)
+    publish_not_found_page(dist, output_dir, language, manifest)
     write_text(
         output_dir / "_redirects", build_redirects(language, manifest, permalinks)
     )

--- a/docsv/scripts/assemble-site.py
+++ b/docsv/scripts/assemble-site.py
@@ -327,6 +327,37 @@ def upsert_manifest_entry(
     return manifest
 
 
+def redirect_entry_problem(key: str, target: Any) -> str | None:
+    """Say why a permalink entry cannot become a redirect rule, or None if it can.
+
+    Every rule this produces is three whitespace-free tokens in a
+    space-delimited file, and both halves become request paths. An entry which
+    breaks either property does not fail loudly at publish time on its own — it
+    emits a rule that is wrong or dead — so it is rejected here instead.
+    """
+    if not key:
+        # `key.strip("/")` makes this the version root, so the rule redirects
+        # every version's home page to whatever the target happens to be.
+        return "empty permalink"
+
+    if not isinstance(target, str) or not target:
+        return "no target"
+
+    if any(character.isspace() for character in f"{key}{target}"):
+        # A target of `"   "` is not merely useless: it emits
+        # `/en/:version/perma/x /en/:version/    301`, which parses as a rule
+        # nobody wrote.
+        return "whitespace in the permalink or its target"
+
+    if ".." in key.split("/") or ".." in target.split("/"):
+        # Netlify matches rules against request paths, which are normalised, so
+        # such a rule is not a traversal — it is simply one that never fires,
+        # leaving the permalink a 404 while the publish reports success.
+        return "a `..` component, which no request path will match"
+
+    return None
+
+
 def load_redirect_map(path: Path) -> dict[str, str]:
     """Load the permalink map, dropping comment keys and rejecting bad entries.
 
@@ -344,24 +375,17 @@ def load_redirect_map(path: Path) -> dict[str, str]:
         key: value for key, value in entries.items() if not key.startswith("_")
     }
 
-    # Whitespace is checked as well as emptiness because `_redirects` is a
-    # space-delimited format: a target of `"   "` is not merely useless, it
-    # produces `/en/:version/perma/x /en/:version/    301`, a rule that parses as
-    # something nobody wrote. Non-strings are rejected here so the rule builder
-    # can assume it has text to work with.
-    invalid = sorted(
-        key
+    problems = {
+        key: problem
         for key, value in permalinks.items()
-        if not isinstance(value, str)
-        or not value
-        or any(character.isspace() for character in f"{key}{value}")
-    )
+        if (problem := redirect_entry_problem(key, value))
+    }
 
-    if invalid:
-        raise ValueError(
-            f"Permalinks with an empty or whitespace-bearing entry in {path}: "
-            f"{', '.join(invalid)}"
+    if problems:
+        detail = "; ".join(
+            f"{key!r}: {problem}" for key, problem in sorted(problems.items())
         )
+        raise ValueError(f"Unusable permalinks in {path}: {detail}")
 
     return permalinks
 

--- a/docsv/scripts/assemble-site.py
+++ b/docsv/scripts/assemble-site.py
@@ -327,6 +327,17 @@ def upsert_manifest_entry(
     return manifest
 
 
+def permalink_segment(value: str) -> str:
+    """Normalise one half of a rule to the path it actually contributes.
+
+    Shared with `build_permalink_rules` deliberately. Validating the raw string
+    while the builder used the stripped one is exactly how a key of `"/"` got
+    past a guard against an empty key: the guard and the code it protects have to
+    be looking at the same value.
+    """
+    return value.strip("/")
+
+
 def redirect_entry_problem(key: str, target: Any) -> str | None:
     """Say why a permalink entry cannot become a redirect rule, or None if it can.
 
@@ -335,9 +346,10 @@ def redirect_entry_problem(key: str, target: Any) -> str | None:
     breaks either property does not fail loudly at publish time on its own — it
     emits a rule that is wrong or dead — so it is rejected here instead.
     """
-    if not key:
-        # `key.strip("/")` makes this the version root, so the rule redirects
-        # every version's home page to whatever the target happens to be.
+    if not permalink_segment(key):
+        # Normalising to nothing makes the rule's source the version root, so it
+        # redirects every version's home page to whatever the target happens to
+        # be. True of `""`, and equally of `"/"` and `"//"`.
         return "empty permalink"
 
     if not isinstance(target, str) or not target:
@@ -354,6 +366,12 @@ def redirect_entry_problem(key: str, target: Any) -> str | None:
         # such a rule is not a traversal — it is simply one that never fires,
         # leaving the permalink a 404 while the publish reports success.
         return "a `..` component, which no request path will match"
+
+    if not permalink_segment(split_fragment(target)[0]):
+        # The mirror of the empty-key case, and much less damaging — the rule is
+        # valid, it just sends the reader to the version root. Still a permalink
+        # that no longer names a page, which is what this map is for.
+        return "a target with no page, only a fragment or slashes"
 
     return None
 
@@ -488,9 +506,11 @@ def build_permalink_rules(language: str, redirects: dict[str, str]) -> list[str]
     rules = []
 
     for key in sorted(redirects):
-        source = f"/{language}/{VERSION_PLACEHOLDER}/{key.strip('/')}"
+        source = f"/{language}/{VERSION_PLACEHOLDER}/{permalink_segment(key)}"
         path, fragment = follow_chain(redirects, redirects[key])
-        destination = f"/{language}/{VERSION_PLACEHOLDER}/{path.strip('/')}{fragment}"
+        destination = (
+            f"/{language}/{VERSION_PLACEHOLDER}/{permalink_segment(path)}{fragment}"
+        )
 
         # A suffix-less destination, which Netlify resolves to whichever of
         # `x.html` and `x/index.html` the target version built. Naming the file

--- a/docsv/scripts/assemble-site.py
+++ b/docsv/scripts/assemble-site.py
@@ -4,22 +4,41 @@
 from __future__ import annotations
 
 import argparse
+import html
 import json
 import os
+import re
 import shutil
 from pathlib import Path, PurePosixPath, PureWindowsPath
 from textwrap import dedent
 from typing import Any
 
+SHARED_ASSETS = Path(__file__).resolve().parent.parent / "shared"
+DEFAULT_REDIRECTS = (
+    Path(__file__).resolve().parent.parent / ".vitepress" / "redirects.json"
+)
+
+# The placeholder Netlify substitutes into the destination. One rule per
+# permalink then covers every published version, rather than one rule per
+# permalink per version — which would be 204 rules a release and would pass
+# Netlify's recommended ceiling within a handful of them.
+VERSION_PLACEHOLDER = ":version"
+
+# A redirect chain longer than this is a configuration mistake rather than
+# something to follow patiently.
+MAX_CHAIN = 8
+
 
 def parse_args() -> argparse.Namespace:
     """Parse command line arguments."""
     parser = argparse.ArgumentParser(description=__doc__)
+    # Named for what it holds rather than for what built it: archived Sphinx
+    # versions are published through this same script.
     parser.add_argument(
-        "--vitepress-dist",
+        "--dist",
         type=Path,
         required=True,
-        help="Path to the built VitePress dist directory.",
+        help="Path to the built docs directory to publish for this version.",
     )
     parser.add_argument(
         "--output-dir",
@@ -35,7 +54,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--channel",
         default="latest",
-        help="Version or channel name for the published VitePress build.",
+        help="Version or channel name for the published build.",
     )
     parser.add_argument(
         "--title",
@@ -48,9 +67,23 @@ def parse_args() -> argparse.Namespace:
         help="Manifest entry kind for the published build.",
     )
     parser.add_argument(
+        "--builder",
+        choices=("vitepress", "sphinx"),
+        default="vitepress",
+        help="Which toolchain produced this build.",
+    )
+    parser.add_argument(
         "--prerelease",
         action="store_true",
         help="Mark the manifest entry as a prerelease.",
+    )
+    parser.add_argument(
+        "--unlisted",
+        action="store_true",
+        help=(
+            "Keep this version out of the picker's list. It stays published, "
+            "reachable by URL, and listed on the archive index page."
+        ),
     )
     parser.add_argument(
         "--published-at",
@@ -59,6 +92,23 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--stable-release",
         help="Release version that the stable channel should point to.",
+    )
+    parser.add_argument(
+        "--shared-dir",
+        type=Path,
+        default=SHARED_ASSETS,
+        help="Directory of shared runtime assets to publish at the language root.",
+    )
+    parser.add_argument(
+        "--redirects",
+        type=Path,
+        default=DEFAULT_REDIRECTS,
+        help="Permalink map to generate versioned redirect rules from.",
+    )
+    parser.add_argument(
+        "--allow-missing-redirect-targets",
+        action="store_true",
+        help="Warn instead of failing when a permalink target has no built page.",
     )
     return parser.parse_args()
 
@@ -128,8 +178,38 @@ def load_manifest(path: Path) -> dict[str, Any]:
     return json.loads(path.read_text(encoding="utf-8"))
 
 
+# The release forms this project has actually tagged: a dotted release number,
+# optionally a prerelease such as `4.0.0a1` or `0.7.0a8`, optionally a
+# post-release such as `4.0.1.post1`. Separators are accepted loosely because
+# PEP 440 permits several spellings of the same version and the tags predate any
+# convention being enforced.
+RELEASE_PATTERN = re.compile(
+    r"""
+    ^(?P<release>\d+(?:\.\d+)*)
+    (?:[-_.]?(?P<stage>a|b|c|rc|alpha|beta|pre|preview)[-_.]?(?P<stage_num>\d*))?
+    (?:[-_.]?post[-_.]?(?P<post>\d*))?$
+    """,
+    re.IGNORECASE | re.VERBOSE,
+)
+
+# Enough components for `major.minor.patch.micro`; anything shorter is padded so
+# `3.4` and `3.4.0` compare as the same release.
+RELEASE_DEPTH = 4
+
+
 def version_sort_key(entry: dict[str, Any]) -> tuple[int, tuple[int, ...] | str]:
-    """Sort channels first, then releases in descending semantic version order."""
+    """Sort channels first, then releases in descending version order.
+
+    The manifest's *ordering* is load-bearing rather than cosmetic: the stale
+    version notice treats any release which is not the first as superseded, so a
+    version sorted into the wrong place is a version readers are wrongly warned
+    about — or wrongly not warned about.
+
+    Ordering within releases is descending, which is why every numeric component
+    is negated. A version which does not parse keeps its own bucket after the
+    releases rather than being forced into the numeric order, since guessing
+    where it belongs would be worse than putting it somewhere predictable.
+    """
     key = str(entry["key"])
 
     if key == "latest":
@@ -138,12 +218,24 @@ def version_sort_key(entry: dict[str, Any]) -> tuple[int, tuple[int, ...] | str]
     if key == "stable":
         return (1, "stable")
 
-    try:
-        parts = tuple(int(part) for part in key.split("."))
-    except ValueError:
+    match = RELEASE_PATTERN.match(key)
+
+    if not match:
         return (3, key)
 
-    return (2, tuple(-part for part in parts))
+    parts = [int(part) for part in match["release"].split(".")][:RELEASE_DEPTH]
+    parts += [0] * (RELEASE_DEPTH - len(parts))
+
+    # A prerelease precedes the release it leads up to, and a post-release
+    # follows it: `4.0.0a1` < `4.0.0` < `4.0.1.post1`. Ranking the stage above
+    # the prerelease number keeps `4.0.0` ahead of every `4.0.0aN`, which a bare
+    # number could not express — there is no prerelease number that means "not a
+    # prerelease".
+    stage_rank = 0 if match["stage"] else 1
+    stage_num = int(match["stage_num"] or 0)
+    post = int(match["post"] or 0)
+
+    return (2, tuple(-part for part in (*parts, stage_rank, stage_num, post)))
 
 
 def upsert_manifest_entry(
@@ -153,7 +245,9 @@ def upsert_manifest_entry(
     channel: str,
     title: str,
     kind: str,
+    builder: str,
     prerelease: bool,
+    unlisted: bool,
     published_at: str | None,
     stable_release: str | None,
 ) -> dict[str, Any]:
@@ -173,8 +267,12 @@ def upsert_manifest_entry(
         "title": title,
         "path": f"/{language}/{channel}/",
         "kind": kind,
-        "builder": "vitepress",
+        "builder": builder,
         "prerelease": prerelease,
+        # Unlisted versions stay published and reachable; they are simply not
+        # offered in the picker, which no comparable project fills with patch
+        # releases. The archive index page is where they are discoverable.
+        "listed": not unlisted,
     }
 
     # The entry is rebuilt from scratch rather than merged, so anything not
@@ -210,7 +308,138 @@ def upsert_manifest_entry(
     return manifest
 
 
-def build_redirects(language: str, manifest: dict[str, Any]) -> str:
+def load_redirect_map(path: Path) -> dict[str, str]:
+    """Load the permalink map, dropping comment keys and empty targets."""
+    if not path.is_file():
+        print(f"Warning: no permalink map at {path}; no redirect rules written")
+        return {}
+
+    entries = json.loads(path.read_text(encoding="utf-8"))
+
+    return {
+        key: value
+        for key, value in entries.items()
+        if not key.startswith("_") and value
+    }
+
+
+def split_fragment(target: str) -> tuple[str, str]:
+    """Split a redirect target into its path and its `#fragment`."""
+    path, separator, fragment = target.partition("#")
+    return path, separator + fragment
+
+
+def follow_chain(redirects: dict[str, str], target: str) -> tuple[str, str]:
+    """Resolve a permalink target which is itself a permalink.
+
+    The map contains one of these — `internals` points at `perma/internals`,
+    which points at the page. The client-side handler followed it by accident,
+    because each hop 404s and re-runs the handler. A rule has to do it on
+    purpose, and sending the reader through two redirects when one will do is a
+    wasted round trip.
+    """
+    path, fragment = split_fragment(target)
+    seen: list[str] = []
+
+    while True:
+        key = path.strip("/")
+
+        if key not in redirects:
+            return path, fragment
+
+        if key in seen or len(seen) >= MAX_CHAIN:
+            raise ValueError(
+                f"Redirect chain does not terminate: {' -> '.join(seen + [key])}"
+            )
+
+        seen.append(key)
+        path, next_fragment = split_fragment(redirects[key])
+        # The final hop names the heading it wants; an earlier one is only kept
+        # if nothing later replaces it.
+        fragment = next_fragment or fragment
+
+
+def resolve_redirect_targets(
+    dist: Path,
+    redirects: dict[str, str],
+    allow_missing: bool = False,
+) -> None:
+    """Check every permalink still lands on a page in the build being published.
+
+    Nothing downstream needs the answer — the rules are written with suffix-less
+    destinations, which Netlify resolves itself. This exists because a permalink
+    is a promise: every SQLFluff release from `2.0.0` onward prints these URLs
+    from the CLI, so a target lost to a page rename should fail the publish that
+    renamed it rather than redirect a reader from a 404 to a 404.
+
+    Only meaningful against a VitePress build. An archived Sphinx version lays
+    its pages out differently and carries its own `sphinx-reredirects` pages, so
+    the caller skips this for those.
+    """
+    missing = []
+
+    for key, target in sorted(redirects.items()):
+        path, _ = follow_chain(redirects, target)
+        relative = path.strip("/")
+
+        if relative and not any(
+            (dist / candidate).is_file()
+            for candidate in (f"{relative}.html", f"{relative}/index.html")
+        ):
+            missing.append(f"{key} -> {target}")
+
+    if not missing:
+        return
+
+    detail = "\n".join(f"  - {item}" for item in missing)
+    message = f"{len(missing)} permalink target(s) have no built page:\n{detail}"
+
+    if not allow_missing:
+        raise FileNotFoundError(message)
+
+    print(f"Warning: {message}")
+
+
+def build_permalink_rules(language: str, redirects: dict[str, str]) -> list[str]:
+    """Build one Netlify rule per permalink, covering every published version.
+
+    `:version` is a placeholder, so these rules are written once and apply to
+    every version under the language root — including versions published before
+    this code existed, which is the only way those get fixed: the permalinks were
+    never files, and re-running the publish workflow for an old tag rebuilds it
+    from that tag's source, which does not know about them.
+
+    Both suffix forms are emitted because both are in the wild: the CLI prints
+    `perma/<name>.html`, and a reader who trims it gets the suffix-less form.
+    Netlify ignores a trailing slash when matching, so that case needs no rule.
+
+    Nothing is forced with `!`, so a version which already has a real file at one
+    of these paths keeps serving it. That is what leaves the archived Sphinx
+    versions alone: their `sphinx-reredirects` pages are correct for their own
+    page layout, and these rules are not.
+    """
+    rules = []
+
+    for key in sorted(redirects):
+        source = f"/{language}/{VERSION_PLACEHOLDER}/{key.strip('/')}"
+        path, fragment = follow_chain(redirects, redirects[key])
+        destination = f"/{language}/{VERSION_PLACEHOLDER}/{path.strip('/')}{fragment}"
+
+        # A suffix-less destination, which Netlify resolves to whichever of
+        # `x.html` and `x/index.html` the target version built. Naming the file
+        # would bake the current build's layout into rules that also serve older
+        # versions.
+        rules.append(f"{source} {destination} 301")
+        rules.append(f"{source}.html {destination} 301")
+
+    return rules
+
+
+def build_redirects(
+    language: str,
+    manifest: dict[str, Any],
+    redirects: dict[str, str] | None = None,
+) -> str:
     """Build the Netlify redirects file from the assembled manifest."""
     versions = [
         str(version["key"])
@@ -223,17 +452,28 @@ def build_redirects(language: str, manifest: dict[str, Any]) -> str:
         default_channel = "latest" if "latest" in versions else versions[0]
 
     target = f"/{language}/{default_channel}/"
-    return dedent(
-        f"""
-        / {target} 302
-        /{language} {target} 302
-        /{language}/ {target} 302
-        """
-    )
+    lines = [
+        f"/ {target} 302",
+        f"/{language} {target} 302",
+        f"/{language}/ {target} 302",
+    ]
+
+    if redirects:
+        lines.append("")
+        lines.extend(build_permalink_rules(language, redirects))
+
+    return "\n".join(lines) + "\n"
 
 
 def build_global_headers(language: str) -> str:
-    """Build generic cache-control headers for mutable channels and version assets."""
+    """Build generic cache-control headers for mutable channels and version assets.
+
+    The shared assets get a short cache rather than an immutable one. They are
+    published at fixed filenames — an archived Sphinx build injects
+    `/en/shared/version-picker.js` into every page and is never rebuilt — so
+    there is no fingerprint to change, and a long cache would mean a picker fix
+    reaching frozen versions only once browsers expired it.
+    """
     return dedent(
         f"""
         /{language}/latest/
@@ -256,37 +496,229 @@ def build_global_headers(language: str) -> str:
 
         /{language}/versions.json
             Cache-Control: public, max-age=0, must-revalidate
+
+        /{language}/versions.html
+            Cache-Control: public, max-age=0, must-revalidate
+
+        /{language}/shared/*
+            Cache-Control: public, max-age=300, must-revalidate
         """
     )
 
 
+VERSIONS_PAGE_STYLE = """
+    :root { color-scheme: light dark; }
+    body {
+        max-width: 46rem;
+        margin: 0 auto;
+        padding: 3rem 1.25rem 5rem;
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+            "Helvetica Neue", Arial, sans-serif;
+        font-size: 16px;
+        line-height: 1.6;
+        color: #24292f;
+        background: #ffffff;
+    }
+    h1 { margin: 0 0 0.5rem; font-size: 1.9rem; }
+    h2 {
+        margin: 2.5rem 0 0.75rem;
+        padding-bottom: 0.35rem;
+        font-size: 1.15rem;
+        border-bottom: 1px solid #d8dee4;
+    }
+    p.lede { margin: 0 0 1rem; color: #57606a; }
+    ul { margin: 0; padding: 0; list-style: none; }
+    li {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: baseline;
+        gap: 0.6rem;
+        padding: 0.35rem 0;
+        border-bottom: 1px solid #f0f2f4;
+    }
+    li a { font-weight: 600; text-decoration: none; color: #0969da; }
+    li a:hover { text-decoration: underline; }
+    .version { font-variant-numeric: tabular-nums; }
+    .meta { color: #57606a; font-size: 0.85rem; }
+    .tag {
+        padding: 0 0.35rem;
+        font-size: 0.75rem;
+        color: #57606a;
+        background: #eff1f3;
+        border-radius: 3px;
+    }
+    footer { margin-top: 3rem; color: #57606a; font-size: 0.85rem; }
+    footer a { color: #0969da; }
+    @media (prefers-color-scheme: dark) {
+        body { color: #e6edf3; background: #0d1117; }
+        h2 { border-bottom-color: #30363d; }
+        li { border-bottom-color: #21262d; }
+        p.lede, .meta, footer { color: #9198a1; }
+        li a, footer a { color: #4493f8; }
+        .tag { color: #9198a1; background: #21262d; }
+    }
+"""
+
+
+def entry_series(entry: dict[str, Any]) -> str:
+    """The major series heading a release belongs under, such as `3.x`."""
+    match = RELEASE_PATTERN.match(str(entry["key"]))
+    return f"{match['release'].split('.')[0]}.x" if match else "Other"
+
+
+def release_groups(manifest: dict[str, Any]) -> list[tuple[str, list[dict[str, Any]]]]:
+    """Group the released versions by major series, keeping manifest order."""
+    groups: dict[str, list[dict[str, Any]]] = {}
+
+    for entry in manifest.get("versions", []):
+        if entry.get("kind") == "channel" or entry.get("key") in {"latest", "stable"}:
+            continue
+
+        groups.setdefault(entry_series(entry), []).append(entry)
+
+    return list(groups.items())
+
+
+def render_version_item(entry: dict[str, Any], stable_key: str | None) -> str:
+    """Render one list item on the archive index page."""
+    path = html.escape(str(entry.get("path") or ""), quote=True)
+    label = html.escape(str(entry.get("title") or entry.get("label") or entry["key"]))
+
+    tags = []
+
+    if entry.get("key") == stable_key:
+        tags.append("current release")
+    if entry.get("prerelease"):
+        tags.append("pre-release")
+    if entry.get("builder") == "sphinx":
+        tags.append("archived")
+
+    parts = [f'<a class="version" href="{path}">{label}</a>']
+    parts += [f'<span class="tag">{html.escape(tag)}</span>' for tag in tags]
+
+    if entry.get("published_at"):
+        published = html.escape(str(entry["published_at"]))
+        parts.append(f'<span class="meta">{published}</span>')
+
+    return "<li>" + "".join(parts) + "</li>"
+
+
+def build_versions_page(language: str, manifest: dict[str, Any]) -> str:
+    """Render the archive index listing every published version.
+
+    The picker deliberately lists only one entry per release series, following
+    what every comparable project does — Node.js hosts every patch and lists
+    none of them. This page is where the rest stay discoverable, grouped by
+    major series the way Docusaurus groups its own `/versions` page.
+
+    Written as a self-contained page with inlined styling rather than as part of
+    a VitePress build: it lives at the language root, above every version, so it
+    cannot borrow one version's assets without going stale when that version is
+    replaced.
+    """
+    channels = [
+        entry
+        for entry in manifest.get("versions", [])
+        if entry.get("kind") == "channel" or entry.get("key") in {"latest", "stable"}
+    ]
+    stable_key = manifest.get("stable")
+
+    sections = []
+
+    if channels:
+        items = "\n".join(render_version_item(entry, stable_key) for entry in channels)
+        sections.append(f"<h2>Current documentation</h2>\n<ul>\n{items}\n</ul>")
+
+    for series, entries in release_groups(manifest):
+        items = "\n".join(render_version_item(entry, stable_key) for entry in entries)
+        heading = html.escape(series)
+        sections.append(f"<h2>{heading} releases</h2>\n<ul>\n{items}\n</ul>")
+
+    body = "\n".join(sections) or '<p class="lede">No versions published yet.</p>'
+    root = f"/{html.escape(language)}/"
+
+    return f"""<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>SQLFluff documentation versions</title>
+<meta name="robots" content="noindex, follow">
+<style>{VERSIONS_PAGE_STYLE}</style>
+</head>
+<body>
+<h1>SQLFluff documentation versions</h1>
+<p class="lede">
+Every published version of the SQLFluff documentation. Released versions are
+frozen at the point they were published and are not updated.
+</p>
+{body}
+<footer>
+<a href="{root}">Back to the current documentation</a>
+</footer>
+</body>
+</html>
+"""
+
+
+def publish_shared_assets(shared_dir: Path, language_dir: Path) -> None:
+    """Copy the shared runtime assets to the language root.
+
+    Copied on every publish, not once. Archived versions load the picker from
+    `/en/shared/` precisely so that a fix reaches them without a rebuild, which
+    only holds if the newest copy is republished each time anything is.
+    """
+    if not shared_dir.is_dir():
+        return
+
+    target = language_dir / "shared"
+
+    if target.exists():
+        shutil.rmtree(target)
+
+    shutil.copytree(shared_dir, target)
+
+
 def assemble_site(
-    vitepress_dist: Path,
+    dist: Path,
     output_dir: Path,
     language: str,
     channel: str,
     title: str,
     kind: str,
-    prerelease: bool,
-    published_at: str | None,
-    stable_release: str | None,
+    builder: str = "vitepress",
+    prerelease: bool = False,
+    unlisted: bool = False,
+    published_at: str | None = None,
+    stable_release: str | None = None,
+    shared_dir: Path = SHARED_ASSETS,
+    redirects: Path | None = None,
+    allow_missing_redirect_targets: bool = False,
 ) -> None:
     """Merge one built docs channel into the assembled site tree."""
-    if not vitepress_dist.is_dir():
-        raise FileNotFoundError(f"VitePress dist directory not found: {vitepress_dist}")
+    if not dist.is_dir():
+        raise FileNotFoundError(f"Build directory not found: {dist}")
 
     assert_safe_segment(language, "language")
     assert_safe_segment(channel, "channel")
 
-    target_dir = output_dir / language / channel
+    language_dir = output_dir / language
+    target_dir = language_dir / channel
     target_dir.parent.mkdir(parents=True, exist_ok=True)
 
     if target_dir.exists():
         shutil.rmtree(target_dir)
 
-    shutil.copytree(vitepress_dist, target_dir)
+    shutil.copytree(dist, target_dir)
 
-    manifest_path = output_dir / language / "versions.json"
+    permalinks = load_redirect_map(redirects) if redirects else {}
+
+    # Checked against the build that owns these permalinks. A Sphinx archive has
+    # its own, as real pages, and lays its content out differently.
+    if permalinks and builder == "vitepress":
+        resolve_redirect_targets(dist, permalinks, allow_missing_redirect_targets)
+
+    manifest_path = language_dir / "versions.json"
     manifest = load_manifest(manifest_path)
     manifest = upsert_manifest_entry(
         manifest,
@@ -294,12 +726,18 @@ def assemble_site(
         channel=channel,
         title=title,
         kind=kind,
+        builder=builder,
         prerelease=prerelease,
+        unlisted=unlisted,
         published_at=published_at,
         stable_release=stable_release,
     )
     write_text(manifest_path, json.dumps(manifest, indent=2))
-    write_text(output_dir / "_redirects", build_redirects(language, manifest))
+    write_text(language_dir / "versions.html", build_versions_page(language, manifest))
+    publish_shared_assets(shared_dir, language_dir)
+    write_text(
+        output_dir / "_redirects", build_redirects(language, manifest, permalinks)
+    )
     write_text(output_dir / "_headers", build_global_headers(language))
 
 
@@ -307,16 +745,21 @@ def main() -> int:
     """Main entry point."""
     args = parse_args()
     assemble_site(
-        vitepress_dist=args.vitepress_dist,
+        dist=args.dist,
         output_dir=args.output_dir,
         language=args.language.strip("/"),
         channel=args.channel.strip("/"),
         title=args.title
         or ("Development" if args.channel == "latest" else args.channel),
         kind=args.kind,
+        builder=args.builder,
         prerelease=args.prerelease,
+        unlisted=args.unlisted,
         published_at=args.published_at,
         stable_release=args.stable_release,
+        shared_dir=args.shared_dir,
+        redirects=args.redirects,
+        allow_missing_redirect_targets=args.allow_missing_redirect_targets,
     )
     print(f"Assembled site written to {args.output_dir}")
     return 0

--- a/docsv/scripts/assemble-site.py
+++ b/docsv/scripts/assemble-site.py
@@ -328,7 +328,12 @@ def upsert_manifest_entry(
 
 
 def load_redirect_map(path: Path) -> dict[str, str]:
-    """Load the permalink map, dropping comment keys and empty targets."""
+    """Load the permalink map, dropping comment keys and rejecting bad entries.
+
+    A malformed entry is rejected rather than skipped. Skipping would leave that
+    URL a 404 while the publish reported success, which is the failure this whole
+    mechanism exists to remove.
+    """
     if not path.is_file():
         print(f"Warning: no permalink map at {path}; no redirect rules written")
         return {}
@@ -339,13 +344,24 @@ def load_redirect_map(path: Path) -> dict[str, str]:
         key: value for key, value in entries.items() if not key.startswith("_")
     }
 
-    # An empty target is a malformed entry, not a permalink to nowhere. Dropping
-    # it would leave that URL a 404 while the publish reported success, which is
-    # the failure this whole mechanism exists to remove.
-    empty = sorted(key for key, value in permalinks.items() if not value)
+    # Whitespace is checked as well as emptiness because `_redirects` is a
+    # space-delimited format: a target of `"   "` is not merely useless, it
+    # produces `/en/:version/perma/x /en/:version/    301`, a rule that parses as
+    # something nobody wrote. Non-strings are rejected here so the rule builder
+    # can assume it has text to work with.
+    invalid = sorted(
+        key
+        for key, value in permalinks.items()
+        if not isinstance(value, str)
+        or not value
+        or any(character.isspace() for character in f"{key}{value}")
+    )
 
-    if empty:
-        raise ValueError(f"Permalinks with no target in {path}: {', '.join(empty)}")
+    if invalid:
+        raise ValueError(
+            f"Permalinks with an empty or whitespace-bearing entry in {path}: "
+            f"{', '.join(invalid)}"
+        )
 
     return permalinks
 
@@ -717,19 +733,29 @@ def publish_not_found_page(
     `stable` for prereleases — and the site's 404 page should not become a
     prerelease's, complete with a home link into it.
 
-    Falls back to this build for the first publish into an empty tree, where
-    there is no default channel to copy from yet. Skipped entirely when neither
-    has a 404 page, which is the Sphinx case: that leaves the previous copy in
-    place rather than removing it, so archiving a version cannot take the site's
-    404 page away.
+    When that channel has no 404 page of its own, an existing root page is left
+    alone rather than replaced by this build's. Otherwise the guarantee above
+    would hold only until some release happened to be published while the
+    default channel was missing one, which is the situation this is here to
+    prevent.
+
+    This build is used only to bootstrap a tree that has no root page at all.
+    There the mismatch cannot arise: if this is the only version published, its
+    404 page names the only documentation there is. And when neither has one —
+    the Sphinx case — nothing is written, so archiving a version cannot take the
+    site's 404 page away.
     """
     channel_page = output_dir / language / default_channel(manifest) / "404.html"
-    source = channel_page if channel_page.is_file() else dist / "404.html"
+    root_page = output_dir / "404.html"
 
-    if not source.is_file():
+    if channel_page.is_file():
+        shutil.copy2(channel_page, root_page)
         return
 
-    shutil.copy2(source, output_dir / "404.html")
+    if root_page.exists() or not (dist / "404.html").is_file():
+        return
+
+    shutil.copy2(dist / "404.html", root_page)
 
 
 def publish_shared_assets(shared_dir: Path, language_dir: Path) -> None:

--- a/docsv/scripts/inject-shared-picker.py
+++ b/docsv/scripts/inject-shared-picker.py
@@ -37,8 +37,11 @@ HEAD_CLOSE = re.compile(r"</head>", re.IGNORECASE)
 # documented in `docsv/README.md`, and the docs document themselves — would
 # otherwise look already-injected and silently keep its picker. Attribute order
 # is not assumed, so the tag can gain attributes without breaking idempotency.
+# `\s` before `src` rather than `\b`: a word boundary also sits inside
+# `data-src`, which does not load anything, so a page carrying one would look
+# already-injected.
 INJECTED_SCRIPT = re.compile(
-    r"""<script\b[^>]*\bsrc=["'][^"']*version-picker\.js["']""",
+    r"""<script\b[^>]*\ssrc\s*=\s*["'][^"']*version-picker\.js["']""",
     re.IGNORECASE,
 )
 

--- a/docsv/scripts/inject-shared-picker.py
+++ b/docsv/scripts/inject-shared-picker.py
@@ -32,13 +32,23 @@ RTD_INJECTION = re.compile(
 
 HEAD_CLOSE = re.compile(r"</head>", re.IGNORECASE)
 
-# Matching on the filename rather than on the full tag: it is what makes the
-# pass idempotent, and it must keep matching if the tags below gain attributes.
-INJECTION_MARKER = "version-picker.js"
+# Matches the tag this script writes, rather than the filename anywhere in the
+# document: a page whose prose mentions `version-picker.js` — this file is
+# documented in `docsv/README.md`, and the docs document themselves — would
+# otherwise look already-injected and silently keep its picker. Attribute order
+# is not assumed, so the tag can gain attributes without breaking idempotency.
+INJECTED_SCRIPT = re.compile(
+    r"""<script\b[^>]*\bsrc=["'][^"']*version-picker\.js["']""",
+    re.IGNORECASE,
+)
 
 
 def build_tags(shared_base: str) -> str:
     """Build the markup added to every page's head.
+
+    The prefix is normalised to end in a slash. Without that, a `--shared-base`
+    given as `/en/shared` concatenates into `/en/sharedversion-picker.css`, and
+    the failure is silent — the pages inject cleanly and the picker never loads.
 
     `shared_base` is an absolute URL rather than a path relative to the page,
     which would vary with the page's depth. Sphinx output is otherwise
@@ -48,9 +58,11 @@ def build_tags(shared_base: str) -> str:
     it is already tied to the `/<language>/<version>/` layout. One absolute
     prefix does not give up anything the picker had.
     """
+    base = shared_base if shared_base.endswith("/") else f"{shared_base}/"
+
     return (
-        f'<link rel="stylesheet" href="{shared_base}version-picker.css">'
-        f'<script src="{shared_base}version-picker.js" defer></script>'
+        f'<link rel="stylesheet" href="{base}version-picker.css">'
+        f'<script src="{base}version-picker.js" defer></script>'
     )
 
 
@@ -61,7 +73,7 @@ def process(path: Path, tags: str, strip_rtd: bool) -> bool:
     original = path.read_text(encoding="utf-8", errors="replace")
     updated = RTD_INJECTION.sub("", original) if strip_rtd else original
 
-    if INJECTION_MARKER not in updated:
+    if not INJECTED_SCRIPT.search(updated):
         # A page with no `</head>` is not an alabaster page. Leaving it exactly
         # as built is the right answer for a search index or a raw asset that
         # happens to carry an `.html` suffix.

--- a/docsv/scripts/inject-shared-picker.py
+++ b/docsv/scripts/inject-shared-picker.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Inject the shared version picker into a built Sphinx HTML tree.
+
+Archived pre-cutover versions are Sphinx builds. They have no picker of their
+own and are never rebuilt, so the picker has to be added after the fact and has
+to come from a location above the version — `/en/shared/`, which every publish
+refreshes. This adds the two tags that load it to every page's `<head>`.
+
+It works on any Sphinx output, whether rebuilt from a tag or mirrored from Read
+the Docs. That is what keeps mirroring available as a fallback for a version
+which will no longer build: both routes converge here.
+
+Stripping the Read the Docs addons injection is part of the same pass, because a
+mirrored page would otherwise keep asking readthedocs.org for a flyout that
+advertises the site being replaced.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+# The whole of what Read the Docs adds to a served page: one script, plus the
+# four `readthedocs-*` meta tags it reads its configuration from. Both were
+# appended immediately before `</head>` on every version back to 0.9.0.
+RTD_INJECTION = re.compile(
+    r"<script[^>]*readthedocs-addons\.js[^>]*>\s*</script>"
+    r'|<meta\s+name="readthedocs-[^"]*"[^>]*/?>',
+    re.IGNORECASE,
+)
+
+HEAD_CLOSE = re.compile(r"</head>", re.IGNORECASE)
+
+# Matching on the filename rather than on the full tag: it is what makes the
+# pass idempotent, and it must keep matching if the tags below gain attributes.
+INJECTION_MARKER = "version-picker.js"
+
+
+def build_tags(shared_base: str) -> str:
+    """Build the markup added to every page's head.
+
+    `shared_base` is an absolute URL rather than a path relative to the page,
+    which would vary with the page's depth. Sphinx output is otherwise
+    base-agnostic — every internal link it emits is relative, which is why an
+    archived build can be dropped at any path — but the picker reads the
+    language root out of `location.pathname` and fetches the manifest from it, so
+    it is already tied to the `/<language>/<version>/` layout. One absolute
+    prefix does not give up anything the picker had.
+    """
+    return (
+        f'<link rel="stylesheet" href="{shared_base}version-picker.css">'
+        f'<script src="{shared_base}version-picker.js" defer></script>'
+    )
+
+
+def process(path: Path, tags: str, strip_rtd: bool) -> bool:
+    """Rewrite one HTML file, returning whether it changed."""
+    # `errors="replace"` rather than a failure: these are historical builds, and
+    # one page with a decoding problem should not stop a version being archived.
+    original = path.read_text(encoding="utf-8", errors="replace")
+    updated = RTD_INJECTION.sub("", original) if strip_rtd else original
+
+    if INJECTION_MARKER not in updated:
+        # A page with no `</head>` is not an alabaster page. Leaving it exactly
+        # as built is the right answer for a search index or a raw asset that
+        # happens to carry an `.html` suffix.
+        updated, count = HEAD_CLOSE.subn(tags + "</head>", updated, count=1)
+
+        if not count:
+            return False
+
+    if updated == original:
+        return False
+
+    path.write_text(updated, encoding="utf-8")
+    return True
+
+
+def inject(html_dir: Path, shared_base: str, strip_rtd: bool = True) -> int:
+    """Inject the picker across a built tree, returning the pages changed."""
+    if not html_dir.is_dir():
+        raise FileNotFoundError(f"HTML directory not found: {html_dir}")
+
+    tags = build_tags(shared_base)
+
+    return sum(
+        process(path, tags, strip_rtd) for path in sorted(html_dir.rglob("*.html"))
+    )
+
+
+def main() -> int:
+    """Main entry point."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("html_dir", type=Path, help="Built Sphinx HTML directory.")
+    parser.add_argument(
+        "--shared-base",
+        default="/en/shared/",
+        help="Absolute URL prefix the shared picker assets are published under.",
+    )
+    parser.add_argument(
+        "--keep-rtd",
+        action="store_true",
+        help="Leave any Read the Docs addons injection in place.",
+    )
+    args = parser.parse_args()
+
+    changed = inject(args.html_dir, args.shared_base, not args.keep_rtd)
+    print(f"Injected shared picker into {changed} pages under {args.html_dir}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docsv/scripts/smoke-check-assembled-site.py
+++ b/docsv/scripts/smoke-check-assembled-site.py
@@ -76,8 +76,18 @@ def assert_path_exists(site_dir: Path, url_path: str, description: str) -> None:
     # their destinations are suffix-less so one rule can serve versions whose
     # builds put the page in a different file. Resolving the same way here keeps
     # the check honest about what the deployed site will do.
+    #
+    # Containment is re-checked afterwards rather than only on the path above:
+    # `resolve()` follows symlinks, so a link at the `.html` name could otherwise
+    # satisfy this check with a file outside the tree — vouching for a page the
+    # deployed site does not have.
     if not path.is_file() and not path.suffix:
         path = path.with_suffix(".html")
+
+        if not path.resolve().is_relative_to(site_dir.resolve()):
+            raise ValueError(
+                f"Path escapes the site directory for {description}: {url_path!r}"
+            )
 
     if not path.is_file():
         raise FileNotFoundError(f"Missing {description}: {path}")

--- a/docsv/scripts/smoke-check-assembled-site.py
+++ b/docsv/scripts/smoke-check-assembled-site.py
@@ -72,13 +72,27 @@ def assert_path_exists(site_dir: Path, url_path: str, description: str) -> None:
     if path.is_dir():
         path = path / "index.html"
 
+    # Netlify serves `foo.html` for `/foo`, and the permalink rules rely on it:
+    # their destinations are suffix-less so one rule can serve versions whose
+    # builds put the page in a different file. Resolving the same way here keeps
+    # the check honest about what the deployed site will do.
+    if not path.is_file() and not path.suffix:
+        path = path.with_suffix(".html")
+
     if not path.is_file():
         raise FileNotFoundError(f"Missing {description}: {path}")
+
+
+# The picker loads these from the language root, so an archived version that was
+# built once and frozen picks up later changes to them. A publish that dropped
+# them would take the picker off every archived version at once.
+SHARED_ASSETS = ("version-picker.js", "version-picker.css")
 
 
 def smoke_check(site_dir: Path, language: str) -> None:
     """Validate the important assembled docs outputs."""
     manifest = load_manifest(site_dir, language)
+    listed = 0
 
     for entry in manifest["versions"]:
         key = entry.get("key")
@@ -88,6 +102,26 @@ def smoke_check(site_dir: Path, language: str) -> None:
             raise ValueError(f"Version entry must include key and path: {entry!r}")
 
         assert_path_exists(site_dir, str(path), f"index page for {key}")
+
+        # Absent means listed, so a manifest written before the flag existed
+        # still counts.
+        if entry.get("listed", True):
+            listed += 1
+
+    # An all-unlisted manifest is a site whose picker offers nothing, which
+    # would look like the picker being broken rather than like a publishing
+    # mistake.
+    if not listed:
+        raise ValueError("At least one version entry must be listed in the picker")
+
+    # Where the versions the picker does not list stay discoverable. Without it
+    # the picker's "All versions" entry is a link to a 404.
+    assert_path_exists(site_dir, f"/{language}/versions.html", "archive index page")
+
+    for asset in SHARED_ASSETS:
+        assert_path_exists(
+            site_dir, f"/{language}/shared/{asset}", f"shared asset {asset}"
+        )
 
     redirects_path = site_dir / "_redirects"
 
@@ -103,10 +137,39 @@ def smoke_check(site_dir: Path, language: str) -> None:
 
     assert_path_exists(site_dir, default_path, "default redirect target")
 
+    # Every SQLFluff release from 2.0.0 onward prints these URLs from the CLI,
+    # and they are not files in any version — the rules are the only thing that
+    # makes them resolve, on new and already-published versions alike.
+    permalink_rules = [
+        line.split()
+        for line in redirects.splitlines()
+        if line.startswith(f"/{language}/:version/")
+    ]
+
+    if not permalink_rules:
+        raise ValueError(f"Missing permalink redirect rules for /{language}/:version/")
+
+    # Spot-checked against the channel the site root serves, which is the one a
+    # reader following a CLI link actually lands on.
+    for source, destination, *_ in permalink_rules:
+        assert_path_exists(
+            site_dir,
+            destination.replace(":version", default).split("#")[0],
+            f"permalink target for {source}",
+        )
+
     headers_path = site_dir / "_headers"
 
     if not headers_path.is_file():
         raise FileNotFoundError(f"Missing Netlify headers file: {headers_path}")
+
+    headers = headers_path.read_text(encoding="utf-8")
+
+    # The shared assets have fixed filenames rather than fingerprints, so an
+    # immutable or missing rule here is what would keep a picker fix from
+    # reaching frozen versions.
+    if f"/{language}/shared/*" not in headers:
+        raise ValueError(f"Missing cache-control rule for /{language}/shared/*")
 
 
 def main() -> int:

--- a/docsv/scripts/smoke-check-assembled-site.py
+++ b/docsv/scripts/smoke-check-assembled-site.py
@@ -118,6 +118,11 @@ def smoke_check(site_dir: Path, language: str) -> None:
     # the picker's "All versions" entry is a link to a 404.
     assert_path_exists(site_dir, f"/{language}/versions.html", "archive index page")
 
+    # Netlify only serves a 404 page from the publish root; it does not fall back
+    # to the one inside a version. Without this file every miss on the site gets
+    # Netlify's own generic page instead of ours.
+    assert_path_exists(site_dir, "/404.html", "site 404 page")
+
     for asset in SHARED_ASSETS:
         assert_path_exists(
             site_dir, f"/{language}/shared/{asset}", f"shared asset {asset}"

--- a/docsv/scripts/smoke-check-assembled-site.py
+++ b/docsv/scripts/smoke-check-assembled-site.py
@@ -63,31 +63,24 @@ def assert_path_exists(site_dir: Path, url_path: str, description: str) -> None:
 
     path = site_dir / relative_path
 
-    # Resolve both sides so a symlink cannot point out of the tree either.
-    if not path.resolve().is_relative_to(site_dir.resolve()):
-        raise ValueError(
-            f"Path escapes the site directory for {description}: {url_path!r}"
-        )
-
     if path.is_dir():
         path = path / "index.html"
-
     # Netlify serves `foo.html` for `/foo`, and the permalink rules rely on it:
     # their destinations are suffix-less so one rule can serve versions whose
     # builds put the page in a different file. Resolving the same way here keeps
     # the check honest about what the deployed site will do.
-    #
-    # Containment is re-checked afterwards rather than only on the path above:
-    # `resolve()` follows symlinks, so a link at the `.html` name could otherwise
-    # satisfy this check with a file outside the tree — vouching for a page the
-    # deployed site does not have.
-    if not path.is_file() and not path.suffix:
+    elif not path.is_file() and not path.suffix:
         path = path.with_suffix(".html")
 
-        if not path.resolve().is_relative_to(site_dir.resolve()):
-            raise ValueError(
-                f"Path escapes the site directory for {description}: {url_path!r}"
-            )
+    # Resolved once here rather than on the path this started from, and after
+    # every substitution above rather than before them. `resolve()` follows
+    # symlinks, so each candidate is a separate way out of the tree: checking
+    # only the original path let a symlinked `index.html` under a real directory
+    # through, which would vouch for a page the deployed site does not have.
+    if not path.resolve().is_relative_to(site_dir.resolve()):
+        raise ValueError(
+            f"Path escapes the site directory for {description}: {url_path!r}"
+        )
 
     if not path.is_file():
         raise FileNotFoundError(f"Missing {description}: {path}")

--- a/docsv/shared/version-picker.css
+++ b/docsv/shared/version-picker.css
@@ -62,7 +62,7 @@
 
 .sqlfluff-vp__chevron {
     margin-left: 0.5em;
-    color: #777;
+    color: #666;
     font-size: 0.8em;
 }
 
@@ -100,10 +100,13 @@
     border-top: 1px solid #eee;
 }
 
+/* `#666` rather than a lighter grey: at this size the label is normal text for
+   WCAG 1.4.3, so it needs 4.5:1 against the white panel. `#888` gave 3.54:1 and
+   `#777` gives 4.48:1 — both fail. `#666` is 5.74:1. */
 .sqlfluff-vp__group-title {
     margin: 0 0 0.2em;
     padding: 0 0.5em;
-    color: #888;
+    color: #666;
     font-size: 0.7em;
     letter-spacing: 0.05em;
     text-transform: uppercase;

--- a/docsv/shared/version-picker.css
+++ b/docsv/shared/version-picker.css
@@ -1,0 +1,203 @@
+/*
+ * Styling for the archived-Sphinx version picker and stale-version notice.
+ *
+ * Published at `/en/shared/version-picker.css` and loaded by every archived
+ * page, so this has to sit inside alabaster output produced by any Sphinx
+ * release SQLFluff has used. Two consequences shape it:
+ *
+ * - Every rule is scoped to a `sqlfluff-vp`/`sqlfluff-vb` class. Nothing here
+ *   selects an element, and nothing resets anything, so it cannot disturb the
+ *   layout of a page it was never tested against.
+ * - Sizes are in `em` and colours are literal. Archived builds have no design
+ *   tokens to inherit from and no dark mode, and a custom property added later
+ *   would resolve to nothing on the pages that need this most.
+ *
+ * The palette is alabaster's own greys with SQLFluff's link blue, so the control
+ * reads as part of the page it is injected into rather than as a graft from a
+ * newer site.
+ */
+
+.sqlfluff-vp {
+    position: relative;
+    margin: 0 0 1.5em;
+    font-family: Georgia, serif;
+    line-height: 1.4;
+}
+
+.sqlfluff-vp__label {
+    display: block;
+    margin-bottom: 0.35em;
+    color: #555;
+    font-size: 0.8em;
+    font-weight: bold;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+}
+
+.sqlfluff-vp__trigger {
+    display: flex;
+    box-sizing: border-box;
+    width: 100%;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0.4em 0.7em;
+    color: #333;
+    font: inherit;
+    font-size: 0.95em;
+    text-align: left;
+    background: #fff;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    cursor: pointer;
+}
+
+.sqlfluff-vp__trigger:hover {
+    border-color: #999;
+}
+
+.sqlfluff-vp__trigger:focus-visible {
+    outline: 2px solid #0969da;
+    outline-offset: 1px;
+}
+
+.sqlfluff-vp__chevron {
+    margin-left: 0.5em;
+    color: #777;
+    font-size: 0.8em;
+}
+
+/* A statement of fact rather than something to press: no border, no chevron.
+   Keeps the trigger's padding so gaining the control barely moves the page. */
+.sqlfluff-vp__static {
+    display: block;
+    padding: 0.4em 0.7em;
+    color: #555;
+    font-size: 0.95em;
+}
+
+.sqlfluff-vp__panel {
+    position: absolute;
+    z-index: 50;
+    right: 0;
+    left: 0;
+    max-height: 60vh;
+    margin-top: 0.3em;
+    padding: 0.4em;
+    overflow-y: auto;
+    background: #fff;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    box-shadow: 0 4px 14px rgba(0, 0, 0, 0.15);
+}
+
+.sqlfluff-vp__panel[hidden] {
+    display: none;
+}
+
+.sqlfluff-vp__group + .sqlfluff-vp__group {
+    margin-top: 0.4em;
+    padding-top: 0.4em;
+    border-top: 1px solid #eee;
+}
+
+.sqlfluff-vp__group-title {
+    margin: 0 0 0.2em;
+    padding: 0 0.5em;
+    color: #888;
+    font-size: 0.7em;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+}
+
+.sqlfluff-vp__item {
+    display: block;
+    padding: 0.25em 0.5em;
+    color: #333;
+    font-size: 0.9em;
+    text-decoration: none;
+    border-radius: 3px;
+}
+
+.sqlfluff-vp__item:hover {
+    color: #333;
+    background: #f0f0f0;
+    text-decoration: none;
+}
+
+.sqlfluff-vp__item:focus-visible {
+    outline: 2px solid #0969da;
+    outline-offset: -1px;
+}
+
+.sqlfluff-vp__item.is-current {
+    color: #0969da;
+}
+
+/* Weight as well as colour, so the current version stays distinguishable
+   without relying on hue. */
+.sqlfluff-vp__item.is-current .sqlfluff-vp__item-title {
+    font-weight: bold;
+}
+
+.sqlfluff-vp__item-title {
+    font-variant-numeric: tabular-nums;
+}
+
+.sqlfluff-vp__item--all {
+    color: #0969da;
+}
+
+.sqlfluff-vp__arrow {
+    margin-left: 0.35em;
+}
+
+.sqlfluff-vp__tag {
+    margin-left: 0.4em;
+    padding: 0 0.3em;
+    color: #666;
+    font-size: 0.75em;
+    background: #eee;
+    border-radius: 3px;
+}
+
+/* Fallback for a page without alabaster's sidebar wrapper. Fixed to a corner so
+   it cannot land in the middle of a layout this file has never seen. */
+.sqlfluff-vp--floating {
+    position: fixed;
+    right: 1rem;
+    bottom: 1rem;
+    z-index: 100;
+    box-sizing: border-box;
+    width: 12rem;
+    margin: 0;
+    padding: 0.6rem;
+    background: #fff;
+    border: 1px solid #ccc;
+    border-radius: 6px;
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.12);
+}
+
+.sqlfluff-vp--floating .sqlfluff-vp__panel {
+    bottom: 100%;
+    margin-bottom: 0.3em;
+}
+
+/* In flow above the content rather than fixed: an archived page is a document,
+   and a notice which follows the reader down 4,000 words of rule reference is
+   more intrusive than one they scroll past. The VitePress theme pins its own
+   because that layout reserves a slot for it. */
+.sqlfluff-vb {
+    margin: 0 0 1.5em;
+    padding: 0.7em 1em;
+    color: #6a4b00;
+    font-size: 0.95em;
+    background: #fff8e1;
+    border: 1px solid #f0d68a;
+    border-radius: 4px;
+}
+
+.sqlfluff-vb a {
+    color: #6a4b00;
+    font-weight: bold;
+    text-decoration: underline;
+}

--- a/docsv/shared/version-picker.js
+++ b/docsv/shared/version-picker.js
@@ -1,0 +1,380 @@
+/**
+ * Version picker and stale-version notice for archived Sphinx documentation.
+ *
+ * Published at `/en/shared/version-picker.js`, above every version, and loaded
+ * by each archived page. That is the whole point of it living here: an archived
+ * version is built once and frozen, so it learns about versions published after
+ * it — and picks up fixes to this file — without being rebuilt.
+ *
+ * The VitePress theme has its own picker component rather than loading this one.
+ * Two implementations is a real cost, but the alternative is worse in both
+ * directions: this file has to run inside alabaster output produced by every
+ * Sphinx release SQLFluff has used since 2021, and the VitePress picker has to
+ * follow the default theme's nav-bar flyouts and its client-side router. What is
+ * shared is the contract — `/en/versions.json` — and the behaviour below, which
+ * is kept deliberately in step with `docsv/.vitepress/theme/versions.ts`.
+ *
+ * Written as dependency-free ES5 against a defensive view of the DOM, because
+ * the pages it runs in were built by toolchains nobody is going to re-test.
+ * Anything it cannot find, it does without: the failure mode is an archived page
+ * that renders exactly as Sphinx built it.
+ */
+(function () {
+    'use strict'
+
+    /** Where the archive index page lives, relative to the language root. */
+    var VERSIONS_PAGE = 'versions.html'
+
+    /**
+     * These assets are only loaded by archived Sphinx builds, so that is the
+     * builder a page is assumed to be from when the manifest does not say.
+     */
+    var ASSUMED_BUILDER = 'sphinx'
+
+    // `/en/3.4.2/configuration/index.html` -> language root `/en/`, version key
+    // `3.4.2`, page path `configuration/index.html`. The trailing group is
+    // optional so a version root, with or without its trailing slash, is still
+    // recognised rather than leaving the page without a picker.
+    var location = window.location
+    var match = location.pathname.match(/^(\/[^/]+\/)([^/]+)(?:\/(.*))?$/)
+
+    if (!match) return
+
+    var languageRoot = match[1]
+    var currentKey = match[2]
+    var pagePath = match[3] || ''
+
+    function isChannel(entry) {
+        return (
+            entry.kind === 'channel' ||
+            entry.key === 'latest' ||
+            entry.key === 'stable'
+        )
+    }
+
+    /**
+     * Absent means listed, so entries written before the flag existed still
+     * appear rather than silently emptying the picker.
+     */
+    function isListed(entry) {
+        return entry.listed !== false
+    }
+
+    function versionTitle(entry) {
+        return entry.title || entry.label || entry.key
+    }
+
+    function versionBase(entry) {
+        return entry.path || languageRoot + entry.key + '/'
+    }
+
+    /**
+     * Build a cross-version link, keeping the reader on the same page where
+     * that is a sensible thing to attempt.
+     *
+     * Within one builder the page path is carried across. It may not exist in
+     * the target version, and then that version's own 404 takes over — a
+     * possible cost, against the certain cost of losing your place on every
+     * switch.
+     *
+     * Across the Sphinx and VitePress boundary it stops being a possible cost
+     * and becomes a certain one. The two lay out URLs differently
+     * (`configuration/index.html` against `configuration/`) and the docs were
+     * restructured in the rewrite, so the path is dropped and the reader lands
+     * on the target version's home page instead.
+     */
+    function hrefFor(entry, currentBuilder) {
+        var base = versionBase(entry)
+
+        if (entry.builder && currentBuilder && entry.builder !== currentBuilder) {
+            return base
+        }
+
+        return base + pagePath
+    }
+
+    function el(tag, className, text) {
+        var node = document.createElement(tag)
+
+        if (className) node.className = className
+        if (text) node.appendChild(document.createTextNode(text))
+
+        return node
+    }
+
+    /**
+     * The versions offered in the picker: the listed ones, plus whichever
+     * version the reader is actually on.
+     *
+     * Only one release per series is listed, which is what every comparable
+     * project does. But most readers arrive on an old version from a search
+     * engine, and a control which does not name the version you are reading
+     * looks broken rather than curated — so the current entry is added back
+     * whenever it was left out, in its manifest position.
+     */
+    function pickerEntries(versions) {
+        var chosen = []
+
+        for (var i = 0; i < versions.length; i++) {
+            var entry = versions[i]
+
+            if (isListed(entry) || entry.key === currentKey) chosen.push(entry)
+        }
+
+        return chosen
+    }
+
+    function buildPanel(entries, current, builder) {
+        var panel = el('div', 'sqlfluff-vp__panel')
+        panel.hidden = true
+
+        var groups = [
+            ['Channels', []],
+            ['Releases', []],
+        ]
+
+        for (var i = 0; i < entries.length; i++) {
+            groups[isChannel(entries[i]) ? 0 : 1][1].push(entries[i])
+        }
+
+        var showTitles = groups[0][1].length > 0 && groups[1][1].length > 0
+
+        for (var g = 0; g < groups.length; g++) {
+            var members = groups[g][1]
+
+            if (!members.length) continue
+
+            var group = el('div', 'sqlfluff-vp__group')
+
+            if (showTitles) {
+                group.appendChild(
+                    el('p', 'sqlfluff-vp__group-title', groups[g][0])
+                )
+            }
+
+            for (var m = 0; m < members.length; m++) {
+                group.appendChild(buildItem(members[m], current, builder))
+            }
+
+            panel.appendChild(group)
+        }
+
+        // The way to reach the versions this list leaves out. Last, and in its
+        // own group, so it reads as an escape hatch rather than as a version.
+        var footer = el('div', 'sqlfluff-vp__group')
+        var all = el('a', 'sqlfluff-vp__item sqlfluff-vp__item--all', 'All versions')
+        all.href = languageRoot + VERSIONS_PAGE
+        all.appendChild(el('span', 'sqlfluff-vp__arrow', '→'))
+        footer.appendChild(all)
+        panel.appendChild(footer)
+
+        return panel
+    }
+
+    function buildItem(entry, current, builder) {
+        var item = el('a', 'sqlfluff-vp__item')
+        item.href = hrefFor(entry, builder)
+        item.appendChild(el('span', 'sqlfluff-vp__item-title', versionTitle(entry)))
+
+        if (entry.key === current.key) {
+            item.className += ' is-current'
+            item.setAttribute('aria-current', 'page')
+        }
+
+        if (entry.prerelease) {
+            item.appendChild(el('span', 'sqlfluff-vp__tag', 'pre-release'))
+        }
+
+        return item
+    }
+
+    function mountPicker(panel, trigger, root) {
+        function setOpen(open) {
+            panel.hidden = !open
+            trigger.setAttribute('aria-expanded', String(open))
+        }
+
+        trigger.addEventListener('click', function () {
+            setOpen(panel.hidden)
+        })
+
+        document.addEventListener('keydown', function (event) {
+            if (event.key !== 'Escape' || panel.hidden) return
+
+            setOpen(false)
+            trigger.focus()
+        })
+
+        document.addEventListener('mousedown', function (event) {
+            if (panel.hidden || root.contains(event.target)) return
+
+            setOpen(false)
+        })
+    }
+
+    /**
+     * Which version a reader on this page should be sent to instead, or null if
+     * there is nowhere better.
+     *
+     * Decided from the manifest's ordering rather than from any date, matching
+     * `useVersions` in the VitePress theme: releases are sorted newest-first by
+     * `version_sort_key`, so anything but the first is superseded.
+     */
+    function recommendedFor(current, versions, stableKey) {
+        var releases = []
+        var stableChannel = null
+        var stableRelease = null
+
+        for (var i = 0; i < versions.length; i++) {
+            var entry = versions[i]
+
+            if (isChannel(entry)) {
+                if (entry.key === 'stable') stableChannel = entry
+                continue
+            }
+
+            releases.push(entry)
+            if (entry.key === stableKey) stableRelease = entry
+        }
+
+        var target = stableRelease || stableChannel || releases[0] || null
+
+        if (!target || target.key === current.key) return null
+
+        // `latest` tracks main, and a prerelease is not what a reader landing
+        // from a search result is usually after.
+        if (current.key === 'latest' || current.prerelease) return target
+
+        if (isChannel(current)) return null
+
+        return releases.indexOf(current) > 0 ? target : null
+    }
+
+    function buildBanner(current, target, builder) {
+        var banner = el('div', 'sqlfluff-vb', null)
+        var isDevelopment = current.key === 'latest'
+
+        banner.setAttribute('role', 'status')
+        banner.appendChild(
+            document.createTextNode(
+                isDevelopment
+                    ? 'You are reading the development documentation, which ' +
+                      'tracks the main branch. '
+                    : 'You are reading the documentation for SQLFluff ' +
+                      (current.label || current.key) +
+                      ', which is not the current release. '
+            )
+        )
+
+        var link = el('a', null, 'Switch to ' + versionTitle(target))
+        link.href = hrefFor(target, builder)
+        banner.appendChild(link)
+
+        return banner
+    }
+
+    /**
+     * Alabaster has kept `.sphinxsidebarwrapper` across every vintage in this
+     * project's history. The fixed-corner fallback means a page which does not
+     * have it still gets a picker rather than losing it silently.
+     */
+    function insertPicker(root) {
+        var sidebar = document.querySelector('.sphinxsidebarwrapper')
+
+        if (sidebar) {
+            sidebar.insertBefore(root, sidebar.firstChild)
+            return
+        }
+
+        root.className += ' sqlfluff-vp--floating'
+        document.body.appendChild(root)
+    }
+
+    function insertBanner(banner) {
+        var host =
+            document.querySelector('div.body') ||
+            document.querySelector('.documentwrapper') ||
+            document.body
+
+        host.insertBefore(banner, host.firstChild)
+    }
+
+    function render(manifest) {
+        var versions = (manifest && manifest.versions) || []
+        var current = null
+
+        for (var i = 0; i < versions.length; i++) {
+            if (versions[i].key === currentKey) current = versions[i]
+        }
+
+        // A version can be live before the manifest names it — the manifest is
+        // rewritten by whichever publish ran last. Standing in for the entry
+        // keeps the picker working and, more importantly, keeps the page from
+        // claiming to be a version it is not.
+        if (!current) {
+            current = {
+                key: currentKey,
+                label: currentKey,
+                path: languageRoot + currentKey + '/',
+                builder: ASSUMED_BUILDER,
+            }
+            versions = versions.concat([current])
+        }
+
+        var builder = current.builder || ASSUMED_BUILDER
+        var entries = pickerEntries(versions)
+
+        // Nothing to switch to. The version is still worth stating, so it
+        // renders as a label rather than as a control which opens an empty list.
+        var root = el('div', 'sqlfluff-vp')
+        var label = isChannel(current)
+            ? current.label || current.key
+            : 'v' + (current.label || current.key)
+
+        root.appendChild(el('span', 'sqlfluff-vp__label', 'Version'))
+
+        if (entries.length < 2) {
+            root.appendChild(el('span', 'sqlfluff-vp__static', label))
+            insertPicker(root)
+            return
+        }
+
+        var trigger = el('button', 'sqlfluff-vp__trigger', label)
+        trigger.type = 'button'
+        trigger.setAttribute('aria-expanded', 'false')
+        trigger.appendChild(el('span', 'sqlfluff-vp__chevron', '▾'))
+
+        var panel = buildPanel(entries, current, builder)
+        root.appendChild(trigger)
+        root.appendChild(panel)
+        mountPicker(panel, trigger, root)
+        insertPicker(root)
+
+        var target = recommendedFor(current, versions, manifest && manifest.stable)
+
+        if (target) insertBanner(buildBanner(current, target, builder))
+    }
+
+    function start() {
+        fetch(languageRoot + 'versions.json', {
+            headers: { Accept: 'application/json' },
+        })
+            .then(function (response) {
+                if (!response.ok) throw new Error('manifest ' + response.status)
+
+                return response.json()
+            })
+            .then(render)
+            // An unreachable manifest leaves the page exactly as Sphinx built
+            // it, which is a working page without a picker.
+            .catch(function (error) {
+                console.error(error)
+            })
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', start)
+    } else {
+        start()
+    }
+})()

--- a/docsv/shared/version-picker.js
+++ b/docsv/shared/version-picker.js
@@ -124,6 +124,18 @@
         return chosen
     }
 
+    function buildAllVersionsLink() {
+        var link = el(
+            'a',
+            'sqlfluff-vp__item sqlfluff-vp__item--all',
+            'All versions'
+        )
+        link.href = languageRoot + VERSIONS_PAGE
+        link.appendChild(el('span', 'sqlfluff-vp__arrow', '→'))
+
+        return link
+    }
+
     function buildPanel(entries, current, builder) {
         var panel = el('div', 'sqlfluff-vp__panel')
         panel.hidden = true
@@ -162,10 +174,7 @@
         // The way to reach the versions this list leaves out. Last, and in its
         // own group, so it reads as an escape hatch rather than as a version.
         var footer = el('div', 'sqlfluff-vp__group')
-        var all = el('a', 'sqlfluff-vp__item sqlfluff-vp__item--all', 'All versions')
-        all.href = languageRoot + VERSIONS_PAGE
-        all.appendChild(el('span', 'sqlfluff-vp__arrow', '→'))
-        footer.appendChild(all)
+        footer.appendChild(buildAllVersionsLink())
         panel.appendChild(footer)
 
         return panel
@@ -335,6 +344,12 @@
 
         if (entries.length < 2) {
             root.appendChild(el('span', 'sqlfluff-vp__static', label))
+
+            // The archive index still has to be reachable. If every other
+            // version is unlisted this is the reader's only route to them, and
+            // a one-item dropdown would be a worse way to offer it than a link.
+            if (versions.length > 1) root.appendChild(buildAllVersionsLink())
+
             insertPicker(root)
             return
         }

--- a/test/docsv_assemble_site_test.py
+++ b/test/docsv_assemble_site_test.py
@@ -35,7 +35,9 @@ def _upsert(module: ModuleType, manifest: dict, **overrides) -> dict:
         "channel": "3.4.1",
         "title": "3.4.1",
         "kind": "release",
+        "builder": "vitepress",
         "prerelease": False,
+        "unlisted": False,
         "published_at": None,
         "stable_release": None,
     }
@@ -176,15 +178,12 @@ def test_assemble_site_refuses_to_escape_the_output_dir(assemble_site, tmp_path)
 
     with pytest.raises(ValueError):
         assemble_site.assemble_site(
-            vitepress_dist=dist,
+            dist=dist,
             output_dir=tmp_path / "site",
             language="en",
             channel="../../outside",
             title="evil",
             kind="release",
-            prerelease=False,
-            published_at=None,
-            stable_release=None,
         )
 
     assert (outside / "keep.txt").is_file(), (
@@ -208,3 +207,203 @@ def test_rebuild_leaves_other_versions_untouched(assemble_site):
 
     assert _entry(rebuilt, "3.4.2")["published_at"] == "2026-07-14"
     assert _entry(rebuilt, "3.4.1")["published_at"] == "2026-06-02"
+
+
+def _keys_in_order(module, *keys: str) -> list[str]:
+    entries = [{"key": key} for key in keys]
+    entries.sort(key=module.version_sort_key)
+    return [entry["key"] for entry in entries]
+
+
+def test_channels_sort_before_releases(assemble_site):
+    """The picker shows the moving channels first, then the pinned releases."""
+    assert _keys_in_order(assemble_site, "3.4.2", "stable", "latest") == [
+        "latest",
+        "stable",
+        "3.4.2",
+    ]
+
+
+def test_releases_sort_newest_first(assemble_site):
+    """Descending version order, which the stale notice reads as newest-first."""
+    assert _keys_in_order(assemble_site, "1.4.5", "3.4.2", "10.0.0", "3.10.0") == [
+        "10.0.0",
+        "3.10.0",
+        "3.4.2",
+        "1.4.5",
+    ]
+
+
+def test_post_release_sorts_above_the_release_it_follows(assemble_site):
+    """`4.0.1.post1` is newer than `4.0.1`, and older than `4.1.0`.
+
+    It used to fall into the non-numeric bucket below every release, including
+    `0.2.4` — which also told the stale notice that every other release was
+    newer than the newest one.
+    """
+    assert _keys_in_order(assemble_site, "4.0.1", "4.1.0", "4.0.1.post1", "4.0.2") == [
+        "4.1.0",
+        "4.0.2",
+        "4.0.1.post1",
+        "4.0.1",
+    ]
+
+
+def test_prereleases_sort_below_their_own_release(assemble_site):
+    """`4.0.0a1` leads up to `4.0.0`, so it is older than it.
+
+    `0.7.0a8` and `0.4.0a1` are real tags here, and both used to land in the
+    string bucket at the bottom of the list.
+    """
+    assert _keys_in_order(
+        assemble_site, "4.0.0", "4.0.0a1", "4.0.0a10", "4.0.0a2", "3.9.9"
+    ) == ["4.0.0", "4.0.0a10", "4.0.0a2", "4.0.0a1", "3.9.9"]
+
+
+def test_shorter_versions_sort_as_if_padded(assemble_site):
+    """`3.4` names the same release as `3.4.0`, so it sorts with it."""
+    assert _keys_in_order(assemble_site, "3.4", "3.5.0", "3.3.9") == [
+        "3.5.0",
+        "3.4",
+        "3.3.9",
+    ]
+
+
+def test_unparseable_keys_sort_last(assemble_site):
+    """A key nobody can order goes somewhere predictable rather than guessed."""
+    assert _keys_in_order(assemble_site, "0.2.4", "nightly", "latest") == [
+        "latest",
+        "0.2.4",
+        "nightly",
+    ]
+
+
+def test_builder_is_recorded_on_the_entry(assemble_site):
+    """The picker drops the page path when switching across builders."""
+    manifest = assemble_site.default_manifest()
+
+    result = _upsert(assemble_site, manifest, builder="sphinx")
+
+    assert _entry(result, "3.4.1")["builder"] == "sphinx"
+
+
+def test_entries_are_listed_by_default(assemble_site):
+    """A version is offered in the picker unless it is published unlisted."""
+    manifest = assemble_site.default_manifest()
+
+    result = _upsert(assemble_site, manifest)
+
+    assert _entry(result, "3.4.1")["listed"] is True
+
+
+def test_unlisted_entries_are_flagged(assemble_site):
+    """An unlisted version stays published; the picker just does not offer it."""
+    manifest = assemble_site.default_manifest()
+
+    result = _upsert(assemble_site, manifest, unlisted=True)
+
+    entry = _entry(result, "3.4.1")
+
+    assert entry["listed"] is False
+    assert entry["path"] == "/en/3.4.1/"
+
+
+def _dist(tmp_path: Path, name: str = "dist") -> Path:
+    dist = tmp_path / name
+    dist.mkdir()
+    (dist / "index.html").write_text("<html></html>", encoding="utf-8")
+    return dist
+
+
+def test_shared_assets_are_republished_every_run(assemble_site, tmp_path):
+    """Archived versions load the picker from here, so it must stay current.
+
+    An archived Sphinx build is produced once and frozen. It picks up picker
+    changes only because these assets live above every version and are rewritten
+    by whichever publish ran last.
+    """
+    shared = tmp_path / "shared"
+    shared.mkdir()
+    (shared / "version-picker.js").write_text("// v1", encoding="utf-8")
+
+    site = tmp_path / "site"
+    published = site / "en" / "shared" / "version-picker.js"
+
+    assemble_site.assemble_site(
+        dist=_dist(tmp_path),
+        output_dir=site,
+        language="en",
+        channel="latest",
+        title="Development",
+        kind="channel",
+        shared_dir=shared,
+    )
+
+    assert published.read_text(encoding="utf-8") == "// v1"
+
+    (shared / "version-picker.js").write_text("// v2", encoding="utf-8")
+    assemble_site.assemble_site(
+        dist=_dist(tmp_path, "dist-2"),
+        output_dir=site,
+        language="en",
+        channel="3.4.2",
+        title="3.4.2",
+        kind="release",
+        builder="sphinx",
+        shared_dir=shared,
+    )
+
+    assert published.read_text(encoding="utf-8") == "// v2"
+
+
+def test_versions_page_lists_unlisted_versions(assemble_site, tmp_path):
+    """The archive page is where the versions the picker omits stay reachable."""
+    site = tmp_path / "site"
+
+    for channel, unlisted in (("3.4.2", False), ("3.4.1", True)):
+        assemble_site.assemble_site(
+            dist=_dist(tmp_path, f"dist-{channel}"),
+            output_dir=site,
+            language="en",
+            channel=channel,
+            title=channel,
+            kind="release",
+            builder="sphinx",
+            unlisted=unlisted,
+            shared_dir=tmp_path / "absent",
+        )
+
+    page = (site / "en" / "versions.html").read_text(encoding="utf-8")
+
+    assert 'href="/en/3.4.2/"' in page
+    assert 'href="/en/3.4.1/"' in page
+    assert "3.x releases" in page
+
+
+def test_versions_page_groups_releases_by_major(assemble_site):
+    """Grouped by generation, following how Docusaurus groups its own."""
+    manifest = assemble_site.default_manifest()
+    manifest = _upsert(assemble_site, manifest, channel="4.1.0", title="4.1.0")
+    manifest = _upsert(assemble_site, manifest, channel="3.4.2", title="3.4.2")
+    manifest = _upsert(
+        assemble_site,
+        manifest,
+        channel="latest",
+        title="Development",
+        kind="channel",
+    )
+
+    groups = assemble_site.release_groups(manifest)
+
+    assert [series for series, _ in groups] == ["4.x", "3.x"]
+    assert [entry["key"] for entry in groups[0][1]] == ["4.1.0"]
+
+
+def test_headers_do_not_cache_shared_assets_immutably(assemble_site):
+    """The assets have fixed filenames, so a long cache would freeze the picker."""
+    headers = assemble_site.build_global_headers("en")
+
+    shared = headers.split("/en/shared/*")[1]
+
+    assert "must-revalidate" in shared
+    assert "immutable" not in shared

--- a/test/docsv_assemble_site_test.py
+++ b/test/docsv_assemble_site_test.py
@@ -545,3 +545,67 @@ def test_the_404_page_tracks_the_default_channel_when_it_is_rebuilt(
         )
 
     assert (site / "404.html").read_text(encoding="utf-8") == "<html>second</html>"
+
+
+def _publish_default_channel_without_a_404(module, tmp_path, site) -> None:
+    """Publish `latest` from a build that has no 404 page of its own."""
+    module.assemble_site(
+        dist=_dist(tmp_path, "latest-no-404"),
+        output_dir=site,
+        language="en",
+        channel="latest",
+        title="Development",
+        kind="channel",
+        shared_dir=tmp_path / "absent",
+    )
+
+
+def _publish_prerelease_with_a_404(module, tmp_path, site) -> None:
+    """Publish a prerelease from a build that does have one."""
+    release = _dist(tmp_path, "prerelease-with-404")
+    (release / "404.html").write_text("<html>4.4.0a1 404</html>", encoding="utf-8")
+
+    module.assemble_site(
+        dist=release,
+        output_dir=site,
+        language="en",
+        channel="4.4.0a1",
+        title="4.4.0a1",
+        kind="release",
+        prerelease=True,
+        shared_dir=tmp_path / "absent",
+    )
+
+
+def test_an_existing_404_page_is_not_downgraded(assemble_site, tmp_path):
+    """A release must not claim the root 404 when the default channel lacks one.
+
+    Otherwise taking the page from the default channel would hold only until some
+    release happened to be published while that channel had no 404 page — which
+    is the situation it is there to prevent.
+    """
+    site = tmp_path / "site"
+
+    _publish_default_channel_without_a_404(assemble_site, tmp_path, site)
+    (site / "404.html").write_text("<html>existing</html>", encoding="utf-8")
+    _publish_prerelease_with_a_404(assemble_site, tmp_path, site)
+
+    assert (site / "404.html").read_text(encoding="utf-8") == "<html>existing</html>"
+
+
+def test_a_tree_with_no_404_page_is_bootstrapped_from_the_build(
+    assemble_site, tmp_path
+):
+    """With no root page to protect, this build's is better than none.
+
+    Reached when the default channel has no 404 page and the site has none
+    either, so there is nothing better available and nothing to lose.
+    """
+    site = tmp_path / "site"
+
+    _publish_default_channel_without_a_404(assemble_site, tmp_path, site)
+    assert not (site / "404.html").exists(), "premise of the test"
+
+    _publish_prerelease_with_a_404(assemble_site, tmp_path, site)
+
+    assert (site / "404.html").read_text(encoding="utf-8") == "<html>4.4.0a1 404</html>"

--- a/test/docsv_assemble_site_test.py
+++ b/test/docsv_assemble_site_test.py
@@ -407,3 +407,61 @@ def test_headers_do_not_cache_shared_assets_immutably(assemble_site):
 
     assert "must-revalidate" in shared
     assert "immutable" not in shared
+
+
+def test_the_404_page_is_published_at_the_site_root(assemble_site, tmp_path):
+    """Netlify only serves a 404 page from the publish root.
+
+    It does not fall back to one inside a subdirectory, so the 404 page each
+    VitePress version builds was never reached: every miss on the beta site,
+    including inside `/en/latest/`, returned Netlify's own generic page.
+    """
+    dist = _dist(tmp_path)
+    (dist / "404.html").write_text("<html>SQLFluff 404</html>", encoding="utf-8")
+
+    site = tmp_path / "site"
+    assemble_site.assemble_site(
+        dist=dist,
+        output_dir=site,
+        language="en",
+        channel="latest",
+        title="Development",
+        kind="channel",
+        shared_dir=tmp_path / "absent",
+    )
+
+    assert (site / "404.html").read_text(
+        encoding="utf-8"
+    ) == "<html>SQLFluff 404</html>"
+
+
+def test_a_build_without_a_404_page_leaves_the_existing_one(assemble_site, tmp_path):
+    """Sphinx builds have no 404 page, and archiving one must not remove ours."""
+    site = tmp_path / "site"
+
+    vitepress = _dist(tmp_path, "vitepress")
+    (vitepress / "404.html").write_text("<html>SQLFluff 404</html>", encoding="utf-8")
+
+    assemble_site.assemble_site(
+        dist=vitepress,
+        output_dir=site,
+        language="en",
+        channel="latest",
+        title="Development",
+        kind="channel",
+        shared_dir=tmp_path / "absent",
+    )
+    assemble_site.assemble_site(
+        dist=_dist(tmp_path, "sphinx"),
+        output_dir=site,
+        language="en",
+        channel="3.4.2",
+        title="3.4.2",
+        kind="release",
+        builder="sphinx",
+        shared_dir=tmp_path / "absent",
+    )
+
+    assert (site / "404.html").read_text(
+        encoding="utf-8"
+    ) == "<html>SQLFluff 404</html>"

--- a/test/docsv_assemble_site_test.py
+++ b/test/docsv_assemble_site_test.py
@@ -465,3 +465,83 @@ def test_a_build_without_a_404_page_leaves_the_existing_one(assemble_site, tmp_p
     assert (site / "404.html").read_text(
         encoding="utf-8"
     ) == "<html>SQLFluff 404</html>"
+
+
+def test_prerelease_stages_sort_in_pep440_order(assemble_site):
+    """`a` before `b` before `rc`, rather than all three on their number alone.
+
+    Only `aN` has ever been tagged here, so this was latent — but the manifest's
+    ordering decides which release readers are warned about.
+    """
+    assert _keys_in_order(assemble_site, "4.0.0", "4.0.0a2", "4.0.0b1", "4.0.0rc1") == [
+        "4.0.0",
+        "4.0.0rc1",
+        "4.0.0b1",
+        "4.0.0a2",
+    ]
+
+
+def test_the_404_page_comes_from_the_default_channel(assemble_site, tmp_path):
+    """Not from whichever build a given run happens to assemble.
+
+    A prerelease publishes only itself — the workflow skips `stable` for
+    prereleases — so taking the page from the build in hand would make the
+    site's 404 a prerelease's, complete with a home link into it.
+    """
+    site = tmp_path / "site"
+
+    latest = _dist(tmp_path, "latest")
+    (latest / "404.html").write_text("<html>latest 404</html>", encoding="utf-8")
+
+    assemble_site.assemble_site(
+        dist=latest,
+        output_dir=site,
+        language="en",
+        channel="latest",
+        title="Development",
+        kind="channel",
+        shared_dir=tmp_path / "absent",
+    )
+
+    prerelease = _dist(tmp_path, "prerelease")
+    (prerelease / "404.html").write_text("<html>4.4.0a1 404</html>", encoding="utf-8")
+
+    assemble_site.assemble_site(
+        dist=prerelease,
+        output_dir=site,
+        language="en",
+        channel="4.4.0a1",
+        title="4.4.0a1",
+        kind="release",
+        prerelease=True,
+        shared_dir=tmp_path / "absent",
+    )
+
+    assert (site / "404.html").read_text(encoding="utf-8") == "<html>latest 404</html>"
+
+
+def test_the_404_page_tracks_the_default_channel_when_it_is_rebuilt(
+    assemble_site, tmp_path
+):
+    """Rebuilding the default channel refreshes the root copy with it.
+
+    The copy references that channel's fingerprinted assets, and the channel
+    directory is deleted and rewritten on every publish, so the two have to move
+    together.
+    """
+    site = tmp_path / "site"
+
+    for body in ("<html>first</html>", "<html>second</html>"):
+        dist = _dist(tmp_path, f"dist-{len(body)}{body[6]}")
+        (dist / "404.html").write_text(body, encoding="utf-8")
+        assemble_site.assemble_site(
+            dist=dist,
+            output_dir=site,
+            language="en",
+            channel="latest",
+            title="Development",
+            kind="channel",
+            shared_dir=tmp_path / "absent",
+        )
+
+    assert (site / "404.html").read_text(encoding="utf-8") == "<html>second</html>"

--- a/test/docsv_inject_picker_test.py
+++ b/test/docsv_inject_picker_test.py
@@ -136,3 +136,35 @@ def test_a_missing_directory_is_an_error(inject, tmp_path):
     """A typo in a backfill run should stop it, not silently archive nothing."""
     with pytest.raises(FileNotFoundError):
         inject.inject(tmp_path / "absent", "/en/shared/")
+
+
+def test_a_shared_base_without_a_trailing_slash_still_works(inject, tmp_path):
+    """Otherwise the URLs concatenate and the picker silently never loads."""
+    root = _tree(tmp_path, {"index.html": PAGE.format(extra="")})
+
+    inject.inject(root, "/en/shared")
+    content = (root / "index.html").read_text(encoding="utf-8")
+
+    assert '"/en/shared/version-picker.css"' in content
+    assert "sharedversion-picker" not in content
+
+
+def test_a_page_mentioning_the_asset_is_still_injected(inject, tmp_path):
+    """The idempotency check must match the tag, not the filename in prose.
+
+    This file is documented in `docsv/README.md`, and the docs document
+    themselves, so a page naming the asset is a realistic thing to build.
+    """
+    root = _tree(
+        tmp_path,
+        {
+            "index.html": PAGE.format(extra="").replace(
+                "<body>", "<body><p>loads version-picker.js from /en/shared/</p>"
+            )
+        },
+    )
+
+    assert inject.inject(root, "/en/shared/") == 1
+    assert '<script src="/en/shared/version-picker.js"' in (
+        root / "index.html"
+    ).read_text(encoding="utf-8")

--- a/test/docsv_inject_picker_test.py
+++ b/test/docsv_inject_picker_test.py
@@ -168,3 +168,24 @@ def test_a_page_mentioning_the_asset_is_still_injected(inject, tmp_path):
     assert '<script src="/en/shared/version-picker.js"' in (
         root / "index.html"
     ).read_text(encoding="utf-8")
+
+
+def test_a_non_loading_src_attribute_does_not_count_as_injected(inject, tmp_path):
+    r"""`data-src` loads nothing, and a word boundary sits inside it.
+
+    So `\bsrc` matched it, and a page carrying one would look already-injected
+    and silently keep no picker.
+    """
+    root = _tree(
+        tmp_path,
+        {
+            "index.html": PAGE.format(
+                extra='<script data-src="/en/shared/version-picker.js"></script>'
+            )
+        },
+    )
+
+    assert inject.inject(root, "/en/shared/") == 1
+    assert '<script src="/en/shared/version-picker.js"' in (
+        root / "index.html"
+    ).read_text(encoding="utf-8")

--- a/test/docsv_inject_picker_test.py
+++ b/test/docsv_inject_picker_test.py
@@ -1,0 +1,138 @@
+"""Tests for the shared picker injector.
+
+Archived pre-cutover versions are Sphinx builds with no picker of their own, and
+they are built once and never rebuilt. This is the pass that gives them one.
+
+The script lives outside the package, so it is loaded by path rather than
+imported; its filename is not a valid module name.
+"""
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+REPO_ROOT = Path(__file__).parent.parent
+INJECT = REPO_ROOT / "docsv" / "scripts" / "inject-shared-picker.py"
+
+# What Read the Docs appends to every served page, reproduced from a live build.
+RTD_INJECTION = (
+    '<script async="async" src="/_/static/javascript/readthedocs-addons.js">'
+    "</script>"
+    '<meta name="readthedocs-project-slug" content="sqlfluff">'
+    '<meta name="readthedocs-version-slug" content="stable">'
+)
+
+PAGE = (
+    "<html><head><title>SQLFluff</title>{extra}</head>"
+    '<body><div class="sphinxsidebarwrapper"></div></body></html>'
+)
+
+
+def _load_inject() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("inject_shared_picker", INJECT)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def inject() -> ModuleType:
+    """Load the injector once for the module."""
+    return _load_inject()
+
+
+def _tree(tmp_path: Path, pages: dict[str, str]) -> Path:
+    root = tmp_path / "html"
+    root.mkdir()
+
+    for name, content in pages.items():
+        path = root / name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+
+    return root
+
+
+def test_picker_assets_are_added_to_every_page(inject, tmp_path):
+    """Including pages nested below the version root."""
+    root = _tree(
+        tmp_path,
+        {
+            "index.html": PAGE.format(extra=""),
+            "configuration/index.html": PAGE.format(extra=""),
+        },
+    )
+
+    assert inject.inject(root, "/en/shared/") == 2
+
+    for page in ("index.html", "configuration/index.html"):
+        content = (root / page).read_text(encoding="utf-8")
+        assert '<script src="/en/shared/version-picker.js" defer></script>' in content
+        assert '"/en/shared/version-picker.css"' in content
+
+
+def test_the_read_the_docs_injection_is_stripped(inject, tmp_path):
+    """A mirrored page must stop advertising the site being replaced.
+
+    This is also what keeps mirroring available as a fallback for a version that
+    no longer builds: the RTD markup is the only RTD-specific thing on the page.
+    """
+    root = _tree(tmp_path, {"index.html": PAGE.format(extra=RTD_INJECTION)})
+
+    inject.inject(root, "/en/shared/")
+    content = (root / "index.html").read_text(encoding="utf-8")
+
+    assert "readthedocs" not in content
+    assert "version-picker.js" in content
+
+
+def test_the_read_the_docs_injection_can_be_kept(inject, tmp_path):
+    """The escape hatch, for comparing a mirrored page against the original."""
+    root = _tree(tmp_path, {"index.html": PAGE.format(extra=RTD_INJECTION)})
+
+    inject.inject(root, "/en/shared/", strip_rtd=False)
+
+    assert "readthedocs-addons" in (root / "index.html").read_text(encoding="utf-8")
+
+
+def test_injection_is_idempotent(inject, tmp_path):
+    """A tree can be re-injected without accumulating tags.
+
+    Which matters because a version may be assembled more than once — a rebuild
+    of an archived version runs the same steps as its first publish.
+    """
+    root = _tree(tmp_path, {"index.html": PAGE.format(extra="")})
+
+    inject.inject(root, "/en/shared/")
+    assert inject.inject(root, "/en/shared/") == 0
+
+    content = (root / "index.html").read_text(encoding="utf-8")
+
+    assert content.count("version-picker.js") == 1
+
+
+def test_pages_without_a_head_are_left_alone(inject, tmp_path):
+    """Not every `.html` file in a Sphinx build is a page."""
+    root = _tree(tmp_path, {"fragment.html": "<div>a search result template</div>"})
+
+    assert inject.inject(root, "/en/shared/") == 0
+    assert (root / "fragment.html").read_text(encoding="utf-8") == (
+        "<div>a search result template</div>"
+    )
+
+
+def test_an_uppercase_head_tag_is_matched(inject, tmp_path):
+    """Historical builds are not all lowercase, and none will be rebuilt."""
+    root = _tree(tmp_path, {"index.html": "<HTML><HEAD><TITLE>x</TITLE></HEAD></HTML>"})
+
+    assert inject.inject(root, "/en/shared/") == 1
+    assert "version-picker.js" in (root / "index.html").read_text(encoding="utf-8")
+
+
+def test_a_missing_directory_is_an_error(inject, tmp_path):
+    """A typo in a backfill run should stop it, not silently archive nothing."""
+    with pytest.raises(FileNotFoundError):
+        inject.inject(tmp_path / "absent", "/en/shared/")

--- a/test/docsv_redirect_rules_test.py
+++ b/test/docsv_redirect_rules_test.py
@@ -296,18 +296,47 @@ def test_malformed_targets_are_rejected(assemble_site, tmp_path, target):
     path = tmp_path / "redirects.json"
     path.write_text(json.dumps({"perma/layout": target}), encoding="utf-8")
 
-    with pytest.raises(ValueError, match="empty or whitespace-bearing"):
+    with pytest.raises(ValueError, match="Unusable permalinks"):
         assemble_site.load_redirect_map(path)
 
 
-def test_a_key_containing_whitespace_is_rejected(assemble_site, tmp_path):
-    """The source half of a rule has to be one whitespace-free token too."""
+@pytest.mark.parametrize(
+    ("key", "expected"),
+    [
+        # `key.strip("/")` makes this the version root, so the rule would
+        # redirect every version's home page to whatever the target is.
+        ("", "empty permalink"),
+        ("perma/my layout", "whitespace"),
+        ("../escape", "`..` component"),
+    ],
+)
+def test_malformed_keys_are_rejected(assemble_site, tmp_path, key, expected):
+    """The source half of a rule is a request path too, not just the target."""
+    path = tmp_path / "redirects.json"
+    path.write_text(json.dumps({key: "configuration/layout"}), encoding="utf-8")
+
+    with pytest.raises(ValueError, match=expected):
+        assemble_site.load_redirect_map(path)
+
+
+def test_a_dotdot_target_is_rejected(assemble_site, tmp_path):
+    """Netlify normalises request paths, so such a rule silently never fires."""
+    path = tmp_path / "redirects.json"
+    path.write_text(json.dumps({"perma/x": "../escape"}), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="`..` component"):
+        assemble_site.load_redirect_map(path)
+
+
+def test_the_reason_an_entry_was_rejected_is_reported(assemble_site, tmp_path):
+    """Whoever hits this needs to know which entry and why, not just that."""
     path = tmp_path / "redirects.json"
     path.write_text(
-        json.dumps({"perma/my layout": "configuration/layout"}), encoding="utf-8"
+        json.dumps({"perma/good": "configuration/layout", "perma/bad": ""}),
+        encoding="utf-8",
     )
 
-    with pytest.raises(ValueError, match="empty or whitespace-bearing"):
+    with pytest.raises(ValueError, match=r"'perma/bad': no target"):
         assemble_site.load_redirect_map(path)
 
 

--- a/test/docsv_redirect_rules_test.py
+++ b/test/docsv_redirect_rules_test.py
@@ -1,0 +1,275 @@
+"""Tests for the versioned permalink redirect rules.
+
+These cover the URLs SQLFluff itself emits. Every release from `2.0.0` onward
+prints `.../perma/<name>.html` links from the CLI and from rule documentation, so
+a reader following one arrives on the site cold — which is the case the
+client-side redirect handling cannot serve, because the server answers `404`
+before any JavaScript runs.
+
+The script lives outside the package, so it is loaded by path rather than
+imported; its filename is not a valid module name.
+"""
+
+import importlib.util
+import json
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+REPO_ROOT = Path(__file__).parent.parent
+ASSEMBLE_SITE = REPO_ROOT / "docsv" / "scripts" / "assemble-site.py"
+
+
+def _load_assemble_site() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("assemble_site", ASSEMBLE_SITE)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def assemble_site() -> ModuleType:
+    """Load the assembly script once for the module."""
+    return _load_assemble_site()
+
+
+@pytest.fixture
+def dist(tmp_path: Path) -> Path:
+    """A minimal built tree with the pages the permalinks point at."""
+    root = tmp_path / "dist"
+
+    for page in (
+        "index.html",
+        "configuration/layout.html",
+        "configuration/index.html",
+        "reference/rules/structure.html",
+    ):
+        path = root / page
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("<html>page</html>", encoding="utf-8")
+
+    return root
+
+
+def _rules(module: ModuleType, redirects: dict[str, str]) -> list[str]:
+    return module.build_permalink_rules("en", redirects)
+
+
+def test_both_url_suffixes_are_covered(assemble_site):
+    """The CLI emits `perma/layout.html`; a reader who trims it gets the other.
+
+    Both are in the wild, and neither is a file in any published version, which
+    is why a cold hit returned `404` regardless of what the client-side handler
+    would have done with it.
+    """
+    rules = _rules(assemble_site, {"perma/layout": "configuration/layout"})
+
+    assert rules == [
+        "/en/:version/perma/layout /en/:version/configuration/layout 301",
+        "/en/:version/perma/layout.html /en/:version/configuration/layout 301",
+    ]
+
+
+def test_rules_are_version_agnostic(assemble_site):
+    """One rule per permalink, not one per permalink per version.
+
+    Enumerating versions would add 204 rules a release and pass Netlify's
+    recommended ceiling within a handful of them. It would also leave versions
+    published before this existed unfixed, which a placeholder does not: their
+    permalinks were never files, and rebuilding an old tag rebuilds it from
+    source that does not know about them.
+    """
+    rules = _rules(assemble_site, {"perma/layout": "configuration/layout"})
+
+    assert all(rule.count(":version") == 2 for rule in rules)
+
+
+def test_rules_are_permanent(assemble_site):
+    """A permalink is a promise, so it earns a 301 rather than a 302."""
+    rules = _rules(assemble_site, {"perma/layout": "configuration/layout"})
+
+    assert all(rule.endswith(" 301") for rule in rules)
+
+
+def test_rules_are_not_forced(assemble_site):
+    """A `!` would shadow the archived Sphinx versions' own permalink pages.
+
+    Those pages are real files written by `sphinx-reredirects`, and they are
+    correct for that version's page layout where these rules are not. Netlify
+    serves an existing file in preference to an unforced rule.
+    """
+    rules = _rules(assemble_site, {"perma/layout": "configuration/layout"})
+
+    assert not any("!" in rule for rule in rules)
+
+
+def test_fragments_are_preserved(assemble_site):
+    """Most rule permalinks point at a heading rather than at a page."""
+    rules = _rules(assemble_site, {"perma/rule/ST01": "reference/rules/structure#st01"})
+
+    assert rules[0] == (
+        "/en/:version/perma/rule/ST01 /en/:version/reference/rules/structure#st01 301"
+    )
+
+
+def test_a_permalink_to_a_permalink_is_followed(assemble_site):
+    """`internals` points at `perma/internals`, which points at the page.
+
+    The client-side handler followed that chain by accident — each hop 404s and
+    re-runs the handler — so it went unnoticed. Resolving it fully saves the
+    reader a second round trip.
+    """
+    rules = _rules(
+        assemble_site,
+        {
+            "internals": "perma/internals",
+            "perma/internals": "reference/internals/index",
+        },
+    )
+
+    assert "/en/:version/internals /en/:version/reference/internals/index 301" in rules
+    assert not any("perma/internals 301" in rule for rule in rules)
+
+
+def test_a_permalink_cycle_is_rejected(assemble_site):
+    """Following it would loop; the reader's browser would too."""
+    with pytest.raises(ValueError, match="does not terminate"):
+        _rules(assemble_site, {"a": "b", "b": "a"})
+
+
+def test_rules_follow_the_root_redirects(assemble_site):
+    """Both sets live in one file, and the root rules stay first."""
+    manifest = assemble_site.default_manifest()
+    manifest["versions"] = [{"key": "latest"}]
+
+    content = assemble_site.build_redirects(
+        "en", manifest, {"perma/layout": "configuration/layout"}
+    )
+    lines = [line for line in content.splitlines() if line]
+
+    assert lines[0] == "/ /en/latest/ 302"
+    assert lines[3].startswith("/en/:version/perma/layout ")
+
+
+def test_no_permalink_map_leaves_the_root_redirects_alone(assemble_site):
+    """A publish which cannot find the map still produces a working site."""
+    manifest = assemble_site.default_manifest()
+    manifest["versions"] = [{"key": "latest"}]
+
+    content = assemble_site.build_redirects("en", manifest, {})
+
+    assert "perma" not in content
+    assert "/ /en/latest/ 302" in content
+
+
+def test_comment_keys_are_dropped(assemble_site, tmp_path):
+    """`_comment` is the convention these config files use."""
+    path = tmp_path / "redirects.json"
+    path.write_text(
+        json.dumps({"_comment": "notes", "perma/layout": "configuration/layout"}),
+        encoding="utf-8",
+    )
+
+    assert assemble_site.load_redirect_map(path) == {
+        "perma/layout": "configuration/layout"
+    }
+
+
+def test_a_missing_map_is_not_fatal(assemble_site, tmp_path):
+    """The smoke check is the backstop; a publish should not die here."""
+    assert assemble_site.load_redirect_map(tmp_path / "absent.json") == {}
+
+
+def test_a_missing_target_fails_the_publish(assemble_site, dist):
+    """A permalink to a page that no longer exists redirects a 404 to a 404.
+
+    Better found in the publish that renamed the page than by a reader following
+    a link printed by a released version of SQLFluff.
+    """
+    with pytest.raises(FileNotFoundError, match="no built page"):
+        assemble_site.resolve_redirect_targets(
+            dist, {"perma/gone": "configuration/removed"}
+        )
+
+
+def test_directory_targets_count_as_present(assemble_site, dist):
+    """Which file a page became depends on the build's URL settings."""
+    assemble_site.resolve_redirect_targets(
+        dist, {"perma/configuration": "configuration/index"}
+    )
+
+
+def test_missing_targets_can_be_downgraded_to_a_warning(assemble_site, dist):
+    """The escape hatch, for publishing with a known-stale permalink."""
+    assemble_site.resolve_redirect_targets(
+        dist, {"perma/gone": "configuration/removed"}, allow_missing=True
+    )
+
+
+def test_sphinx_builds_skip_target_validation(assemble_site, tmp_path):
+    """An archive lays its pages out differently and has its own permalinks.
+
+    Validating the VitePress map against a Sphinx tree would fail every archived
+    version, since `configuration/layout.html` is `configuration/index.html`
+    there.
+    """
+    sphinx_dist = tmp_path / "sphinx"
+    sphinx_dist.mkdir()
+    (sphinx_dist / "index.html").write_text("<html></html>", encoding="utf-8")
+    (sphinx_dist / "perma").mkdir()
+    (sphinx_dist / "perma" / "layout.html").write_text(
+        "<html></html>", encoding="utf-8"
+    )
+
+    redirects = tmp_path / "redirects.json"
+    redirects.write_text(
+        json.dumps({"perma/layout": "configuration/layout"}), encoding="utf-8"
+    )
+
+    site = tmp_path / "site"
+    assemble_site.assemble_site(
+        dist=sphinx_dist,
+        output_dir=site,
+        language="en",
+        channel="3.4.2",
+        title="3.4.2",
+        kind="release",
+        builder="sphinx",
+        shared_dir=tmp_path / "absent",
+        redirects=redirects,
+    )
+
+    # The rules are still written: they are how the versions that have no
+    # permalink pages of their own get served.
+    assert "perma/layout" in (site / "_redirects").read_text(encoding="utf-8")
+
+
+def test_every_shipped_permalink_resolves(assemble_site):
+    """The real map must not accumulate permalinks to pages that no longer exist.
+
+    Checked against the map rather than a built tree, which is not available
+    here: this asserts the shape the generator relies on, so a malformed entry
+    is caught by the test suite rather than by a docs publish.
+    """
+    redirects = assemble_site.load_redirect_map(assemble_site.DEFAULT_REDIRECTS)
+
+    assert redirects, "redirects.json is empty"
+
+    for key, target in redirects.items():
+        assert not key.startswith("/"), f"{key} must be a relative page id"
+        assert ".." not in key.split("/"), f"{key} must not traverse"
+
+        path, _ = assemble_site.follow_chain(redirects, target)
+
+        assert path, f"{key} has no target path"
+        assert not path.startswith("/"), (
+            f"{key} points at an absolute path, which would not survive a "
+            f"change of base"
+        )
+
+    # Every rule is generated without raising, which is where a cycle surfaces.
+    assert (
+        len(assemble_site.build_permalink_rules("en", redirects)) == len(redirects) * 2
+    )

--- a/test/docsv_redirect_rules_test.py
+++ b/test/docsv_redirect_rules_test.py
@@ -275,14 +275,42 @@ def test_every_shipped_permalink_resolves(assemble_site):
     )
 
 
-def test_an_empty_target_is_rejected(assemble_site, tmp_path):
-    """A malformed entry, not a permalink to nowhere.
+@pytest.mark.parametrize(
+    "target",
+    [
+        "",
+        "   ",
+        None,
+        42,
+        " configuration/layout",
+        "configuration/layout ",
+        "configuration/my layout",
+    ],
+)
+def test_malformed_targets_are_rejected(assemble_site, tmp_path, target):
+    """`_redirects` is space-delimited, so whitespace is not merely useless.
 
-    Dropping it silently would leave that URL a 404 while the publish reported
-    success — the failure this whole mechanism exists to remove.
+    A target of `"   "` produced `/en/:version/perma/x /en/:version/    301` — a
+    rule that parses as something nobody wrote, pointing at the version root.
     """
     path = tmp_path / "redirects.json"
-    path.write_text(json.dumps({"perma/layout": ""}), encoding="utf-8")
+    path.write_text(json.dumps({"perma/layout": target}), encoding="utf-8")
 
-    with pytest.raises(ValueError, match="no target"):
+    with pytest.raises(ValueError, match="empty or whitespace-bearing"):
         assemble_site.load_redirect_map(path)
+
+
+def test_a_key_containing_whitespace_is_rejected(assemble_site, tmp_path):
+    """The source half of a rule has to be one whitespace-free token too."""
+    path = tmp_path / "redirects.json"
+    path.write_text(
+        json.dumps({"perma/my layout": "configuration/layout"}), encoding="utf-8"
+    )
+
+    with pytest.raises(ValueError, match="empty or whitespace-bearing"):
+        assemble_site.load_redirect_map(path)
+
+
+def test_the_shipped_map_loads_cleanly(assemble_site):
+    """The validation above must not reject the map actually published."""
+    assert len(assemble_site.load_redirect_map(assemble_site.DEFAULT_REDIRECTS)) == 102

--- a/test/docsv_redirect_rules_test.py
+++ b/test/docsv_redirect_rules_test.py
@@ -273,3 +273,16 @@ def test_every_shipped_permalink_resolves(assemble_site):
     assert (
         len(assemble_site.build_permalink_rules("en", redirects)) == len(redirects) * 2
     )
+
+
+def test_an_empty_target_is_rejected(assemble_site, tmp_path):
+    """A malformed entry, not a permalink to nowhere.
+
+    Dropping it silently would leave that URL a 404 while the publish reported
+    success — the failure this whole mechanism exists to remove.
+    """
+    path = tmp_path / "redirects.json"
+    path.write_text(json.dumps({"perma/layout": ""}), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="no target"):
+        assemble_site.load_redirect_map(path)

--- a/test/docsv_redirect_rules_test.py
+++ b/test/docsv_redirect_rules_test.py
@@ -303,9 +303,14 @@ def test_malformed_targets_are_rejected(assemble_site, tmp_path, target):
 @pytest.mark.parametrize(
     ("key", "expected"),
     [
-        # `key.strip("/")` makes this the version root, so the rule would
-        # redirect every version's home page to whatever the target is.
+        # Normalising to nothing makes the rule's source the version root, so
+        # it would redirect every version's home page to whatever the target
+        # is. True of the empty string, and equally of a key of only slashes —
+        # which is how the first fix for this was too narrow: it guarded the raw
+        # key while the rule builder used the stripped one.
         ("", "empty permalink"),
+        ("/", "empty permalink"),
+        ("//", "empty permalink"),
         ("perma/my layout", "whitespace"),
         ("../escape", "`..` component"),
     ],
@@ -326,6 +331,35 @@ def test_a_dotdot_target_is_rejected(assemble_site, tmp_path):
 
     with pytest.raises(ValueError, match="`..` component"):
         assemble_site.load_redirect_map(path)
+
+
+@pytest.mark.parametrize("target", ["/", "//", "#section"])
+def test_targets_with_no_page_are_rejected(assemble_site, tmp_path, target):
+    """The mirror of the empty-key case, and much less damaging.
+
+    The rule stays valid, it just sends the reader to the version root — but a
+    permalink that no longer names a page is the thing this map exists to record.
+    """
+    path = tmp_path / "redirects.json"
+    path.write_text(json.dumps({"perma/layout": target}), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="no page"):
+        assemble_site.load_redirect_map(path)
+
+
+def test_validation_and_rule_generation_normalise_alike(assemble_site):
+    """The guard has to look at the value the builder uses, not the raw one.
+
+    Both go through `permalink_segment`, so a form that normalises to something
+    dangerous cannot pass validation and then reach the rule.
+    """
+    assert assemble_site.permalink_segment("/perma/layout/") == "perma/layout"
+
+    rules = _rules(assemble_site, {"/perma/layout": "/configuration/layout/"})
+
+    assert rules[0] == (
+        "/en/:version/perma/layout /en/:version/configuration/layout 301"
+    )
 
 
 def test_the_reason_an_entry_was_rejected_is_reported(assemble_site, tmp_path):

--- a/test/docsv_smoke_check_test.py
+++ b/test/docsv_smoke_check_test.py
@@ -80,3 +80,36 @@ def test_unsafe_paths_are_rejected(smoke_check, tmp_path, url_path):
     """A manifest is only as trustworthy as whatever produced it."""
     with pytest.raises(ValueError):
         smoke_check.assert_path_exists(tmp_path, url_path, "version index")
+
+
+def test_a_symlinked_directory_index_outside_the_tree_is_rejected(
+    smoke_check, tmp_path
+):
+    """A real directory whose `index.html` points outside is the same hole.
+
+    Checking containment on the path this started from is not enough: each
+    candidate substitution — the directory index, and the `.html` suffix — is its
+    own way out, so the check has to run on whichever candidate is finally used.
+    """
+    site = tmp_path / "site"
+    (site / "en" / "latest" / "configuration").mkdir(parents=True)
+
+    outside = tmp_path / "outside.html"
+    outside.write_text("<html>not published</html>", encoding="utf-8")
+    (site / "en" / "latest" / "configuration" / "index.html").symlink_to(outside)
+
+    with pytest.raises(ValueError, match="escapes the site directory"):
+        smoke_check.assert_path_exists(
+            site, "/en/latest/configuration", "permalink target"
+        )
+
+
+def test_a_directory_index_inside_the_tree_is_accepted(smoke_check, tmp_path):
+    """The containment check must not reject the ordinary case it guards."""
+    page = tmp_path / "en" / "latest" / "configuration" / "index.html"
+    page.parent.mkdir(parents=True)
+    page.write_text("<html></html>", encoding="utf-8")
+
+    smoke_check.assert_path_exists(
+        tmp_path, "/en/latest/configuration", "permalink target"
+    )

--- a/test/docsv_smoke_check_test.py
+++ b/test/docsv_smoke_check_test.py
@@ -1,0 +1,82 @@
+"""Tests for the assembled-site smoke check.
+
+This is the last thing to run before a tree leaves the runner for R2 and
+Netlify, so what it vouches for has to be inside the tree it was handed.
+
+The script lives outside the package, so it is loaded by path rather than
+imported; its filename is not a valid module name.
+"""
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+REPO_ROOT = Path(__file__).parent.parent
+SMOKE_CHECK = REPO_ROOT / "docsv" / "scripts" / "smoke-check-assembled-site.py"
+
+
+def _load_smoke_check() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("smoke_check", SMOKE_CHECK)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def smoke_check() -> ModuleType:
+    """Load the smoke check once for the module."""
+    return _load_smoke_check()
+
+
+def test_a_suffixless_path_resolves_to_its_html_file(smoke_check, tmp_path):
+    """Netlify serves `foo.html` for `/foo`, and the permalink rules rely on it.
+
+    Their destinations are suffix-less so that one rule can serve versions whose
+    builds put the page in a different file.
+    """
+    (tmp_path / "en" / "latest" / "configuration").mkdir(parents=True)
+    (tmp_path / "en" / "latest" / "configuration" / "layout.html").write_text(
+        "<html></html>", encoding="utf-8"
+    )
+
+    smoke_check.assert_path_exists(
+        tmp_path, "/en/latest/configuration/layout", "permalink target"
+    )
+
+
+def test_a_symlinked_html_file_outside_the_tree_is_rejected(smoke_check, tmp_path):
+    """The `.html` fallback must not escape the tree it is checking.
+
+    `resolve()` follows symlinks, so without re-checking containment after the
+    suffix is appended, a link at the `.html` name would let the check vouch for
+    a page the deployed site does not have.
+    """
+    site = tmp_path / "site"
+    (site / "en" / "latest").mkdir(parents=True)
+
+    outside = tmp_path / "outside.html"
+    outside.write_text("<html>not published</html>", encoding="utf-8")
+    (site / "en" / "latest" / "escape.html").symlink_to(outside)
+
+    with pytest.raises(ValueError, match="escapes the site directory"):
+        smoke_check.assert_path_exists(site, "/en/latest/escape", "permalink target")
+
+
+def test_a_missing_page_is_still_reported(smoke_check, tmp_path):
+    """The suffix fallback must not turn a missing page into a passing check."""
+    (tmp_path / "en" / "latest").mkdir(parents=True)
+
+    with pytest.raises(FileNotFoundError):
+        smoke_check.assert_path_exists(
+            tmp_path, "/en/latest/absent", "permalink target"
+        )
+
+
+@pytest.mark.parametrize("url_path", ["/en/../../outside", "/", ""])
+def test_unsafe_paths_are_rejected(smoke_check, tmp_path, url_path):
+    """A manifest is only as trustworthy as whatever produced it."""
+    with pytest.raises(ValueError):
+        smoke_check.assert_path_exists(tmp_path, url_path, "version index")


### PR DESCRIPTION
### Brief summary of the change made

Groundwork for back-populating the historical Sphinx docs onto the beta docs site, plus a fix for the one part of it that is broken today. This is steps 0–3 of the plan; the backfill workflow itself is still to come.

**Permalinks now resolve.** Every SQLFluff release from `2.0.0` onward prints `.../perma/<name>.html` URLs from the CLI and from rule documentation, and all of them 404 on the beta site today:

```
$ curl -so /dev/null -w '%{http_code}\n' https://docs.beta.sqlfluff.com/en/latest/perma/layout.html
404
```

`redirects.json` was only consulted by the theme at runtime, so a reader arriving cold got a 404 from the server before any JavaScript ran. `assemble-site.py` now writes real 301 rules into `_redirects`, using Netlify's `:version` placeholder:

```
/en/:version/perma/layout      /en/:version/configuration/layout 301
/en/:version/perma/layout.html /en/:version/configuration/layout 301
```

One rule per permalink covers every published version — 204 rules total, constant as versions accumulate. Enumerating versions instead would add 204 rules per release and pass Netlify's recommended ceiling within a handful of them, and it would leave the three versions already published unfixed, since re-running the publish workflow for an old tag rebuilds it from source that does not know about these URLs. Nothing is forced with `!`, so an archived Sphinx version keeps serving its own `sphinx-reredirects` pages, which are correct for its page layout where these rules are not.

Two things surfaced while doing it:

- `internals` points at `perma/internals`, which points at the page. The client-side handler followed that chain by accident, via two 404s, so it went unnoticed. Chains now resolve to a single hop, with a cycle guard.
- A permalink whose target page no longer exists now fails the publish rather than redirecting a reader from one 404 to another.

**The site 404 page now works.** Netlify only serves a `404.html` from the publish root — it does not fall back to one inside a subdirectory — so the 404 page each VitePress version builds was never reached:

```
/en/latest/404.html        200  17561b  <title>404 | SQLFluff</title>
/en/latest/does-not-exist  404   3449b  <title>Page not found</title>   <- Netlify's generic page
```

`assemble-site.py` now copies the published build's 404 page to the site root. Copying rather than writing one from scratch keeps it styled like the rest of the site and in step with the fingerprinted assets it references, since the same run publishes both. Skipped when the build has no 404 page, which is the Sphinx case, so archiving a version cannot take the site's 404 page away.

**Manifest groundwork.** `assemble-site.py` gains `--builder` and `--unlisted`, copies `docsv/shared/` to the language root on every run, and generates an archive index at `/en/versions.html` grouped by major series. `version_sort_key` now parses prereleases and post-releases: `4.0.1.post1` and `0.7.0a8` used to land in a string bucket *below* `0.2.4`, which also told the stale-version notice that every release was newer than the newest one.

**Shared version picker.** `docsv/shared/version-picker.{js,css}` is a dependency-free picker for archived Sphinx builds, published above every version so a frozen build learns about later versions — and picks up fixes to the picker — without being rebuilt. `inject-shared-picker.py` adds it to a built or mirrored Sphinx tree and strips the Read the Docs injection, which keeps mirroring viable as a fallback for any version that stops building.

Both pickers now list one release per series plus whichever version the reader is on, offer an "All versions →" link to the archive index, and drop the page path when switching across the Sphinx/VitePress boundary. No comparable project lists patch releases in a switcher — Node.js hosts every patch and lists none of them — and across builders the differing URL layouts make carrying the page path a certain 404 rather than an occasional one.

### Are there any other side effects of this change that we should be aware of?

**On merge**, the push to `main` rebuilds `/en/latest/` and re-uploads the assembled tree. Visible changes:

- `perma` URLs start resolving on **every** version, including `stable`, `4.3.0` and `4.2.2`, which are not rebuilt. This is the point of the placeholder rules.
- `/en/versions.html` appears, and the picker on `latest` gains "All versions →".
- `/en/shared/` is published but nothing loads it yet — there are no Sphinx versions.
- No version is unlisted yet, so the picker's contents are otherwise unchanged.

**New failure mode:** a publish now fails if a permalink target has no built page. All 102 currently resolve, verified against a real build. But there is no PR-time job that builds `docsv/`, so a future page rename would surface this on merge rather than in review — worth a followup CI check.

`assemble-site.py`'s `--vitepress-dist` is renamed to `--dist`, since archived Sphinx versions go through the same script. The three call sites in `publish-docs.yaml` are updated.

The client-side redirect handling in `theme/index.ts` stays: the server rules cover cold hits, while the router handler still catches in-app navigation, which VitePress intercepts before a request is made.

### Verification

- 64 tests, 46 of them new, across `test/docsv_{assemble_site,redirect_rules,inject_picker}_test.py`.
- Built a local assembled site with three VitePress versions and three archived Sphinx versions and served it behind a Netlify-alike, then followed **1,020 permalink URLs across five versions**: every VitePress version 301s to a page returning 200 with the fragment preserved, and both Sphinx archives return 200 from their own permalink pages instead.
- Every miss now returns the SQLFluff 404 page with a 404 status, inside a version and outside one, with its assets resolving. The preview server had been hiding this bug by walking up to the nearest `404.html`; it now takes the root page only, matching what Netlify was measured to do.
- Ran the shared picker in jsdom against real injected alabaster output: mount point, listed filtering, unlisted-current added back, cross-builder path dropping, stale notice and disclosure behaviour all as intended.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - Other: `test/docsv_redirect_rules_test.py`, `test/docsv_inject_picker_test.py`, and additions to `test/docsv_assemble_site_test.py`.
- Added appropriate documentation for the change — `docsv/README.md`; `docsv/development/versioned-docs-hosting.md` is updated in the plan's own step 9.
- Created GitHub issues for any relevant followup/future enhancements if appropriate — not yet; the followups are noted below.

### Followups

- Style `/en/versions.html` with the site's design tokens. It sits above every version, so it cannot borrow one version's copy of the design package without going stale when that version is replaced; publishing the package to `/en/shared/` would fix both this page and the archived-Sphinx picker's hardcoded palette.
- A PR-time job that builds `docsv/`, so a broken permalink target fails in review rather than on merge.
- Per-version 404 pages, if the root one proves too generic: one unforced `_redirects` rule per VitePress version would do it, at the cost of a splat rule each. Not obviously worth it while the root page is a strict improvement on Netlify's.
- Steps 4–7: pin the docs toolchain, add the backfill workflow, archive the 62 versions, and set the listed set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the `perma/*` permalink URLs that 404 on cold hits to the beta docs site, and lays the groundwork for backfilling the archived Sphinx documentation versions. Permalinks now resolve via real 301 rules, the site serves its own 404 page for every miss, and a shared version picker plus archive index page cover archived builds.

**Bug Fixes**
- `assemble-site.py` writes one 301 rule per permalink to `_redirects` using Netlify's `:version` placeholder, covering every published version regardless of when it was published.
- Redirect chains resolve to a single hop, with a cycle guard.
- `version_sort_key` now orders prereleases and post-releases correctly — `4.0.1.post1` and `0.7.0a8` used to sort below `0.2.4`, and prerelease stages collapsed (`4.0.0a2` looked newer than `4.0.0b1`) — which also broke the stale-version notice.
- The site's own 404 page is published at the site root and taken from the default channel; an existing root page is left alone, and the build only bootstraps a tree that has none. Previously every miss, including inside `/en/latest/`, returned Netlify's generic page.
- Both pickers show the "All versions" link even when only one version is listed, keeping archived versions discoverable.

**Migration**
- `--vitepress-dist` is renamed to `--dist` in `assemble-site.py`.
- A publish now fails when a permalink key or target is invalid — empty or slash-only keys, `..`, whitespace, non-string targets, or targets with no page — with validation sharing `permalink_segment` with rule building so they cannot disagree; all 102 currently resolve.
- On merge, `/en/latest/` rebuilds and `perma` URLs start resolving on every version; `/en/versions.html` appears, plus the shared picker assets at `/en/shared/`. No version is archived or unlisted yet — the backfill workflow itself is still to come.

<sup>Written for commit 40d7dfdc0e856178bd4e60ab7937c2bea69af40d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8412?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

