### PR TITLE
Trino: support SHOW FUNCTIONS, SHOW STATS and DESCRIBE

### DIFF
--- a/src/sqlfluff/dialects/dialect_trino.py
+++ b/src/sqlfluff/dialects/dialect_trino.py
@@ -590,11 +590,65 @@ class StatementSegment(ansi.StatementSegment):
         Ref("MergeStatementSegment"),
         Ref("SelectableGrammar"),
         Ref("SetSchemaStatementSegment"),
+        Ref("ShowStatementSegment"),
         Ref("TransactionStatementSegment"),
         Ref("UpdateStatementSegment"),
         Ref("UseStatementSegment"),
         Ref("SetSessionStatementSegment"),
         terminators=[Ref("DelimiterGrammar")],
+    )
+
+
+class ShowStatementSegment(BaseSegment):
+    """A `SHOW FUNCTIONS` or `SHOW STATS` statement.
+
+    https://trino.io/docs/current/sql/show-functions.html
+    https://trino.io/docs/current/sql/show-stats.html
+    """
+
+    type = "show_statement"
+    match_grammar = Sequence(
+        "SHOW",
+        OneOf(
+            Sequence(
+                "FUNCTIONS",
+                Sequence(
+                    OneOf("FROM", "IN"),
+                    Ref("SchemaReferenceSegment"),
+                    optional=True,
+                ),
+                Sequence(
+                    "LIKE",
+                    Ref("QuotedLiteralSegment"),
+                    Sequence("ESCAPE", Ref("QuotedLiteralSegment"), optional=True),
+                    optional=True,
+                ),
+            ),
+            Sequence(
+                "STATS",
+                "FOR",
+                OneOf(
+                    Ref("TableReferenceSegment"),
+                    Bracketed(Ref("SelectableGrammar")),
+                ),
+            ),
+        ),
+    )
+
+
+class DescribeStatementSegment(ansi.DescribeStatementSegment):
+    """A `DESCRIBE` statement, also abbreviated to `DESC`.
+
+    https://trino.io/docs/current/sql/describe.html
+    """
+
+    match_grammar = OneOf(
+        Sequence(OneOf("DESCRIBE", "DESC"), Ref("TableReferenceSegment")),
+        Sequence(
+            "DESCRIBE",
+            OneOf("INPUT", "OUTPUT"),
+            Ref("SingleIdentifierGrammar"),
+        ),
     )
 
 

--- a/test/dialects/trino_test.py
+++ b/test/dialects/trino_test.py
@@ -1,0 +1,25 @@
+"""Tests for the Trino dialect."""
+
+import pytest
+
+from sqlfluff.core import Linter
+
+
+@pytest.mark.parametrize(
+    "sql",
+    [
+        "SHOW FUNCTIONS FROM;",
+        "SHOW FUNCTIONS LIKE 123;",
+        "SHOW FUNCTIONS ESCAPE '$';",
+        "SHOW STATS motor;",
+        "SHOW STATS FOR ();",
+        "SHOW STATS FOR SELECT * FROM motor;",
+        "DESCRIBE;",
+        "DESCRIBE TABLE motor;",
+        "DESC INPUT prepared_query;",
+    ],
+)
+def test_trino_show_describe_invalid(sql):
+    """Reject incomplete statements and invalid SHOW clause combinations."""
+    parsed = Linter(dialect="trino").parse_string(sql)
+    assert any(violation.rule_code() == "PRS" for violation in parsed.violations)

--- a/test/fixtures/dialects/trino/describe.sql
+++ b/test/fixtures/dialects/trino/describe.sql
@@ -1,0 +1,11 @@
+DESCRIBE motor;
+
+DESCRIBE delta.hm_iot_db.motor;
+
+DESC motor;
+
+DESC "catalog-name"."schema-name"."table-name";
+
+DESCRIBE INPUT prepared_query;
+
+DESCRIBE OUTPUT "prepared-query";

