### PR TITLE
docs(parser): drop the stale tf arg from RustParser.parse's docstring

### DIFF
--- a/src/sqlfluff/core/parser/rust_parser.py
+++ b/src/sqlfluff/core/parser/rust_parser.py
@@ -202,7 +202,6 @@ try:
                 segments: Tuple of RawSegment objects from the lexer
                 fname: Optional filename for error reporting
                 parse_statistics: Whether to log parse statistics (not yet implemented)
-                tf: Optional TemplatedFile for position marker reconstruction
 
             Returns:
                 BaseSegment tree representing the parsed SQL, or None if empty


### PR DESCRIPTION
`RustParser.parse(self, segments, fname=None, parse_statistics=False)`'s Args block documents a `tf: Optional TemplatedFile` parameter. `tf` isn't in the signature and appears nowhere else in the file — a leftover from an earlier design where the Rust parser took a TemplatedFile (the sibling native parser documents the same signature without it). The stale line is removed.

**AI disclosure**: this fix was found and prepared with AI assistance (Claude); the final PR is reviewed and submitted by @simpleqt, per the AI-Assisted Contributions policy.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the stale `tf` parameter from `RustParser.parse`'s docstring, since the method signature has no such argument and the parameter is a leftover from an earlier design.

<sup>Written for commit 5bfa4681babec84e3ec70b810445016c1b0f27e7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8454?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

