### PR TITLE
SQLite: add ATTACH, DETACH, VACUUM, REINDEX and ANALYZE statements

### DIFF
--- a/src/sqlfluff/dialects/dialect_sqlite.py
+++ b/src/sqlfluff/dialects/dialect_sqlite.py
@@ -1186,17 +1186,107 @@ class CreateVirtualTableStatementSegment(BaseSegment):
     )
 
 
+class AttachStatementSegment(BaseSegment):
+    """An `ATTACH DATABASE` statement.
+
+    https://www.sqlite.org/lang_attach.html
+    """
+
+    type = "attach_statement"
+
+    match_grammar = Sequence(
+        "ATTACH",
+        Ref.keyword("DATABASE", optional=True),
+        Ref("ExpressionSegment"),
+        "AS",
+        Ref("SchemaReferenceSegment"),
+    )
+
+
+class DetachStatementSegment(BaseSegment):
+    """A `DETACH DATABASE` statement.
+
+    https://www.sqlite.org/lang_detach.html
+    """
+
+    type = "detach_statement"
+
+    match_grammar = Sequence(
+        "DETACH",
+        Ref.keyword("DATABASE", optional=True),
+        Ref("SchemaReferenceSegment"),
+    )
+
+
+class VacuumStatementSegment(BaseSegment):
+    """A `VACUUM` statement.
+
+    https://www.sqlite.org/lang_vacuum.html
+    """
+
+    type = "vacuum_statement"
+
+    match_grammar = Sequence(
+        "VACUUM",
+        Ref("SchemaReferenceSegment", optional=True),
+        Sequence(
+            "INTO",
+            Ref("ExpressionSegment"),
+            optional=True,
+        ),
+    )
+
+
+class ReindexStatementSegment(BaseSegment):
+    """A `REINDEX` statement.
+
+    https://www.sqlite.org/lang_reindex.html
+
+    The optional argument is a collation name, or a table or index name
+    which may be schema-qualified. They are not distinguishable
+    syntactically, so both are matched as an object reference.
+    """
+
+    type = "reindex_statement"
+
+    match_grammar = Sequence(
+        "REINDEX",
+        Ref("ObjectReferenceSegment", optional=True),
+    )
+
+
+class AnalyzeStatementSegment(BaseSegment):
+    """An `ANALYZE` statement.
+
+    https://www.sqlite.org/lang_analyze.html
+
+    The optional argument is a schema name, or a table or index name which
+    may be schema-qualified. They are not distinguishable syntactically, so
+    both are matched as an object reference.
+    """
+
+    type = "analyze_statement"
+
+    match_grammar = Sequence(
+        "ANALYZE",
+        Ref("ObjectReferenceSegment", optional=True),
+    )
+
+
 class StatementSegment(ansi.StatementSegment):
     """Overriding StatementSegment to allow for additional segment parsing."""
 
     match_grammar = OneOf(
         Ref("AlterTableStatementSegment"),
+        Ref("AnalyzeStatementSegment"),
+        Ref("AttachStatementSegment"),
         Ref("CreateIndexStatementSegment"),
         Ref("CreateTableStatementSegment"),
         Ref("CreateVirtualTableStatementSegment"),
         Ref("CreateTriggerStatementSegment"),
         Ref("CreateViewStatementSegment"),
         Ref("DeleteStatementSegment"),
+        Ref("DetachStatementSegment"),
         Ref("DropIndexStatementSegment"),
         Ref("DropTableStatementSegment"),
         Ref("DropTriggerStatementSegment"),
@@ -1204,9 +1294,11 @@ class StatementSegment(ansi.StatementSegment):
         Ref("ExplainStatementSegment"),
         Ref("InsertStatementSegment"),
         Ref("PragmaStatementSegment"),
+        Ref("ReindexStatementSegment"),
         Ref("SelectableGrammar"),
         Ref("TransactionStatementSegment"),
         Ref("UpdateStatementSegment"),
+        Ref("VacuumStatementSegment"),
         Bracketed(Ref("StatementSegment")),
     )
 

