### PR TITLE
Oracle: add column-level USING INDEX support

### DIFF
--- a/src/sqlfluff/dialects/dialect_oracle.py
+++ b/src/sqlfluff/dialects/dialect_oracle.py
@@ -2566,6 +2566,49 @@ class TableConstraintSegment(ansi.TableConstraintSegment):
     )
 
 
+class ColumnConstraintSegment(ansi.ColumnConstraintSegment):
+    """A column constraint, e.g. for CREATE TABLE or ALTER TABLE ADD/MODIFY.
+
+    Extends ANSI to support Oracle's inline `USING INDEX` clause, which Oracle
+    allows after a column-level (unnamed-column-list) `PRIMARY KEY` or `UNIQUE`
+    constraint, in addition to the table-level constraint form already handled
+    by `TableConstraintSegment`.
+
+    https://docs.oracle.com/en/database/oracle/oracle-database/23/sqlrf/constraint.html
+    """
+
+    type = "column_constraint_segment"
+
+    match_grammar: Matchable = Sequence(
+        Sequence(
+            "CONSTRAINT",
+            Ref("ObjectReferenceSegment"),
+            optional=True,
+        ),
+        OneOf(
+            Sequence(Ref.keyword("NOT", optional=True), "NULL"),
+            Sequence("CHECK", Bracketed(Ref("ExpressionSegment"))),
+            Sequence(
+                "DEFAULT",
+                Ref("ColumnConstraintDefaultGrammar"),
+            ),
+            Sequence(
+                Ref("PrimaryKeyGrammar"),
+                Ref("UsingIndexClauseSegment", optional=True),
+            ),
+            Sequence(
+                Ref("UniqueKeyGrammar"),
+                Ref("UsingIndexClauseSegment", optional=True),
+            ),
+            Ref("AutoIncrementGrammar"),
+            Ref("ReferenceDefinitionGrammar"),
+            Ref("CommentClauseSegment"),
+            Sequence("COLLATE", Ref("CollationReferenceSegment")),
+            Ref("ColumnGeneratedGrammar"),
+        ),
+    )
+
+
 class TransactionStatementSegment(BaseSegment):
     """A `COMMIT`, `ROLLBACK` or `TRANSACTION` statement."""
 

--- a/test/fixtures/dialects/oracle/alter_table.sql
+++ b/test/fixtures/dialects/oracle/alter_table.sql
@@ -46,3 +46,11 @@ ALTER TABLE table_name
 MODIFY (column_name DEFAULT 10 NOT NULL ENABLE);
 
 ALTER TABLE employees ADD CONSTRAINT salary_check CHECK (salary > 0);
+
+-- add_column_clause with an inline column-level PRIMARY KEY ... USING INDEX
+ALTER TABLE table_name
+ADD (column_name NUMBER CONSTRAINT pk_column_name PRIMARY KEY USING INDEX TABLESPACE idx_ts);
+
+-- modify_column_clause with an inline column-level UNIQUE ... USING INDEX
+ALTER TABLE table_name
+MODIFY (column_name VARCHAR2(10) CONSTRAINT uq_column_name UNIQUE USING INDEX PCTFREE 10);

--- a/test/fixtures/dialects/oracle/alter_table.yml
+++ b/test/fixtures/dialects/oracle/alter_table.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: c153c69f134fe0d1534d7504a1ec01a54793b92c32cffacff26a3965ff958ca4
+_hash: cde62de20e2596bcaaaf9df375810fa2b8106c8fcb597de55ac3f2f56aadf51e
 file:
   batch:
   - statement:
@@ -296,4 +296,65 @@ file:
                   raw_comparison_operator: '>'
                 numeric_literal: '0'
               end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      alter_table_statement:
