### PR TITLE
fix: .sqlfluffignore relative path matching one level down

### DIFF
--- a/src/sqlfluff/core/linter/discovery.py
+++ b/src/sqlfluff/core/linter/discovery.py
@@ -198,7 +198,7 @@ def _iter_files_in_path(
         for inner_dirname, inner_file, inner_spec in inner_ignore_specs[:]:
             if not (
                 dirname == inner_dirname
-                or dirname.startswith(os.path.abspath(inner_dirname) + os.sep)
+                or dirname.startswith(inner_dirname + os.sep)
             ):
                 inner_ignore_specs.remove((inner_dirname, inner_file, inner_spec))
 


### PR DESCRIPTION
## Summary

Fixes #8428

## Problem

A `.sqlfluffignore` file in a subdirectory stops applying one level below itself when the path on the command line is relative. `sqlfluff lint .` lints the ignored files, and `sqlfluff fix .` rewrites them.

The bug was in the inner_ignore_specs pruning logic at line 201:

```python
dirname.startswith(os.path.abspath(inner_dirname) + os.sep)
```

When `path` is relative (e.g., `.`), `dirname` from `os.walk(path)` is relative, but `os.path.abspath(inner_dirname)` returns an absolute path. The `startswith` comparison always fails, causing inner ignore specs to be dropped too early.

## Solution

Compare both paths as relative paths:

```python
dirname.startswith(inner_dirname + os.sep)
```

Both `dirname` and `inner_dirname` are relative to the same root path, so the comparison now works correctly for relative path arguments.

## Verification

```bash
mkdir -p /tmp/sfign/proj/sub/deeper
cd /tmp/sfign/proj
printf '[sqlfluff]\ndialect = ansi\n' > .sqlfluff
printf '*.sql\n' > sub/.sqlfluffignore
printf 'SELECT 1\n' > top.sql
printf 'SELECT 2\n' > sub/a.sql
printf 'SELECT    3   from t\n' > sub/deeper/b.sql

sqlfluff lint .                 # Before fix: lists sub/deeper/b.sql (wrong)
sqlfluff lint .                 # After fix: lists top.sql only (correct)
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `.sqlfluffignore` not applying to subdirectories when the command path is relative, so ignored files are now correctly excluded from linting and fixing. The fix compares directory paths consistently as relative paths in the ignore spec pruning logic.

<sup>Written for commit 29a9c1b69ac0139553ba998aba60977a4b2d97d2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8435?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

