### PR TITLE
fix(reflow): anchor duplicate-whitespace fixes on the whitespace removed

### DIFF
--- a/src/sqlfluff/utils/reflow/respace.py
+++ b/src/sqlfluff/utils/reflow/respace.py
@@ -280,8 +280,8 @@ def process_spacing(
             removal_buffer.append(ws)
             result_buffer.append(
                 LintResult(
-                    seg,
-                    [LintFix.delete(seg)],
+                    ws,
+                    [LintFix.delete(ws)],
                     description="Removing duplicate whitespace.",
                 )
             )

--- a/test/utils/reflow/respace_test.py
+++ b/test/utils/reflow/respace_test.py
@@ -8,9 +8,32 @@ import logging
 import pytest
 
 from sqlfluff.core import FluffConfig, Linter
+from sqlfluff.core.parser import WhitespaceSegment
 from sqlfluff.utils.reflow.elements import ReflowPoint
 from sqlfluff.utils.reflow.helpers import fixes_from_results
+from sqlfluff.utils.reflow.respace import process_spacing
 from sqlfluff.utils.reflow.sequence import ReflowSequence
+
+
+def test_reflow__process_spacing_duplicate_whitespace_fix_anchors():
+    """Each duplicate-whitespace fix must anchor the whitespace it removes.
+
+    The "Removing duplicate whitespace" fixes anchored the leaked loop variable
+    (the last segment of the buffer) instead of each ``ws`` being removed, so
+    for three adjacent whitespaces both deletes targeted the final segment and
+    the middle one was never fixed.
+    """
+    w1, w2, w3 = WhitespaceSegment(" "), WhitespaceSegment(" "), WhitespaceSegment(" ")
+    buffer, _, results = process_spacing([w1, w2, w3], strip_newlines=False)
+
+    # w1 is kept; w2 and w3 are pruned from the returned buffer.
+    assert len(buffer) == 1 and buffer[0] is w1
+    # Each pruned whitespace is the anchor of exactly one delete fix, and the
+    # kept one is never targeted.
+    anchors = [fix.anchor for result in results for fix in result.fixes]
+    assert sum(anchor is w2 for anchor in anchors) == 1
+    assert sum(anchor is w3 for anchor in anchors) == 1
+    assert all(anchor is not w1 for anchor in anchors)
 
 
 def parse_ansi_string(sql, config):


### PR DESCRIPTION
### Brief summary of the change made

In `process_spacing` (`reflow/respace.py`), the "Removing duplicate whitespace" `LintResult`s built their anchor and `LintFix.delete` from the leaked loop variable `seg` (the last segment of the buffer) rather than the `ws` being iterated in `for ws in last_whitespace[1:]`. For three or more adjacent whitespaces both deletes therefore anchored the final segment and the middle one was never targeted in that pass.

The removal buffer already prunes the correct segments, so the net fixed output is usually unchanged, but the emitted fixes point at the wrong segment (wrong reported anchor, and a single pass under-targets 3+ duplicate whitespaces). This anchors and deletes `ws`.

Function-level reproduction on `main`:

```python
from sqlfluff.core.parser import WhitespaceSegment
from sqlfluff.utils.reflow.respace import process_spacing

w1, w2, w3 = WhitespaceSegment(" "), WhitespaceSegment(" "), WhitespaceSegment(" ")
buffer, _, results = process_spacing([w1, w2, w3], strip_newlines=False)
anchors = [f.anchor for r in results for f in r.fixes]
# main:      w3 anchored twice, w2 zero times
# this PR:   w2 once, w3 once
```

### Are there any other side effects of this change that we should be aware of?

No. It only corrects which segment each duplicate-whitespace fix anchors. The returned buffer is unchanged, and the full `test/utils/reflow/` suite stays green (123 passed).

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - [x] Other: a function-level regression test in `test/utils/reflow/respace_test.py` (`test_reflow__process_spacing_duplicate_whitespace_fix_anchors`) asserting each duplicate whitespace is the anchor of exactly one delete fix. It fails on `main` and passes here.
- [x] Added appropriate documentation for the change (none needed; internal behaviour only).
- [x] Created GitHub issues for any relevant followup/future enhancements if appropriate (none).

---

**AI assistance disclosure:** an AI coding assistant (Claude Code) helped locate the leaked-variable bug and draft the regression test. I validated the change myself: reproduced the wrong anchors at the function level on `main`, confirmed the corrected anchors after the change, and ran the full `test/utils/reflow/` suite (123 passed). I understand and take responsibility for the change.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `process_spacing` so each "Removing duplicate whitespace" fix anchors and deletes the actual whitespace being pruned instead of the leaked loop variable (the buffer's last segment).

Previously, with three or more adjacent whitespaces, both fixes targeted the final segment, so the middle one was never fixed in that pass and the reported anchors were wrong. The returned buffer is unchanged; a regression test asserts each pruned whitespace is the anchor of exactly one delete fix.

<sup>Written for commit 5755d17ed62ce57190273a70d99b1dd7d088bd13. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8419?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

