### PR TITLE
Postgres: support MERGE ... RETURNING (PostgreSQL 17)

### DIFF
--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -7526,3 +7526,35 @@ class FileSegment(BaseFileSegment):
             allow_trailing=True,
         ),
     )
+
+
+class MergeStatementSegment(ansi.MergeStatementSegment):
+    """A `MERGE` statement.
+
+    https://www.postgresql.org/docs/17/sql-merge.html
+
+    PostgreSQL 17 added a `RETURNING` clause to `MERGE`, matching the one
+    already supported on `INSERT`, `UPDATE` and `DELETE`. Output expressions
+    may use the `merge_action()` function to report which action produced a
+    given row.
+    """
+
+    match_grammar = ansi.MergeStatementSegment.match_grammar.copy(
+        insert=[
+            Sequence(
+                "RETURNING",
+                Indent,
+                OneOf(
+                    Ref("StarSegment"),
+                    Delimited(
+                        Sequence(
+                            Ref("ExpressionSegment"),
+                            Ref("AliasExpressionSegment", optional=True),
+                        ),
+                    ),
+                ),
+                Dedent,
+                optional=True,
+            ),
+        ],
+    )

--- a/test/fixtures/dialects/postgres/merge_returning.sql
+++ b/test/fixtures/dialects/postgres/merge_returning.sql
@@ -1,0 +1,34 @@
+-- PostgreSQL 17 added a RETURNING clause to MERGE.
+-- https://www.postgresql.org/docs/17/sql-merge.html
+
+MERGE INTO customer_account ca
+USING recent_transactions t
+ON t.customer_id = ca.customer_id
+WHEN MATCHED THEN
+    UPDATE SET balance = balance + transaction_value
+RETURNING ca.customer_id, ca.balance;
+
+MERGE INTO wines w
+USING wine_stock_changes s
+ON s.winename = w.winename
+WHEN NOT MATCHED AND s.stock_delta > 0 THEN
+    INSERT VALUES(s.winename, s.stock_delta)
+WHEN MATCHED AND w.stock + s.stock_delta > 0 THEN
+    UPDATE SET stock = w.stock + s.stock_delta
+WHEN MATCHED THEN
+    DELETE
+RETURNING merge_action(), w.*;
+
+MERGE INTO t
+USING s
+ON t.id = s.id
+WHEN MATCHED THEN
+    UPDATE SET a = s.a
+RETURNING *;
+
+MERGE INTO t
+USING s
+ON t.id = s.id
+WHEN MATCHED THEN
+    UPDATE SET a = s.a
+RETURNING merge_action() AS action, t.id AS ident, t.a * 2;

