### PR TITLE
Oracle: parse division inside CREATE VIEW ... AS SELECT

### DIFF
--- a/src/sqlfluff/dialects/dialect_oracle.py
+++ b/src/sqlfluff/dialects/dialect_oracle.py
@@ -3,6 +3,10 @@
 This inherits from the ansi dialect.
 """
 
+# Aliased: `Sequence` in this module is the grammar class.
+from collections.abc import Sequence as SequenceABC
+from typing import Optional
+
 from sqlfluff.core.dialects import load_raw_dialect
 from sqlfluff.core.parser import (
     AnyNumberOf,
@@ -38,10 +42,13 @@ from sqlfluff.core.parser import (
     TypedParser,
     WordSegment,
 )
+from sqlfluff.core.parser.context import ParseContext
 from sqlfluff.core.parser.grammar.lookbehind import (
     PrecededByMatcher,
     is_distinct_from_lookbehind,
 )
+from sqlfluff.core.parser.match_result import MatchResult
+from sqlfluff.core.parser.types import SimpleHintType
 from sqlfluff.dialects import dialect_ansi as ansi
 from sqlfluff.dialects.dialect_oracle_keywords import (
     oracle_reserved_keywords,
@@ -1502,6 +1509,55 @@ class SlashBufferExecutorSegment(BaseSegment):
     match_grammar = Ref("SlashSegment")
 
 
+class SharesLineWithCodeMatcher(Matchable):
+    """Matches a segment that has other code on the same line.
+
+    SQL*Plus only runs the buffer for a `/` that is alone on its line. Used as
+    an ``exclude`` on the batch delimiter, this stops the division operator in
+    ``1 / 100`` from being taken for one.
+    """
+
+    def is_optional(self) -> bool:  # pragma: no cover
+        """A lookaround matcher is never optional."""
+        return False
+
+    def simple(
+        self, parse_context: ParseContext, crumbs: Optional[tuple[str, ...]] = None
+    ) -> SimpleHintType:  # pragma: no cover
+        """This element doesn't work with simple."""
+        return None
+
+    def cache_key(self) -> str:  # pragma: no cover
+        """Get the cache key for the matcher."""
+        return "shares-line-with-code"
+
+    @staticmethod
+    def _code_before_newline(
+        segments: SequenceABC[BaseSegment], idx: int, step: int
+    ) -> bool:
+        """Walk from ``idx`` in ``step`` direction until a newline or code."""
+        while 0 <= idx < len(segments):
+            if segments[idx].is_type("newline"):
+                return False
+            if segments[idx].is_code and not segments[idx].is_meta:
+                return True
+            idx += step
+        return False
+
+    def match(
+        self,
+        segments: SequenceABC[BaseSegment],
+        idx: int,
+        parse_context: ParseContext,
+    ) -> MatchResult:
+        """Match if there is code before or after ``idx`` on its line."""
+        if self._code_before_newline(
+            segments, idx - 1, -1
+        ) or self._code_before_newline(segments, idx + 1, 1):
+            return MatchResult(slice(idx, idx + 1))
+        return MatchResult.empty_at(idx)
+
+
 class SqlplusSetStatementSegment(BaseSegment):
     """A SQL*Plus `SET` command."""
 
@@ -1611,7 +1667,12 @@ class CreateViewStatementSegment(ansi.CreateViewStatementSegment):
         Ref("BracketedColumnReferenceListGrammar", optional=True),
         "AS",
         OptionallyBracketed(
-            Ref("SelectableGrammar"), terminators=[Ref("BatchDelimiterGrammar")]
+            Ref("SelectableGrammar"),
+            # A `/` only ends the view when it is alone on its line; anywhere
+            # else it is division (`sysdate - 1/24`).
+            terminators=[
+                Ref("BatchDelimiterGrammar", exclude=SharesLineWithCodeMatcher())
+            ],
         ),
         Ref("WithNoSchemaBindingClauseSegment", optional=True),
     )

--- a/test/fixtures/dialects/oracle/create_view_division.sql
+++ b/test/fixtures/dialects/oracle/create_view_division.sql
@@ -1,0 +1,14 @@
+-- A `/` inside a view is division; only one alone on its line is the
+-- SQL*Plus buffer executor (see slash_batch_delimiter.sql).
+CREATE VIEW myview AS
+select 1 / 100 as z from dual;
+
+create or replace view recent_samples as
+select sample_time, nvl(bytes, 0) / 1024 / 1024 as size_mb
+from io_stats
+where sample_time > sysdate - 1/24;
+
+create or replace view ratios as
+select a / b as ratio
+from t
+/

