### PR TITLE
Add AM10, AM11, AM12: ambiguous-reference rules for aggregates, clause order, and CTEs

### DIFF
--- a/src/sqlfluff/rules/ambiguous/AM10.py
+++ b/src/sqlfluff/rules/ambiguous/AM10.py
@@ -1,0 +1,320 @@
+"""Implementation of Rule AM10."""
+
+from typing import Optional
+
+from sqlfluff.core.parser import BaseSegment
+from sqlfluff.core.rules import BaseRule, LintResult, RuleContext
+from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
+from sqlfluff.utils.functional import FunctionalContext, sp
+
+# Aggregate functions shared by the ANSI and major warehouse dialects.
+_AGGREGATE_FUNCTION_NAMES = frozenset(
+    {
+        "count",
+        "sum",
+        "avg",
+        "min",
+        "max",
+        "array_agg",
+        "string_agg",
+        "stddev",
+        "stddev_pop",
+        "stddev_samp",
+        "variance",
+        "var_pop",
+        "var_samp",
+        "bool_and",
+        "bool_or",
+        "every",
+        "bit_and",
+        "bit_or",
+        "json_agg",
+        "json_arrayagg",
+        "json_objectagg",
+        "listagg",
+        "group_concat",
+    }
+)
+
+
+def _function_name(function_segment: BaseSegment) -> Optional[str]:
+    """The lowercased name of a ``function`` segment, if it has one."""
+    name_id = next(function_segment.recursive_crawl("function_name_identifier"), None)
+    return name_id.raw.lower() if name_id else None
+
+
+def _is_aggregate_call(function_segment: BaseSegment) -> bool:
+    """Is this a non-windowed call to one of the aggregate functions?
+
+    A windowed aggregate (``SUM(x) OVER (...)``) does not collapse rows the
+    way a grouped aggregate does, so it is not subject to the projection
+    restrictions this rule checks.
+    """
+    if _function_name(function_segment) not in _AGGREGATE_FUNCTION_NAMES:
+        return False
+    return not any(function_segment.recursive_crawl("over_clause"))
+
+
+def _has_nested_aggregate(function_segment: BaseSegment) -> bool:
+    """Does an aggregate call have another aggregate call among its args?"""
+    contents = next(function_segment.recursive_crawl("function_contents"), None)
+    if contents is None:
+        return False
+    return any(
+        _is_aggregate_call(inner)
+        for inner in _own_level_functions(contents)
+        if inner is not function_segment
+    )
+
+
+def _own_level_functions(segment: BaseSegment) -> list[BaseSegment]:
+    """Find functions without crossing into a nested SELECT scope."""
+    found: list[BaseSegment] = []
+
+    def _walk(seg: BaseSegment) -> None:
+        if seg.is_type("select_statement"):
+            return
+        if seg.is_type("function"):
+            found.append(seg)
+        for child in seg.segments:
+            _walk(child)
+
+    for child in segment.segments:
+        _walk(child)
+    return found
+
+
+def _bare_column_refs(
+    segment: BaseSegment, group_expressions: set[str]
+) -> list[BaseSegment]:
+    """Column references in ``segment``, outside of any aggregate call.
+
+    Columns used only as *inputs* to an aggregate (``COUNT(a)``) are not
+    collected -- an aggregate consumes whatever it is given. Only column
+    references that survive outside of aggregate calls are potentially
+    subject to the "must be a grouping key" restriction.
+    """
+    found: list[BaseSegment] = []
+
+    def _walk(seg: BaseSegment) -> None:
+        if seg.is_type("select_statement"):
+            return
+        if seg.is_type("expression", "bracketed", "function") and (
+            _normalized_expression(seg) in group_expressions
+        ):
+            # A complete grouping expression can be projected as a value of
+            # the group. Its component references are not bare columns.
+            return
+        if seg.is_type("column_reference"):
+            found.append(seg)
+            return
+        if seg.is_type("function") and (
+            _is_aggregate_call(seg) or any(seg.recursive_crawl("over_clause"))
+        ):
+            # Do not descend into an aggregate's own arguments: those
+            # columns are consumed by the aggregate, not projected bare.
+            # A windowed call (has an OVER clause) does not collapse rows
+            # at all, so its contents are exempt from this restriction
+            # entirely, not just the columns fed to the aggregate itself.
+            return
+        for child in seg.segments:
+            _walk(child)
+
+    for child in segment.segments:
+        _walk(child)
+    return found
+
+
+def _group_by_keys(groupby_clause: BaseSegment) -> set[str]:
+    """The lowercased names of the plain-variable GROUP BY keys.
+
+    Only a ``column_reference`` that is a *direct* child of the clause
+    counts: grouping by a computed expression (``GROUP BY (a + b)``) does
+    not make the variables inside that expression individually available,
+    it makes the expression's *result* the group key.
+    """
+    return {
+        _normalized_expression(child)
+        for child in groupby_clause.segments
+        if child.is_type("column_reference")
+    }
+
+
+def _normalized_expression(segment: BaseSegment) -> str:
+    """Return a comparable ANSI expression spelling.
+
+    Unquoted identifiers and keywords are case-insensitive, while quoted
+    identifiers and string literals retain their case. Redundant parentheses
+    around an entire expression do not change the grouping key it denotes.
+    """
+    raw = segment.raw
+    normalized: list[str] = []
+    quote: Optional[str] = None
+    index = 0
+
+    while index < len(raw):
+        char = raw[index]
+        if quote:
+            normalized.append(char)
+            if char == quote:
+                if index + 1 < len(raw) and raw[index + 1] == quote:
+                    normalized.append(raw[index + 1])
+                    index += 1
+                else:
+                    quote = None
+        elif char in ("'", '"'):
+            quote = char
+            normalized.append(char)
+        elif not char.isspace():
+            normalized.append(char.lower())
+        index += 1
+
+    return _strip_outer_parentheses("".join(normalized))
+
+
+def _strip_outer_parentheses(expression: str) -> str:
+    """Remove parentheses only when they enclose the whole expression."""
+    while expression.startswith("(") and expression.endswith(")"):
+        depth = 0
+        quote: Optional[str] = None
+        closes_at_end = True
+        index = 0
+
+        while index < len(expression):
+            char = expression[index]
+            if quote:
+                if char == quote:
+                    if index + 1 < len(expression) and expression[index + 1] == quote:
+                        index += 1
+                    else:
+                        quote = None
+            elif char in ("'", '"'):
+                quote = char
+            elif char == "(":
+                depth += 1
+            elif char == ")":
+                depth -= 1
+                if depth == 0 and index != len(expression) - 1:
+                    closes_at_end = False
+                    break
+            index += 1
+
+        if depth or not closes_at_end:
+            break
+        expression = expression[1:-1]
+    return expression
+
+
+def _group_by_expressions(groupby_clause: BaseSegment) -> set[str]:
+    """Return the complete expressions used as GROUP BY keys.
+
+    A computed grouping key is available as that same expression, but its
+    component columns are not independently available. Keeping complete
+    expression spellings separate from :func:`_group_by_keys` preserves that
+    distinction.
+    """
+    return {
+        _normalized_expression(child)
+        for child in groupby_clause.segments
+        if child.is_type("expression", "bracketed", "column_reference", "function")
+    }
+
+
+class Rule_AM10(BaseRule):
+    """Aggregate projection restrictions are not enforced.
+
+    In a query that uses aggregation -- either explicitly via ``GROUP BY``,
+    or implicitly by using an aggregate function with no ``GROUP BY`` at
+    all -- anything projected or referenced in ``HAVING`` outside of an
+    aggregate call must be one of the ``GROUP BY`` keys. A bare column that
+    is neither a grouping key nor wrapped in an aggregate is ambiguous: it
+    has no well-defined single value per group. The same restriction
+    applies to ``HAVING``, since it is evaluated per group, after the
+    grouping has already happened.
+
+    Aggregate functions may not be nested inside one another either
+    (``SUM(COUNT(x))``): each aggregate already collapses its group, so
+    there is nothing left for an outer aggregate to further collapse.
+
+    A windowed aggregate (using ``OVER``) does not collapse rows, so it is
+    exempt from this restriction.
+
+    **Anti-pattern**
+
+    ``b`` is projected bare, but the query only groups by ``a``.
+
+    .. code-block:: sql
+
+        SELECT a, b, COUNT(*)
+        FROM foo
+        GROUP BY a
+
+    **Best practice**
+
+    Add the column to ``GROUP BY``, or wrap it in an aggregate.
+
+    .. code-block:: sql
+
+        SELECT a, b, COUNT(*)
+        FROM foo
+        GROUP BY a, b
+    """
+
+    name = "ambiguous.aggregate_projection"
+    groups: tuple[str, ...] = ("all", "ambiguous")
+    crawl_behaviour = SegmentSeekerCrawler({"select_statement"})
+
+    def _eval(self, context: RuleContext) -> Optional[LintResult]:
+        """Aggregate projection restrictions are not enforced."""
+        if not context.segment.is_type("select_statement"):
+            return None
+        segment = FunctionalContext(context).segment
+
+        groupby_clause = next(
+            iter(segment.children(sp.is_type("groupby_clause"))), None
+        )
+        select_clause = next(iter(segment.children(sp.is_type("select_clause"))), None)
+        having_clause = next(iter(segment.children(sp.is_type("having_clause"))), None)
+        if select_clause is None:
+            return None
+
+        select_targets = [
+            child
+            for child in select_clause.segments
+            if child.is_type("select_clause_element")
+        ]
+        select_functions = [
+            fn for el in select_targets for fn in _own_level_functions(el)
+        ]
+        having_functions = (
+            _own_level_functions(having_clause) if having_clause is not None else []
+        )
+        aggregate_calls = [
+            fn for fn in select_functions + having_functions if _is_aggregate_call(fn)
+        ]
+
+        # Nested aggregates are invalid regardless of GROUP BY.
+        for fn in aggregate_calls:
+            if _has_nested_aggregate(fn):
+                return LintResult(anchor=fn)
+
+        has_aggregation = bool(groupby_clause) or bool(aggregate_calls)
+        if not has_aggregation:
+            return None
+
+        group_keys = _group_by_keys(groupby_clause) if groupby_clause else set()
+        group_expressions = (
+            _group_by_expressions(groupby_clause) if groupby_clause else set()
+        )
+
+        for target in select_targets:
+            for ref in _bare_column_refs(target, group_expressions):
+                if _normalized_expression(ref) not in group_keys:
+                    return LintResult(anchor=ref)
+
+        if having_clause is not None:
+            for ref in _bare_column_refs(having_clause, group_expressions):
+                if _normalized_expression(ref) not in group_keys:
+                    return LintResult(anchor=ref)
+
+        return None

