### PR TITLE
Parse a bare division in an oracle CREATE VIEW body

### DIFF
--- a/src/sqlfluff/dialects/dialect_oracle.py
+++ b/src/sqlfluff/dialects/dialect_oracle.py
@@ -1611,7 +1611,16 @@ class CreateViewStatementSegment(ansi.CreateViewStatementSegment):
         Ref("BracketedColumnReferenceListGrammar", optional=True),
         "AS",
         OptionallyBracketed(
-            Ref("SelectableGrammar"), terminators=[Ref("BatchDelimiterGrammar")]
+            Ref("SelectableGrammar"),
+            terminators=[
+                Ref(
+                    "BatchDelimiterGrammar",
+                    exclude=Sequence(
+                        Ref("SlashSegment"),
+                        Ref("Tail_Recurse_Expression_A_Grammar"),
+                    ),
+                )
+            ],
         ),
         Ref("WithNoSchemaBindingClauseSegment", optional=True),
     )

--- a/test/fixtures/dialects/oracle/create_view_division.sql
+++ b/test/fixtures/dialects/oracle/create_view_division.sql
@@ -1,0 +1,17 @@
+CREATE VIEW v1 AS
+SELECT 1 / 100 AS z
+FROM dual;
+
+CREATE OR REPLACE VIEW v2 AS
+SELECT nvl(bytes, 0) / 1024 / 1024 AS size_mb
+FROM v$datafile;
+
+CREATE VIEW v3 AS
+SELECT a / b AS ratio
+FROM t
+WHERE sample_time > sysdate - 1 / 24;
+
+create or replace view v4 as
+select smthng / 2
+from smwhr
+/

--- a/test/fixtures/dialects/oracle/create_view_division.yml
+++ b/test/fixtures/dialects/oracle/create_view_division.yml
@@ -1,0 +1,146 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 055fddbe907434fb02432e67ff62e49eb467dd6ffe6000b27339f7417bbb38c6
+file:
+  batch:
+  - statement:
+      create_view_statement:
+      - keyword: CREATE
+      - keyword: VIEW
+      - table_reference:
+          naked_identifier: v1
+      - keyword: AS
+      - select_statement:
+          select_clause:
+            keyword: SELECT
+            select_clause_element:
+              expression:
+              - numeric_literal: '1'
+              - binary_operator: /
+              - numeric_literal: '100'
+              alias_expression:
+                alias_operator:
+                  keyword: AS
+                naked_identifier: z
+          from_clause:
+            keyword: FROM
+            from_expression:
+              from_expression_element:
+                table_expression:
+                  table_reference:
+                    naked_identifier: dual
+  - statement_terminator: ;
+  - statement:
+      create_view_statement:
+      - keyword: CREATE
+      - keyword: OR
+      - keyword: REPLACE
+      - keyword: VIEW
+      - table_reference:
+          naked_identifier: v2
+      - keyword: AS
+      - select_statement:
+          select_clause:
+            keyword: SELECT
+            select_clause_element:
+              expression:
+              - function:
+                  function_name:
+                    function_name_identifier: nvl
+                  function_contents:
+                    bracketed:
+                    - start_bracket: (
+                    - expression:
+                        column_reference:
+                          naked_identifier: bytes
+                    - comma: ','
+                    - expression:
+                        numeric_literal: '0'
+                    - end_bracket: )
+              - binary_operator: /
+              - numeric_literal: '1024'
+              - binary_operator: /
+              - numeric_literal: '1024'
+              alias_expression:
+                alias_operator:
+                  keyword: AS
+                naked_identifier: size_mb
+          from_clause:
+            keyword: FROM
+            from_expression:
+              from_expression_element:
+                table_expression:
+                  table_reference:
+                    naked_identifier: v$datafile
+  - statement_terminator: ;
+  - statement:
+      create_view_statement:
+      - keyword: CREATE
+      - keyword: VIEW
+      - table_reference:
+          naked_identifier: v3
+      - keyword: AS
+      - select_statement:
+          select_clause:
+            keyword: SELECT
+            select_clause_element:
+              expression:
+              - column_reference:
+                  naked_identifier: a
+              - binary_operator: /
+              - column_reference:
+                  naked_identifier: b
+              alias_expression:
+                alias_operator:
+                  keyword: AS
+                naked_identifier: ratio
+          from_clause:
+            keyword: FROM
+            from_expression:
+              from_expression_element:
+                table_expression:
+                  table_reference:
+                    naked_identifier: t
+          where_clause:
+            keyword: WHERE
+            expression:
+            - column_reference:
+                naked_identifier: sample_time
+            - comparison_operator:
+                raw_comparison_operator: '>'
+            - bare_function: sysdate
+            - binary_operator: '-'
+            - numeric_literal: '1'
+            - binary_operator: /
+            - numeric_literal: '24'
+  - statement_terminator: ;
+  - statement:
+      create_view_statement:
+      - keyword: create
+      - keyword: or
+      - keyword: replace
+      - keyword: view
+      - table_reference:
+          naked_identifier: v4
+      - keyword: as
+      - select_statement:
+          select_clause:
+            keyword: select
+            select_clause_element:
+              expression:
+                column_reference:
+                  naked_identifier: smthng
+                binary_operator: /
+                numeric_literal: '2'
+          from_clause:
+            keyword: from
+            from_expression:
+              from_expression_element:
+                table_expression:
+                  table_reference:
+                    naked_identifier: smwhr
+  - slash_buffer_executor:
+      slash: /


