### PR TITLE
TSQL: support touching table alias column lists

### DIFF
--- a/src/sqlfluff/core/default_config.cfg
+++ b/src/sqlfluff/core/default_config.cfg
@@ -237,6 +237,11 @@ spacing_within = touch:inline
 [sqlfluff:layout:type:bracketed_arguments]
 spacing_before = touch:inline
 
+[sqlfluff:layout:type:alias_column_list]
+# T-SQL permits both forms, but the default follows the attached form used by
+# table-valued method examples: `AS table_alias(column_alias)`.
+spacing_before = touch:inline
+
 [sqlfluff:layout:type:match_condition]
 spacing_within = touch:inline
 

--- a/src/sqlfluff/core/default_config.cfg
+++ b/src/sqlfluff/core/default_config.cfg
@@ -240,7 +240,7 @@ spacing_before = touch:inline
 [sqlfluff:layout:type:alias_column_list]
 # T-SQL permits both forms, but the default follows the attached form used by
 # table-valued method examples: `AS table_alias(column_alias)`.
-spacing_before = touch:inline
+spacing_before = touch
 
 [sqlfluff:layout:type:match_condition]
 spacing_within = touch:inline

--- a/src/sqlfluff/dialects/AGENTS.md
+++ b/src/sqlfluff/dialects/AGENTS.md
@@ -105,6 +105,10 @@ Located in `src/sqlfluff/core/parser/grammar/`:
 | `Ref()` | Reference to another segment | `Ref("TableReferenceSegment")` |
 | `Optional()` | Optional element (or use `optional=True`) | `Optional(Ref("WhereClause"))` |
 
+When a dialect needs dedicated spacing for `alias(columns)`, give its bracketed
+column alias list a segment type such as `alias_column_list`. This avoids relaxing
+spacing throughout every `alias_expression`.
+
 ### Grammar Organization Patterns
 
 #### Internal Grammar (Private Attributes with `_` prefix)

--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -2094,7 +2094,9 @@ class AliasColumnListSegment(BaseSegment):
 class AliasExpressionSegment(ansi.AliasExpressionSegment):
     """A T-SQL alias, optionally followed by a column alias list."""
 