--- a/src/sqlfluff/rules/ambiguous/AM11.py
+++ b/src/sqlfluff/rules/ambiguous/AM11.py
@@ -1,0 +1,222 @@
+"""Implementation of Rule AM11."""
+
+from typing import Optional
+
+from sqlfluff.core.parser import BaseSegment
+from sqlfluff.core.rules import BaseRule, LintResult, RuleContext
+from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
+
+# Aggregate functions shared by the ANSI and major warehouse dialects. Kept
+# in step with AM10 and duplicated because rule modules are self-contained.
+_AGGREGATE_FUNCTION_NAMES = frozenset(
+    {
+        "count",
+        "sum",
+        "avg",
+        "min",
+        "max",
+        "array_agg",
+        "string_agg",
+        "stddev",
+        "stddev_pop",
+        "stddev_samp",
+        "variance",
+        "var_pop",
+        "var_samp",
+        "bool_and",
+        "bool_or",
+        "every",
+        "bit_and",
+        "bit_or",
+        "json_agg",
+        "json_arrayagg",
+        "json_objectagg",
+        "listagg",
+        "group_concat",
+    }
+)
+
+# The clauses a window function may never appear in. WHERE, JOIN ... ON,
+# GROUP BY and HAVING are all resolved before window functions are computed.
+_WINDOW_FORBIDDEN_CLAUSE_TYPES = (
+    "where_clause",
+    "join_on_condition",
+    "groupby_clause",
+    "having_clause",
+)
+
+# Aggregates only need a separate timing check in the row-level predicates.
+_AGGREGATE_FORBIDDEN_CLAUSE_TYPES = ("where_clause", "join_on_condition")
+
+
+def _has_own_over_clause(function_segment: BaseSegment) -> bool:
+    """Whether this function, rather than an argument, is windowed."""
+    found = False
+
+    def _walk(seg: BaseSegment) -> None:
+        nonlocal found
+        if found or seg.is_type("select_statement"):
+            return
+        if seg is not function_segment and seg.is_type("function"):
+            return
+        if seg.is_type("over_clause"):
+            found = True
+            return
+        for child in seg.segments:
+            _walk(child)
+
+    _walk(function_segment)
+    return found
+
+
+def _is_bare_aggregate_call(function_segment: BaseSegment) -> bool:
+    """Is this a non-windowed call to one of the aggregate functions?
+
+    A windowed aggregate (``SUM(x) OVER (...)``) is a different case,
+    already covered by the window-function check in this same rule.
+    """
+    name_id = next(function_segment.recursive_crawl("function_name_identifier"), None)
+    name = name_id.raw.lower() if name_id else None
+    if name not in _AGGREGATE_FUNCTION_NAMES:
+        return False
+    return not _has_own_over_clause(function_segment)
+
+
+def _own_level_functions(segment: BaseSegment) -> list[BaseSegment]:
+    """``function`` segments in ``segment``, not inside a nested subquery.
+
+    A subquery is its own query level with its own ``WHERE``: the crawler
+    already visits it separately, so a function inside it must not also be
+    attributed to the outer level's clause.
+    """
+    found: list[BaseSegment] = []
+
+    def _walk(seg: BaseSegment) -> None:
+        if seg.is_type("select_statement"):
+            return
+        if seg.is_type("function"):
+            found.append(seg)
+        for child in seg.segments:
+            _walk(child)
+
+    for child in segment.segments:
+        _walk(child)
+    return found
+
+
+def _own_level_clauses(segment: BaseSegment, clause_type: str) -> list[BaseSegment]:
+    """Find clauses at this SELECT level without descending into subqueries."""
+    found: list[BaseSegment] = []
+
+    def _walk(seg: BaseSegment) -> None:
+        if seg.is_type("select_statement"):
+            return
+        if seg.is_type(clause_type):
+            found.append(seg)
+            return
+        for child in seg.segments:
+            _walk(child)
+
+    for child in segment.segments:
+        _walk(child)
+    return found
+
+
+def _window_in_aggregate_argument(
+    function_segment: BaseSegment,
+) -> Optional[BaseSegment]:
+    """Return a window clause used as an argument of a plain aggregate."""
+    contents = next(function_segment.recursive_crawl("function_contents"), None)
+    if contents is None:
+        return None
+    for inner in _own_level_functions(contents):
+        over_clause = next(inner.recursive_crawl("over_clause"), None)
+        if over_clause is not None:
+            return over_clause
+    return None
+
+
+class Rule_AM11(BaseRule):
+    """A value is referenced before the clause that would compute it runs.
+
+    Window functions are computed only once the ``FROM``, ``WHERE``,
+    ``GROUP BY`` and ``HAVING`` clauses have already been resolved: they
+    operate on the rows those clauses have already produced. Using one
+    inside ``WHERE``, ``GROUP BY`` or ``HAVING`` is therefore not a style
+    preference but a logical impossibility -- the value the window function
+    would need to compute over does not exist yet at that stage. This holds
+    for any window function, not just the aggregate ones, and is rejected
+    consistently by SQL engines rather than varying between them.
+
+    ``WHERE`` runs earlier still: it filters individual rows before any
+    grouping happens at all, so a plain (non-windowed) aggregate function
+    cannot appear there either -- there is no group yet for it to aggregate.
+    ``HAVING`` permits normal aggregate calls because it operates on groups.
+    This rule's aggregate check is deliberately limited to ``WHERE``; it does
+    not add a separate diagnostic for aggregate calls in ``GROUP BY``.
+
+    A window function is legal in the projection or in ``ORDER BY``, since
+    both are evaluated after grouping and filtering are complete.
+
+    **Anti-pattern**
+
+    ``HAVING`` is evaluated before window functions exist; ``WHERE`` is
+    evaluated before any aggregate has anything to aggregate.
+
+    .. code-block:: sql
+
+        SELECT a
+        FROM foo
+        GROUP BY a
+        HAVING SUM(x) OVER (PARTITION BY a) > 1
+
+    .. code-block:: sql
+
+        SELECT a
+        FROM foo
+        WHERE COUNT(*) > 1
+
+    **Best practice**
+
+    Move the condition to a plain aggregate in ``HAVING``, or filter using
+    the value in a later step (for example, a subquery or CTE that computes
+    it first).
+
+    .. code-block:: sql
+
+        SELECT a
+        FROM foo
+        GROUP BY a
+        HAVING SUM(x) > 1 AND COUNT(*) > 1
+    """
+
+    name = "ambiguous.window_function_placement"
+    groups: tuple[str, ...] = ("all", "ambiguous")
+    crawl_behaviour = SegmentSeekerCrawler({"select_statement"})
+
+    def _eval(self, context: RuleContext) -> Optional[LintResult]:
+        """A value is referenced before the clause that computes it runs."""
+        if not context.segment.is_type("select_statement"):
+            return None
+
+        for select_clause in _own_level_clauses(context.segment, "select_clause"):
+            for fn in _own_level_functions(select_clause):
+                if _is_bare_aggregate_call(fn):
+                    over_clause = _window_in_aggregate_argument(fn)
+                    if over_clause is not None:
+                        return LintResult(anchor=over_clause)
+
+        for clause_type in _WINDOW_FORBIDDEN_CLAUSE_TYPES:
+            for clause in _own_level_clauses(context.segment, clause_type):
+                for fn in _own_level_functions(clause):
+                    if any(fn.recursive_crawl("over_clause")):
+                        over_clause = next(fn.recursive_crawl("over_clause"))
+                        return LintResult(anchor=over_clause)
+
+        for clause_type in _AGGREGATE_FORBIDDEN_CLAUSE_TYPES:
+            for clause in _own_level_clauses(context.segment, clause_type):
+                for fn in _own_level_functions(clause):
+                    if _is_bare_aggregate_call(fn):
+                        return LintResult(anchor=fn)
+
+        return None