--- a/test/fixtures/dialects/trino/describe.yml
+++ b/test/fixtures/dialects/trino/describe.yml
@@ -1,0 +1,51 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: e6cecdd77f973801cbf7c2934e680350fc89d5de13f688dd1adb7c8e0686cb41
+file:
+- statement:
+    describe_statement:
+      keyword: DESCRIBE
+      table_reference:
+        naked_identifier: motor
+- statement_terminator: ;
+- statement:
+    describe_statement:
+      keyword: DESCRIBE
+      table_reference:
+      - naked_identifier: delta
+      - dot: .
+      - naked_identifier: hm_iot_db
+      - dot: .
+      - naked_identifier: motor
+- statement_terminator: ;
+- statement:
+    describe_statement:
+      keyword: DESC
+      table_reference:
+        naked_identifier: motor
+- statement_terminator: ;
+- statement:
+    describe_statement:
+      keyword: DESC
+      table_reference:
+      - quoted_identifier: '"catalog-name"'
+      - dot: .
+      - quoted_identifier: '"schema-name"'
+      - dot: .
+      - quoted_identifier: '"table-name"'
+- statement_terminator: ;
+- statement:
+    describe_statement:
+    - keyword: DESCRIBE
+    - keyword: INPUT
+    - naked_identifier: prepared_query
+- statement_terminator: ;
+- statement:
+    describe_statement:
+    - keyword: DESCRIBE
+    - keyword: OUTPUT
+    - quoted_identifier: '"prepared-query"'
+- statement_terminator: ;

--- a/test/fixtures/dialects/trino/show.sql
+++ b/test/fixtures/dialects/trino/show.sql
@@ -1,0 +1,30 @@
+SHOW FUNCTIONS;
+
+SHOW FUNCTIONS FROM catalog_name.schema_name;
+
+SHOW FUNCTIONS IN "catalog-name"."schema-name";
+
+SHOW FUNCTIONS LIKE 'array%';
+
+SHOW FUNCTIONS LIKE 'my$_function%' ESCAPE '$';
+
+SHOW FUNCTIONS FROM catalog_name.schema_name LIKE 'my%';
+
+SHOW FUNCTIONS IN catalog_name.schema_name LIKE 'my$_function%' ESCAPE '$';
+
+SHOW STATS FOR motor;
+
+SHOW STATS FOR delta.hm_iot_db.motor;
+
+SHOW STATS FOR "catalog-name"."schema-name"."table-name";
+
+SHOW STATS FOR (SELECT * FROM delta.hm_iot_db.motor WHERE voltage > 10);
+
+SHOW STATS FOR (
+    WITH readings AS (SELECT voltage FROM delta.hm_iot_db.motor)
+    SELECT * FROM readings WHERE voltage > 10
+);
+
+SHOW STATS FOR (SELECT voltage FROM motor UNION ALL SELECT voltage FROM backup);
+
+SHOW STATS FOR (VALUES (1), (2));