--- a/test/fixtures/dialects/postgres/merge_returning.yml
+++ b/test/fixtures/dialects/postgres/merge_returning.yml
@@ -1,0 +1,299 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 56d871e0f2b46cbb112619b5bfd72b23fa721cf8a2dd6d4e300252f42a2456f5
+file:
+- statement:
+    merge_statement:
+    - keyword: MERGE
+    - keyword: INTO
+    - table_reference:
+        naked_identifier: customer_account
+    - alias_expression:
+        naked_identifier: ca
+    - keyword: USING
+    - table_reference:
+        naked_identifier: recent_transactions
+    - alias_expression:
+        naked_identifier: t
+    - join_on_condition:
+        keyword: 'ON'
+        expression:
+        - column_reference:
+          - naked_identifier: t
+          - dot: .
+          - naked_identifier: customer_id
+        - comparison_operator:
+            raw_comparison_operator: '='
+        - column_reference:
+          - naked_identifier: ca
+          - dot: .
+          - naked_identifier: customer_id
+    - merge_match:
+        merge_when_matched_clause:
+        - keyword: WHEN
+        - keyword: MATCHED
+        - keyword: THEN
+        - merge_update_clause:
+            keyword: UPDATE
+            set_clause_list:
+              keyword: SET
+              set_clause:
+                column_reference:
+                  naked_identifier: balance
+                comparison_operator:
+                  raw_comparison_operator: '='
+                expression:
+                - column_reference:
+                    naked_identifier: balance
+                - binary_operator: +
+                - column_reference:
+                    naked_identifier: transaction_value
+    - keyword: RETURNING
+    - expression:
+        column_reference:
+        - naked_identifier: ca
+        - dot: .
+        - naked_identifier: customer_id
+    - comma: ','
+    - expression:
+        column_reference:
+        - naked_identifier: ca
+        - dot: .
+        - naked_identifier: balance
+- statement_terminator: ;
+- statement:
+    merge_statement:
+    - keyword: MERGE
+    - keyword: INTO
+    - table_reference:
+        naked_identifier: wines
+    - alias_expression:
+        naked_identifier: w
+    - keyword: USING
+    - table_reference:
+        naked_identifier: wine_stock_changes
+    - alias_expression:
+        naked_identifier: s
+    - join_on_condition:
+        keyword: 'ON'
+        expression:
+        - column_reference:
+          - naked_identifier: s
+          - dot: .
+          - naked_identifier: winename
+        - comparison_operator:
+            raw_comparison_operator: '='
+        - column_reference:
+          - naked_identifier: w
+          - dot: .
+          - naked_identifier: winename
+    - merge_match:
+      - merge_when_not_matched_clause:
+        - keyword: WHEN
+        - keyword: NOT
+        - keyword: MATCHED
+        - keyword: AND
+        - expression:
+            column_reference:
+            - naked_identifier: s
+            - dot: .
+            - naked_identifier: stock_delta
+            comparison_operator:
+              raw_comparison_operator: '>'
+            numeric_literal: '0'
+        - keyword: THEN
+        - merge_insert_clause:
+            keyword: INSERT
+            values_clause:
+              keyword: VALUES
+              bracketed:
+              - start_bracket: (
+              - expression:
+                  column_reference:
+                  - naked_identifier: s
+                  - dot: .
+                  - naked_identifier: winename
+              - comma: ','
+              - expression:
+                  column_reference:
+                  - naked_identifier: s
+                  - dot: .
+                  - naked_identifier: stock_delta
+              - end_bracket: )
+      - merge_when_matched_clause:
+        - keyword: WHEN
+        - keyword: MATCHED
+        - keyword: AND
+        - expression:
+          - column_reference:
+            - naked_identifier: w
+            - dot: .
+            - naked_identifier: stock
+          - binary_operator: +
+          - column_reference:
+            - naked_identifier: s
+            - dot: .
+            - naked_identifier: stock_delta
+          - comparison_operator:
+              raw_comparison_operator: '>'
+          - numeric_literal: '0'
+        - keyword: THEN
+        - merge_update_clause:
+            keyword: UPDATE
+            set_clause_list:
+              keyword: SET
+              set_clause:
+                column_reference:
+                  naked_identifier: stock
+                comparison_operator:
+                  raw_comparison_operator: '='
+                expression:
+                - column_reference:
+                  - naked_identifier: w
+                  - dot: .
+                  - naked_identifier: stock
+                - binary_operator: +
+                - column_reference:
+                  - naked_identifier: s
+                  - dot: .
+                  - naked_identifier: stock_delta
+      - merge_when_matched_clause:
+        - keyword: WHEN
+        - keyword: MATCHED
+        - keyword: THEN
+        - merge_delete_clause:
+            keyword: DELETE
+    - keyword: RETURNING
+    - expression:
+        function:
+          function_name:
+            function_name_identifier: merge_action
+          function_contents:
+            bracketed:
+              start_bracket: (
+              end_bracket: )
+    - comma: ','
+    - expression:
+        wildcard_identifier:
+          naked_identifier: w
+          dot: .
+          star: '*'
+- statement_terminator: ;
+- statement:
+    merge_statement:
+    - keyword: MERGE
+    - keyword: INTO
+    - table_reference:
+        naked_identifier: t
+    - keyword: USING
+    - table_reference:
+        naked_identifier: s
+    - join_on_condition:
+        keyword: 'ON'
+        expression:
+        - column_reference:
+          - naked_identifier: t
+          - dot: .
+          - naked_identifier: id
+        - comparison_operator:
+            raw_comparison_operator: '='
+        - column_reference:
+          - naked_identifier: s
+          - dot: .
+          - naked_identifier: id
+    - merge_match:
+        merge_when_matched_clause:
+        - keyword: WHEN
+        - keyword: MATCHED
+        - keyword: THEN
+        - merge_update_clause:
+            keyword: UPDATE
+            set_clause_list:
+              keyword: SET
+              set_clause:
+              - column_reference:
+                  naked_identifier: a
+              - comparison_operator:
+                  raw_comparison_operator: '='
+              - column_reference:
+                - naked_identifier: s
+                - dot: .
+                - naked_identifier: a
+    - keyword: RETURNING
+    - star: '*'
+- statement_terminator: ;
+- statement:
+    merge_statement:
+    - keyword: MERGE
+    - keyword: INTO
+    - table_reference:
+        naked_identifier: t
+    - keyword: USING
+    - table_reference:
+        naked_identifier: s
+    - join_on_condition:
+        keyword: 'ON'
+        expression:
+        - column_reference:
+          - naked_identifier: t
+          - dot: .
+          - naked_identifier: id
+        - comparison_operator:
+            raw_comparison_operator: '='
+        - column_reference:
+          - naked_identifier: s
+          - dot: .
+          - naked_identifier: id
+    - merge_match:
+        merge_when_matched_clause:
+        - keyword: WHEN
+        - keyword: MATCHED
+        - keyword: THEN
+        - merge_update_clause:
+            keyword: UPDATE
+            set_clause_list:
+              keyword: SET
+              set_clause:
+              - column_reference:
+                  naked_identifier: a
+              - comparison_operator:
+                  raw_comparison_operator: '='
+              - column_reference:
+                - naked_identifier: s
+                - dot: .
+                - naked_identifier: a
+    - keyword: RETURNING
+    - expression:
+        function:
+          function_name:
+            function_name_identifier: merge_action
+          function_contents:
+            bracketed:
+              start_bracket: (
+              end_bracket: )
+    - alias_expression:
+        alias_operator:
+          keyword: AS
+        naked_identifier: action
+    - comma: ','
+    - expression:
+        column_reference:
+        - naked_identifier: t
+        - dot: .
+        - naked_identifier: id
+    - alias_expression:
+        alias_operator:
+          keyword: AS
+        naked_identifier: ident
+    - comma: ','
+    - expression:
+        column_reference:
+        - naked_identifier: t
+        - dot: .
+        - naked_identifier: a
+        binary_operator: '*'
+        numeric_literal: '2'
+- statement_terminator: ;


