### PR TITLE
docs: fix PyPI publishing workflow link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -347,7 +347,7 @@ for more information on how to build and test this.
 ### Building Package
 
 New versions of SQLFluff will be published to PyPI automatically via
-[GitHub Actions](.github/workflows/publish-release-to-pypi.yaml)
+[GitHub Actions](.github/workflows/publish-sqlfluff-release-to-pypi.yaml)
 whenever a new release is published to GitHub.
 
 #### Release checklist:


### PR DESCRIPTION
### Brief summary of the change made

Fix the broken GitHub Actions link in `CONTRIBUTING.md` so it points to the existing `publish-sqlfluff-release-to-pypi.yaml` workflow.

### Are there any other side effects of this change that we should be aware of?

None. This is a documentation-only change.

### Pull Request checklist

- [x] Added appropriate documentation for the change.
- [x] No code behavior changed, so test cases are not required.

### Validation

- Confirmed `.github/workflows/publish-sqlfluff-release-to-pypi.yaml` exists.
- Ran `git diff --check`.

### AI assistance

This contribution was prepared with AI assistance. I manually verified the target workflow path and reviewed the final diff.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the broken GitHub Actions link in `CONTRIBUTING.md` so it points to the existing `publish-sqlfluff-release-to-pypi.yaml` workflow.

<sup>Written for commit c364ac0beebdae194a3de279d1a68784b0f246e3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8413?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