--- a/src/sqlfluff/rules/ambiguous/AM12.py
+++ b/src/sqlfluff/rules/ambiguous/AM12.py
@@ -1,0 +1,167 @@
+"""Implementation of Rule AM12."""
+
+from typing import Optional
+
+from sqlfluff.core.parser import BaseSegment
+from sqlfluff.core.rules import BaseRule, LintResult, RuleContext
+from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
+
+
+def _normalized_identifier(raw: str) -> str:
+    """Return a comparable spelling for a CTE name or a reference to one.
+
+    Unquoted identifiers are case-insensitive, so they are lower-cased.
+    Quoted identifiers keep their case, so only the surrounding quote
+    characters are removed.
+    """
+    stripped = raw.strip()
+    if len(stripped) >= 2 and stripped[0] == stripped[-1] and stripped[0] in ("'", '"'):
+        return stripped[1:-1]
+    return stripped.lower()
+
+
+def _cte_name(cte_definition: BaseSegment) -> Optional[str]:
+    """The declared name of a ``common_table_expression`` segment."""
+    for child in cte_definition.segments:
+        if child.is_type("identifier"):
+            return _normalized_identifier(child.raw)
+    return None
+
+
+def _unqualified_reference_name(table_reference: BaseSegment) -> Optional[str]:
+    """The bare name of a ``table_reference``, or ``None`` if it is qualified.
+
+    A CTE name is never schema- or table-qualified, so ``public.cte1`` can
+    never be a reference to a CTE named ``cte1`` and must not be treated as
+    one.
+    """
+    identifiers = [
+        child for child in table_reference.segments if child.is_type("identifier")
+    ]
+    if len(identifiers) != 1:
+        return None
+    return _normalized_identifier(identifiers[0].raw)
+
+
+def _own_scope_table_references(segment: BaseSegment) -> list[BaseSegment]:
+    """``table_reference`` segments that belong to this WITH block's scope.
+
+    A nested ``WITH`` clause introduces its own CTE names, which shadow
+    this block's names for everything inside it, so the walk stops there
+    rather than attributing its references to this outer scope. An
+    ordinary subquery is different: it does not start a new CTE scope, so
+    a reference to a later sibling buried inside a subquery in a CTE's own
+    body is exactly as illegal as one written directly in that body, and
+    the walk must continue into it rather than stop.
+    """
+    found: list[BaseSegment] = []
+
+    def _walk(seg: BaseSegment) -> None:
+        if seg.is_type("with_compound_statement"):
+            return
+        if seg.is_type("table_reference"):
+            found.append(seg)
+            return
+        for child in seg.segments:
+            _walk(child)
+
+    for child in segment.segments:
+        _walk(child)
+    return found
+
+
+class Rule_AM12(BaseRule):
+    """A CTE is referenced before its definition is complete.
+
+    Within one ``WITH`` block, each common table expression may only
+    reference common table expressions that were already fully defined
+    earlier in the same block -- referencing a sibling defined later, or
+    referencing itself, means the engine would need the result of a query
+    it has not finished building yet, which is not possible. ``WITH
+    RECURSIVE`` relaxes this in exactly one way: a common table expression
+    may reference itself, because the engine builds it up one iteration at
+    a time rather than needing the whole result at once. It does not allow
+    a common table expression to reference a different sibling defined
+    later, and it does not allow two common table expressions to reference
+    each other, since neither of those forms can be built up iteratively
+    the way a single self-reference can. The final query that follows the
+    ``WITH`` block may always reference any of the block's common table
+    expressions, since it runs only once every one of them is complete.
+
+    A common table expression's own name is visible to every reference
+    inside its body, including one buried inside a subquery, since a plain
+    subquery does not start a new naming scope. A nested ``WITH`` block
+    is different: the common table expressions it defines are a separate
+    scope, and a name it reuses from an enclosing block refers to its own,
+    inner definition rather than the outer one.
+
+    **Anti-pattern**
+
+    ``later`` is defined after ``first``, so ``first`` cannot reference it.
+
+    .. code-block:: sql
+
+        WITH first AS (SELECT * FROM later), later AS (SELECT 1 AS x)
+        SELECT * FROM first
+
+    A common table expression referencing itself without ``RECURSIVE``:
+
+    .. code-block:: sql
+
+        WITH cte AS (SELECT * FROM cte)
+        SELECT * FROM cte
+
+    **Best practice**
+
+    Reorder the common table expressions so each one only reaches back to
+    ones already defined, or add ``RECURSIVE`` for a genuine self-reference.
+
+    .. code-block:: sql
+
+        WITH later AS (SELECT 1 AS x), first AS (SELECT * FROM later)
+        SELECT * FROM first
+    """
+
+    name = "ambiguous.cte_reference_order"
+    groups: tuple[str, ...] = ("all", "ambiguous")
+    crawl_behaviour = SegmentSeekerCrawler({"with_compound_statement"})
+
+    def _eval(self, context: RuleContext) -> Optional[LintResult]:
+        """A CTE is referenced before its definition is complete."""
+        segment = context.segment
+        if not segment.is_type("with_compound_statement"):
+            return None
+
+        is_recursive = any(
+            child.is_type("keyword") and child.raw.upper() == "RECURSIVE"
+            for child in segment.segments
+        )
+
+        cte_definitions = [
+            child
+            for child in segment.segments
+            if child.is_type("common_table_expression")
+        ]
+        if not cte_definitions:
+            return None
+
+        positions: dict[str, int] = {}
+        for index, cte in enumerate(cte_definitions):
+            name = _cte_name(cte)
+            if name is not None and name not in positions:
+                positions[name] = index
+
+        for index, cte in enumerate(cte_definitions):
+            for ref in _own_scope_table_references(cte):
+                ref_name = _unqualified_reference_name(ref)
+                if ref_name is None:
+                    continue
+                target_index = positions.get(ref_name)
+                if target_index is None:
+                    continue
+                if target_index > index:
+                    return LintResult(anchor=ref)
+                if target_index == index and not is_recursive:
+                    return LintResult(anchor=ref)
+
+        return None