-    match_grammar = Sequence(
+    # Mirrors ANSI's alias grammar except for the typed column-list segment.
+    # Keep this override synchronized with ansi.AliasExpressionSegment.
+    match_grammar: Matchable = Sequence(
         Indent,
         Ref("AsAliasOperatorSegment", optional=True),
         OneOf(

--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -2084,6 +2084,30 @@ class SelectClauseElementSegment(ansi.SelectClauseElementSegment):
     )
 
 
+class AliasColumnListSegment(BaseSegment):
+    """A bracketed column list belonging to a T-SQL table alias."""
+
+    type = "alias_column_list"
+    match_grammar: Matchable = Bracketed(Ref("SingleIdentifierListSegment"))
+
+
+class AliasExpressionSegment(ansi.AliasExpressionSegment):
+    """A T-SQL alias, optionally followed by a column alias list."""
+
+    match_grammar = Sequence(
+        Indent,
+        Ref("AsAliasOperatorSegment", optional=True),
+        OneOf(
+            Sequence(
+                Ref("SingleIdentifierGrammar"),
+                Ref("AliasColumnListSegment", optional=True),
+            ),
+            Ref("SingleQuotedIdentifierSegment"),
+        ),
+        Dedent,
+    )
+
+
 class AltAliasExpressionSegment(BaseSegment):
     """An alternative alias clause as used by tsql using `=`."""
 

--- a/test/fixtures/dialects/tsql/datatype_methods.yml
+++ b/test/fixtures/dialects/tsql/datatype_methods.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 11c659de66b99a66717b06502719fc73d6298c843a998e3ccd226c7ec38e7330
+_hash: 9104490326dbbd14e1313c426b22577fb58ef1ed3cfd49f3c3c5c84b7a6b1d58
 file:
   batch:
   - statement:
@@ -383,11 +383,12 @@ file:
                   alias_operator:
                     keyword: AS
                   naked_identifier: na
-                  bracketed:
-                    start_bracket: (
-                    identifier_list:
-                      naked_identifier: Loc
-                    end_bracket: )
+                  alias_column_list:
+                    bracketed:
+                      start_bracket: (
+                      identifier_list:
+                        naked_identifier: Loc
+                      end_bracket: )
   - statement_terminator: ;
   - statement:
       select_statement:
@@ -425,11 +426,12 @@ file:
                         end_bracket: )
               alias_expression:
                 naked_identifier: T
-                bracketed:
-                  start_bracket: (
-                  identifier_list:
-                    naked_identifier: c
-                  end_bracket: )
+                alias_column_list:
+                  bracketed:
+                    start_bracket: (
+                    identifier_list:
+                      naked_identifier: c
+                    end_bracket: )
   - statement_terminator: ;
   - go_statement:
       keyword: GO

--- a/test/fixtures/dialects/tsql/merge.yml
+++ b/test/fixtures/dialects/tsql/merge.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 70a5b3bc59b926385cc2e033bb93535faa30e849d14e3aea00b40e8e96ae250b
+_hash: 5112e02c635af372e3b2805823b0d238b04dc515a0d61826bacb923f75f8118c
 file:
 - batch:
     statement:
@@ -492,13 +492,14 @@ file:
           alias_operator:
             keyword: as
           naked_identifier: src
-          bracketed:
-            start_bracket: (
-            identifier_list:
-            - naked_identifier: UnitMeasureCode
-            - comma: ','
-            - naked_identifier: Name
-            end_bracket: )
+          alias_column_list:
+            bracketed:
+              start_bracket: (
+              identifier_list:
+              - naked_identifier: UnitMeasureCode
+              - comma: ','
+              - naked_identifier: Name
+              end_bracket: )
       - join_on_condition:
           keyword: 'ON'
           bracketed:
@@ -672,13 +673,14 @@ file:
           alias_operator:
             keyword: as
           naked_identifier: src
-          bracketed:
-            start_bracket: (
-            identifier_list:
-            - naked_identifier: ProductID
-            - comma: ','
-            - naked_identifier: OrderQty
-            end_bracket: )
+          alias_column_list:
+            bracketed:
+              start_bracket: (
+              identifier_list:
+              - naked_identifier: ProductID
+              - comma: ','
+              - naked_identifier: OrderQty
+              end_bracket: )
       - join_on_condition:
           keyword: 'ON'
           bracketed:
@@ -878,13 +880,14 @@ file:
           alias_operator:
             keyword: AS
           naked_identifier: src
-          bracketed:
-            start_bracket: (
-            identifier_list:
-            - naked_identifier: ProductID
-            - comma: ','
-            - naked_identifier: OrderQty
-            end_bracket: )
+          alias_column_list:
+            bracketed:
+              start_bracket: (
+              identifier_list:
+              - naked_identifier: ProductID
+              - comma: ','
+              - naked_identifier: OrderQty
+              end_bracket: )
       - join_on_condition:
           keyword: 'ON'
           expression:
@@ -1133,13 +1136,14 @@ file:
           alias_operator:
             keyword: as
           naked_identifier: src
-          bracketed:
-            start_bracket: (
-            identifier_list:
-            - naked_identifier: UnitMeasureCode
-            - comma: ','
-            - naked_identifier: Name
-            end_bracket: )
+          alias_column_list:
+            bracketed:
+              start_bracket: (
+              identifier_list:
+              - naked_identifier: UnitMeasureCode
+              - comma: ','
+              - naked_identifier: Name
+              end_bracket: )
       - join_on_condition:
           keyword: 'ON'
           bracketed:
@@ -1332,13 +1336,14 @@ file:
           alias_operator:
             keyword: AS
           naked_identifier: src
-          bracketed:
-            start_bracket: (
-            identifier_list:
-            - naked_identifier: ProductID
-            - comma: ','
-            - naked_identifier: OrderQty
-            end_bracket: )
+          alias_column_list:
+            bracketed:
+              start_bracket: (
+              identifier_list:
+              - naked_identifier: ProductID
+              - comma: ','
+              - naked_identifier: OrderQty
+              end_bracket: )
       - join_on_condition:
           keyword: 'ON'
           expression:

--- a/test/fixtures/dialects/tsql/openrowset.yml
+++ b/test/fixtures/dialects/tsql/openrowset.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 52a7a08a72ad411173d5547e1d0f83859d89af746bc0edb9875e6aca8e6729db
+_hash: bc8ffc29f25fd7c55c09689285b98d24444ff151228be78b03f3b99139849fc5
 file:
 - batch:
     statement:
@@ -440,13 +440,14 @@ file:
                 alias_operator:
                   keyword: AS
                 naked_identifier: Document
-                bracketed:
-                  start_bracket: (
-                  identifier_list:
-                  - naked_identifier: column1
-                  - comma: ','
-                  - naked_identifier: column2
-                  end_bracket: )
+                alias_column_list:
+                  bracketed:
+                    start_bracket: (
+                    identifier_list:
+                    - naked_identifier: column1
+                    - comma: ','
+                    - naked_identifier: column2
+                    end_bracket: )
     statement_terminator: ;
     go_statement:
       keyword: GO

--- a/test/fixtures/rules/std_rule_cases/LT01-missing.yml
+++ b/test/fixtures/rules/std_rule_cases/LT01-missing.yml
@@ -1,5 +1,26 @@
 rule: LT01
 
+test_pass_tsql_values_alias_columns:
+  pass_str: SELECT * FROM (VALUES (1, 2)) AS t(a, b);
+  configs:
+    core:
+      dialect: tsql
+
+test_pass_tsql_alias_columns_preserve_newline:
+  pass_str: |
+    SELECT * FROM (VALUES (1, 2)) AS t
+    (a, b);
+  configs:
+    core:
+      dialect: tsql
+
+test_fail_tsql_values_alias_columns_excess_space:
+  fail_str: SELECT * FROM (VALUES (1, 2)) AS t  (a, b);
+  fix_str: SELECT * FROM (VALUES (1, 2)) AS t(a, b);
+  configs:
+    core:
+      dialect: tsql
+
 test_fail_no_space_after_using_clause:
   fail_str: select * from a JOIN b USING(x)
   fix_str: select * from a JOIN b USING (x)

--- a/test/fixtures/rules/std_rule_cases/LT01-missing.yml
+++ b/test/fixtures/rules/std_rule_cases/LT01-missing.yml
@@ -50,6 +50,36 @@ test_fail_cte_newline_and_spaces_after_as:
     )
     select * from a
 
