### PR TITLE
fix(snowflake): allow arbitrary expressions in EXECUTE IMMEDIATE

### DIFF
--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -10202,15 +10202,18 @@ class ExecuteImmediateClauseSegment(BaseSegment):
     match_grammar = Sequence(
         "EXECUTE",
         "IMMEDIATE",
-        Ref.keyword("FROM", optional=True),
         OneOf(
-            Ref("QuotedLiteralSegment"),
-            Ref("ReferencedVariableNameSegment"),
-            Ref("StorageLocation"),
             Sequence(
-                Ref("ColonPrefixSegment"),
-                Ref("LocalVariableNameSegment"),
+                "FROM",
+                OneOf(
+                    Ref("StorageLocation"),
+                    Ref("QuotedLiteralSegment"),
+                ),
             ),
+            # A string literal, session/local variable, or any expression
+            # that evaluates to a SQL statement string (e.g. built up via
+            # concatenation with `||`).
+            Ref("ExpressionSegment"),
         ),
         Sequence(
             "USING",

--- a/test/fixtures/dialects/snowflake/execute_immediate.sql
+++ b/test/fixtures/dialects/snowflake/execute_immediate.sql
@@ -23,3 +23,7 @@ EXECUTE IMMEDIATE :three USING (one, two);
 EXECUTE IMMEDIATE FROM './insert-inventory.sql';
 
 EXECUTE IMMEDIATE FROM @my_stage/scripts/create-inventory.sql;
+
+-- The statement string can also be an arbitrary expression that evaluates
+-- to a string, e.g. built up via concatenation.
+EXECUTE IMMEDIATE 'CREATE OR REPLACE TABLE ' || :backup_table_name || ' AS SELECT * FROM t';

--- a/test/fixtures/dialects/snowflake/execute_immediate.yml
+++ b/test/fixtures/dialects/snowflake/execute_immediate.yml
@@ -3,19 +3,21 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 8617b4deee749e41987f262451ed93214ad7dc49f8eb3a96c19efeb08024066a
+_hash: ba547ecc0b47f1f1c49e00e3270e3c70184b271d5a495890e43cead5eb2240a9
 file:
 - statement:
     execute_immediate_clause:
     - keyword: EXECUTE
     - keyword: IMMEDIATE
-    - quoted_literal: "'select 1'"
+    - expression:
+        quoted_literal: "'select 1'"
 - statement_terminator: ;
 - statement:
     execute_immediate_clause:
     - keyword: EXECUTE
     - keyword: IMMEDIATE
-    - quoted_literal: "$$\n  SELECT PI();\n$$"
+    - expression:
+        quoted_literal: "$$\n  SELECT PI();\n$$"
 - statement_terminator: ;
 - statement:
     set_statement:
@@ -48,13 +50,15 @@ file:
     execute_immediate_clause:
     - keyword: EXECUTE
     - keyword: IMMEDIATE
-    - variable: $pie
+    - expression:
+        variable: $pie
 - statement_terminator: ;
 - statement:
     execute_immediate_clause:
     - keyword: EXECUTE
     - keyword: IMMEDIATE
-    - variable: $pie
+    - expression:
+        variable: $pie
     - keyword: USING
     - bracketed:
       - start_bracket: (
@@ -76,15 +80,19 @@ file:
     execute_immediate_clause:
     - keyword: EXECUTE
     - keyword: IMMEDIATE
-    - colon_prefix: ':'
-    - variable: three
+    - expression:
+        bind_variable:
+          colon_prefix: ':'
+          variable: three
 - statement_terminator: ;
 - statement:
     execute_immediate_clause:
     - keyword: EXECUTE
     - keyword: IMMEDIATE
-    - colon_prefix: ':'
-    - variable: three
+    - expression:
+        bind_variable:
+          colon_prefix: ':'
+          variable: three
     - keyword: USING
     - bracketed:
       - start_bracket: (
@@ -107,4 +115,21 @@ file:
     - keyword: FROM
     - storage_location:
         stage_path: '@my_stage/scripts/create-inventory.sql'
+- statement_terminator: ;
+- statement:
+    execute_immediate_clause:
+    - keyword: EXECUTE
+    - keyword: IMMEDIATE
+    - expression:
+      - quoted_literal: "'CREATE OR REPLACE TABLE '"
+      - binary_operator:
+        - pipe: '|'
+        - pipe: '|'
+      - bind_variable:
+          colon_prefix: ':'
+          variable: backup_table_name
+      - binary_operator:
+        - pipe: '|'
+        - pipe: '|'
+      - quoted_literal: "' AS SELECT * FROM t'"
 - statement_terminator: ;


### PR DESCRIPTION
### Brief summary of the change made

`ExecuteImmediateClauseSegment` only accepted a bare string literal, a
`$session_variable`, a `:local_variable`, or (with `FROM`) a storage
location. Per the [Snowflake EXECUTE IMMEDIATE
docs](https://docs.snowflake.com/en/sql-reference/sql/execute-immediate),
the non-`FROM` form accepts any expression that evaluates to a SQL statement
string, which commonly includes string concatenation, e.g.:

```sql
EXECUTE IMMEDIATE 'CREATE OR REPLACE TABLE ' || :name || ' AS SELECT * FROM t';
```

This was previously an unparsable section, even though it's valid and
common Snowflake scripting syntax (e.g. for dynamically-named backup
tables).

### Are there any other side effects of this change that we should be aware of?

Replaced the closed set of literal/variable alternatives with
`Ref("ExpressionSegment")`, which already covers all previously supported
forms (string literals, `$var`, `:var`) plus general expressions. The
`FROM <path>` form is unaffected apart from also accepting a quoted literal
path (already covered by the existing fixture), not just an unquoted
stage/cloud path — this was needed to keep the existing
`EXECUTE IMMEDIATE FROM './insert-inventory.sql';` fixture case parsing.

The AST shape for the simple literal cases changes slightly (the literal is
now wrapped in an `expression` node, consistent with how other clauses in
the dialect represent expressions), so the existing `execute_immediate.yml`
fixture was regenerated.

### Pull Request checklist
- [x] Included test cases to demonstrate any code changes
  - Extended `test/fixtures/dialects/snowflake/execute_immediate.sql`
    (+ regenerated `.yml`) with a concatenation-expression case.
- [x] Added appropriate documentation for the change — n/a, bugfix only.
- [x] Created GitHub issues for any relevant followup/future enhancements if
  appropriate — n/a.

### AI-assisted contribution disclosure

This fix was investigated and prepared with AI assistance (Claude Code)
while linting a real Snowflake migration script. The reproduction, root
cause, the fix, and the regression test were validated by running the
snowflake dialect test suite locally before opening this PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Snowflake `EXECUTE IMMEDIATE` to accept any expression that evaluates to a statement string, so dynamic SQL built with concatenation (e.g. `'CREATE TABLE ' || :name`) now parses. Previously only a literal, session/local variable, or `FROM` storage location was allowed.

**Side effects**
- Simple literals and variables are now wrapped in an `expression` node in the parse tree.
- `FROM` now also accepts quoted literal paths, matching the existing fixture.

<sup>Written for commit 54fa67546dd403ed7458a6b835410e98ec0cb0a1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8470?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

