### PR TITLE
Locate the where clause in CV12 instead of assuming it is last

### DIFF
--- a/src/sqlfluff/rules/convention/CV12.py
+++ b/src/sqlfluff/rules/convention/CV12.py
@@ -287,15 +287,16 @@ class Rule_CV12(BaseRule):
                 ],
             )
         else:
-            assert select_statement.segments[-1].is_type("where_clause")
-            assert select_statement.segments[-2].is_type("whitespace", "newline")
-            yield LintResult(
-                anchor=where_clause,
-                fixes=[
-                    LintFix.delete(select_statement.segments[-2]),
-                    LintFix.delete(select_statement.segments[-1]),
-                ],
-            )
+            # The where clause is not always the last child of the select
+            # statement. A clause such as GROUP BY, ORDER BY or LIMIT can
+            # follow it, so locate it rather than assume its position.
+            where_idx = select_statement.segments.index(where_clause)
+            fixes = [LintFix.delete(where_clause)]
+            if where_idx and select_statement.segments[where_idx - 1].is_type(
+                "whitespace", "newline"
+            ):
+                fixes.append(LintFix.delete(select_statement.segments[where_idx - 1]))
+            yield LintResult(anchor=where_clause, fixes=fixes)
 
     @staticmethod
     def _get_from_expression_element_alias(from_expr_element: BaseSegment) -> str:

--- a/test/fixtures/rules/std_rule_cases/CV12.yml
+++ b/test/fixtures/rules/std_rule_cases/CV12.yml
@@ -267,3 +267,44 @@ test_pass_sqlite_left_join_with_on_and_where:
   configs:
     core:
       dialect: sqlite
+
+test_fail_where_followed_by_order_by:
+  # The whole WHERE clause moves to the join, and a clause after it means the
+  # WHERE clause is not the last child of the select statement.
+  fail_str: |
+    SELECT foo.a
+    FROM foo
+    INNER JOIN bar
+    WHERE foo.x = bar.y
+    ORDER BY foo.a
+  fix_str: |
+    SELECT foo.a
+    FROM foo
+    INNER JOIN bar ON foo.x = bar.y
+    ORDER BY foo.a
+
+test_fail_where_followed_by_group_by:
+  fail_str: |
+    SELECT foo.a
+    FROM foo
+    INNER JOIN bar
+    WHERE foo.x = bar.y
+    GROUP BY foo.a
+  fix_str: |
+    SELECT foo.a
+    FROM foo
+    INNER JOIN bar ON foo.x = bar.y
+    GROUP BY foo.a
+
+test_fail_where_followed_by_limit:
+  fail_str: |
+    SELECT foo.a
+    FROM foo
+    INNER JOIN bar
+    WHERE foo.x = bar.y
+    LIMIT 1
+  fix_str: |
+    SELECT foo.a
+    FROM foo
+    INNER JOIN bar ON foo.x = bar.y
+    LIMIT 1


### PR DESCRIPTION
### Brief summary of the change made

fixes #8430

CV12 raised `AssertionError` on valid ANSI SQL under the default rule set. The trigger is a join condition in a WHERE clause with any clause after it.

```
$ printf 'SELECT foo.a FROM foo INNER JOIN bar WHERE foo.x = bar.y ORDER BY foo.a;\n' \
  | sqlfluff lint --dialect ansi -
CRITICAL   [CV12] Applying rule CV12 to 'stdin' threw an Exception:
  File ".../sqlfluff/rules/convention/CV12.py", line 290, in _eval_gen
    assert select_statement.segments[-1].is_type("where_clause")
AssertionError
```

`CV12.py:289-297` runs when every condition in the WHERE clause moves to the join, so the rule deletes the clause. It reached the clause through `segments[-1]` and the whitespace before it through `segments[-2]`. The WHERE clause is the last child of the select statement only when nothing follows it. `ORDER BY`, `GROUP BY` and `LIMIT` each add a later child.

The change finds the WHERE clause by index, deletes it, and deletes the segment before it only when that segment is whitespace or a newline. The other arm of the same `if/else` at `CV12.py:278-288` already reaches its target by lookup (`where_clause.get_child`) rather than by position. `segments.index` is the idiom used in `LT03.py:115`, `LT09.py:219` and `LT09.py:368`.

Measured with `--rules CV12`:

| input | before | after |
|---|---|---|
| `... WHERE foo.x = bar.y ORDER BY foo.a;` | AssertionError | `... INNER JOIN bar ON foo.x = bar.y ORDER BY foo.a;` |
| `... WHERE foo.x = bar.y GROUP BY foo.a;` | AssertionError | `... INNER JOIN bar ON foo.x = bar.y GROUP BY foo.a;` |
| `... WHERE foo.x = bar.y LIMIT 1;` | AssertionError | `... INNER JOIN bar ON foo.x = bar.y LIMIT 1;` |
| `... WHERE foo.x = bar.y;` (control) | correct | unchanged |

The fixed SQL reparses with no unparsable section.

### Are there any other side effects of this change that we should be aware of?

The index-based branch is a superset of the old one. When the WHERE clause is the last child, `where_idx` is the last index and `where_idx - 1` is the same segment the old code read as `segments[-2]`, so the fix for that shape is byte identical. `test/rules/` is 2561 passed, 101 skipped, unchanged from `main`.

The old code asserted that the segment before the WHERE clause is whitespace or a newline. The new code tests it instead of asserting it, so a WHERE clause that starts the select statement body with no leading whitespace no longer raises. I did not find a dialect that produces that shape, so this only removes a way to crash.

`git log --oneline -3 -- src/sqlfluff/rules/convention/CV12.py` shows `72c127a77` (#8203) as the last touch, which is elsewhere in the file. No open PR touches `CV12.py`.

AI usage: Claude Code CLI with Opus 5, used on the code. I ran every measurement above myself and confirmed the three new rule cases fail on unpatched `main`.

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - [X] `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`: `test_fail_where_followed_by_order_by`, `test_fail_where_followed_by_group_by` and `test_fail_where_followed_by_limit` in `CV12.yml`. With the fix reverted all three fail; with the fix all 40 CV12 cases pass.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- [X] Added appropriate documentation for the change: the rule's documented behaviour does not change, so the new comment in `CV12.py` is the only note needed.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.

Test results:

```
test/rules/yaml_test_cases_test.py -k CV12      40 passed
test/rules/                                   2561 passed, 101 skipped
```


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #8430 where CV12 raised an AssertionError on valid ANSI SQL when a WHERE clause is followed by `ORDER BY`, `GROUP BY`, or `LIMIT`.

**Details**
- Locates the WHERE clause by index instead of assuming it is the last segment.
- Deletes the preceding whitespace only when present, replacing the assert.
- Adds rule test cases for the three clause types after the WHERE clause.

<sup>Written for commit 6696f147a4028724154c5f68ec980a08a785767d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8431?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


