### PR TITLE
fix: preserve conversions in dotted Python template variables

### DIFF
--- a/src/sqlfluff/core/templaters/python.py
+++ b/src/sqlfluff/core/templaters/python.py
@@ -248,7 +248,9 @@ class PythonTemplater(RawTemplater):
             """
             # Hack to allow template variables with dot notation (e.g. foo.bar)
             raw_str_with_dot_notation_hack = re.sub(
-                r"{([^:}]*\.[^:}]*)(:\S*)?}", r"{sqlfluff[\1]\2}", raw_str
+                r"{([^:!}]*\.[^:!}]*)(![ars])?(:\S*)?}",
+                r"{sqlfluff[\1]\2\3}",
+                raw_str,
             )
             templater_logger.debug(
                 "    Raw String with Dot Notation Hack: %r",

--- a/test/core/templaters/python_test.py
+++ b/test/core/templaters/python_test.py
@@ -522,15 +522,40 @@ def test__templater_python_large_file_check():
             "SELECT * FROM {obj.schema}.{obj.table}",
             "SELECT * FROM my_schema.my_table",
         ),
+        (
+            "SELECT {foo!r}",
+            "SELECT 'bar'",
+        ),
+        (
+            "SELECT {foo.bar!s}",
+            "SELECT foobar",
+        ),
+        (
+            "SELECT {foo.bar!r}",
+            "SELECT 'foobar'",
+        ),
+        (
+            "SELECT {foo.label!a}",
+            r"SELECT 'caf\xe9'",
+        ),
+        (
+            "SELECT {foo.bar!r:>10}",
+            "SELECT   'foobar'",
+        ),
+        (
+            "SELECT {self.number!s:0>4}",
+            "SELECT 0042",
+        ),
     ],
 )
-def test__templater_python_dot_notation_variables(raw_str, result):
+def test__templater_python_dot_notation_variables(raw_str: str, result: str) -> None:
     """Test template variables that contain a dot character (`.`)."""
     context = {
         "foo": "bar",
         "num": 123,
         "sqlfluff": {
             "foo.bar": "foobar",
+            "foo.label": "café",
             "self.number": 42,
             "obj.schema": "my_schema",
             "obj.table": "my_table",
@@ -592,6 +617,13 @@ def test__templater_python_dot_notation_fail(context, error_string):
         # (with dots replaced by underscores) is used as a placeholder.
         (
             "SELECT * FROM {foo.bar}",
+            "templating",
+            None,
+            "SELECT * FROM foo_bar",
+            None,
+        ),
+        (
+            "SELECT * FROM {foo.bar!s}",
             "templating",
             None,
             "SELECT * FROM foo_bar",


### PR DESCRIPTION
### Brief summary of the change made

Python templates such as `SELECT {customer.name!r} AS customer_name` raise a missing-key error even when `customer.name` is configured. The dotted-variable rewrite includes the conversion flag in the lookup key, producing `{sqlfluff[customer.name!r]}` instead of `{sqlfluff[customer.name]!r}`.

Keep `!s`, `!r`, and `!a` separate from the variable name and preserve the following format specifier. With `sqlfluff = {"customer.name": "Ada"}` in the Python templater context, the example now renders as `SELECT 'Ada' AS customer_name`.

This also prevents `ignore=templating` from leaking a dotted variable's `!s` suffix into the rendered SQL.

### Are there any other side effects of this change that we should be aware of?

The change is limited to the dotted-variable rewrite. It uses the existing Python formatter and requires no new dependencies or configuration. Regression cases cover all three conversion flags, non-ASCII text, conversion followed by a format specifier, an ordinary variable, and `ignore=templating`.

Validation on Windows with Python 3.12:

- Before the fix: 6 regression cases failed; 41 cases passed.
- After the fix: all 47 tests in `test/core/templaters/python_test.py` passed.
- The CLI reproduction now renders `SELECT 'Ada' AS customer_name;` successfully.
- `pre-commit run --all-files` passed, including mypy, Ruff checks and formatting, doc8, yamllint, and codespell.

### Pull Request checklist

- [x] Please confirm you have completed any of the necessary steps below.

- Added regression cases to the existing Python templater tests.
- This restores documented Python formatting behavior; no documentation changes are needed.
- No follow-up issues are required for this change.

AI assistance: Codex assisted with diagnosis, implementation, and regression tests. The validation listed above was executed locally against the modified source.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missing-key errors when dotted Python template variables include a conversion flag (`!r`, `!s`, `!a`). The flag is now kept separate from the variable name, so `{customer.name!r}` resolves to `customer.name` instead of `customer.name!r`, and any format specifier is preserved.

Conversion flags are also respected in the `ignore=templating` fallback path, so rendered SQL no longer leaks suffixes or quote styles from `!r`. No new dependencies or configuration are required.

<sup>Written for commit 3a48ed98eb1d645a8bd449bfdbb6e641bda6942b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8464?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