+test_pass_tsql_table_alias_column_list_touching:
+  # T-SQL table-valued methods use a touching column alias list, e.g. r(c).
+  # https://github.com/sqlfluff/sqlfluff/issues/6733
+  pass_str: |
+    DECLARE @xml XML = '<rows><row><column>asdf</column></row></rows>';
+    SELECT r.c.value('column[1]', 'varchar(10)') AS 'Value'
+    FROM @xml.nodes('/rows/row') AS r(c);
+    SELECT * FROM (SELECT 1 AS a, 2 AS b) AS derived(a, b);
+    SELECT * FROM (SELECT 1 AS a, 2 AS b) implicit_alias(a, b);
+  configs:
+    core:
+      dialect: tsql
+
+test_fail_tsql_table_alias_column_list_spaced:
+  fail_str: SELECT * FROM (SELECT 1 AS a) AS spaced_alias (a);
+  fix_str: SELECT * FROM (SELECT 1 AS a) AS spaced_alias(a);
+  configs:
+    core:
+      dialect: tsql
+
+test_pass_tsql_table_alias_column_list_spacing_override:
+  pass_str: SELECT * FROM (SELECT 1 AS a) AS spaced_alias (a);
+  configs:
+    core:
+      dialect: tsql
+    layout:
+      type:
+        alias_column_list:
+          spacing_before: any
+
 test_pass_cte_comment_after_as:
   # https://github.com/sqlfluff/sqlfluff/issues/6125
   # When handling the 'single:inline' constraint,


### PR DESCRIPTION
Closes #6733.

LT01 currently rewrites valid T-SQL `AS r(c)` aliases to `AS r (c)`. This gives alias column lists a dedicated segment and defaults it to `touch:inline`, following the maintainer feedback on closed PR #8285. Users can still override the spacing.

Credit to @Pawansingh3889 for the prior implementation in #8285.

Tests: 191 LT01 cases; affected T-SQL parser fixtures; mypy, Ruff, yamllint, and codespell.

AI-assisted contribution: I reviewed the issue history, predecessor feedback, implementation, generated fixtures, and test results.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops LT01 from rewriting valid T-SQL table aliases with column lists, so `AS r(c)` stays as written instead of becoming `AS r (c)`, and line breaks between the alias and its column list are preserved. Closes #6733.

- Gives table alias column lists a dedicated `alias_column_list` segment and defaults its `spacing_before` to `touch`.
- Users can override the spacing with layout config.
- Adds LT01 tests for the touching default, the fix, line-break preservation, and the override.

<sup>Written for commit de23f83975abc790113e24d19c562221db27e2fe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8451?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

