### PR TITLE
Fix RF05 crash and false positive on an all-underscore identifier

### DIFF
--- a/src/sqlfluff/rules/references/RF05.py
+++ b/src/sqlfluff/rules/references/RF05.py
@@ -201,7 +201,7 @@ class Rule_RF05(BaseRule):
         # redshift allows a # at the beginning of temporary table names
         if (
             context.dialect.name == "redshift"
-            and identifier[0] == "#"
+            and identifier.startswith("#")
             and context.parent_stack
             and context.parent_stack[-1].is_type("table_reference")
         ):
@@ -218,7 +218,7 @@ class Rule_RF05(BaseRule):
 
         # Finally test if the remaining identifier is only made up of alphanumerics
         if identifiers_policy_applicable(policy, context.parent_stack) and not (
-            identifier.isalnum()
+            identifier == "" or identifier.isalnum()
         ):
             return LintResult(anchor=context.segment)
 

--- a/test/fixtures/rules/std_rule_cases/RF05.yml
+++ b/test/fixtures/rules/std_rule_cases/RF05.yml
@@ -524,3 +524,21 @@ test_fail_tsql_single_quoted_alias_special_chars:
   configs:
     core:
       dialect: tsql
+
+test_pass_underscore_only_identifier_redshift:
+  # Stripping the allowed underscores leaves an empty string. On redshift the
+  # temporary table check then indexed that empty string and raised IndexError.
+  pass_str: |
+    SELECT _ FROM t
+  configs:
+    core:
+      dialect: redshift
+
+test_pass_underscore_only_identifier_postgres:
+  # The same empty string reached the alphanumeric test, which reported special
+  # characters for an identifier that holds none.
+  pass_str: |
+    SELECT _ FROM t
+  configs:
+    core:
+      dialect: postgres


### PR DESCRIPTION
### Brief summary of the change made

Fixes #8423.

`RF05` strips underscores before it inspects an identifier, so an identifier made only of underscores becomes an empty string. Two later steps do not expect that.

The redshift temporary table check reads index 0 of it and raises `IndexError`, which the linter reports as an internal error:

```
$ sqlfluff lint --dialect redshift --rules RF05 q.sql     # q.sql is: SELECT _ FROM t
CRITICAL [RF05] Applying rule RF05 to 'q.sql' threw an Exception: string index out of range
  File "src/sqlfluff/rules/references/RF05.py", line 204, in _eval
    and identifier[0] == "#"
IndexError: string index out of range
```

The `#` test is redshift only, so on other dialects the empty string reaches the alphanumeric test and `"".isalnum()` is `False`:

```
$ sqlfluff lint --dialect postgres --rules RF05 q.sql
L:   1 | P:   8 | RF05 | Do not use special characters in identifiers.
```

`_` holds no special characters, and the comment at the strip site says underscores are always allowed.

The change is two lines: use `startswith` for the `#` test, and accept an empty identifier at the alphanumeric test.

```python
and identifier.startswith("#")
...
identifier == "" or identifier.isalnum()
```

Both are needed. Fixing only the first turns the crash into the false positive above; I checked that before settling on this. The sibling probe 51 lines earlier already guards the same pattern with `if identifier and identifier[-1] == "*":`.

### Are there any other side effects of this change that we should be aware of?

An all-underscore identifier now passes `RF05` on every dialect instead of crashing on redshift or being reported elsewhere. No other rule behaviour changes.

Genuine violations are unaffected:

```
$ sqlfluff lint --dialect tsql --rules RF05 bad.sql    # "Internal Space" INT
L:   2 | P:   5 | RF05 | Do not use special characters in identifiers.
```

The existing `test_pass_special_chars_redshift_hash_table` and `test_fail_special_chars_redshift_hash_column` cases still pass, so the redshift `#` handling is intact.

### Pull Request checklist

- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - [x] `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`. Two cases in `RF05.yml`, one per symptom: redshift for the crash path and postgres for the alphanumeric path.
  - [ ] `.sql`/`.yml` parser test cases in `test/fixtures/dialects`.
  - [ ] Full autofix test cases in `test/fixtures/linter/autofix`.
  - [ ] Other.
- [x] Added appropriate documentation for the change. No user-facing documentation applies; the rule's behaviour for valid identifiers is unchanged.
- [x] Created GitHub issues for any relevant followup/future enhancements if appropriate. None needed.

Test results:

```
pytest test/rules/yaml_test_cases_test.py -k RF05
60 passed, 2331 deselected

pytest test/rules/
2558 passed, 101 skipped
```

Reverting the source change and keeping the tests fails exactly the two new cases. `ruff check` and `black --check` pass on the changed file.

### AI usage disclosure

Per the AI-Assisted Contributions section of CONTRIBUTING:

- AI-assisted: locating the defect, drafting the two-line fix and the two YAML cases, and drafting this description.
- Validated by me: I reproduced both symptoms against the installed CLI before writing anything, confirmed that fixing only the `#` check converts the crash into the false positive, ran the RF05 suite and the full `test/rules/` suite, and re-ran with the source change reverted to confirm both new cases fail without it.
