### PR TITLE
Fix RF06 unquoting for function name segments

### DIFF
--- a/src/sqlfluff/rules/references/RF06.py
+++ b/src/sqlfluff/rules/references/RF06.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Optional, cast
 
 import regex
 
-from sqlfluff.core.parser import CodeSegment
+from sqlfluff.core.parser import CodeSegment, WordSegment
 from sqlfluff.core.rules import BaseRule, LintFix, LintResult, RuleContext
 from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
 from sqlfluff.utils.functional import FunctionalContext, sp
@@ -235,9 +235,6 @@ class Rule_RF06(BaseRule):
             "RegexParser", context.dialect._library["NakedIdentifierSegment"]
         )
         anti_template = cast(str, naked_identifier_parser.anti_template)
-        NakedIdentifierSegment = cast(
-            type[CodeSegment], context.dialect.get_segment("IdentifierSegment")
-        )
 
         # For this to be a candidate for unquoting, it must:
         # - Casefold to it's current exact case. i.e. already be in the default
@@ -275,12 +272,7 @@ class Rule_RF06(BaseRule):
             fixes=[
                 LintFix.replace(
                     context.segment,
-                    [
-                        NakedIdentifierSegment(
-                            raw=identifier_contents,
-                            **naked_identifier_parser.segment_kwargs(),
-                        )
-                    ],
+                    [WordSegment(raw=identifier_contents)],
                 )
             ],
             description=f"Unnecessary quoted identifier {context.segment.raw}.",

--- a/test/fixtures/rules/std_rule_cases/RF06_function_name.yml
+++ b/test/fixtures/rules/std_rule_cases/RF06_function_name.yml
@@ -1,0 +1,10 @@
+rule: RF06
+
+test_fail_function_name_mariadb:
+  fail_str: |
+    CALL `somefunction`('a');
+  fix_str: |
+    CALL somefunction('a');
+  configs:
+    core:
+      dialect: mariadb


### PR DESCRIPTION
Closes #8466.

RF06 currently replaces quoted identifiers with a semantic naked-identifier segment. In function/procedure name positions, the grammar expects a raw `word` so validation rejects an otherwise safe fix.

This changes the replacement to a `WordSegment`, matching the lexer-level type those grammar slots consume, and adds a focused MariaDB regression fixture for `CALL `somefunction`('a')`.

Validation performed in this run was source-level only because the available environment does not provide a runnable SQLFluff checkout. I did not claim or record any test execution. The added fixture targets the reproducer from #8466.

AI assistance was used to trace the issue, inspect the relevant parser/rule code, and prepare this focused patch; the issue reproduction, competing-PR state, repository contribution policy, and changed-file diff were reviewed before submission.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes RF06 so quoted identifiers in function-name positions are replaced with a `WordSegment` instead of a `NakedIdentifierSegment`. The grammar expects a raw word in those slots, so the previous fix was rejected during validation.

- Adds a MariaDB regression fixture covering the `CALL` reproducer from issue #8466.

<sup>Written for commit ce1ebd2fb1e214fc57541da4286a6fe0db17615e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff/pull/8478?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

