### PR TITLE
Oracle: Add support for IF NOT EXISTS clause in CREATE INDEX statement

### DIFF
--- a/src/sqlfluff/dialects/dialect_oracle.py
+++ b/src/sqlfluff/dialects/dialect_oracle.py
@@ -1704,6 +1704,9 @@ class CreateTableStatementSegment(BaseSegment):
 class CreateIndexStatementSegment(ansi.CreateIndexStatementSegment):
     """A CREATE INDEX statement, Oracle-specific extension.
 
+    The `IF NOT EXISTS` clause was introduced in Oracle Database 19c Release
+    Update 19.28 onwards.
+
     https://docs.oracle.com/en/database/oracle/oracle-database/23/sqlrf/CREATE-INDEX.html
     """
 
@@ -1713,6 +1716,7 @@ class CreateIndexStatementSegment(ansi.CreateIndexStatementSegment):
         "CREATE",
         OneOf(Ref.keyword("UNIQUE"), Ref.keyword("BITMAP"), optional=True),
         "INDEX",
+        Ref("IfNotExistsGrammar", optional=True),
         Ref("IndexReferenceSegment"),
         "ON",
         Ref("TableReferenceSegment"),

--- a/test/fixtures/dialects/oracle/create_index.sql
+++ b/test/fixtures/dialects/oracle/create_index.sql
@@ -8,9 +8,9 @@ CREATE BITMAP INDEX s1.t_bitmap_idx ON s1.t (status_col);
 
 CREATE INDEX s1.t_schema_idx ON s1.t (col1);
 
-CREATE INDEX s1.t_ts_idx ON s1.t (col1)
+CREATE INDEX s1.t_ts_idx ON s1.t (col1) TABLESPACE idx_ts;
 
-TABLESPACE idx_ts;
+CREATE INDEX IF NOT EXISTS s1.t_ts_idx ON s1.t (col1); -- Oracle 19.28 and later
 
 -- Physical attributes
 CREATE INDEX s1.t_pct_idx ON s1.t (col1)

--- a/test/fixtures/dialects/oracle/create_index.yml
+++ b/test/fixtures/dialects/oracle/create_index.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 532b899bf0a1b5871868dec909b1d218c69e3fabfaf3f6a7a25ef4af2500ad63
+_hash: 4557544264991ac97e142e8569b5e3ab79cd14bd6569eedf7db1e72d2ecfa01e
 file:
   batch:
   - statement:
@@ -134,6 +134,28 @@ file:
           keyword: TABLESPACE
           object_reference:
             naked_identifier: idx_ts
+  - statement_terminator: ;
+  - statement:
+      create_index_statement:
+      - keyword: CREATE
+      - keyword: INDEX
+      - keyword: IF
+      - keyword: NOT
+      - keyword: EXISTS
+      - index_reference:
+        - naked_identifier: s1
+        - dot: .
+        - naked_identifier: t_ts_idx
+      - keyword: 'ON'
+      - table_reference:
+        - naked_identifier: s1
+        - dot: .
+        - naked_identifier: t
+      - bracketed:
+          start_bracket: (
+          index_column_definition:
+            naked_identifier: col1
+          end_bracket: )
   - statement_terminator: ;
   - statement:
       create_index_statement:


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Oracle Database 19c Release Update 19.28 introduced support for the `IF NOT EXISTS` clause on `CREATE INDEX` statements. Currently, the Oracle dialect does not recognize this syntax, causing parsing/compilation errors when generating or executing these DDL statements.

This PR adds support for `IF NOT EXISTS` on `CREATE INDEX` to the Oracle dialect.

Fixes #8443.

### Are there any other side effects of this change that we should be aware of?
No.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for the Oracle `CREATE INDEX IF NOT EXISTS` syntax, so statements using it no longer cause parsing errors. Oracle introduced this syntax in 19c Release Update 19.28. Fixes #8443.

<sup>Written for commit 67e160e5e250edfa126f8ec20dfb831894655bb2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8445?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

