### PR TITLE
Add multiline-aware CV03 trailing comma policy

### DIFF
--- a/src/sqlfluff/rules/convention/CV03.py
+++ b/src/sqlfluff/rules/convention/CV03.py
@@ -18,6 +18,12 @@ class Rule_CV03(BaseRule):
        as a syntax error, and as such the `SQLFluff` default is to
        forbid trailing commas in the select clause.
 
+       Set ``select_clause_trailing_comma`` to
+       ``require_multiline_forbid_single_line`` to require trailing commas
+       only for multiline SELECT clauses. This uses the rendered SQL from
+       the SELECT keyword through the last target, ignoring trailing comments,
+       whitespace and commas when determining whether a clause is multiline.
+
     **Anti-pattern**
 
     .. code-block:: sql
@@ -54,8 +60,20 @@ class Rule_CV03(BaseRule):
         # Iterate content to find last element
         last_content: BaseSegment = children.last(sp.is_code())[0]
 
-        # What mode are we in?
-        if self.select_clause_trailing_comma == "forbid":
+        # Resolve the policy per clause without changing the configured mode.
+        comma_policy = self.select_clause_trailing_comma
+        if comma_policy == "require_multiline_forbid_single_line":
+            code_segments = segment.raw_segments.select(
+                sp.and_(sp.is_code(), sp.not_(sp.is_type("comma")))
+            )
+            first_code, last_code = code_segments[0], code_segments[-1]
+            assert first_code.pos_marker
+            assert last_code.pos_marker
+            start_line = first_code.pos_marker.working_line_no
+            end_line = last_code.pos_marker.working_loc_after(last_code.raw)[0]
+            comma_policy = "require" if start_line != end_line else "forbid"
+
+        if comma_policy == "forbid":
             # Is it a comma?
             if last_content.is_type("comma"):
                 # The last content is a comma. Before we try and remove it, we
@@ -97,7 +115,7 @@ class Rule_CV03(BaseRule):
                     fixes=fixes,
                     description="Trailing comma in select statement forbidden",
                 )
-        elif self.select_clause_trailing_comma == "require":
+        elif comma_policy == "require":
             if not last_content.is_type("comma"):
                 new_comma = SymbolSegment(",", type="comma")
                 return LintResult(

--- a/src/sqlfluff/rules/convention/__init__.py
+++ b/src/sqlfluff/rules/convention/__init__.py
@@ -15,9 +15,15 @@ def get_configs_info() -> dict[str, ConfigInfo]:
             ),
         },
         "select_clause_trailing_comma": {
-            "validation": ["forbid", "require"],
+            "validation": [
+                "forbid",
+                "require",
+                "require_multiline_forbid_single_line",
+            ],
             "definition": (
-                "Should trailing commas within select clauses be required or forbidden?"
+                "Should trailing commas within select clauses be required, forbidden, "
+                "or required only for multiline clauses and forbidden for single-line "
+                "clauses?"
             ),
         },
         "prefer_count_1": {

--- a/test/fixtures/rules/std_rule_cases/CV03.yml
+++ b/test/fixtures/rules/std_rule_cases/CV03.yml
@@ -62,3 +62,117 @@ test_fail_templated:
     rules:
       convention.select_trailing_comma:
         select_clause_trailing_comma: forbid
+
+test_conditional_pass_single_line:
+  pass_str: |
+    SELECT *
+    FROM foo
+  configs:
+    core:
+      dialect: bigquery
+    rules:
+      convention.select_trailing_comma:
+        select_clause_trailing_comma: require_multiline_forbid_single_line
+
+test_conditional_pass_multiline:
+  pass_str: |
+    SELECT
+        a,
+        b,
+    FROM foo
+  configs:
+    core:
+      dialect: bigquery
+    rules:
+      convention.select_trailing_comma:
+        select_clause_trailing_comma: require_multiline_forbid_single_line
+
+test_conditional_fail_single_line:
+  fail_str: SELECT a, b, FROM foo
+  fix_str: SELECT a, b FROM foo
+  configs:
+    core:
+      dialect: bigquery
+    rules:
+      convention.select_trailing_comma:
+        select_clause_trailing_comma: require_multiline_forbid_single_line
+
+test_conditional_fail_multiline_with_comment:
+  fail_str: |
+    SELECT
+        a,
+        b -- Keep this comment.
+    FROM foo
+  fix_str: |
+    SELECT
+        a,
+        b, -- Keep this comment.
+    FROM foo
+  configs:
+    core:
+      dialect: bigquery
+    rules:
+      convention.select_trailing_comma:
+        select_clause_trailing_comma: require_multiline_forbid_single_line
+
+test_conditional_fail_multiline_expression:
+  fail_str: |
+    SELECT COALESCE(
+        a, b
+    ) FROM foo
+  fix_str: |
+    SELECT COALESCE(
+        a, b
+    ), FROM foo
+  configs:
+    core:
+      dialect: bigquery
+    rules:
+      convention.select_trailing_comma:
+        select_clause_trailing_comma: require_multiline_forbid_single_line
+
+test_conditional_fail_mixed_nested_clauses:
+  fail_str: |
+    SELECT b, FROM (
+        SELECT
+            b
+        FROM bar
+    ) AS sub
+    UNION ALL
+    SELECT c, FROM baz
+  fix_str: |
+    SELECT b FROM (
+        SELECT
+            b,
+        FROM bar
+    ) AS sub
+    UNION ALL
+    SELECT c FROM baz
+  configs:
+    core:
+      dialect: bigquery
+    rules:
+      convention.select_trailing_comma:
+        select_clause_trailing_comma: require_multiline_forbid_single_line
+
+test_conditional_fail_comma_on_own_line:
+  # Removing the comma must not change the single-line classification.
+  fail_str: "SELECT a\n    ,\nFROM foo\n"
+  fix_str: "SELECT a\n    \nFROM foo\n"
+  configs:
+    core:
+      dialect: bigquery
+    rules:
+      convention.select_trailing_comma:
+        select_clause_trailing_comma: require_multiline_forbid_single_line
+
+test_conditional_fail_templated_no_fix:
+  # Without fix_str, the harness asserts that the source is unchanged.
+  fail_str: |
+    SELECT {% for col in ['a', 'b', 'c'] %}{{col}}, {% endfor %} FROM tbl
+  configs:
+    core:
+      dialect: bigquery
+    rules:
+      convention.select_trailing_comma:
+        select_clause_trailing_comma: require_multiline_forbid_single_line


### PR DESCRIPTION
## Summary
- add require_multiline_forbid_single_line to CV03
- require a trailing comma for multiline select clauses and forbid it for single-line clauses
- determine multiline layout from rendered code while ignoring the trailing comma and non-code segments

Closes #4574

## Tests
- all YAML rule cases (2,489 passed)
- pre-commit hooks for all changed files

AI assistance was used to draft the initial patch and tests. I manually reviewed the implementation, adjusted it to the current codebase, and ran the checks above.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new `select_clause_trailing_comma` policy, `require_multiline_forbid_single_line`, that requires trailing commas for multiline SELECT clauses and forbids them for single-line clauses. Multiline detection uses the rendered SQL from the SELECT keyword through the last target, ignoring comments, whitespace, and commas.

**New Features**
- New config value `require_multiline_forbid_single_line` added to `select_clause_trailing_comma`, alongside existing `forbid` and `require`.
- Templated SELECT clauses are flagged but not auto-fixed, leaving the source unchanged.
- All existing YAML rule cases pass (2,489 tests).

<sup>Written for commit 4632ec57e51a9b06b5ceedbc9fec9e07d5065220. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8473?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