--- a/src/sqlfluff/rules/ambiguous/__init__.py
+++ b/src/sqlfluff/rules/ambiguous/__init__.py
@@ -41,6 +41,9 @@ def get_rules() -> list[type[BaseRule]]:
     from sqlfluff.rules.ambiguous.AM07 import Rule_AM07
     from sqlfluff.rules.ambiguous.AM08 import Rule_AM08
     from sqlfluff.rules.ambiguous.AM09 import Rule_AM09
+    from sqlfluff.rules.ambiguous.AM10 import Rule_AM10
+    from sqlfluff.rules.ambiguous.AM11 import Rule_AM11
+    from sqlfluff.rules.ambiguous.AM12 import Rule_AM12
 
     return [
         Rule_AM01,
@@ -52,4 +55,7 @@ def get_rules() -> list[type[BaseRule]]:
         Rule_AM07,
         Rule_AM08,
         Rule_AM09,
+        Rule_AM10,
+        Rule_AM11,
+        Rule_AM12,
     ]

--- a/test/fixtures/rules/std_rule_cases/AM10.yml
+++ b/test/fixtures/rules/std_rule_cases/AM10.yml
@@ -1,0 +1,167 @@
+rule: AM10
+
+test_invalid_projection_reported:
+  fail_str: |
+    SELECT a, b, COUNT(*) AS c
+    FROM foo
+    GROUP BY b;
+
+test_having_ungrouped_column_reported:
+  fail_str: |
+    SELECT b, COUNT(*) AS c FROM foo GROUP BY b HAVING a > 1;
+
+test_group_by_without_aggregate_reported:
+  fail_str: |
+    SELECT a FROM foo GROUP BY b;
+
+test_implicit_group_having_ungrouped_column_reported:
+  fail_str: |
+    SELECT COUNT(*) FROM foo HAVING a > 0;
+
+test_nested_aggregate_reported:
+  fail_str: |
+    SELECT SUM(COUNT(x)) AS c FROM foo;
+
+test_different_nested_aggregate_reported:
+  fail_str: |
+    SELECT AVG(SUM(x)) AS c FROM foo;
+
+test_nested_aggregate_in_having_reported:
+  fail_str: |
+    SELECT b FROM foo GROUP BY b HAVING SUM(COUNT(x)) > 1;
+
+test_implicit_group_bare_column_reported:
+  fail_str: |
+    SELECT a, COUNT(*) AS c FROM foo;
+
+test_implicit_group_stddev_reported:
+  fail_str: |
+    SELECT a, STDDEV_POP(b) FROM foo;
+
+test_implicit_group_min_reported:
+  fail_str: |
+    SELECT a, MIN(b) FROM foo;
+
+test_array_aggregate_implicit_group_reported:
+  fail_str: |
+    SELECT a, ARRAY_AGG(b) FROM foo;
+
+test_group_expression_components_reported:
+  fail_str: |
+    SELECT a, COUNT(*) AS c FROM foo GROUP BY (a + b);
+
+test_compound_projection_reported:
+  fail_str: |
+    SELECT (a + 1) AS c, COUNT(*) FROM foo GROUP BY b;
+
+test_nested_scalar_projection_reported:
+  fail_str: |
+    SELECT LOWER(a), COUNT(*) FROM foo GROUP BY b;
+
+test_computed_group_key_reused_no_violation:
+  pass_str: |
+    SELECT a + b AS key, COUNT(*) FROM foo GROUP BY a + b;
+
+test_computed_group_key_plus_column_reported:
+  fail_str: |
+    SELECT a + b + c, COUNT(*) FROM foo GROUP BY a + b;
+
+test_computed_key_case_and_whitespace_no_violation:
+  pass_str: |
+    SELECT A+B, COUNT(*) FROM foo GROUP BY a + b;
+
+test_parenthesized_computed_key_no_violation:
+  pass_str: |
+    SELECT (a + b), COUNT(*) FROM foo GROUP BY a + b;
+
+test_non_select_statement_no_violation:
+  pass_str: |
+    CREATE TABLE foo (id INT, name TEXT);
+
+test_grouped_column_projected_no_violation:
+  pass_str: |
+    SELECT b, COUNT(*) AS c FROM foo GROUP BY b;
+
+test_qualified_grouped_column_no_violation:
+  pass_str: |
+    SELECT t.a, COUNT(*) FROM foo AS t GROUP BY t.a;
+
+test_function_of_grouped_column_no_violation:
+  pass_str: |
+    SELECT LOWER(a), COUNT(*) FROM foo GROUP BY a;
+
+test_computed_function_key_reused_no_violation:
+  pass_str: |
+    SELECT LOWER(a), COUNT(*) FROM foo GROUP BY LOWER(a);
+
+test_aggregate_over_group_key_no_violation:
+  pass_str: |
+    SELECT b, SUM(x) AS t FROM foo GROUP BY b;
+
+test_no_aggregation_at_all_no_violation:
+  pass_str: |
+    SELECT a, b FROM foo;
+
+test_implicit_group_aggregate_only_no_violation:
+  pass_str: |
+    SELECT COUNT(*) AS c FROM foo;
+
+test_having_over_aggregate_no_violation:
+  pass_str: |
+    SELECT b, COUNT(*) AS c FROM foo GROUP BY b HAVING COUNT(*) > 1;
+
+test_implicit_group_having_column_reported:
+  fail_str: |
+    SELECT a FROM foo HAVING COUNT(*) > 1;
+
+test_window_function_no_group_by_no_violation:
+  pass_str: |
+    SELECT a, SUM(x) OVER (PARTITION BY a) AS running FROM foo;
+
+test_aggregate_inside_window_no_violation:
+  pass_str: |
+    SELECT SUM(COUNT(*)) OVER () FROM foo;
+
+test_expression_of_two_group_keys_no_violation:
+  pass_str: |
+    SELECT (a + b) AS s, COUNT(*) AS c FROM foo GROUP BY a, b;
+
+test_aggregate_argument_not_grouped_no_violation:
+  pass_str: |
+    SELECT b, COUNT(a) AS c FROM foo GROUP BY b;
+
+test_subselect_has_own_scope_no_violation:
+  pass_str: |
+    SELECT x FROM (SELECT a AS x, COUNT(*) FROM foo GROUP BY a) t;
+
+test_scalar_aggregate_subquery_no_outer_violation:
+  pass_str: |
+    SELECT a, (SELECT COUNT(*) FROM bar) AS n FROM foo;
+
+test_scalar_subquery_does_not_leak_into_grouped_outer:
+  pass_str: |
+    SELECT a, (SELECT COUNT(*) FROM bar) AS n, COUNT(*) FROM foo GROUP BY a;
+
+test_invalid_scalar_subquery_is_reported_at_its_level:
+  fail_str: |
+    SELECT a, (SELECT b, COUNT(*) FROM bar) AS n FROM foo;
+
+test_invalid_subselect_is_reported:
+  fail_str: |
+    SELECT b FROM (SELECT a, b, COUNT(*) FROM foo GROUP BY b) AS s;
+
+test_case_insensitive_group_by_key_no_violation:
+  pass_str: |
+    SELECT b, COUNT(*) AS c FROM foo GROUP BY B;
+
+test_quoted_group_by_key_is_case_sensitive:
+  fail_str: |
+    SELECT "A", COUNT(*) AS c FROM foo GROUP BY "a";
+
+test_multiple_group_keys_projected_no_violation:
+  pass_str: |
+    SELECT a, b, COUNT(*) AS c FROM foo GROUP BY a, b;
+
+test_having_references_group_key_no_violation:
+  pass_str: |
+    SELECT b, COUNT(*) AS c FROM foo GROUP BY b HAVING b > 1;

