### PR TITLE
Snowflake: fix EXCEPTION handler indentation

### DIFF
--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -4549,7 +4549,13 @@ class ScriptingBlockStatementSegment(BaseSegment):
         AnyNumberOf(
             Sequence(
                 Ref("DelimiterGrammar"),
-                Ref("StatementSegment"),
+                # Exclude ExceptionBlockStatementSegment so that the EXCEPTION
+                # section is matched below as a section of this block rather
+                # than as one of the statements inside it.
+                Ref(
+                    "StatementSegment",
+                    exclude=Ref("ExceptionBlockStatementSegment"),
+                ),
             ),
             terminators=[
                 OneOf(
@@ -4569,6 +4575,15 @@ class ScriptingBlockStatementSegment(BaseSegment):
         ),
         Ref("DelimiterGrammar"),
         Dedent,
+        # The EXCEPTION handler is a section of the block and not a statement
+        # within it, so it comes after the statement body has been closed and
+        # lines up with `BEGIN`.
+        # https://docs.snowflake.com/en/sql-reference/snowflake-scripting/exception
+        Sequence(
+            Ref("ExceptionBlockStatementSegment"),
+            Ref("DelimiterGrammar"),
+            optional=True,
+        ),
         "END",
         reset_terminators=True,
     )
@@ -11973,83 +11988,63 @@ class AlterTagStatementSegment(BaseSegment):
 
 
 class ExceptionBlockStatementSegment(BaseSegment):
-    """A snowflake `BEGIN ... END` statement for SQL scripting.
+    """A snowflake `EXCEPTION` handler section for SQL scripting.
 
-    https://docs.snowflake.com/en/sql-reference/snowflake-scripting/begin
+    https://docs.snowflake.com/en/sql-reference/snowflake-scripting/exception
     """
 
     type = "exception_block_statement"
 
-    match_grammar = Sequence(
-        Sequence(
-            "EXCEPTION",
-            Indent,
-            OneOf(
-                Sequence(
-                    "WHEN",
-                    Ref("ObjectReferenceSegment"),
-                    AnyNumberOf(
-                        Sequence(
-                            "OR",
-                            Ref("ObjectReferenceSegment"),
-                        ),
+    # A single `WHEN ... THEN` handler and the statements it runs. The handler
+    # body is a level of its own, below the `WHEN` that introduces it.
+    _when_handler = Sequence(
+        OneOf(
+            Sequence(
+                "WHEN",
+                Ref("ObjectReferenceSegment"),
+                AnyNumberOf(
+                    Sequence(
+                        "OR",
+                        Ref("ObjectReferenceSegment"),
                     ),
-                    "THEN",
                 ),
-                Sequence(
-                    "WHEN",
-                    "OTHER",
-                    "THEN",
-                ),
+                "THEN",
             ),
-            Ref("StatementSegment"),
-            AnyNumberOf(
-                Sequence(
-                    Ref("DelimiterGrammar"),
-                    # Exclude ExceptionBlockStatementSegment to prevent greedy
-                    # consumption of the next EXCEPTION block as a statement body.
-                    Ref(
-                        "StatementSegment",
-                        exclude=Ref("ExceptionBlockStatementSegment"),
-                    ),
-                ),
+            Sequence(
+                "WHEN",
+                "OTHER",
+                "THEN",
             ),
         ),
+        Indent,
+        Ref("StatementSegment"),
         AnyNumberOf(
             Sequence(
                 Ref("DelimiterGrammar"),
-                OneOf(
-                    Sequence(
-                        "WHEN",
-                        Ref("ObjectReferenceSegment"),
-                        AnyNumberOf(
-                            Sequence(
-                                "OR",
-                                Ref("ObjectReferenceSegment"),
-                            ),
-                        ),
-                        "THEN",
-                    ),
-                    Sequence(
-                        "WHEN",
-                        "OTHER",
-                        "THEN",
-                    ),
-                ),
-                Ref("StatementSegment"),
-                AnyNumberOf(
-                    Sequence(
-                        Ref("DelimiterGrammar"),
-                        # Exclude ExceptionBlockStatementSegment to prevent greedy
-                        # consumption of the next EXCEPTION block as a statement body.
-                        Ref(
-                            "StatementSegment",
-                            exclude=Ref("ExceptionBlockStatementSegment"),
-                        ),
-                    ),
+                # Exclude ExceptionBlockStatementSegment to prevent greedy
+                # consumption of the next EXCEPTION block as a statement body.
+                Ref(
+                    "StatementSegment",
+                    exclude=Ref("ExceptionBlockStatementSegment"),
                 ),
             ),
         ),
+        Dedent,
+    )
+
+    match_grammar = Sequence(
+        "EXCEPTION",
+        Indent,
+        # As in the oracle dialect, `AnyNumberOf(min_times=1)` isn't greedy
+        # enough to pick up every handler, so match one and then any more.
+        _when_handler,
+        AnyNumberOf(
+            Sequence(
+                Ref("DelimiterGrammar"),
+                _when_handler,
+            ),
+        ),
+        Dedent,
     )
 
 

--- a/test/fixtures/dialects/snowflake/exception.sql
+++ b/test/fixtures/dialects/snowflake/exception.sql
@@ -58,3 +58,46 @@ EXCEPTION
     WHEN OTHER THEN
         ROLLBACK;
         RAISE;
+
+BEGIN
+    LET x NUMBER := 1;
+EXCEPTION
+    WHEN OTHER THEN
+        RETURN 'handled';
+END;
+
+BEGIN
+    LET x NUMBER := 1;
+EXCEPTION
+    WHEN MY_EXCEPTION OR MY_OTHER_EXCEPTION THEN
+        LET err_msg := SQLERRM;
+        RETURN err_msg;
+    WHEN OTHER THEN
+        ROLLBACK;
+        RAISE;
+END;
+
+BEGIN
+    IF (TRUE) THEN
+        BEGIN
+            LET x NUMBER := 1;
+        EXCEPTION
+            WHEN OTHER THEN
+                RETURN 'inner';
+        END;
+    END IF;
+
+    RETURN 'ok';
+EXCEPTION
+    WHEN OTHER THEN
+        RETURN 'outer';
+END;
+
+BEGIN
+    LET x NUMBER := 1;
+EXCEPTION
+    WHEN OTHER THEN
+        BEGIN
+            RETURN 'nested block in handler';
+        END;
+END;

--- a/test/fixtures/dialects/snowflake/exception.yml
+++ b/test/fixtures/dialects/snowflake/exception.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 4a2b8a051b7901394feeb2de0888ded60ff4f1e62daa2d593b7d699c5b9d31f1
+_hash: 98b4b41db14c55e7dc0841ca7a973058d8e83344023149631be03608fdcae2b9
 file:
 - statement:
     exception_block_statement:
@@ -373,4 +373,177 @@ file:
     - statement:
         scripting_raise_statement:
           keyword: RAISE
+    - statement_terminator: ;
+    - statement:
+        scripting_block_statement:
+        - keyword: BEGIN
+        - statement:
+            scripting_let_statement:
+              keyword: LET
+              variable: x
+              data_type:
+                data_type_identifier: NUMBER
+              assignment_operator: :=
+              expression:
+                numeric_literal: '1'
+        - statement_terminator: ;
+        - exception_block_statement:
+          - keyword: EXCEPTION
+          - keyword: WHEN
+          - object_reference:
+              naked_identifier: OTHER
+          - keyword: THEN
+          - statement:
+              return_statement:
+                keyword: RETURN
+                expression:
+                  quoted_literal: "'handled'"
+        - statement_terminator: ;
+        - keyword: END
+    - statement_terminator: ;
+    - statement:
+        scripting_block_statement:
+        - keyword: BEGIN
+        - statement:
+            scripting_let_statement:
+              keyword: LET
+              variable: x
+              data_type:
+                data_type_identifier: NUMBER
+              assignment_operator: :=
+              expression:
+                numeric_literal: '1'
+        - statement_terminator: ;
+        - exception_block_statement:
+          - keyword: EXCEPTION
+          - keyword: WHEN
+          - object_reference:
+              naked_identifier: MY_EXCEPTION
+          - keyword: OR
+          - object_reference:
+              naked_identifier: MY_OTHER_EXCEPTION
+          - keyword: THEN
+          - statement:
+              scripting_let_statement:
+                keyword: LET
+                variable: err_msg
+                assignment_operator: :=
+                expression:
+                  column_reference:
+                    naked_identifier: SQLERRM
+          - statement_terminator: ;
+          - statement:
+              return_statement:
+                keyword: RETURN
+                expression:
+                  column_reference:
+                    naked_identifier: err_msg
+          - statement_terminator: ;
+          - keyword: WHEN
+          - object_reference:
+              naked_identifier: OTHER
+          - keyword: THEN
+          - statement:
+              transaction_statement:
+                keyword: ROLLBACK
+          - statement_terminator: ;
+          - statement:
+              scripting_raise_statement:
+                keyword: RAISE
+        - statement_terminator: ;
+        - keyword: END
+    - statement_terminator: ;
+    - statement:
+        scripting_block_statement:
+        - keyword: BEGIN
+        - statement:
+            scripting_if_statement:
+            - keyword: IF
+            - bracketed:
+                start_bracket: (
+                expression:
+                  boolean_literal: 'TRUE'
+                end_bracket: )
+            - keyword: THEN
+            - statement:
+                scripting_block_statement:
+                - keyword: BEGIN
+                - statement:
+                    scripting_let_statement:
+                      keyword: LET
+                      variable: x
+                      data_type:
+                        data_type_identifier: NUMBER
+                      assignment_operator: :=
+                      expression:
+                        numeric_literal: '1'
+                - statement_terminator: ;
+                - exception_block_statement:
+                  - keyword: EXCEPTION
+                  - keyword: WHEN
+                  - object_reference:
+                      naked_identifier: OTHER
+                  - keyword: THEN
+                  - statement:
+                      return_statement:
+                        keyword: RETURN
+                        expression:
+                          quoted_literal: "'inner'"
+                - statement_terminator: ;
+                - keyword: END
+            - statement_terminator: ;
+            - keyword: END
+            - keyword: IF
+        - statement_terminator: ;
+        - statement:
+            return_statement:
+              keyword: RETURN
+              expression:
+                quoted_literal: "'ok'"
+        - statement_terminator: ;
+        - exception_block_statement:
+          - keyword: EXCEPTION
+          - keyword: WHEN
+          - object_reference:
+              naked_identifier: OTHER
+          - keyword: THEN
+          - statement:
+              return_statement:
+                keyword: RETURN
+                expression:
+                  quoted_literal: "'outer'"
+        - statement_terminator: ;
+        - keyword: END
+    - statement_terminator: ;
+    - statement:
+        scripting_block_statement:
+        - keyword: BEGIN
+        - statement:
+            scripting_let_statement:
+              keyword: LET
+              variable: x
+              data_type:
+                data_type_identifier: NUMBER
+              assignment_operator: :=
+              expression:
+                numeric_literal: '1'
+        - statement_terminator: ;
+        - exception_block_statement:
+          - keyword: EXCEPTION
+          - keyword: WHEN
+          - object_reference:
+              naked_identifier: OTHER
+          - keyword: THEN
+          - statement:
+              scripting_block_statement:
+              - keyword: BEGIN
+              - statement:
+                  return_statement:
+                    keyword: RETURN
+                    expression:
+                      quoted_literal: "'nested block in handler'"
+              - statement_terminator: ;
+              - keyword: END
+        - statement_terminator: ;
+        - keyword: END
 - statement_terminator: ;

--- a/test/fixtures/dialects/snowflake/raise_statement.yml
+++ b/test/fixtures/dialects/snowflake/raise_statement.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 29eb4c03dc1b00b49d04366804f3d263eb08976f34ac81fe989aaa1a47cc5491
+_hash: 5f611b085836befcad5a2c922625ac2799bed73824f0cef7f12eabc725a94a35
 file:
 - statement:
     scripting_block_statement:
@@ -15,16 +15,15 @@ file:
             select_clause_element:
               numeric_literal: '1'
     - statement_terminator: ;
-    - statement:
-        exception_block_statement:
-        - keyword: EXCEPTION
-        - keyword: WHEN
-        - object_reference:
-            naked_identifier: OTHER
-        - keyword: THEN
-        - statement:
-            scripting_raise_statement:
-              keyword: RAISE
+    - exception_block_statement:
+      - keyword: EXCEPTION
+      - keyword: WHEN
+      - object_reference:
+          naked_identifier: OTHER
+      - keyword: THEN
+      - statement:
+          scripting_raise_statement:
+            keyword: RAISE
     - statement_terminator: ;
     - keyword: END
 - statement_terminator: ;

--- a/test/fixtures/rules/std_rule_cases/LT02-indent.yml
+++ b/test/fixtures/rules/std_rule_cases/LT02-indent.yml
@@ -3017,3 +3017,81 @@ test_pass_bigquery_pipe_extend_multiline:
   configs:
     core:
       dialect: bigquery
+
+test_pass_snowflake_exception_block_in_scripting_block:
+  # Issue 8452: EXCEPTION is a section of the enclosing Snowflake Scripting
+  # block, so it aligns with its BEGIN rather than with the statements
+  # inside the block.
+  pass_str: |
+    BEGIN
+        LET x NUMBER := 1;
+    EXCEPTION
+        WHEN OTHER THEN
+            RETURN 'handled';
+    END;
+  configs:
+    core:
+      dialect: snowflake
+
+test_pass_snowflake_exception_block_multiple_when:
+  # Each WHEN branch sits one level below EXCEPTION and its body one
+  # level below that, however many branches and statements there are.
+  pass_str: |
+    BEGIN
+        LET x NUMBER := 1;
+    EXCEPTION
+        WHEN MY_EXCEPTION THEN
+            LET err_msg := SQLERRM;
+            RETURN err_msg;
+        WHEN OTHER THEN
+            ROLLBACK;
+            RAISE;
+    END;
+  configs:
+    core:
+      dialect: snowflake
+
+test_pass_snowflake_exception_block_standalone:
+  # An EXCEPTION section on its own still indents its WHEN branches and
+  # their bodies as separate levels.
+  pass_str: |
+    EXCEPTION
+        WHEN OTHER THEN
+            ROLLBACK;
+            RAISE;
+  configs:
+    core:
+      dialect: snowflake
+
+test_fail_snowflake_exception_block_nested:
+  # Issue 8452: an EXCEPTION section in a nested block must not push the
+  # indentation of the code that follows it.
+  fail_str: |
+    BEGIN
+        IF (TRUE) THEN
+            BEGIN
+                LET x NUMBER := 1;
+              EXCEPTION
+              WHEN OTHER THEN
+                RETURN 'handled';
+              END;
+        END IF;
+
+        RETURN 'ok';
+    END;
+  fix_str: |
+    BEGIN
+        IF (TRUE) THEN
+            BEGIN
+                LET x NUMBER := 1;
+            EXCEPTION
+                WHEN OTHER THEN
+                    RETURN 'handled';
+            END;
+        END IF;
+
+        RETURN 'ok';
+    END;
+  configs:
+    core:
+      dialect: snowflake


### PR DESCRIPTION
### Brief summary of the change made

Fixes #8452.

The Snowflake Scripting `EXCEPTION` section was matched as a `StatementSegment`
inside `BEGIN ... END`, and the segment emitted an `Indent` with no matching
`Dedent`. One cause, three symptoms:

- `EXCEPTION` was indented as if it were a statement in the block, instead of
  aligning with the `BEGIN` that owns it.
- Handler bodies sat level with their own `WHEN` instead of one level below it.
- The unbalanced `Indent` leaked a level into everything after the block, so
  `sqlfluff format` walked `END`, `END IF` and the following statements steadily
  to the right.

So this change does two things. `ScriptingBlockStatementSegment` now matches the
`EXCEPTION` section after the block body's `Dedent` and before `END`, and
excludes `ExceptionBlockStatementSegment` from the statements that follow the
first one in the block body, so the section cannot be swallowed as one of them.
`ExceptionBlockStatementSegment` has balanced markers, and each `WHEN ... THEN`
body gets its own indent level. The two duplicated copies of the `WHEN` branch
grammar are factored into one private `_when_handler`, so the markers only have
to be right in one place.

That gives the layout in the [Snowflake Scripting exception
docs](https://docs.snowflake.com/en/sql-reference/snowflake-scripting/exception):
`EXCEPTION` at the `BEGIN` level, `WHEN` one level below, handler bodies one
below that. It is also what the existing
`test/fixtures/dialects/snowflake/raise_statement.sql` already writes.

Two dialects here model the same shape. `BeginStatementSegment` in
`dialect_bigquery.py` closes the block body before `EXCEPTION`, and
`ExceptionBlockGrammar` in `dialect_oracle.py` gives each handler body its own
level. Oracle keeps `EXCEPTION` inside the block indent because its fixtures
indent it one level. Snowflake's docs put it at the `BEGIN` level, so here the
section goes after the `Dedent`.

### Are there any other side effects of this change that we should be aware of?

- The issue reports this for a *nested* block, but the nesting only makes the
  drift visible. A single-level `BEGIN ... EXCEPTION ... END`, and a bare
  `EXCEPTION` section on its own, are mis-indented on `main` in the same way and
  are fixed by the same change. There are test cases for both.
- The parse tree changes shape. Inside a block, `exception_block_statement` is
  no longer wrapped in a `statement` node, since it is now a section of the
  block rather than one of its statements. You can see that in
  `test/fixtures/dialects/snowflake/raise_statement.yml`.
- No existing fixture tree regressed. The six standalone sections already in
  `exception.sql` produce a byte-identical tree, and the `raise_statement.yml`
  one above is the only pre-existing tree that moved.
- `ExceptionBlockStatementSegment` stays registered in `StatementSegment`. That
  is what keeps those standalone sections parsing, and it also means a block
  whose *only* content is an `EXCEPTION` section still parses as it did before.
  That form is not valid Snowflake, since the block needs at least one
  statement, but this change does not newly reject it.
- I left the class name and its `exception_block_statement` type alone, even
  though the section is no longer matched as a statement. Renaming the type
  would churn every Snowflake parse fixture without changing any behaviour.
  Happy to rename it if you would rather I did.
- `DECLARE ... my_exc EXCEPTION (-20001, '...') ... BEGIN ... END` is still
  unparsable. It is unparsable on `main` too. That is a separate gap in the
  exception *declaration* grammar, so I left it alone.

### Pull Request checklist

- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - [x] `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - [x] `.sql`/`.yml` parser test cases in `test/fixtures/dialects`.
  - [ ] Full autofix test cases in `test/fixtures/linter/autofix`.
  - [ ] Other.
- [x] Added appropriate documentation for the change.
- [ ] Created GitHub issues for any relevant followup/future enhancements if appropriate.

`test/fixtures/rules/std_rule_cases/LT02-indent.yml` gains four cases: a block
with a handler, multiple `WHEN` branches, a standalone `EXCEPTION` section, and
the nested `fail_str`/`fix_str` pair from the issue. All four fail on `main`.

`test/fixtures/dialects/snowflake/exception.sql` gains four blocks to pin the
new tree shape: a block with a handler, multiple `WHEN` branches inside a block,
a nested block where both levels have a handler, and a handler whose body is
itself a block. Its `.yml` was regenerated with
`python test/generate_parse_fixture_yml.py -d snowflake`.

### Validation

I ran these on Python 3.12.13 on Windows:

- `pytest test/rules/yaml_test_cases_test.py -k LT02`: 220 passed
- `pytest test/dialects/dialects_test.py -k snowflake`: 714 passed
- `pytest test/rules/std_fix_auto_test.py`: 61 passed
- `pytest test/`: 11060 passed, 4 failed
- `ruff check`, `ruff format --check` and `mypy` on the changed source file, and
  `yamllint` on the changed fixtures
- `python test/generate_parse_fixture_yml.py -d snowflake`: no further diff
- `python utils/rustify.py build`: succeeds

Re-running `sqlfluff format` on the fixed output is a no-op for every case above.

The 4 remaining full-suite failures are all in
`test/diff_quality_plugin_test.py`. They fail the same way on `main` with these
changes stashed, because `diff_cover`'s tool probe does not detect the sqlfluff
CLI in my environment. I have no Rust toolchain locally, so I only exercised the
Python path. The `utils/rustify.py build` code generation step that consumes
these grammars does succeed.

### AI assistance

Noting this per the AI-assisted contributions section of `CONTRIBUTING.md`. I
used AI assistance for the grammar edit, the test cases and this description. I
checked the behaviour against the Snowflake documentation linked above, and
every claim in the Validation section above comes from a command that was
actually run. That includes confirming that the four new LT02 cases fail on
`main` before the grammar change, and that the failures listed above also happen
on `main` without it.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Snowflake Scripting `EXCEPTION` handler indentation so `EXCEPTION` aligns with its `BEGIN`, handler bodies sit one level below their `WHEN`, and `sqlfluff format` no longer drifts code after the block to the right.

**Bug Fixes**
- The `EXCEPTION` section is now matched as a block section after the body's `Dedent` instead of as a statement inside the body.
- Each `WHEN ... THEN` body gets its own indent level; the duplicated `WHEN` branch grammar is factored into one private `_when_handler`.
- Inside a block, `exception_block_statement` is no longer wrapped in a `statement` node; standalone `EXCEPTION` sections still parse as before.

<sup>Written for commit 5edf813b818a96ee5516c52832013cf727a9225c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8453?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