+      - keyword: ALTER
+      - keyword: TABLE
+      - table_reference:
+          naked_identifier: table_name
+      - alter_table_column_clauses:
+          keyword: ADD
+          bracketed:
+            start_bracket: (
+            column_definition:
+              naked_identifier: column_name
+              data_type:
+                data_type_identifier: NUMBER
+              column_constraint_segment:
+              - keyword: CONSTRAINT
+              - object_reference:
+                  naked_identifier: pk_column_name
+              - keyword: PRIMARY
+              - keyword: KEY
+              - using_index_clause:
+                - keyword: USING
+                - keyword: INDEX
+                - oracle_index_physical_attributes:
+                    keyword: TABLESPACE
+                    object_reference:
+                      naked_identifier: idx_ts
+            end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      alter_table_statement:
+      - keyword: ALTER
+      - keyword: TABLE
+      - table_reference:
+          naked_identifier: table_name
+      - alter_table_column_clauses:
+          keyword: MODIFY
+          bracketed:
+            start_bracket: (
+            column_definition:
+              naked_identifier: column_name
+              data_type:
+                data_type_identifier: VARCHAR2
+                bracketed_arguments:
+                  bracketed:
+                    start_bracket: (
+                    numeric_literal: '10'
+                    end_bracket: )
+              column_constraint_segment:
+              - keyword: CONSTRAINT
+              - object_reference:
+                  naked_identifier: uq_column_name
+              - keyword: UNIQUE
+              - using_index_clause:
+                - keyword: USING
+                - keyword: INDEX
+                - oracle_index_physical_attributes:
+                    keyword: PCTFREE
+                    numeric_literal: '10'
+            end_bracket: )
   - statement_terminator: ;

--- a/test/fixtures/dialects/oracle/using_index.sql
+++ b/test/fixtures/dialects/oracle/using_index.sql
@@ -196,3 +196,79 @@ CREATE TABLE t_anon_uq_attrs (
     code VARCHAR2(10),
     UNIQUE (code) USING INDEX PCTFREE 10 TABLESPACE idx_ts
 );
+
+-- Column-level (inline) constraints: PRIMARY KEY / UNIQUE with USING INDEX
+
+CREATE TABLE t_col_pk_not_null (
+    id NUMBER NOT NULL
+        CONSTRAINT pk_t_col_pk_not_null PRIMARY KEY
+        USING INDEX TABLESPACE idx_ts
+);
+
+CREATE TABLE t_col_pk_bare (
+    id NUMBER
+        CONSTRAINT pk_t_col_pk_bare PRIMARY KEY
+        USING INDEX
+);
+
+CREATE TABLE t_col_pk_named_idx (
+    id NUMBER
+        CONSTRAINT pk_t_col_pk_named_idx PRIMARY KEY
+        USING INDEX pk_t_col_pk_named_idx_idx
+);
+
+CREATE TABLE t_col_pk_tablespace (
+    id NUMBER
+        CONSTRAINT pk_t_col_pk_tablespace PRIMARY KEY
+        USING INDEX TABLESPACE idx_ts
+);
+
+CREATE TABLE t_col_pk_multi_attrs (
+    id NUMBER
+        CONSTRAINT pk_t_col_pk_multi_attrs PRIMARY KEY
+        USING INDEX
+            PCTFREE 10
+            INITRANS 2
+            TABLESPACE idx_ts
+            NOLOGGING
+);
+
+CREATE TABLE t_col_pk_inline_idx (
+    id NUMBER
+        CONSTRAINT pk_t_col_pk_inline_idx PRIMARY KEY
+        USING INDEX (CREATE INDEX pk_t_col_pk_inline_idx_i ON t_col_pk_inline_idx (id))
+);
+
+CREATE TABLE t_col_uq_tablespace (
+    code VARCHAR2(10)
+        CONSTRAINT uq_t_col_uq_tablespace UNIQUE
+        USING INDEX TABLESPACE idx_ts
+);
+
+CREATE TABLE t_col_anon_pk (
+    id NUMBER
+        PRIMARY KEY
+        USING INDEX TABLESPACE idx_ts
+);
+
+CREATE TABLE t_col_anon_uq (
+    code VARCHAR2(10)
+        UNIQUE
+        USING INDEX PCTFREE 10
+);
+
+CREATE TABLE t_col_multi_constraints (
+    id NUMBER
+        CONSTRAINT pk_t_col_multi_constraints PRIMARY KEY
+        USING INDEX pk_t_col_multi_constraints_idx,
+    code VARCHAR2(10)
+        CONSTRAINT uq_t_col_multi_constraints_code UNIQUE
+        USING INDEX TABLESPACE idx_ts NOLOGGING,
+    status NUMBER
+        CONSTRAINT uq_t_col_multi_constraints_status UNIQUE
+        USING INDEX (
+            CREATE INDEX uq_t_col_multi_constraints_status_i
+                ON t_col_multi_constraints (status)
+            TABLESPACE idx_ts
+        )
+);

--- a/test/fixtures/dialects/oracle/using_index.yml
+++ b/test/fixtures/dialects/oracle/using_index.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 2af9e2424b621edc982d42fe216554a75c6b8700ed4fa4dab468a2c9433a1788
+_hash: 655dbd847d27540d98cee4cde86623e1a6fb85e6eed869bb116367c41e43e742
 file:
   batch:
   - statement:
@@ -1015,4 +1015,343 @@ file:
               - object_reference:
                   naked_identifier: idx_ts
           end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      create_table_statement:
+      - keyword: CREATE
+      - keyword: TABLE
+      - table_reference:
+          naked_identifier: t_col_pk_not_null
+      - bracketed:
+          start_bracket: (
+          column_definition:
+          - naked_identifier: id
+          - data_type:
+              data_type_identifier: NUMBER
+          - column_constraint_segment:
+            - keyword: NOT
+            - keyword: 'NULL'
+          - column_constraint_segment:
+            - keyword: CONSTRAINT
+            - object_reference:
+                naked_identifier: pk_t_col_pk_not_null
+            - keyword: PRIMARY
+            - keyword: KEY
+            - using_index_clause:
+              - keyword: USING
+              - keyword: INDEX
+              - oracle_index_physical_attributes:
+                  keyword: TABLESPACE
+                  object_reference:
+                    naked_identifier: idx_ts
+          end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      create_table_statement:
+      - keyword: CREATE
+      - keyword: TABLE
+      - table_reference:
+          naked_identifier: t_col_pk_bare
+      - bracketed:
+          start_bracket: (
+          column_definition:
+            naked_identifier: id
+            data_type:
+              data_type_identifier: NUMBER
+            column_constraint_segment:
+            - keyword: CONSTRAINT
+            - object_reference:
+                naked_identifier: pk_t_col_pk_bare
+            - keyword: PRIMARY
+            - keyword: KEY
+            - using_index_clause:
+              - keyword: USING
+              - keyword: INDEX
+          end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      create_table_statement:
+      - keyword: CREATE
+      - keyword: TABLE
+      - table_reference:
+          naked_identifier: t_col_pk_named_idx
+      - bracketed:
+          start_bracket: (
+          column_definition:
+            naked_identifier: id
+            data_type:
+              data_type_identifier: NUMBER
+            column_constraint_segment:
+            - keyword: CONSTRAINT
+            - object_reference:
+                naked_identifier: pk_t_col_pk_named_idx
+            - keyword: PRIMARY
+            - keyword: KEY
+            - using_index_clause:
+              - keyword: USING
+              - keyword: INDEX
+              - index_reference:
+                  naked_identifier: pk_t_col_pk_named_idx_idx
+          end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      create_table_statement:
+      - keyword: CREATE
+      - keyword: TABLE
+      - table_reference:
+          naked_identifier: t_col_pk_tablespace
+      - bracketed:
+          start_bracket: (
+          column_definition:
+            naked_identifier: id
+            data_type:
+              data_type_identifier: NUMBER
+            column_constraint_segment:
+            - keyword: CONSTRAINT
+            - object_reference:
+                naked_identifier: pk_t_col_pk_tablespace
+            - keyword: PRIMARY
+            - keyword: KEY
+            - using_index_clause:
+              - keyword: USING
+              - keyword: INDEX
+              - oracle_index_physical_attributes:
+                  keyword: TABLESPACE
+                  object_reference:
+                    naked_identifier: idx_ts
+          end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      create_table_statement:
+      - keyword: CREATE
+      - keyword: TABLE
+      - table_reference:
+          naked_identifier: t_col_pk_multi_attrs
+      - bracketed:
+          start_bracket: (
+          column_definition:
+            naked_identifier: id
+            data_type:
+              data_type_identifier: NUMBER
+            column_constraint_segment:
+            - keyword: CONSTRAINT
+            - object_reference:
+                naked_identifier: pk_t_col_pk_multi_attrs
+            - keyword: PRIMARY
+            - keyword: KEY
+            - using_index_clause:
+              - keyword: USING
+              - keyword: INDEX
+              - oracle_index_physical_attributes:
+                - keyword: PCTFREE
+                - numeric_literal: '10'
+                - keyword: INITRANS
+                - numeric_literal: '2'
+                - keyword: TABLESPACE
+                - object_reference:
+                    naked_identifier: idx_ts
+                - keyword: NOLOGGING
+          end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      create_table_statement:
+      - keyword: CREATE
+      - keyword: TABLE
+      - table_reference:
+          naked_identifier: t_col_pk_inline_idx
+      - bracketed:
+          start_bracket: (
+          column_definition:
+            naked_identifier: id
+            data_type:
+              data_type_identifier: NUMBER
+            column_constraint_segment:
+            - keyword: CONSTRAINT
+            - object_reference:
+                naked_identifier: pk_t_col_pk_inline_idx
+            - keyword: PRIMARY
+            - keyword: KEY
+            - using_index_clause:
+              - keyword: USING
+              - keyword: INDEX
+              - bracketed:
+                  start_bracket: (
+                  create_index_statement:
+                  - keyword: CREATE
+                  - keyword: INDEX
+                  - index_reference:
+                      naked_identifier: pk_t_col_pk_inline_idx_i
+                  - keyword: 'ON'
+                  - table_reference:
+                      naked_identifier: t_col_pk_inline_idx
+                  - bracketed:
+                      start_bracket: (
+                      index_column_definition:
+                        naked_identifier: id
+                      end_bracket: )
+                  end_bracket: )
+          end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      create_table_statement:
+      - keyword: CREATE
+      - keyword: TABLE
+      - table_reference:
+          naked_identifier: t_col_uq_tablespace
+      - bracketed:
+          start_bracket: (
+          column_definition:
+            naked_identifier: code
+            data_type:
+              data_type_identifier: VARCHAR2
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  numeric_literal: '10'
+                  end_bracket: )
+            column_constraint_segment:
+            - keyword: CONSTRAINT
+            - object_reference:
+                naked_identifier: uq_t_col_uq_tablespace
+            - keyword: UNIQUE
+            - using_index_clause:
+              - keyword: USING
+              - keyword: INDEX
+              - oracle_index_physical_attributes:
+                  keyword: TABLESPACE
+                  object_reference:
+                    naked_identifier: idx_ts
+          end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      create_table_statement:
+      - keyword: CREATE
+      - keyword: TABLE
+      - table_reference:
+          naked_identifier: t_col_anon_pk
+      - bracketed:
+          start_bracket: (
+          column_definition:
+            naked_identifier: id
+            data_type:
+              data_type_identifier: NUMBER
+            column_constraint_segment:
+            - keyword: PRIMARY
+            - keyword: KEY
+            - using_index_clause:
+              - keyword: USING
+              - keyword: INDEX
+              - oracle_index_physical_attributes:
+                  keyword: TABLESPACE
+                  object_reference:
+                    naked_identifier: idx_ts
+          end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      create_table_statement:
+      - keyword: CREATE
+      - keyword: TABLE
+      - table_reference:
+          naked_identifier: t_col_anon_uq
+      - bracketed:
+          start_bracket: (
+          column_definition:
+            naked_identifier: code
+            data_type:
+              data_type_identifier: VARCHAR2
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  numeric_literal: '10'
+                  end_bracket: )
+            column_constraint_segment:
+              keyword: UNIQUE
+              using_index_clause:
+              - keyword: USING
+              - keyword: INDEX
+              - oracle_index_physical_attributes:
+                  keyword: PCTFREE
+                  numeric_literal: '10'
+          end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      create_table_statement:
+      - keyword: CREATE
+      - keyword: TABLE
+      - table_reference:
+          naked_identifier: t_col_multi_constraints
+      - bracketed:
+        - start_bracket: (
+        - column_definition:
+            naked_identifier: id
+            data_type:
+              data_type_identifier: NUMBER
+            column_constraint_segment:
+            - keyword: CONSTRAINT
+            - object_reference:
+                naked_identifier: pk_t_col_multi_constraints
+            - keyword: PRIMARY
+            - keyword: KEY
+            - using_index_clause:
+              - keyword: USING
+              - keyword: INDEX
+              - index_reference:
+                  naked_identifier: pk_t_col_multi_constraints_idx
+        - comma: ','
+        - column_definition:
+            naked_identifier: code
+            data_type:
+              data_type_identifier: VARCHAR2
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  numeric_literal: '10'
+                  end_bracket: )
+            column_constraint_segment:
+            - keyword: CONSTRAINT
+            - object_reference:
+                naked_identifier: uq_t_col_multi_constraints_code
+            - keyword: UNIQUE
+            - using_index_clause:
+              - keyword: USING
+              - keyword: INDEX
+              - oracle_index_physical_attributes:
+                - keyword: TABLESPACE
+                - object_reference:
+                    naked_identifier: idx_ts
+                - keyword: NOLOGGING
+        - comma: ','
+        - column_definition:
+            naked_identifier: status
+            data_type:
+              data_type_identifier: NUMBER
+            column_constraint_segment:
+            - keyword: CONSTRAINT
+            - object_reference:
+                naked_identifier: uq_t_col_multi_constraints_status
+            - keyword: UNIQUE
+            - using_index_clause:
+              - keyword: USING
+              - keyword: INDEX
+              - bracketed:
+                  start_bracket: (
+                  create_index_statement:
+                  - keyword: CREATE
+                  - keyword: INDEX
+                  - index_reference:
+                      naked_identifier: uq_t_col_multi_constraints_status_i
+                  - keyword: 'ON'
+                  - table_reference:
+                      naked_identifier: t_col_multi_constraints
+                  - bracketed:
+                      start_bracket: (
+                      index_column_definition:
+                        naked_identifier: status
+                      end_bracket: )
+                  - oracle_index_physical_attributes:
+                      keyword: TABLESPACE
+                      object_reference:
+                        naked_identifier: idx_ts
+                  end_bracket: )
+        - end_bracket: )
   - statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Extend the Oracle dialect to support `USING INDEX` on columns/inline form.

Fixes #8425.

### Are there any other side effects of this change that we should be aware of?
No.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