### PR DESCRIPTION
### Brief summary of the change made

PostgreSQL 17 added a `RETURNING` clause to `MERGE`, and the postgres dialect doesn't support it. On `main`, every form of it is unparsable:

```sql
MERGE INTO t USING s ON t.id = s.id
WHEN MATCHED THEN UPDATE SET a = s.a
RETURNING merge_action(), t.id;
```

```
L:  1 | P:  1 | PRS | Found unparsable section: 'RETURNING merge_action(), t.id;'
```

`INSERT`, `UPDATE` and `DELETE` all support `RETURNING` in this dialect already — `MERGE` was simply missed, because postgres inherits the ANSI `MergeStatementSegment` unchanged and ANSI has no `RETURNING`.

This adds a postgres override which appends the same optional `RETURNING` clause the other three statements use. `merge_action()` needs no special handling — it already parses as an ordinary function.

I didn't find an existing issue for this; happy to open one first if you'd prefer that order.

### Are there any other side effects of this change that we should be aware of?

The clause is `optional=True` and appended to the end of the existing grammar, so `MERGE` statements without `RETURNING` are unaffected — covered by the existing `merge.sql` and `merge_when_not_matched_by_source.sql` fixtures, which still pass.

One thing to flag: I added the new class at the end of `dialect_postgres.py` rather than next to `MergeMatchedClauseSegment` where it would naturally sit. That was a limitation of how I was editing the file, not a deliberate choice — very happy to move it if you'd like it grouped with the other `Merge*` classes.

New fixture `test/fixtures/dialects/postgres/merge_returning.sql` covers `RETURNING *`, a bare column list, `merge_action()`, `AS` aliases, and an arithmetic output expression, plus the full worked example from the PostgreSQL 17 docs (which combines `INSERT`/`UPDATE`/`DELETE` branches with `RETURNING merge_action(), w.*`).

Verified locally on this exact commit: 1007 tests pass across postgres and every dialect inheriting from it (duckdb, greenplum, materialize, redshift); the wider dialect suite is green too (6933 before I added the fixture). `ruff format`, `ruff check`, `mypy` and `yamllint` all clean. Re-running `python test/generate_parse_fixture_yml.py --dialect postgres` produces no diff, so the committed YAML matches the generator.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - [x] `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change — n/a, dialect grammar addition with no user-facing configuration change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate — none needed; happy to file one for the class placement note above if useful.

---

*Disclosure, per the AI-assisted contributions section of `CONTRIBUTING.md`: this change was AI-assisted. The gap was found by probing documented dialect syntax against `main`, and the implementation, fixture and commit messages were AI-generated. All of it was validated by execution against a local checkout of this exact commit — the failing reproduction on `main`, the dialect test suites, the fixture regeneration check, and the `ruff` / `mypy` / `yamllint` runs.*


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for PostgreSQL 17's `MERGE ... RETURNING` in the `postgres` dialect; previously every such statement was unparsable.

**New Features**
- Overrides the ANSI `MergeStatementSegment` to append an optional `RETURNING` clause, mirroring the existing grammar on `INSERT`, `UPDATE`, and `DELETE`.
- Adds a fixture covering `RETURNING *`, bare columns, `merge_action()`, aliases, and an arithmetic expression.

<sup>Written for commit 46533e60556538a1d3d59c7bf81405b81a400b4a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8424?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