--- a/test/fixtures/rules/std_rule_cases/AM11.yml
+++ b/test/fixtures/rules/std_rule_cases/AM11.yml
@@ -1,0 +1,125 @@
+rule: AM11
+
+test_invalid_where_reported:
+  fail_str: |
+    SELECT a FROM foo WHERE SUM(x) OVER (PARTITION BY a) > 1;
+
+test_window_function_in_group_by_reported:
+  fail_str: |
+    SELECT a FROM foo GROUP BY SUM(x) OVER (PARTITION BY a);
+
+test_window_function_in_having_reported:
+  fail_str: |
+    SELECT a FROM foo GROUP BY a HAVING SUM(x) OVER (PARTITION BY a) > 1;
+
+test_non_aggregate_window_function_in_where_reported:
+  fail_str: |
+    SELECT a FROM foo WHERE ROW_NUMBER() OVER (ORDER BY a) = 1;
+
+test_window_nested_in_scalar_where_reported:
+  fail_str: |
+    SELECT a FROM foo WHERE COALESCE(ROW_NUMBER() OVER (ORDER BY a), 0) = 1;
+
+test_count_in_where_reported:
+  fail_str: |
+    SELECT a FROM foo WHERE COUNT(*) > 1;
+
+test_sum_in_where_reported:
+  fail_str: |
+    SELECT a FROM foo WHERE SUM(x) > 10;
+
+test_max_nested_in_where_reported:
+  fail_str: |
+    SELECT a FROM foo WHERE COALESCE(MAX(x), 0) > 10;
+
+test_array_aggregate_in_where_reported:
+  fail_str: |
+    SELECT a FROM foo WHERE ARRAY_AGG(x) IS NOT NULL;
+
+test_avg_in_where_reported:
+  fail_str: |
+    SELECT a FROM foo WHERE AVG(x) > 10;
+
+test_max_in_where_reported:
+  fail_str: |
+    SELECT a FROM foo WHERE MAX(x) > 10;
+
+test_window_inside_aggregate_in_select_reported:
+  fail_str: |
+    SELECT SUM(ROW_NUMBER() OVER (ORDER BY a)) FROM foo;
+
+test_nested_window_inside_aggregate_in_select_reported:
+  fail_str: |
+    SELECT SUM(COALESCE(ROW_NUMBER() OVER (ORDER BY a), 0)) FROM foo;
+
+test_aggregate_inside_window_in_select_no_violation:
+  pass_str: |
+    SELECT SUM(COUNT(*)) OVER () FROM foo;
+
+test_window_function_in_join_on_reported:
+  fail_str: |
+    SELECT t.a FROM t JOIN u ON ROW_NUMBER() OVER (ORDER BY t.a) = u.a;
+
+test_aggregate_in_join_on_reported:
+  fail_str: |
+    SELECT t.a FROM t JOIN u ON COUNT(*) = u.a;
+
+test_aggregate_nested_in_join_on_reported:
+  fail_str: |
+    SELECT t.a FROM t JOIN u ON COALESCE(SUM(t.x), 0) = u.a;
+
+test_plain_join_on_no_violation:
+  pass_str: |
+    SELECT t.a FROM t JOIN u ON COALESCE(t.a, 0) = u.a;
+
+test_window_function_in_select_no_violation:
+  pass_str: |
+    SELECT a, SUM(x) OVER (PARTITION BY a) AS r FROM foo;
+
+test_window_function_in_order_by_no_violation:
+  pass_str: |
+    SELECT a FROM foo ORDER BY SUM(x) OVER (PARTITION BY a);
+
+test_aggregate_legally_in_having_no_violation:
+  pass_str: |
+    SELECT a, COUNT(*) AS c FROM foo GROUP BY a HAVING COUNT(*) > 1;
+
+test_aggregate_legally_in_select_no_violation:
+  pass_str: |
+    SELECT COUNT(*) FROM foo;
+
+test_aggregate_in_subquery_select_list_no_violation:
+  pass_str: |
+    SELECT a FROM foo WHERE a IN (SELECT COUNT(*) FROM bar GROUP BY c);
+
+test_invalid_subquery_where_is_reported:
+  fail_str: |
+    SELECT a FROM foo WHERE a IN (SELECT b FROM bar WHERE COUNT(*) > 1);
+
+test_window_in_subquery_where_is_reported:
+  fail_str: |
+    SELECT a FROM foo WHERE a IN (SELECT b FROM bar WHERE ROW_NUMBER() OVER (ORDER BY b) = 1);
+
+test_window_in_nested_select_is_not_outer_join_on:
+  pass_str: |
+    SELECT t.a FROM t JOIN u ON t.a = (SELECT ROW_NUMBER() OVER (ORDER BY v.a) FROM v);
+
+test_plain_where_no_violation:
+  pass_str: |
+    SELECT a FROM foo WHERE a > 1;
+
+test_plain_group_by_having_no_violation:
+  pass_str: |
+    SELECT a, COUNT(*) FROM foo GROUP BY a HAVING COUNT(*) > 1;
+
+test_aggregate_in_group_by_no_extra_diagnostic:
+  pass_str: |
+    SELECT a FROM foo GROUP BY COUNT(*);
+
+test_no_clauses_at_all_no_violation:
+  pass_str: |
+    SELECT a, b FROM foo;
+
+test_non_select_statement_no_violation:
+  pass_str: |
+    CREATE TABLE foo (id INT, name TEXT);

