### PR TITLE
SQLite: support INDEXED BY / NOT INDEXED

### DIFF
--- a/src/sqlfluff/dialects/dialect_sqlite.py
+++ b/src/sqlfluff/dialects/dialect_sqlite.py
@@ -303,6 +303,7 @@ sqlite_dialect.replace(
         Ref("FilterClauseGrammar", optional=True),
         Ref("OverClauseSegment", optional=True),
     ),
+    PostTableExpressionGrammar=Ref("IndexedByClauseSegment"),
     IgnoreRespectNullsGrammar=Nothing(),
     SelectClauseTerminatorGrammar=OneOf(
         Ref(
@@ -1075,6 +1076,7 @@ class UpdateStatementSegment(ansi.UpdateStatementSegment):
         Indent,
         Ref("TableReferenceSegment"),
         Ref("AliasExpressionSegment", optional=True),
+        Ref("IndexedByClauseSegment", optional=True),
         Dedent,
         Ref("SetClauseListSegment"),
         Ref("FromClauseSegment", optional=True),
@@ -1270,6 +1272,23 @@ class AnalyzeStatementSegment(BaseSegment):
     match_grammar = Sequence(
         "ANALYZE",
         Ref("ObjectReferenceSegment", optional=True),
+    )
+
+
+class IndexedByClauseSegment(BaseSegment):
+    """An `INDEXED BY` or `NOT INDEXED` clause.
+
+    https://www.sqlite.org/lang_indexedby.html
+
+    These suffix a table name in `SELECT`, `DELETE` and `UPDATE` to force or
+    forbid the use of a particular index.
+    """
+
+    type = "indexed_by_clause"
+
+    match_grammar = OneOf(
+        Sequence("INDEXED", "BY", Ref("IndexReferenceSegment")),
+        Sequence("NOT", "INDEXED"),
     )
 
 

--- a/test/fixtures/dialects/sqlite/indexed_by.sql
+++ b/test/fixtures/dialects/sqlite/indexed_by.sql
@@ -1,0 +1,15 @@
+-- https://www.sqlite.org/lang_indexedby.html
+
+SELECT * FROM my_table INDEXED BY my_index WHERE a = 1;
+SELECT * FROM my_table NOT INDEXED WHERE a = 1;
+SELECT * FROM my_table AS t INDEXED BY my_index;
+SELECT *
+FROM my_table
+INNER JOIN other_table INDEXED BY other_index
+    ON my_table.id = other_table.id;
+
+DELETE FROM my_table INDEXED BY my_index WHERE a = 1;
+DELETE FROM my_table NOT INDEXED;
+
+UPDATE my_table INDEXED BY my_index SET a = 1 WHERE b = 2;
+UPDATE my_table AS t NOT INDEXED SET a = 1;

--- a/test/fixtures/dialects/sqlite/indexed_by.yml
+++ b/test/fixtures/dialects/sqlite/indexed_by.yml
@@ -1,0 +1,215 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: fb039190996bdb57c60ea303b980c8dc8e0cc0313d9c12cb9d0aff260b4fb21a
+file:
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: my_table
+            indexed_by_clause:
+            - keyword: INDEXED
+            - keyword: BY
+            - index_reference:
+                naked_identifier: my_index
+      where_clause:
+        keyword: WHERE
+        expression:
+          column_reference:
+            naked_identifier: a
+          comparison_operator:
+            raw_comparison_operator: '='
+          numeric_literal: '1'
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: my_table
+            indexed_by_clause:
+            - keyword: NOT
+            - keyword: INDEXED
+      where_clause:
+        keyword: WHERE
+        expression:
+          column_reference:
+            naked_identifier: a
+          comparison_operator:
+            raw_comparison_operator: '='
+          numeric_literal: '1'
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: my_table
+            alias_expression:
+              alias_operator:
+                keyword: AS
+              naked_identifier: t
+            indexed_by_clause:
+            - keyword: INDEXED
+            - keyword: BY
+            - index_reference:
+                naked_identifier: my_index
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: my_table
+          join_clause:
+          - keyword: INNER
+          - keyword: JOIN
+          - from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: other_table
+              indexed_by_clause:
+              - keyword: INDEXED
+              - keyword: BY
+              - index_reference:
+                  naked_identifier: other_index
+          - join_on_condition:
+              keyword: 'ON'
+              expression:
+              - column_reference:
+                - naked_identifier: my_table
+                - dot: .
+                - naked_identifier: id
+              - comparison_operator:
+                  raw_comparison_operator: '='
+              - column_reference:
+                - naked_identifier: other_table
+                - dot: .
+                - naked_identifier: id
+- statement_terminator: ;
+- statement:
+    delete_statement:
+      keyword: DELETE
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: my_table
+            indexed_by_clause:
+            - keyword: INDEXED
+            - keyword: BY
+            - index_reference:
+                naked_identifier: my_index
+      where_clause:
+        keyword: WHERE
+        expression:
+          column_reference:
+            naked_identifier: a
+          comparison_operator:
+            raw_comparison_operator: '='
+          numeric_literal: '1'
+- statement_terminator: ;
+- statement:
+    delete_statement:
+      keyword: DELETE
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: my_table
+            indexed_by_clause:
+            - keyword: NOT
+            - keyword: INDEXED
+- statement_terminator: ;
+- statement:
+    update_statement:
+      keyword: UPDATE
+      table_reference:
+        naked_identifier: my_table
+      indexed_by_clause:
+      - keyword: INDEXED
+      - keyword: BY
+      - index_reference:
+          naked_identifier: my_index
+      set_clause_list:
+        keyword: SET
+        set_clause:
+          naked_identifier: a
+          comparison_operator:
+            raw_comparison_operator: '='
+          expression:
+            numeric_literal: '1'
+      where_clause:
+        keyword: WHERE
+        expression:
+          column_reference:
+            naked_identifier: b
+          comparison_operator:
+            raw_comparison_operator: '='
+          numeric_literal: '2'
+- statement_terminator: ;
+- statement:
+    update_statement:
+      keyword: UPDATE
+      table_reference:
+        naked_identifier: my_table
+      alias_expression:
+        alias_operator:
+          keyword: AS
+        naked_identifier: t
+      indexed_by_clause:
+      - keyword: NOT
+      - keyword: INDEXED
+      set_clause_list:
+        keyword: SET
+        set_clause:
+          naked_identifier: a
+          comparison_operator:
+            raw_comparison_operator: '='
+          expression:
+            numeric_literal: '1'
+- statement_terminator: ;


### PR DESCRIPTION
### Brief summary of the change made

SQLite lets a table name be suffixed with `INDEXED BY <index-name>` or `NOT INDEXED` in `SELECT`, `DELETE` and `UPDATE`, to force or forbid the use of a particular index (https://www.sqlite.org/lang_indexedby.html). None of these parsed on the sqlite dialect before this change:

```sql
SELECT * FROM my_table INDEXED BY my_index WHERE a = 1;
DELETE FROM my_table NOT INDEXED;
UPDATE my_table INDEXED BY my_index SET a = 1 WHERE b = 2;
```

All three produced `Found unparsable section`.

The change adds an `IndexedByClauseSegment` and wires it in two ways, because the two statement families reach the table name differently:

- `SELECT` and `DELETE` go through `FromExpressionElementSegment`, which already has a `PostTableExpressionGrammar` hook. That hook was previously unset on sqlite, so the clause is simply bound to it. This also covers the clause appearing on a joined table, and after an alias.
- `UPDATE` takes a `TableReferenceSegment` directly rather than a from-expression, so it needs an explicit optional reference, placed after the alias to match SQLite's grammar diagram.

### Are there any other side effects of this change that we should be aware of?

None that I can find. `PostTableExpressionGrammar` was `Nothing()` on sqlite before, so nothing else claimed that slot. Regenerating every sqlite fixture produces a diff only for the new file — the other 37 parse trees are unchanged.

`INDEXED` is already in the sqlite keyword list, so no keyword changes were needed.

Verified on the pushed commit, from a clean checkout:

- `pytest test/dialects/ -k sqlite` — 114 passed
- `python test/generate_parse_fixture_yml.py --dialect sqlite` — no diff, so the committed YAML matches what CI's `ymlchecks` will generate
- `ruff format --check`, `ruff check`, `mypy`, `yamllint` — all clean

### Pull Request checklist

- [x] Please confirm you have completed any of the necessary steps below.
- [x] Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- [x] Added appropriate documentation for the change.
- [x] Created GitHub issues for any relevant followup/future enhancements if appropriate.

---

Disclosure, per CONTRIBUTING.md: this change was AI-assisted. The grammar, the fixture and this description were written with AI help, and everything asserted above was actually executed against a local checkout of the pushed commit rather than assumed.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds SQLite `INDEXED BY <index>` and `NOT INDEXED` parsing for `SELECT`, `DELETE`, and `UPDATE` statements. These clauses previously failed with `Found unparsable section` and now parse correctly, including on joined tables and after aliases.

- Introduces an `IndexedByClauseSegment` wired into the SQLite dialect.
- `SELECT` and `DELETE` pick it up via `PostTableExpressionGrammar`; `UPDATE` gets an explicit optional reference.
- No other dialect behavior changes; existing SQLite parse fixtures are unaffected.

<sup>Written for commit 7652363233a22020b100e801a4032204a2370991. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8437?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

