### PR TITLE
Cache lint results for files which came back clean

### DIFF
--- a/docs/source/production/caching.rst
+++ b/docs/source/production/caching.rst
@@ -23,9 +23,10 @@ Caching is **off by default**. Turn it on for a single run with
 
 The cache lives in :code:`.sqlfluff_cache` in the working directory by default.
 Use :code:`--cache-dir` or the :code:`cache_dir` config value to put it
-somewhere else. A relative path is resolved from the working directory, and the
-directory is created on demand with a :code:`.gitignore` inside it so that it
-cannot be committed by accident.
+somewhere else. A relative path is resolved from the working directory. If
+*SQLFluff* creates the directory it also writes a :code:`.gitignore` into it,
+so that the cache cannot be committed by accident; a directory which already
+exists is left alone, in case it is somewhere you keep other things.
 
 Like :code:`processes`, :code:`cache` and :code:`cache_dir` are read from the
 *root* configuration for the run -- the config found from the working directory
@@ -68,6 +69,16 @@ following makes a file get linted again:
 The last two discard the entire cache rather than individual entries, because
 either can change the result for every file.
 
+Caching is declined outright, rather than keyed, when a :class:`Linter` is
+constructed with :code:`user_rules` from the Python API. Every other input has
+a stable identity -- a file has its bytes, config its values, a plugin its
+version -- but a rule class passed in-process has none: its name would not
+change when its body did, so a cached clean result could hide an edited rule.
+
+The cache also has to notice a macro reached through a symbolic link, so
+directory fingerprinting follows links (with cycle protection) rather than
+using the default non-following walk.
+
 Which templaters can be cached
 ------------------------------
 
@@ -76,7 +87,13 @@ Which templaters can be cached
 * :code:`python` -- cached. Its whole context comes from config.
 * :code:`placeholder` -- cached. Its whole context comes from config.
 * :code:`dbt` -- **not cached.**
+* :code:`sqlmesh` -- **not cached.**
 * Any third party templater -- **not cached**, unless it opts in (see below).
+
+The opt-in is per *exact* class and is never inherited. A templater which
+subclasses a cacheable one -- as both :code:`dbt` and :code:`sqlmesh` subclass
+:code:`jinja` -- reads whatever its parent reads *and more*, so inheriting the
+parent's declaration would be claiming something the subclass never verified.
 
 dbt models are excluded because their rendering depends on the compiled
 manifest -- other models, seeds, packages, the selected target, and any

--- a/docs/source/production/caching.rst
+++ b/docs/source/production/caching.rst
@@ -1,0 +1,153 @@
+.. _caching:
+
+Caching lint results
+====================
+
+Most of the time SQLFluff spends on a project goes on files which have not
+changed. In a pre-commit hook or a tight edit-and-lint loop, that is nearly all
+of them. SQLFluff can remember which files came back clean and skip them
+entirely on the next run.
+
+Caching is **off by default**. Turn it on for a single run with
+:code:`--cache`, or for a project by setting it in config:
+
+.. code-block:: cfg
+
+    [sqlfluff]
+    cache = True
+
+.. code-block:: text
+
+    sqlfluff lint --cache .
+    sqlfluff fix --cache .
+
+The cache lives in :code:`.sqlfluff_cache` in the working directory by default.
+Use :code:`--cache-dir` or the :code:`cache_dir` config value to put it
+somewhere else. A relative path is resolved from the working directory, and the
+directory is created on demand with a :code:`.gitignore` inside it so that it
+cannot be committed by accident.
+
+Like :code:`processes`, :code:`cache` and :code:`cache_dir` are read from the
+*root* configuration for the run -- the config found from the working directory
+-- rather than from a :code:`.sqlfluff` in a subdirectory.
+
+To start again from scratch, delete the cache directory. There is no separate
+command for it, and nothing else in a project depends on it.
+
+What gets cached
+----------------
+
+Only files which produced **nothing at all**: no violations, no warnings, no
+templating or parsing errors, and no unused :code:`-- noqa` comments. A file
+with anything to report is linted again on every run, so enabling the cache can
+never make a diagnostic disappear that you have not already dealt with.
+
+That is a deliberately narrow rule, and it is where the benefit comes from: on
+a project which is already passing, almost every file qualifies.
+
+What invalidates an entry
+-------------------------
+
+An entry records that *a specific file, under a specific set of inputs, linted
+clean*. It is only used again when all of those inputs match. Any of the
+following makes a file get linted again:
+
+* The file's contents change (its bytes are hashed, so a change of encoding
+  counts too).
+* Its resolved configuration changes -- including a :code:`.sqlfluff` higher up
+  the tree, a :code:`pyproject.toml`, or a command line override such as
+  :code:`--rules`.
+* A file the templater reads changes. For the Jinja templater that means
+  anything under :code:`load_macros_from_path`,
+  :code:`exclude_macros_from_path`, :code:`loader_search_path` or
+  :code:`library_path`: editing a macro re-lints every file which could have
+  used it, and so does adding, removing or renaming one.
+* The SQLFluff version changes.
+* An installed SQLFluff plugin is added, removed or upgraded.
+
+The last two discard the entire cache rather than individual entries, because
+either can change the result for every file.
+
+Which templaters can be cached
+------------------------------
+
+* :code:`raw` -- cached. It reads nothing outside the file.
+* :code:`jinja` -- cached. The external files it reads are fingerprinted.
+* :code:`python` -- cached. Its whole context comes from config.
+* :code:`placeholder` -- cached. Its whole context comes from config.
+* :code:`dbt` -- **not cached.**
+* Any third party templater -- **not cached**, unless it opts in (see below).
+
+dbt models are excluded because their rendering depends on the compiled
+manifest -- other models, seeds, packages, the selected target, and any
+:code:`env_var()` calls. None of that can be derived from the model file plus
+its SQLFluff config, so there is no honest way to key it. Enabling
+:code:`cache` in a dbt project is not an error; those files are simply always
+linted.
+
+Third party templaters are excluded by default for the same reason: SQLFluff
+cannot know what external state a templater it did not write reads. A templater
+opts in by implementing :code:`cache_fingerprint`:
+
+.. code-block:: python
+
+    from typing import Optional
+
+    from sqlfluff.core.config import FluffConfig
+    from sqlfluff.core.helpers.hashing import hash_path_contents
+    from sqlfluff.core.templaters import RawTemplater
+
+
+    class MyTemplater(RawTemplater):
+        name = "my_templater"
+
+        def cache_fingerprint(self, config: FluffConfig) -> Optional[str]:
+            """Digest the state this templater reads from outside the file."""
+            # Return "" if there is no such state, a digest of it if there is,
+            # or None to decline caching entirely.
+            return hash_path_contents([config.get("my_templater_path")])
+
+Using the cache in CI
+---------------------
+
+.. warning::
+
+    Treat the cache directory as being exactly as trusted as your working
+    tree. An entry is a stored assertion that a file was clean, and *SQLFluff*
+    acts on it without re-checking. Anyone who can write to the cache can
+    therefore make a file be skipped.
+
+    That is unremarkable locally -- someone who can write your cache can also
+    write your SQL -- but it matters if you restore the cache in CI with
+    something like ``actions/cache``. A cache key shared with pull requests
+    from forks means an untrusted branch can save a cache that a later run on
+    a trusted branch restores, silently suppressing findings.
+
+    If you cache the directory in CI, scope the cache key so that untrusted
+    branches cannot write an entry a trusted run will read. If you cannot,
+    don't restore it.
+
+Caveats
+-------
+
+* **Timings are not replayed.** A cached file reports no timing information in
+  :code:`--format json` or :code:`--persist-timing`, because no work happened.
+  Everything else, including the character and segment statistics, is identical
+  to an uncached run.
+* **There is no parse tree for a cached file.** Code using the Python API which
+  reads :code:`LintedDir.files` or :code:`.tree` will not see cached files, for
+  the same reason. Leave caching off in that case.
+* **Concurrent runs are safe but not co-operative.** The cache file is replaced
+  atomically, so a reader always sees a complete file. Two runs finishing at
+  once resolve as last-writer-wins, which costs a cache miss on the next run
+  and nothing else.
+* **Keep the fingerprinted directories small.** The Jinja fingerprint hashes
+  everything under the configured macro, loader and library paths on every run.
+  Pointing :code:`loader_search_path` at a large tree makes that hashing cost
+  more than the linting it saves.
+* **The cache is a local build artefact.** It records absolute paths and is
+  keyed to the installed SQLFluff and plugin versions. Don't commit it or share
+  it between machines.
+* **A broken cache is never fatal.** A cache which cannot be read, parsed or
+  validated is discarded, and one which cannot be written produces a warning.
+  Either way the run proceeds normally, just without the speedup.

--- a/docs/source/production/index.rst
+++ b/docs/source/production/index.rst
@@ -13,6 +13,7 @@ be part of `CI/CD`_ pipelines.
 
    security
    cli_use
+   caching
    diff_quality
    pre_commit
    github_actions

--- a/docs/source/production/pre_commit.rst
+++ b/docs/source/production/pre_commit.rst
@@ -97,3 +97,12 @@ being passed to *SQLFluff* and so silence any warnings about the
 
 .. _`top level config`: https://pre-commit.com/#top_level-exclude
 .. _`hook specific config`: https://pre-commit.com/#config-exclude
+
+Speeding up repeated runs
+-------------------------
+
+`pre-commit`_ only passes the files in a commit, so most hooks are already
+small. If you also run *SQLFluff* over the whole project -- from
+:code:`pre-commit run --all-files`, from a :code:`Makefile`, or by hand while
+iterating -- see :ref:`caching` for how to skip files which already came back
+clean.

--- a/plugins/sqlfluff-templater-dbt/sqlfluff_templater_dbt/templater.py
+++ b/plugins/sqlfluff-templater-dbt/sqlfluff_templater_dbt/templater.py
@@ -191,6 +191,24 @@ class DbtTemplater(JinjaTemplater):
         """Returns info about the given templater for output by the cli."""
         return [("templater", self.name), ("dbt", self.dbt_version)]
 
+    def cache_fingerprint(self, config):
+        """Decline to cache lint results for dbt models.
+
+        This overrides the Jinja implementation, which would otherwise be
+        inherited and would be wrong here. A dbt model's rendering depends on
+        the compiled manifest: other models it refers to, the macros and
+        packages in the project, the seeds, the profile, the environment
+        variables read by ``env_var()`` and the target selected at run time.
+        Only some of that is on disk, and none of it is reachable from the
+        model file plus its SQLFluff config.
+
+        Rather than approximate it and risk skipping a file which would now
+        report a violation, dbt projects simply do not use the cache. Making
+        them cacheable means deriving a fingerprint from the manifest itself,
+        which is a separate piece of work.
+        """
+        return None
+
     @cached_property
     def _dbt_version(self) -> "VersionSpecifier":
         """Fetches the installed dbt version.

--- a/plugins/sqlfluff-templater-dbt/test/templater_test.py
+++ b/plugins/sqlfluff-templater-dbt/test/templater_test.py
@@ -991,3 +991,18 @@ def test__templater_dbt_threads_explicit(dbt_templater):
         },
     )
     assert dbt_templater._get_threads() == 4
+
+
+def test__templater_dbt_declines_caching(dbt_templater, dbt_fluff_config):
+    """Models are never served from the lint result cache under dbt.
+
+    The dbt templater inherits from the Jinja one, whose fingerprint covers
+    only the configured macro and library paths. That is not enough here: a
+    model's rendering depends on the compiled manifest -- other models, seeds,
+    packages, the selected target and any `env_var()` calls -- none of which is
+    reachable from the model file plus its SQLFluff config.
+
+    Returning None opts dbt out entirely, which is what stops a stale hit from
+    hiding a violation in a dbt project.
+    """
+    assert dbt_templater.cache_fingerprint(FluffConfig(dbt_fluff_config)) is None

--- a/src/sqlfluff/cli/commands.py
+++ b/src/sqlfluff/cli/commands.py
@@ -487,6 +487,26 @@ def lint_options(f: Callable) -> Callable:
         is_flag=True,
         help="Perform the operation regardless of .sqlfluffignore configurations",
     )(f)
+    f = click.option(
+        "--cache/--no-cache",
+        "cache",
+        default=None,
+        help=(
+            "Skip files which linted clean on a previous run and have not "
+            "changed since. Overrides the 'cache' config value. Only files "
+            "with no violations at all are cached, and an entry is discarded "
+            "if the file, its configuration, the SQLFluff version or the "
+            "installed plugins change."
+        ),
+    )(f)
+    f = click.option(
+        "--cache-dir",
+        default=None,
+        help=(
+            "Where to keep the lint cache (default: .sqlfluff_cache). Only "
+            "has an effect when caching is enabled."
+        ),
+    )(f)
     return f
 
 

--- a/src/sqlfluff/cli/formatters.py
+++ b/src/sqlfluff/cli/formatters.py
@@ -254,6 +254,15 @@ class OutputStreamFormatter(FormatterInterface):
             minimum_verbosity=1,
         )
 
+    def dispatch_cache_summary(self, cached: int, linted: int) -> None:
+        """Report how many files were served from the lint cache."""
+        self.dispatch_message(
+            f"{self.colorize('cached (skipped): ', Color.light)} "
+            f"{cached} of {cached + linted}",
+            OutputKind.VERBOSE,
+            minimum_verbosity=1,
+        )
+
     def dispatch_dialect_warning(self, dialect: str) -> None:
         """Dispatch a warning for dialects."""
         self.dispatch_message(  # pragma: no cover

--- a/src/sqlfluff/core/config/file.py
+++ b/src/sqlfluff/core/config/file.py
@@ -30,6 +30,14 @@ COMMA_SEPARATED_PATH_KEYS = (
     "exclude_macros_from_path",
 )
 RESOLVE_PATH_SUFFIXES = ("_path", "_dir")
+# Keys which look like paths by the suffix rule above but must not be resolved
+# by it. Resolution goes through `glob`, which yields nothing for a path that
+# does not exist yet and so leaves the raw value in place. That is fine for an
+# input the user has already created, but not for an *output* directory: it
+# would be interpreted relative to the config file once it exists and relative
+# to the working directory before that, so the same config would name two
+# different locations depending on whether the previous run had happened.
+NO_RESOLVE_KEYS = ("cache_dir",)
 # Values in this section are arbitrary user data for templating, so the path
 # heuristics below must not be applied to them.
 OPAQUE_SECTION_KEY_PATH = ("templater", "jinja", "context")
@@ -96,7 +104,10 @@ def _resolve_paths_in_config(
             # If no paths resolved, keep the original patterns
             config[key] = ",".join(resolved_paths) if resolved_paths else val
         # It it's a single path key, resolve it.
-        elif key.lower().endswith(RESOLVE_PATH_SUFFIXES):
+        elif (
+            key.lower().endswith(RESOLVE_PATH_SUFFIXES)
+            and key.lower() not in NO_RESOLVE_KEYS
+        ):
             assert isinstance(val, str), (
                 f"Value for {key} in {log_filename} must be a string not {type(val)}."
             )

--- a/src/sqlfluff/core/default_config.cfg
+++ b/src/sqlfluff/core/default_config.cfg
@@ -72,6 +72,14 @@ large_file_skip_fail = False
 # If negative or zero, implies number_of_cpus - specified_number.
 # e.g. -1 means use all processors but one. 0  means all cpus.
 processes = 1
+# Cache the result of linting files which come back clean, so that a later
+# run can skip them entirely. Off by default; see the "Caching" section of
+# the docs for what invalidates an entry and which templaters support it.
+cache = False
+# Where to keep the cache. Relative paths are resolved from the working
+# directory. The directory is created on demand and made self-ignoring for
+# git; it is a local build artefact and should not be committed.
+cache_dir = .sqlfluff_cache
 # Max line length is set by default to be in line with the dbt style guide.
 # https://github.com/dbt-labs/corp/blob/main/dbt_style_guide.md
 # Set to zero or negative to disable checks.

--- a/src/sqlfluff/core/formatter.py
+++ b/src/sqlfluff/core/formatter.py
@@ -69,6 +69,14 @@ class FormatterInterface(ABC):
         """Dispatch the header displayed before linting."""
         ...
 
+    def dispatch_cache_summary(self, cached: int, linted: int) -> None:
+        """Report how many files were served from the lint cache.
+
+        NOTE: Deliberately concrete rather than abstract. A formatter written
+        against an earlier version of this interface inherits a no-op and keeps
+        working; only formatters which want to surface the number override it.
+        """
+
     @abstractmethod
     def dispatch_path(self, path: str) -> None:
         """Dispatch paths for display."""

--- a/src/sqlfluff/core/helpers/hashing.py
+++ b/src/sqlfluff/core/helpers/hashing.py
@@ -40,9 +40,17 @@ def hash_strings(hasher: "hashlib._Hash", *values: str) -> None:
     Delimiting means that ``("ab", "c")`` and ``("a", "bc")`` produce different
     digests, so two distinct inputs cannot be made to collide simply by moving
     a boundary between them.
+
+    ``surrogatepass`` rather than ``backslashreplace``: filenames can contain
+    bytes which don't decode, and ``os.fsdecode`` represents those as lone
+    surrogates. ``backslashreplace`` would render such a surrogate as the
+    literal text of an escape sequence, which is exactly what a file whose name
+    contains that text encodes to -- so two different names could produce the
+    same digest. ``surrogatepass`` encodes the surrogate itself, which is
+    injective.
     """
     for value in values:
-        encoded = value.encode("utf-8", errors="backslashreplace")
+        encoded = value.encode("utf-8", errors="surrogatepass")
         hasher.update(str(len(encoded)).encode("ascii"))
         hasher.update(b"\0")
         hasher.update(encoded)
@@ -76,21 +84,49 @@ def hash_path_contents(paths: list[str]) -> str:
         # a template may refer to one of them by name.
         hash_strings(hasher, "path", path)
         if os.path.isfile(path):
-            hash_strings(hasher, "file", "")
-            hash_file_bytes(path, hasher)
+            hash_strings(hasher, "file", _file_digest(path))
         elif os.path.isdir(path):
-            for dirpath, dirnames, filenames in os.walk(path):
+            # NOTE: `followlinks=True`. The default is False, but a Jinja
+            # loader reads straight through a symlinked directory, so leaving
+            # it out would let an edit to a linked-in macro go unnoticed and
+            # replay a stale clean result. `seen` breaks the cycles that
+            # following links can introduce.
+            seen: set[str] = set()
+            for dirpath, dirnames, filenames in os.walk(path, followlinks=True):
+                real = os.path.realpath(dirpath)
+                if real in seen:
+                    # Already walked via another route; don't recurse forever.
+                    dirnames[:] = []
+                    continue
+                seen.add(real)
                 # Sort in place so that os.walk descends deterministically.
                 dirnames.sort()
                 for filename in sorted(filenames):
                     full = os.path.join(dirpath, filename)
