### PR TITLE
fix(tests): expand XDG config home variable

### DIFF
--- a/test/core/config/loader_test.py
+++ b/test/core/config/loader_test.py
@@ -37,8 +37,10 @@ config_a = {
 
 @pytest.fixture
 def mock_xdg_home(monkeypatch):
-    """Sets the XDG_CONFIG_HOME variable."""
-    monkeypatch.setenv("XDG_CONFIG_HOME", "~/.config/my/special/path")
+    """Sets the XDG_CONFIG_HOME variable which must be an absolute path."""
+    monkeypatch.setenv(
+        "XDG_CONFIG_HOME", os.path.expanduser("~/.config/my/special/path")
+    )
 
 
 def test__config__load_file_dir():


### PR DESCRIPTION
### Brief summary of the change made
This upstream change in platformdirs, https://github.com/tox-dev/platformdirs/pull/540, currently leads to our CI runs failing, https://github.com/sqlfluff/sqlfluff/actions/runs/34280554614/job/102314535713?pr=8372 or https://github.com/sqlfluff/sqlfluff/actions/runs/34264561277/job/102311959342?pr=8296.

> The XDG Base Directory Specification requires XDG directory environment variables to contain absolute paths. Relative values must be ignored.

This change expands the relative fixture path to an absolute path.


### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [ ] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CI failures from `platformdirs` ignoring relative `XDG_CONFIG_HOME` values. The test fixture now expands the path to an absolute one before setting the environment variable.

<sup>Written for commit ff8f5025c2bf3db369f5956c371de5957a1156dd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8461?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

