### PR TITLE
Snowflake: Fix SEMANTIC_VIEW bracket spacing

### DIFF
--- a/src/sqlfluff/core/default_config.cfg
+++ b/src/sqlfluff/core/default_config.cfg
@@ -240,6 +240,9 @@ spacing_before = touch:inline
 [sqlfluff:layout:type:match_condition]
 spacing_within = touch:inline
 
+[sqlfluff:layout:type:semantic_view]
+spacing_within = touch:inline
+
 [sqlfluff:layout:type:typed_struct_literal]
 spacing_within = touch
 

--- a/test/fixtures/rules/std_rule_cases/LT01-brackets.yml
+++ b/test/fixtures/rules/std_rule_cases/LT01-brackets.yml
@@ -61,6 +61,37 @@ test_fail_snowflake_match_condition:
     core:
       dialect: snowflake
 
+test_pass_snowflake_semantic_view_touching_bracket:
+  pass_str: |
+    select *
+    from semantic_view(
+        sales_analysis
+        dimensions orders.order_date
+        metrics orders.revenue
+    );
+  configs:
+    core:
+      dialect: snowflake
+
+test_fail_snowflake_semantic_view_spaced_bracket:
+  fail_str: |
+    select *
+    from semantic_view (
+        sales_analysis
+        dimensions orders.order_date
+        metrics orders.revenue
+    );
+  fix_str: |
+    select *
+    from semantic_view(
+        sales_analysis
+        dimensions orders.order_date
+        metrics orders.revenue
+    );
+  configs:
+    core:
+      dialect: snowflake
+
 test_pass_ansi_bracketed_data_types:
   pass_str: |
     CREATE TABLE fractest (c1 TIME(2), c2 DATETIME(2), c3 TIMESTAMP(2));


### PR DESCRIPTION
### Brief summary of the change made

Follow-up to #8447.

Fixes #8458.

Snowflake documents and consistently demonstrates the query construct as `SEMANTIC_VIEW(...)`. After #8447 gave it a dedicated `semantic_view` parse segment, LT01 applied the default keyword-to-bracket spacing at that newly visible boundary. As a result, valid documented syntax raised:

```text
Expected single whitespace between 'SEMANTIC_VIEW' keyword and start bracket '('.
```

Running `sqlfluff fix` then rewrote `SEMANTIC_VIEW(` to `SEMANTIC_VIEW (`. The inverse spaced form passed LT01.

This change gives the dedicated `semantic_view` segment an inline touch-spacing policy, analogous to other keyword-led Snowflake constructs with attached brackets. It keeps the specialized parse tree and RF01 behavior introduced by #8447 intact; this is only a layout policy.

### Test coverage and red/green evidence

Two LT01 YAML cases cover both directions:

- documented `SEMANTIC_VIEW(` syntax passes unchanged;
- accidental `SEMANTIC_VIEW (` spacing fails and fixes to the documented form.

The tests-only commit `84e93ea25` was run against unchanged production code:

```text
2 failed, 5 passed, 2453 deselected
```

The pass case failed with the unwanted single-space fix, while the fail/fix case produced no LT01 violation. With implementation commit `2f835fea2`, the same focused selection passes:

```text
7 passed, 2453 deselected
```

### Validation

```text
uvx tox -e py310 -- test/rules/yaml_test_cases_test.py -k LT01
  190 passed, 2270 deselected

uvx tox -e linting,mypy,yamllint
  PASS; Ruff checks/format/import contracts, mypy, and yamllint

uvx tox -e py310
  11104 passed, 2586 skipped in 562.61s

uvx tox -e pre-commit
  PASS; all pre-commit hooks

uvx tox -e generate-rs
uvx tox -e check-rs
  PASS; generated Rust dialect fixtures match
```

I also linted a downstream corpus of 72 templated Snowflake semantic-view queries with the branch build and the downstream project's normal SQLFluff configuration. With `noqa` disabled, every file parsed and produced zero PRS, RF01, or LT01 violations.

LT02 output was evaluated separately and intentionally left unchanged: the same indentation behavior reproduces for ordinary multiline table functions when `implicit_indents = allow`, so it is configuration-wide behavior rather than a `SEMANTIC_VIEW` layout defect.

### Are there any other side effects of this change that we should be aware of?

The policy is scoped to boundaries inside the dedicated `semantic_view` segment. It does not change generic functions, Snowflake grammar, parse-tree structure, indentation metadata, or reference-rule behavior. At the inline keyword/bracket boundary, whitespace is normalized to touching, matching Snowflake's documented syntax and existing attached-bracket layout policies.

No changelog file is included because SQLFluff's release notes are generated from meaningful PR titles.

### Pull Request checklist

- [x] Included passing and failing/fix LT01 rule cases.
- [x] Tested against current `main` after #8447.
- [x] Kept indentation behavior outside this narrowly scoped fix.

AI assistance was used to inspect the repository, implement the layout policy, and run validation. I reviewed the code, tests, downstream corpus results, and generated diff and take responsibility for the contribution.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Snowflake `SEMANTIC_VIEW` bracket spacing so documented `SEMANTIC_VIEW(...)` syntax no longer triggers LT01 or gets rewritten to `SEMANTIC_VIEW (...)`.

**Bug Fixes**
- Adds an inline touch-spacing policy scoped to the dedicated `semantic_view` segment.
- LT01 now rejects `SEMANTIC_VIEW (` and `sqlfluff fix` rewrites it to the documented form.
- Other layout behavior, indentation, and parse-tree structure are unchanged.

<sup>Written for commit 2f835fea2ee0830d0337622a03bbf24d87fd8a41. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8459?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

