### PR TITLE
fix(oracle): only treat a line-starting / as the SQL*Plus buffer executor

### DIFF
--- a/src/sqlfluff/core/parser/grammar/lookbehind.py
+++ b/src/sqlfluff/core/parser/grammar/lookbehind.py
@@ -110,8 +110,64 @@ class PrecededByMatcher(Matchable):
         return True
 
 
+class PrecededOnLineByCodeMatcher(Matchable):
+    """Matches when code precedes the current position on the same line.
+
+    This is used as an ``exclude`` pattern on matchers for constructs that
+    are only meaningful when they start a line, so that the same character
+    used mid-line means something else.
+
+    For example, Oracle's SQL*Plus buffer executor ``/`` sits alone on its
+    own line, whereas a ``/`` with code before it on the line is division.
+    """
+
+    def is_optional(self) -> bool:  # pragma: no cover
+        """Return whether this element is optional.
+
+        A lookbehind matcher is never optional — it must always be evaluated.
+        """
+        return False
+
+    def simple(
+        self, parse_context: ParseContext, crumbs: Optional[tuple[str, ...]] = None
+    ) -> SimpleHintType:  # pragma: no cover
+        """This element doesn't work with simple."""
+        return None
+
+    def cache_key(self) -> str:  # pragma: no cover
+        """Get the cache key for the matcher."""
+        return "preceded-on-line-by-code"
+
+    def match(
+        self,
+        segments: Sequence["BaseSegment"],
+        idx: int,
+        parse_context: "ParseContext",
+    ) -> MatchResult:
+        """Match when a code segment precedes this position on the same line.
+
+        Scans backward from ``idx``. A newline (or the start of the file)
+        found before any code segment means the position starts its line, so
+        this returns an empty result and the caller's outer match is allowed.
+        """
+        prev = idx - 1
+        while prev >= 0:
+            segment = segments[prev]
+            if segment.is_code and not segment.is_meta:
+                return MatchResult(slice(idx, idx + 1))
+            if segment.is_type("newline"):
+                break
+            prev -= 1
+
+        return MatchResult.empty_at(idx)
+
+
 # Shared exclude pattern for the FROM keyword in select clause terminators.
 # Prevents FROM in "IS [NOT] DISTINCT FROM" being treated as a FROM clause.
 is_distinct_from_lookbehind = PrecededByMatcher(
     preceding_sequences=(("IS", "DISTINCT"), ("IS", "NOT", "DISTINCT")),
 )
+
+# Shared exclude pattern for constructs that are only meaningful at the start of
+# a line, such as Oracle's SQL*Plus buffer executor `/`.
+preceded_on_line_by_code_lookbehind = PrecededOnLineByCodeMatcher()

