### PR TITLE
fix(ansi): parse nested joins wrapped in redundant parentheses

### DIFF
--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -1630,7 +1630,23 @@ class FrameClauseSegment(BaseSegment):
 
 ansi_dialect.add(
     # This is a hook point to allow subclassing for other dialects
-    PostTableExpressionGrammar=Nothing()
+    PostTableExpressionGrammar=Nothing(),
+    # A nested join carrying redundant parentheses, e.g. the outer pair in
+    # `a LEFT JOIN ((b INNER JOIN c ON TRUE)) ON TRUE`. Self-referential so that
+    # any number of redundant pairs is allowed. The innermost pair must contain a
+    # join, which keeps constructs that already parse, such as `((my_table tt))`
+    # and `((a JOIN b ON TRUE) JOIN c ON TRUE)`, matching as they did before.
+    BracketedNestedJoinGrammar=Bracketed(
+        OneOf(
+            Ref("BracketedNestedJoinGrammar"),
+            Bracketed(
+                Sequence(
+                    Ref("FromExpressionElementSegment"),
+                    AnyNumberOf(Ref("JoinClauseSegment"), min_times=1),
+                )
+            ),
+        )
+    ),
 )
 
 
@@ -1667,6 +1683,7 @@ class FromExpressionElementSegment(BaseSegment):
                 AnyNumberOf(Ref("JoinClauseSegment")),
             ),
         ),
+        Ref("BracketedNestedJoinGrammar"),
     )
 
     def get_eventual_alias(self) -> Generator[AliasInfo, None, None]:

--- a/test/fixtures/dialects/ansi/select_nested_join.sql
+++ b/test/fixtures/dialects/ansi/select_nested_join.sql
@@ -94,3 +94,13 @@ group by
     customers.email
 order by
     orders.order_id;
+
+-- nested join wrapped in redundant brackets
+select 1
+from a
+    left join ((b inner join c on true)) on true;
+
+-- nested join wrapped in several redundant brackets
+select 1
+from a
+    left join (((b inner join c on true))) on true;

--- a/test/fixtures/dialects/ansi/select_nested_join.yml
+++ b/test/fixtures/dialects/ansi/select_nested_join.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 61d9b77e97d00d4c8d80182e1b184a084793a528f7519595a86a0dd67f08deca
+_hash: f29f35d92b21c74c947327a4f6e4fe138e9e8ad81376480d3ec35cb941072dbf
 file:
 - statement:
     select_statement:
@@ -457,4 +457,93 @@ file:
         - naked_identifier: orders
         - dot: .
         - naked_identifier: order_id
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: select
+        select_clause_element:
+          numeric_literal: '1'
+      from_clause:
+        keyword: from
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: a
+          join_clause:
+          - keyword: left
+          - keyword: join
+          - from_expression_element:
+              bracketed:
+                start_bracket: (
+                bracketed:
+                  start_bracket: (
+                  from_expression_element:
+                    table_expression:
+                      table_reference:
+                        naked_identifier: b
+                  join_clause:
+                  - keyword: inner
+                  - keyword: join
+                  - from_expression_element:
+                      table_expression:
+                        table_reference:
+                          naked_identifier: c
+                  - join_on_condition:
+                      keyword: 'on'
+                      expression:
+                        boolean_literal: 'true'
+                  end_bracket: )
+                end_bracket: )
+          - join_on_condition:
+              keyword: 'on'
+              expression:
+                boolean_literal: 'true'
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: select
+        select_clause_element:
+          numeric_literal: '1'
+      from_clause:
+        keyword: from
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: a
+          join_clause:
+          - keyword: left
+          - keyword: join
+          - from_expression_element:
+              bracketed:
+                start_bracket: (
+                bracketed:
+                  start_bracket: (
+                  bracketed:
+                    start_bracket: (
+                    from_expression_element:
+                      table_expression:
+                        table_reference:
+                          naked_identifier: b
+                    join_clause:
+                    - keyword: inner
+                    - keyword: join
+                    - from_expression_element:
+                        table_expression:
+                          table_reference:
+                            naked_identifier: c
+                    - join_on_condition:
+                        keyword: 'on'
+                        expression:
+                          boolean_literal: 'true'
+                    end_bracket: )
+                  end_bracket: )
+                end_bracket: )
+          - join_on_condition:
+              keyword: 'on'
+              expression:
+                boolean_literal: 'true'
 - statement_terminator: ;


### PR DESCRIPTION
### Brief summary of the change made

Fixes #8382

A nested join in a JOIN clause could only carry one pair of parentheses, so
`a LEFT JOIN ((b INNER JOIN c ON TRUE)) ON TRUE` was reported as an unparsable
section even though the single-bracket form parsed fine.

Note that this is not MySQL specific as the issue title suggests — I reproduced
it on ansi, postgres, bigquery, tsql and snowflake. FromExpressionSegment is
already self-referential through `Bracketed(Ref("FromExpressionSegment"))`, but
the JOIN path had no equivalent recursion.

FromExpressionElementSegment now also matches a new BracketedNestedJoinGrammar,
which is self-referential so any number of redundant pairs is accepted. Its
innermost pair must contain a join (`min_times=1`), which is what keeps
constructs that already parsed matching exactly as before.

### Are there any other side effects of this change that we should be aware of?

None that I could find, and I specifically checked for two:

- Parse trees. Regenerating all 2249 fixtures changes no existing .yml file. The
  `min_times=1` constraint is what makes that true: an earlier version of this
  patch without it changed the tree for `select * from (((my_table tt)))` and
  stopped AL01 firing on it.
- Rule crashes. `get_join_clause_aliases()` asserts that a join_clause has a
  direct `from_expression_element` child. An earlier version of this patch that
  changed JoinClauseSegment instead broke that assumption and made AL04, AL05,
  AM04, RF01, RF02, RF03, ST05 and ST09 raise on the newly parsable input. The
  version here keeps the from_expression_element wrapper, and linting the new
  forms raises no exceptions.

Snowflake still fails on `LEFT JOIN ((b)) ON TRUE`, but it did so before this
change too, so I have left it alone.

Disclosure: this change was AI-assisted. I used an LLM to help locate the
grammar and draft the patch. I manually validated it by regenerating all
dialect fixtures and diffing them, comparing lint output before and after on
the affected constructs, and running the full test suite (10908 passed, 2573
skipped, with test/core/plugin_test.py excluded as it also fails on a clean
checkout in my environment).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #8382: nested joins wrapped in redundant parentheses now parse. Only one pair of parentheses could previously wrap a nested join, so `a LEFT JOIN ((b INNER JOIN c ON TRUE)) ON TRUE` was reported as an unparsable section. Any number of redundant pairs is now accepted across ansi, postgres, bigquery, tsql, and snowflake dialects, so the fix is not MySQL-specific as the issue title suggests.

**Side effects**
- Regenerating all parse fixtures changes no existing `.yml` files; the new grammar only matches forms that previously errored.
- Linting the newly accepted forms raises no rule crashes.
- Snowflake still rejects `LEFT JOIN ((b)) ON TRUE`, but it did before this change.

<sup>Written for commit 3c7eb8e2f3ae3ab856bf1d519fb8832c716a843b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8416?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