--- a/test/fixtures/rules/std_rule_cases/AM12.yml
+++ b/test/fixtures/rules/std_rule_cases/AM12.yml
@@ -1,0 +1,121 @@
+rule: AM12
+
+test_forward_reference_reported:
+  fail_str: |
+    WITH first AS (SELECT * FROM later), later AS (SELECT 1 AS x) SELECT * FROM first;
+
+test_self_reference_without_recursive_reported:
+  fail_str: |
+    WITH cte AS (SELECT * FROM cte) SELECT * FROM cte;
+
+test_valid_recursive_self_reference_no_violation:
+  pass_str: |
+    WITH RECURSIVE cte AS (SELECT 1 AS n UNION ALL SELECT n + 1 FROM cte WHERE n < 5) SELECT * FROM cte;
+
+test_mutual_recursion_reported:
+  fail_str: |
+    WITH RECURSIVE a AS (SELECT 1 AS n UNION ALL SELECT n + 1 FROM b WHERE n < 5), b AS (SELECT 1 AS n UNION ALL SELECT n + 1 FROM a WHERE n < 5) SELECT * FROM a;
+
+test_earlier_sibling_reference_no_violation:
+  pass_str: |
+    WITH cte1 AS (SELECT 1 AS x), cte2 AS (SELECT * FROM cte1) SELECT * FROM cte2;
+
+test_nested_with_shadows_outer_name_no_violation:
+  pass_str: |
+    WITH cte1 AS (SELECT 1 AS x) SELECT * FROM (WITH cte1 AS (SELECT 2 AS x) SELECT * FROM cte1) t;
+
+test_three_way_cycle_reported:
+  fail_str: |
+    WITH cte1 AS (SELECT * FROM cte3), cte2 AS (SELECT * FROM cte1), cte3 AS (SELECT * FROM cte2) SELECT * FROM cte3;
+
+test_forward_reference_inside_subquery_reported:
+  fail_str: |
+    WITH cte1 AS (SELECT * FROM (SELECT * FROM cte2) inner_sq), cte2 AS (SELECT 1 AS x) SELECT * FROM cte1;
+
+test_final_query_reference_via_subquery_no_violation:
+  pass_str: |
+    WITH cte1 AS (SELECT 1 AS x) SELECT * FROM (SELECT * FROM cte1) t;
+
+test_two_independent_recursive_ctes_no_violation:
+  pass_str: |
+    WITH RECURSIVE a AS (SELECT 1 AS n UNION ALL SELECT n + 1 FROM a WHERE n < 3), b AS (SELECT 1 AS n UNION ALL SELECT n + 1 FROM b WHERE n < 3) SELECT * FROM a, b;
+
+test_case_insensitive_name_forward_reference_reported:
+  fail_str: |
+    WITH first AS (SELECT * FROM LATER), later AS (SELECT 1 AS x) SELECT * FROM first;
+
+test_quoted_name_case_sensitivity_no_violation:
+  pass_str: |
+    WITH "Later" AS (SELECT 1 AS x), first AS (SELECT * FROM "later") SELECT * FROM first;
+
+test_qualified_reference_not_treated_as_cte:
+  pass_str: |
+    WITH cte1 AS (SELECT * FROM other_schema.cte2), cte2 AS (SELECT 1 AS x) SELECT * FROM cte1;
+
+test_reference_to_real_table_no_violation:
+  pass_str: |
+    WITH cte1 AS (SELECT * FROM some_real_table) SELECT * FROM cte1;
+
+test_single_cte_no_self_reference_no_violation:
+  pass_str: |
+    WITH cte1 AS (SELECT * FROM foo) SELECT * FROM cte1;
+
+test_no_with_clause_no_violation:
+  pass_str: |
+    SELECT * FROM foo;
+
+test_non_select_statement_no_violation:
+  pass_str: |
+    CREATE TABLE foo (id INT);
+
+test_self_reference_in_join_reported:
+  fail_str: |
+    WITH cte AS (SELECT a.x FROM foo a JOIN cte b ON a.x = b.x) SELECT * FROM cte;
+
+test_recursive_keyword_present_but_only_linear_refs_no_violation:
+  pass_str: |
+    WITH RECURSIVE cte1 AS (SELECT 1 AS x), cte2 AS (SELECT * FROM cte1) SELECT * FROM cte2;
+
+test_recursive_keyword_does_not_permit_forward_reference:
+  fail_str: |
+    WITH RECURSIVE first AS (SELECT * FROM later), later AS (SELECT 1 AS x) SELECT * FROM first;
+
+test_deeply_nested_with_still_isolates_scope:
+  pass_str: |
+    WITH outer_cte AS (SELECT 1 AS x) SELECT * FROM (  SELECT * FROM (    WITH outer_cte AS (SELECT 2 AS x) SELECT * FROM outer_cte  ) inner_t) outer_t;
+
+test_cte_with_column_list_forward_reference_reported:
+  fail_str: |
+    WITH first (a) AS (SELECT * FROM later), later (a) AS (SELECT 1 AS x) SELECT * FROM first;
+
+test_multiple_legal_siblings_no_violation:
+  pass_str: |
+    WITH a AS (SELECT 1 AS x), b AS (SELECT * FROM a), c AS (SELECT * FROM a JOIN b ON TRUE) SELECT * FROM c;
+
+test_recursive_step_can_still_reference_earlier_sibling:
+  pass_str: |
+    WITH RECURSIVE bound AS (SELECT 5 AS n), counter AS (SELECT 1 AS n UNION ALL SELECT counter.n + 1 FROM counter, bound WHERE counter.n < bound.n) SELECT * FROM counter;
+
+test_earlier_sibling_reference_alphabetically_later_name_no_violation:
+  pass_str: |
+    WITH zzz_first AS (SELECT 1 AS x), aaa_second AS (SELECT * FROM zzz_first) SELECT * FROM aaa_second;
+
+test_forward_reference_alphabetically_earlier_name_reported:
+  fail_str: |
+    WITH zzz_first AS (SELECT * FROM aaa_second), aaa_second AS (SELECT 1 AS x) SELECT * FROM zzz_first;
+
+test_quoted_name_genuine_forward_reference_reported:
+  fail_str: |
+    WITH "first" AS (SELECT * FROM "later"), "later" AS (SELECT 1 AS x) SELECT * FROM "first";
+
+test_self_reference_via_subquery_without_recursive_reported:
+  fail_str: |
+    WITH cte AS (SELECT * FROM (SELECT * FROM cte) inner_sq) SELECT * FROM cte;
+
+test_later_positioned_cte_self_reference_without_recursive_reported:
+  fail_str: |
+    WITH cte1 AS (SELECT 1 AS x), cte2 AS (SELECT * FROM cte2) SELECT * FROM cte2;
+
+test_valid_self_reference_does_not_mask_sibling_forward_reference:
+  fail_str: |
+    WITH RECURSIVE a AS (SELECT 1 AS n UNION ALL SELECT n + 1 FROM a WHERE n < 3), b AS (SELECT * FROM c), c AS (SELECT 1 AS x) SELECT * FROM a, b;