--- a/test/fixtures/dialects/sqlite/admin_statements.sql
+++ b/test/fixtures/dialects/sqlite/admin_statements.sql
@@ -1,0 +1,28 @@
+-- Database administration and maintenance statements.
+
+-- https://www.sqlite.org/lang_attach.html
+ATTACH DATABASE 'aux.db' AS aux;
+ATTACH 'aux.db' AS aux;
+ATTACH DATABASE :path AS aux;
+
+-- https://www.sqlite.org/lang_detach.html
+DETACH DATABASE aux;
+DETACH aux;
+
+-- https://www.sqlite.org/lang_vacuum.html
+VACUUM;
+VACUUM main;
+VACUUM INTO 'backup.db';
+VACUUM main INTO 'backup.db';
+
+-- https://www.sqlite.org/lang_reindex.html
+REINDEX;
+REINDEX nocase;
+REINDEX my_table;
+REINDEX main.my_index;
+
+-- https://www.sqlite.org/lang_analyze.html
+ANALYZE;
+ANALYZE main;
+ANALYZE my_table;
+ANALYZE main.my_index;

--- a/test/fixtures/dialects/sqlite/admin_statements.yml
+++ b/test/fixtures/dialects/sqlite/admin_statements.yml
@@ -1,0 +1,124 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 2885ea5e1eb4245a4d07858b17b3ce1db574203b63557178909c74960b1dbcde
+file:
+- statement:
+    attach_statement:
+    - keyword: ATTACH
+    - keyword: DATABASE
+    - expression:
+        quoted_literal: "'aux.db'"
+    - keyword: AS
+    - schema_reference:
+        naked_identifier: aux
+- statement_terminator: ;
+- statement:
+    attach_statement:
+    - keyword: ATTACH
+    - expression:
+        quoted_literal: "'aux.db'"
+    - keyword: AS
+    - schema_reference:
+        naked_identifier: aux
+- statement_terminator: ;
+- statement:
+    attach_statement:
+    - keyword: ATTACH
+    - keyword: DATABASE
+    - expression:
+        parameterized_expression:
+          colon_literal: :path
+    - keyword: AS
+    - schema_reference:
+        naked_identifier: aux
+- statement_terminator: ;
+- statement:
+    detach_statement:
+    - keyword: DETACH
+    - keyword: DATABASE
+    - schema_reference:
+        naked_identifier: aux
+- statement_terminator: ;
+- statement:
+    detach_statement:
+      keyword: DETACH
+      schema_reference:
+        naked_identifier: aux
+- statement_terminator: ;
+- statement:
+    vacuum_statement:
+      keyword: VACUUM
+- statement_terminator: ;
+- statement:
+    vacuum_statement:
+      keyword: VACUUM
+      schema_reference:
+        naked_identifier: main
+- statement_terminator: ;
+- statement:
+    vacuum_statement:
+    - keyword: VACUUM
+    - keyword: INTO
+    - expression:
+        quoted_literal: "'backup.db'"
+- statement_terminator: ;
+- statement:
+    vacuum_statement:
+    - keyword: VACUUM
+    - schema_reference:
+        naked_identifier: main
+    - keyword: INTO
+    - expression:
+        quoted_literal: "'backup.db'"
+- statement_terminator: ;
+- statement:
+    reindex_statement:
+      keyword: REINDEX
+- statement_terminator: ;
+- statement:
+    reindex_statement:
+      keyword: REINDEX
+      object_reference:
+        naked_identifier: nocase
+- statement_terminator: ;
+- statement:
+    reindex_statement:
+      keyword: REINDEX
+      object_reference:
+        naked_identifier: my_table
+- statement_terminator: ;
+- statement:
+    reindex_statement:
+      keyword: REINDEX
+      object_reference:
+      - naked_identifier: main
+      - dot: .
+      - naked_identifier: my_index
+- statement_terminator: ;
+- statement:
+    analyze_statement:
+      keyword: ANALYZE
+- statement_terminator: ;
+- statement:
+    analyze_statement:
+      keyword: ANALYZE
+      object_reference:
+        naked_identifier: main
+- statement_terminator: ;
+- statement:
+    analyze_statement:
+      keyword: ANALYZE
+      object_reference:
+        naked_identifier: my_table
+- statement_terminator: ;
+- statement:
+    analyze_statement:
+      keyword: ANALYZE
+      object_reference:
+      - naked_identifier: main
+      - dot: .
+      - naked_identifier: my_index
+- statement_terminator: ;


