### PR TITLE
DuckDB: parse INSTALL and LOAD extension statements

### DIFF
--- a/src/sqlfluff/dialects/dialect_duckdb.py
+++ b/src/sqlfluff/dialects/dialect_duckdb.py
@@ -69,6 +69,7 @@ duckdb_dialect.sets("unreserved_keywords").update(
         "COMPRESSION",
         "COMPRESSION_LEVEL",
         "GLOB",
+        "INSTALL",
         "MACRO",
         "MAP",
         "OVERWRITE",
@@ -1026,6 +1027,38 @@ class ObjectLiteralElementSegment(ansi.ObjectLiteralElementSegment):
     )
 
 
+class InstallStatementSegment(BaseSegment):
+    """An `INSTALL` statement.
+
+    https://duckdb.org/docs/stable/sql/statements/load_and_install
+    """
+
+    type = "install_statement"
+    match_grammar = Sequence(
+        Ref.keyword("FORCE", optional=True),
+        "INSTALL",
+        OneOf(Ref("SingleIdentifierGrammar"), Ref("QuotedLiteralSegment")),
+        Sequence(
+            "FROM",
+            OneOf(Ref("SingleIdentifierGrammar"), Ref("QuotedLiteralSegment")),
+            optional=True,
+        ),
+    )
+
+
+class LoadStatementSegment(postgres.LoadStatementSegment):
+    """A `LOAD` statement.
+
+    DuckDB names the extension, where Postgres takes a quoted file name.
+    https://duckdb.org/docs/stable/sql/statements/load_and_install
+    """
+
+    match_grammar = Sequence(
+        "LOAD",
+        OneOf(Ref("SingleIdentifierGrammar"), Ref("QuotedLiteralSegment")),
+    )
+
+
 class StatementSegment(postgres.StatementSegment):
     """An element in the targets of a select statement."""
 
@@ -1033,6 +1066,7 @@ class StatementSegment(postgres.StatementSegment):
         insert=[
             Ref("SimplifiedPivotExpressionSegment"),
             Ref("SimplifiedUnpivotExpressionSegment"),
+            Ref("InstallStatementSegment"),
         ]
     )
 

--- a/test/fixtures/dialects/duckdb/install_and_load.sql
+++ b/test/fixtures/dialects/duckdb/install_and_load.sql
@@ -1,0 +1,23 @@
+INSTALL httpfs;
+
+INSTALL 'httpfs';
+
+FORCE INSTALL httpfs;
+
+INSTALL h3 FROM community;
+
+INSTALL spatial FROM core_nightly;
+
+FORCE INSTALL h3 FROM community;
+
+INSTALL custom_ext FROM 'http://my-extension-repository';
+
+INSTALL '/path/to/httpfs.duckdb_extension';
+
+LOAD httpfs;
+
+LOAD 'httpfs';
+
+LOAD '/path/to/httpfs.duckdb_extension';
+
+SELECT install FROM install;

--- a/test/fixtures/dialects/duckdb/install_and_load.yml
+++ b/test/fixtures/dialects/duckdb/install_and_load.yml
@@ -1,0 +1,87 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: cd3916ba1884383a1838c82b074f634b9fa71cee2b674f5e5aece224b0f4d727
+file:
+- statement:
+    install_statement:
+      keyword: INSTALL
+      naked_identifier: httpfs
+- statement_terminator: ;
+- statement:
+    install_statement:
+      keyword: INSTALL
+      quoted_literal: "'httpfs'"
+- statement_terminator: ;
+- statement:
+    install_statement:
+    - keyword: FORCE
+    - keyword: INSTALL
+    - naked_identifier: httpfs
+- statement_terminator: ;
+- statement:
+    install_statement:
+    - keyword: INSTALL
+    - naked_identifier: h3
+    - keyword: FROM
+    - naked_identifier: community
+- statement_terminator: ;
+- statement:
+    install_statement:
+    - keyword: INSTALL
+    - naked_identifier: spatial
+    - keyword: FROM
+    - naked_identifier: core_nightly
+- statement_terminator: ;
+- statement:
+    install_statement:
+    - keyword: FORCE
+    - keyword: INSTALL
+    - naked_identifier: h3
+    - keyword: FROM
+    - naked_identifier: community
+- statement_terminator: ;
+- statement:
+    install_statement:
+    - keyword: INSTALL
+    - naked_identifier: custom_ext
+    - keyword: FROM
+    - quoted_literal: "'http://my-extension-repository'"
+- statement_terminator: ;
+- statement:
+    install_statement:
+      keyword: INSTALL
+      quoted_literal: "'/path/to/httpfs.duckdb_extension'"
+- statement_terminator: ;
+- statement:
+    load_statement:
+      keyword: LOAD
+      naked_identifier: httpfs
+- statement_terminator: ;
+- statement:
+    load_statement:
+      keyword: LOAD
+      quoted_literal: "'httpfs'"
+- statement_terminator: ;
+- statement:
+    load_statement:
+      keyword: LOAD
+      quoted_literal: "'/path/to/httpfs.duckdb_extension'"
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          column_reference:
+            naked_identifier: install
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: install
+- statement_terminator: ;