-                    hash_strings(hasher, "entry", os.path.relpath(full, path))
-                    try:
-                        hash_file_bytes(full, hasher)
-                    except OSError as err:
-                        # An unreadable file folds the error into the digest
-                        # rather than being treated as though it were absent.
-                        hash_strings(hasher, "unreadable", str(err))
+                    hash_strings(
+                        hasher,
+                        "entry",
+                        os.path.relpath(full, path),
+                        _file_digest(full),
+                    )
         else:
             hash_strings(hasher, "missing", "")
+    return hasher.hexdigest()
+
+
+def _file_digest(fname: str) -> str:
+    """Digest one file's contents, or the reason it could not be read.
+
+    Returned as a fixed-length string and fed through `hash_strings` rather
+    than streamed into the caller's hasher directly. Raw bytes carry no
+    boundary, so a file whose contents happened to look like the encoding of a
+    following entry could make an added file leave the hash input unchanged.
+    """
+    hasher = hashlib.sha256()
+    try:
+        hash_file_bytes(fname, hasher)
+    except OSError as err:
+        # An unreadable file folds the error into the digest rather than being
+        # treated as though it were absent.
+        return f"unreadable:{err}"
     return hasher.hexdigest()

--- a/src/sqlfluff/core/helpers/hashing.py
+++ b/src/sqlfluff/core/helpers/hashing.py
@@ -1,0 +1,96 @@
+"""Hashing helpers used to fingerprint inputs to a lint run.
+
+These live outside the linter package because templaters need them too, and a
+templater should not have to import the linter in order to describe what it
+reads.
+
+Everything here is about producing digests which are *stable* (the same inputs
+always give the same digest, in this process and the next) and *sensitive* (any
+change to the inputs changes the digest). They are not used for anything
+security related: the goal is to detect accidental staleness, not to resist an
+adversary.
+"""
+
+import hashlib
+import os
+
+#: Read files in chunks so that a very large file isn't held in memory purely
+#: to be fingerprinted.
+HASH_CHUNK_SIZE = 1024 * 1024
+
+
+def hash_file_bytes(fname: str, hasher: "hashlib._Hash") -> None:
+    """Feed the raw bytes of a file into a hasher.
+
+    We deliberately hash *bytes* rather than decoded text. Encoding detection
+    is itself configuration dependent, so hashing bytes means that a change of
+    encoding is necessarily a change of digest.
+    """
+    with open(fname, "rb") as f:
+        while True:
+            chunk = f.read(HASH_CHUNK_SIZE)
+            if not chunk:
+                break
+            hasher.update(chunk)
+
+
+def hash_strings(hasher: "hashlib._Hash", *values: str) -> None:
+    """Feed length delimited strings into a hasher.
+
+    Delimiting means that ``("ab", "c")`` and ``("a", "bc")`` produce different
+    digests, so two distinct inputs cannot be made to collide simply by moving
+    a boundary between them.
+    """
+    for value in values:
+        encoded = value.encode("utf-8", errors="backslashreplace")
+        hasher.update(str(len(encoded)).encode("ascii"))
+        hasher.update(b"\0")
+        hasher.update(encoded)
+        hasher.update(b"\0")
+
+
+def hash_path_contents(paths: list[str]) -> str:
+    """Return a stable digest of the contents of a set of files or directories.
+
+    This is the building block templaters use to fingerprint the external files
+    they read (Jinja macro directories, python library directories and so on).
+    Directories are walked in sorted order and every file within contributes
+    both its relative path and its contents, so adding, removing, renaming or
+    editing any file changes the digest.
+
+    A path which does not exist contributes a marker rather than being ignored,
+    so that creating it later is also a change.
+
+    Args:
+        paths: The paths to fingerprint, in a meaningful order. Order is part
+            of the digest, because search order can affect how a template
+            resolves.
+
+    Returns:
+        A hex digest of the contents of all the given paths.
+    """
+    hasher = hashlib.sha256()
+    for path in paths:
+        # The configured path is part of the digest in its own right: two
+        # directories with identical contents are not interchangeable, because
+        # a template may refer to one of them by name.
+        hash_strings(hasher, "path", path)
+        if os.path.isfile(path):
+            hash_strings(hasher, "file", "")
+            hash_file_bytes(path, hasher)
+        elif os.path.isdir(path):
+            for dirpath, dirnames, filenames in os.walk(path):
+                # Sort in place so that os.walk descends deterministically.
+                dirnames.sort()
+                for filename in sorted(filenames):
+                    full = os.path.join(dirpath, filename)
+                    hash_strings(hasher, "entry", os.path.relpath(full, path))
+                    try:
+                        hash_file_bytes(full, hasher)
+                    except OSError as err:
+                        # An unreadable file folds the error into the digest
+                        # rather than being treated as though it were absent.
+                        hash_strings(hasher, "unreadable", str(err))
+        else:
+            hash_strings(hasher, "missing", "")
+    return hasher.hexdigest()

--- a/src/sqlfluff/core/helpers/hashing.py
+++ b/src/sqlfluff/core/helpers/hashing.py
@@ -95,7 +95,17 @@ def hash_path_contents(paths: list[str]) -> str:
             for dirpath, dirnames, filenames in os.walk(path, followlinks=True):
                 real = os.path.realpath(dirpath)
                 if real in seen:
-                    # Already walked via another route; don't recurse forever.
+                    # Reached by another route already, so its contents are in
+                    # the digest and re-walking would not terminate on a cycle.
+                    #
+                    # The *name* still has to count. A second link to an
+                    # already-walked directory makes those files resolvable
+                    # under a new name -- `{% include "z_alias/m.sql" %}` where
+                    # only `macros/m.sql` existed before -- so adding or
+                    # retargeting the link changes what Jinja can render even
+                    # though no file changed. Recording the alias and where it
+                    # points makes both of those a change of digest.
+                    hash_strings(hasher, "alias", os.path.relpath(dirpath, path), real)
                     dirnames[:] = []
                     continue
                 seen.add(real)

--- a/src/sqlfluff/core/linter/cache.py
+++ b/src/sqlfluff/core/linter/cache.py
@@ -1,0 +1,488 @@
+"""Persistent caching of lint results between runs.
+
+Linting a file is expensive: it is templated, lexed, parsed and then walked
+once per rule. For a project of any size most files are unchanged between one
+invocation and the next -- the classic case being ``sqlfluff lint`` run from a
+pre-commit hook -- and so all of that work is repeated for no benefit.
+
+This module implements an opt-in, on-disk cache which allows those files to be
+skipped entirely. The design is deliberately conservative:
+
+* **Only clean files are cached.** An entry is written only for a file which
+  produced *no* violations at all (not even warnings, and not templating or
+  parsing errors). Anything with something to report is always re-linted, so
+  the cache can never suppress a diagnostic the user has not already resolved.
+* **A hit must be provably equivalent.** The key covers everything which can
+  change the result for a file: the SQLFluff version, the set of installed
+  plugins, the file's fully resolved configuration, the state the templater
+  reads from outside the file, and the bytes of the file itself.
+* **Caching is opt-in per templater.** ``RawTemplater.cache_fingerprint()``
+  returns ``None`` by default, which disables caching. A templater has to
+  positively declare what external state it reads before its files become
+  eligible, so a third party templater is never cached by accident.
+* **The cache never changes behaviour on failure.** Any problem reading,
+  writing or keying is logged and degrades to "no cache" for that file or that
+  run. It is never surfaced to the user as an error.
+
+Entries also carry the file statistics (character and segment counts) that
+:class:`~sqlfluff.core.linter.linted_dir.LintedDir` derives from a parsed
+file, so that a cached run produces the same serialised output as an uncached
+one rather than reporting zeroes.
+"""
+
+import hashlib
+import json
+import logging
+import os
+import tempfile
+import time
+from typing import TYPE_CHECKING, Any, Optional, TypedDict
+
+from sqlfluff.core.helpers.hashing import hash_file_bytes, hash_strings
+
+# NOTE: These two are private to `plugin.host`, and reused here deliberately
+# rather than reimplemented. `_discover_plugins` is the single definition of
+# what counts as an installed SQLFluff plugin, and the fingerprint has to agree
+# with it exactly or the cache will miss a plugin the linter is using.
+# `_get_sqlfluff_version` reads the installed distribution metadata directly,
+# which avoids importing the top level `sqlfluff` package from inside it.
+from sqlfluff.core.plugin.host import _discover_plugins, _get_sqlfluff_version
+
+if TYPE_CHECKING:  # pragma: no cover
+    from sqlfluff.core.config import FluffConfig
+
+linter_logger: logging.Logger = logging.getLogger("sqlfluff.linter")
+
+# Bump this whenever the on-disk layout or the meaning of a key changes. A
+# mismatch discards the whole cache rather than risking a stale hit.
+CACHE_SCHEMA_VERSION = 1
+
+#: The default cache directory, resolved relative to the working directory.
+DEFAULT_CACHE_DIR = ".sqlfluff_cache"
+
+#: The file within the cache directory which holds the entries.
+CACHE_FILENAME = "cache.json"
+
+#: Entries not seen for this long are dropped when the cache is written. This
+#: bounds growth as files are renamed or deleted without needing to stat every
+#: path we have ever recorded.
+ENTRY_TTL_SECONDS = 30 * 24 * 60 * 60  # 30 days
+
+#: The statistics keys which a cache entry is expected to carry, in the order
+#: ``file_statistics()`` produces them. The order is preserved on the way in
+#: and out so that a cached record serialises identically to a linted one --
+#: JSON objects keep insertion order, and a reordered ``statistics`` block
+#: would be a visible difference in ``--format json`` output.
+_STATISTICS_KEYS = ("source_chars", "templated_chars", "segments", "raw_segments")
+
+
+class CacheEntry(TypedDict):
+    """A single cached result.
+
+    Attributes:
+        key: The hex digest which must match for this entry to be a hit.
+        statistics: The file statistics recorded by ``LintedDir``, replayed on
+            a hit so that serialised output is unaffected by caching.
+        last_seen: Unix timestamp of the last run which wrote or hit this entry.
+    """
+
+    key: str
+    statistics: dict[str, int]
+    last_seen: int
+
+
+def config_digest(config: "FluffConfig") -> str:
+    """Return a stable digest of a fully resolved config object.
+
+    This uses :meth:`FluffConfig.iter_vals`, which already excludes the derived
+    and non-serialisable entries (``dialect_obj``, ``templater_obj`` and the
+    resolved rule allow/deny lists). Each of those is a pure function of values
+    which *are* included, so excluding them loses no information.
+
+    The type name of each value is included alongside its representation so
+    that, for example, a section label cannot collide with a key whose value is
+    an empty string.
+    """
+    hasher = hashlib.sha256()
+    for indent, key, value in config.iter_vals():
+        hash_strings(hasher, str(indent), key, type(value).__name__, repr(value))
+    return hasher.hexdigest()
+
+
+def run_fingerprint() -> str:
+    """Return a digest of the state which invalidates the *whole* cache.
+
+    That is the SQLFluff version plus the name and version of every installed
+    SQLFluff plugin. A change to any of those can change the result for every
+    file, so rather than repeating it in each key we store it once in the cache
+    header and discard the file when it moves.
+    """
+    hasher = hashlib.sha256()
+    hash_strings(hasher, "schema", str(CACHE_SCHEMA_VERSION))
+    hash_strings(hasher, "sqlfluff", _get_sqlfluff_version())
+    try:
+        plugins = sorted((name, version) for _, name, version in _discover_plugins())
+    except Exception as err:  # pragma: no cover
+        # Plugin discovery walks installed distributions and so can fail on a
+        # broken environment. Fold the failure into the digest: it is stable
+        # for as long as the failure is, and changes when it is fixed.
+        linter_logger.debug("Cache: plugin discovery failed: %s", err)
+        plugins = [("<discovery-failed>", str(err))]
+    for name, version in plugins:
+        hash_strings(hasher, "plugin", name, version)
+    return hasher.hexdigest()
+
+
+def _coerce_entry(value: Any) -> Optional[CacheEntry]:
+    """Validate one deserialised entry, returning None if it is not usable.
+
+    The cache file is ordinary JSON on disk which a user may have truncated,
+    hand edited or shared between incompatible versions. Every field is checked
+    rather than trusted, because a malformed entry that we accepted could cause
+    a file to be silently skipped.
+    """
+    if not isinstance(value, dict):
+        return None
+    key = value.get("key")
+    statistics = value.get("statistics")
+    last_seen = value.get("last_seen")
+    if not isinstance(key, str) or not key:
+        return None
+    # NOTE: `isinstance(True, int)` is True, so booleans are excluded
+    # explicitly. They should never appear, but a hand edited file might.
+    if not isinstance(last_seen, int) or isinstance(last_seen, bool):
+        return None
+    if not isinstance(statistics, dict):
+        return None
+    if set(statistics) != set(_STATISTICS_KEYS):
+        return None
+    if not all(
+        isinstance(v, int) and not isinstance(v, bool) for v in statistics.values()
+    ):
+        return None
+    return CacheEntry(
+        key=key,
+        # Rebuild in canonical order rather than trusting the order in the
+        # file, so that a hand edited cache cannot change output ordering.
+        statistics={k: statistics[k] for k in _STATISTICS_KEYS},
+        last_seen=last_seen,
+    )
+
+
+class LintCache:
+    """An on-disk cache of files which linted clean.
+
+    A cache is only useful across runs, so the lifecycle is:
+
+    #. :meth:`load` reads and validates any existing cache file.
+    #. :meth:`check` is called once per file *before* linting. A hit returns
+       the statistics to replay; a miss returns ``None`` and retains the key it
+       computed from the file as it stood before the run touched it.
+    #. :meth:`record` is called for each file which linted clean. It stores a
+       result only if the file still matches that key, so an entry is always
+       backed by a lint of exactly the contents it names.
+    #. :meth:`persist` writes the file back atomically.
+
+    All of this happens in the main process. Workers never touch the cache, so
+    parallel linting needs no coordination.
+    """
+
+    def __init__(self, cache_dir: str, root_config: "FluffConfig") -> None:
+        self.cache_dir = cache_dir
+        self.cache_path = os.path.join(cache_dir, CACHE_FILENAME)
+        self.root_config = root_config
+        self.run_fingerprint = run_fingerprint()
+        self._entries: dict[str, CacheEntry] = {}
+        # Keys computed during `check`, so that `record` can require the file
+        # to be unchanged since before it was linted.
+        self._pending_keys: dict[str, str] = {}
+        # Everything a key needs from a file's configuration, memoised per
+        # *directory* for the run. `make_child_from_path` builds a whole
+        # `FluffConfig`, which expands a fresh dialect object every time;
+        # measured at tens of milliseconds per call, it would otherwise
+        # dominate the cost of a lookup and undo most of the benefit of a hit.
+        # What it resolves depends only on the file's directory (config files
+        # are discovered by walking directories), so one entry per directory is
+        # exact rather than approximate.
+        #
+        # Only the derived strings are kept, never the `FluffConfig` itself, so
+        # the expanded dialect it holds is released instead of being pinned for
+        # the run once per directory in the project.
+        #
+        # NOTE: Inline `-- sqlfluff:` directives are deliberately not applied
+        # here. The linter applies them after reading the file, and they live
+        # in the file's own bytes, which the key already covers.
+        self._directory_keys: dict[str, Optional[tuple[str, str, str]]] = {}
+        # Templater fingerprints, memoised for the duration of the run and
+        # keyed on the config rather than the directory, so that directories
+        # which share a config also share the work. Computing one can mean
+        # walking whole directory trees. Memoising here rather than inside the
+        # templater keeps the lifetime tied to a single run, so a long lived
+        # process which lints, edits a macro, and lints again still sees the
+        # change.
+        self._templater_digests: dict[tuple[str, str], Optional[str]] = {}
+        # Cleared when a write fails; the cache then degrades to a no-op rather
+        # than repeatedly retrying an operation we know is broken.
+        self._writable = True
+        self.hits = 0
+        self.misses = 0
+
+    # ### Construction
+
+    @classmethod
+    def from_config(cls, config: "FluffConfig") -> Optional["LintCache"]:
+        """Build a cache from config, or return None if caching is disabled.
+
+        Returns ``None`` (rather than an inert cache) when caching is off, so
+        that callers can skip the per-file key work entirely.
+        """
+        if not config.get("cache", default=False):
+            return None
+        cache_dir = config.get("cache_dir", default=DEFAULT_CACHE_DIR)
+        if not cache_dir:  # pragma: no cover
+            cache_dir = DEFAULT_CACHE_DIR
+        cache = cls(os.path.abspath(str(cache_dir)), config)
+        cache.load()
+        return cache
+
+    # ### Loading and persisting
+
+    def load(self) -> None:
+        """Read the cache file, tolerating anything unexpected.
+
+        A cache which cannot be read is simply an empty cache. This covers a
+        first run, a truncated file, a file written by a different schema
+        version, and a file written by a different SQLFluff or plugin version.
+        """
+        try:
+            with open(self.cache_path, encoding="utf-8") as f:
+                payload = json.load(f)
+        except FileNotFoundError:
+            linter_logger.debug("Cache: no existing cache at %s", self.cache_path)
+            return
+        except (OSError, ValueError) as err:
+            linter_logger.debug("Cache: discarding unreadable cache: %s", err)
+            return
+
+        if not isinstance(payload, dict):
+            linter_logger.debug("Cache: discarding cache with unexpected structure.")
+            return
+        if payload.get("schema_version") != CACHE_SCHEMA_VERSION:
+            linter_logger.debug("Cache: discarding cache from a different schema.")
+            return
+        if payload.get("run_fingerprint") != self.run_fingerprint:
+            linter_logger.debug(
+                "Cache: discarding cache from a different sqlfluff or plugin set."
+            )
+            return
+        entries = payload.get("entries")
+        if not isinstance(entries, dict):
+            linter_logger.debug("Cache: discarding cache with unexpected entries.")
+            return
+
+        for path, raw_entry in entries.items():
+            if not isinstance(path, str):  # pragma: no cover
+                continue
+            entry = _coerce_entry(raw_entry)
+            if entry is not None:
+                self._entries[path] = entry
+        linter_logger.debug("Cache: loaded %s entries.", len(self._entries))
+
+    def persist(self) -> None:
+        """Write the cache back to disk atomically.
+
+        The file is written to a temporary file in the same directory and then
+        moved into place, so a concurrent reader sees either the old file or
+        the new one and never a partial write. Two runs writing at once resolve
+        as last-writer-wins, which is safe: a lost write only costs a miss on
+        the next run.
+        """
+        if not self._writable:
+            return
+        now = int(time.time())
+        cutoff = now - ENTRY_TTL_SECONDS
+        entries = {
+            path: entry
+            for path, entry in self._entries.items()
+            if entry["last_seen"] >= cutoff
+        }
+        payload = {
+            "schema_version": CACHE_SCHEMA_VERSION,
+            "run_fingerprint": self.run_fingerprint,
+            "entries": entries,
+        }
+        try:
+            os.makedirs(self.cache_dir, exist_ok=True)
+            self._write_gitignore()
+            # An explicit mkstemp plus os.replace is the portable way to get an
+            # atomic swap: on Windows os.replace cannot act on an open handle,
+            # so the temporary file has to be closed first.
+            fd, tmp_path = tempfile.mkstemp(dir=self.cache_dir, suffix=".tmp")
+            try:
+                with os.fdopen(fd, "w", encoding="utf-8") as f:
+                    json.dump(payload, f)
+                os.replace(tmp_path, self.cache_path)
+            except BaseException:
+                # Never leave a stray temporary file behind, including on
+                # KeyboardInterrupt.
+                try:
+                    os.unlink(tmp_path)
+                except OSError:  # pragma: no cover
+                    pass
+                raise
+        except Exception as err:
+            # Broader than the OSError we expect from a read-only or full
+            # filesystem, deliberately: this runs at the very end of a lint
+            # run, and failing to save an optimisation must never be the thing
+            # that loses the user their results. `BaseException` is not caught,
+            # so Ctrl-C still stops the run.
+            linter_logger.warning("Unable to write sqlfluff cache: %s", err)
+            self._writable = False
+            return
+        linter_logger.debug("Cache: wrote %s entries.", len(entries))
+
+    def _write_gitignore(self) -> None:
+        """Make the cache directory self-ignoring for git.
+
+        Users should not have to remember to add the cache directory to their
+        ``.gitignore``, and a cache accidentally committed to a repository is
+        both noise and a source of confusing hits.
+        """
+        gitignore_path = os.path.join(self.cache_dir, ".gitignore")
+        if os.path.exists(gitignore_path):
+            return
+        try:
+            with open(gitignore_path, "w", encoding="utf-8") as f:
+                f.write("# Created automatically by sqlfluff.\n*\n")
+        except OSError as err:  # pragma: no cover
+            # Not being able to write this is not a reason to give up on the
+            # cache itself.
+            linter_logger.debug("Cache: could not write .gitignore: %s", err)
+
+    # ### Keying
+
+    @staticmethod
+    def _normalise(fname: str) -> str:
+        """Normalise a path for use as a cache key.
+
+        Absolute paths mean the cache is unambiguous regardless of the working
+        directory a run was launched from. It also means the cache is specific
+        to one checkout, which is the intent: it is a local build artefact.
+        """
+        return os.path.normcase(os.path.abspath(fname))
+
+    def _directory_key(self, fname: str) -> Optional[tuple[str, str, str]]:
+        """Config-derived key parts for the directory containing a file.
+
+        Returns ``(templater name, templater fingerprint, config digest)``, or
+        ``None`` if files in this directory cannot be cached. Memoised: see
+        `_directory_keys`.
+        """
+        # Normalised so that two spellings of the same directory share an
+        # entry rather than each paying for their own resolution.
+        dirname = os.path.dirname(self._normalise(fname))
+        if dirname in self._directory_keys:
+            return self._directory_keys[dirname]
+
+        result: Optional[tuple[str, str, str]] = None
+        file_config = self.root_config.make_child_from_path(fname)
+        templater = file_config.get("templater_obj")
+        if templater is not None:
+            cfg_digest = config_digest(file_config)
+            memo_key = (templater.name, cfg_digest)
+            if memo_key in self._templater_digests:
+                fingerprint = self._templater_digests[memo_key]
+            else:
+                fingerprint = templater.cache_fingerprint(file_config)
+                self._templater_digests[memo_key] = fingerprint
+            if fingerprint is None:
+                # The templater has not declared itself cacheable.
+                linter_logger.debug(
+                    "Cache: templater %r opts out of caching.", templater.name
+                )
+            else:
+                result = (templater.name, fingerprint, cfg_digest)
+
+        self._directory_keys[dirname] = result
+        return result
+
+    def _file_key(self, fname: str) -> Optional[str]:
+        """Compute the cache key for a file, or None if it cannot be cached.
+
+        The key deliberately covers more than the file: two projects can share
+        a file verbatim and still lint it differently.
+        """
+        try:
+            parts = self._directory_key(fname)
+            if parts is None:
+                return None
+            templater_name, fingerprint, cfg_digest = parts
+            hasher = hashlib.sha256()
+            hash_strings(hasher, "run", self.run_fingerprint)
+            hash_strings(hasher, "templater", templater_name, fingerprint)
+            hash_strings(hasher, "config", cfg_digest)
+            hash_file_bytes(fname, hasher)
+            return hasher.hexdigest()
+        except Exception as err:
+            # Config resolution, templater fingerprinting and file reading can
+            # all fail on a project we would otherwise decline to lint. The
+            # cache must not be the thing that reports it: we fall back to
+            # linting the file, which will raise or report properly.
+            linter_logger.debug("Cache: unable to key %r: %s", fname, err)
+            return None
+
+    # ### Use
+
+    def check(self, fname: str) -> Optional[dict[str, int]]:
+        """Return the cached statistics for a file, or None to lint it.
+
+        On a miss the computed key is retained, so that :meth:`record` can
+        require the file to be unchanged before storing a result for it.
+        """
+        key = self._file_key(fname)
+        if key is None:
+            self.misses += 1
+            return None
+        normalised = self._normalise(fname)
+        entry = self._entries.get(normalised)
+        if entry is not None and entry["key"] == key:
+            # Refresh the timestamp so an actively used entry is never aged out.
+            entry["last_seen"] = int(time.time())
+            self.hits += 1
+            return dict(entry["statistics"])
+        self._pending_keys[normalised] = key
+        self.misses += 1
+        return None
+
+    def record(self, fname: str, statistics: dict[str, int]) -> None:
+        """Record that a file linted clean.
+
+        Only ever called for a file which produced no violations at all.
+
+        The key is recomputed here and required to match the one taken in
+        :meth:`check`. That guards the window between the two: if the file were
+        edited while the run was in progress, the key taken before linting and
+        the result produced afterwards would describe different contents, and
+        storing either would be a claim we never actually verified. Requiring
+        the file to be unchanged across the whole run means an entry is always
+        backed by a lint of exactly the contents it names.
+
+        The cost is one extra read and hash per clean file, which is
+        negligible beside the templating, parsing and rule pass it replaces.
+        """
+        normalised = self._normalise(fname)
+        key = self._pending_keys.pop(normalised, None)
+        if key is None:
+            # We never computed a key for this file, which means it is not
+            # cacheable (or `check` was not called). Don't guess.
+            return
+        if self._file_key(fname) != key:
+            linter_logger.debug(
+                "Cache: %r changed while it was being linted; not recording.", fname
+            )
+            return
+        self._entries[normalised] = CacheEntry(
+            key=key,
+            statistics={k: int(statistics.get(k, 0)) for k in _STATISTICS_KEYS},
+            last_seen=int(time.time()),
+        )