### PR DESCRIPTION
### Brief summary of the change made

The sqlite dialect can't parse five core SQLite statements. On `main`, all of these are unparsable — including a bare `VACUUM;`:

```sql
ATTACH DATABASE 'aux.db' AS aux;   -- https://www.sqlite.org/lang_attach.html
DETACH aux;                        -- https://www.sqlite.org/lang_detach.html
VACUUM;                            -- https://www.sqlite.org/lang_vacuum.html
REINDEX my_table;                  -- https://www.sqlite.org/lang_reindex.html
ANALYZE main.my_index;             -- https://www.sqlite.org/lang_analyze.html
```

sqlite's `StatementSegment` is an explicit whitelist and these five simply aren't on it. All the keywords involved (`ATTACH`, `DETACH`, `VACUUM`, `REINDEX`, `ANALYZE`, `DATABASE`, `INTO`) are already registered as reserved in `dialect_sqlite_keywords.py`, so this is purely missing grammar.

This adds a segment for each and registers them. Nothing existing is modified — the diff is additive apart from the six new entries on the whitelist.

I didn't find existing issues for these; happy to open them first if you'd prefer that order.

### Are there any other side effects of this change that we should be aware of?

Two modelling notes, both visible in the fixture YAML:

**`VACUUM`'s optional argument is a schema name**, so it parses as `schema_reference`. `REINDEX` and `ANALYZE` take *either* a schema name, a collation name, or a (possibly schema-qualified) table or index name, and those aren't distinguishable syntactically — so both use `object_reference`. That asymmetry is deliberate and noted in the docstrings.

**`ATTACH`'s filename is an `ExpressionSegment`** rather than a bare literal, since SQLite accepts any expression there. That also means parameterised forms like `ATTACH DATABASE :path AS aux` parse, which is covered in the fixture.

I've put all five statements in a single `admin_statements.sql` fixture since they're one coherent group, but I'm happy to split them into one fixture per statement if you'd rather follow the finer-grained naming used elsewhere in that directory.

Verified locally on this exact commit: 111 sqlite dialect tests pass, and the wider suites are green (7020 dialect tests and 2556 rule tests on the same working tree). `ruff format`, `ruff check`, `mypy` and `yamllint` all clean. Re-running `python test/generate_parse_fixture_yml.py --dialect sqlite` produces no diff, so the committed YAML matches the generator.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - [x] `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change — n/a, dialect grammar addition with no user-facing configuration change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate — see note below.

One related gap I found but deliberately left out of this PR: SQLite's `INDEXED BY` / `NOT INDEXED` clause (`SELECT * FROM t INDEXED BY idx`) is also unsupported. That one modifies existing `SELECT`/`UPDATE`/`DELETE` grammar rather than just adding statements, so it carries more risk and belongs in its own change. Happy to open an issue or a follow-up PR for it.

---

*Disclosure, per the AI-assisted contributions section of `CONTRIBUTING.md`: this change was AI-assisted. The gaps were found by probing documented SQLite syntax against `main`, and the implementation, fixture and commit messages were AI-generated. All of it was validated by execution against a local checkout of this exact commit — the failing reproductions on `main`, the dialect and rule suites, the fixture regeneration check, and the `ruff` / `mypy` / `yamllint` runs.*


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds parsing for five SQLite statements that previously failed to parse: `ATTACH DATABASE`, `DETACH`, `VACUUM`, `REINDEX`, and `ANALYZE`. The change is purely additive — new statement segments are registered in the statement whitelist, with no existing grammar modified.

- `VACUUM`'s optional argument parses as a schema reference; `REINDEX` and `ANALYZE` use object references because their argument can be a collation, table, or index name.
- `ATTACH`'s filename is an expression, so parameterized forms like `ATTACH DATABASE :path AS aux` parse.
- Adds a fixture covering all five statements and their variants.

<sup>Written for commit 1aa17427243d0f0b00bcc3c21078bb3dfc8a677d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8427?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

