### PR TITLE
Postgres: support SET ACCESS METHOD on tables and materialized views

### DIFF
--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -2937,6 +2937,15 @@ class AlterTableActionSegment(BaseSegment):
         Sequence("CLUSTER", "ON", Ref("ParameterNameSegment")),
         Sequence("SET", "WITHOUT", OneOf("CLUSTER", "OIDS")),
         Sequence("SET", "TABLESPACE", Ref("TablespaceReferenceSegment")),
+        # `SET ACCESS METHOD` was added in PostgreSQL 15, and accepting
+        # `DEFAULT` (meaning `default_table_access_method`) in PostgreSQL 17.
+        # https://www.postgresql.org/docs/current/sql-altertable.html
+        Sequence(
+            "SET",
+            "ACCESS",
+            "METHOD",
+            OneOf(Ref("ParameterNameSegment"), "DEFAULT"),
+        ),
         Sequence("SET", OneOf("LOGGED", "UNLOGGED")),
         Sequence("SET", Ref("RelationOptionsSegment")),
         # Documentation says you can only provide keys in RESET options, but the
@@ -3429,6 +3438,14 @@ class AlterMaterializedViewActionSegment(BaseSegment):
         ),
         Sequence("CLUSTER", "ON", Ref("ParameterNameSegment")),
         Sequence("SET", "WITHOUT", "CLUSTER"),