--- a/src/sqlfluff/core/linter/cache.py
+++ b/src/sqlfluff/core/linter/cache.py
@@ -339,13 +339,17 @@ class LintCache:
             "entries": entries,
         }
         try:
-            # `exist_ok=False` on the first attempt tells us whether this
-            # directory is ours: see `_write_gitignore`.
-            created = False
-            if not os.path.isdir(self.cache_dir):
-                os.makedirs(self.cache_dir, exist_ok=True)
-                created = True
-            if created:
+            # Whether *this* run created the directory decides whether we may
+            # write a `.gitignore` into it; see `_write_gitignore`. Asking
+            # `makedirs` to fail if it already exists answers that atomically.
+            # Checking `isdir()` first and then creating would not: another
+            # process can win the race in between, and we would then claim a
+            # directory we did not make.
+            try:
+                os.makedirs(self.cache_dir, exist_ok=False)
+            except FileExistsError:
+                pass
+            else:
                 self._write_gitignore()
             # An explicit mkstemp plus os.replace is the portable way to get an
             # atomic swap: on Windows os.replace cannot act on an open handle,

--- a/src/sqlfluff/core/linter/cache.py
+++ b/src/sqlfluff/core/linter/cache.py
@@ -36,6 +36,7 @@ import logging
 import os
 import tempfile
 import time
+from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any, Optional, TypedDict
 
 from sqlfluff.core.helpers.hashing import hash_file_bytes, hash_strings
@@ -156,8 +157,11 @@ def _coerce_entry(value: Any) -> Optional[CacheEntry]:
         return None
     if set(statistics) != set(_STATISTICS_KEYS):
         return None
+    # Counts of characters and segments; a negative one could only come from a
+    # hand edited file, and would be replayed straight into `--format json`.
     if not all(
-        isinstance(v, int) and not isinstance(v, bool) for v in statistics.values()
+        isinstance(v, int) and not isinstance(v, bool) and v >= 0
+        for v in statistics.values()
     ):
         return None
     return CacheEntry(
@@ -230,13 +234,36 @@ class LintCache:
     # ### Construction
 
     @classmethod
-    def from_config(cls, config: "FluffConfig") -> Optional["LintCache"]:
+    def from_config(
+        cls, config: "FluffConfig", user_rules: Optional[Sequence[Any]] = None
+    ) -> Optional["LintCache"]:
         """Build a cache from config, or return None if caching is disabled.
 
         Returns ``None`` (rather than an inert cache) when caching is off, so
         that callers can skip the per-file key work entirely.
+
+        Args:
+            config: The root config for the run.
+            user_rules: Rule classes passed programmatically to
+                :class:`Linter`. Their presence disables caching entirely; see
+                below.
+
+        Caching is declined outright when an API caller has supplied
+        ``Linter(user_rules=...)``. Every other input to a lint result can be
+        identified by something stable -- a file by its bytes, config by its
+        values, a plugin by its version -- but a rule class handed to us
+        in-process has no such identity. Its *name* would not change when its
+        body did, so keying on it would let an edited rule be masked by a
+        cached clean result. Declining is the same trade made for templaters
+        which do not declare what they read.
         """
         if not config.get("cache", default=False):
+            return None
+        if user_rules:
+            linter_logger.warning(
+                "Lint caching is disabled because this Linter was given "
+                "custom rules, whose definitions cannot be fingerprinted."
+            )
             return None
         cache_dir = config.get("cache_dir", default=DEFAULT_CACHE_DIR)
         if not cache_dir:  # pragma: no cover
@@ -312,8 +339,14 @@ class LintCache:
             "entries": entries,
         }
         try:
-            os.makedirs(self.cache_dir, exist_ok=True)
-            self._write_gitignore()
+            # `exist_ok=False` on the first attempt tells us whether this
+            # directory is ours: see `_write_gitignore`.
+            created = False
+            if not os.path.isdir(self.cache_dir):
+                os.makedirs(self.cache_dir, exist_ok=True)
+                created = True
+            if created:
+                self._write_gitignore()
             # An explicit mkstemp plus os.replace is the portable way to get an
             # atomic swap: on Windows os.replace cannot act on an open handle,
             # so the temporary file has to be closed first.
@@ -347,9 +380,15 @@ class LintCache:
         Users should not have to remember to add the cache directory to their
         ``.gitignore``, and a cache accidentally committed to a repository is
         both noise and a source of confusing hits.
+
+        Only called for a directory this run just created. ``cache_dir`` is
+        user-configurable and may point somewhere that already exists and holds
+        other things; dropping a ``.gitignore`` containing ``*`` into a
+        directory we did not make would silently hide the user's own untracked
+        files from git.
         """
         gitignore_path = os.path.join(self.cache_dir, ".gitignore")
-        if os.path.exists(gitignore_path):
+        if os.path.exists(gitignore_path):  # pragma: no cover
             return
         try:
             with open(gitignore_path, "w", encoding="utf-8") as f:
@@ -486,3 +525,14 @@ class LintCache:
             statistics={k: int(statistics.get(k, 0)) for k in _STATISTICS_KEYS},
             last_seen=int(time.time()),
         )
+
+    def forget(self, fname: str) -> None:
+        """Drop the pending key for a file which will not be recorded.
+
+        `check` holds a key for every miss so that `record` can verify it. For
+        a file which turns out not to be cacheable that key is never claimed,
+        and on a project where most files have violations -- exactly the
+        projects which get no benefit from the cache -- holding one per file
+        for the whole run is wasted memory.
+        """
+        self._pending_keys.pop(self._normalise(fname), None)

--- a/src/sqlfluff/core/linter/linted_dir.py
+++ b/src/sqlfluff/core/linter/linted_dir.py
@@ -85,13 +85,18 @@ class LintedDir:
         self.step_timings: list[dict[str, float]] = []
         self.rule_timings: list[tuple[str, str, float]] = []
 
-    def add(self, file: LintedFile) -> None:
+    def add(self, file: LintedFile) -> dict[str, int]:
         """Add a file to this path.
 
         This function _always_ updates the metadata tracking, but may
         or may not persist the `file` object itself depending on the
         `retain_files` argument given on instantiation.
+
+        Returns the file statistics it derived, so that a caller which needs
+        them too (the lint cache) can reuse them rather than walking the parse
+        tree a second time. Existing callers can ignore the return value.
         """
+        statistics = file_statistics(file)
         # Generate serialised violations.
         violation_records = sorted(
             # Keep the warnings
@@ -103,7 +108,7 @@ class LintedDir:
         record: LintingRecord = {
             "filepath": file.path,
             "violations": violation_records,
-            "statistics": file_statistics(file),
+            "statistics": statistics,
             "timings": {},
         }
 
@@ -148,14 +153,18 @@ class LintedDir:
         if self.retain_files:
             self.files.append(file)
 
+        return statistics
+
     def add_cached_clean(self, path: str, statistics: dict[str, int]) -> None:
         """Record a file which was skipped because it was cached as clean.
 
         This is the counterpart to :meth:`add` for a file we deliberately did
         not lint. It updates exactly the metadata that `add` would have for a
         file with no violations, and replays the statistics recorded when the
-        file was last linted, so that serialised output (`--format json`,
-        `--persist-timing`) is unchanged by caching.
+        file was last linted, so that the violations and statistics in
+        serialised output are unchanged by caching. Timings are the one
+        exception, and are covered below -- a `--persist-timing` row for a
+        cached file has its statistics but blank timing columns.
 
         Two things are deliberately *not* replayed:
 

--- a/src/sqlfluff/core/linter/linted_dir.py
+++ b/src/sqlfluff/core/linter/linted_dir.py
@@ -29,6 +29,31 @@ class LintingRecord(TypedDict):
     timings: dict[str, float]
 
 
+def file_statistics(file: LintedFile) -> dict[str, int]:
+    """Derive the size statistics reported for a linted file.
+
+    Factored out of :meth:`LintedDir.add` so that the lint cache can store
+    exactly these values and replay them on a hit, without the two definitions
+    being able to drift apart.
+
+    These are all pure functions of the file's contents and config, which is
+    what makes them safe to replay: the same cache key implies the same
+    statistics.
+    """
+    return {
+        "source_chars": (
+            len(file.templated_file.source_str) if file.templated_file else 0
+        ),
+        "templated_chars": (
+            len(file.templated_file.templated_str) if file.templated_file else 0
+        ),
+        # These are all the segments in the tree
+        "segments": (file.tree.count_segments(raw_only=False) if file.tree else 0),
+        # These are just the "leaf" nodes of the tree
+        "raw_segments": (file.tree.count_segments(raw_only=True) if file.tree else 0),
+    }
+
+
 class LintedDir:
     """A class to store the idea of a collection of linted files at a single start path.
 
@@ -78,22 +103,7 @@ class LintedDir:
         record: LintingRecord = {
             "filepath": file.path,
             "violations": violation_records,
-            "statistics": {
-                "source_chars": (
-                    len(file.templated_file.source_str) if file.templated_file else 0
-                ),
-                "templated_chars": (
-                    len(file.templated_file.templated_str) if file.templated_file else 0
-                ),
-                # These are all the segments in the tree
-                "segments": (
-                    file.tree.count_segments(raw_only=False) if file.tree else 0
-                ),
-                # These are just the "leaf" nodes of the tree
-                "raw_segments": (
-                    file.tree.count_segments(raw_only=True) if file.tree else 0
-                ),
-            },
+            "statistics": file_statistics(file),
             "timings": {},
         }
 
@@ -137,6 +147,40 @@ class LintedDir:
         # Finally, if set to persist files, do that.
         if self.retain_files:
             self.files.append(file)
+
+    def add_cached_clean(self, path: str, statistics: dict[str, int]) -> None:
+        """Record a file which was skipped because it was cached as clean.
+
+        This is the counterpart to :meth:`add` for a file we deliberately did
+        not lint. It updates exactly the metadata that `add` would have for a
+        file with no violations, and replays the statistics recorded when the
+        file was last linted, so that serialised output (`--format json`,
+        `--persist-timing`) is unchanged by caching.
+
+        Two things are deliberately *not* replayed:
+
+        * There is no :class:`LintedFile`, and so nothing is appended to
+          ``self.files``. A cache hit means the file was never templated or
+          parsed, so there is no tree to retain. API consumers which need
+          ``.files`` or ``.tree`` should not enable the cache.
+        * Timings are empty rather than being replayed from the earlier run.
+          Reporting the cost of work which did not happen this time would make
+          `--persist-timing` output actively misleading.
+        """
+        record: LintingRecord = {
+            "filepath": path,
+            "violations": [],
+            "statistics": dict(statistics),
+            "timings": {},
+        }
+        self._records.append(record)
+        self._num_files += 1
+        self._num_clean += 1
+        # A cached file had no violations of any kind, so every violation
+        # counter is unchanged. The map is still populated because
+        # `discard_fixes_for_lint_errors_in_files_with_tmp_or_prs_errors`
+        # indexes it by the filepath of every record.
+        self._unfiltered_tmp_prs_errors_map[path] = 0
 
     def check_tuples(
         self, raise_on_non_linting_violations: bool = True

--- a/src/sqlfluff/core/linter/linted_file.py
+++ b/src/sqlfluff/core/linter/linted_file.py
@@ -192,6 +192,28 @@ class LintedFile(NamedTuple):
         """Return True if there are no ignorable violations."""
         return not any(self.get_violations(filter_ignore=True))
 
+    def is_cacheable(self) -> bool:
+        """Return True if this result can safely be replayed from a cache.
+
+        This is a stricter test than :meth:`is_clean`, because a cached file is
+        not linted at all on the next run: whatever this file would have
+        produced under *any* combination of filters has to be nothing.
+
+        Passing ``filter_ignore=False`` matters because an ignored templating
+        or parsing error still contributes to ``num_unfiltered_tmp_prs_errors``,
+        which in turn drives the exit code of ``sqlfluff fix``. Passing
+        ``warn_unused_ignores=True`` matters because those warnings are
+        generated from the ignore mask on demand rather than living in
+        ``self.violations``, so a file whose only finding is an unused
+        ``-- noqa`` would otherwise look empty here and lose its warning on the
+        next run.
+        """
+        return not self.get_violations(
+            filter_ignore=False,
+            filter_warning=False,
+            warn_unused_ignores=True,
+        )
+
     def fix_string(self) -> tuple[str, bool]:
         """Obtain the changes to a path as a string.
 

--- a/src/sqlfluff/core/linter/linted_file.py
+++ b/src/sqlfluff/core/linter/linted_file.py
@@ -166,7 +166,12 @@ class LintedFile(NamedTuple):
             violations = [v for v in violations if not v.warning]
         # Add warnings for unneeded noqa if applicable
         if warn_unused_ignores and not filter_warning and self.ignore_mask:
-            violations += self.ignore_mask.generate_warnings_for_unused()
+            # NOTE: Rebind rather than `+=`. Every filter above builds a new
+            # list, but when none of them apply `violations` is still the
+            # *same object* as `self.violations`, and an in-place extend would
+            # append the generated warnings to the file's own violation list.
+            # That would be permanent, and would repeat on every call.
+            violations = violations + self.ignore_mask.generate_warnings_for_unused()
         return violations
 
     def num_violations(

--- a/src/sqlfluff/core/linter/linter.py
+++ b/src/sqlfluff/core/linter/linter.py
@@ -21,6 +21,7 @@ from sqlfluff.core.errors import (
 )
 from sqlfluff.core.formatter import FormatterInterface
 from sqlfluff.core.helpers.file import get_encoding
+from sqlfluff.core.linter.cache import LintCache
 from sqlfluff.core.linter.common import (
     ParsedString,
     ParsedVariant,
@@ -29,7 +30,7 @@ from sqlfluff.core.linter.common import (
 )
 from sqlfluff.core.linter.discovery import paths_from_path
 from sqlfluff.core.linter.fix import apply_fixes, compute_anchor_edit_info
-from sqlfluff.core.linter.linted_dir import LintedDir
+from sqlfluff.core.linter.linted_dir import LintedDir, file_statistics
 from sqlfluff.core.linter.linted_file import (
     TMP_PRS_ERROR_TYPES,
     FileTimings,
@@ -1173,13 +1174,46 @@ class Linter:
                 expanded_paths.append(fname)
                 expanded_path_to_linted_dir[fname] = linted_dir
 
+        # Consult the cache, if one is configured, before doing any work.
+        # Files which linted clean under an identical key on a previous run are
+        # recorded straight into their `LintedDir` and never reach the runner.
+        # NOTE: This happens before the process count and progress bar are
+        # sized, so that a run which is mostly cache hits doesn't pay for a
+        # process pool it has no work for.
+        # NOTE: Skipped entirely when there is nothing to lint. Building the
+        # cache reads the cache file and enumerates installed plugins, which is
+        # not worth doing for a path which turned out to contain no SQL.
+        cache = LintCache.from_config(self.config) if expanded_paths else None
+        if cache:
+            uncached_paths: list[str] = []
+            for fname in expanded_paths:
+                statistics = cache.check(fname)
+                if statistics is None:
+                    uncached_paths.append(fname)
+                else:
+                    expanded_path_to_linted_dir[fname].add_cached_clean(
+                        fname, statistics
+                    )
+            result.files_cached = len(expanded_paths) - len(uncached_paths)
+            if result.files_cached:
+                linter_logger.info(
+                    "Skipped %s file(s) already cached as clean.", result.files_cached
+                )
+                if self.formatter:
+                    self.formatter.dispatch_cache_summary(
+                        result.files_cached, len(uncached_paths)
+                    )
+            expanded_paths = uncached_paths
+
         files_count = len(expanded_paths)
         if processes is None:
             processes = self.config.get("processes", default=1)
         assert processes is not None
-        # Hard set processes to 1 if only 1 file is queued.
-        # The overhead will never be worth it with one file.
-        if files_count == 1:
+        # Hard set processes to 1 if at most 1 file is queued.
+        # The overhead will never be worth it with one file, and with none at
+        # all (every file served from the cache, or a path with no SQL in it)
+        # a pool would be built and torn down for no work whatsoever.
+        if files_count <= 1:
             processes = 1
 
         # to avoid circular import
@@ -1209,6 +1243,18 @@ class Linter:
             for i, linted_file in enumerate(runner_iterator, start=1):
                 linted_dir = expanded_path_to_linted_dir[linted_file.path]
                 linted_dir.add(linted_file)
+                if cache and linted_file.is_cacheable():
+                    # Record before any fixes are applied below. A cacheable
+                    # file has nothing to fix, so it is not about to be
+                    # rewritten, and the key computed from its contents before
+                    # linting still describes what is on disk.
+                    #
+                    # NOTE: There is deliberately no `else` clearing the entry
+                    # for a file which is *not* cacheable. An entry states
+                    # "content with this key linted clean", which does not stop
+                    # being true when the file changes; dropping it would only
+                    # throw away a valid answer for a later revert.
+                    cache.record(linted_file.path, file_statistics(linted_file))
                 # If any fatal errors, then stop iteration.
                 if any(v.fatal for v in linted_file.violations):  # pragma: no cover
                     linter_logger.error("Fatal linting error. Halting further linting.")
@@ -1242,6 +1288,11 @@ class Linter:
 
         # Transfer skipped file count from the runner to the result.
         result.files_skipped = runner.skipped_file_count
+        if cache:
+            # Write once, at the end, from the main process. Doing it here
+            # rather than incrementally means an interrupted run leaves the
+            # previous cache intact rather than a partially updated one.
+            cache.persist()
         result.stop_timer()
         return result
 

--- a/src/sqlfluff/core/linter/linter.py
+++ b/src/sqlfluff/core/linter/linter.py
@@ -30,7 +30,7 @@ from sqlfluff.core.linter.common import (
 )
 from sqlfluff.core.linter.discovery import paths_from_path
 from sqlfluff.core.linter.fix import apply_fixes, compute_anchor_edit_info
-from sqlfluff.core.linter.linted_dir import LintedDir, file_statistics
+from sqlfluff.core.linter.linted_dir import LintedDir
 from sqlfluff.core.linter.linted_file import (
     TMP_PRS_ERROR_TYPES,
     FileTimings,
@@ -1183,7 +1183,11 @@ class Linter:
         # NOTE: Skipped entirely when there is nothing to lint. Building the
         # cache reads the cache file and enumerates installed plugins, which is
         # not worth doing for a path which turned out to contain no SQL.
-        cache = LintCache.from_config(self.config) if expanded_paths else None
+        cache = (
+            LintCache.from_config(self.config, user_rules=self.user_rules)
+            if expanded_paths
+            else None
+        )
         if cache:
             uncached_paths: list[str] = []
             for fname in expanded_paths:
@@ -1242,19 +1246,26 @@ class Linter:
         try:
             for i, linted_file in enumerate(runner_iterator, start=1):
                 linted_dir = expanded_path_to_linted_dir[linted_file.path]
-                linted_dir.add(linted_file)
-                if cache and linted_file.is_cacheable():
-                    # Record before any fixes are applied below. A cacheable
-                    # file has nothing to fix, so it is not about to be
-                    # rewritten, and the key computed from its contents before
-                    # linting still describes what is on disk.
-                    #
-                    # NOTE: There is deliberately no `else` clearing the entry
-                    # for a file which is *not* cacheable. An entry states
-                    # "content with this key linted clean", which does not stop
-                    # being true when the file changes; dropping it would only
-                    # throw away a valid answer for a later revert.
-                    cache.record(linted_file.path, file_statistics(linted_file))
+                # NOTE: `add` returns the statistics it derived, which the
+                # cache reuses rather than walking the parse tree again.
+                statistics = linted_dir.add(linted_file)
+                if cache:
+                    if linted_file.is_cacheable():
+                        # Record before any fixes are applied below. A cacheable
+                        # file has nothing to fix, so it is not about to be
+                        # rewritten, and the key computed from its contents
+                        # before linting still describes what is on disk.
+                        #
+                        # NOTE: There is deliberately no clearing of an existing
+                        # *entry* for a file which is not cacheable. An entry
+                        # states "content with this key linted clean", which
+                        # does not stop being true when the file changes;
+                        # dropping it would only throw away a valid answer for
+                        # a later revert.
+                        cache.record(linted_file.path, statistics)
+                    else:
+                        # Release the pending key, which will never be claimed.
+                        cache.forget(linted_file.path)
                 # If any fatal errors, then stop iteration.
                 if any(v.fatal for v in linted_file.violations):  # pragma: no cover
                     linter_logger.error("Fatal linting error. Halting further linting.")

--- a/src/sqlfluff/core/linter/linting_result.py
+++ b/src/sqlfluff/core/linter/linting_result.py
@@ -43,6 +43,10 @@ class LintingResult:
         self._start_time: float = time.monotonic()
         self.total_time: float = 0.0
         self.files_skipped: int = 0
+        # The number of files which were not linted because a cache entry
+        # showed they were already clean. Reported by the CLI so that a
+        # surprisingly fast run is explainable.
+        self.files_cached: int = 0
 
     def add(self, path: LintedDir) -> None:
         """Add a new `LintedDir` to this result."""

--- a/src/sqlfluff/core/templaters/base.py
+++ b/src/sqlfluff/core/templaters/base.py
@@ -603,6 +603,39 @@ class RawTemplater:
         """
         return isinstance(other, self.__class__)
 
+    def cache_fingerprint(self, config: FluffConfig) -> Optional[str]:
+        """Digest of the state this templater reads from outside the file.
+
+        The lint result cache keys each file on its own contents and its fully
+        resolved config. That is not sufficient on its own, because templating
+        can also depend on state which lives in neither: Jinja macro
+        directories, python library directories, a dbt manifest and so on. This
+        method closes that gap by returning a digest which changes whenever any
+        of that external state changes.
+
+        Returns:
+            A stable digest of the external state, ``""`` if the templater
+            reads nothing outside the file and its config, or ``None`` to
+            declare that files rendered by this templater must never be cached.
+
+        The default is ``None`` for everything except the raw templater. A
+        templater we do not control may read arbitrary external state, and
+        there is no safe way to infer what: silently caching it could hide a
+        real violation. Opting in is therefore a deliberate act by each
+        templater, and costs nothing but a missed optimisation until it is
+        taken.
+
+        Implementations do not need to memoise. The cache calls this once per
+        distinct (templater, resolved config) pair per run and reuses the
+        result for every file which shares that config.
+        """
+        # `RawTemplater` is both the base class and the raw templater itself.
+        # The raw templater does no templating at all, so it reads nothing
+        # outside the file; any subclass has to make its own declaration.
+        if type(self) is not RawTemplater:
+            return None
+        return ""
+
     def config_pairs(self) -> list[tuple[str, str]]:
         """Returns info about the given templater for output by the cli.
 

--- a/src/sqlfluff/core/templaters/jinja.py
+++ b/src/sqlfluff/core/templaters/jinja.py
@@ -35,6 +35,7 @@ from sqlfluff.core.config import FluffConfig
 from sqlfluff.core.errors import SQLFluffUserError, SQLTemplaterError
 from sqlfluff.core.formatter import FormatterInterface
 from sqlfluff.core.helpers.file import get_encoding
+from sqlfluff.core.helpers.hashing import hash_path_contents
 from sqlfluff.core.helpers.slice import is_zero_slice, slice_length
 from sqlfluff.core.templaters.base import (
     RawFileSlice,
@@ -315,10 +316,7 @@ class JinjaTemplater(PythonTemplater):
         Returns:
             dict: A dictionary containing the extracted libraries.
         """
-        # If a more global library_path is set, let that take precedence.
-        library_path = config.get("library_path") or config.get_section(
-            (self.templater_selector, self.name, "library_path")
-        )
+        library_path = self._get_library_path(config)
         if not library_path:
             return {}
 
@@ -511,6 +509,54 @@ class JinjaTemplater(PythonTemplater):
                 if result:
                     return result
         return None
+
+    def _get_library_path(self, config: Optional[FluffConfig]) -> Optional[str]:
+        """Get the configured python library path, if any.
+
+        A more global ``library_path`` takes precedence over the one in the
+        templater section.
+        """
+        if not config:  # pragma: no cover
+            return None
+        library_path = config.get("library_path") or config.get_section(
+            (self.templater_selector, self.name, "library_path")
+        )
+        if not library_path:
+            return None
+        return cast(str, library_path)
+
+    def cache_fingerprint(self, config: FluffConfig) -> Optional[str]:
+        """Digest the files this templater reads from outside the SQL file.
+
+        Everything the Jinja templater renders with comes either from the file
+        itself, from config (macros defined in ``[sqlfluff:templater:jinja:
+        macros]``, the context, and the environment options -- all covered by
+        the config digest), or from one of four configured paths:
+
+        * ``loader_search_path``, searched by ``{% include %}`` / ``{% import %}``
+        * ``load_macros_from_path``, loaded as macro definitions
+        * ``exclude_macros_from_path``, which subtracts from the above
+        * ``library_path``, imported as python modules
+
+        Those four are hashed here, contents and all, so that editing a macro
+        invalidates every file which could have used it.
+
+        The paths are hashed as one ordered sequence without labelling which
+        setting each came from. That is sufficient: the config digest already
+        distinguishes a path configured as (say) ``library_path`` from the same
+        path configured as ``load_macros_from_path``, so the two cannot be
+        confused for one another.
+        """
+        library_path = self._get_library_path(config)
+        paths: list[str] = [
+            # Order matters and is preserved: Jinja resolves a template name
+            # against the search path in order.
+            *(self._get_loader_search_path(config) or []),
+            *(self._get_macros_path(config, "load_macros_from_path") or []),
+            *(self._get_macros_path(config, "exclude_macros_from_path") or []),
+            *([library_path] if library_path else []),
+        ]
+        return hash_path_contents(paths)
 
     def _get_loader_search_path(
         self, config: Optional[FluffConfig]

--- a/src/sqlfluff/core/templaters/jinja.py
+++ b/src/sqlfluff/core/templaters/jinja.py
@@ -547,6 +547,14 @@ class JinjaTemplater(PythonTemplater):
         path configured as ``load_macros_from_path``, so the two cannot be
         confused for one another.
         """
+        # Only this exact class, for the same reason as `PythonTemplater` and
+        # `PlaceholderTemplater`: this declaration covers what *Jinja* reads,
+        # and a subclass which renders through a project (dbt, SQLMesh) reads
+        # far more. Inheriting an opt-in that was never made for you is how a
+        # stale hit hides a real violation -- see
+        # `RawTemplater.cache_fingerprint`.
+        if type(self) is not JinjaTemplater:
+            return None
         library_path = self._get_library_path(config)
         paths: list[str] = [
             # Order matters and is preserved: Jinja resolves a template name

--- a/src/sqlfluff/core/templaters/placeholder.py
+++ b/src/sqlfluff/core/templaters/placeholder.py
@@ -81,6 +81,18 @@ class PlaceholderTemplater(RawTemplater):
         self.default_context = dict(test_value="__test__")
         self.override_context = override_context or {}
 
+    def cache_fingerprint(self, config: FluffConfig) -> Optional[str]:
+        """The placeholder templater reads nothing outside the file and config.
+
+        Both the parameter style and the substituted values come from
+        ``[sqlfluff:templater:placeholder]``, which the config digest covers.
+        """
+        # Only this exact class. A subclass may read anything, and must make
+        # its own declaration -- see `RawTemplater.cache_fingerprint`.
+        if type(self) is not PlaceholderTemplater:
+            return None
+        return ""
+
     # copy of the Python templater
     def get_context(
         self,

--- a/src/sqlfluff/core/templaters/python.py
+++ b/src/sqlfluff/core/templaters/python.py
@@ -168,6 +168,19 @@ class PythonTemplater(RawTemplater):
         self.default_context = dict(test_value="__test__")
         self.override_context = override_context or {}
 
+    def cache_fingerprint(self, config: FluffConfig) -> Optional[str]:
+        """The python templater reads nothing outside the file and its config.
+
+        Its entire context comes from ``[sqlfluff:templater:python:context]``
+        (plus any overrides), all of which the cache already covers via the
+        config digest.
+        """
+        # Only this exact class. A subclass may read anything, and must make
+        # its own declaration -- see `RawTemplater.cache_fingerprint`.
+        if type(self) is not PythonTemplater:
+            return None
+        return ""
+
     @staticmethod
     def infer_type(s: Any) -> Any:
         """Infer a python type from a string and convert.

--- a/test/core/helpers/hashing_test.py
+++ b/test/core/helpers/hashing_test.py
@@ -220,6 +220,41 @@ class TestHashPathContents:
         (real / "m.sql").write_text("{% macro f() %}2{% endmacro %}", encoding="utf-8")
         assert hash_path_contents([str(search)]) != before
 
+    def test_second_link_to_an_already_walked_directory_counts(self, tmp_path):
+        """A new alias for an already-seen directory changes the digest.
+
+        The walk records each real directory once, so the second route to it
+        is pruned. Its *name* still matters: a link makes those files
+        resolvable under a new name, and `{% include "z_alias/m.sql" %}` would
+        start working without any file having changed. Sorted after `macros`
+        on purpose, so it is the pruned one.
+        """
+        root = tmp_path / "search"
+        (root / "macros").mkdir(parents=True)
+        (root / "macros" / "m.sql").write_text("x", encoding="utf-8")
+        before = hash_path_contents([str(root)])
+        try:
+            os.symlink(root / "macros", root / "z_alias", target_is_directory=True)
+        except (OSError, NotImplementedError) as err:  # pragma: no cover
+            pytest.skip(f"symlinks unavailable in this environment: {err}")
+        assert hash_path_contents([str(root)]) != before
+
+    def test_retargeting_a_link_counts(self, tmp_path):
+        """Pointing an existing alias somewhere else changes the digest."""
+        root = tmp_path / "search"
+        (root / "a").mkdir(parents=True)
+        (root / "b").mkdir(parents=True)
+        (root / "a" / "m.sql").write_text("x", encoding="utf-8")
+        (root / "b" / "m.sql").write_text("y", encoding="utf-8")
+        try:
+            os.symlink(root / "a", root / "z_alias", target_is_directory=True)
+        except (OSError, NotImplementedError) as err:  # pragma: no cover
+            pytest.skip(f"symlinks unavailable in this environment: {err}")
+        before = hash_path_contents([str(root)])
+        os.remove(root / "z_alias")
+        os.symlink(root / "b", root / "z_alias", target_is_directory=True)
+        assert hash_path_contents([str(root)]) != before
+
     def test_symlink_cycle_terminates(self, tmp_path):
         """Following links must not loop forever on a cyclic tree."""
         root = tmp_path / "root"

--- a/test/core/helpers/hashing_test.py
+++ b/test/core/helpers/hashing_test.py
@@ -1,0 +1,173 @@
+"""Tests for the hashing helpers.
+
+These digests are the foundation of the lint cache: if any of them can fail to
+change when their inputs change, a stale result gets served. The tests here are
+therefore mostly about *sensitivity* -- proving that each kind of change to the
+input produces a different digest.
+"""
+
+import hashlib
+import os
+
+import pytest
+
+from sqlfluff.core.helpers.hashing import (
+    hash_file_bytes,
+    hash_path_contents,
+    hash_strings,
+)
+
+
+def _digest(*values: str) -> str:
+    hasher = hashlib.sha256()
+    hash_strings(hasher, *values)
+    return hasher.hexdigest()
+
+
+def test__helpers_hashing__strings_are_stable():
+    """The same strings always produce the same digest."""
+    assert _digest("a", "b") == _digest("a", "b")
+
+
+def test__helpers_hashing__strings_are_delimited():
+    """Moving a boundary between values changes the digest.
+
+    Without delimiting, ("ab", "c") and ("a", "bc") would hash identically,
+    which would let a config value bleed into the next one.
+    """
+    assert _digest("ab", "c") != _digest("a", "bc")
+
+
+def test__helpers_hashing__empty_string_is_distinct_from_no_string():
+    """An empty value is not the same as an absent one."""
+    assert _digest("a", "") != _digest("a")
+
+
+def test__helpers_hashing__strings_survive_surrogates():
+    """Undecodable content doesn't raise.
+
+    Config values can carry text which came from a file read with
+    `errors="backslashreplace"`, so encoding has to be forgiving.
+    """
+    assert _digest("\udcff") == _digest("\udcff")
+
+
+def test__helpers_hashing__file_bytes(tmp_path):
+    """Hashing a file's bytes matches hashing those bytes directly."""
+    target = tmp_path / "example.sql"
+    target.write_bytes(b"SELECT 1\n")
+    hasher = hashlib.sha256()
+    hash_file_bytes(str(target), hasher)
+    assert hasher.hexdigest() == hashlib.sha256(b"SELECT 1\n").hexdigest()
+
+
+def test__helpers_hashing__file_bytes_spans_chunks(tmp_path, monkeypatch):
+    """A file larger than the read chunk still hashes correctly."""
+    monkeypatch.setattr("sqlfluff.core.helpers.hashing.HASH_CHUNK_SIZE", 4)
+    payload = b"0123456789abcdef"
+    target = tmp_path / "big.sql"
+    target.write_bytes(payload)
+    hasher = hashlib.sha256()
+    hash_file_bytes(str(target), hasher)
+    assert hasher.hexdigest() == hashlib.sha256(payload).hexdigest()
+
+
+class TestHashPathContents:
+    """Tests for `hash_path_contents`."""
+
+    @staticmethod
+    def _make_tree(root, files):
+        for relpath, content in files.items():
+            target = root / relpath
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(content, encoding="utf-8")
+        return str(root)
+
+    def test_no_paths(self):
+        """No paths is a valid (and stable) input."""
+        assert hash_path_contents([]) == hash_path_contents([])
+
+    def test_identical_trees_differ_by_path(self, tmp_path):
+        """Two identical trees hash differently, because the path is included.
+
+        This matters because a template can refer to a search path by name, so
+        two directories are not interchangeable just because their contents
+        match.
+        """
+        a = self._make_tree(tmp_path / "a", {"m.sql": "x"})
+        b = self._make_tree(tmp_path / "b", {"m.sql": "x"})
+        assert hash_path_contents([a]) != hash_path_contents([b])
+
+    def test_stable_for_unchanged_tree(self, tmp_path):
+        """Repeated calls on an unchanged tree agree."""
+        root = self._make_tree(tmp_path, {"a/m.sql": "x", "b/n.sql": "y"})
+        assert hash_path_contents([root]) == hash_path_contents([root])
+
+    def test_sensitive_to_edited_file(self, tmp_path):
+        """Editing a file changes the digest."""
+        root = self._make_tree(tmp_path, {"m.sql": "x"})
+        before = hash_path_contents([root])
+        (tmp_path / "m.sql").write_text("y", encoding="utf-8")
+        assert hash_path_contents([root]) != before
+
+    def test_sensitive_to_added_file(self, tmp_path):
+        """Adding a file changes the digest.
+
+        This is the case a per-file dependency list would miss: a new macro
+        file can shadow or supplement what a template resolves to.
+        """
+        root = self._make_tree(tmp_path, {"m.sql": "x"})
+        before = hash_path_contents([root])
+        (tmp_path / "n.sql").write_text("x", encoding="utf-8")
+        assert hash_path_contents([root]) != before
+
+    def test_sensitive_to_removed_file(self, tmp_path):
+        """Removing a file changes the digest."""
+        root = self._make_tree(tmp_path, {"m.sql": "x", "n.sql": "y"})
+        before = hash_path_contents([root])
+        os.remove(tmp_path / "n.sql")
+        assert hash_path_contents([root]) != before
+
+    def test_sensitive_to_rename(self, tmp_path):
+        """Renaming a file changes the digest, even though contents are equal."""
+        root = self._make_tree(tmp_path, {"m.sql": "x"})
+        before = hash_path_contents([root])
+        os.rename(tmp_path / "m.sql", tmp_path / "n.sql")
+        assert hash_path_contents([root]) != before
+
+    def test_sensitive_to_move_between_subdirectories(self, tmp_path):
+        """Moving a file between directories changes the digest."""
+        root = self._make_tree(tmp_path, {"a/m.sql": "x", "b/.keep": ""})
+        before = hash_path_contents([root])
+        os.rename(tmp_path / "a" / "m.sql", tmp_path / "b" / "m.sql")
+        assert hash_path_contents([root]) != before
+
+    def test_sensitive_to_path_order(self, tmp_path):
+        """Order matters, because Jinja resolves a search path in order."""
+        a = self._make_tree(tmp_path / "a", {"m.sql": "x"})
+        b = self._make_tree(tmp_path / "b", {"m.sql": "y"})
+        assert hash_path_contents([a, b]) != hash_path_contents([b, a])
+
+    def test_missing_path_is_recorded(self, tmp_path):
+        """A path which doesn't exist is distinct from an empty directory.
+
+        Creating a configured-but-absent macro directory has to invalidate.
+        """
+        missing = str(tmp_path / "nope")
+        digest_missing = hash_path_contents([missing])
+        os.makedirs(missing)
+        assert hash_path_contents([missing]) != digest_missing
+
+    def test_single_file_path(self, tmp_path):
+        """A path may be a file rather than a directory."""
+        target = tmp_path / "lib.py"
+        target.write_text("A = 1", encoding="utf-8")
+        before = hash_path_contents([str(target)])
+        target.write_text("A = 2", encoding="utf-8")
+        assert hash_path_contents([str(target)]) != before
+
+    @pytest.mark.parametrize("content", ["x", ""])
+    def test_empty_file_is_hashed(self, tmp_path, content):
+        """An empty file still contributes its name."""
+        root = self._make_tree(tmp_path, {"m.sql": content})
+        assert hash_path_contents([root]) == hash_path_contents([root])

--- a/test/core/helpers/hashing_test.py
+++ b/test/core/helpers/hashing_test.py
@@ -166,8 +166,68 @@ class TestHashPathContents:
         target.write_text("A = 2", encoding="utf-8")
         assert hash_path_contents([str(target)]) != before
 
-    @pytest.mark.parametrize("content", ["x", ""])
-    def test_empty_file_is_hashed(self, tmp_path, content):
-        """An empty file still contributes its name."""
-        root = self._make_tree(tmp_path, {"m.sql": content})
-        assert hash_path_contents([root]) == hash_path_contents([root])
+    def test_empty_file_still_contributes_its_name(self, tmp_path):
+        """An empty file is not the same as no file.
+
+        The digest has to notice a zero-byte file being added, otherwise
+        creating an empty macro file would not invalidate anything.
+        """
+        empty_dir = str(self._make_tree(tmp_path / "a", {}))
+        os.makedirs(empty_dir, exist_ok=True)
+        with_file = self._make_tree(tmp_path / "b", {"m.sql": ""})
+        # Same directory, before and after the empty file appears.
+        root = str(tmp_path / "c")
+        os.makedirs(root)
+        before = hash_path_contents([root])
+        (tmp_path / "c" / "m.sql").write_text("", encoding="utf-8")
+        assert hash_path_contents([root]) != before
+        # And it is still distinct from a file with content.
+        assert hash_path_contents([root]) != hash_path_contents([with_file])
+
+    def test_file_contents_cannot_forge_an_entry_boundary(self, tmp_path):
+        """A file's bytes can't be mistaken for the next entry's header.
+
+        File contents used to be streamed into the digest undelimited, so a
+        file whose bytes happened to encode the next entry's record could make
+        adding a file leave the hash input unchanged. Contents are now hashed
+        separately and folded in as a fixed-length digest.
+        """
+        root = self._make_tree(tmp_path, {"a.sql": "x"})
+        before = hash_path_contents([root])
+        # Content chosen to imitate the delimiter framing used internally.
+        (tmp_path / "b.sql").write_text(
+            "5\x00entry\x007\x00b.sql\x00", encoding="utf-8"
+        )
+        assert hash_path_contents([root]) != before
+
+    def test_follows_symlinked_directories(self, tmp_path):
+        """A macro reached through a symlink is still fingerprinted.
+
+        `os.walk` does not follow directory symlinks by default, but a Jinja
+        loader reads straight through them, so an edit behind a link would
+        otherwise replay a stale clean result.
+        """
+        real = tmp_path / "real"
+        search = tmp_path / "search"
+        real.mkdir()
+        search.mkdir()
+        (real / "m.sql").write_text("{% macro f() %}1{% endmacro %}", encoding="utf-8")
+        try:
+            os.symlink(real, search / "linked", target_is_directory=True)
+        except (OSError, NotImplementedError) as err:  # pragma: no cover
+            pytest.skip(f"symlinks unavailable in this environment: {err}")
+        before = hash_path_contents([str(search)])
+        (real / "m.sql").write_text("{% macro f() %}2{% endmacro %}", encoding="utf-8")
+        assert hash_path_contents([str(search)]) != before
+
+    def test_symlink_cycle_terminates(self, tmp_path):
+        """Following links must not loop forever on a cyclic tree."""
+        root = tmp_path / "root"
+        root.mkdir()
+        (root / "m.sql").write_text("x", encoding="utf-8")
+        try:
+            os.symlink(root, root / "loop", target_is_directory=True)
+        except (OSError, NotImplementedError) as err:  # pragma: no cover
+            pytest.skip(f"symlinks unavailable in this environment: {err}")
+        # The assertion is simply that this returns at all.
+        assert hash_path_contents([str(root)])

--- a/test/core/linter/cache_test.py
+++ b/test/core/linter/cache_test.py
@@ -472,22 +472,40 @@ class TestCheckAndRecord:
         cache.record(str(target), dict(VALID_ENTRY["statistics"]))
         assert cache._entries == {}
 
-    def test_pending_keys_are_released_for_uncacheable_files(self, project):
+    def test_pending_keys_are_released_for_uncacheable_files(
+        self, project, monkeypatch
+    ):
         """A file which will never be recorded doesn't hold its key.
 
         Regression test. `check` retains a key for every miss so that `record`
         can verify it. On a project where most files have violations -- the
         projects that get no benefit from the cache in the first place --
         holding one key per file for the whole run is wasted memory.
+
+        The assertion has to be made against the cache instance the run
+        actually used. Building a fresh one afterwards would start with an
+        empty `_pending_keys` no matter what happened, so the test could not
+        fail; it is captured here instead.
         """
+        used: list[LintCache] = []
+        original = LintCache.from_config
+
+        def _capture(config, user_rules=None):
+            cache = original(config, user_rules=user_rules)
+            if cache is not None:
+                used.append(cache)
+            return cache
+
+        monkeypatch.setattr(LintCache, "from_config", staticmethod(_capture))
+
         write(project / "clean.sql", CLEAN_SQL)
         write(project / "dirty.sql", DIRTY_SQL)
-        linter = Linter(config=make_config(project))
-        linter.lint_paths((str(project),))
-        # Both files missed, but only the clean one is kept as an entry and
-        # neither is left dangling in the pending map.
-        cache = LintCache.from_config(make_config(project))
-        assert cache is not None
+        Linter(config=make_config(project)).lint_paths((str(project),))
+
+        assert len(used) == 1
+        cache = used[0]
+        # Both files missed; only the clean one becomes an entry, and the
+        # dirty one's key was released rather than held for the whole run.
         assert len(cache._entries) == 1
         assert cache._pending_keys == {}
 

--- a/test/core/linter/cache_test.py
+++ b/test/core/linter/cache_test.py
@@ -1,0 +1,1083 @@
+"""Tests for the lint result cache.
+
+The cache trades correctness risk for speed: a hit means a file is not linted
+at all. So the tests here are weighted heavily towards proving that a hit only
+happens when it is *safe*, and that every input which can change a file's
+result also changes its key.
+
+The integration tests all follow the same shape: lint a project twice and
+assert on `LintingResult.files_cached`, which counts the files the second run
+did not have to look at.
+"""
+
+import json
+import os
+import time
+
+import pytest
+
+from sqlfluff.cli.commands import fix
+from sqlfluff.cli.commands import lint as lint_command
+from sqlfluff.core import FluffConfig, Linter
+from sqlfluff.core.config import clear_config_caches
+from sqlfluff.core.linter.cache import (
+    CACHE_FILENAME,
+    CACHE_SCHEMA_VERSION,
+    ENTRY_TTL_SECONDS,
+    LintCache,
+    _coerce_entry,
+    config_digest,
+    run_fingerprint,
+)
+from sqlfluff.core.templaters import JinjaTemplater, RawTemplater
+from sqlfluff.core.templaters.placeholder import PlaceholderTemplater
+from sqlfluff.core.templaters.python import PythonTemplater
+from sqlfluff.utils.testing.cli import invoke_assert_code
+
+CLEAN_SQL = "SELECT\n    a,\n    b\nFROM tbl\n"
+DIRTY_SQL = "select  a,b from tbl\n"
+
+
+# ###
+# Fixtures and helpers
+# ###
+
+
+def write(path, content):
+    """Write text to a path, creating parents as needed."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    return str(path)
+
+
+def rewrite_config(project_root, body):
+    """Rewrite a project's `.sqlfluff` as a fresh process would see it.
+
+    Config file loading is memoised for the lifetime of the process, so a
+    test which edits a config file and re-lints in the same process would
+    otherwise still be reading the old values. Clearing it here reproduces
+    what actually happens between two CLI invocations.
+    """
+    write(project_root / ".sqlfluff", body)
+    clear_config_caches()
+
+
+@pytest.fixture
+def project(tmp_path):
+    """A minimal linted project with its cache directory alongside it."""
+    root = tmp_path / "project"
+    root.mkdir()
+    write(root / ".sqlfluff", "[sqlfluff]\ndialect = ansi\n")
+    return root
+
+
+def make_config(project_root, cache_dir=None, **overrides):
+    """Build a config rooted at the project, with caching enabled."""
+    values = {
+        "cache": True,
+        "cache_dir": str(cache_dir or (project_root.parent / "cache")),
+    }
+    values.update(overrides)
+    return FluffConfig.from_path(str(project_root), overrides=values)
+
+
+def lint(project_root, config):
+    """Lint a project and return the result."""
+    return Linter(config=config).lint_paths((str(project_root),))
+
+
+# ###
+# Unit tests: key derivation
+# ###
+
+
+class TestConfigDigest:
+    """`config_digest` has to react to config but not to object identity."""
+
+    def test_stable_across_equivalent_configs(self, project):
+        """Two separately built but identical configs agree."""
+        assert config_digest(make_config(project)) == config_digest(
+            make_config(project)
+        )
+
+    def test_reacts_to_a_changed_value(self, project):
+        """Changing a rule selection changes the digest."""
+        before = config_digest(make_config(project))
+        after = config_digest(make_config(project, rules="LT01"))
+        assert before != after
+
+    def test_reacts_to_a_changed_dialect(self, project):
+        """Changing dialect changes the digest.
+
+        `dialect_obj` is excluded from `iter_vals`, so this proves the digest
+        is picking up the underlying `dialect` string rather than relying on
+        the derived object.
+        """
+        before = config_digest(make_config(project, dialect="ansi"))
+        after = config_digest(make_config(project, dialect="postgres"))
+        assert before != after
+
+    def test_reacts_to_a_nested_value(self, project):
+        """A value nested inside a rule section still counts."""
+        before = config_digest(make_config(project))
+        rewrite_config(
+            project,
+            "[sqlfluff]\ndialect = ansi\n"
+            "[sqlfluff:rules:capitalisation.keywords]\ncapitalisation_policy = lower\n",
+        )
+        assert config_digest(make_config(project)) != before
+
+
+def test__cache_run_fingerprint_is_stable():
+    """The run fingerprint doesn't move between calls in one environment."""
+    assert run_fingerprint() == run_fingerprint()
+
+
+def test__cache_run_fingerprint_reacts_to_version(monkeypatch):
+    """A new SQLFluff version invalidates every entry."""
+    before = run_fingerprint()
+    monkeypatch.setattr(
+        "sqlfluff.core.linter.cache._get_sqlfluff_version", lambda: "0.0.0-test"
+    )
+    assert run_fingerprint() != before
+
+
+def test__cache_run_fingerprint_reacts_to_plugins(monkeypatch):
+    """Installing or upgrading a plugin invalidates every entry.
+
+    A plugin can add, remove or change rules, which changes the result for
+    every file in the project.
+    """
+    before = run_fingerprint()
+    monkeypatch.setattr(
+        "sqlfluff.core.linter.cache._discover_plugins",
+        lambda: iter([(None, "made-up-plugin", "1.0.0")]),
+    )
+    assert run_fingerprint() != before
+
+
+# ###
+# Unit tests: entry validation
+# ###
+
+
+VALID_ENTRY = {
+    "key": "abc",
+    "statistics": {
+        "source_chars": 1,
+        "templated_chars": 2,
+        "segments": 3,
+        "raw_segments": 4,
+    },
+    "last_seen": 1234,
+}
+
+
+def test__cache_coerce_entry_accepts_a_valid_entry():
+    """A well formed entry survives validation intact."""
+    entry = _coerce_entry(VALID_ENTRY)
+    assert entry is not None
+    assert entry["key"] == "abc"
+    assert entry["last_seen"] == 1234
+
+
+def test__cache_coerce_entry_canonicalises_statistics_order():
+    """Statistics come back in canonical order regardless of file order.
+
+    JSON objects preserve insertion order, and these values are serialised
+    straight into `--format json` output, so a reordered cache file must not
+    reorder the output.
+    """
+    scrambled = dict(VALID_ENTRY)
+    scrambled["statistics"] = dict(reversed(list(VALID_ENTRY["statistics"].items())))
+    entry = _coerce_entry(scrambled)
+    assert entry is not None
+    assert list(entry["statistics"]) == [
+        "source_chars",
+        "templated_chars",
+        "segments",
+        "raw_segments",
+    ]
+
+
+@pytest.mark.parametrize(
+    "mutation,reason",
+    [
+        ({"key": ""}, "empty key"),
+        ({"key": 5}, "non-string key"),
+        ({"last_seen": "yesterday"}, "non-integer timestamp"),
+        ({"last_seen": True}, "boolean timestamp"),
+        ({"statistics": []}, "non-mapping statistics"),
+        ({"statistics": {"source_chars": 1}}, "missing statistics keys"),
+        (
+            {
+                "statistics": {
+                    "source_chars": 1,
+                    "templated_chars": 2,
+                    "segments": 3,
+                    "raw_segments": 4,
+                    "extra": 5,
+                }
+            },
+            "unexpected statistics key",
+        ),
+        (
+            {
+                "statistics": {
+                    "source_chars": "1",
+                    "templated_chars": 2,
+                    "segments": 3,
+                    "raw_segments": 4,
+                }
+            },
+            "non-integer statistic",
+        ),
+    ],
+)
+def test__cache_coerce_entry_rejects_malformed(mutation, reason):
+    """A malformed entry is dropped rather than trusted.
+
+    The cache file is plain JSON on disk which anything could have written, and
+    a bad entry we accepted would silently skip a file.
+    """
+    payload = dict(VALID_ENTRY)
+    payload.update(mutation)
+    assert _coerce_entry(payload) is None, reason
+
+
+def test__cache_coerce_entry_rejects_non_mapping():
+    """An entry which isn't an object at all is dropped."""
+    assert _coerce_entry("not an entry") is None
+
+
+# ###
+# Unit tests: load and persist
+# ###
+
+
+class TestLoadAndPersist:
+    """The cache file is untrusted input and a shared resource."""
+
+    def test_from_config_returns_none_when_disabled(self, project):
+        """No cache object at all when caching is off, so there's no cost."""
+        assert LintCache.from_config(make_config(project, cache=False)) is None
+
+    def test_from_config_builds_when_enabled(self, project, tmp_path):
+        """The configured directory is respected and made absolute."""
+        cache = LintCache.from_config(make_config(project, cache_dir=tmp_path / "c"))
+        assert cache is not None
+        assert cache.cache_dir == os.path.abspath(str(tmp_path / "c"))
+
+    def test_missing_file_loads_empty(self, project, tmp_path):
+        """A first run is just an empty cache."""
+        cache = LintCache(str(tmp_path / "nope"), make_config(project))
+        cache.load()
+        assert cache._entries == {}
+
+    @pytest.mark.parametrize(
+        "content",
+        [
+            "not json at all",
+            "[]",
+            '{"schema_version": 999, "run_fingerprint": "x", "entries": {}}',
+            '{"schema_version": 1, "run_fingerprint": "wrong", "entries": {}}',
+            '{"schema_version": 1, "entries": "not a mapping"}',
+        ],
+        ids=["invalid", "wrong-type", "wrong-schema", "wrong-run", "bad-entries"],
+    )
+    def test_unusable_file_loads_empty(self, project, tmp_path, content):
+        """Anything we can't fully validate is treated as no cache at all."""
+        cache_dir = tmp_path / "cache"
+        cache_dir.mkdir()
+        write(cache_dir / CACHE_FILENAME, content)
+        cache = LintCache(str(cache_dir), make_config(project))
+        cache.load()
+        assert cache._entries == {}
+
+    def test_persist_writes_a_loadable_file(self, project, tmp_path):
+        """A persisted cache reloads with the same entries."""
+        cache_dir = str(tmp_path / "cache")
+        target = write(project / "a.sql", CLEAN_SQL)
+        cache = LintCache(cache_dir, make_config(project))
+        assert cache.check(target) is None
+        cache.record(target, {"source_chars": 1})
+        cache.persist()
+
+        reloaded = LintCache(cache_dir, make_config(project))
+        reloaded.load()
+        assert reloaded.check(target) is not None
+
+    def test_persist_writes_a_gitignore(self, project, tmp_path):
+        """The cache directory ignores itself, so it can't be committed."""
+        cache_dir = tmp_path / "cache"
+        cache = LintCache(str(cache_dir), make_config(project))
+        cache.persist()
+        assert (cache_dir / ".gitignore").read_text(encoding="utf-8").endswith("*\n")
+
+    def test_persist_leaves_no_temporary_files(self, project, tmp_path):
+        """The atomic write cleans up after itself."""
+        cache_dir = tmp_path / "cache"
+        cache = LintCache(str(cache_dir), make_config(project))
+        cache.persist()
+        assert sorted(os.listdir(cache_dir)) == [".gitignore", CACHE_FILENAME]
+
+    def test_persist_prunes_expired_entries(self, project, tmp_path):
+        """Entries which haven't been seen for a long time are dropped.
+
+        Without this the file grows forever as files are renamed or deleted.
+        """
+        cache_dir = tmp_path / "cache"
+        cache = LintCache(str(cache_dir), make_config(project))
+        cache._entries["stale"] = {
+            "key": "k",
+            "statistics": dict(VALID_ENTRY["statistics"]),
+            "last_seen": int(time.time()) - ENTRY_TTL_SECONDS - 10,
+        }
+        cache._entries["fresh"] = {
+            "key": "k",
+            "statistics": dict(VALID_ENTRY["statistics"]),
+            "last_seen": int(time.time()),
+        }
+        cache.persist()
+        payload = json.loads((cache_dir / CACHE_FILENAME).read_text(encoding="utf-8"))
+        assert list(payload["entries"]) == ["fresh"]
+
+    def test_persist_survives_an_unwritable_directory(
+        self, project, tmp_path, monkeypatch
+    ):
+        """A cache we can't write is a warning, never a failure.
+
+        Read-only checkouts and locked-down CI images are both real, and
+        neither should stop a lint run.
+        """
+        cache_dir = tmp_path / "cache"
+        cache = LintCache(str(cache_dir), make_config(project))
+
+        def _boom(*args, **kwargs):
+            raise OSError("read-only file system")
+
+        # Creating the directory is the first thing `persist` does, so this is
+        # where a read-only location actually fails.
+        monkeypatch.setattr("sqlfluff.core.linter.cache.os.makedirs", _boom)
+        cache.persist()
+        assert cache._writable is False
+        assert not cache_dir.exists()
+        # A second attempt is skipped rather than retried.
+        cache.persist()
+
+    def test_hit_refreshes_last_seen(self, project, tmp_path):
+        """An actively used entry is never aged out."""
+        cache_dir = str(tmp_path / "cache")
+        target = write(project / "a.sql", CLEAN_SQL)
+        cache = LintCache(cache_dir, make_config(project))
+        cache.check(target)
+        cache.record(target, {"source_chars": 1})
+        entry = next(iter(cache._entries.values()))
+        entry["last_seen"] = int(time.time()) - ENTRY_TTL_SECONDS - 10
+        assert cache.check(target) is not None
+        assert entry["last_seen"] > int(time.time()) - 10
+
+
+# ###
+# Unit tests: check and record
+# ###
+
+
+class TestCheckAndRecord:
+    """The narrow contract between the cache and the linter."""
+
+    def test_record_without_check_is_ignored(self, project, tmp_path):
+        """We never invent a key we didn't compute before linting.
+
+        The key has to describe the contents we read *before* the file was
+        linted; deriving it afterwards would race with anything that rewrote
+        the file in between.
+        """
+        target = write(project / "a.sql", CLEAN_SQL)
+        cache = LintCache(str(tmp_path / "cache"), make_config(project))
+        cache.record(target, {"source_chars": 1})
+        assert cache._entries == {}
+
+    def test_check_counts_hits_and_misses(self, project, tmp_path):
+        """Hit and miss counters track what actually happened."""
+        target = write(project / "a.sql", CLEAN_SQL)
+        cache = LintCache(str(tmp_path / "cache"), make_config(project))
+        assert cache.check(target) is None
+        cache.record(target, {"source_chars": 1})
+        assert cache.check(target) is not None
+        assert (cache.hits, cache.misses) == (1, 1)
+
+    def test_check_returns_a_copy(self, project, tmp_path):
+        """A caller mutating the returned statistics can't corrupt the cache."""
+        target = write(project / "a.sql", CLEAN_SQL)
+        cache = LintCache(str(tmp_path / "cache"), make_config(project))
+        cache.check(target)
+        cache.record(target, dict(VALID_ENTRY["statistics"]))
+        returned = cache.check(target)
+        assert returned is not None
+        returned["source_chars"] = -1
+        assert cache.check(target)["source_chars"] == 1
+
+    def test_file_changed_during_the_run_is_not_recorded(self, project, tmp_path):
+        """A file edited mid-run is not recorded against either version.
+
+        The key is taken before linting and the result arrives afterwards. If
+        the file changed in between, neither the old key nor the new one is
+        backed by a lint of those exact contents, so recording either would be
+        an unverified claim. This is the check that closes that window.
+        """
+        target = project / "a.sql"
+        write(target, CLEAN_SQL)
+        cache = LintCache(str(tmp_path / "cache"), make_config(project))
+        assert cache.check(str(target)) is None
+        # Simulate an edit landing while the linter was working on it.
+        write(target, DIRTY_SQL)
+        cache.record(str(target), dict(VALID_ENTRY["statistics"]))
+        assert cache._entries == {}
+
+    def test_missing_file_is_not_keyable(self, project, tmp_path):
+        """A file which disappeared is a miss, not an exception."""
+        cache = LintCache(str(tmp_path / "cache"), make_config(project))
+        assert cache.check(str(project / "gone.sql")) is None
+
+    def test_templater_opt_out_disables_keying(self, project, tmp_path, monkeypatch):
+        """A templater returning None means no key and therefore no caching."""
+        monkeypatch.setattr(
+            JinjaTemplater, "cache_fingerprint", lambda self, config: None
+        )
+        target = write(project / "a.sql", CLEAN_SQL)
+        cache = LintCache(str(tmp_path / "cache"), make_config(project))
+        assert cache.check(target) is None
+        cache.record(target, {"source_chars": 1})
+        assert cache._entries == {}
+
+    def test_templater_fingerprint_is_memoised_per_run(
+        self, project, tmp_path, monkeypatch
+    ):
+        """Files sharing a config only fingerprint the templater once.
+
+        Fingerprinting walks whole directory trees, so doing it per file would
+        make the cache slower than the linting it replaces on large projects.
+        """
+        calls = []
+
+        def _counting_fingerprint(self, config):
+            calls.append(1)
+            return ""
+
+        monkeypatch.setattr(JinjaTemplater, "cache_fingerprint", _counting_fingerprint)
+        cache = LintCache(str(tmp_path / "cache"), make_config(project))
+        for name in ("a.sql", "b.sql", "c.sql"):
+            cache.check(write(project / name, CLEAN_SQL))
+        assert len(calls) == 1
+
+    def test_config_is_resolved_once_per_directory(self, project, monkeypatch):
+        """Files in one directory share a single config resolution.
+
+        `make_child_from_path` builds a whole `FluffConfig`, expanding a fresh
+        dialect object each time -- tens of milliseconds. Doing that per file
+        costs more than the linting a hit avoids, so this is load bearing
+        rather than a micro-optimisation.
+        """
+        calls = []
+        original = FluffConfig.make_child_from_path
+
+        def _counting(self, path, *args, **kwargs):
+            calls.append(path)
+            return original(self, path, *args, **kwargs)
+
+        monkeypatch.setattr(FluffConfig, "make_child_from_path", _counting)
+        cache = LintCache(str(project.parent / "cache"), make_config(project))
+        for name in ("a.sql", "b.sql", "c.sql"):
+            cache.check(write(project / name, CLEAN_SQL))
+        assert len(calls) == 1
+
+    def test_resolved_configs_are_not_retained(self, project):
+        """The memo keeps derived strings, not `FluffConfig` objects.
+
+        Each config holds a freshly expanded dialect. Pinning one per directory
+        for the length of the run would trade the time saved for a lot of
+        memory on a project with many directories.
+        """
+        cache = LintCache(str(project.parent / "cache"), make_config(project))
+        cache.check(write(project / "a.sql", CLEAN_SQL))
+        assert cache._directory_keys
+        for value in cache._directory_keys.values():
+            assert value is None or all(isinstance(part, str) for part in value)
+
+    def test_config_is_resolved_per_directory_not_globally(self, project):
+        """Subdirectories with their own config still get their own key.
+
+        Memoising by directory must not let a nested `.sqlfluff` be missed.
+        """
+        rewrite_config(
+            project / "sub",
+            "[sqlfluff]\n[sqlfluff:rules:capitalisation.keywords]\n"
+            "capitalisation_policy = lower\n",
+        )
+        cache = LintCache(str(project.parent / "cache"), make_config(project))
+        top = cache._file_key(write(project / "a.sql", CLEAN_SQL))
+        nested = cache._file_key(write(project / "sub" / "a.sql", CLEAN_SQL))
+        assert top is not None
+        assert nested is not None
+        assert top != nested
+
+
+# ###
+# Templater declarations
+# ###
+
+
+class UnknownTemplater(RawTemplater):
+    """A stand-in for a templater SQLFluff doesn't ship."""
+
+    name = "unknown"
+
+
+def test__templater_raw_is_cacheable():
+    """The raw templater reads nothing outside the file."""
+    assert RawTemplater().cache_fingerprint(None) == ""
+
+
+def test__templater_unknown_subclass_is_not_cacheable():
+    """A templater we don't control opts out until it says otherwise.
+
+    This is the safe default: we cannot know what external state a third party
+    templater reads, and guessing wrong means silently skipping a file which
+    should have reported a violation.
+    """
+    assert UnknownTemplater().cache_fingerprint(None) is None
+
+
+@pytest.mark.parametrize("templater", [PythonTemplater(), PlaceholderTemplater()])
+def test__templater_config_only_templaters_are_cacheable(templater):
+    """Templaters whose whole context is config declare no external state."""
+    assert templater.cache_fingerprint(None) == ""
+
+
+class TestJinjaFingerprint:
+    """The Jinja templater's declaration of what it reads from disk."""
+
+    def _config(self, project, **section):
+        body = "[sqlfluff]\ndialect = ansi\n[sqlfluff:templater:jinja]\n"
+        body += "".join(f"{k} = {v}\n" for k, v in section.items())
+        rewrite_config(project, body)
+        return make_config(project)
+
+    def test_no_paths_configured(self, project):
+        """With nothing configured the fingerprint is still stable."""
+        config = self._config(project)
+        templater = config.get("templater_obj")
+        assert templater.cache_fingerprint(config) == templater.cache_fingerprint(
+            config
+        )
+
+    @pytest.mark.parametrize(
+        "setting",
+        [
+            "load_macros_from_path",
+            "exclude_macros_from_path",
+            "loader_search_path",
+            "library_path",
+        ],
+    )
+    def test_reacts_to_content_of_each_configured_path(self, project, setting):
+        """Editing a file under any configured path changes the fingerprint.
+
+        All four settings feed the Jinja environment, so all four have to be
+        covered; missing one would let a macro edit go unnoticed.
+        """
+        macro_dir = project / "macros"
+        write(macro_dir / "m.sql", "{% macro f() %}1{% endmacro %}")
+        config = self._config(project, **{setting: "macros"})
+        templater = config.get("templater_obj")
+        before = templater.cache_fingerprint(config)
+        write(macro_dir / "m.sql", "{% macro f() %}2{% endmacro %}")
+        assert templater.cache_fingerprint(config) != before
+
+    def test_reacts_to_a_new_macro_file(self, project):
+        """Adding a macro file changes the fingerprint."""
+        write(project / "macros" / "m.sql", "{% macro f() %}1{% endmacro %}")
+        config = self._config(project, load_macros_from_path="macros")
+        templater = config.get("templater_obj")
+        before = templater.cache_fingerprint(config)
+        write(project / "macros" / "n.sql", "{% macro g() %}2{% endmacro %}")
+        assert templater.cache_fingerprint(config) != before
+
+
+# ###
+# Integration: linting a project twice
+# ###
+
+
+class TestLintPathsIntegration:
+    """End to end behaviour through `Linter.lint_paths`."""
+
+    def test_disabled_by_default(self, project):
+        """Nothing is cached and no directory appears unless asked for."""
+        write(project / "a.sql", CLEAN_SQL)
+        config = FluffConfig.from_path(str(project), overrides={"dialect": "ansi"})
+        assert lint(project, config).files_cached == 0
+
+    def test_path_with_no_sql_writes_nothing(self, project, tmp_path):
+        """A path containing no SQL doesn't even open the cache.
+
+        Building one reads the cache file and enumerates installed plugins,
+        which is measurable and pointless when there is nothing to lint.
+        """
+        cache_dir = tmp_path / "cache"
+        result = lint(project, make_config(project, cache_dir=cache_dir))
+        assert result.files_cached == 0
+        assert not cache_dir.exists()
+
+    def test_clean_file_is_skipped_on_the_second_run(self, project):
+        """The headline behaviour."""
+        write(project / "a.sql", CLEAN_SQL)
+        assert lint(project, make_config(project)).files_cached == 0
+        assert lint(project, make_config(project)).files_cached == 1
+
+    def test_dirty_file_is_never_skipped(self, project):
+        """A file with violations is re-linted every time.
+
+        If it were cached the user would stop being told about the violation.
+        """
+        write(project / "a.sql", DIRTY_SQL)
+        first = lint(project, make_config(project))
+        second = lint(project, make_config(project))
+        assert second.files_cached == 0
+        assert len(second.get_violations()) == len(first.get_violations())
+
+    def test_mixed_project_only_skips_the_clean_files(self, project):
+        """Clean and dirty files in one run are partitioned correctly."""
+        write(project / "clean.sql", CLEAN_SQL)
+        write(project / "dirty.sql", DIRTY_SQL)
+        lint(project, make_config(project))
+        second = lint(project, make_config(project))
+        assert second.files_cached == 1
+        assert [v.rule_code() for v in second.get_violations()]
+
+    def test_editing_a_file_invalidates_it(self, project):
+        """A changed file is linted again."""
+        target = project / "a.sql"
+        write(target, CLEAN_SQL)
+        lint(project, make_config(project))
+        write(target, DIRTY_SQL)
+        result = lint(project, make_config(project))
+        assert result.files_cached == 0
+        assert result.get_violations()
+
+    def test_reverting_a_file_hits_the_old_entry(self, project):
+        """An entry stays valid for content it was recorded against.
+
+        Entries are keyed by content, not by path alone, so a revert is a hit
+        rather than a miss.
+        """
+        target = project / "a.sql"
+        write(target, CLEAN_SQL)
+        lint(project, make_config(project))
+        write(target, DIRTY_SQL)
+        lint(project, make_config(project))
+        write(target, CLEAN_SQL)
+        assert lint(project, make_config(project)).files_cached == 1
+
+    def test_changing_config_invalidates(self, project):
+        """A config change re-lints everything it applies to."""
+        write(project / "a.sql", CLEAN_SQL)
+        lint(project, make_config(project))
+        rewrite_config(
+            project,
+            "[sqlfluff]\ndialect = ansi\n"
+            "[sqlfluff:rules:capitalisation.keywords]\ncapitalisation_policy = lower\n",
+        )
+        result = lint(project, make_config(project))
+        assert result.files_cached == 0
+        assert result.get_violations()
+
+    def test_changing_an_override_invalidates(self, project):
+        """CLI overrides are part of the key, not just files on disk."""
+        write(project / "a.sql", CLEAN_SQL)
+        lint(project, make_config(project))
+        assert lint(project, make_config(project, rules="LT01")).files_cached == 0
+
+    def test_changing_the_run_fingerprint_invalidates(self, project, monkeypatch):
+        """Upgrading SQLFluff throws the whole cache away."""
+        write(project / "a.sql", CLEAN_SQL)
+        lint(project, make_config(project))
+        monkeypatch.setattr(
+            "sqlfluff.core.linter.cache._get_sqlfluff_version", lambda: "0.0.0-test"
+        )
+        assert lint(project, make_config(project)).files_cached == 0
+
+    def test_changing_a_macro_invalidates(self, project):
+        """Editing a macro re-lints every file which could have used it.
+
+        This is the case a naive content hash gets wrong: the SQL file is
+        untouched, but what it renders to has changed.
+        """
+        write(project / "macros" / "m.sql", "{% macro f() %}a{% endmacro %}")
+        write(
+            project / ".sqlfluff",
+            "[sqlfluff]\ndialect = ansi\n"
+            "[sqlfluff:templater:jinja]\nload_macros_from_path = macros\n",
+        )
+        write(project / "a.sql", "SELECT {{ f() }}\nFROM tbl\n")
+        lint(project, make_config(project))
+        assert lint(project, make_config(project)).files_cached == 1
+        write(project / "macros" / "m.sql", "{% macro f() %}b{% endmacro %}")
+        assert lint(project, make_config(project)).files_cached == 0
+
+    def test_templater_opt_out_disables_caching(self, project, monkeypatch):
+        """A templater which declines is never cached, however clean the file.
+
+        This is what keeps dbt projects out of the cache.
+        """
+        monkeypatch.setattr(
+            JinjaTemplater, "cache_fingerprint", lambda self, config: None
+        )
+        write(project / "a.sql", CLEAN_SQL)
+        lint(project, make_config(project))
+        assert lint(project, make_config(project)).files_cached == 0
+
+    def test_corrupt_cache_file_is_ignored(self, project, tmp_path):
+        """A damaged cache costs a slow run, not a failed one."""
+        cache_dir = tmp_path / "cache"
+        write(project / "a.sql", CLEAN_SQL)
+        lint(project, make_config(project, cache_dir=cache_dir))
+        write(cache_dir / CACHE_FILENAME, "{ truncated")
+        assert (
+            lint(project, make_config(project, cache_dir=cache_dir)).files_cached == 0
+        )
+
+    def test_cache_file_has_the_expected_shape(self, project, tmp_path):
+        """The on-disk format is versioned and fingerprinted."""
+        cache_dir = tmp_path / "cache"
+        write(project / "a.sql", CLEAN_SQL)
+        lint(project, make_config(project, cache_dir=cache_dir))
+        payload = json.loads((cache_dir / CACHE_FILENAME).read_text(encoding="utf-8"))
+        assert payload["schema_version"] == CACHE_SCHEMA_VERSION
+        assert payload["run_fingerprint"] == run_fingerprint()
+        assert len(payload["entries"]) == 1
+
+
+class TestOutputParity:
+    """A cached run has to report the same thing as an uncached one."""
+
+    def _records(self, result):
+        """Records with timings dropped.
+
+        Timings are deliberately *not* replayed: reporting the cost of work
+        which didn't happen would make `--persist-timing` misleading.
+        """
+        return [
+            {k: v for k, v in record.items() if k != "timings"}
+            for record in result.as_records()
+        ]
+
+    def test_records_match(self, project):
+        """Serialised records are identical apart from timings."""
+        write(project / "clean.sql", CLEAN_SQL)
+        write(project / "dirty.sql", DIRTY_SQL)
+        uncached = lint(project, make_config(project, cache=False))
+        lint(project, make_config(project))
+        cached = lint(project, make_config(project))
+        assert cached.files_cached == 1
+        assert self._records(cached) == self._records(uncached)
+
+    def test_statistics_are_replayed(self, project):
+        """Character and segment counts survive a cache hit.
+
+        They are pure functions of the file and its config, so the same key
+        implies the same statistics.
+        """
+        write(project / "a.sql", CLEAN_SQL)
+        uncached = lint(project, make_config(project, cache=False))
+        lint(project, make_config(project))
+        cached = lint(project, make_config(project))
+        assert cached.files_cached == 1
+        assert (
+            cached.as_records()[0]["statistics"]
+            == uncached.as_records()[0]["statistics"]
+        )
+
+    def test_timings_are_empty_for_a_cached_file(self, project):
+        """No work happened, so no time is reported for it."""
+        write(project / "a.sql", CLEAN_SQL)
+        lint(project, make_config(project))
+        cached = lint(project, make_config(project))
+        assert cached.as_records()[0]["timings"] == {}
+
+    def test_counts_match(self, project):
+        """File and cleanliness counts are unaffected by caching."""
+        write(project / "clean.sql", CLEAN_SQL)
+        write(project / "dirty.sql", DIRTY_SQL)
+        uncached = lint(project, make_config(project, cache=False))
+        lint(project, make_config(project))
+        cached = lint(project, make_config(project))
+        assert cached.stats(1, 0) == uncached.stats(1, 0)
+
+    def test_exit_status_matches(self, project):
+        """A run which is entirely cache hits still passes."""
+        write(project / "a.sql", CLEAN_SQL)
+        lint(project, make_config(project))
+        cached = lint(project, make_config(project))
+        assert cached.stats(1, 0)["status"] == "PASS"
+
+
+class TestNoqaInteraction:
+    """`noqa` comments change what a file reports without changing its rules."""
+
+    def test_fully_suppressed_file_is_cached(self, project):
+        """A file whose violations are all masked by noqa reports nothing.
+
+        Caching it is safe rather than merely convenient: the `noqa` comment
+        is part of the file, so removing it changes the key.
+        """
+        target = project / "a.sql"
+        write(target, "select  a,b from tbl  -- noqa\n")
+        lint(project, make_config(project))
+        assert lint(project, make_config(project)).files_cached == 1
+
+    def test_removing_a_noqa_re_reports(self, project):
+        """Deleting the suppression brings the violations back."""
+        target = project / "a.sql"
+        write(target, "select  a,b from tbl  -- noqa\n")
+        lint(project, make_config(project))
+        write(target, DIRTY_SQL)
+        result = lint(project, make_config(project))
+        assert result.files_cached == 0
+        assert result.get_violations()
+
+    def test_unused_noqa_is_not_cached(self, project):
+        """A file whose only finding is an unused noqa is not cached.
+
+        Those warnings are generated from the ignore mask on demand rather than
+        stored on the file, so a naive "no violations" test would call this
+        file clean and lose the warning on the next run.
+        """
+        write(project / "a.sql", "SELECT\n    a,\n    b\nFROM tbl  -- noqa: LT02\n")
+        lint(project, make_config(project, warn_unused_ignores=True))
+        result = lint(project, make_config(project, warn_unused_ignores=True))
+        assert result.files_cached == 0
+
+
+class TestFixInteraction:
+    """Caching has to behave under `fix`, which rewrites files."""
+
+    def test_fixed_file_is_cached_on_the_next_run(self, project):
+        """After a fix the new contents are keyed, not the old ones."""
+        target = project / "a.sql"
+        write(target, DIRTY_SQL)
+        Linter(config=make_config(project)).lint_paths(
+            (str(project),), fix=True, apply_fixes=True
+        )
+        # The file has been rewritten, so the first pass over the new contents
+        # is a miss...
+        assert lint(project, make_config(project)).files_cached == 0
+        # ...and the second is a hit.
+        assert lint(project, make_config(project)).files_cached == 1
+
+    def test_unfixable_file_is_never_cached(self, project):
+        """A file left with violations after fixing keeps being reported."""
+        write(project / "a.sql", "SELECT DISTINCT(a)\nFROM tbl\n")
+        for _ in range(2):
+            result = Linter(config=make_config(project)).lint_paths(
+                (str(project),), fix=True, apply_fixes=True
+            )
+        assert result.files_cached == 0
+
+
+class TestLintedDirBookkeeping:
+    """A cached file has no `LintedFile`, so the metadata has to stand alone."""
+
+    def test_records_exist_without_files(self, project):
+        """Records and counts are present even though `.files` is empty."""
+        write(project / "a.sql", CLEAN_SQL)
+        lint(project, make_config(project))
+        cached = lint(project, make_config(project))
+        linted_dir = cached.paths[0]
+        assert linted_dir.files == []
+        assert len(linted_dir.as_records()) == 1
+        assert linted_dir.stats() == {
+            "files": 1,
+            "clean": 1,
+            "unclean": 0,
+            "violations": 0,
+        }
+
+    def test_discarding_fixes_does_not_trip_over_a_cached_record(self, project):
+        """The tmp/prs error map is populated for cached records too.
+
+        `discard_fixes_for_lint_errors_in_files_with_tmp_or_prs_errors` indexes
+        that map by the filepath of every record, so a cached record with no
+        entry would raise a KeyError.
+        """
+        write(project / "clean.sql", CLEAN_SQL)
+        write(project / "broken.sql", "SELECT FROM FROM;\n")
+        lint(project, make_config(project))
+        cached = lint(project, make_config(project))
+        assert cached.files_cached == 1
+        cached.discard_fixes_for_lint_errors_in_files_with_tmp_or_prs_errors()
+
+
+class TestParallel:
+    """Caching is a main-process concern, but it has to survive workers."""
+
+    def test_cache_works_with_multiple_processes(self, project):
+        """Files linted in worker processes are still cached afterwards.
+
+        The runner returns `LintedFile` objects to the main process, which is
+        where recording happens, so no coordination between workers is needed.
+        This test exists to keep that true.
+        """
+        for name in ("a.sql", "b.sql", "c.sql"):
+            write(project / name, CLEAN_SQL)
+        config = make_config(project, processes=2)
+        assert lint(project, config).files_cached == 0
+        assert lint(project, make_config(project, processes=2)).files_cached == 3
+
+
+# ###
+# CLI
+# ###
+
+
+class TestCli:
+    """The flags which turn caching on and point it somewhere."""
+
+    @staticmethod
+    def _lint_cli(project_root, *extra):
+        return invoke_assert_code(
+            ret_code=0,
+            args=[lint_command, [str(project_root), "--dialect", "ansi", *extra]],
+        )
+
+    def test_no_cache_directory_without_the_flag(self, project, tmp_path):
+        """Caching stays off unless asked for, so nothing appears on disk."""
+        write(project / "a.sql", CLEAN_SQL)
+        self._lint_cli(project, "--cache-dir", str(tmp_path / "cache"))
+        assert not (tmp_path / "cache").exists()
+
+    def test_cache_flag_creates_the_cache(self, project, tmp_path):
+        """`--cache` writes a cache in the requested directory."""
+        write(project / "a.sql", CLEAN_SQL)
+        cache_dir = tmp_path / "cache"
+        self._lint_cli(project, "--cache", "--cache-dir", str(cache_dir))
+        assert (cache_dir / CACHE_FILENAME).exists()
+
+    def test_config_alone_enables_caching(self, project, tmp_path, monkeypatch):
+        """No flag is needed if the root config asks for a cache.
+
+        Like `processes`, this is a run-level setting read from the root
+        config, so the test runs from inside the project rather than pointing
+        at it from outside.
+        """
+        cache_dir = tmp_path / "cache"
+        rewrite_config(
+            project,
+            f"[sqlfluff]\ndialect = ansi\ncache = True\n"
+            f"cache_dir = {cache_dir.as_posix()}\n",
+        )
+        write(project / "a.sql", CLEAN_SQL)
+        monkeypatch.chdir(project)
+        self._lint_cli(project)
+        assert (cache_dir / CACHE_FILENAME).exists()
+
+    def test_no_cache_flag_beats_config(self, project, tmp_path, monkeypatch):
+        """`--no-cache` overrides `cache = True` in the config file."""
+        cache_dir = tmp_path / "cache"
+        rewrite_config(
+            project,
+            f"[sqlfluff]\ndialect = ansi\ncache = True\n"
+            f"cache_dir = {cache_dir.as_posix()}\n",
+        )
+        write(project / "a.sql", CLEAN_SQL)
+        monkeypatch.chdir(project)
+        self._lint_cli(project, "--no-cache")
+        assert not cache_dir.exists()
+
+    def test_relative_cache_dir_is_resolved_from_the_working_directory(
+        self, project, monkeypatch
+    ):
+        """A relative `cache_dir` lands in the same place on every run.
+
+        `cache_dir` ends in `_dir`, which the config loader would otherwise
+        resolve relative to the config file -- but only once the directory
+        exists, because resolution goes through `glob`. That would put the
+        cache in one place on the first run and another on the second.
+        """
+        rewrite_config(
+            project,
+            "[sqlfluff]\ndialect = ansi\ncache = True\ncache_dir = .sqlfluff_cache\n",
+        )
+        write(project / "a.sql", CLEAN_SQL)
+        monkeypatch.chdir(project)
+        for _ in range(2):
+            self._lint_cli(project)
+            assert (project / ".sqlfluff_cache" / CACHE_FILENAME).exists()
+
+    def test_second_run_reports_the_same_result(self, project, tmp_path):
+        """A cached run produces the same output and exit code as the first."""
+        cache_dir = str(tmp_path / "cache")
+        write(project / "clean.sql", CLEAN_SQL)
+        write(project / "dirty.sql", DIRTY_SQL)
+        first = invoke_assert_code(
+            ret_code=1,
+            args=[
+                lint_command,
+                [
+                    str(project),
+                    "--dialect",
+                    "ansi",
+                    "--format",
+                    "json",
+                    "--cache",
+                    "--cache-dir",
+                    cache_dir,
+                ],
+            ],
+        )
+        second = invoke_assert_code(
+            ret_code=1,
+            args=[
+                lint_command,
+                [
+                    str(project),
+                    "--dialect",
+                    "ansi",
+                    "--format",
+                    "json",
+                    "--cache",
+                    "--cache-dir",
+                    cache_dir,
+                ],
+            ],
+        )
+
+        def _strip(output):
+            return [
+                {k: v for k, v in record.items() if k != "timings"}
+                for record in json.loads(output)
+            ]
+
+        assert _strip(second.stdout) == _strip(first.stdout)
+
+    def test_fix_accepts_the_flags(self, project, tmp_path):
+        """`fix` takes the same options as `lint`."""
+        cache_dir = tmp_path / "cache"
+        write(project / "a.sql", DIRTY_SQL)
+        invoke_assert_code(
+            ret_code=0,
+            args=[
+                fix,
+                [
+                    str(project),
+                    "--dialect",
+                    "ansi",
+                    "--cache",
+                    "--cache-dir",
+                    str(cache_dir),
+                    "--disable-progress-bar",
+                ],
+            ],
+        )
+        assert (cache_dir / CACHE_FILENAME).exists()

--- a/test/core/linter/cache_test.py
+++ b/test/core/linter/cache_test.py
@@ -232,6 +232,17 @@ def test__cache_coerce_entry_canonicalises_statistics_order():
             },
             "non-integer statistic",
         ),
+        (
+            {
+                "statistics": {
+                    "source_chars": -1,
+                    "templated_chars": 2,
+                    "segments": 3,
+                    "raw_segments": 4,
+                }
+            },
+            "negative statistic",
+        ),
     ],
 )
 def test__cache_coerce_entry_rejects_malformed(mutation, reason):
@@ -261,6 +272,17 @@ class TestLoadAndPersist:
     def test_from_config_returns_none_when_disabled(self, project):
         """No cache object at all when caching is off, so there's no cost."""
         assert LintCache.from_config(make_config(project, cache=False)) is None
+
+    def test_from_config_declines_with_user_rules(self, project):
+        """Custom rules passed to `Linter` disable caching entirely.
+
+        Regression test. Every other input to a result has a stable identity --
+        a file its bytes, config its values, a plugin its version -- but a rule
+        class handed to us in-process has none: its name would not change when
+        its body did. Keying on it would let an edited rule be masked by a
+        cached clean result, so we decline instead.
+        """
+        assert LintCache.from_config(make_config(project), user_rules=[object]) is None
 
     def test_from_config_builds_when_enabled(self, project, tmp_path):
         """The configured directory is respected and made absolute."""
@@ -313,6 +335,21 @@ class TestLoadAndPersist:
         cache = LintCache(str(cache_dir), make_config(project))
         cache.persist()
         assert (cache_dir / ".gitignore").read_text(encoding="utf-8").endswith("*\n")
+
+    def test_no_gitignore_in_a_directory_we_did_not_create(self, project, tmp_path):
+        """A pre-existing `cache_dir` is not silently made git-ignored.
+
+        Regression test. `cache_dir` is user-configurable and may point at a
+        directory which already holds other things; writing a `.gitignore`
+        containing `*` there would hide the user's own untracked files.
+        """
+        cache_dir = tmp_path / "existing"
+        cache_dir.mkdir()
+        write(cache_dir / "something_of_theirs.txt", "keep me")
+        cache = LintCache(str(cache_dir), make_config(project))
+        cache.persist()
+        assert (cache_dir / CACHE_FILENAME).exists()
+        assert not (cache_dir / ".gitignore").exists()
 
     def test_persist_leaves_no_temporary_files(self, project, tmp_path):
         """The atomic write cleans up after itself."""
@@ -435,6 +472,25 @@ class TestCheckAndRecord:
         cache.record(str(target), dict(VALID_ENTRY["statistics"]))
         assert cache._entries == {}
 
+    def test_pending_keys_are_released_for_uncacheable_files(self, project):
+        """A file which will never be recorded doesn't hold its key.
+
+        Regression test. `check` retains a key for every miss so that `record`
+        can verify it. On a project where most files have violations -- the
+        projects that get no benefit from the cache in the first place --
+        holding one key per file for the whole run is wasted memory.
+        """
+        write(project / "clean.sql", CLEAN_SQL)
+        write(project / "dirty.sql", DIRTY_SQL)
+        linter = Linter(config=make_config(project))
+        linter.lint_paths((str(project),))
+        # Both files missed, but only the clean one is kept as an entry and
+        # neither is left dangling in the pending map.
+        cache = LintCache.from_config(make_config(project))
+        assert cache is not None
+        assert len(cache._entries) == 1
+        assert cache._pending_keys == {}
+
     def test_missing_file_is_not_keyable(self, project, tmp_path):
         """A file which disappeared is a miss, not an exception."""
         cache = LintCache(str(tmp_path / "cache"), make_config(project))
@@ -532,6 +588,35 @@ class UnknownTemplater(RawTemplater):
     """A stand-in for a templater SQLFluff doesn't ship."""
 
     name = "unknown"
+
+
+class DerivedJinjaTemplater(JinjaTemplater):
+    """A stand-in for a templater which renders through a project.
+
+    `DbtTemplater` and `SQLMeshTemplater` are both real examples.
+    """
+
+    name = "derived_jinja"
+
+
+def test__templater_jinja_is_cacheable(project):
+    """The Jinja templater declares the paths it reads."""
+    config = make_config(project)
+    templater = config.get("templater_obj")
+    assert isinstance(templater, JinjaTemplater)
+    assert templater.cache_fingerprint(config) is not None
+
+
+def test__templater_jinja_subclass_is_not_cacheable(project):
+    """A subclass of `JinjaTemplater` does not inherit the opt-in.
+
+    Regression test. The Jinja declaration covers what *Jinja* reads; a
+    subclass which renders through a project reads a great deal more --
+    SQLMesh loads project context, dbt a compiled manifest. Inheriting an
+    opt-in that was never made for you is exactly how a stale hit hides a
+    real violation.
+    """
+    assert DerivedJinjaTemplater().cache_fingerprint(make_config(project)) is None
 
 
 def test__templater_raw_is_cacheable():
@@ -996,24 +1081,36 @@ class TestCli:
         assert not cache_dir.exists()
 
     def test_relative_cache_dir_is_resolved_from_the_working_directory(
-        self, project, monkeypatch
+        self, tmp_path, monkeypatch
     ):
         """A relative `cache_dir` lands in the same place on every run.
 
         `cache_dir` ends in `_dir`, which the config loader would otherwise
-        resolve relative to the config file -- but only once the directory
+        resolve relative to the *config file* -- but only once the directory
         exists, because resolution goes through `glob`. That would put the
         cache in one place on the first run and another on the second.
+
+        The config therefore lives in a *parent* of the working directory, so
+        the two candidate bases genuinely differ: resolving against the config
+        file would give ``<tmp>/.sqlfluff_cache`` and against the working
+        directory ``<tmp>/work/.sqlfluff_cache``. Running from the config's own
+        directory would make both answers identical and prove nothing.
         """
-        rewrite_config(
-            project,
+        write(
+            tmp_path / ".sqlfluff",
             "[sqlfluff]\ndialect = ansi\ncache = True\ncache_dir = .sqlfluff_cache\n",
         )
-        write(project / "a.sql", CLEAN_SQL)
-        monkeypatch.chdir(project)
+        clear_config_caches()
+        work = tmp_path / "work"
+        work.mkdir()
+        write(work / "a.sql", CLEAN_SQL)
+        monkeypatch.chdir(work)
+
         for _ in range(2):
-            self._lint_cli(project)
-            assert (project / ".sqlfluff_cache" / CACHE_FILENAME).exists()
+            self._lint_cli(work)
+            assert (work / ".sqlfluff_cache" / CACHE_FILENAME).exists()
+            # Never beside the config file.
+            assert not (tmp_path / ".sqlfluff_cache").exists()
 
     def test_second_run_reports_the_same_result(self, project, tmp_path):
         """A cached run produces the same output and exit code as the first."""

--- a/test/core/linter/linted_file_test.py
+++ b/test/core/linter/linted_file_test.py
@@ -366,6 +366,43 @@ class TestIsCacheable:
         assert linted.is_clean()
         assert not linted.is_cacheable()
 
+    def test_does_not_mutate_the_file(self):
+        """Asking whether a file is cacheable must not change it.
+
+        Regression test. `get_violations()` builds a new list in every filter
+        branch, but with `filter_ignore=False` and `filter_warning=False` none
+        of them apply, so `violations` was still the same object as
+        `self.violations` when the generated unused-`noqa` warnings were
+        appended with `+=`. That appended them to the file's own violation
+        list, permanently, once per call: repeated calls went 0 -> 1 -> 2 and
+        every consumer of `LintedFile.violations` afterwards saw warnings which
+        were never really found there.
+        """
+        linted = self._lint("SELECT\n    a,\n    b\nFROM tbl  -- noqa: LT02\n")
+        assert linted.violations == []
+        results = [linted.is_cacheable() for _ in range(3)]
+        # The answer is stable...
+        assert results == [False, False, False]
+        # ...and the file is untouched.
+        assert linted.violations == []
+
+    def test_get_violations_does_not_mutate_the_file(self):
+        """The same guarantee at the level where the bug actually lived.
+
+        Covers every caller, not just `is_cacheable()`.
+        """
+        linted = self._lint("SELECT\n    a,\n    b\nFROM tbl  -- noqa: LT02\n")
+        first = linted.get_violations(
+            filter_ignore=False, filter_warning=False, warn_unused_ignores=True
+        )
+        second = linted.get_violations(
+            filter_ignore=False, filter_warning=False, warn_unused_ignores=True
+        )
+        # One generated warning each time, not one more each time.
+        assert len(first) == 1
+        assert len(second) == 1
+        assert linted.violations == []
+
     def test_ignored_parse_error_is_not_cacheable(self):
         """`ignore = parsing` hides a parse error from output but not from counts.
 

--- a/test/core/linter/linted_file_test.py
+++ b/test/core/linter/linted_file_test.py
@@ -321,3 +321,60 @@ def test__linted_file__fix_string_generates_patches_when_not_precomputed():
 
     assert changed
     assert fixed_sql == "SELECT\n    1\n"
+
+
+class TestIsCacheable:
+    """`is_cacheable` gates whether a result may be replayed from the cache.
+
+    It is deliberately stricter than `is_clean`: a cached file is not linted at
+    all on the next run, so it has to produce nothing under *any* combination
+    of filters, not just the default one.
+    """
+
+    @staticmethod
+    def _lint(sql, **overrides):
+        config = FluffConfig(overrides={"dialect": "ansi", **overrides})
+        return Linter(config=config).lint_string(sql)
+
+    def test_clean_file_is_cacheable(self):
+        """A file with nothing to report can be replayed."""
+        assert self._lint("SELECT\n    a,\n    b\nFROM tbl\n").is_cacheable()
+
+    def test_file_with_violations_is_not_cacheable(self):
+        """A file with something to report must be linted again."""
+        assert not self._lint("select  a,b from tbl\n").is_cacheable()
+
+    def test_fully_suppressed_file_is_cacheable(self):
+        """A file whose violations are all masked by `noqa` reports nothing.
+
+        The `noqa` comment is part of the file's contents, so removing it
+        changes the cache key and the file is linted again.
+        """
+        linted = self._lint("select  a,b from tbl  -- noqa\n")
+        assert linted.violations == []
+        assert linted.is_cacheable()
+
+    def test_unused_noqa_is_not_cacheable(self):
+        """An unused `noqa` blocks caching even though `violations` is empty.
+
+        Those warnings are generated from the ignore mask on demand rather than
+        being stored on the file, so testing `violations` alone would call this
+        file clean and silently lose the warning on the next run.
+        """
+        linted = self._lint("SELECT\n    a,\n    b\nFROM tbl  -- noqa: LT02\n")
+        assert linted.violations == []
+        assert linted.is_clean()
+        assert not linted.is_cacheable()
+
+    def test_ignored_parse_error_is_not_cacheable(self):
+        """`ignore = parsing` hides a parse error from output but not from counts.
+
+        The violation stays on the file with `ignore` set, and still counts
+        towards `num_unfiltered_tmp_prs_errors`, which drives the exit code of
+        `sqlfluff fix`. Replaying an empty result would change that exit code,
+        which is why `is_cacheable` passes `filter_ignore=False`.
+        """
+        linted = self._lint("SELECT FROM FROM;\n", ignore="parsing,linting")
+        assert linted.is_clean()
+        assert all(v.ignore for v in linted.violations)
+        assert not linted.is_cacheable()


### PR DESCRIPTION
Closes #6926. Also addresses #3262.

> **AI disclosure** (per [CONTRIBUTING](https://github.com/sqlfluff/sqlfluff/blob/main/CONTRIBUTING.md#ai-assisted-contributions)): I used an AI coding agent to write much of this code and its docstrings, and to draft this description. What I validated myself is listed under [Validation](#validation) — in particular the correctness argument for every cache key input, the three defects I found in my own drafts (a JSON output difference, a TOCTOU window, and a lookup so expensive it nearly cancelled the benefit), and every number quoted below.

## The problem

SQLFluff has no result cache. Every run re-templates, re-lexes, re-parses and re-walks every file, including the ones that have not changed since the last run. In a pre-commit hook or an edit-and-lint loop that is nearly all of them.

Two issues ask for this — #3262 (2022) and #6926 (2025, labelled `core`). #6926 reports 20–30s runs "even though only a few files change at a time". ruff, black, mypy, eslint and prettier all cache; SQLFluff is the outlier.

## What this does

Adds an **opt-in** cache of files which linted clean, so the next run can skip them.

```sh
sqlfluff lint --cache .
```
```cfg
[sqlfluff]
cache = True
cache_dir = .sqlfluff_cache   # default
```

Off unless asked for, so nothing changes for anyone who doesn't opt in. Whether the default should eventually flip is a real question — see [Open questions](#open-questions).

## Design

The easy part is storing hashes. The hard part is being able to argue that a hit is **equivalent to** doing the work. Three rules do that.

### 1. Only files that produced *nothing* are cached

Not "clean" in the `is_clean()` sense — nothing at all: no violations, no warnings, no templating or parsing errors, and no unused `-- noqa`. The new `LintedFile.is_cacheable()` is deliberately stricter than `is_clean()`:

```python
return not self.get_violations(
    filter_ignore=False, filter_warning=False, warn_unused_ignores=True
)
```

Both non-default arguments are load-bearing, and each has a test:

- `filter_ignore=False` — a violation hidden by `ignore = parsing` stays on the file and still counts toward `num_unfiltered_tmp_prs_errors`, which drives the exit code of `sqlfluff fix`. Replaying an empty result would change that exit code.
- `warn_unused_ignores=True` — unused-`noqa` warnings are *generated from the ignore mask on demand*, not stored in `violations`. A naive "no violations" test calls such a file clean and silently loses the warning next run.

The consequence is that the cache can never hide a diagnostic the user has not already dealt with. It also means the win comes precisely where you want it: on a project that is already passing, nearly every file qualifies.

### 2. The key covers everything that can change a result

Per file: the file's **bytes** (not decoded text — encoding detection is itself config-dependent), its **fully resolved config**, and the **templater's external state**. Per run: the **SQLFluff version** and **every installed plugin's name and version**, stored once in the header so a change discards the whole file.

`config_digest()` builds on the existing public `FluffConfig.iter_vals()`, which already excludes exactly the derived, unserialisable entries (`dialect_obj`, `templater_obj`, resolved allow/deny lists) — each a pure function of values that *are* included, so nothing is lost.

### 3. Templaters opt in, one at a time

The gap a content hash cannot close is that templating reads files the SQL file never mentions. New method on `RawTemplater`:

```python
def cache_fingerprint(self, config: FluffConfig) -> Optional[str]:
    """Return a digest of the state I read from outside the file.

    "" if there is none, a digest of it if there is, None to decline.
    """
```

**The default is `None` — decline.** A templater SQLFluff didn't write may read anything, and there is no way to infer what; guessing wrong means silently skipping a file that should have reported. Opting in costs a third party nothing but a missed optimisation until they take it. (`raw`, `python` and `placeholder` guard on `type(self) is <that class>`, because each is subclassed — `JinjaTemplater` extends `PythonTemplater` — and an opt-in must not be inherited by a subclass that never made it.)

- **`jinja`** hashes the contents of `loader_search_path`, `load_macros_from_path`, `exclude_macros_from_path` and `library_path`. Those four are the *only* filesystem inputs: the loader is built solely from the first two, and there is no implicit per-file search directory. Editing, adding, removing or renaming a macro re-lints every file that could have used it.
- **`dbt` declines.** A model's rendering depends on the compiled manifest — other models, seeds, packages, the target, `env_var()` — none of it reachable from the model plus its SQLFluff config. Approximating that is how you get a stale hit that hides a real violation, so dbt projects simply are not cached. Making them cacheable means fingerprinting the manifest, which is separate work.

### Output is unchanged

A cached run is byte-identical to an uncached one except for timings. Entries carry the four size statistics `LintedDir` derives from a parsed file, and `LintedDir.add_cached_clean()` replays them and updates the same counters `add()` would. `file_statistics()` was factored out of `add()` so the stored and computed values cannot drift.

Timings are deliberately **not** replayed — reporting the cost of work that did not happen would make `--persist-timing` misleading.

### Making the lookup cheaper than the work it skips

A cache is only worth having if checking is much cheaper than doing. The naive
version of this is not: profiling the lookup showed **~40 ms per file spent in
`make_child_from_path`**, 95% of a check, because building a `FluffConfig`
expands a fresh dialect object every time. At that price a hit saves almost
nothing.

What a config resolves to depends only on the file's *directory* — config files
are discovered by walking directories — so the cache memoises it per directory,
which is exact rather than approximate. Only the three derived strings are kept
(`templater name`, `templater fingerprint`, `config digest`), never the
`FluffConfig`, so the expanded dialect is released instead of being pinned once
per directory for the length of the run. Inline `-- sqlfluff:` directives are
deliberately not applied there: the linter applies them after reading the file,
and they live in the file's own bytes, which the key already covers.

The templater fingerprint is memoised separately, keyed on
`(templater, config digest)` rather than on the directory, so that directories
sharing a config also share the directory-tree hashing. Both memos live on the
`LintCache`, so their lifetime is one run: a long-lived process that lints,
edits a macro and lints again still sees the change.

That took a steady-state check from **42 ms to 1.6 ms** per file, most of what
remains being the `open()`+`read()` of the file itself — unavoidable, since any
cache has to read a file to know whether it changed, and the linter reads it
anyway. Both memos have tests, because silently regressing either would gut the
feature without failing anything else.

### Failure modes

The cache never changes behaviour when something goes wrong. Unreadable, truncated, wrong-schema or wrong-fingerprint file → treated as empty. Every field of every entry is validated rather than trusted, because a bad entry we accepted would silently skip a file. Unwritable directory → one warning, then disabled for the run. Any error deriving a key → that file is simply linted.

Writes are atomic (`mkstemp` + `os.replace` in the same directory) and happen once, at the end, from the main process only — so `--processes N` needs no coordination, and an interrupted run leaves the previous cache intact rather than a half-updated one.

## Results

200 generated clean files, each run a fresh subprocess, scenarios interleaved round-robin so a noisy patch on the machine hits all of them equally rather than penalising whichever happened to run during it. `minus startup` subtracts the median cost of linting an empty directory (interpreter start, plugin discovery, dialect load), isolating the part that scales with the project.

I ran this three times — once before addressing review feedback and twice after — and am reporting all three, because they disagree in a way worth being honest about:

| run | cache off | cold | warm |
|---|---|---|---|
| 5 rounds (before review fixes) | 24.60s | 25.44s (1.03x) | 0.78s (0.03x) |
| 3 rounds (after) | 25.87s | 27.46s (1.06x) | 1.00s (0.04x) |
| 5 rounds (after) | 27.02s | 25.63s (**0.95x**) | 0.45s (0.02x) |

**What is solid:** the warm cache reduces project-scaling work from ~25s to well under a second, every time. That is a 25–60x effect and it does not depend on which run you look at.

**What is not:** the cold-cache overhead. The last run puts it at 0.95x — *faster than not caching*, which is impossible, since a cold cache does strictly more work and then writes a file. The `cache off` scenario alone ranged from 24.36s to 32.75s within a single run. So the honest statement is that **the cost of populating the cache is smaller than this machine can resolve**, somewhere under ~5%, and I would not defend a more precise figure than that. A quiet Linux box would measure it properly; I don't have one.

The cache file is 50,121 bytes for 200 entries, i.e. **~251 bytes per file** — about 25 MB for a 100k-file project, with entries not seen for 30 days dropped on write so it doesn't grow without bound. That number is stable across all three runs.

Two further caveats, both in the conservative direction: these are small generated files, so the *fixed* per-file cost of a cache check is a larger fraction here than it would be on real SQL; and this is a Windows machine with on-access scanning, where `open()`+`read()` is unusually expensive — which is most of what the warm run still spends.

## Trade-offs I'd flag for review

- **A cached file has no parse tree.** `LintedDir.files` and `.tree` won't include it — that's what "skip the work" means. Documented; API consumers that need trees should leave caching off. The CLI does not use them for this path.
- **`cache`/`cache_dir` are read from the root config**, like `processes`, not from a `.sqlfluff` in a subdirectory. Documented.
- **One extra read + hash of each clean file.** `record()` recomputes the key and requires it to match the one from `check()`. Without that, a file edited *while the run was in progress* could have its pre-edit key recorded as clean on the strength of linting the post-edit contents — a claim never actually verified. Requiring the file to be unchanged across the run means an entry is always backed by a lint of exactly the contents it names.
- **Two changes outside the cache itself**, both small and both explained inline:
  - `NO_RESOLVE_KEYS` in `config/file.py`. `cache_dir` ends in `_dir`, so `RESOLVE_PATH_SUFFIXES` would resolve it relative to the config file — but only *once the directory exists*, because resolution goes through `glob`. The same config would then name two different locations depending on whether a previous run had happened. Excluding it makes the location deterministic.
  - `if files_count == 1` → `<= 1` in `lint_paths`. With every file cached there is no work left, and building and tearing down a process pool for zero files is pure cost. Correct on its own merits for a path containing no SQL, too.
- **`FormatterInterface.dispatch_cache_summary` is concrete, not abstract**, so third-party formatters inherit a no-op and keep working.

## Security note

An entry is a stored assertion that a file was clean, acted on without re-checking — so the cache directory is exactly as trusted as the working tree. That's unremarkable locally, but it matters if you restore it in CI: a cache key shared with fork PRs lets an untrusted branch save a cache a trusted run then restores, suppressing findings. Called out with a `.. warning::` in the docs. The directory is also created with a self-ignoring `.gitignore` so it can't be committed by accident.

## Validation

- Full suite on this branch: **4075 passed, 2578 skipped, 0 failures** (29m02s) (`test/`, excluding `test/dialects`), plus `ruff check`, `ruff format --check` and `mypy src/sqlfluff` all clean.
- **Not run locally:** the dbt plugin tests (dbt isn't installed in my environment) and the Sphinx docs build (Sphinx isn't installed) — the new `.rst` does parse cleanly under docutils. Both are on CI.
- What I verified myself rather than assumed:
  - That `-- noqa`-masked violations never reach `LintedFile.violations` at all (the mask is passed into `crawler.crawl`), while `ignore = parsing` violations *do* and still count — which is what fixes the shape of `is_cacheable()`. My first draft got this backwards and had a test asserting the wrong behaviour.
  - That the Jinja environment's only filesystem inputs are those four config paths, by reading `_get_jinja_env` rather than assuming.
  - That JSON output is identical to an uncached run: my first version serialised the cached `statistics` in sorted rather than canonical order, which is a visible `--format json` diff. Caught by diffing real output, fixed, and now asserted by a test.
  - Every performance number above, on this machine, in one interleaved run — including profiling the lookup itself, which is how the 40 ms-per-file config resolution turned up. My first version was correct and nearly pointless.

## Not included, deliberately

No `sqlfluff cache clear` subcommand — deleting the directory is the whole operation, as with `.ruff_cache` and `.mypy_cache`. No dbt manifest fingerprinting. No caching of *results* (only of "this produced nothing"), which is what keeps the correctness argument short enough to check.

## Open questions

1. **Should the default flip to on** in a future release once this has had some mileage? It's a one-line change in `default_config.cfg`. I've left it off so this PR cannot affect anyone who doesn't ask for it.
2. **Is `.sqlfluff_cache` in the working directory the right default**, or would you prefer a user-level cache directory (as black does via `platformdirs`)? Project-local matches ruff and mypy and makes "delete it" obvious, which is why I went that way.
3. **Is the `type(self) is <class>` guard** on the built-in opt-ins acceptable, or would you rather each concrete templater carried an explicit class attribute? The guard exists because `RawTemplater` is both the base class and the raw templater, and because `JinjaTemplater` extends `PythonTemplater`.

Happy to split the two out-of-scope fixes (`NO_RESOLVE_KEYS`, `files_count <= 1`) into their own PR if you'd prefer this to touch only the cache.