### PR DESCRIPTION
### Brief summary of the change made

fixes #8354

DuckDB installs and loads an extension by name. `INSTALL httpfs;` and `LOAD httpfs;` are both unparsable today, and the linter reports the whole statement as an unparsable section.

DuckDB inherits `LoadStatementSegment` from Postgres, which takes only a quoted file name. This change subclasses it to also take a bare extension name, and adds an `InstallStatementSegment` for `INSTALL`.

The grammar is `[FORCE] INSTALL <extension> [FROM <repository>]` and `LOAD <extension>`. The extension and the repository are each a bare identifier or a single-quoted string. `FORCE` applies to `INSTALL` only.

rubytobi asked on #8357 for the DuckDB-specific subclass, and for a test that keeps `install` unreserved. Both are here.

Measured on `main` at `63df28344`, then on this branch:

| statement | main | this branch |
|---|---|---|
| `INSTALL httpfs;` | unparsable | parses |
| `INSTALL 'httpfs';` | unparsable | parses |
| `FORCE INSTALL httpfs;` | unparsable | parses |
| `INSTALL h3 FROM community;` | unparsable | parses |
| `INSTALL spatial FROM core_nightly;` | unparsable | parses |
| `FORCE INSTALL h3 FROM community;` | unparsable | parses |
| `INSTALL custom_ext FROM 'http://my-extension-repository';` | unparsable | parses |
| `INSTALL '/path/to/httpfs.duckdb_extension';` | unparsable | parses |
| `LOAD httpfs;` | unparsable | parses |
| `LOAD 'httpfs';` | parses | parses |
| `LOAD '/path/to/httpfs.duckdb_extension';` | parses | parses |
| `SELECT install FROM install;` (control) | parses | parses |

I took the accepted forms from DuckDB 1.5.4 itself, with `duckdb.extract_statements()`. Two forms it rejects are `FORCE LOAD httpfs;` and `INSTALL httpfs FROM community FORCE;`. Both stay unparsable here.

### Are there any other side effects of this change that we should be aware of?

`INSTALL` goes in the unreserved keyword set, not the reserved one, so it can still be a column name or a table name. `SELECT install FROM install;` is the last line of the new fixture, and the `.yml` records it as a `column_reference` and a `table_reference`.

`LoadStatementSegment` keeps the `load_statement` type it has in Postgres, and the change sits in the DuckDB dialect only. I regenerated every fixture in the repo with `python test/generate_parse_fixture_yml.py`: 2259 fixtures, and the new file is the only one that differs.

`git log --oneline -3 -- src/sqlfluff/dialects/dialect_duckdb.py` shows `e7763abfa` (#8229) as the last touch, which is elsewhere in the file. #8396 is the one open PR on this file. It adds four names to the same unreserved keyword list, so the two may need a one-line merge.

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - [X] `.sql`/`.yml` parser test cases in `test/fixtures/dialects`: `test/fixtures/dialects/duckdb/install_and_load.sql` and its generated `.yml`. With the dialect change reverted, `test__dialect__base_file_parse`, `test__dialect__base_broad_fix` and `test__dialect__base_parse_struct` all fail on that fixture.
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- [X] Added appropriate documentation for the change: both new segments carry the DuckDB documentation link. The dialect docs are generated from the dialect docstring, which does not change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.

AI usage: Claude Code CLI with Opus 5, used on the code. I ran every measurement above myself, and I checked each accepted form and each rejected form against DuckDB 1.5.4.

Test results:

```
test/dialects/dialects_test.py -k "duckdb or postgres"    630 passed
python test/generate_parse_fixture_yml.py                 2259 fixtures, all success
ruff format --check .                                     479 files already formatted
ruff check .                                              All checks passed
```


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #8354 so DuckDB `INSTALL` and `LOAD` extension statements parse instead of being flagged as unparsable sections.

- Adds a DuckDB `InstallStatementSegment` for `[FORCE] INSTALL <extension> [FROM <repository>]` and subclasses Postgres's `LoadStatementSegment` to accept a bare extension name.
- `INSTALL` goes into the unreserved keyword set, so `SELECT install FROM install;` still parses.
- New fixture covers all accepted forms from DuckDB 1.5.4; `FORCE LOAD` and `FORCE` after the repository stay unparsable.

<sup>Written for commit ae4d258b253a81f70843b09f5fb13b92782421ac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8438?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