+        # `SET ACCESS METHOD` was added in PostgreSQL 15.
+        # https://www.postgresql.org/docs/current/sql-altermaterializedview.html
+        Sequence(
+            "SET",
+            "ACCESS",
+            "METHOD",
+            OneOf(Ref("ParameterNameSegment"), "DEFAULT"),
+        ),
         Sequence(
             "SET",
             Bracketed(

--- a/test/fixtures/dialects/postgres/alter_table_set_access_method.sql
+++ b/test/fixtures/dialects/postgres/alter_table_set_access_method.sql
@@ -1,0 +1,11 @@
+-- SET ACCESS METHOD was added in PostgreSQL 15, and accepting DEFAULT in
+-- PostgreSQL 17.
+-- https://www.postgresql.org/docs/current/sql-altertable.html
+
+ALTER TABLE my_table SET ACCESS METHOD heap;
+ALTER TABLE my_table SET ACCESS METHOD DEFAULT;
+ALTER TABLE IF EXISTS ONLY my_schema.my_table SET ACCESS METHOD my_access_method;
+
+-- https://www.postgresql.org/docs/current/sql-altermaterializedview.html
+ALTER MATERIALIZED VIEW my_view SET ACCESS METHOD heap;
+ALTER MATERIALIZED VIEW IF EXISTS my_view SET ACCESS METHOD DEFAULT;

--- a/test/fixtures/dialects/postgres/alter_table_set_access_method.yml
+++ b/test/fixtures/dialects/postgres/alter_table_set_access_method.yml
@@ -1,0 +1,76 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: fb76d97ce56c02069a48201f6b773794debec5f04d7a025cbdf0849469279899
+file:
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: my_table
+    - alter_table_action_segment:
+      - keyword: SET
+      - keyword: ACCESS
+      - keyword: METHOD
+      - parameter: heap
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: my_table
+    - alter_table_action_segment:
+      - keyword: SET
+      - keyword: ACCESS
+      - keyword: METHOD
+      - parameter: DEFAULT
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - keyword: IF
+    - keyword: EXISTS
+    - keyword: ONLY
+    - table_reference:
+      - naked_identifier: my_schema
+      - dot: .
+      - naked_identifier: my_table
+    - alter_table_action_segment:
+      - keyword: SET
+      - keyword: ACCESS
+      - keyword: METHOD
+      - parameter: my_access_method
+- statement_terminator: ;
+- statement:
+    alter_materialized_view_statement:
+    - keyword: ALTER
+    - keyword: MATERIALIZED
+    - keyword: VIEW
+    - table_reference:
+        naked_identifier: my_view
+    - alter_materialized_view_action_segment:
+      - keyword: SET
+      - keyword: ACCESS
+      - keyword: METHOD
+      - parameter: heap
+- statement_terminator: ;
+- statement:
+    alter_materialized_view_statement:
+    - keyword: ALTER
+    - keyword: MATERIALIZED
+    - keyword: VIEW
+    - keyword: IF
+    - keyword: EXISTS
+    - table_reference:
+        naked_identifier: my_view
+    - alter_materialized_view_action_segment:
+      - keyword: SET
+      - keyword: ACCESS
+      - keyword: METHOD
+      - parameter: DEFAULT
+- statement_terminator: ;


### PR DESCRIPTION
### Brief summary of the change made

`SET ACCESS METHOD` is unparsable in the postgres dialect. It was added in PostgreSQL 15, and extended in PostgreSQL 17 to accept `DEFAULT` (meaning `default_table_access_method`). On `main`, all of these produce `Found unparsable section`:

    ALTER TABLE my_table SET ACCESS METHOD heap;
    ALTER TABLE my_table SET ACCESS METHOD DEFAULT;
    ALTER MATERIALIZED VIEW my_view SET ACCESS METHOD heap;

Both `ALTER TABLE` and `ALTER MATERIALIZED VIEW` support the clause and both were missing it, so this adds it to `AlterTableActionSegment` and `AlterMaterializedViewActionSegment`. `ACCESS` and `METHOD` are already registered as unreserved keywords, so this is purely missing grammar.

Docs: https://www.postgresql.org/docs/current/sql-altertable.html and https://www.postgresql.org/docs/current/sql-altermaterializedview.html

I didn't find existing issues for these; happy to open them first if you'd prefer that order.

### Are there any other side effects of this change that we should be aware of?

Both additions are new alternatives in an existing `OneOf`, so nothing that parses today changes. The neighbouring `SET TABLESPACE`, `SET LOGGED`/`UNLOGGED`, `SET WITHOUT CLUSTER` and `SET (...)` actions are unaffected, and the existing `alter_table` fixtures still pass.

One judgement call worth flagging: `DEFAULT` is strictly PG17+ for `ALTER TABLE`. I've allowed it on `ALTER MATERIALIZED VIEW` too for consistency, since sqlfluff doesn't currently gate postgres grammar by server version. Happy to tighten that if you'd rather it were exact.

Verified locally on this exact commit: 1007 tests pass across postgres and every dialect inheriting from it (duckdb, greenplum, materialize, redshift). `ruff format`, `ruff check`, `mypy` and `yamllint` all clean. Re-running the fixture generator for the postgres dialect produces no diff, so the committed YAML matches it.

### Pull Request checklist

Test cases: `.sql`/`.yml` parser test cases added in `test/fixtures/dialects/postgres/alter_table_set_access_method.sql` and `.yml`, generated with the standard fixture generator.

Documentation: n/a, dialect grammar addition with no user-facing configuration change.

Follow-up issues: none needed.

---

*Disclosure, per the AI-assisted contributions section of CONTRIBUTING.md: this change was AI-assisted. The gap was found by probing documented PostgreSQL syntax against `main`, and the implementation, fixture and commit messages were AI-generated. All of it was validated by execution against a local checkout of this exact commit: the failing reproductions on `main`, the dialect test suites, the fixture regeneration check, and the ruff / mypy / yamllint runs.*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds parsing support for `SET ACCESS METHOD` on `ALTER TABLE` and `ALTER MATERIALIZED VIEW` statements in the Postgres dialect. Previously both produced `Found unparsable section`; now they parse, including the `DEFAULT` option.

**Notes**
- Missing grammar in `AlterTableActionSegment` and `AlterMaterializedViewActionSegment`; `ACCESS` and `METHOD` were already unreserved keywords.
- `DEFAULT` is PostgreSQL 17+ for tables but is allowed on both for consistency since sqlfluff doesn't gate grammar by server version.
- Adds parser test fixtures; no existing parse behavior changes.

<sup>Written for commit 5e7d800996c16c33f1bf9cabfb2504de467492d3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8436?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