--- a/test/fixtures/dialects/trino/show.yml
+++ b/test/fixtures/dialects/trino/show.yml
@@ -1,0 +1,260 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 7a04128be5e01608c45fc1e77876f73099fae5c5ca3398a22ed4a73ecee5c4db
+file:
+- statement:
+    show_statement:
+    - keyword: SHOW
+    - keyword: FUNCTIONS
+- statement_terminator: ;
+- statement:
+    show_statement:
+    - keyword: SHOW
+    - keyword: FUNCTIONS
+    - keyword: FROM
+    - schema_reference:
+      - naked_identifier: catalog_name
+      - dot: .
+      - naked_identifier: schema_name
+- statement_terminator: ;
+- statement:
+    show_statement:
+    - keyword: SHOW
+    - keyword: FUNCTIONS
+    - keyword: IN
+    - schema_reference:
+      - quoted_identifier: '"catalog-name"'
+      - dot: .
+      - quoted_identifier: '"schema-name"'
+- statement_terminator: ;
+- statement:
+    show_statement:
+    - keyword: SHOW
+    - keyword: FUNCTIONS
+    - keyword: LIKE
+    - quoted_literal: "'array%'"
+- statement_terminator: ;
+- statement:
+    show_statement:
+    - keyword: SHOW
+    - keyword: FUNCTIONS
+    - keyword: LIKE
+    - quoted_literal: "'my$_function%'"
+    - keyword: ESCAPE
+    - quoted_literal: "'$'"
+- statement_terminator: ;
+- statement:
+    show_statement:
+    - keyword: SHOW
+    - keyword: FUNCTIONS
+    - keyword: FROM
+    - schema_reference:
+      - naked_identifier: catalog_name
+      - dot: .
+      - naked_identifier: schema_name
+    - keyword: LIKE
+    - quoted_literal: "'my%'"
+- statement_terminator: ;
+- statement:
+    show_statement:
+    - keyword: SHOW
+    - keyword: FUNCTIONS
+    - keyword: IN
+    - schema_reference:
+      - naked_identifier: catalog_name
+      - dot: .
+      - naked_identifier: schema_name
+    - keyword: LIKE
+    - quoted_literal: "'my$_function%'"
+    - keyword: ESCAPE
+    - quoted_literal: "'$'"
+- statement_terminator: ;
+- statement:
+    show_statement:
+    - keyword: SHOW
+    - keyword: STATS
+    - keyword: FOR
+    - table_reference:
+        naked_identifier: motor
+- statement_terminator: ;
+- statement:
+    show_statement:
+    - keyword: SHOW
+    - keyword: STATS
+    - keyword: FOR
+    - table_reference:
+      - naked_identifier: delta
+      - dot: .
+      - naked_identifier: hm_iot_db
+      - dot: .
+      - naked_identifier: motor
+- statement_terminator: ;
+- statement:
+    show_statement:
+    - keyword: SHOW
+    - keyword: STATS
+    - keyword: FOR
+    - table_reference:
+      - quoted_identifier: '"catalog-name"'
+      - dot: .
+      - quoted_identifier: '"schema-name"'
+      - dot: .
+      - quoted_identifier: '"table-name"'
+- statement_terminator: ;
+- statement:
+    show_statement:
+    - keyword: SHOW
+    - keyword: STATS
+    - keyword: FOR
+    - bracketed:
+        start_bracket: (
+        select_statement:
+          select_clause:
+            keyword: SELECT
+            select_clause_element:
+              wildcard_expression:
+                wildcard_identifier:
+                  star: '*'
+          from_clause:
+            keyword: FROM
+            from_expression:
+              from_expression_element:
+                table_expression:
+                  table_reference:
+                  - naked_identifier: delta
+                  - dot: .
+                  - naked_identifier: hm_iot_db
+                  - dot: .
+                  - naked_identifier: motor
+          where_clause:
+            keyword: WHERE
+            expression:
+              column_reference:
+                naked_identifier: voltage
+              comparison_operator:
+                raw_comparison_operator: '>'
+              numeric_literal: '10'
+        end_bracket: )
+- statement_terminator: ;
+- statement:
+    show_statement:
+    - keyword: SHOW
+    - keyword: STATS
+    - keyword: FOR
+    - bracketed:
+        start_bracket: (
+        with_compound_statement:
+          keyword: WITH
+          common_table_expression:
+            naked_identifier: readings
+            keyword: AS
+            bracketed:
+              start_bracket: (
+              select_statement:
+                select_clause:
+                  keyword: SELECT
+                  select_clause_element:
+                    column_reference:
+                      naked_identifier: voltage
+                from_clause:
+                  keyword: FROM
+                  from_expression:
+                    from_expression_element:
+                      table_expression:
+                        table_reference:
+                        - naked_identifier: delta
+                        - dot: .
+                        - naked_identifier: hm_iot_db
+                        - dot: .
+                        - naked_identifier: motor
+              end_bracket: )
+          select_statement:
+            select_clause:
+              keyword: SELECT
+              select_clause_element:
+                wildcard_expression:
+                  wildcard_identifier:
+                    star: '*'
+            from_clause:
+              keyword: FROM
+              from_expression:
+                from_expression_element:
+                  table_expression:
+                    table_reference:
+                      naked_identifier: readings
+            where_clause:
+              keyword: WHERE
+              expression:
+                column_reference:
+                  naked_identifier: voltage
+                comparison_operator:
+                  raw_comparison_operator: '>'
+                numeric_literal: '10'
+        end_bracket: )
+- statement_terminator: ;
+- statement:
+    show_statement:
+    - keyword: SHOW
+    - keyword: STATS
+    - keyword: FOR
+    - bracketed:
+        start_bracket: (
+        set_expression:
+        - select_statement:
+            select_clause:
+              keyword: SELECT
+              select_clause_element:
+                column_reference:
+                  naked_identifier: voltage
+            from_clause:
+              keyword: FROM
+              from_expression:
+                from_expression_element:
+                  table_expression:
+                    table_reference:
+                      naked_identifier: motor
+        - set_operator:
+          - keyword: UNION
+          - keyword: ALL
+        - select_statement:
+            select_clause:
+              keyword: SELECT
+              select_clause_element:
+                column_reference:
+                  naked_identifier: voltage
+            from_clause:
+              keyword: FROM
+              from_expression:
+                from_expression_element:
+                  table_expression:
+                    table_reference:
+                      naked_identifier: backup
+        end_bracket: )
+- statement_terminator: ;
+- statement:
+    show_statement:
+    - keyword: SHOW
+    - keyword: STATS
+    - keyword: FOR
+    - bracketed:
+        start_bracket: (
+        values_clause:
+        - keyword: VALUES
+        - expression:
+            bracketed:
+              start_bracket: (
+              expression:
+                numeric_literal: '1'
+              end_bracket: )
+        - comma: ','
+        - expression:
+            bracketed:
+              start_bracket: (
+              expression:
+                numeric_literal: '2'
+              end_bracket: )
+        end_bracket: )
+- statement_terminator: ;