--- a/test/fixtures/dialects/oracle/create_view_division.yml
+++ b/test/fixtures/dialects/oracle/create_view_division.yml
@@ -1,0 +1,126 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: f4fcee153edaa36812af87f3be257328fa68a720081ee171068b4e38f535565a
+file:
+  batch:
+  - statement:
+      create_view_statement:
+      - keyword: CREATE
+      - keyword: VIEW
+      - table_reference:
+          naked_identifier: myview
+      - keyword: AS
+      - select_statement:
+          select_clause:
+            keyword: select
+            select_clause_element:
+              expression:
+              - numeric_literal: '1'
+              - binary_operator: /
+              - numeric_literal: '100'
+              alias_expression:
+                alias_operator:
+                  keyword: as
+                naked_identifier: z
+          from_clause:
+            keyword: from
+            from_expression:
+              from_expression_element:
+                table_expression:
+                  table_reference:
+                    naked_identifier: dual
+  - statement_terminator: ;
+  - statement:
+      create_view_statement:
+      - keyword: create
+      - keyword: or
+      - keyword: replace
+      - keyword: view
+      - table_reference:
+          naked_identifier: recent_samples
+      - keyword: as
+      - select_statement:
+          select_clause:
+          - keyword: select
+          - select_clause_element:
+              column_reference:
+                naked_identifier: sample_time
+          - comma: ','
+          - select_clause_element:
+              expression:
+              - function:
+                  function_name:
+                    function_name_identifier: nvl
+                  function_contents:
+                    bracketed:
+                    - start_bracket: (
+                    - expression:
+                        column_reference:
+                          naked_identifier: bytes
+                    - comma: ','
+                    - expression:
+                        numeric_literal: '0'
+                    - end_bracket: )
+              - binary_operator: /
+              - numeric_literal: '1024'
+              - binary_operator: /
+              - numeric_literal: '1024'
+              alias_expression:
+                alias_operator:
+                  keyword: as
+                naked_identifier: size_mb
+          from_clause:
+            keyword: from
+            from_expression:
+              from_expression_element:
+                table_expression:
+                  table_reference:
+                    naked_identifier: io_stats
+          where_clause:
+            keyword: where
+            expression:
+            - column_reference:
+                naked_identifier: sample_time
+            - comparison_operator:
+                raw_comparison_operator: '>'
+            - bare_function: sysdate
+            - binary_operator: '-'
+            - numeric_literal: '1'
+            - binary_operator: /
+            - numeric_literal: '24'
+  - statement_terminator: ;
+  - statement:
+      create_view_statement:
+      - keyword: create
+      - keyword: or
+      - keyword: replace
+      - keyword: view
+      - table_reference:
+          naked_identifier: ratios
+      - keyword: as
+      - select_statement:
+          select_clause:
+            keyword: select
+            select_clause_element:
+              expression:
+              - column_reference:
+                  naked_identifier: a
+              - binary_operator: /
+              - column_reference:
+                  naked_identifier: b
+              alias_expression:
+                alias_operator:
+                  keyword: as
+                naked_identifier: ratio
+          from_clause:
+            keyword: from
+            from_expression:
+              from_expression_element:
+                table_expression:
+                  table_reference:
+                    naked_identifier: t
+  - slash_buffer_executor:
+      slash: /


### PR DESCRIPTION
### Brief summary of the change made

fixes #8373

#7945 let a SQL*Plus `/` end an Oracle view by adding `BatchDelimiterGrammar` as a terminator of the view's `SELECT`. Terminators are checked at every position in the statement, and a symbol terminator doesn't need whitespace in front of it, so any unbracketed division ended the view: `select 1 / 100 as z from dual` became `select 1`, a `slash_buffer_executor`, and an unparsable remainder. Bracketed division survived only because terminators don't look inside brackets, which is why `(1/24)` and `round(x / 1024)` were fine.

SQL*Plus only runs the buffer for a `/` that is alone on its line, so the terminator now excludes any `/` that shares its line with code. This uses a small lookaround matcher, `SharesLineWithCodeMatcher`, passed as `exclude` on the terminator's `Ref`, the same way `PrecededByMatcher` is used for `IS DISTINCT FROM`. The #7945 case (a `/` on its own line after the view) still terminates it; division goes back to the expression parser.

New fixture `create_view_division.sql` covers the issue's shapes (`1 / 100`, `nvl(bytes, 0) / 1024 / 1024`, `sysdate - 1/24`) plus a view that has division *and* is closed by a standalone `/`. `slash_batch_delimiter.yml` is unchanged.

### Are there any other side effects of this change that we should be aware of?

A `/` after a view on the same line as code (`... from t /`) no longer ends the view. SQL*Plus wouldn't execute that either. The change only touches the `CREATE VIEW` terminator; the file-level batch delimiter is untouched.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects`: `oracle/create_view_division.sql` / `.yml`.

Checked locally: the issue's repro parses without errors; `pytest test/dialects/dialects_test.py -k oracle` passes (306); `ruff check`, `ruff format --check`, mypy, codespell and yamllint are clean on the changed files.

**AI assistance:** I used Claude Code to help trace the regression to #7945 and to draft the matcher. I reproduced the bug and checked every fixture statement with `sqlfluff parse`, and ran the checks above myself.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a regression in Oracle `CREATE VIEW` parsing where a division operator (like `1 / 100`) was incorrectly treated as the SQL*Plus batch delimiter, truncating the view definition. Now only a `/` alone on its line terminates the view, matching SQL*Plus behavior; division is parsed as an expression.

**Bug Fixes**
- Adds a `SharesLineWithCodeMatcher` to exclude `/` that shares its line with code from the `BatchDelimiterGrammar` terminator.
- Adds fixture `create_view_division.sql` covering division in views and an explicit standalone `/` terminator.
- A `/` after code on the same line (e.g., `... from t /`) no longer ends the view, consistent with SQL*Plus; the file-level batch delimiter is unaffected.

<sup>Written for commit bdd8873a1904528abaac0fe39e735eaab778a4e4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8474?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