--- a/src/sqlfluff/dialects/dialect_oracle.py
+++ b/src/sqlfluff/dialects/dialect_oracle.py
@@ -41,6 +41,7 @@ from sqlfluff.core.parser import (
 from sqlfluff.core.parser.grammar.lookbehind import (
     PrecededByMatcher,
     is_distinct_from_lookbehind,
+    preceded_on_line_by_code_lookbehind,
 )
 from sqlfluff.dialects import dialect_ansi as ansi
 from sqlfluff.dialects.dialect_oracle_keywords import (
@@ -1587,7 +1588,15 @@ class CreateViewStatementSegment(ansi.CreateViewStatementSegment):
         Ref("BracketedColumnReferenceListGrammar", optional=True),
         "AS",
         OptionallyBracketed(
-            Ref("SelectableGrammar"), terminators=[Ref("BatchDelimiterGrammar")]
+            Ref("SelectableGrammar"),
+            # Only a `/` that starts its own line is the SQL*Plus buffer
+            # executor. One with code before it on the line is division.
+            terminators=[
+                Ref(
+                    "BatchDelimiterGrammar",
+                    exclude=preceded_on_line_by_code_lookbehind,
+                )
+            ],
         ),
         Ref("WithNoSchemaBindingClauseSegment", optional=True),
     )

--- a/test/fixtures/dialects/oracle/slash_batch_delimiter.sql
+++ b/test/fixtures/dialects/oracle/slash_batch_delimiter.sql
@@ -15,3 +15,11 @@ select 1 / 100 as z, nvl(bytes, 0) / 1024 / 1024 as size_mb
 from smwhr
 where sample_time > sysdate - 1/24
 /
+
+-- A `/` at the end of a line, with its right-hand operand on the next line,
+-- is still division: it isn't alone on its own line.
+create or replace view example_multiline_division as
+select 1 /
+100 as quotient
+from smwhr
+/

--- a/test/fixtures/dialects/oracle/slash_batch_delimiter.sql
+++ b/test/fixtures/dialects/oracle/slash_batch_delimiter.sql
@@ -8,3 +8,10 @@ comment on table example is 'abc'
 
 create or replace public synonym example for example
 /
+
+-- A bare `/` mid-line is division, not the buffer executor
+create or replace view example_division as
+select 1 / 100 as z, nvl(bytes, 0) / 1024 / 1024 as size_mb
+from smwhr
+where sample_time > sysdate - 1/24
+/

--- a/test/fixtures/dialects/oracle/slash_batch_delimiter.yml
+++ b/test/fixtures/dialects/oracle/slash_batch_delimiter.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 39952379cbb396da12521214e71093dfaa5817bb574a5470c18612a7fba7898a
+_hash: 55d90dd4397f7eba03cdc3aafb7b7b093d590a4da102cf110ecd70b23ce448ad
 file:
 - batch:
     statement:
@@ -55,5 +55,72 @@ file:
       - keyword: for
       - object_reference:
           naked_identifier: example
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      create_view_statement:
+      - keyword: create
+      - keyword: or
+      - keyword: replace
+      - keyword: view
+      - table_reference:
+          naked_identifier: example_division
+      - keyword: as
+      - select_statement:
+          select_clause:
+          - keyword: select
+          - select_clause_element:
+              expression:
+              - numeric_literal: '1'
+              - binary_operator: /
+              - numeric_literal: '100'
+              alias_expression:
+                alias_operator:
+                  keyword: as
+                naked_identifier: z
+          - comma: ','
+          - select_clause_element:
+              expression:
+              - function:
+                  function_name:
+                    function_name_identifier: nvl
+                  function_contents:
+                    bracketed:
+                    - start_bracket: (
+                    - expression:
+                        column_reference:
+                          naked_identifier: bytes
+                    - comma: ','
+                    - expression:
+                        numeric_literal: '0'
+                    - end_bracket: )
+              - binary_operator: /
+              - numeric_literal: '1024'
+              - binary_operator: /
+              - numeric_literal: '1024'
+              alias_expression:
+                alias_operator:
+                  keyword: as
+                naked_identifier: size_mb
+          from_clause:
+            keyword: from
+            from_expression:
+              from_expression_element:
+                table_expression:
+                  table_reference:
+                    naked_identifier: smwhr
+          where_clause:
+            keyword: where
+            expression:
+            - column_reference:
+                naked_identifier: sample_time
+            - comparison_operator:
+                raw_comparison_operator: '>'
+            - bare_function: sysdate
+            - binary_operator: '-'
+            - numeric_literal: '1'
+            - binary_operator: /
+            - numeric_literal: '24'
     slash_buffer_executor:
       slash: /

--- a/test/fixtures/dialects/oracle/slash_batch_delimiter.yml
+++ b/test/fixtures/dialects/oracle/slash_batch_delimiter.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 55d90dd4397f7eba03cdc3aafb7b7b093d590a4da102cf110ecd70b23ce448ad
+_hash: 6e568701544fd04f2c828a751a4fba1c8a8de24821c5ee27ef7dd0fd5bca9e64
 file:
 - batch:
     statement:
@@ -122,5 +122,36 @@ file:
             - numeric_literal: '1'
             - binary_operator: /
             - numeric_literal: '24'
+    slash_buffer_executor:
+      slash: /
+- batch:
+    statement:
+      create_view_statement:
+      - keyword: create
+      - keyword: or
+      - keyword: replace
+      - keyword: view
+      - table_reference:
+          naked_identifier: example_multiline_division
+      - keyword: as
+      - select_statement:
+          select_clause:
+            keyword: select
+            select_clause_element:
+              expression:
+              - numeric_literal: '1'
+              - binary_operator: /
+              - numeric_literal: '100'
+              alias_expression:
+                alias_operator:
+                  keyword: as
+                naked_identifier: quotient
+          from_clause:
+            keyword: from
+            from_expression:
+              from_expression_element:
+                table_expression:
+                  table_reference:
+                    naked_identifier: smwhr
     slash_buffer_executor:
       slash: /


### PR DESCRIPTION
### Brief summary of the change made
#7945 added a `BatchDelimiterGrammar` terminator to the `CREATE VIEW` body
so that a trailing SQL*Plus `/` ends the statement. That terminator fires
on any bare `/`, so a division operator inside `CREATE VIEW ... AS SELECT`
ended the statement early and everything after it became an unparsable
section. It only affects `CREATE VIEW`, and only when the `/` is not
already inside parentheses.

Oracle only treats `/` as the buffer executor when it starts its own line,
so the terminator is now excluded when code precedes the `/` on the same
line, via a new `PrecededOnLineByCodeMatcher` lookbehind alongside the
existing `PrecededByMatcher`.

fixes #8373

Note: #8379 is already open for this same issue using a different approach
(a separate lexer token). I left a comment there — this PR additionally
handles the multiline case (`1 /\n100`) that was blocking that one, via an
explicit regression test.

### Are there any other side effects of this change that we should be aware of?
None — this only narrows when the SQL*Plus buffer-executor terminator
fires; genuine trailing `/` batch delimiters still work as before (covered
by the existing `slash_batch_delimiter` fixture).

### Pull Request checklist
- [x] Added `.sql`/`.yml` parser test cases in `test/fixtures/dialects/oracle/slash_batch_delimiter.{sql,yml}` (yml regenerated via `test/generate_parse_fixture_yml.py --dialect oracle`), including a case for a division split across a line break.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Oracle parsing so a `/` used as division inside `CREATE VIEW` is no longer mistaken for the SQL*Plus buffer executor. A `/` now only terminates the statement when it starts its own line; with code before it on the same line, it parses as division. Fixes #8373.

**Details**
- Adds `PrecededOnLineByCodeMatcher`, a lookbehind that scans back to the newline to check for preceding code.
- Handles division split across a line break (`1 /\n100`), since only same-line code disables the terminator.
- Genuine trailing `/` batch delimiters still work; the existing `slash_batch_delimiter` fixture covers that.

<sup>Written for commit 6be9da557a6c0400fb10d85313afd79a99539867. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8442?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

