### PR TITLE
Fix RF06 unquoting MySQL and MariaDB account specifications

### DIFF
--- a/src/sqlfluff/dialects/dialect_mysql.py
+++ b/src/sqlfluff/dialects/dialect_mysql.py
@@ -1574,7 +1574,7 @@ class RoleReferenceSegment(ansi.RoleReferenceSegment):
             OneOf(
                 Ref("NakedIdentifierSegment"),
                 Ref("QuotedIdentifierSegment"),
-                Ref("SingleQuotedIdentifierSegment"),
+                Ref("QuotedLiteralSegment"),
                 Ref("DoubleQuotedLiteralSegment"),
             ),
             Sequence(
@@ -1582,7 +1582,7 @@ class RoleReferenceSegment(ansi.RoleReferenceSegment):
                 OneOf(
                     Ref("NakedIdentifierSegment"),
                     Ref("QuotedIdentifierSegment"),
-                    Ref("SingleQuotedIdentifierSegment"),
+                    Ref("QuotedLiteralSegment"),
                     Ref("DoubleQuotedLiteralSegment"),
                 ),
                 optional=True,

--- a/test/fixtures/dialects/mariadb/create_user.yml
+++ b/test/fixtures/dialects/mariadb/create_user.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 9f2e8d3839abebe5ce821bdd713a832ce22ddfaddb47afca8d044e321e902592
+_hash: db12b469ea6a3df8ffb8db146949d0270ac495441320792a197b1418b052f0dc
 file:
 - statement:
     create_user_statement:
@@ -27,7 +27,7 @@ file:
     - keyword: CREATE
     - keyword: USER
     - role_reference:
-        quoted_identifier: "'prj_svc'"
+        quoted_literal: "'prj_svc'"
     - keyword: IDENTIFIED
     - keyword: WITH
     - object_reference:
@@ -40,9 +40,9 @@ file:
     - keyword: CREATE
     - keyword: USER
     - role_reference:
-      - quoted_identifier: "'jeffrey'"
+      - quoted_literal: "'jeffrey'"
       - at_sign_literal: '@'
-      - quoted_identifier: "'localhost'"
+      - quoted_literal: "'localhost'"
     - keyword: IDENTIFIED
     - keyword: BY
     - quoted_literal: "'password'"
@@ -76,9 +76,9 @@ file:
     - keyword: CREATE
     - keyword: USER
     - role_reference:
-      - quoted_identifier: "'jeffrey'"
+      - quoted_literal: "'jeffrey'"
       - at_sign_literal: '@'
-      - quoted_identifier: "'localhost'"
+      - quoted_literal: "'localhost'"
     - keyword: IDENTIFIED
     - keyword: BY
     - quoted_literal: "'new_password'"
@@ -90,9 +90,9 @@ file:
     - keyword: CREATE
     - keyword: USER
     - role_reference:
-      - quoted_identifier: "'jeffrey'"
+      - quoted_literal: "'jeffrey'"
       - at_sign_literal: '@'
-      - quoted_identifier: "'localhost'"
+      - quoted_literal: "'localhost'"
     - keyword: IDENTIFIED
     - keyword: WITH
     - object_reference:
@@ -114,9 +114,9 @@ file:
     - keyword: CREATE
     - keyword: USER
     - role_reference:
-      - quoted_identifier: "'jeffrey'"
+      - quoted_literal: "'jeffrey'"
       - at_sign_literal: '@'
-      - quoted_identifier: "'localhost'"
+      - quoted_literal: "'localhost'"
     - keyword: IDENTIFIED
     - keyword: WITH
     - object_reference:
@@ -125,9 +125,9 @@ file:
     - quoted_literal: "'new_password1'"
     - comma: ','
     - role_reference:
-      - quoted_identifier: "'jeanne'"
+      - quoted_literal: "'jeanne'"
       - at_sign_literal: '@'
-      - quoted_identifier: "'localhost'"
+      - quoted_literal: "'localhost'"
     - keyword: IDENTIFIED
     - keyword: WITH
     - object_reference:
@@ -150,9 +150,9 @@ file:
     - keyword: CREATE
     - keyword: USER
     - role_reference:
-      - quoted_identifier: "'jeffrey'"
+      - quoted_literal: "'jeffrey'"
       - at_sign_literal: '@'
-      - quoted_identifier: "'localhost'"
+      - quoted_literal: "'localhost'"
     - keyword: IDENTIFIED
     - keyword: WITH
     - object_reference:
@@ -165,9 +165,9 @@ file:
     - keyword: CREATE
     - keyword: USER
     - role_reference:
-      - quoted_identifier: "'u1'"
+      - quoted_literal: "'u1'"
       - at_sign_literal: '@'
-      - quoted_identifier: "'localhost'"
+      - quoted_literal: "'localhost'"
     - keyword: IDENTIFIED
     - keyword: WITH
     - object_reference:
@@ -187,9 +187,9 @@ file:
     - keyword: CREATE
     - keyword: USER
     - role_reference:
-      - quoted_identifier: "'u1'"
+      - quoted_literal: "'u1'"
       - at_sign_literal: '@'
-      - quoted_identifier: "'localhost'"
+      - quoted_literal: "'localhost'"
     - keyword: IDENTIFIED
     - keyword: WITH
     - object_reference:
@@ -231,9 +231,9 @@ file:
     - keyword: CREATE
     - keyword: USER
     - role_reference:
-      - quoted_identifier: "'joe'"
+      - quoted_literal: "'joe'"
       - at_sign_literal: '@'
-      - quoted_identifier: "'10.0.0.1'"
+      - quoted_literal: "'10.0.0.1'"
     - keyword: DEFAULT
     - keyword: ROLE
     - role_reference:
@@ -247,9 +247,9 @@ file:
     - keyword: CREATE
     - keyword: USER
     - role_reference:
-      - quoted_identifier: "'jeffrey'"
+      - quoted_literal: "'jeffrey'"
       - at_sign_literal: '@'
-      - quoted_identifier: "'localhost'"
+      - quoted_literal: "'localhost'"
     - keyword: REQUIRE
     - keyword: NONE
 - statement_terminator: ;
@@ -258,9 +258,9 @@ file:
     - keyword: CREATE
     - keyword: USER
     - role_reference:
-      - quoted_identifier: "'jeffrey'"
+      - quoted_literal: "'jeffrey'"
       - at_sign_literal: '@'
-      - quoted_identifier: "'localhost'"
+      - quoted_literal: "'localhost'"
     - keyword: REQUIRE
     - keyword: SSL
 - statement_terminator: ;
@@ -269,9 +269,9 @@ file:
     - keyword: CREATE
     - keyword: USER
     - role_reference:
-      - quoted_identifier: "'jeffrey'"
+      - quoted_literal: "'jeffrey'"
       - at_sign_literal: '@'
-      - quoted_identifier: "'localhost'"
+      - quoted_literal: "'localhost'"
     - keyword: REQUIRE
     - keyword: X509
 - statement_terminator: ;
@@ -280,9 +280,9 @@ file:
     - keyword: CREATE
     - keyword: USER
     - role_reference:
-      - quoted_identifier: "'jeffrey'"
+      - quoted_literal: "'jeffrey'"
       - at_sign_literal: '@'
-      - quoted_identifier: "'localhost'"
+      - quoted_literal: "'localhost'"
     - keyword: REQUIRE
     - keyword: ISSUER
     - quoted_literal: "'/C=SE/ST=Stockholm/L=Stockholm/\n    O=MySQL/CN=CA/emailAddress=ca@example.com'"
@@ -292,9 +292,9 @@ file:
     - keyword: CREATE
     - keyword: USER
     - role_reference:
-      - quoted_identifier: "'jeffrey'"
+      - quoted_literal: "'jeffrey'"
       - at_sign_literal: '@'
-      - quoted_identifier: "'localhost'"
+      - quoted_literal: "'localhost'"
     - keyword: REQUIRE
     - keyword: SUBJECT
     - quoted_literal: "'/C=SE/ST=Stockholm/L=Stockholm/\n    O=MySQL demo client certificate/\n\
@@ -305,9 +305,9 @@ file:
     - keyword: CREATE
     - keyword: USER
     - role_reference:
-      - quoted_identifier: "'jeffrey'"
+      - quoted_literal: "'jeffrey'"
       - at_sign_literal: '@'
-      - quoted_identifier: "'localhost'"
+      - quoted_literal: "'localhost'"
     - keyword: REQUIRE
     - keyword: CIPHER
     - quoted_literal: "'EDH-RSA-DES-CBC3-SHA'"
@@ -317,9 +317,9 @@ file:
     - keyword: CREATE
     - keyword: USER
     - role_reference:
-      - quoted_identifier: "'jeffrey'"
+      - quoted_literal: "'jeffrey'"
       - at_sign_literal: '@'
-      - quoted_identifier: "'localhost'"
+      - quoted_literal: "'localhost'"
     - keyword: REQUIRE
     - keyword: SUBJECT
     - quoted_literal: "'/C=SE/ST=Stockholm/L=Stockholm/\n    O=MySQL demo client certificate/\n\
@@ -336,9 +336,9 @@ file:
     - keyword: CREATE
     - keyword: USER
     - role_reference:
-      - quoted_identifier: "'jeffrey'"
+      - quoted_literal: "'jeffrey'"
       - at_sign_literal: '@'
-      - quoted_identifier: "'localhost'"
+      - quoted_literal: "'localhost'"
     - keyword: WITH
     - keyword: MAX_QUERIES_PER_HOUR
     - numeric_literal: '500'
@@ -350,9 +350,9 @@ file:
     - keyword: CREATE
     - keyword: USER
     - role_reference:
-      - quoted_identifier: "'jeffrey'"
+      - quoted_literal: "'jeffrey'"
       - at_sign_literal: '@'
-      - quoted_identifier: "'localhost'"
+      - quoted_literal: "'localhost'"
     - keyword: PASSWORD
     - keyword: EXPIRE
 - statement_terminator: ;
@@ -361,9 +361,9 @@ file:
     - keyword: CREATE
     - keyword: USER
     - role_reference:
-      - quoted_identifier: "'jeffrey'"
+      - quoted_literal: "'jeffrey'"
       - at_sign_literal: '@'
-      - quoted_identifier: "'localhost'"
+      - quoted_literal: "'localhost'"
     - keyword: PASSWORD
     - keyword: EXPIRE
     - keyword: DEFAULT
@@ -373,9 +373,9 @@ file:
     - keyword: CREATE
     - keyword: USER
     - role_reference:
-      - quoted_identifier: "'jeffrey'"
+      - quoted_literal: "'jeffrey'"
       - at_sign_literal: '@'
-      - quoted_identifier: "'localhost'"
+      - quoted_literal: "'localhost'"
     - keyword: PASSWORD
     - keyword: EXPIRE
     - keyword: NEVER
@@ -385,9 +385,9 @@ file:
     - keyword: CREATE
     - keyword: USER
     - role_reference:
-      - quoted_identifier: "'jeffrey'"
+      - quoted_literal: "'jeffrey'"
       - at_sign_literal: '@'
-      - quoted_identifier: "'localhost'"
+      - quoted_literal: "'localhost'"
     - keyword: PASSWORD
     - keyword: EXPIRE
     - keyword: INTERVAL
@@ -399,9 +399,9 @@ file:
     - keyword: CREATE
     - keyword: USER
     - role_reference:
-      - quoted_identifier: "'jeffrey'"
+      - quoted_literal: "'jeffrey'"
       - at_sign_literal: '@'
-      - quoted_identifier: "'localhost'"
+      - quoted_literal: "'localhost'"
     - keyword: PASSWORD
     - keyword: HISTORY
     - keyword: DEFAULT
@@ -411,9 +411,9 @@ file:
     - keyword: CREATE
     - keyword: USER
     - role_reference:
-      - quoted_identifier: "'jeffrey'"
+      - quoted_literal: "'jeffrey'"
       - at_sign_literal: '@'
-      - quoted_identifier: "'localhost'"
+      - quoted_literal: "'localhost'"
     - keyword: PASSWORD
     - keyword: HISTORY
     - numeric_literal: '6'
@@ -423,9 +423,9 @@ file:
     - keyword: CREATE
     - keyword: USER
     - role_reference:
-      - quoted_identifier: "'jeffrey'"
+      - quoted_literal: "'jeffrey'"
       - at_sign_literal: '@'
-      - quoted_identifier: "'localhost'"
+      - quoted_literal: "'localhost'"
     - keyword: PASSWORD
     - keyword: REUSE
     - keyword: INTERVAL
@@ -436,9 +436,9 @@ file:
     - keyword: CREATE
     - keyword: USER
     - role_reference:
-      - quoted_identifier: "'jeffrey'"
+      - quoted_literal: "'jeffrey'"
       - at_sign_literal: '@'
-      - quoted_identifier: "'localhost'"
+      - quoted_literal: "'localhost'"
     - keyword: PASSWORD
     - keyword: REUSE
     - keyword: INTERVAL
@@ -450,9 +450,9 @@ file:
     - keyword: CREATE
     - keyword: USER
     - role_reference:
-      - quoted_identifier: "'jeffrey'"
+      - quoted_literal: "'jeffrey'"
       - at_sign_literal: '@'
-      - quoted_identifier: "'localhost'"
+      - quoted_literal: "'localhost'"
     - keyword: PASSWORD
     - keyword: REQUIRE
     - keyword: CURRENT
@@ -462,9 +462,9 @@ file:
     - keyword: CREATE
     - keyword: USER
     - role_reference:
-      - quoted_identifier: "'jeffrey'"
+      - quoted_literal: "'jeffrey'"
       - at_sign_literal: '@'
-      - quoted_identifier: "'localhost'"
+      - quoted_literal: "'localhost'"
     - keyword: PASSWORD
     - keyword: REQUIRE
     - keyword: CURRENT
@@ -475,9 +475,9 @@ file:
     - keyword: CREATE
     - keyword: USER
     - role_reference:
-      - quoted_identifier: "'jeffrey'"
+      - quoted_literal: "'jeffrey'"
       - at_sign_literal: '@'
-      - quoted_identifier: "'localhost'"
+      - quoted_literal: "'localhost'"
     - keyword: PASSWORD
     - keyword: REQUIRE
     - keyword: CURRENT
@@ -488,9 +488,9 @@ file:
     - keyword: CREATE
     - keyword: USER
     - role_reference:
-      - quoted_identifier: "'jeffrey'"
+      - quoted_literal: "'jeffrey'"
       - at_sign_literal: '@'
-      - quoted_identifier: "'localhost'"
+      - quoted_literal: "'localhost'"
     - keyword: FAILED_LOGIN_ATTEMPTS
     - numeric_literal: '4'
     - keyword: PASSWORD_LOCK_TIME
@@ -501,9 +501,9 @@ file:
     - keyword: CREATE
     - keyword: USER
     - role_reference:
-      - quoted_identifier: "'jon'"
+      - quoted_literal: "'jon'"
       - at_sign_literal: '@'
-      - quoted_identifier: "'localhost'"
+      - quoted_literal: "'localhost'"
     - keyword: COMMENT
     - quoted_literal: "'Some information about Jon'"
 - statement_terminator: ;
@@ -512,9 +512,9 @@ file:
     - keyword: CREATE
     - keyword: USER
     - role_reference:
-      - quoted_identifier: "'jim'"
+      - quoted_literal: "'jim'"
       - at_sign_literal: '@'
-      - quoted_identifier: "'localhost'"
+      - quoted_literal: "'localhost'"
     - keyword: ATTRIBUTE
     - quoted_literal: "'{\"fname\": \"James\", \"lname\": \"Scott\", \"phone\": \"\
         123-456-7890\"}'"
@@ -547,7 +547,7 @@ file:
     - keyword: REPLACE
     - keyword: USER
     - role_reference:
-        quoted_identifier: "'prj_svc'"
+        quoted_literal: "'prj_svc'"
     - keyword: IDENTIFIED
     - keyword: WITH
     - object_reference:
@@ -562,9 +562,9 @@ file:
     - keyword: REPLACE
     - keyword: USER
     - role_reference:
-      - quoted_identifier: "'jeffrey'"
+      - quoted_literal: "'jeffrey'"
       - at_sign_literal: '@'
-      - quoted_identifier: "'localhost'"
+      - quoted_literal: "'localhost'"
     - keyword: IDENTIFIED
     - keyword: BY
     - quoted_literal: "'password'"
@@ -604,9 +604,9 @@ file:
     - keyword: REPLACE
     - keyword: USER
     - role_reference:
-      - quoted_identifier: "'jeffrey'"
+      - quoted_literal: "'jeffrey'"
       - at_sign_literal: '@'
-      - quoted_identifier: "'localhost'"
+      - quoted_literal: "'localhost'"
     - keyword: IDENTIFIED
     - keyword: BY
     - quoted_literal: "'new_password'"
@@ -620,9 +620,9 @@ file:
     - keyword: REPLACE
     - keyword: USER
     - role_reference:
-      - quoted_identifier: "'jeffrey'"
+      - quoted_literal: "'jeffrey'"
       - at_sign_literal: '@'
-      - quoted_identifier: "'localhost'"
+      - quoted_literal: "'localhost'"
     - keyword: IDENTIFIED
     - keyword: WITH
     - object_reference:
@@ -646,9 +646,9 @@ file:
     - keyword: REPLACE
     - keyword: USER
     - role_reference:
-      - quoted_identifier: "'jeffrey'"
+      - quoted_literal: "'jeffrey'"
       - at_sign_literal: '@'
-      - quoted_identifier: "'localhost'"
+      - quoted_literal: "'localhost'"
     - keyword: IDENTIFIED
     - keyword: WITH
     - object_reference:
@@ -657,9 +657,9 @@ file:
     - quoted_literal: "'new_password1'"
     - comma: ','
     - role_reference:
-      - quoted_identifier: "'jeanne'"
+      - quoted_literal: "'jeanne'"
       - at_sign_literal: '@'
-      - quoted_identifier: "'localhost'"
+      - quoted_literal: "'localhost'"
     - keyword: IDENTIFIED
     - keyword: WITH
     - object_reference:
@@ -684,9 +684,9 @@ file:
     - keyword: REPLACE
     - keyword: USER
     - role_reference:
-      - quoted_identifier: "'jeffrey'"
+      - quoted_literal: "'jeffrey'"
       - at_sign_literal: '@'
-      - quoted_identifier: "'localhost'"
+      - quoted_literal: "'localhost'"
     - keyword: IDENTIFIED
     - keyword: WITH
     - object_reference:
@@ -701,9 +701,9 @@ file:
     - keyword: REPLACE
     - keyword: USER
     - role_reference:
-      - quoted_identifier: "'u1'"
+      - quoted_literal: "'u1'"
       - at_sign_literal: '@'
-      - quoted_identifier: "'localhost'"
+      - quoted_literal: "'localhost'"
     - keyword: IDENTIFIED
     - keyword: WITH
     - object_reference:
@@ -725,9 +725,9 @@ file:
     - keyword: REPLACE
     - keyword: USER
     - role_reference:
-      - quoted_identifier: "'u1'"
+      - quoted_literal: "'u1'"
       - at_sign_literal: '@'
-      - quoted_identifier: "'localhost'"
+      - quoted_literal: "'localhost'"
     - keyword: IDENTIFIED
     - keyword: WITH
     - object_reference:
@@ -773,9 +773,9 @@ file:
     - keyword: REPLACE
     - keyword: USER
     - role_reference:
-      - quoted_identifier: "'joe'"
+      - quoted_literal: "'joe'"
       - at_sign_literal: '@'
-      - quoted_identifier: "'10.0.0.1'"
+      - quoted_literal: "'10.0.0.1'"
     - keyword: DEFAULT
     - keyword: ROLE
     - role_reference:
@@ -791,9 +791,9 @@ file:
     - keyword: REPLACE
     - keyword: USER
     - role_reference:
-      - quoted_identifier: "'jeffrey'"
+      - quoted_literal: "'jeffrey'"
       - at_sign_literal: '@'
-      - quoted_identifier: "'localhost'"
+      - quoted_literal: "'localhost'"
     - keyword: REQUIRE
     - keyword: NONE
 - statement_terminator: ;
@@ -804,9 +804,9 @@ file:
     - keyword: REPLACE
     - keyword: USER
     - role_reference:
-      - quoted_identifier: "'jeffrey'"
+      - quoted_literal: "'jeffrey'"
       - at_sign_literal: '@'
-      - quoted_identifier: "'localhost'"
+      - quoted_literal: "'localhost'"
     - keyword: REQUIRE
     - keyword: SSL
 - statement_terminator: ;
@@ -817,9 +817,9 @@ file:
     - keyword: REPLACE
     - keyword: USER
     - role_reference:
-      - quoted_identifier: "'jeffrey'"
+      - quoted_literal: "'jeffrey'"
       - at_sign_literal: '@'
-      - quoted_identifier: "'localhost'"
+      - quoted_literal: "'localhost'"
     - keyword: REQUIRE
     - keyword: X509
 - statement_terminator: ;
@@ -830,9 +830,9 @@ file:
     - keyword: REPLACE
     - keyword: USER
     - role_reference:
-      - quoted_identifier: "'jeffrey'"
+      - quoted_literal: "'jeffrey'"
       - at_sign_literal: '@'
-      - quoted_identifier: "'localhost'"
+      - quoted_literal: "'localhost'"
     - keyword: REQUIRE
     - keyword: ISSUER
     - quoted_literal: "'/C=SE/ST=Stockholm/L=Stockholm/\n    O=MySQL/CN=CA/emailAddress=ca@example.com'"
@@ -844,9 +844,9 @@ file:
     - keyword: REPLACE
     - keyword: USER
     - role_reference:
-      - quoted_identifier: "'jeffrey'"
+      - quoted_literal: "'jeffrey'"
       - at_sign_literal: '@'
-      - quoted_identifier: "'localhost'"
+      - quoted_literal: "'localhost'"
     - keyword: REQUIRE
     - keyword: SUBJECT
     - quoted_literal: "'/C=SE/ST=Stockholm/L=Stockholm/\n    O=MySQL demo client certificate/\n\
@@ -859,9 +859,9 @@ file:
     - keyword: REPLACE
     - keyword: USER
     - role_reference:
-      - quoted_identifier: "'jeffrey'"
+      - quoted_literal: "'jeffrey'"
       - at_sign_literal: '@'
-      - quoted_identifier: "'localhost'"
+      - quoted_literal: "'localhost'"
     - keyword: REQUIRE
     - keyword: CIPHER
     - quoted_literal: "'EDH-RSA-DES-CBC3-SHA'"
@@ -873,9 +873,9 @@ file:
     - keyword: REPLACE
     - keyword: USER
     - role_reference:
-      - quoted_identifier: "'jeffrey'"
+      - quoted_literal: "'jeffrey'"
       - at_sign_literal: '@'
-      - quoted_identifier: "'localhost'"
+      - quoted_literal: "'localhost'"
     - keyword: REQUIRE
     - keyword: SUBJECT
     - quoted_literal: "'/C=SE/ST=Stockholm/L=Stockholm/\n    O=MySQL demo client certificate/\n\
@@ -894,9 +894,9 @@ file:
     - keyword: REPLACE
     - keyword: USER
     - role_reference:
-      - quoted_identifier: "'jeffrey'"
+      - quoted_literal: "'jeffrey'"
       - at_sign_literal: '@'
-      - quoted_identifier: "'localhost'"
+      - quoted_literal: "'localhost'"
     - keyword: WITH
     - keyword: MAX_QUERIES_PER_HOUR
     - numeric_literal: '500'
@@ -910,9 +910,9 @@ file:
     - keyword: REPLACE
     - keyword: USER
     - role_reference:
-      - quoted_identifier: "'jeffrey'"
+      - quoted_literal: "'jeffrey'"
       - at_sign_literal: '@'
-      - quoted_identifier: "'localhost'"
+      - quoted_literal: "'localhost'"
     - keyword: PASSWORD
     - keyword: EXPIRE
 - statement_terminator: ;
@@ -923,9 +923,9 @@ file:
     - keyword: REPLACE
     - keyword: USER
     - role_reference:
-      - quoted_identifier: "'jeffrey'"
+      - quoted_literal: "'jeffrey'"
       - at_sign_literal: '@'
-      - quoted_identifier: "'localhost'"
+      - quoted_literal: "'localhost'"
     - keyword: PASSWORD
     - keyword: EXPIRE
     - keyword: DEFAULT
@@ -937,9 +937,9 @@ file:
     - keyword: REPLACE
     - keyword: USER
     - role_reference:
-      - quoted_identifier: "'jeffrey'"
+      - quoted_literal: "'jeffrey'"
       - at_sign_literal: '@'
-      - quoted_identifier: "'localhost'"
+      - quoted_literal: "'localhost'"
     - keyword: PASSWORD
     - keyword: EXPIRE
     - keyword: NEVER
@@ -951,9 +951,9 @@ file:
     - keyword: REPLACE
     - keyword: USER
     - role_reference:
-      - quoted_identifier: "'jeffrey'"
+      - quoted_literal: "'jeffrey'"
       - at_sign_literal: '@'
-      - quoted_identifier: "'localhost'"
+      - quoted_literal: "'localhost'"
     - keyword: PASSWORD
     - keyword: EXPIRE
     - keyword: INTERVAL
@@ -967,9 +967,9 @@ file:
     - keyword: REPLACE
     - keyword: USER
     - role_reference:
-      - quoted_identifier: "'jeffrey'"
+      - quoted_literal: "'jeffrey'"
       - at_sign_literal: '@'
-      - quoted_identifier: "'localhost'"
+      - quoted_literal: "'localhost'"
     - keyword: PASSWORD
     - keyword: HISTORY
     - keyword: DEFAULT
@@ -981,9 +981,9 @@ file:
     - keyword: REPLACE
     - keyword: USER
     - role_reference:
-      - quoted_identifier: "'jeffrey'"
+      - quoted_literal: "'jeffrey'"
       - at_sign_literal: '@'
-      - quoted_identifier: "'localhost'"
+      - quoted_literal: "'localhost'"
     - keyword: PASSWORD
     - keyword: HISTORY
     - numeric_literal: '6'
@@ -995,9 +995,9 @@ file:
     - keyword: REPLACE
     - keyword: USER
     - role_reference:
-      - quoted_identifier: "'jeffrey'"
+      - quoted_literal: "'jeffrey'"
       - at_sign_literal: '@'
-      - quoted_identifier: "'localhost'"
+      - quoted_literal: "'localhost'"
     - keyword: PASSWORD
     - keyword: REUSE
     - keyword: INTERVAL
@@ -1010,9 +1010,9 @@ file:
     - keyword: REPLACE
     - keyword: USER
     - role_reference:
-      - quoted_identifier: "'jeffrey'"
+      - quoted_literal: "'jeffrey'"
       - at_sign_literal: '@'
-      - quoted_identifier: "'localhost'"
+      - quoted_literal: "'localhost'"
     - keyword: PASSWORD
     - keyword: REUSE
     - keyword: INTERVAL
@@ -1026,9 +1026,9 @@ file:
     - keyword: REPLACE
     - keyword: USER
     - role_reference:
-      - quoted_identifier: "'jeffrey'"
+      - quoted_literal: "'jeffrey'"
       - at_sign_literal: '@'
-      - quoted_identifier: "'localhost'"
+      - quoted_literal: "'localhost'"
     - keyword: PASSWORD
     - keyword: REQUIRE
     - keyword: CURRENT
@@ -1040,9 +1040,9 @@ file:
     - keyword: REPLACE
     - keyword: USER
     - role_reference:
-      - quoted_identifier: "'jeffrey'"
+      - quoted_literal: "'jeffrey'"
       - at_sign_literal: '@'
-      - quoted_identifier: "'localhost'"
+      - quoted_literal: "'localhost'"
     - keyword: PASSWORD
     - keyword: REQUIRE
     - keyword: CURRENT
@@ -1055,9 +1055,9 @@ file:
     - keyword: REPLACE
     - keyword: USER
     - role_reference:
-      - quoted_identifier: "'jeffrey'"
+      - quoted_literal: "'jeffrey'"
       - at_sign_literal: '@'
-      - quoted_identifier: "'localhost'"
+      - quoted_literal: "'localhost'"
     - keyword: PASSWORD
     - keyword: REQUIRE
     - keyword: CURRENT
@@ -1070,9 +1070,9 @@ file:
     - keyword: REPLACE
     - keyword: USER
     - role_reference:
-      - quoted_identifier: "'jeffrey'"
+      - quoted_literal: "'jeffrey'"
       - at_sign_literal: '@'
-      - quoted_identifier: "'localhost'"
+      - quoted_literal: "'localhost'"
     - keyword: FAILED_LOGIN_ATTEMPTS
     - numeric_literal: '4'
     - keyword: PASSWORD_LOCK_TIME
@@ -1085,9 +1085,9 @@ file:
     - keyword: REPLACE
     - keyword: USER
     - role_reference:
-      - quoted_identifier: "'jon'"
+      - quoted_literal: "'jon'"
       - at_sign_literal: '@'
-      - quoted_identifier: "'localhost'"
+      - quoted_literal: "'localhost'"
     - keyword: COMMENT
     - quoted_literal: "'Some information about Jon'"
 - statement_terminator: ;
@@ -1098,9 +1098,9 @@ file:
     - keyword: REPLACE
     - keyword: USER
     - role_reference:
-      - quoted_identifier: "'jim'"
+      - quoted_literal: "'jim'"
       - at_sign_literal: '@'
-      - quoted_identifier: "'localhost'"
+      - quoted_literal: "'localhost'"
     - keyword: ATTRIBUTE
     - quoted_literal: "'{\"fname\": \"James\", \"lname\": \"Scott\", \"phone\": \"\
         123-456-7890\"}'"

--- a/test/fixtures/dialects/mariadb/grant.yml
+++ b/test/fixtures/dialects/mariadb/grant.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 90f523a9a8314055dc0fbcd07d953e2ecf3ae1f2257eacc1d9b0986a2bd04e57
+_hash: 6e503c0127b379617513e37b1f729a38cad0d08b7cef8fd845dbcaa79b2f5f52
 file:
 - statement:
     access_statement:
@@ -57,7 +57,7 @@ file:
             naked_identifier: prj_table
       - keyword: TO
       - role_reference:
-          quoted_identifier: "'prj_svc'"
+          quoted_literal: "'prj_svc'"
 - statement_terminator: ;
 - statement:
     access_statement:
@@ -138,9 +138,9 @@ file:
             naked_identifier: prj_table
       - keyword: TO
       - role_reference:
-        - quoted_identifier: "'prj_svc'"
+        - quoted_literal: "'prj_svc'"
         - at_sign_literal: '@'
-        - quoted_identifier: "'%'"
+        - quoted_literal: "'%'"
 - statement_terminator: ;
 - statement:
     access_statement:
@@ -244,9 +244,9 @@ file:
             star: '*'
       - keyword: TO
       - role_reference:
-        - quoted_identifier: "'prj_svc'"
+        - quoted_literal: "'prj_svc'"
         - at_sign_literal: '@'
-        - quoted_identifier: "'%'"
+        - quoted_literal: "'%'"
 - statement_terminator: ;
 - statement:
     access_statement:
@@ -264,9 +264,9 @@ file:
             star: '*'
       - keyword: TO
       - role_reference:
-        - quoted_identifier: "'prj_svc'"
+        - quoted_literal: "'prj_svc'"
         - at_sign_literal: '@'
-        - quoted_identifier: "'localhost'"
+        - quoted_literal: "'localhost'"
 - statement_terminator: ;
 - statement:
     access_statement:
@@ -284,7 +284,7 @@ file:
           - star: '*'
       - keyword: TO
       - role_reference:
-        - quoted_identifier: "'prj_svc'"
+        - quoted_literal: "'prj_svc'"
         - at_sign_literal: '@'
-        - quoted_identifier: "'%'"
+        - quoted_literal: "'%'"
 - statement_terminator: ;

--- a/test/fixtures/dialects/mysql/create_user.yml
+++ b/test/fixtures/dialects/mysql/create_user.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: cfac964903c8d0523874124c9112fc8b2656dee2662863d82245c0c631d0b947
+_hash: f6da763957b95e8f1779ffeb52cea6651e303e4c921d79fa88c0d3c546e87045
 file:
 - statement:
     create_user_statement:
@@ -27,7 +27,7 @@ file:
     - keyword: CREATE
     - keyword: USER
     - role_reference:
-        quoted_identifier: "'prj_svc'"
+        quoted_literal: "'prj_svc'"
     - keyword: IDENTIFIED
     - keyword: WITH
     - object_reference:
@@ -40,9 +40,9 @@ file:
     - keyword: CREATE
     - keyword: USER
     - role_reference:
-      - quoted_identifier: "'jeffrey'"
+      - quoted_literal: "'jeffrey'"
       - at_sign_literal: '@'
-      - quoted_identifier: "'localhost'"
+      - quoted_literal: "'localhost'"
     - keyword: IDENTIFIED
     - keyword: BY
     - quoted_literal: "'password'"
@@ -76,9 +76,9 @@ file:
     - keyword: CREATE
     - keyword: USER
     - role_reference:
-      - quoted_identifier: "'jeffrey'"
+      - quoted_literal: "'jeffrey'"
       - at_sign_literal: '@'
-      - quoted_identifier: "'localhost'"
+      - quoted_literal: "'localhost'"
     - keyword: IDENTIFIED
     - keyword: BY
     - quoted_literal: "'new_password'"
@@ -90,9 +90,9 @@ file:
     - keyword: CREATE
     - keyword: USER
     - role_reference:
-      - quoted_identifier: "'jeffrey'"
+      - quoted_literal: "'jeffrey'"
       - at_sign_literal: '@'
-      - quoted_identifier: "'localhost'"
+      - quoted_literal: "'localhost'"
     - keyword: IDENTIFIED
     - keyword: WITH
     - object_reference:
@@ -114,9 +114,9 @@ file:
     - keyword: CREATE
     - keyword: USER
     - role_reference:
-      - quoted_identifier: "'jeffrey'"
+      - quoted_literal: "'jeffrey'"
       - at_sign_literal: '@'
-      - quoted_identifier: "'localhost'"
+      - quoted_literal: "'localhost'"
     - keyword: IDENTIFIED
     - keyword: WITH
     - object_reference:
@@ -125,9 +125,9 @@ file:
     - quoted_literal: "'new_password1'"
     - comma: ','
     - role_reference:
-      - quoted_identifier: "'jeanne'"
+      - quoted_literal: "'jeanne'"
       - at_sign_literal: '@'
-      - quoted_identifier: "'localhost'"
+      - quoted_literal: "'localhost'"
     - keyword: IDENTIFIED
     - keyword: WITH
     - object_reference:
@@ -150,9 +150,9 @@ file:
     - keyword: CREATE
     - keyword: USER
     - role_reference:
-      - quoted_identifier: "'jeffrey'"
+      - quoted_literal: "'jeffrey'"
       - at_sign_literal: '@'
-      - quoted_identifier: "'localhost'"
+      - quoted_literal: "'localhost'"
     - keyword: IDENTIFIED
     - keyword: WITH
     - object_reference:
@@ -165,9 +165,9 @@ file:
     - keyword: CREATE
     - keyword: USER
     - role_reference:
-      - quoted_identifier: "'u1'"
+      - quoted_literal: "'u1'"
       - at_sign_literal: '@'
-      - quoted_identifier: "'localhost'"
+      - quoted_literal: "'localhost'"
     - keyword: IDENTIFIED
     - keyword: WITH
     - object_reference:
@@ -187,9 +187,9 @@ file:
     - keyword: CREATE
     - keyword: USER
     - role_reference:
-      - quoted_identifier: "'u1'"
+      - quoted_literal: "'u1'"
       - at_sign_literal: '@'
-      - quoted_identifier: "'localhost'"
+      - quoted_literal: "'localhost'"
     - keyword: IDENTIFIED
     - keyword: WITH
     - object_reference:
@@ -231,9 +231,9 @@ file:
     - keyword: CREATE
     - keyword: USER
     - role_reference:
-      - quoted_identifier: "'joe'"
+      - quoted_literal: "'joe'"
       - at_sign_literal: '@'
-      - quoted_identifier: "'10.0.0.1'"
+      - quoted_literal: "'10.0.0.1'"
     - keyword: DEFAULT
     - keyword: ROLE
     - role_reference:
@@ -247,9 +247,9 @@ file:
     - keyword: CREATE
     - keyword: USER
     - role_reference:
-      - quoted_identifier: "'jeffrey'"
+      - quoted_literal: "'jeffrey'"
       - at_sign_literal: '@'
-      - quoted_identifier: "'localhost'"
+      - quoted_literal: "'localhost'"
     - keyword: REQUIRE
     - keyword: NONE
 - statement_terminator: ;
@@ -258,9 +258,9 @@ file:
     - keyword: CREATE
     - keyword: USER
     - role_reference:
-      - quoted_identifier: "'jeffrey'"
+      - quoted_literal: "'jeffrey'"
       - at_sign_literal: '@'
-      - quoted_identifier: "'localhost'"
+      - quoted_literal: "'localhost'"
     - keyword: REQUIRE
     - keyword: SSL
 - statement_terminator: ;
@@ -269,9 +269,9 @@ file:
     - keyword: CREATE
     - keyword: USER
     - role_reference:
-      - quoted_identifier: "'jeffrey'"
+      - quoted_literal: "'jeffrey'"
       - at_sign_literal: '@'
-      - quoted_identifier: "'localhost'"
+      - quoted_literal: "'localhost'"
     - keyword: REQUIRE
     - keyword: X509
 - statement_terminator: ;
@@ -280,9 +280,9 @@ file:
     - keyword: CREATE
     - keyword: USER
     - role_reference:
-      - quoted_identifier: "'jeffrey'"
+      - quoted_literal: "'jeffrey'"
       - at_sign_literal: '@'
-      - quoted_identifier: "'localhost'"
+      - quoted_literal: "'localhost'"
     - keyword: REQUIRE
     - keyword: ISSUER
     - quoted_literal: "'/C=SE/ST=Stockholm/L=Stockholm/\n    O=MySQL/CN=CA/emailAddress=ca@example.com'"
@@ -292,9 +292,9 @@ file:
     - keyword: CREATE
     - keyword: USER
     - role_reference:
-      - quoted_identifier: "'jeffrey'"
+      - quoted_literal: "'jeffrey'"
       - at_sign_literal: '@'
-      - quoted_identifier: "'localhost'"
+      - quoted_literal: "'localhost'"
     - keyword: REQUIRE
     - keyword: SUBJECT
     - quoted_literal: "'/C=SE/ST=Stockholm/L=Stockholm/\n    O=MySQL demo client certificate/\n\
@@ -305,9 +305,9 @@ file:
     - keyword: CREATE
     - keyword: USER
     - role_reference:
-      - quoted_identifier: "'jeffrey'"
+      - quoted_literal: "'jeffrey'"
       - at_sign_literal: '@'
-      - quoted_identifier: "'localhost'"
+      - quoted_literal: "'localhost'"
     - keyword: REQUIRE
     - keyword: CIPHER
     - quoted_literal: "'EDH-RSA-DES-CBC3-SHA'"
@@ -317,9 +317,9 @@ file:
     - keyword: CREATE
     - keyword: USER
     - role_reference:
-      - quoted_identifier: "'jeffrey'"
+      - quoted_literal: "'jeffrey'"
       - at_sign_literal: '@'
-      - quoted_identifier: "'localhost'"
+      - quoted_literal: "'localhost'"
     - keyword: REQUIRE
     - keyword: SUBJECT
     - quoted_literal: "'/C=SE/ST=Stockholm/L=Stockholm/\n    O=MySQL demo client certificate/\n\
@@ -336,9 +336,9 @@ file:
     - keyword: CREATE
     - keyword: USER
     - role_reference:
-      - quoted_identifier: "'jeffrey'"
+      - quoted_literal: "'jeffrey'"
       - at_sign_literal: '@'
-      - quoted_identifier: "'localhost'"
+      - quoted_literal: "'localhost'"
     - keyword: WITH
     - keyword: MAX_QUERIES_PER_HOUR
     - numeric_literal: '500'
@@ -350,9 +350,9 @@ file:
     - keyword: CREATE
     - keyword: USER
     - role_reference:
-      - quoted_identifier: "'jeffrey'"
+      - quoted_literal: "'jeffrey'"
       - at_sign_literal: '@'
-      - quoted_identifier: "'localhost'"
+      - quoted_literal: "'localhost'"
     - keyword: PASSWORD
     - keyword: EXPIRE
 - statement_terminator: ;
@@ -361,9 +361,9 @@ file:
     - keyword: CREATE
     - keyword: USER
     - role_reference:
-      - quoted_identifier: "'jeffrey'"
+      - quoted_literal: "'jeffrey'"
       - at_sign_literal: '@'
-      - quoted_identifier: "'localhost'"
+      - quoted_literal: "'localhost'"
     - keyword: PASSWORD
     - keyword: EXPIRE
     - keyword: DEFAULT
@@ -373,9 +373,9 @@ file:
     - keyword: CREATE
     - keyword: USER
     - role_reference:
-      - quoted_identifier: "'jeffrey'"
+      - quoted_literal: "'jeffrey'"
       - at_sign_literal: '@'
-      - quoted_identifier: "'localhost'"
+      - quoted_literal: "'localhost'"
     - keyword: PASSWORD
     - keyword: EXPIRE
     - keyword: NEVER
@@ -385,9 +385,9 @@ file:
     - keyword: CREATE
     - keyword: USER
     - role_reference:
-      - quoted_identifier: "'jeffrey'"
+      - quoted_literal: "'jeffrey'"
       - at_sign_literal: '@'
-      - quoted_identifier: "'localhost'"
+      - quoted_literal: "'localhost'"
     - keyword: PASSWORD
     - keyword: EXPIRE
     - keyword: INTERVAL
@@ -399,9 +399,9 @@ file:
     - keyword: CREATE
     - keyword: USER
     - role_reference:
-      - quoted_identifier: "'jeffrey'"
+      - quoted_literal: "'jeffrey'"
       - at_sign_literal: '@'
-      - quoted_identifier: "'localhost'"
+      - quoted_literal: "'localhost'"
     - keyword: PASSWORD
     - keyword: HISTORY
     - keyword: DEFAULT
@@ -411,9 +411,9 @@ file:
     - keyword: CREATE
     - keyword: USER
     - role_reference:
-      - quoted_identifier: "'jeffrey'"
+      - quoted_literal: "'jeffrey'"
       - at_sign_literal: '@'
-      - quoted_identifier: "'localhost'"
+      - quoted_literal: "'localhost'"
     - keyword: PASSWORD
     - keyword: HISTORY
     - numeric_literal: '6'
@@ -423,9 +423,9 @@ file:
     - keyword: CREATE
     - keyword: USER
     - role_reference:
-      - quoted_identifier: "'jeffrey'"
+      - quoted_literal: "'jeffrey'"
       - at_sign_literal: '@'
-      - quoted_identifier: "'localhost'"
+      - quoted_literal: "'localhost'"
     - keyword: PASSWORD
     - keyword: REUSE
     - keyword: INTERVAL
@@ -436,9 +436,9 @@ file:
     - keyword: CREATE
     - keyword: USER
     - role_reference:
-      - quoted_identifier: "'jeffrey'"
+      - quoted_literal: "'jeffrey'"
       - at_sign_literal: '@'
-      - quoted_identifier: "'localhost'"
+      - quoted_literal: "'localhost'"
     - keyword: PASSWORD
     - keyword: REUSE
     - keyword: INTERVAL
@@ -450,9 +450,9 @@ file:
     - keyword: CREATE
     - keyword: USER
     - role_reference:
-      - quoted_identifier: "'jeffrey'"
+      - quoted_literal: "'jeffrey'"
       - at_sign_literal: '@'
-      - quoted_identifier: "'localhost'"
+      - quoted_literal: "'localhost'"
     - keyword: PASSWORD
     - keyword: REQUIRE
     - keyword: CURRENT
@@ -462,9 +462,9 @@ file:
     - keyword: CREATE
     - keyword: USER
     - role_reference:
-      - quoted_identifier: "'jeffrey'"
+      - quoted_literal: "'jeffrey'"
       - at_sign_literal: '@'
-      - quoted_identifier: "'localhost'"
+      - quoted_literal: "'localhost'"
     - keyword: PASSWORD
     - keyword: REQUIRE
     - keyword: CURRENT
@@ -475,9 +475,9 @@ file:
     - keyword: CREATE
     - keyword: USER
     - role_reference:
-      - quoted_identifier: "'jeffrey'"
+      - quoted_literal: "'jeffrey'"
       - at_sign_literal: '@'
-      - quoted_identifier: "'localhost'"
+      - quoted_literal: "'localhost'"
     - keyword: PASSWORD
     - keyword: REQUIRE
     - keyword: CURRENT
@@ -488,9 +488,9 @@ file:
     - keyword: CREATE
     - keyword: USER
     - role_reference:
-      - quoted_identifier: "'jeffrey'"
+      - quoted_literal: "'jeffrey'"
       - at_sign_literal: '@'
-      - quoted_identifier: "'localhost'"
+      - quoted_literal: "'localhost'"
     - keyword: FAILED_LOGIN_ATTEMPTS
     - numeric_literal: '4'
     - keyword: PASSWORD_LOCK_TIME
@@ -501,9 +501,9 @@ file:
     - keyword: CREATE
     - keyword: USER
     - role_reference:
-      - quoted_identifier: "'jon'"
+      - quoted_literal: "'jon'"
       - at_sign_literal: '@'
-      - quoted_identifier: "'localhost'"
+      - quoted_literal: "'localhost'"
     - keyword: COMMENT
     - quoted_literal: "'Some information about Jon'"
 - statement_terminator: ;
@@ -512,9 +512,9 @@ file:
     - keyword: CREATE
     - keyword: USER
     - role_reference:
-      - quoted_identifier: "'jim'"
+      - quoted_literal: "'jim'"
       - at_sign_literal: '@'
-      - quoted_identifier: "'localhost'"
+      - quoted_literal: "'localhost'"
     - keyword: ATTRIBUTE
     - quoted_literal: "'{\"fname\": \"James\", \"lname\": \"Scott\", \"phone\": \"\
         123-456-7890\"}'"

--- a/test/fixtures/dialects/mysql/grant.yml
+++ b/test/fixtures/dialects/mysql/grant.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 6345cd7f4d54d1b9ac88a05c469dac1d95483e525997ac2bbd8a8eba5043fbc6
+_hash: 4792351601b4e0d73e33ddaf4f23df1ff3a8b23289affc1ed9bca0d1e80b122a
 file:
 - statement:
     access_statement:
@@ -57,7 +57,7 @@ file:
             naked_identifier: prj_table
       - keyword: TO
       - role_reference:
-          quoted_identifier: "'prj_svc'"
+          quoted_literal: "'prj_svc'"
 - statement_terminator: ;
 - statement:
     access_statement:
@@ -138,9 +138,9 @@ file:
             naked_identifier: prj_table
       - keyword: TO
       - role_reference:
-        - quoted_identifier: "'prj_svc'"
+        - quoted_literal: "'prj_svc'"
         - at_sign_literal: '@'
-        - quoted_identifier: "'%'"
+        - quoted_literal: "'%'"
 - statement_terminator: ;
 - statement:
     access_statement:
@@ -244,9 +244,9 @@ file:
             star: '*'
       - keyword: TO
       - role_reference:
-        - quoted_identifier: "'prj_svc'"
+        - quoted_literal: "'prj_svc'"
         - at_sign_literal: '@'
-        - quoted_identifier: "'%'"
+        - quoted_literal: "'%'"
 - statement_terminator: ;
 - statement:
     access_statement:
@@ -264,9 +264,9 @@ file:
             star: '*'
       - keyword: TO
       - role_reference:
-        - quoted_identifier: "'prj_svc'"
+        - quoted_literal: "'prj_svc'"
         - at_sign_literal: '@'
-        - quoted_identifier: "'localhost'"
+        - quoted_literal: "'localhost'"
 - statement_terminator: ;
 - statement:
     access_statement:
@@ -284,42 +284,42 @@ file:
           - star: '*'
       - keyword: TO
       - role_reference:
-        - quoted_identifier: "'prj_svc'"
+        - quoted_literal: "'prj_svc'"
         - at_sign_literal: '@'
-        - quoted_identifier: "'%'"
+        - quoted_literal: "'%'"
 - statement_terminator: ;
 - statement:
     access_statement:
       grant_statement:
       - keyword: GRANT
       - role_reference:
-        - quoted_identifier: "'role-name'"
+        - quoted_literal: "'role-name'"
         - at_sign_literal: '@'
-        - quoted_identifier: "'%'"
+        - quoted_literal: "'%'"
       - keyword: TO
       - role_reference:
-        - quoted_identifier: "'user_name'"
+        - quoted_literal: "'user_name'"
         - at_sign_literal: '@'
-        - quoted_identifier: "'%'"
+        - quoted_literal: "'%'"
 - statement_terminator: ;
 - statement:
     access_statement:
       grant_statement:
       - keyword: GRANT
       - role_reference:
-        - quoted_identifier: "'role-one'"
+        - quoted_literal: "'role-one'"
         - at_sign_literal: '@'
-        - quoted_identifier: "'%'"
+        - quoted_literal: "'%'"
       - comma: ','
       - role_reference:
-        - quoted_identifier: "'role-two'"
+        - quoted_literal: "'role-two'"
         - at_sign_literal: '@'
-        - quoted_identifier: "'%'"
+        - quoted_literal: "'%'"
       - keyword: TO
       - role_reference:
-        - quoted_identifier: "'user_name'"
+        - quoted_literal: "'user_name'"
         - at_sign_literal: '@'
-        - quoted_identifier: "'%'"
+        - quoted_literal: "'%'"
 - statement_terminator: ;
 - statement:
     set_default_role_statement:
@@ -329,9 +329,9 @@ file:
     - keyword: ALL
     - keyword: TO
     - role_reference:
-      - quoted_identifier: "'user_name'"
+      - quoted_literal: "'user_name'"
       - at_sign_literal: '@'
-      - quoted_identifier: "'%'"
+      - quoted_literal: "'%'"
 - statement_terminator: ;
 - statement:
     set_default_role_statement:
@@ -341,9 +341,9 @@ file:
     - keyword: NONE
     - keyword: TO
     - role_reference:
-      - quoted_identifier: "'user_name'"
+      - quoted_literal: "'user_name'"
       - at_sign_literal: '@'
-      - quoted_identifier: "'%'"
+      - quoted_literal: "'%'"
 - statement_terminator: ;
 - statement:
     set_default_role_statement:
@@ -351,12 +351,12 @@ file:
     - keyword: DEFAULT
     - keyword: ROLE
     - role_reference:
-      - quoted_identifier: "'role-name'"
+      - quoted_literal: "'role-name'"
       - at_sign_literal: '@'
-      - quoted_identifier: "'%'"
+      - quoted_literal: "'%'"
     - keyword: TO
     - role_reference:
-      - quoted_identifier: "'user_name'"
+      - quoted_literal: "'user_name'"
       - at_sign_literal: '@'
-      - quoted_identifier: "'%'"
+      - quoted_literal: "'%'"
 - statement_terminator: ;

--- a/test/fixtures/rules/std_rule_cases/RF06.yml
+++ b/test/fixtures/rules/std_rule_cases/RF06.yml
@@ -737,3 +737,25 @@ test_snowflake_default_keyword:
   configs:
     core:
       dialect: snowflake
+
+test_pass_mysql_create_user_account_specification:
+  # Issue 8462: MySQL user and host account specifications should remain quoted.
+  pass_str: |
+    CREATE USER 'jeffrey'@'localhost' IDENTIFIED BY 'password';
+  configs:
+    rules:
+      references.quoting:
+        prefer_quoted_identifiers: false
+    core:
+      dialect: mysql
+
+test_pass_mariadb_create_user_account_specification:
+  # Issue 8462: MariaDB user and host account specifications should remain quoted.
+  pass_str: |
+    CREATE USER 'jeffrey'@'localhost' IDENTIFIED BY 'password';
+  configs:
+    rules:
+      references.quoting:
+        prefer_quoted_identifiers: false
+    core:
+      dialect: mariadb


### PR DESCRIPTION
## Summary

Resolves #8462.

In MySQL and MariaDB, account specifications such as `'user'@'host'` were parsed using `SingleQuotedIdentifierSegment`. This caused RF06 to treat the quoted account components as identifiers and remove their quotes, producing SQL that no longer parses correctly.

This changes the relevant `RoleReferenceSegment` references to `QuotedLiteralSegment`, preserving the required quoting for MySQL/MariaDB account specifications.

## Changes

- Updated MySQL `RoleReferenceSegment` to use `QuotedLiteralSegment`
- Added RF06 regression coverage for MySQL and MariaDB
- Regenerated affected MySQL/MariaDB parse fixtures
- Verified CREATE USER, GRANT, and DROP USER account specifications

## Tests

- MySQL/MariaDB dialect tests
- RF06 YAML rule tests
- Direct verification that CREATE USER, GRANT and DROP USER remain correctly quoted and parse successfully

Closes #8462

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes RF06 incorrectly unquoting MySQL and MariaDB account specifications like `'user'@'host'`, which produced SQL that no longer parsed. Quoted account components are now parsed as `QuotedLiteralSegment` instead of quoted identifiers, so RF06 leaves them intact.

**Bug Fixes**
- Added RF06 regression coverage for MySQL and MariaDB `CREATE USER` statements.
- Regenerated affected MySQL and MariaDB parse fixtures for `CREATE USER` and `GRANT`.

<sup>Written for commit 704f76b28372c0d1b46932ea712f15966c1465ab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8463?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