### PR DESCRIPTION
### Brief summary of the change made

fixes #8373

`CreateViewStatementSegment` in the oracle dialect terminates the view body on `BatchDelimiterGrammar`, which is the SQL*Plus slash buffer executor. A bare `/` division operator inside the SELECT matches that terminator first, so the view body stops at the `/` and everything after it becomes one unparsable section.

This adds `exclude=Sequence(Ref("SlashSegment"), Ref("Tail_Recurse_Expression_A_Grammar"))` to that terminator. `Tail_Recurse_Expression_A_Grammar` is the right operand of a binary operator, so a `/` followed by an expression is division and no longer ends the body. A `/` with no expression after it still ends the batch.

Measured on the issue repro, `CREATE VIEW myview AS select 1 / 100 as z from dual;`:

| ref | result |
|---|---|
| 4.3.0 | `PRS  Found unparsable section: '100 as z from dual;'` |
| main at d3e8358 | same failure |
| this branch | clean parse, 0 unparsable sections |

### Are there any other side effects of this change that we should be aware of?

The terminator is used only by `CreateViewStatementSegment` in the oracle dialect. `CREATE TABLE ... AS SELECT` and a plain `SELECT` do not use it, which matches the isolation the reporter measured.

The batch `/` is not lost. `BatchSegment` already accepts an optional `BatchDelimiterGrammar` after its statements, so a `/` on its own line still parses as `slash_buffer_executor`. The new fixture covers a view whose body holds a division and ends with a batch `/`. Both behaviours are asserted in the same file.

`test/dialects/dialect_test.py` passes 6800 fixture cases with no failures. `test/dialects/oracle_test.py` passes 321.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - [x] `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.

`test/fixtures/dialects/oracle/create_view_division.sql` holds four views: a literal divisor, two chained divisions after an `nvl()` call, a division inside a `WHERE`, and a body with a division that ends with a batch `/`. The `.yml` was generated with `python test/generate_parse_fixture_yml.py -d oracle --new-only`.

AI usage disclosure: I use Claude Code CLI with Opus 5. I ran the reporter's repro by hand on released 4.3.0, on main at d3e8358 and on this branch. I also ran the oracle and full dialect fixture suites.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #8373: Oracle `CREATE VIEW` parsing no longer mistakes a bare division operator inside the SELECT body for the SQL*Plus batch delimiter.

**Details**
- Updates the `CreateViewStatementSegment` terminator to exclude a `/` followed by an expression, so it is parsed as division instead of ending the view body.
- A `/` on its own line still ends the batch, preserving the `slash_buffer_executor` behavior.
- Only affects Oracle `CREATE VIEW`; `CREATE TABLE AS SELECT` and plain `SELECT` are unaffected.
- Adds a fixture covering literal divisors, chained divisions, division in a `WHERE` clause, and a batch `/` after a division.

<sup>Written for commit 412d0b28fe0aa6bfe6c41403b987e75d661558cf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8456?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