--- a/test/rules/std_AM10_test.py
+++ b/test/rules/std_AM10_test.py
@@ -1,0 +1,76 @@
+"""Tests the python routines within AM10."""
+
+import sqlfluff
+
+
+def test__rules__std_AM10_invalid_projection() -> None:
+    """A bare column outside an aggregate, not a grouping key, is flagged."""
+    sql = """
+    SELECT a, b, COUNT(*) AS c
+    FROM foo
+    GROUP BY b;
+    """
+    result = sqlfluff.lint(sql)
+
+    results_AM10 = [r for r in result if r["code"] == "AM10"]
+    assert len(results_AM10) >= 1
+
+
+def test__rules__std_AM10_grouped_column_no_violation() -> None:
+    """A column that is itself a plain grouping key is fine."""
+    sql = """
+    SELECT b, COUNT(*) AS c
+    FROM foo
+    GROUP BY b;
+    """
+    result = sqlfluff.lint(sql)
+
+    results_AM10 = [r for r in result if r["code"] == "AM10"]
+    assert len(results_AM10) == 0
+
+
+def test__rules__std_AM10_computed_key_reuse_no_violation() -> None:
+    """The full computed grouping expression may be reused in the projection.
+
+    This holds through cosmetic parenthesis or whitespace differences, but
+    that does not make an additional bare component column valid on its own.
+    """
+    reused = sqlfluff.lint("SELECT a + b AS key, COUNT(*) FROM foo GROUP BY a + b;")
+    assert len([r for r in reused if r["code"] == "AM10"]) == 0
+
+    parenthesized = sqlfluff.lint("SELECT (a + b), COUNT(*) FROM foo GROUP BY a + b;")
+    assert len([r for r in parenthesized if r["code"] == "AM10"]) == 0
+
+    extra_column = sqlfluff.lint("SELECT a + b + c, COUNT(*) FROM foo GROUP BY a + b;")
+    assert len([r for r in extra_column if r["code"] == "AM10"]) >= 1
+
+
+def test__rules__std_AM10_quoted_identifier_case_sensitivity() -> None:
+    """Quoted identifiers are compared case-sensitively, unlike bare ones."""
+    result = sqlfluff.lint('SELECT "A", COUNT(*) AS c FROM foo GROUP BY "a";')
+
+    results_AM10 = [r for r in result if r["code"] == "AM10"]
+    assert len(results_AM10) >= 1
+
+
+def test__rules__std_AM10_window_function_no_violation() -> None:
+    """A windowed aggregate does not collapse rows, so it is exempt."""
+    sql = """
+    SELECT a, SUM(x) OVER (PARTITION BY a) AS running
+    FROM foo;
+    """
+    result = sqlfluff.lint(sql)
+
+    results_AM10 = [r for r in result if r["code"] == "AM10"]
+    assert len(results_AM10) == 0
+
+
+def test__rules__std_AM10_non_select_statement_integration() -> None:
+    """Non-SELECT statements should never trigger AM10."""
+    sql = """
+    CREATE TABLE foo (id INT, name TEXT);
+    """
+    result = sqlfluff.lint(sql)
+
+    results_AM10 = [r for r in result if r["code"] == "AM10"]
+    assert len(results_AM10) == 0

--- a/test/rules/std_AM11_test.py
+++ b/test/rules/std_AM11_test.py
@@ -1,0 +1,60 @@
+"""Tests the python routines within AM11."""
+
+import sqlfluff
+
+
+def test__rules__std_AM11_window_in_where_reported() -> None:
+    """A window function may not be evaluated inside a row filter."""
+    sql = "SELECT a FROM foo WHERE ROW_NUMBER() OVER (ORDER BY a) = 1;"
+    result = sqlfluff.lint(sql)
+
+    results_AM11 = [r for r in result if r["code"] == "AM11"]
+    assert len(results_AM11) >= 1
+
+
+def test__rules__std_AM11_aggregate_in_where_reported() -> None:
+    """A non-window aggregate may not be evaluated inside a row filter."""
+    sql = "SELECT a FROM foo WHERE COUNT(*) > 1;"
+    result = sqlfluff.lint(sql)
+
+    results_AM11 = [r for r in result if r["code"] == "AM11"]
+    assert len(results_AM11) >= 1
+
+
+def test__rules__std_AM11_aggregate_in_having_no_violation() -> None:
+    """Aggregates remain legal in HAVING, unlike WHERE."""
+    sql = "SELECT a, COUNT(*) FROM foo GROUP BY a HAVING COUNT(*) > 1;"
+    result = sqlfluff.lint(sql)
+
+    results_AM11 = [r for r in result if r["code"] == "AM11"]
+    assert len(results_AM11) == 0
+
+
+def test__rules__std_AM11_window_in_select_no_violation() -> None:
+    """Window functions remain legal in SELECT and ORDER BY."""
+    sql = "SELECT a, SUM(x) OVER (PARTITION BY a) AS r FROM foo;"
+    result = sqlfluff.lint(sql)
+
+    results_AM11 = [r for r in result if r["code"] == "AM11"]
+    assert len(results_AM11) == 0
+
+
+def test__rules__std_AM11_window_inside_aggregate_reported() -> None:
+    """A window function nested inside a non-window aggregate is illegal.
+
+    The reverse nesting, an aggregate inside a window, remains fine.
+    """
+    illegal = sqlfluff.lint("SELECT SUM(ROW_NUMBER() OVER (ORDER BY a)) FROM foo;")
+    assert len([r for r in illegal if r["code"] == "AM11"]) >= 1
+
+    legal = sqlfluff.lint("SELECT SUM(COUNT(*)) OVER () FROM foo;")
+    assert len([r for r in legal if r["code"] == "AM11"]) == 0
+
+
+def test__rules__std_AM11_non_select_statement_integration() -> None:
+    """Non-SELECT statements should never trigger AM11."""
+    sql = "CREATE TABLE foo (id INT, name TEXT);"
+    result = sqlfluff.lint(sql)
+
+    results_AM11 = [r for r in result if r["code"] == "AM11"]
+    assert len(results_AM11) == 0

