### PR TITLE
fix(snowflake): stop scripting IF terminators leaking into CASE expressions

### DIFF
--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -11789,7 +11789,7 @@ class ScriptingIfStatementSegment(BaseSegment):
             AnyNumberOf(
                 Sequence(
                     Ref("DelimiterGrammar"),
-                    Ref("StatementSegment"),
+                    Ref("StatementSegment", reset_terminators=True),
                 ),
                 terminators=[
                     "ELSEIF",
@@ -11810,7 +11810,7 @@ class ScriptingIfStatementSegment(BaseSegment):
                 AnyNumberOf(
                     Sequence(
                         Ref("DelimiterGrammar"),
-                        Ref("StatementSegment"),
+                        Ref("StatementSegment", reset_terminators=True),
                     ),
                     terminators=[
                         "ELSEIF",
@@ -11834,7 +11834,7 @@ class ScriptingIfStatementSegment(BaseSegment):
                 AnyNumberOf(
                     Sequence(
                         Ref("DelimiterGrammar"),
-                        Ref("StatementSegment"),
+                        Ref("StatementSegment", reset_terminators=True),
                     ),
                     terminators=[
                         Sequence("END", "IF"),

--- a/test/fixtures/dialects/snowflake/if_statement_case_expression.sql
+++ b/test/fixtures/dialects/snowflake/if_statement_case_expression.sql
@@ -1,0 +1,16 @@
+-- Regression test: a CASE expression inside a non-first statement of an
+-- IF/ELSEIF/ELSE scripting block used to be truncated at its own ELSE,
+-- because the block's ELSEIF/ELSE/END IF terminators leaked into the
+-- statement match.
+BEGIN
+    IF (1 = 1) THEN
+        SELECT 1;
+        SELECT CASE WHEN 1 = 1 THEN 'a' ELSE 'b' END;
+    ELSEIF (2 = 2) THEN
+        SELECT 2;
+        SELECT CASE WHEN 2 = 2 THEN 'c' ELSE 'd' END;
+    ELSE
+        SELECT 3;
+        SELECT CASE WHEN 3 = 3 THEN 'e' ELSE 'f' END;
+    END IF;
+END;

--- a/test/fixtures/dialects/snowflake/if_statement_case_expression.yml
+++ b/test/fixtures/dialects/snowflake/if_statement_case_expression.yml
@@ -1,0 +1,131 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 32cb4d3d3af9e579f50a5b5ce2f305f36f089b8de9d96bd5224bf651f8c15dac
+file:
+  statement:
+    scripting_block_statement:
+    - keyword: BEGIN
+    - statement:
+        scripting_if_statement:
+        - keyword: IF
+        - bracketed:
+            start_bracket: (
+            expression:
+            - numeric_literal: '1'
+            - comparison_operator:
+                raw_comparison_operator: '='
+            - numeric_literal: '1'
+            end_bracket: )
+        - keyword: THEN
+        - statement:
+            select_statement:
+              select_clause:
+                keyword: SELECT
+                select_clause_element:
+                  numeric_literal: '1'
+        - statement_terminator: ;
+        - statement:
+            select_statement:
+              select_clause:
+                keyword: SELECT
+                select_clause_element:
+                  expression:
+                    case_expression:
+                    - keyword: CASE
+                    - when_clause:
+                      - keyword: WHEN
+                      - expression:
+                        - numeric_literal: '1'
+                        - comparison_operator:
+                            raw_comparison_operator: '='
+                        - numeric_literal: '1'
+                      - keyword: THEN
+                      - expression:
+                          quoted_literal: "'a'"
+                    - else_clause:
+                        keyword: ELSE
+                        expression:
+                          quoted_literal: "'b'"
+                    - keyword: END
+        - statement_terminator: ;
+        - keyword: ELSEIF
+        - bracketed:
+            start_bracket: (
+            expression:
+            - numeric_literal: '2'
+            - comparison_operator:
+                raw_comparison_operator: '='
+            - numeric_literal: '2'
+            end_bracket: )
+        - keyword: THEN
+        - statement:
+            select_statement:
+              select_clause:
+                keyword: SELECT
+                select_clause_element:
+                  numeric_literal: '2'
+        - statement_terminator: ;
+        - statement:
+            select_statement:
+              select_clause:
+                keyword: SELECT
+                select_clause_element:
+                  expression:
+                    case_expression:
+                    - keyword: CASE
+                    - when_clause:
+                      - keyword: WHEN
+                      - expression:
+                        - numeric_literal: '2'
+                        - comparison_operator:
+                            raw_comparison_operator: '='
+                        - numeric_literal: '2'
+                      - keyword: THEN
+                      - expression:
+                          quoted_literal: "'c'"
+                    - else_clause:
+                        keyword: ELSE
+                        expression:
+                          quoted_literal: "'d'"
+                    - keyword: END
+        - statement_terminator: ;
+        - keyword: ELSE
+        - statement:
+            select_statement:
+              select_clause:
+                keyword: SELECT
+                select_clause_element:
+                  numeric_literal: '3'
+        - statement_terminator: ;
+        - statement:
+            select_statement:
+              select_clause:
+                keyword: SELECT
+                select_clause_element:
+                  expression:
+                    case_expression:
+                    - keyword: CASE
+                    - when_clause:
+                      - keyword: WHEN
+                      - expression:
+                        - numeric_literal: '3'
+                        - comparison_operator:
+                            raw_comparison_operator: '='
+                        - numeric_literal: '3'
+                      - keyword: THEN
+                      - expression:
+                          quoted_literal: "'e'"
+                    - else_clause:
+                        keyword: ELSE
+                        expression:
+                          quoted_literal: "'f'"
+                    - keyword: END
+        - statement_terminator: ;
+        - keyword: END
+        - keyword: IF
+    - statement_terminator: ;
+    - keyword: END
+  statement_terminator: ;


### PR DESCRIPTION
### Brief summary of the change made

In `ScriptingIfStatementSegment` (Snowflake `IF ... ELSEIF ... ELSE ... END IF`
scripting blocks), statements after the first one in each branch are matched
inside an `AnyNumberOf` bounded by the bare-keyword terminators `ELSEIF`,
`ELSE`, and `END` + `IF`. Those terminators were being inherited into the
match of the nested `StatementSegment`, so a `CASE` expression's own `ELSE`
(e.g. `CASE WHEN x THEN 1 ELSE 2 END`) was mistaken for the branch's `ELSE`,
truncating the statement and leaving the rest of the block unparsable.

Example that previously failed to parse:

```sql
BEGIN
    IF (1 = 1) THEN
        SELECT 1;
        SELECT CASE WHEN 1 = 1 THEN 'a' ELSE 'b' END;
    END IF;
END;
```

Fix: add `reset_terminators=True` to the `StatementSegment` refs inside the
IF/ELSEIF/ELSE branch-continuation loops, so nested expressions get their
own terminator scope instead of inheriting the IF statement's.

### Are there any other side effects of this change that we should be aware of?

None expected — this only affects statements after the first one within an
IF/ELSEIF/ELSE branch of a Snowflake scripting block. Ran the full
`test/dialects` suite (all dialects, 6800 tests) with no regressions.

### Pull Request checklist
- [x] Included test cases to demonstrate any code changes
  - Added `test/fixtures/dialects/snowflake/if_statement_case_expression.sql`
    (+ generated `.yml`) covering a `CASE` expression as a non-first
    statement in the `IF`, `ELSEIF`, and `ELSE` branches.
- [x] Added appropriate documentation for the change — n/a, bugfix only.
- [x] Created GitHub issues for any relevant followup/future enhancements if
  appropriate — n/a.

### AI-assisted contribution disclosure

This fix was investigated and prepared with AI assistance (Claude Code). The
bug was discovered while linting a real Snowflake migration script; the
minimal reproduction, root-cause analysis of the terminator-inheritance
behavior, the fix, and the regression test were all validated by running the
existing dialect test suite locally before opening this PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Snowflake parsing where `CASE` expressions in scripting `IF`/`ELSEIF`/`ELSE` branches were truncated at the CASE's own `ELSE`, leaving the rest of the block unparsable.

**Bug Fixes**
- Adds `reset_terminators=True` to the branch `StatementSegment` refs so IF branch terminators don't leak into nested expressions.
- Extracts the repeated branch body into a shared helper and consumes each statement with its delimiter.
- Adds a regression fixture covering CASE in each branch, including nested and multi-statement branches.

<sup>Written for commit 27c86b79a00ae67f7447b99c8642fac19fe51dd6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8468?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