### PR DESCRIPTION
### Brief summary of the change made

Fixes #5151.

Trino's statement grammar does not recognize `SHOW FUNCTIONS` or `SHOW STATS`, and its inherited ANSI `DESCRIBE` grammar expects an extra object type. The reported commands therefore produce parsing errors even though Trino supports them.

Add Trino-specific parsing for `SHOW FUNCTIONS` (including `FROM`/`IN`, `LIKE`, and `ESCAPE`), `SHOW STATS FOR` a table or bracketed query, and `DESCRIBE`/`DESC` a table. Preserve the existing `DESCRIBE INPUT` and `DESCRIBE OUTPUT` forms. `ANALYZE` already parses on main, so no change is needed for that part of the report.

Syntax references: [SHOW FUNCTIONS](https://trino.io/docs/current/sql/show-functions.html), [SHOW STATS](https://trino.io/docs/current/sql/show-stats.html), [DESCRIBE](https://trino.io/docs/current/sql/describe.html), and [Trino's grammar](https://github.com/trinodb/trino/blob/master/core/trino-grammar/src/main/antlr4/io/trino/grammar/sql/SqlBase.g4).

### Are there any other side effects of this change that we should be aware of?

The change is confined to Trino. The new fixtures cover qualified and quoted names, query targets, filter clauses, and the existing prepared-statement descriptions. A parameterized test rejects incomplete statements and invalid clause combinations.

### Validation

- Confirmed the reported `SHOW` and table `DESCRIBE` failures on unchanged main; confirmed `ANALYZE` already succeeds.
- 87 Trino parsing, parse-tree, broad-fix, and invalid-syntax tests passed.
- The issue's five original statements parse successfully; fixing twice is stable. The original `SELECT *` still receives the normal AM04 lint finding.
- Regenerated all 2,264 dialect fixtures and the Rust dialect tables; existing YAML fixtures are unchanged.
- All pre-commit hooks passed (including mypy, doc8, yamllint, Ruff and codespell).
- Python 3.12.14 on Windows: the full suite stopped after 8,326 passed, 2,492 skipped and one failure. Running the remaining documentation, rules and utility tests to completion produced 2,785 passed, 101 skipped and two failures (including the original failure).
- Both failures are in unchanged `test/docsv_smoke_check_test.py`: creating symlinks raises `WinError 1314` because this environment lacks the required privilege. No tests were removed or altered to avoid these failures.
- Combined local line coverage is 98.70%; `dialect_trino.py` has 100% line coverage (111/111 statements). The Rust extension, dbt integration and other Python/platform combinations have not been tested locally. The initial CI and pre-commit workflows ended before any jobs ran; remote validation is still outstanding.

### Pull Request checklist

- [x] Included SQL fixtures and generated YAML parse trees, plus invalid-syntax tests.
- [x] Added official syntax references to the affected segment docstrings.
- [x] No follow-up issues are needed for this change.

### AI assistance

The GitHub account owner requested this contribution and authorized its submission. Codex investigated the issue, authored the implementation and tests, and ran the validation commands. No independent human review or execution against a live Trino server is claimed.

Requesting maintainer review following the invitation in the automated AgentScan notice. This is the only PR submitted by this account to SQLFluff.