--- a/test/rules/std_AM12_test.py
+++ b/test/rules/std_AM12_test.py
@@ -1,0 +1,70 @@
+"""Tests the python routines within AM12."""
+
+import sqlfluff
+
+
+def test__rules__std_AM12_forward_reference_reported() -> None:
+    """A CTE may not reference a sibling defined later in the same block."""
+    sql = "WITH first AS (SELECT * FROM later), later AS (SELECT 1 AS x) SELECT * FROM first;"
+    result = sqlfluff.lint(sql)
+
+    results_AM12 = [r for r in result if r["code"] == "AM12"]
+    assert len(results_AM12) >= 1
+
+
+def test__rules__std_AM12_earlier_sibling_no_violation() -> None:
+    """Referencing an earlier sibling is exactly what CTEs are for."""
+    sql = "WITH first AS (SELECT 1 AS x), later AS (SELECT * FROM first) SELECT * FROM later;"
+    result = sqlfluff.lint(sql)
+
+    results_AM12 = [r for r in result if r["code"] == "AM12"]
+    assert len(results_AM12) == 0
+
+
+def test__rules__std_AM12_self_reference_without_recursive_reported() -> None:
+    """A CTE referencing itself needs WITH RECURSIVE."""
+    sql = "WITH cte AS (SELECT * FROM cte) SELECT * FROM cte;"
+    result = sqlfluff.lint(sql)
+
+    results_AM12 = [r for r in result if r["code"] == "AM12"]
+    assert len(results_AM12) >= 1
+
+
+def test__rules__std_AM12_recursive_self_reference_no_violation() -> None:
+    """WITH RECURSIVE legalizes a genuine self-reference.
+
+    It does not, however, legalize a forward reference to a different,
+    later sibling.
+    """
+    legal = sqlfluff.lint(
+        "WITH RECURSIVE cte AS (SELECT 1 AS n UNION ALL SELECT n + 1 FROM cte "
+        "WHERE n < 3) SELECT * FROM cte;"
+    )
+    assert len([r for r in legal if r["code"] == "AM12"]) == 0
+
+    still_illegal = sqlfluff.lint(
+        "WITH RECURSIVE first AS (SELECT * FROM later), later AS (SELECT 1 AS x) "
+        "SELECT * FROM first;"
+    )
+    assert len([r for r in still_illegal if r["code"] == "AM12"]) >= 1
+
+
+def test__rules__std_AM12_nested_with_shadows_outer_scope_no_violation() -> None:
+    """A nested WITH block starts its own scope and may reuse an outer name."""
+    sql = (
+        "WITH outer_cte AS (WITH outer_cte AS (SELECT 1 AS x) "
+        "SELECT * FROM outer_cte) SELECT * FROM outer_cte;"
+    )
+    result = sqlfluff.lint(sql)
+
+    results_AM12 = [r for r in result if r["code"] == "AM12"]
+    assert len(results_AM12) == 0
+
+
+def test__rules__std_AM12_non_select_statement_integration() -> None:
+    """Non-SELECT statements should never trigger AM12."""
+    sql = "CREATE TABLE foo (id INT, name TEXT);"
+    result = sqlfluff.lint(sql)
+
+    results_AM12 = [r for r in result if r["code"] == "AM12"]
+    assert len(results_AM12) == 0


### PR DESCRIPTION
## Summary

Three new rules in the `ambiguous` family (AM01-AM09 already exist), following
the same `BaseRule` / `SegmentSeekerCrawler` idiom as the existing rules:

- **AM10** — flags a column reference in `SELECT`/`HAVING` that is outside an
  aggregate and is not a valid grouping key: either a bare column not directly
  present in `GROUP BY`, or a component of a computed grouping expression
  rather than the full expression itself. Also flags nested non-window
  aggregates. A windowed aggregate is exempt, since it doesn't collapse rows.
- **AM11** — flags a window function used in `WHERE`, `JOIN ... ON`,
  `GROUP BY`, or `HAVING` (none of these clauses have access to a window's
  result at evaluation time); a non-window aggregate used in `WHERE` or
  `JOIN ... ON`; and a window function nested inside a non-window aggregate
  in `SELECT` (the reverse nesting is fine).
- **AM12** — flags a common table expression referencing a sibling defined
  later in the same `WITH` block, or referencing itself without
  `WITH RECURSIVE`. `WITH RECURSIVE` legalizes self-reference but not a
  forward reference to a different sibling.

All three respect per-query-level scope isolation — a subquery does not leak
into its enclosing clause's check — and AM12 additionally respects CTE-scope
shadowing, where a nested `WITH` block's own names take precedence over an
enclosing block's names of the same spelling.

## Test plan
- [x] New YAML fixture cases in `test/fixtures/rules/std_rule_cases/AM10.yml`,
      `AM11.yml`, `AM12.yml` (102 cases total)
- [x] New integration-style tests in `test/rules/std_AM10_test.py`,
      `std_AM11_test.py`, `std_AM12_test.py`
- [x] Full existing test suite passes with no regressions (2768 passed)
- [x] `ruff check`, `ruff format --check`, and `mypy` all clean on the new files

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds three new `ambiguous` family lint rules: AM10 for invalid aggregate projections, AM11 for window/aggregate functions in clauses that run before they compute, and AM12 for CTE references to later or self-referencing siblings without `WITH RECURSIVE`. All respect subquery scope isolation, and AM12 also respects CTE name shadowing.

- AM10 flags bare columns or partial computed grouping expressions in `SELECT`/`HAVING` that aren't valid grouping keys, and nested non-window aggregates.
- AM11 flags window functions in `WHERE`, `JOIN ... ON`, `GROUP BY`, or `HAVING`, aggregates in `WHERE`/`JOIN ... ON`, and windows nested inside aggregates.
- AM12 flags CTEs referencing later siblings or self-referencing without `WITH RECURSIVE`; `WITH RECURSIVE` only permits self-reference, not forward or mutual references.
- Adds YAML fixture cases and integration tests for all three rules; full test suite passes.

<sup>Written for commit 0933785719b269ced91704f8edba63ac1702552e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8467?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

