### PR TITLE
fix(snowflake): allow CREATE STREAM APPEND_ONLY/SHOW_INITIAL_ROWS in either order

### DIFF
--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -9230,17 +9230,17 @@ class CreateStreamStatementSegment(BaseSegment):
                     Ref("FromBeforeExpressionSegment"),
                     optional=True,
                 ),
-                Sequence(
-                    "APPEND_ONLY",
-                    Ref("EqualsSegment"),
-                    Ref("BooleanLiteralGrammar"),
-                    optional=True,
-                ),
-                Sequence(
-                    "SHOW_INITIAL_ROWS",
-                    Ref("EqualsSegment"),
-                    Ref("BooleanLiteralGrammar"),
-                    optional=True,
+                AnySetOf(
+                    Sequence(
+                        "APPEND_ONLY",
+                        Ref("EqualsSegment"),
+                        Ref("BooleanLiteralGrammar"),
+                    ),
+                    Sequence(
+                        "SHOW_INITIAL_ROWS",
+                        Ref("EqualsSegment"),
+                        Ref("BooleanLiteralGrammar"),
+                    ),
                 ),
             ),
             Sequence(

--- a/test/fixtures/dialects/snowflake/create_stream.sql
+++ b/test/fixtures/dialects/snowflake/create_stream.sql
@@ -43,3 +43,10 @@ CREATE STREAM IF NOT EXISTS dynamic_table_stream
 ON DYNAMIC TABLE dynamic_table_name
 APPEND_ONLY = FALSE
 COMMENT = 'amazing comment';
+
+-- APPEND_ONLY and SHOW_INITIAL_ROWS are independent optional parameters and
+-- may appear in either order.
+CREATE STREAM IF NOT EXISTS new_stream
+ON TABLE table_name
+SHOW_INITIAL_ROWS = TRUE
+APPEND_ONLY = TRUE;

--- a/test/fixtures/dialects/snowflake/create_stream.yml
+++ b/test/fixtures/dialects/snowflake/create_stream.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: efa482612cfba3aa09da01bd47163402d624e8b39124ecdb94151a4726bcd7c3
+_hash: 09998d3285951115dc54e834a56ae21737a60dbf3d10440972e1b4026cacc1f8
 file:
 - statement:
     create_stream_statement:
@@ -283,4 +283,26 @@ file:
         comparison_operator:
           raw_comparison_operator: '='
         quoted_literal: "'amazing comment'"
+- statement_terminator: ;
+- statement:
+    create_stream_statement:
+    - keyword: CREATE
+    - keyword: STREAM
+    - keyword: IF
+    - keyword: NOT
+    - keyword: EXISTS
+    - object_reference:
+        naked_identifier: new_stream
+    - keyword: 'ON'
+    - keyword: TABLE
+    - object_reference:
+        naked_identifier: table_name
+    - keyword: SHOW_INITIAL_ROWS
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - boolean_literal: 'TRUE'
+    - keyword: APPEND_ONLY
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - boolean_literal: 'TRUE'
 - statement_terminator: ;


### PR DESCRIPTION
### Brief summary of the change made

`CreateStreamStatementSegment` required `APPEND_ONLY` to appear before
`SHOW_INITIAL_ROWS`. Per the [Snowflake CREATE STREAM
docs](https://docs.snowflake.com/en/sql-reference/sql/create-stream), these
are independent optional parameters, and Snowflake accepts them in either
order. As a result, valid Snowflake syntax such as:

```sql
CREATE STREAM IF NOT EXISTS s ON TABLE t
    SHOW_INITIAL_ROWS = TRUE
    APPEND_ONLY = TRUE;
```

produced an unparsable section.

Fix: switch the fixed-order `Sequence` for `AnySetOf` (already used
extensively elsewhere in this dialect for the same unordered-optional-clause
pattern), so either ordering parses correctly.

### Are there any other side effects of this change that we should be aware of?

None expected — this only widens what's accepted for `CREATE STREAM`
parameters and doesn't change previously-accepted syntax.

### Pull Request checklist
- [x] Included test cases to demonstrate any code changes
  - Added a case to `test/fixtures/dialects/snowflake/create_stream.sql`
    (+ regenerated `.yml`) with `SHOW_INITIAL_ROWS` before `APPEND_ONLY`.
- [x] Added appropriate documentation for the change — n/a, bugfix only.
- [x] Created GitHub issues for any relevant followup/future enhancements if
  appropriate — n/a.

### AI-assisted contribution disclosure

This fix was investigated and prepared with AI assistance (Claude Code) while
linting a real Snowflake migration script. The reproduction, root cause
(fixed statement ordering instead of `AnySetOf`), the fix, and the
regression test were validated by running the snowflake dialect test suite
locally before opening this PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Snowflake dialect so `CREATE STREAM` accepts `APPEND_ONLY` and `SHOW_INITIAL_ROWS` in either order, matching Snowflake's actual syntax. Previously, statements with `SHOW_INITIAL_ROWS` before `APPEND_ONLY` failed to parse.

**Bug Fixes**
- Replaces the fixed-order clause sequence with `AnySetOf`, the same pattern used elsewhere in the dialect for unordered optional clauses.
- Adds a regression test covering `SHOW_INITIAL_ROWS` before `APPEND_ONLY`.

<sup>Written for commit c2e0f2a28f71f03fcdedd5237ee0b93d63541b2e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8469?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

