### PR TITLE
Accept more than one bracket pair around a join target

### DIFF
--- a/src/sqlfluff/core/dialects/common.py
+++ b/src/sqlfluff/core/dialects/common.py
@@ -431,6 +431,16 @@ def get_join_clause_aliases(
     buff = []
 
     from_expression = segment.get_child("from_expression_element")
+    if not from_expression:
+        # A bracketed nested join holds its first element under the brackets
+        # rather than beside them. Stop at the first join clause, because the
+        # loop below reads those.
+        for element in segment.recursive_crawl(
+            "from_expression_element",
+            no_recursive_seg_type=["select_statement", "join_clause"],
+        ):
+            from_expression = element
+            break
     # As per grammar, there will always be a FromExpressionElementSegment
     assert from_expression
     from_aliases = get_from_expression_element_alias(from_expression, dialect_name)

--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -1916,13 +1916,22 @@ class JoinClauseSegment(BaseSegment):
     """Any number of join clauses, including the `JOIN` keyword."""
 
     type = "join_clause"
+
+    # A bracketed nested join can carry more than one pair of brackets.
+    # FromExpressionSegment already recurses through its own bracketed branch,
+    # so refer to it for the extra pairs.
+    _join_target = OneOf(
+        Ref("FromExpressionElementSegment"),
+        Bracketed(Ref("FromExpressionSegment")),
+    )
+
     match_grammar: Matchable = OneOf(
         # NB These qualifiers are optional
         Sequence(
             Ref("ConditionalJoinKeywordsGrammar", optional=True),
             Ref("JoinKeywordsGrammar"),
             Indent,
-            Ref("FromExpressionElementSegment"),
+            _join_target,
             AnyNumberOf(Ref("NestedJoinGrammar")),
             Dedent,
             Sequence(
@@ -1948,7 +1957,7 @@ class JoinClauseSegment(BaseSegment):
             Ref("UnconditionalJoinKeywordsGrammar"),
             Ref("JoinKeywordsGrammar"),
             Indent,
-            Ref("FromExpressionElementSegment"),
+            _join_target,
             Ref("MatchConditionSegment", optional=True),
             Dedent,
         ),
@@ -1956,7 +1965,7 @@ class JoinClauseSegment(BaseSegment):
         Sequence(
             Ref("ExtendedNaturalJoinKeywordsGrammar"),
             Indent,
-            Ref("FromExpressionElementSegment"),
+            _join_target,
             Dedent,
         ),
     )

--- a/test/fixtures/dialects/ansi/select_bracketed_join_target.sql
+++ b/test/fixtures/dialects/ansi/select_bracketed_join_target.sql
@@ -1,0 +1,24 @@
+-- one pair of brackets around the join target
+select 1
+from a
+left join (b inner join c on true) on true;
+
+-- two pairs
+select 1
+from a
+left join ((b inner join c on true)) on true;
+
+-- three pairs
+select 1
+from a
+left join (((b inner join c on true))) on true;
+
+-- a bracketed target that itself carries a trailing join
+select 1
+from a
+left join ((b inner join c on true) inner join d on true) on true;
+
+-- natural join with a bracketed target
+select 1
+from a
+natural join ((b inner join c on true));

--- a/test/fixtures/dialects/ansi/select_bracketed_join_target.yml
+++ b/test/fixtures/dialects/ansi/select_bracketed_join_target.yml
@@ -1,0 +1,228 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: b36499fd2294922b5162440287a00f89c9ac18553e5eddc6bfdd0884f3edd919
+file:
+- statement:
+    select_statement:
+      select_clause:
+        keyword: select
+        select_clause_element:
+          numeric_literal: '1'
+      from_clause:
+        keyword: from
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: a
+          join_clause:
+          - keyword: left
+          - keyword: join
+          - from_expression_element:
+              bracketed:
+                start_bracket: (
+                table_expression:
+                  table_reference:
+                    naked_identifier: b
+                join_clause:
+                - keyword: inner
+                - keyword: join
+                - from_expression_element:
+                    table_expression:
+                      table_reference:
+                        naked_identifier: c
+                - join_on_condition:
+                    keyword: 'on'
+                    expression:
+                      boolean_literal: 'true'
+                end_bracket: )
+          - join_on_condition:
+              keyword: 'on'
+              expression:
+                boolean_literal: 'true'
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: select
+        select_clause_element:
+          numeric_literal: '1'
+      from_clause:
+        keyword: from
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: a
+          join_clause:
+          - keyword: left
+          - keyword: join
+          - bracketed:
+              start_bracket: (
+              from_expression:
+                bracketed:
+                  start_bracket: (
+                  from_expression_element:
+                    table_expression:
+                      table_reference:
+                        naked_identifier: b
+                  join_clause:
+                  - keyword: inner
+                  - keyword: join
+                  - from_expression_element:
+                      table_expression:
+                        table_reference:
+                          naked_identifier: c
+                  - join_on_condition:
+                      keyword: 'on'
+                      expression:
+                        boolean_literal: 'true'
+                  end_bracket: )
+              end_bracket: )
+          - join_on_condition:
+              keyword: 'on'
+              expression:
+                boolean_literal: 'true'
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: select
+        select_clause_element:
+          numeric_literal: '1'
+      from_clause:
+        keyword: from
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: a
+          join_clause:
+          - keyword: left
+          - keyword: join
+          - bracketed:
+              start_bracket: (
+              from_expression:
+                bracketed:
+                  start_bracket: (
+                  from_expression_element:
+                    bracketed:
+                      start_bracket: (
+                      table_expression:
+                        table_reference:
+                          naked_identifier: b
+                      join_clause:
+                      - keyword: inner
+                      - keyword: join
+                      - from_expression_element:
+                          table_expression:
+                            table_reference:
+                              naked_identifier: c
+                      - join_on_condition:
+                          keyword: 'on'
+                          expression:
+                            boolean_literal: 'true'
+                      end_bracket: )
+                  end_bracket: )
+              end_bracket: )
+          - join_on_condition:
+              keyword: 'on'
+              expression:
+                boolean_literal: 'true'
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: select
+        select_clause_element:
+          numeric_literal: '1'
+      from_clause:
+        keyword: from
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: a
+          join_clause:
+          - keyword: left
+          - keyword: join
+          - bracketed:
+              start_bracket: (
+              from_expression:
+                from_expression_element:
+                  bracketed:
+                    start_bracket: (
+                    table_expression:
+                      table_reference:
+                        naked_identifier: b
+                    join_clause:
+                    - keyword: inner
+                    - keyword: join
+                    - from_expression_element:
+                        table_expression:
+                          table_reference:
+                            naked_identifier: c
+                    - join_on_condition:
+                        keyword: 'on'
+                        expression:
+                          boolean_literal: 'true'
+                    end_bracket: )
+                join_clause:
+                - keyword: inner
+                - keyword: join
+                - from_expression_element:
+                    table_expression:
+                      table_reference:
+                        naked_identifier: d
+                - join_on_condition:
+                    keyword: 'on'
+                    expression:
+                      boolean_literal: 'true'
+              end_bracket: )
+          - join_on_condition:
+              keyword: 'on'
+              expression:
+                boolean_literal: 'true'
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: select
+        select_clause_element:
+          numeric_literal: '1'
+      from_clause:
+        keyword: from
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: a
+          join_clause:
+          - keyword: natural
+          - keyword: join
+          - bracketed:
+              start_bracket: (
+              from_expression:
+                bracketed:
+                  start_bracket: (
+                  from_expression_element:
+                    table_expression:
+                      table_reference:
+                        naked_identifier: b
+                  join_clause:
+                  - keyword: inner
+                  - keyword: join
+                  - from_expression_element:
+                      table_expression:
+                        table_reference:
+                          naked_identifier: c
+                  - join_on_condition:
+                      keyword: 'on'
+                      expression:
+                        boolean_literal: 'true'
+                  end_bracket: )
+              end_bracket: )
+- statement_terminator: ;

--- a/test/fixtures/rules/std_rule_cases/AL04.yml
+++ b/test/fixtures/rules/std_rule_cases/AL04.yml
@@ -75,3 +75,11 @@ test_fail_subquery_join_matches_base_table:
     SELECT tbl.val
     FROM tbl
     LEFT JOIN (SELECT tbl.val FROM tbl2 AS tbl);
+
+test_pass_bracketed_nested_join_target:
+  # A join target can carry more than one pair of brackets. The rule used to
+  # raise an AssertionError on the second pair. See #8382.
+  pass_str: |
+    SELECT 1
+    FROM a
+    LEFT JOIN ((b INNER JOIN c ON TRUE)) ON TRUE


### PR DESCRIPTION
### Brief summary of the change made

fixes #8382

`SELECT 1 FROM a LEFT JOIN ((b INNER JOIN c ON TRUE)) ON TRUE;` fails to parse. One pair of brackets around the join target works, two do not.

The join target in `JoinClauseSegment` is `Ref("FromExpressionElementSegment")`. That segment has a bracketed branch, but the branch holds `_base_from_expression_element`, not a reference back to itself, so it accepts exactly one pair of brackets.

The FROM position does not have this problem. `FromExpressionSegment` carries a `Bracketed(Ref("FromExpressionSegment"))` branch, added in #4890, so `FROM ((b JOIN c))` already parses at any depth. This change gives the join target the same branch, so both positions behave the same way.

`get_join_clause_aliases` asserted that a join clause has a direct `from_expression_element` child. With the extra bracket the element sits one level down, so the assert fired. Eight rules then raised `AssertionError` on valid SQL: AL04, AL05, AM04, RF01, RF02, RF03, ST05 and ST09. The function now looks for the element under the brackets, stopping at the first join clause because the loop below it already reads those.

Measured on `main` at d3e8358 against this branch. A is `FROM (b INNER JOIN c ON TRUE)`, B is `FROM a LEFT JOIN (b INNER JOIN c ON TRUE) ON TRUE`, and the number is the count of bracket pairs.

| dialect | A1 | A2 | A3 | B1 | B2 | B3 |
|---|---|---|---|---|---|---|
| ansi, mysql, mariadb, postgres, sqlite, bigquery, duckdb, redshift, oracle, athena, hive | ok | ok | ok | ok | PRS -> ok | PRS -> ok |
| tsql | ok | ok | ok | ok | ok | ok |
| snowflake | ok | ok | ok | PRS -> ok | PRS -> ok | PRS -> ok |

tsql already passes because it overrides `TableExpressionSegment` with a bracketed branch that refers to `TableExpressionSegment` again. I tried that shape in ansi first and dropped it: it changed the parse tree of the existing `select_nested_join.sql` fixture, added eight LT02 indent violations, dropped two ST09 findings and raised one elsewhere, and changed `sqlfluff fix` output on SQL that already worked.

This change leaves both fixtures alone. I dumped the parse tree of `select_with_brackets.sql` and `select_nested_join.sql` on main and on this branch and diffed them. Each diff is 0 lines.

### Are there any other side effects of this change that we should be aware of?

Snowflake changes from PRS to a clean parse at one bracket pair as well. It failed at every depth before, so this is a second defect that the same branch closes.

Rule output for the already-working single-bracket case is unchanged. `SELECT 1 FROM a LEFT JOIN (b INNER JOIN c ON TRUE) ON TRUE;` still reports the same two ST11 violations as on main.

At two or more bracket pairs the rules report nothing. That matches what main already does for the same shape in the FROM position: `FROM (b INNER JOIN c ON TRUE)` and its two- and three-bracket forms all report zero violations on main today. This change does not widen that gap and does not close it.

`_join_target` is a class attribute on `JoinClauseSegment`. Only sparksql redefines `JoinClauseSegment`, and it sets its own `match_grammar`, so it is unaffected.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.

New parser fixture `test/fixtures/dialects/ansi/select_bracketed_join_target.sql` with the generated `.yml`. It covers one, two and three bracket pairs, a bracketed target that carries its own trailing join, and a natural join with a bracketed target. With the grammar change reverted the fixture produces 8 unparsable sections.

New rule case `AL04_test_pass_bracketed_nested_join_target` in `test/fixtures/rules/std_rule_cases/AL04.yml`. It fails if either half of the change is reverted on its own: without the grammar change the SQL does not parse, without the `common.py` change AL04 raises `AssertionError`.

No documentation change. This is a parse fix with no new configuration or rule behaviour.

`pytest test/dialects/ test/core/ test/rules/` reports 10539 passed and 3 failed. The 3 are `test/core/plugin_test.py`, which needs the example plugin installed. They fail the same way on a clean checkout of main. `ruff format --check .` and `ruff check .` both pass.

AI usage disclosure: I use Claude Code CLI with Opus 5. I ran the reporter's query by hand on main at d3e8358 and on this branch, measured the parse result for both bracket positions across 13 dialects, diffed the parse trees of the two touched fixtures, and ran the dialect, core and rules suites.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes parsing of more than one bracket pair around a join target so `LEFT JOIN ((b INNER JOIN c ON TRUE)) ON TRUE` no longer fails to parse, and stops rules AL04, AL05, AM04, RF01, RF02, RF03, ST05, and ST09 from raising `AssertionError` on that valid SQL.

- The join target now accepts a bracketed `FromExpressionSegment`, which already handles any nesting depth, matching the `FROM` position.
- `get_join_clause_aliases` now finds the join element under the brackets.
- Snowflake now parses a single bracketed join target; it previously failed at every depth.
- Existing rule output and fixture parse trees are unchanged.

<sup>Written for commit f0049def4845cf312f4700a4945877d1d931a572. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8457?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

